### PR TITLE
Move repo to 8.0.100-rtm build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <RuntimeVersion>8.0.0-rc.2.23479.6</RuntimeVersion>
-    <AspNetCoreVersion>8.0.0-rc.2.23480.2</AspNetCoreVersion>
-    <ExtensionsVersion>8.0.0-rc.2.23510.2</ExtensionsVersion>
+    <RuntimeVersion>8.0.0-rtm.23511.16</RuntimeVersion>
+    <AspNetCoreVersion>8.0.0-rtm.23512.10</AspNetCoreVersion>
+    <ExtensionsVersion>8.0.0-rtm.23511.3</ExtensionsVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Azure SDK for .NET dependencies -->
@@ -47,6 +47,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(RuntimeVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Features" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(RuntimeVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(RuntimeVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Features" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(RuntimeVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(RuntimeVersion)" />

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,22 +1,22 @@
 # Set up your environment
 
-## Install Visual Studio 2022 Internal Preview
+## Install Visual Studio 2022 Internal Preview (dogfood)
 
 1. [Visual Studio 2022 Enterprise IntPreview Setup](https://aka.ms/vs/17/intpreview/vs_enterprise.exe)
-    - This channel updates nightly. You need a build from 15-Aug-2023 or later.
+    - This channel updates nightly. You need a build from 29-Sep-2023 or later.
 2. Set an environment variable `VSEnableAspireOrchestrationParameter=1`
 3. Add NuGet sources to apply the following feeds
     - https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json
     - https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-grpc-pre-release/nuget/v3/index.json
     - See [Install and manage packages in Visual Studio](https://learn.microsoft.com/nuget/consume-packages/install-use-packages-visual-studio#package-sources) for instructions.
 
-## Install .NET 8 RC2
+## Install .NET 8 RTM nightly SDK
 
 1. Add the NuGet feed for .NET 8 - https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json (https://github.com/dotnet/installer#installers-and-binaries)
-2. Install the .NET 8 RC2 SDK version 8.0.100-rc.2.23472.8 or newer.
-   1. [Windows x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rc.2.23472.8/dotnet-sdk-8.0.100-rc.2.23472.8-win-x64.exe)
-   2. [Linux x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rc.2.23472.8/dotnet-sdk-8.0.100-rc.2.23472.8-linux-x64.tar.gz)
-   3. [OSX x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rc.2.23472.8/dotnet-sdk-8.0.100-rc.2.23472.8-osx-x64.tar.gz)
+2. Install the .NET 8 RTM nightly SDK version 8.0.100-rtm.23478.7 or newer:
+   1. [Windows x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rtm.23478.7/dotnet-sdk-8.0.100-rtm.23478.7-win-x64.exe)
+   2. [Linux x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rtm.23478.7/dotnet-sdk-8.0.100-rtm.23478.7-linux-x64.tar.gz)
+   3. [OSX x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rtm.23478.7/dotnet-sdk-8.0.100-rtm.23478.7-osx-x64.tar.gz)
 
 ## Install Docker Desktop
 
@@ -24,13 +24,13 @@
 
 ## Install the Aspire dotnet workload
 
-1. The RC2 SDK is aware that the Aspire workload exists, but the real manifest is not installed by default. In order to install it, you'll need to update the workload in a directory that has a NuGet.config[^3] with the right feeds configured[^2] so that it can pull the latest manifest. Once you have created the NuGet.config file in your working directory, then you need to run the following command[^1]:
+1. The RTM nightly SDK is aware that the Aspire workload exists, but the real manifest is not installed by default. In order to install it, you'll need to update the workload in a directory that has a NuGet.config[^3] with the right feeds configured[^2] so that it can pull the latest manifest. Once you have created the NuGet.config file in your working directory, then you need to run the following command[^1]:
 
    ```shell
     dotnet workload update --skip-sign-check --interactive
    ```
 
-2. The above command will update the Aspire manifest in your RC2 build, meaning it will already be setup for command-line (VS support is coming soon) In-product acquisition (IPA) of the Aspire workload. In order to manually install the workload, you can run the following command[^1]:
+2. The above command will update the Aspire manifest in your SDK build, meaning it will already be setup for command-line (VS support is coming soon) In-product acquisition (IPA) of the Aspire workload. In order to manually install the workload, you can run the following command[^1]:
 
    ```shell
     dotnet workload install aspire --skip-sign-check --interactive
@@ -43,7 +43,10 @@
       <configuration>
       <packageSources>
           <clear />
+          <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
+          <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
           <add key="dotnet-tools-internal" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json" />
+          <add key="nuget" value="https://api.nuget.org/v3/index.json" />
       </packageSources>
       </configuration>
       ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,20 +3,45 @@
 ## Install Visual Studio 2022 Internal Preview (dogfood)
 
 1. [Visual Studio 2022 Enterprise IntPreview Setup](https://aka.ms/vs/17/intpreview/vs_enterprise.exe)
-    - This channel updates nightly. You need a build from 29-Sep-2023 or later.
-2. Set an environment variable `VSEnableAspireOrchestrationParameter=1`
-3. Add NuGet sources to apply the following feeds
+    - This channel updates nightly. You need a build from 12-Oct-2023 or later.
+2. Add NuGet sources to apply the following feeds
     - https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json
-    - https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-grpc-pre-release/nuget/v3/index.json
     - See [Install and manage packages in Visual Studio](https://learn.microsoft.com/nuget/consume-packages/install-use-packages-visual-studio#package-sources) for instructions.
 
 ## Install .NET 8 RTM nightly SDK
 
 1. Add the NuGet feed for .NET 8 - https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json (https://github.com/dotnet/installer#installers-and-binaries)
-2. Install the .NET 8 RTM nightly SDK version 8.0.100-rtm.23478.7 or newer:
-   1. [Windows x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rtm.23478.7/dotnet-sdk-8.0.100-rtm.23478.7-win-x64.exe)
-   2. [Linux x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rtm.23478.7/dotnet-sdk-8.0.100-rtm.23478.7-linux-x64.tar.gz)
-   3. [OSX x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rtm.23478.7/dotnet-sdk-8.0.100-rtm.23478.7-osx-x64.tar.gz)
+2. Install the .NET 8 RTM nightly SDK version 8.0.100-rtm.23512.3 or newer:
+   1. [Windows x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rtm.23512.3/dotnet-sdk-8.0.100-rtm.23512.3-win-x64.exe)
+   2. [Linux x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rtm.23512.3/dotnet-sdk-8.0.100-rtm.23512.3-linux-x64.tar.gz)
+   3. [OSX x64 link](https://dotnetbuilds.azureedge.net/public/Sdk/8.0.100-rtm.23512.3/dotnet-sdk-8.0.100-rtm.23512.3-osx-x64.tar.gz)
+
+## Install the Azure Artifacts Credential Provider for NuGet
+
+See [full setup instructions](https://github.com/microsoft/artifacts-credprovider#setup).
+
+### Installation on Windows
+
+#### Automatic PowerShell script
+
+[PowerShell helper script](https://github.com/microsoft/artifacts-credprovider/blob/master/helpers/installcredprovider.ps1)
+
+- To install netcore, run `installcredprovider.ps1`
+  - e.g. `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) }"`
+- To install both netfx and netcore, run `installcredprovider.ps1 -AddNetfx`. The netfx version is needed for nuget.exe.
+  - e.g. `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"`
+
+### Installation on Linux and Mac
+
+#### Automatic bash script
+
+[Linux or Mac helper script](helpers/installcredprovider.sh)
+
+Examples:
+- `wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash`
+- `sh -c "$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)"`
+
+> Note: this script only installs the netcore version of the plugin. If you need to have it working with mono msbuild, you will need to download the version with both netcore and netfx binaries following the steps in [Manual installation on Linux and Mac](#installation-on-linux-and-mac)
 
 ## Install Docker Desktop
 
@@ -26,15 +51,15 @@
 
 1. The RTM nightly SDK is aware that the Aspire workload exists, but the real manifest is not installed by default. In order to install it, you'll need to update the workload in a directory that has a NuGet.config[^3] with the right feeds configured[^2] so that it can pull the latest manifest. Once you have created the NuGet.config file in your working directory, then you need to run the following command[^1]:
 
-   ```shell
+    ```shell
     dotnet workload update --skip-sign-check --interactive
-   ```
+    ```
 
-2. The above command will update the Aspire manifest in your SDK build, meaning it will already be setup for command-line (VS support is coming soon) In-product acquisition (IPA) of the Aspire workload. In order to manually install the workload, you can run the following command[^1]:
+2. The above command will update the Aspire manifest in your SDK build, meaning it will already be setup for command-line and Visual Studio in-product acquisition (IPA) of the Aspire workload. In order to manually install the workload, you can run the following command[^1]:
 
-   ```shell
+    ```shell
     dotnet workload install aspire --skip-sign-check --interactive
-   ```
+    ```
 
 [^1]: The `--skip-sign-check` flag is required because the packages we build out of the Aspire repo are not yet signed.
 [^2]: If you want to create a separate NuGet.config instead, these are the contents you need:
@@ -61,7 +86,7 @@
 ```C#
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddProject<AppHost.Projects.WebApplication22>(); // USE YOUR APP NAME
+builder.AddProject<Projects.WebApplication22>(); // USE YOUR APP NAME
 
 await using var app = builder.Build();
 return await app.RunAsync();

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2",
-    "rollForward": "disable",
+    "version": "8.0.100-rtm.23512.3",
+    "rollForward": "latestPatch",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "8.0.100-rc.2.23502.2"
+    "dotnet": "8.0.100-rtm.23512.3"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23505.1",

--- a/samples/eShopLite/MyFrontend/Program.cs
+++ b/samples/eShopLite/MyFrontend/Program.cs
@@ -19,7 +19,7 @@ var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
 {
-    app.UseExceptionHandler("/error");
+    app.UseExceptionHandler("/error", createScopeForErrors: true);
 }
 
 app.UseStaticFiles();

--- a/samples/eShopLite/ServiceDefaults/Extensions.cs
+++ b/samples/eShopLite/ServiceDefaults/Extensions.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.ServiceDefaults/Extensions.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.ServiceDefaults/Extensions.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.Web/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.Web/Program.cs
@@ -23,7 +23,7 @@ var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
 {
-    app.UseExceptionHandler("/Error");
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
 }
 
 app.UseStaticFiles();


### PR DESCRIPTION
~Currently blocked by regression in Blazor form handling that breaks the sample's add to cart feature dotnet/aspnetcore#50882~

~CLI build should now be working. We're only blocked now by a [Razor compiler regression that's waiting on code flow to VS](https://devdiv.visualstudio.com/DevDiv/_queries/edit/1894345) to unblock building the Blazor apps in VS (Dashboard, Frontend, etc.)~

~Related: https://github.com/dotnet/razor/issues/9342~

Ready to go!