### PR TITLE
Split Container Logs sources for stdout vs stderr

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -17,6 +17,7 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    counter-reset: line-number 0;
 }
 
 ::deep .initial-text {
@@ -26,6 +27,7 @@
 ::deep .line-row-container {
     width:100%;
     overflow: hidden;
+    counter-increment: line-number 1;
 }
 
 ::deep .line-row {
@@ -54,7 +56,7 @@
 }
 
 ::deep .line-number::before {
-    content: attr(data-line-number);
+    content: counter(line-number);
 }
 
 ::deep .timestamp {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
@@ -1,4 +1,3 @@
-let rowIndex = 1;
 const template = createRowTemplate();
 
 /**
@@ -8,7 +7,6 @@ const template = createRowTemplate();
 export function clearLogs() {
     const container = document.getElementById("logContainer");
     container.textContent = '';
-    rowIndex = 1;
 }
 
 /**
@@ -29,8 +27,6 @@ export function addLogEntries(logEntries) {
             const rowContainer = getNewRowContainer();
             const lineRow = rowContainer.firstElementChild;
             const lineArea = lineRow.firstElementChild;
-            const lineNumber = lineArea.firstElementChild;
-            lineNumber.setAttribute("data-line-number", rowIndex++);
             const timestamp = lineArea.children[1];
             if (logEntry.timestamp) {
                 timestamp.textContent = logEntry.timestamp;

--- a/src/Aspire.Dashboard/Components/Pages/ContainerLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ContainerLogs.razor
@@ -34,6 +34,7 @@
     private LogViewer? _logViewer;
     private CancellationTokenSource _watchTokenSource = new CancellationTokenSource();
     private CancellationTokenSource _watchLogsTokenSource = new CancellationTokenSource();
+    private IContainerLogWatcher? _currentWatcher;
 
     protected override async Task OnInitializedAsync()
     {
@@ -68,29 +69,36 @@
     {
         if (_selectedContainer is not null && _logViewer is not null)
         {
-            await _logViewer.ClearLogsAsync();
             await _watchLogsTokenSource.CancelAsync();
+            if (_currentWatcher is not null)
+            {
+                await _currentWatcher.DisposeAsync();
+            }
+            await _logViewer.ClearLogsAsync();
 
             _watchLogsTokenSource = new CancellationTokenSource();
+            _currentWatcher = _selectedContainer.LogSource.GetWatcher();
 
-            _ = Task.Run(async () =>
+            if (await _currentWatcher.InitWatchAsync(_watchLogsTokenSource.Token))
             {
-                await foreach (var logs in _selectedContainer.LogSource.WatchLogsAsync(_watchLogsTokenSource.Token))
+                _ = Task.Run(async () =>
                 {
-                    var logEntries = logs.Select(l =>
+                    await foreach (var logs in _currentWatcher.WatchOutputLogsAsync(_watchLogsTokenSource.Token))
                     {
-                        // Container logs always start with an RFC3339Nano timestamp followed by a space
-                        // and then the rest of the log line
-                        var indexOfSpace = l.IndexOf(" ");
-                        return new LogEntry()
-                        {
-                            Timestamp = l[..indexOfSpace],
-                            Content = l[(indexOfSpace + 1)..]
-                        };
-                    });
-                    await _logViewer.AddLogEntriesAsync(logEntries);
-                }
-            }, _watchLogsTokenSource.Token);
+                        var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Default));
+                        await _logViewer.AddLogEntriesAsync(logEntries);
+                    }
+                }, _watchLogsTokenSource.Token);
+
+                _ = Task.Run(async () =>
+                {
+                    await foreach (var logs in _currentWatcher.WatchErrorLogsAsync(_watchLogsTokenSource.Token))
+                    {
+                        var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Error));
+                        await _logViewer.AddLogEntriesAsync(logEntries);
+                    }
+                }, _watchLogsTokenSource.Token);
+            }
         }
     }
 
@@ -146,5 +154,9 @@
         _watchTokenSource.Dispose();
         await _watchLogsTokenSource.CancelAsync();
         _watchLogsTokenSource.Dispose();
+        if (_currentWatcher is not null)
+        {
+            await _currentWatcher.DisposeAsync();
+        }
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
@@ -85,15 +85,7 @@
             {
                 await foreach (var logs in _selectedProject.LogSource.WatchOutputLogAsync(_watchLogsTokenSource.Token))
                 {
-                    var logEntries = logs.Select(l =>
-                    {
-                        return new LogEntry()
-                        {
-                            Timestamp = string.Empty,
-                            Content = l
-                        };
-                    });
-
+                    var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Default));
                     await _logViewer.AddLogEntriesAsync(logEntries);
                 }
             }, _watchLogsTokenSource.Token);
@@ -102,16 +94,7 @@
             {
                 await foreach (var logs in _selectedProject.LogSource.WatchErrorLogAsync(_watchLogsTokenSource.Token))
                 {
-                    var logEntries = logs.Select(l =>
-                    {
-                        return new LogEntry()
-                        {
-                            Timestamp = string.Empty,
-                            Content = l,
-                            Type = LogEntryType.Error
-                        };
-                    });
-
+                    var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Error));
                     await _logViewer.AddLogEntriesAsync(logEntries);
                 }
             }, _watchLogsTokenSource.Token);

--- a/src/Aspire.Dashboard/Model/IContainerLogSource.cs
+++ b/src/Aspire.Dashboard/Model/IContainerLogSource.cs
@@ -5,5 +5,5 @@ namespace Aspire.Dashboard.Model;
 
 public interface IContainerLogSource
 {
-    IAsyncEnumerable<string[]> WatchLogsAsync(CancellationToken cancellationToken);
+    IContainerLogWatcher GetWatcher();
 }

--- a/src/Aspire.Dashboard/Model/IContainerLogWatcher.cs
+++ b/src/Aspire.Dashboard/Model/IContainerLogWatcher.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public interface IContainerLogWatcher : IAsyncDisposable
+{
+    Task<bool> InitWatchAsync(CancellationToken cancellationToken);
+    IAsyncEnumerable<string[]> WatchOutputLogsAsync(CancellationToken cancellationToken);
+    IAsyncEnumerable<string[]> WatchErrorLogsAsync(CancellationToken cancellationToken);
+}

--- a/src/Aspire.Dashboard/Model/LogEntry.cs
+++ b/src/Aspire.Dashboard/Model/LogEntry.cs
@@ -2,15 +2,38 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 namespace Aspire.Dashboard.Model;
 
-internal sealed class LogEntry
+internal sealed partial class LogEntry
 {
+    private static readonly Regex s_rfc3339NanoRegEx = GenerateRfc3339NanoRegEx();
+
     public string? Content { get; set; }
     public string? Timestamp { get; set; }
     [JsonConverter(typeof(JsonStringEnumConverter<LogEntryType>))]
     public LogEntryType Type { get; init; } = LogEntryType.Default;
+
+    public static LogEntry Create(string s, LogEntryType type)
+    {
+        var indexOfSpace = s.IndexOf(' ');
+        var possibleTimestamp = s[..indexOfSpace];
+
+        // For right now, we only support RFC3339Nano timestamps, which is what (most) containers generate
+        // We can tweak this once project/executable log timestamps are finalized
+        if (s_rfc3339NanoRegEx.IsMatch(possibleTimestamp))
+        {
+            return new() { Timestamp = possibleTimestamp, Content = s[(indexOfSpace + 1)..], Type = type };
+        }
+        else
+        {
+            return new() { Content = s, Type = type };
+        }
+    }
+
+    [GeneratedRegex("^(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):(?:[0-5][0-9]):(?:[0-5][0-9])(?:\\.\\d{1,9})(?:Z|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])?$")]
+    private static partial Regex GenerateRfc3339NanoRegEx();
 }
 
 internal enum LogEntryType

--- a/src/Aspire.Dashboard/Model/LogEntry.cs
+++ b/src/Aspire.Dashboard/Model/LogEntry.cs
@@ -32,7 +32,36 @@ internal sealed partial class LogEntry
         }
     }
 
-    [GeneratedRegex("^(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):(?:[0-5][0-9]):(?:[0-5][0-9])(?:\\.\\d{1,9})(?:Z|[+-](?:[01][0-9]|2[0-3]):[0-5][0-9])?$")]
+    // Regular Expression for an RFC3339 timestamp, including RFC3339Nano
+    //
+    // Example timestamps:
+    // 2023-10-02T12:56:35.123456789Z
+    // 2023-10-02T13:56:35.123456789+10:00
+    // 2023-10-02T13:56:35.123456789-10:00
+    // 2023-10-02T13:56:35.123456789Z10:00
+    // 2023-10-02T13:56:35.123456Z
+    // 2023-10-02T13:56:35Z
+    //
+    // Explanation:
+    // ^                                                   - Starts the string
+    // (?:\\d{4})                                          - Four digits for the year
+    // -                                                   - Separator for the date
+    // (?:0[1-9]|1[0-2])                                   - Two digits for the month, restricted to 01-12
+    // -                                                   - Separator for the date
+    // (?:0[1-9]|[12][0-9]|3[01])                          - Two digits for the day, restricted to 01-31
+    // 'T'                                                 - Literal, separator between date and time
+    // (?:[01][0-9]|2[0-3])                                - Two digits for the hour, restricted to 00-23
+    // :                                                   - Separator for the time
+    // (?:[0-5][0-9])                                      - Two digits for the minutes, restricted to 00-59
+    // :                                                   - Separator for the time
+    // (?:[0-5][0-9])                                      - Two digits for the seconds, restricted to 00-59
+    // (?:\\.\\d{1,9})                                     - A period and up to nine digits for the partial seconds
+    // Z                                                   - Literal, same as +00:00
+    // (?:[Z+-](?:[01][0-9]|2[0-3]):(?:[0-5][0-9]))        - Time Zone offset, in the form ZHH:MM or +HH:MM or -HH:MM
+    // $                                                   - Ends the string
+    //
+    // Note: (?:) is a non-capturing group, since we don't care about the values, we are just interested in whether or not there is a match
+    [GeneratedRegex("^(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):(?:[0-5][0-9]):(?:[0-5][0-9])(?:\\.\\d{1,9})?(?:Z|(?:[Z+-](?:[01][0-9]|2[0-3]):(?:[0-5][0-9])))?$")]
     private static partial Regex GenerateRfc3339NanoRegEx();
 }
 

--- a/src/Aspire.Hosting/Dcp/Process/ProcessSpec.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessSpec.cs
@@ -14,6 +14,7 @@ internal sealed class ProcessSpec
     public Action<int>? OnStart { get; set; }
     public Action<int>? OnStop { get; set; }
     public bool KillEntireProcessTree { get; set; } = true;
+    public bool ThrowOnNonZeroReturnCode { get; set; } = true;
 
     public ProcessSpec(string executablePath)
     {

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -80,7 +80,7 @@ internal static partial class ProcessUtil
         {
             lock (processEventLock)
             {
-                if (process.ExitCode != 0)
+                if (processSpec.ThrowOnNonZeroReturnCode && process.ExitCode != 0)
                 {
                     processLifetimeTcs.TrySetException(new InvalidOperationException(
                         $"Command {processSpec.ExecutablePath} {processSpec.Arguments} returned non-zero exit code {process.ExitCode}"));
@@ -146,7 +146,7 @@ internal static partial class ProcessUtil
                 sys_kill(_process.Id, sig: 2); // SIGINT
             }
 
-            await Task.WhenAny(_processLifetimeTask, Task.Delay(s_processExitTimeout)).ConfigureAwait(false);
+            await _processLifetimeTask.WaitAsync(s_processExitTimeout).ConfigureAwait(false);
             if (!_process.HasExited)
             {
                 // Always try to kill the entire process tree here if all of the above has failed.


### PR DESCRIPTION
The Container logs had stdout/stderr as separate streams, but we were reading them into one channel without differentiation. This PR splits them up so that error log entries can be rendered differently to the page based on their actual source.

As an example, prometheus logs are apparently all stderr at the moment (even though they say "level=info" in them), so they all show up red:

![446428414-d9eb6c3d-1cbe-4be2-9d50-c612b359c42b](https://github.com/user-attachments/assets/f9d5da6e-602a-44ed-bf9d-4f1a650a7e5a)

I also cleaned up the way line numbers were rendered in the logs (doesn't change the display, just how we do the display) and detection of timestamps in the logs (RFC3339Nano only at the moment) so that we don't just render whatever the first non-whitespace characters are as the timestamp.

This issue tracks flaky tests in the repository. It is updated regularly with runs from the Outerloop workflow which runs the Quarantined tests. Also, this tracks any test failures might be potentially flaky tests that haven't been quarantined yet.