### PR TITLE
Remove params from service bus component

### DIFF
--- a/samples/DevHost/Program.cs
+++ b/samples/DevHost/Program.cs
@@ -20,7 +20,7 @@ var catalog = builder.AddProject<Projects.CatalogService>()
                      .WithReplicas(2)
                      .WithSqlServer(sql, "master");
 
-var serviceBus = builder.AddAzureServiceBus("messaging", "orders");
+var serviceBus = builder.AddAzureServiceBus("messaging", queueNames: ["orders"]);
 
 var basket = builder.AddProject<Projects.BasketService>()
                     .WithRedis(redis)

--- a/src/Aspire.Hosting.Azure/AzureComponentExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureComponentExtensions.cs
@@ -34,11 +34,12 @@ public static class AzureComponentExtensions
         });
     }
 
-    public static IDistributedApplicationComponentBuilder<AzureServiceBusComponent> AddAzureServiceBus(this IDistributedApplicationBuilder builder, string name, params string[] queueNames)
+    public static IDistributedApplicationComponentBuilder<AzureServiceBusComponent> AddAzureServiceBus(this IDistributedApplicationBuilder builder, string name, string[]? queueNames = null, string[]? topicNames = null)
     {
         var component = new AzureServiceBusComponent
         {
-            QueueNames = queueNames
+            QueueNames = queueNames ?? [],
+            TopicNames = topicNames ?? []
         };
 
         return builder.AddComponent(name, component);

--- a/src/Aspire.Hosting.Azure/AzureServiceBusComponent.cs
+++ b/src/Aspire.Hosting.Azure/AzureServiceBusComponent.cs
@@ -12,4 +12,5 @@ public class AzureServiceBusComponent : IAzureComponent
     public string ServiceBusNamespace { get; set; } = default!;
 
     public string[] QueueNames { get; set; } = [];
+    public string[] TopicNames { get; set; } = [];
 }


### PR DESCRIPTION
- We need to support crreating both queues and topics so params doesn't work well in AzureAzureServiceBus.
- Expose topics as well and make queues and topics optional.