### PR TITLE
Fix crash in Project Logs when executables are present

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
@@ -30,7 +30,7 @@ public class DashboardViewModelService : IDashboardViewModelService, IDisposable
     {
         var executables = await _kubernetesService.ListAsync<Executable>().ConfigureAwait(false);
         return executables
-            .Where(exe => !exe.Metadata.Annotations.ContainsKey(Executable.CSharpProjectPathAnnotation))
+            .Where(exe => exe.Metadata.Annotations?.ContainsKey(Executable.CSharpProjectPathAnnotation) == false)
             .Select(exe =>
         {
             var model = new ExecutableViewModel()
@@ -59,7 +59,7 @@ public class DashboardViewModelService : IDashboardViewModelService, IDisposable
         var endpoints = await _kubernetesService.ListAsync<Endpoint>().ConfigureAwait(false);
 
         return executables
-            .Where(exe => exe.Metadata.Annotations.ContainsKey(Executable.CSharpProjectPathAnnotation))
+            .Where(exe => exe.Metadata.Annotations?.ContainsKey(Executable.CSharpProjectPathAnnotation) == true)
             .Select(exe =>
             {
                 var expectedEndpointCount = 0;


### PR DESCRIPTION
The Annotations property on Metadata objects can in fact be null, no matter what the nullability says.