### PR TITLE
Add search box to semantic logs and traces pages

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/SemanticLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/SemanticLogs.razor
@@ -20,14 +20,21 @@
                           OptionText="@(c => c.Name)"
                           @bind-SelectedOption="_selectedApplication"
                           @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync" />
+            <FluentSearch @bind-Value="_filter"
+                          @oninput="HandleFilter"
+                          AfterBindValue="HandleClear"
+                          Placeholder="Filter..."
+                          slot="end" />
+            @* Temporary workaround for https://github.com/microsoft/fluentui-blazor/issues/811 *@
+            <fluent-divider orientation="vertical" role="separator" aria-orientation="vertical" slot="end"></fluent-divider>
             <FluentLabel slot="end">Filters: </FluentLabel>
-            @if (_logFilters.Count == 0)
+            @if (ViewModel.Filters.Count == 0)
             {
                 <span slot="end">No Filters</span>
             }
             else
             {
-                foreach (var filter in _logFilters)
+                foreach (var filter in ViewModel.Filters)
                 {
                     <FluentButton slot="end" Appearance="Appearance.Outline" OnClick="() => OpenFilterAsync(filter)">@filter.FilterText</FluentButton>
                 }
@@ -44,7 +51,9 @@
                     </TemplateColumn>
                     <PropertyColumn Title="Severity" Property="@(context => context.Severity)" />
                     <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" />
-                    <PropertyColumn Title="Message" Tooltip=true Property="@(context => context.Message)" />
+                    <TemplateColumn Title="Message" Tooltip=true>
+                        <FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@context.Message" />
+                    </TemplateColumn>
                     <TemplateColumn Title="Trace">
                         @if (!string.IsNullOrEmpty(context.TraceId))
                         {
@@ -69,20 +78,23 @@
 @code {
     private static readonly ApplicationViewModel AllApplication = new ApplicationViewModel { Id = null, Name = "(All)" };
 
-    private readonly List<LogFilter> _logFilters = new();
     private TotalItemsFooter totalItemsFooter = default!;
     private List<ApplicationViewModel>? _applications;
     private ApplicationViewModel _selectedApplication = AllApplication;
     private Subscription? _applicationsSubscription;
     private Subscription? _logsSubscription;
-    private int _totalItemCount;
     private bool _applicationChanged;
+    private CancellationTokenSource? _filterCts;
+    private string _filter = string.Empty;
 
     [Parameter]
     public string? ApplicationInstanceId { get; set; }
 
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; set; }
+
+    [Inject]
+    public required SemanticLogsViewModel ViewModel { get; set; }
 
     [Inject]
     public required IDialogService DialogService { get; set; }
@@ -97,34 +109,27 @@
 
     private ValueTask<GridItemsProviderResult<OtlpLogEntry>> GetData(GridItemsProviderRequest<OtlpLogEntry> request)
     {
-        var logs = TelemetryRepository.GetLogs(new GetLogsContext
-            {
-                ApplicationServiceId = _selectedApplication.Id,
-                StartIndex = request.StartIndex,
-                Count = request.Count,
-                Filters = _logFilters
-            });
+        ViewModel.StartIndex = request.StartIndex;
+        ViewModel.Count = request.Count;
+
+        var logs = ViewModel.GetLogs();
 
         // Updating the total item count as a field doesn't work because it isn't updated with the grid.
         // The workaround is to put the count inside a control and explicitly update and refresh the control.
         totalItemsFooter.SetTotalItemCount(logs.TotalItemCount);
 
-        return ValueTask.FromResult(new GridItemsProviderResult<OtlpLogEntry>
-            {
-                Items = logs.Items,
-                TotalItemCount = _totalItemCount = logs.TotalItemCount
-            });
+        return ValueTask.FromResult(GridItemsProviderResult.From(logs.Items, logs.TotalItemCount));
     }
 
     protected override async Task OnInitializedAsync()
     {
         if (!string.IsNullOrEmpty(TraceId))
         {
-            _logFilters.Add(new LogFilter { Field = "TraceId", Condition = FilterCondition.Equals, Value = TraceId });
+            ViewModel.AddFilter(new LogFilter { Field = "TraceId", Condition = FilterCondition.Equals, Value = TraceId });
         }
         if (!string.IsNullOrEmpty(SpanId))
         {
-            _logFilters.Add(new LogFilter { Field = "SpanId", Condition = FilterCondition.Equals, Value = SpanId });
+            ViewModel.AddFilter(new LogFilter { Field = "SpanId", Condition = FilterCondition.Equals, Value = SpanId });
         }
 
         await UpdateApplicationsAsync();
@@ -160,7 +165,11 @@
         if (_logsSubscription is null || _logsSubscription.ApplicationId != _selectedApplication.Id)
         {
             _logsSubscription?.Dispose();
-            _logsSubscription = TelemetryRepository.OnNewLogs(_selectedApplication.Id, () => InvokeAsync(StateHasChanged));
+            _logsSubscription = TelemetryRepository.OnNewLogs(_selectedApplication.Id, async () =>
+            {
+                ViewModel.ClearData();
+                await InvokeAsync(StateHasChanged);
+            });
         }
     }
 
@@ -211,15 +220,39 @@
         {
             if (filterResult.Delete)
             {
-                _logFilters.Remove(filter);
+                ViewModel.RemoveFilter(filter);
             }
             else if (filterResult.Add)
             {
-                _logFilters.Add(filter);
+                ViewModel.AddFilter(filter);
             }
         }
 
         return Task.CompletedTask;
+    }
+
+    private void HandleFilter(ChangeEventArgs args)
+    {
+        if (args.Value is string newFilter)
+        {
+            _filter = newFilter;
+            _filterCts?.Cancel();
+
+            var cts = _filterCts = new CancellationTokenSource();
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(400, cts.Token);
+                ViewModel.FilterText = newFilter ?? string.Empty;
+                await InvokeAsync(StateHasChanged);
+            });
+        }
+    }
+
+    private void HandleClear(string value)
+    {
+        _filterCts?.Cancel();
+        ViewModel.FilterText = string.Empty;
+        StateHasChanged();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -239,5 +272,6 @@
     {
         _applicationsSubscription?.Dispose();
         _logsSubscription?.Dispose();
+        _filterCts?.Dispose();
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/SemanticLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/SemanticLogs.razor
@@ -57,7 +57,7 @@
                     <TemplateColumn Title="Trace">
                         @if (!string.IsNullOrEmpty(context.TraceId))
                         {
-                            <FluentAnchor Appearance="Appearance.Hypertext" Href="@($"/Traces/Trace/{HttpUtility.UrlEncode(context.TraceId)}")">
+                            <FluentAnchor Appearance="Appearance.Hypertext" Href="@($"/Trace/{HttpUtility.UrlEncode(context.TraceId)}")">
                                 @OtlpHelpers.ToShortenedId(context.TraceId)
                             </FluentAnchor>
                         }
@@ -71,15 +71,15 @@
                 </EmptyContent>
             </FluentDataGrid>
         </div>
-        <TotalItemsFooter @ref="totalItemsFooter" />
+        <TotalItemsFooter @ref="_totalItemsFooter" />
     </FluentStack>
 </div>
 
 @code {
     private static readonly ApplicationViewModel AllApplication = new ApplicationViewModel { Id = null, Name = "(All)" };
 
-    private TotalItemsFooter totalItemsFooter = default!;
-    private List<ApplicationViewModel>? _applications;
+    private TotalItemsFooter _totalItemsFooter = default!;
+    private List<ApplicationViewModel> _applications = default!;
     private ApplicationViewModel _selectedApplication = AllApplication;
     private Subscription? _applicationsSubscription;
     private Subscription? _logsSubscription;
@@ -116,12 +116,12 @@
 
         // Updating the total item count as a field doesn't work because it isn't updated with the grid.
         // The workaround is to put the count inside a control and explicitly update and refresh the control.
-        totalItemsFooter.SetTotalItemCount(logs.TotalItemCount);
+        _totalItemsFooter.SetTotalItemCount(logs.TotalItemCount);
 
         return ValueTask.FromResult(GridItemsProviderResult.From(logs.Items, logs.TotalItemCount));
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
         if (!string.IsNullOrEmpty(TraceId))
         {
@@ -132,29 +132,33 @@
             ViewModel.AddFilter(new LogFilter { Field = "SpanId", Condition = FilterCondition.Equals, Value = SpanId });
         }
 
-        await UpdateApplicationsAsync();
-        _applicationsSubscription = TelemetryRepository.OnNewApplications(() => InvokeAsync(async () =>
+        UpdateApplications();
+        _applicationsSubscription = TelemetryRepository.OnNewApplications(() => InvokeAsync(() =>
         {
-            await UpdateApplicationsAsync();
+            UpdateApplications();
             StateHasChanged();
         }));
+
+        return Task.CompletedTask;
     }
 
-    private Task UpdateApplicationsAsync()
+    protected override void OnParametersSet()
+    {
+        _selectedApplication = _applications.SingleOrDefault(e => e.Id == ApplicationInstanceId) ?? AllApplication;
+        ViewModel.ApplicationServiceId = _selectedApplication.Id;
+        UpdateSubscription();
+    }
+
+    private void UpdateApplications()
     {
         _applications = TelemetryRepository.GetApplications().Select(a => new ApplicationViewModel { Id = a.InstanceId, Name = a.ApplicationName }).ToList();
         _applications.Insert(0, AllApplication);
-        _selectedApplication = _applications.SingleOrDefault(e => e.Id == ApplicationInstanceId) ?? AllApplication;
-        UpdateSubscription();
-
-        return Task.CompletedTask;
     }
 
     private Task HandleSelectedApplicationChangedAsync()
     {
         NavigationManager.NavigateTo($"/SemanticLogs/{_selectedApplication.Id}");
         _applicationChanged = true;
-        UpdateSubscription();
 
         return Task.CompletedTask;
     }

--- a/src/Aspire.Dashboard/Components/Pages/SemanticLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/SemanticLogs.razor
@@ -238,6 +238,7 @@
             _filter = newFilter;
             _filterCts?.Cancel();
 
+            // Debouncing logic. Apply the filter after a delay.
             var cts = _filterCts = new CancellationTokenSource();
             _ = Task.Run(async () =>
             {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -1,5 +1,5 @@
-﻿@page "/Traces/Trace/{traceId}"
-@page "/Traces/Trace/{traceId}/Span/{spanId}"
+﻿@page "/Trace/{traceId}"
+@page "/Trace/{traceId}/Span/{spanId}"
 
 @using Aspire.Dashboard.Components.Dialogs
 @using Aspire.Dashboard.Model

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -1,0 +1,5 @@
+.trace-id {
+    color: rgb(136, 136, 136);
+    padding-left: 0.5rem;
+    font-size: 12px;
+}

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -22,46 +22,51 @@
                           OptionText="@(c => c.Name)"
                           @bind-SelectedOption="_selectedApplication"
                           @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync" />
+            <FluentSearch @bind-Value="_filter"
+                          @oninput="HandleFilter"
+                          AfterBindValue="HandleClear"
+                          Placeholder="Filter..."
+                          slot="end" />
         </FluentToolbar>
         <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
             <FluentDataGrid Class="SemanticLogsDataGrid" Virtualize="true" RowStyle="@GetRowStyle" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="48" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.5fr 0.5fr">
-              <ChildContent>
-                <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
-                <TemplateColumn Title="Name">
-                    <span>@(context.FirstSpan.Source.ApplicationName): @context.FirstSpan.Name</span>
-                    <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
-                </TemplateColumn>
-                <TemplateColumn Title="Spans">
-                    <FluentOverflow>
-                        <ChildContent>
-                            @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Key.ApplicationName))
-                            {
-                                <FluentOverflowItem>
-                                    <span class="trace-tag trace-service-tag" style="border-left-color: @ColorGenerator.Instance.GetColorHexByKey(item.Key.ApplicationName);">
-                                        @if (item.Any(s => s.Status == OtlpSpanStatusCode.Error))
-                                        {
-                                            <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
-                                        }
-                                        @item.Key.ApplicationName (@item.Count())
-                                    </span>
-                                </FluentOverflowItem>
-                            }
-                        </ChildContent>
-                        <MoreButtonTemplate Context="another_name">
-                            <span class="trace-tag">
-                                @($"+{another_name.ItemsOverflow.Count()}")
-                            </span>
-                        </MoreButtonTemplate>
-                    </FluentOverflow>
-                </TemplateColumn>
-                <PropertyColumn Title="Duration" Property="@(context => DurationFormatter.FormatDuration(context.Duration))" />
-                <TemplateColumn>
-                    <FluentButton Appearance="Appearance.Lightweight" OnClick="() => SelectTraceAsync(context)">View</FluentButton>
-                </TemplateColumn>
-             </ChildContent>
-             <EmptyContent>
-                  <FluentIcon Icon="Icons.Regular.Size24.GanttChart" />&nbsp;No traces found
-              </EmptyContent>
+                <ChildContent>
+                    <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
+                    <TemplateColumn Title="Name">
+                        <span><FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@(context.FullName)" /></span>
+                        <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
+                    </TemplateColumn>
+                    <TemplateColumn Title="Spans">
+                        <FluentOverflow>
+                            <ChildContent>
+                                @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Key.ApplicationName))
+                                {
+                                    <FluentOverflowItem>
+                                        <span class="trace-tag trace-service-tag" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(item.Key.ApplicationName));">
+                                            @if (item.Any(s => s.Status == OtlpSpanStatusCode.Error))
+                                            {
+                                                <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
+                                            }
+                                            @item.Key.ApplicationName (@item.Count())
+                                        </span>
+                                    </FluentOverflowItem>
+                                }
+                            </ChildContent>
+                            <MoreButtonTemplate Context="another_name">
+                                <span class="trace-tag">
+                                    @($"+{another_name.ItemsOverflow.Count()}")
+                                </span>
+                            </MoreButtonTemplate>
+                        </FluentOverflow>
+                    </TemplateColumn>
+                    <PropertyColumn Title="Duration" Property="@(context => DurationFormatter.FormatDuration(context.Duration))" />
+                    <TemplateColumn>
+                        <FluentButton Appearance="Appearance.Lightweight" OnClick="() => SelectTraceAsync(context)">View</FluentButton>
+                    </TemplateColumn>
+                </ChildContent>
+                <EmptyContent>
+                    <FluentIcon Icon="Icons.Regular.Size24.GanttChart" />&nbsp;No traces found
+                </EmptyContent>
             </FluentDataGrid>
         </div>
         <TotalItemsFooter @ref="totalItemsFooter" />
@@ -71,15 +76,14 @@
 @code {
     private static readonly ApplicationViewModel AllApplication = new ApplicationViewModel { Id = null, Name = "(All)" };
 
-    private readonly List<LogFilter> _logFilters = new();
     private TotalItemsFooter totalItemsFooter = default!;
     private List<ApplicationViewModel>? _applications;
     private ApplicationViewModel _selectedApplication = AllApplication;
     private Subscription? _applicationsSubscription;
     private Subscription? _tracesSubscription;
-    private int _totalItemCount;
-    private TimeSpan _maxDuration;
     private bool _applicationChanged;
+    private CancellationTokenSource? _filterCts;
+    private string _filter = string.Empty;
 
     [Parameter]
     public string? ApplicationInstanceId { get; set; }
@@ -88,14 +92,17 @@
     public required TelemetryRepository TelemetryRepository { get; set; }
 
     [Inject]
+    public required TracesViewModel ViewModel { get; set; }
+
+    [Inject]
     public required IDialogService DialogService { get; set; }
 
     private string GetRowStyle(OtlpTrace trace)
     {
         var percentage = 0.0;
-        if (_maxDuration != TimeSpan.Zero)
+        if (ViewModel.MaxDuration != TimeSpan.Zero)
         {
-            percentage = trace.Duration / _maxDuration * 100.0;
+            percentage = trace.Duration / ViewModel.MaxDuration * 100.0;
         }
 
         return $"background: linear-gradient(to right, var(--duration-color) {percentage.ToString("0.##")}%, transparent {percentage.ToString("0.##")}%);";
@@ -103,24 +110,16 @@
 
     private ValueTask<GridItemsProviderResult<OtlpTrace>> GetData(GridItemsProviderRequest<OtlpTrace> request)
     {
-        var result = TelemetryRepository.GetTraces(new GetTracesContext
-            {
-                ApplicationServiceId = _selectedApplication.Id,
-                StartIndex = request.StartIndex,
-                Count = request.Count
-            });
-        var traces = result.PagedResult;
-        _maxDuration = result.MaxDuraiton;
+        ViewModel.StartIndex = request.StartIndex;
+        ViewModel.Count = request.Count;
+
+        var traces = ViewModel.GetTraces();
 
         // Updating the total item count as a field doesn't work because it isn't updated with the grid.
         // The workaround is to put the count inside a control and explicitly update and refresh the control.
         totalItemsFooter.SetTotalItemCount(traces.TotalItemCount);
 
-        return ValueTask.FromResult(new GridItemsProviderResult<OtlpTrace>
-            {
-                Items = traces.Items,
-                TotalItemCount = _totalItemCount = traces.TotalItemCount
-            });
+        return ValueTask.FromResult(GridItemsProviderResult.From(traces.Items, traces.TotalItemCount));
     }
 
     protected override async Task OnInitializedAsync()
@@ -158,7 +157,11 @@
         if (_tracesSubscription is null || _tracesSubscription.ApplicationId != _selectedApplication.Id)
         {
             _tracesSubscription?.Dispose();
-            _tracesSubscription = TelemetryRepository.OnNewTraces(_selectedApplication.Id, () => InvokeAsync(StateHasChanged));
+            _tracesSubscription = TelemetryRepository.OnNewTraces(_selectedApplication.Id, async () =>
+            {
+                ViewModel.ClearData();
+                await InvokeAsync(StateHasChanged);
+            });
         }
     }
 
@@ -166,6 +169,30 @@
     {
         NavigationManager.NavigateTo($"/Traces/Trace/{trace.TraceId}");
         return Task.CompletedTask;
+    }
+
+    private void HandleFilter(ChangeEventArgs args)
+    {
+        if (args.Value is string newFilter)
+        {
+            _filter = newFilter;
+            _filterCts?.Cancel();
+
+            var cts = _filterCts = new CancellationTokenSource();
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(400, cts.Token);
+                ViewModel.FilterText = newFilter ?? string.Empty;
+                await InvokeAsync(StateHasChanged);
+            });
+        }
+    }
+
+    private void HandleClear(string value)
+    {
+        _filterCts?.Cancel();
+        ViewModel.FilterText = string.Empty;
+        StateHasChanged();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -69,15 +69,15 @@
                 </EmptyContent>
             </FluentDataGrid>
         </div>
-        <TotalItemsFooter @ref="totalItemsFooter" />
+        <TotalItemsFooter @ref="_totalItemsFooter" />
     </FluentStack>
 </div>
 
 @code {
     private static readonly ApplicationViewModel AllApplication = new ApplicationViewModel { Id = null, Name = "(All)" };
 
-    private TotalItemsFooter totalItemsFooter = default!;
-    private List<ApplicationViewModel>? _applications;
+    private TotalItemsFooter _totalItemsFooter = default!;
+    private List<ApplicationViewModel> _applications = default!;
     private ApplicationViewModel _selectedApplication = AllApplication;
     private Subscription? _applicationsSubscription;
     private Subscription? _tracesSubscription;
@@ -117,36 +117,41 @@
 
         // Updating the total item count as a field doesn't work because it isn't updated with the grid.
         // The workaround is to put the count inside a control and explicitly update and refresh the control.
-        totalItemsFooter.SetTotalItemCount(traces.TotalItemCount);
+        _totalItemsFooter.SetTotalItemCount(traces.TotalItemCount);
 
         return ValueTask.FromResult(GridItemsProviderResult.From(traces.Items, traces.TotalItemCount));
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
-        await UpdateApplicationsAsync();
-        _applicationsSubscription = TelemetryRepository.OnNewApplications(() => InvokeAsync(async () =>
+        UpdateApplications();
+        _applicationsSubscription = TelemetryRepository.OnNewApplications(() => InvokeAsync(() =>
         {
-            await UpdateApplicationsAsync();
+            UpdateApplications();
             StateHasChanged();
         }));
+
+        return Task.CompletedTask;
     }
 
-    private Task UpdateApplicationsAsync()
+    protected override void OnParametersSet()
+    {
+        _selectedApplication = _applications.SingleOrDefault(e => e.Id == ApplicationInstanceId) ?? AllApplication;
+        ViewModel.ApplicationServiceId = _selectedApplication.Id;
+        UpdateSubscription();
+    }
+
+    private void UpdateApplications()
     {
         _applications = TelemetryRepository.GetApplications().Select(a => new ApplicationViewModel { Id = a.InstanceId, Name = a.ApplicationName }).ToList();
         _applications.Insert(0, AllApplication);
-        _selectedApplication = _applications.SingleOrDefault(e => e.Id == ApplicationInstanceId) ?? AllApplication;
         UpdateSubscription();
-
-        return Task.CompletedTask;
     }
 
     private Task HandleSelectedApplicationChangedAsync()
     {
         NavigationManager.NavigateTo($"/Traces/{_selectedApplication.Id}");
         _applicationChanged = true;
-        UpdateSubscription();
 
         return Task.CompletedTask;
     }
@@ -167,7 +172,7 @@
 
     private Task SelectTraceAsync(OtlpTrace trace)
     {
-        NavigationManager.NavigateTo($"/Traces/Trace/{trace.TraceId}");
+        NavigationManager.NavigateTo($"/Trace/{trace.TraceId}");
         return Task.CompletedTask;
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -178,6 +178,7 @@
             _filter = newFilter;
             _filterCts?.Cancel();
 
+            // Debouncing logic. Apply the filter after a delay.
             var cts = _filterCts = new CancellationTokenSource();
             _ = Task.Run(async () =>
             {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -1,21 +1,3 @@
-
-.trace-id {
-    color: rgb(136, 136, 136);
-    padding-left: 0.5rem;
-    font-size: 12px;
-}
-
-.trace-list-reset {
-    padding-left: 0px;
-    margin-bottom: 0px;
-    list-style: none;
-    display: inline-block;
-}
-
-.trace-inline-block {
-    display: inline-block;
-}
-
 .trace-tag {
     display: flex;
     align-items: center;
@@ -28,4 +10,10 @@
 
 .trace-service-tag {
     border-left-width: 15px;
+}
+
+.trace-id {
+    color: rgb(136, 136, 136);
+    padding-left: 0.5rem;
+    font-size: 12px;
 }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -1,3 +1,9 @@
+.trace-id {
+    color: rgb(136, 136, 136);
+    padding-left: 0.5rem;
+    font-size: 12px;
+}
+
 .trace-tag {
     display: flex;
     align-items: center;
@@ -10,10 +16,4 @@
 
 .trace-service-tag {
     border-left-width: 15px;
-}
-
-.trace-id {
-    color: rgb(136, 136, 136);
-    padding-left: 0.5rem;
-    font-size: 12px;
 }

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Aspire.Dashboard.Components;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Grpc;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Services;
@@ -65,6 +66,8 @@ public class DashboardWebApplication : IHostedService
         // OTLP services.
         builder.Services.AddGrpc();
         builder.Services.AddSingleton<TelemetryRepository>();
+        builder.Services.AddTransient<SemanticLogsViewModel>();
+        builder.Services.AddTransient<TracesViewModel>();
 
         builder.Services.AddFluentUIComponents(options =>
         {

--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -31,14 +31,14 @@ public class LogFilter
     private static Func<string, string, bool> ConditionToFuncString(FilterCondition c) =>
         c switch
         {
-            FilterCondition.Equals => (a, b) => a == b,
-            FilterCondition.Contains => (a, b) => a != null && a.Contains(b),
+            FilterCondition.Equals => (a, b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase),
+            FilterCondition.Contains => (a, b) => a != null && a.Contains(b, StringComparison.OrdinalIgnoreCase),
             // Condition.GreaterThan => (a, b) => a > b,
             // Condition.LessThan => (a, b) => a < b,
             // Condition.GreaterThanOrEqual => (a, b) => a >= b,
             // Condition.LessThanOrEqual => (a, b) => a <= b,
-            FilterCondition.NotEqual => (a, b) => a != b,
-            FilterCondition.NotContains => (a, b) => a != null && !a.Contains(b),
+            FilterCondition.NotEqual => (a, b) => !string.Equals(a, b, StringComparison.OrdinalIgnoreCase),
+            FilterCondition.NotContains => (a, b) => a != null && !a.Contains(b, StringComparison.OrdinalIgnoreCase),
             _ => throw new ArgumentOutOfRangeException(nameof(c), c, null)
         };
 

--- a/src/Aspire.Dashboard/Model/SemanticLogsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/SemanticLogsViewModel.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+
+namespace Aspire.Dashboard.Model;
+
+public class SemanticLogsViewModel
+{
+    private readonly TelemetryRepository _telemetryRepository;
+    private readonly List<LogFilter> _filters = new();
+
+    private PagedResult<OtlpLogEntry>? _logs;
+    private string? _applicationServiceId;
+    private string _filterText = string.Empty;
+    private int _logsStartIndex;
+    private int? _logsCount;
+
+    public SemanticLogsViewModel(TelemetryRepository telemetryRepository)
+    {
+        _telemetryRepository = telemetryRepository;
+    }
+
+    public string? ApplicationServiceId { get => _applicationServiceId; set => SetValue(ref _applicationServiceId, value); }
+    public string FilterText { get => _filterText; set => SetValue(ref _filterText, value); }
+    public IReadOnlyList<LogFilter> Filters => _filters;
+    public void AddFilter(LogFilter filter)
+    {
+        _filters.Add(filter);
+        _logs = null;
+    }
+    public bool RemoveFilter(LogFilter filter)
+    {
+        if (_filters.Remove(filter))
+        {
+            _logs = null;
+            return true;
+        }
+        return false;
+    }
+    public int StartIndex { get => _logsStartIndex; set => SetValue(ref _logsStartIndex, value); }
+    public int? Count { get => _logsCount; set => SetValue(ref _logsCount, value); }
+
+    private void SetValue<T>(ref T field, T value)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        _logs = null;
+    }
+
+    public PagedResult<OtlpLogEntry> GetLogs()
+    {
+        var logs = _logs;
+        if (logs == null)
+        {
+            var filters = Filters.ToList();
+            if (!string.IsNullOrWhiteSpace(FilterText))
+            {
+                filters.Add(new LogFilter { Field = "Message", Condition = FilterCondition.Contains, Value = FilterText });
+            }
+
+            logs = _telemetryRepository.GetLogs(new GetLogsContext
+            {
+                ApplicationServiceId = ApplicationServiceId,
+                StartIndex = StartIndex,
+                Count = Count,
+                Filters = filters
+            });
+        }
+
+        return logs;
+    }
+
+    public void ClearData()
+    {
+        _logs = null;
+    }
+}
+

--- a/src/Aspire.Dashboard/Model/TracesViewModel.cs
+++ b/src/Aspire.Dashboard/Model/TracesViewModel.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+
+namespace Aspire.Dashboard.Model;
+
+public class TracesViewModel
+{
+    private readonly TelemetryRepository _telemetryRepository;
+
+    private PagedResult<OtlpTrace>? _traces;
+    private string? _applicationServiceId;
+    private string _filterText = string.Empty;
+    private int _startIndex;
+    private int? _count;
+
+    public TracesViewModel(TelemetryRepository telemetryRepository)
+    {
+        _telemetryRepository = telemetryRepository;
+    }
+
+    public string? ApplicationServiceId { get => _applicationServiceId; set => SetValue(ref _applicationServiceId, value); }
+    public string FilterText { get => _filterText; set => SetValue(ref _filterText, value); }
+    public int StartIndex { get => _startIndex; set => SetValue(ref _startIndex, value); }
+    public int? Count { get => _count; set => SetValue(ref _count, value); }
+    public TimeSpan MaxDuration { get; private set; }
+
+    private void SetValue<T>(ref T field, T value)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return;
+        }
+
+        field = value;
+        _traces = null;
+    }
+
+    public PagedResult<OtlpTrace> GetTraces()
+    {
+        var traces = _traces;
+        if (traces == null)
+        {
+            var result = _telemetryRepository.GetTraces(new GetTracesContext
+            {
+                ApplicationServiceId = ApplicationServiceId,
+                FilterText = FilterText,
+                StartIndex = StartIndex,
+                Count = Count
+            });
+
+            traces = result.PagedResult;
+            MaxDuration = result.MaxDuration;
+        }
+
+        return traces;
+    }
+
+    public void ClearData()
+    {
+        _traces = null;
+    }
+}
+

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -53,11 +53,10 @@ public class OtlpTrace
 
     public void AddSpan(OtlpSpan span)
     {
-        var firstSpan = Spans.FirstOrDefault();
-
         var added = false;
         for (var i = Spans.Count - 1; i >= 0; i--)
         {
+            if (span.StartTime > Spans[i].StartTime)
             {
                 Spans.Insert(i + 1, span);
                 added = true;
@@ -67,7 +66,7 @@ public class OtlpTrace
         if (!added)
         {
             Spans.Insert(0, span);
-            FullName = $"{FirstSpan.Source.ApplicationName}: {FirstSpan.Name}";
+            FullName = $"{span.Source.ApplicationName}: {span.Name}";
         }
 
         if (string.IsNullOrEmpty(span.ParentSpanId))

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -13,6 +13,7 @@ public class OtlpTrace
     public ReadOnlyMemory<byte> Key { get; }
     public string TraceId { get; }
 
+    public string FullName { get; private set; }
     public OtlpSpan FirstSpan => Spans[0]; // There should always be at least one span in a trace.
     public OtlpSpan? RootSpan => _rootSpan;
     public TimeSpan Duration
@@ -52,10 +53,11 @@ public class OtlpTrace
 
     public void AddSpan(OtlpSpan span)
     {
+        var firstSpan = Spans.FirstOrDefault();
+
         var added = false;
         for (var i = Spans.Count - 1; i >= 0; i--)
         {
-            if (span.StartTime > Spans[i].StartTime)
             {
                 Spans.Insert(i + 1, span);
                 added = true;
@@ -65,6 +67,7 @@ public class OtlpTrace
         if (!added)
         {
             Spans.Insert(0, span);
+            FullName = $"{FirstSpan.Source.ApplicationName}: {FirstSpan.Name}";
         }
 
         if (string.IsNullOrEmpty(span.ParentSpanId))
@@ -78,6 +81,7 @@ public class OtlpTrace
         Key = traceId;
         TraceId = OtlpHelpers.ToHexString(traceId);
         TraceScope = traceScope;
+        FullName = string.Empty;
     }
 
     public static OtlpTrace Clone(OtlpTrace trace)

--- a/src/Aspire.Dashboard/Otlp/Storage/GetTracesContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetTracesContext.cs
@@ -10,10 +10,11 @@ public sealed class GetTracesContext
     public required string? ApplicationServiceId { get; init; }
     public required int StartIndex { get; init; }
     public required int? Count { get; init; }
+    public required string FilterText { get; init; }
 }
 
 public sealed class GetTracesResult
 {
     public required PagedResult<OtlpTrace> PagedResult { get; init; }
-    public required TimeSpan MaxDuraiton { get; init; }
+    public required TimeSpan MaxDuration { get; init; }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -291,6 +291,10 @@ public class TelemetryRepository
             {
                 results = results.Where(t => HasApplication(t, context.ApplicationServiceId));
             }
+            if (!string.IsNullOrWhiteSpace(context.FilterText))
+            {
+                results = results.Where(t => t.FullName.Contains(context.FilterText, StringComparison.OrdinalIgnoreCase));
+            }
 
             // Traces can be modified as new spans are added. Copy traces before returning results to avoid concurrency issues.
             var copyFunc = static (OtlpTrace t) => OtlpTrace.Clone(t);
@@ -301,7 +305,7 @@ public class TelemetryRepository
             return new GetTracesResult
             {
                 PagedResult = pagedResults,
-                MaxDuraiton = maxDuration
+                MaxDuration = maxDuration
             };
         }
         finally

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -56,6 +56,7 @@ public class TraceTests
         var traces = repository.GetTraces(new GetTracesContext
         {
             ApplicationServiceId = applications[0].InstanceId,
+            FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
         });
@@ -127,6 +128,7 @@ public class TraceTests
         var traces1 = repository.GetTraces(new GetTracesContext
         {
             ApplicationServiceId = applications[0].InstanceId,
+            FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
         });
@@ -167,6 +169,7 @@ public class TraceTests
         var traces2 = repository.GetTraces(new GetTracesContext
         {
             ApplicationServiceId = applications[0].InstanceId,
+            FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
         });
@@ -218,6 +221,7 @@ public class TraceTests
         var traces = repository.GetTraces(new GetTracesContext
         {
             ApplicationServiceId = null,
+            FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
         });
@@ -266,6 +270,7 @@ public class TraceTests
         var traces1 = repository.GetTraces(new GetTracesContext
         {
             ApplicationServiceId = null,
+            FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
         });
@@ -280,6 +285,7 @@ public class TraceTests
         var traces2 = repository.GetTraces(new GetTracesContext
         {
             ApplicationServiceId = null,
+            FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
         });


### PR DESCRIPTION
Add search boxes to logs and traces pages.

**Semantic logging**

Search is on the message text:
![image](https://github.com/dotnet/aspire/assets/303201/682ac03f-3f1a-4c6b-8e13-000f8c70d03b)

**Tracing**

Search is on the trace/operation name:
![image](https://github.com/dotnet/aspire/assets/303201/443788d8-93b6-40e6-a8af-0f7d0fe9526f)
