### PR TITLE
Remove duplicated Body in starter template

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.Web/Components/Layout/MainLayout.razor
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.Web/Components/Layout/MainLayout.razor
@@ -16,8 +16,6 @@
     </main>
 </div>
 
-@Body
-
 <div id="blazor-error-ui">
     An unhandled error has occurred.
     <a href="" class="reload">Reload</a>


### PR DESCRIPTION
This causes the page to be rendered twice everytime it is loaded.