### PR TITLE
Support retrieving local DCP components for development as package download

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,4 +23,15 @@
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
   </PropertyGroup>
 
+  <!-- OS/Architecture properties for local development resources -->
+  <PropertyGroup>
+    <BuildOs Condition="$([MSBuild]::IsOsPlatform('Linux'))">linux</BuildOs>
+    <BuildOs Condition="$([MSBuild]::IsOsPlatform('OSX'))">darwin</BuildOs>
+    <BuildOs Condition=" '$(BuildOs)' == '' ">windows</BuildOs>
+    <BuildArch Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86' ">386</BuildArch>
+    <BuildArch Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64' ">arm64</BuildArch>
+    <BuildArch Condition=" '$(BuildArch)' == '' ">amd64</BuildArch>
+    <DcpDir>$(NuGetPackageRoot)Microsoft.DeveloperControlPlane.$(BuildOs)-$(BuildArch)/$(_DcpVersion)/tools/</DcpDir>
+  </PropertyGroup>
+
 </Project>

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -38,14 +38,14 @@
 
   <!-- The list of runtimes DCP provides binaries for -->
   <ItemGroup>
-      <_DcpRuntimes Include="win-x86" />
-      <_DcpRuntimes Include="win-x64" />
-      <_DcpRuntimes Include="win-arm64" />
-      <_DcpRuntimes Include="linux-x64" />
-      <_DcpRuntimes Include="linux-arm64" />
-      <_DcpRuntimes Include="osx-x64" />
-      <_DcpRuntimes Include="osx-arm64" />
-    </ItemGroup>
+    <_DcpRuntimes Include="win-x86" />
+    <_DcpRuntimes Include="win-x64" />
+    <_DcpRuntimes Include="win-arm64" />
+    <_DcpRuntimes Include="linux-x64" />
+    <_DcpRuntimes Include="linux-arm64" />
+    <_DcpRuntimes Include="osx-x64" />
+    <_DcpRuntimes Include="osx-arm64" />
+  </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -17,6 +17,11 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>
 
+  <!-- Download DCP orchestrator components for local development -->
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.$(BuildOs)-$(BuildArch)" Version="[$(_DcpVersion)]" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Dashboard\Aspire.Dashboard.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Allow local development to pull in DCP dependencies via PackageDownload instead of requiring manual install