### PR TITLE
Allow setting a custom timeout for k8s commands

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -27,6 +27,7 @@ public class DcpHostService : IHostedService, IAsyncDisposable
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
     private readonly DashboardWebApplication _dashboard;
+    private readonly TimeSpan _maxInitialConnectionRetryDuration = TimeSpan.FromMilliseconds(5000);
 
     public DcpHostService(IHostEnvironment hostEnvironment, DistributedApplicationModel applicationModel, ILoggerFactory loggerFactory)
     {
@@ -99,7 +100,7 @@ public class DcpHostService : IHostedService, IAsyncDisposable
 
             try
             {
-                await new KubernetesService().ListAsync<Container>(cancellationToken: cancellationToken).ConfigureAwait(false);
+                await new KubernetesService(_maxInitialConnectionRetryDuration).ListAsync<Container>(cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch
             {


### PR DESCRIPTION
Rather than a maximum number of retries, use a maximum retry duration (and allow overriding for a given client) to let us increase the timeout on our initial connection after launching DCP.