### PR TITLE
Remove duplicate import already provided by Aspire.Hosting

### DIFF
--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets
@@ -30,7 +30,6 @@
     <IsPublishable Condition="'$(IsPublishable)' == ''">false</IsPublishable>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
   </PropertyGroup>
-  <Import Sdk="Microsoft.NET.Sdk.StaticWebAssets" Project="Sdk.props" />
 
   <!-- *** END ***  -->
 


### PR DESCRIPTION
Aspire.Hosting already has the needed import. We don't need to re-import it since we're acquiring Aspire.Hosting as an implicit package ref.