### PR TITLE
Template updates

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -21,6 +21,23 @@
   "identity": "Aspire.Empty.CSharp.8.0",
   "thirdPartyNotices": "https://aka.ms/aspnetcore/8.0-third-party-notices",
   "groupIdentity": "Aspire.Empty",
+  "guids": [
+    "F98A6C4E-E01C-44BB-BCC9-4C23F1CD09CD",
+    "8CD1957F-C0E5-454E-8BDC-88F84DD58303",
+    "1C1883BC-2DC4-4D49-82A6-9909F00D385D"
+  ],
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(hostIdentifier == \"vs\")",
+          "exclude": [
+            "*.sln"
+          ]
+        }
+      ]
+    }
+  ],
   "symbols": {
     "Framework": {
       "type": "parameter",
@@ -130,6 +147,10 @@
   },
   "primaryOutputs": [
     {
+      "path": "AspireApplication1.sln",
+      "condition": "(hostIdentifier != \"vs\")"
+    },
+    {
       "path": "AspireApplication1.DevHost\\AspireApplication1.DevHost.csproj"
     },
     {
@@ -145,6 +166,18 @@
       "args": {
         "projects": "0"
       }
+    },
+    {
+      "id": "restore",
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
     }
   ]
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.sln
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.0.0
+MinimumVisualStudioVersion = 17.8.0.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireApplication1.DevHost", "AspireApplication1.DevHost\AspireApplication1.DevHost.csproj", "{F98A6C4E-E01C-44BB-BCC9-4C23F1CD09CD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireApplication1.ServiceDefaults", "AspireApplication1.ServiceDefaults\AspireApplication1.ServiceDefaults.csproj", "{8CD1957F-C0E5-454E-8BDC-88F84DD58303}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F98A6C4E-E01C-44BB-BCC9-4C23F1CD09CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F98A6C4E-E01C-44BB-BCC9-4C23F1CD09CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F98A6C4E-E01C-44BB-BCC9-4C23F1CD09CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F98A6C4E-E01C-44BB-BCC9-4C23F1CD09CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CD1957F-C0E5-454E-8BDC-88F84DD58303}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CD1957F-C0E5-454E-8BDC-88F84DD58303}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CD1957F-C0E5-454E-8BDC-88F84DD58303}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CD1957F-C0E5-454E-8BDC-88F84DD58303}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1C1883BC-2DC4-4D49-82A6-9909F00D385D}
+	EndGlobalSection
+EndGlobal

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -25,6 +25,25 @@
   "identity": "Aspire.Starter.CSharp.8.0",
   "thirdPartyNotices": "https://aka.ms/aspnetcore/8.0-third-party-notices",
   "groupIdentity": "Aspire.Starter",
+  "guids": [
+    "80B24B1B-1E78-4FCB-BDC9-13678F1789F4",
+    "DB7A3AC1-6E4F-4805-B710-2FCD1084E96E",
+    "9FEB877E-015D-4E20-AE63-06C596E242E4",
+    "AC2DB38C-F5AD-4CEF-BC4C-04AE6EE86C9F",
+    "EB6E56D3-85C9-43D0-A65C-775F4C780950"
+  ],
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(hostIdentifier == \"vs\")",
+          "exclude": [
+            "*.sln"
+          ]
+        }
+      ]
+    }
+  ],
   "symbols": {
     "Framework": {
       "type": "parameter",
@@ -229,6 +248,10 @@
   },
   "primaryOutputs": [
     {
+      "path": "AspireApplication1.sln",
+      "condition": "(hostIdentifier != \"vs\")"
+    },
+    {
       "path": "AspireStarterApplication1.DevHost\\AspireStarterApplication1.DevHost.csproj"
     },
     {
@@ -250,6 +273,18 @@
       "args": {
         "projects": "0"
       }
+    },
+    {
+      "id": "restore",
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
     }
   ]
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.sln
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.sln
@@ -1,0 +1,42 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.0.0
+MinimumVisualStudioVersion = 17.8.0.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireStarterApplication1.DevHost", "AspireStarterApplication1.DevHost\AspireStarterApplication1.DevHost.csproj", "{80B24B1B-1E78-4FCB-BDC9-13678F1789F4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireStarterApplication1.ServiceDefaults", "AspireStarterApplication1.ServiceDefaults\AspireStarterApplication1.ServiceDefaults.csproj", "{DB7A3AC1-6E4F-4805-B710-2FCD1084E96E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireStarterApplication1.ApiService", "AspireStarterApplication1.ApiService\AspireStarterApplication1.ApiService.csproj", "{9FEB877E-015D-4E20-AE63-06C596E242E4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireStarterApplication1.Web", "AspireStarterApplication1.Web\AspireStarterApplication1.Web.csproj", "{AC2DB38C-F5AD-4CEF-BC4C-04AE6EE86C9F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{80B24B1B-1E78-4FCB-BDC9-13678F1789F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80B24B1B-1E78-4FCB-BDC9-13678F1789F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80B24B1B-1E78-4FCB-BDC9-13678F1789F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80B24B1B-1E78-4FCB-BDC9-13678F1789F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB7A3AC1-6E4F-4805-B710-2FCD1084E96E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB7A3AC1-6E4F-4805-B710-2FCD1084E96E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB7A3AC1-6E4F-4805-B710-2FCD1084E96E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB7A3AC1-6E4F-4805-B710-2FCD1084E96E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9FEB877E-015D-4E20-AE63-06C596E242E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9FEB877E-015D-4E20-AE63-06C596E242E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FEB877E-015D-4E20-AE63-06C596E242E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9FEB877E-015D-4E20-AE63-06C596E242E4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC2DB38C-F5AD-4CEF-BC4C-04AE6EE86C9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC2DB38C-F5AD-4CEF-BC4C-04AE6EE86C9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC2DB38C-F5AD-4CEF-BC4C-04AE6EE86C9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC2DB38C-F5AD-4CEF-BC4C-04AE6EE86C9F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EB6E56D3-85C9-43D0-A65C-775F4C780950}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- Adds missing .sln files to templates so that they're created when creating projects from the CLI
- Update the starter app template to be type "solution" (matching the empty template)
- Add post-create task to restore packages when created from the CLI

Fixes #21

~@phenning despite these changes, when using the starter app template in VS, it's still prompting for a project name and creating an extra directory under the solution directory. Is there something else that needs to be done to get it to work like the empty template? Both seem to be working as intended from the CLI after these changes.~
This was indeed template metadata caching causing the issue.