### PR TITLE
Add Cache-Control: no-cache; to Static Web Assets

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -91,7 +91,20 @@ public class DashboardWebApplication : IHostedService
             _app.UseHttpsRedirection();
         }
 
-        _app.UseStaticFiles();
+        _app.UseStaticFiles(new StaticFileOptions()
+        {
+            OnPrepareResponse = (context) =>
+            {
+                // If Cache-Control isn't already set to something, set it to 'no-cache' so that the 
+                // ETag and Last-Modified headers will be respected by the browser.
+                // This may be able to be removed if https://github.com/dotnet/aspnetcore/issues/44153
+                // is fixed to make this the default
+                if (context.Context.Response.Headers.CacheControl.Count == 0)
+                {
+                    context.Context.Response.Headers.CacheControl = "no-cache";
+                }
+            }
+        });
 
         _app.UseAuthorization();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/astra/issues/705.

Static Web Assets middleware currently sets the ETag and Last-Modified headers, but it does not set the Cache-Control header to no-cache. This means that in some (many? most?) cases the browser ignores the ETag and Last-Modified headers and always pulls the asset from cache. 

https://github.com/dotnet/aspnetcore/issues/44153 has been re-opened to potentially address this in the middleware itself. But for now, we can use the `StaticFileOptions` parameter of `UseStaticFiles` to add the header ourself if we see that it's not set to anything else.