### PR TITLE
Enable tracing in the OrderProcessor

### DIFF
--- a/samples/BasketService/BasketService.csproj
+++ b/samples/BasketService/BasketService.csproj
@@ -22,9 +22,4 @@
     <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" />
   </ItemGroup>
 
-  <!-- Enable Azure ActivitySources so Azure Components participate in tracing. -->
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="Azure.Experimental.EnableActivitySource"
-                                    Value="true" />
-  </ItemGroup>
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -12,4 +12,10 @@
     <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
   </PropertyGroup>
 
+  <!-- Enable Azure ActivitySources so Azure Components participate in tracing. -->
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="Azure.Experimental.EnableActivitySource"
+                                    Value="true" />
+  </ItemGroup>
+
 </Project>

--- a/samples/OrderProcessor/OrderProcessingWorker.cs
+++ b/samples/OrderProcessor/OrderProcessingWorker.cs
@@ -53,7 +53,8 @@ public class OrderProcessingWorker : BackgroundService
 
     private Task ProcessMessageAsync(ProcessMessageEventArgs args)
     {
-        using (var activity = ActivitySource.StartActivity("order-processor.worker"))
+        var parentId = args.Message.ApplicationProperties["traceparent"] as string;
+        using (var activity = ActivitySource.StartActivity("order-processor.worker", ActivityKind.Consumer, parentId))
         {
             _logger.LogInformation($"Processing Order at: {DateTime.UtcNow}");
 

--- a/samples/OrderProcessor/OrderProcessingWorker.cs
+++ b/samples/OrderProcessor/OrderProcessingWorker.cs
@@ -59,12 +59,12 @@ public class OrderProcessingWorker : BackgroundService
 
             var message = args.Message;
 
-            if (_logger.Equals(LogLevel.Debug))
+            if (_logger.IsEnabled(LogLevel.Debug))
             {
                 _logger.LogDebug("""
-                MessageId:{MessageId}
-                MessageBody:{Body}
-                """, message.MessageId, message.Body);
+                    MessageId:{MessageId}
+                    MessageBody:{Body}
+                    """, message.MessageId, message.Body);
             }
             var order = message.Body.ToObjectFromJson<Order>();
 

--- a/samples/OrderProcessor/Program.cs
+++ b/samples/OrderProcessor/Program.cs
@@ -11,6 +11,9 @@ if (!builder.Environment.IsDevelopment() || builder.Configuration[AspireServiceB
 }
 
 builder.Services.AddHostedService<OrderProcessingWorker>();
+// ensure the OrderProcessingWorker's Activities participate in tracing
+builder.Services.AddOpenTelemetry()
+    .WithTracing(traceBuilder => traceBuilder.AddSource(OrderProcessingWorker.ActivitySourceName));
 
 var host = builder.Build();
 host.Run();

--- a/samples/OrderProcessor/appsettings.json
+++ b/samples/OrderProcessor/appsettings.json
@@ -15,7 +15,8 @@
           "MaxRetries": 2,
           "Delay": "00:00:01"
         }
-      }
+      },
+      "Tracing": true
     }
   }
 }


### PR DESCRIPTION
- Move the Azure SDK app context switch to apply to all projects
- Enable the OrderProcessingWorker's Activity in OpenTelemetry