### PR TITLE
Handle Project Logs page disposed during LoadLogsAsync

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -21,12 +21,12 @@
 
     private IJSObjectReference? _jsModule;
 
-    internal async Task ClearLogsAsync()
+    internal async Task ClearLogsAsync(CancellationToken cancellationToken = default)
     {
         if (_jsModule is not null)
         {
             initialMessageCleared = true;
-            await _jsModule.InvokeVoidAsync("clearLogs");
+            await _jsModule.InvokeVoidAsync("clearLogs", cancellationToken);
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/ContainerLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ContainerLogs.razor
@@ -32,9 +32,10 @@
     private IEnumerable<ContainerViewModel> Containers => _containerNameMapping.Select(kvp => kvp.Value).OrderBy(c => c.Name);
     private ContainerViewModel? _selectedContainer;
     private LogViewer? _logViewer;
-    private CancellationTokenSource _watchTokenSource = new CancellationTokenSource();
-    private CancellationTokenSource _watchLogsTokenSource = new CancellationTokenSource();
+    private CancellationTokenSource _watchContainersTokenSource = new CancellationTokenSource();
+    private CancellationTokenSource? _watchLogsTokenSource;
     private IContainerLogWatcher? _currentWatcher;
+    private bool _pageDisposed;
 
     protected override async Task OnInitializedAsync()
     {
@@ -58,7 +59,7 @@
 
         _ = Task.Run(async () =>
         {
-            await foreach (var componentChanged in DashboardViewModelService.WatchContainersAsync(existingContainers: initialList?.Select(t => t.Model), cancellationToken: _watchTokenSource.Token))
+            await foreach (var componentChanged in DashboardViewModelService.WatchContainersAsync(existingContainers: initialList?.Select(t => t.Model), cancellationToken: _watchContainersTokenSource.Token))
             {
                 await OnContainerListChanged(componentChanged.ObjectChangeType, componentChanged.Component);
             }
@@ -69,15 +70,21 @@
     {
         if (_selectedContainer is not null && _logViewer is not null)
         {
-            await _watchLogsTokenSource.CancelAsync();
-            if (_currentWatcher is not null)
+            await DisposeCurrentWatcher();
+            await DisposeWatchLogsTokenSource();
+
+            if (_pageDisposed)
             {
-                await _currentWatcher.DisposeAsync();
+                // If the page got disposed after this call was started, but before we
+                // set up the _watchLogsTokenSource to a new object below, we would end
+                // up leaving the below tasks running indefinitely.
+                return;
             }
-            await _logViewer.ClearLogsAsync();
 
             _watchLogsTokenSource = new CancellationTokenSource();
             _currentWatcher = _selectedContainer.LogSource.GetWatcher();
+
+            await _logViewer.ClearLogsAsync(_watchLogsTokenSource.Token);
 
             if (await _currentWatcher.InitWatchAsync(_watchLogsTokenSource.Token))
             {
@@ -150,13 +157,30 @@
 
     public async ValueTask DisposeAsync()
     {
-        await _watchTokenSource.CancelAsync();
-        _watchTokenSource.Dispose();
-        await _watchLogsTokenSource.CancelAsync();
-        _watchLogsTokenSource.Dispose();
-        if (_currentWatcher is not null)
+        _pageDisposed = true;
+        await DisposeWatchContainersTokenSource();
+        await DisposeWatchLogsTokenSource();
+        await DisposeCurrentWatcher();
+    }
+
+    private ValueTask DisposeCurrentWatcher()
+        => _currentWatcher is null
+            ? ValueTask.CompletedTask
+            : _currentWatcher.DisposeAsync();
+
+    private async Task DisposeWatchContainersTokenSource()
+    {
+        await _watchContainersTokenSource.CancelAsync();
+        _watchContainersTokenSource.Dispose();
+    }
+
+    private async Task DisposeWatchLogsTokenSource()
+    {
+        if (_watchLogsTokenSource is not null)
         {
-            await _currentWatcher.DisposeAsync();
+            await _watchLogsTokenSource.CancelAsync();
+            _watchLogsTokenSource.Dispose();
+            _watchLogsTokenSource = null;
         }
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
@@ -1,7 +1,7 @@
 ﻿@page "/ProjectLogs/{projectname?}"
 @using Aspire.Dashboard.Model;
 @using System.Text
-@implements IDisposable;
+@implements IAsyncDisposable;
 @inject IDashboardViewModelService DashboardViewModelService
 @inject IJSRuntime JS
 @inject NavigationManager NavigationManager
@@ -33,7 +33,8 @@
     private readonly Dictionary<string, ProjectViewModel> _projectNameMapping = new Dictionary<string, ProjectViewModel>();
     private IEnumerable<ProjectViewModel> Projects => _projectNameMapping.Select(kvp => kvp.Value).OrderBy(p => p.Name);
     private CancellationTokenSource _watchProjectsTokenSource = new CancellationTokenSource();
-    private CancellationTokenSource _watchLogsTokenSource = new CancellationTokenSource();
+    private CancellationTokenSource? _watchLogsTokenSource;
+    private bool _pageDisposed;
 
     protected override async Task OnInitializedAsync()
     {
@@ -78,7 +79,17 @@
         if (_selectedProject?.LogSource?.Available == true && _logViewer is not null)
         {
             await _logViewer.ClearLogsAsync();
-            await _watchLogsTokenSource.CancelAsync();
+
+            await DisposeWatchLogsTokenSource();
+
+            if (_pageDisposed)
+            {
+                // If the page got disposed after this call was started, but before we
+                // set up the _watchLogsTokenSource to a new object below, we would end
+                // up leaving the below tasks running indefinitely.
+                return;
+            }
+
             _watchLogsTokenSource = new CancellationTokenSource();
 
             _ = Task.Run(async () =>
@@ -147,11 +158,26 @@
         await InvokeAsync(StateHasChanged);
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
-        _watchProjectsTokenSource.Cancel();
+        _pageDisposed = true;
+        await DisposeWatchProjectsTokenSource();
+        await DisposeWatchLogsTokenSource();
+    }
+
+    private async Task DisposeWatchProjectsTokenSource()
+    {
+        await _watchProjectsTokenSource.CancelAsync();
         _watchProjectsTokenSource.Dispose();
-        _watchLogsTokenSource.Cancel();
-        _watchLogsTokenSource.Dispose();
+    }
+
+    private async Task DisposeWatchLogsTokenSource()
+    {
+        if (_watchLogsTokenSource is not null)
+        {
+            await _watchLogsTokenSource.CancelAsync();
+            _watchLogsTokenSource.Dispose();
+            _watchLogsTokenSource = null;
+        }
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
@@ -78,8 +78,6 @@
     {
         if (_selectedProject?.LogSource?.Available == true && _logViewer is not null)
         {
-            await _logViewer.ClearLogsAsync();
-
             await DisposeWatchLogsTokenSource();
 
             if (_pageDisposed)
@@ -91,6 +89,8 @@
             }
 
             _watchLogsTokenSource = new CancellationTokenSource();
+
+            await _logViewer.ClearLogsAsync(_watchLogsTokenSource.Token);
 
             _ = Task.Run(async () =>
             {


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspire-private-planning/issues/703.

It appears that the page can get disposed after OnInitializedAsync starts but before it finishes, and in particular before LoadLogsAsync creates the new CancellationTokenSource.

This PR makes sure we don't access a disposed CancellationTokenSource in LoadLogsAsync, but also ensures we don't get stuck in a situation where the page is disposed and THEN the CTS is created and tasks are launched, which would mean the tasks are left running. 