### PR TITLE
Update starter template to use named redis cache

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.Web/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.Web/Program.cs
@@ -6,7 +6,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add service defaults & Aspire components.
 builder.AddServiceDefaults();
 #if (UseRedisCache)
-builder.AddRedisOutputCache();
+builder.AddRedisOutputCache("cache");
 #endif
 
 // Add services to the container.


### PR DESCRIPTION
Starter template is throwing an exception when the option to use Redis for caching is ticked without this change.