### PR TITLE
Adjust Service Bus tracing

### DIFF
--- a/samples/OrderProcessor/OrderProcessingWorker.cs
+++ b/samples/OrderProcessor/OrderProcessingWorker.cs
@@ -53,8 +53,7 @@ public class OrderProcessingWorker : BackgroundService
 
     private Task ProcessMessageAsync(ProcessMessageEventArgs args)
     {
-        var parentId = args.Message.ApplicationProperties["traceparent"] as string;
-        using (var activity = ActivitySource.StartActivity("order-processor.worker", ActivityKind.Consumer, parentId))
+        using (var activity = ActivitySource.StartActivity("order-processor.worker"))
         {
             _logger.LogInformation($"Processing Order at: {DateTime.UtcNow}");
 

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -61,7 +61,7 @@ public static class AspireServiceBusExtensions
 
     private sealed class MessageBusComponent : AzureComponent<AzureMessagingServiceBusSettings, ServiceBusClient, ServiceBusClientOptions>
     {
-        protected override string[] ActivitySourceNames => new[] { "Azure.Messaging.ServiceBus.ServiceBusReceiver", "Azure.Messaging.ServiceBus.ServiceBusSender" };
+        protected override string[] ActivitySourceNames => ["Azure.Messaging.ServiceBus", "Azure.Messaging.ServiceBus.ServiceBusReceiver", "Azure.Messaging.ServiceBus.ServiceBusSender", "Azure.Messaging.ServiceBus.ServiceBusProcessor"];
 
         protected override IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureMessagingServiceBusSettings settings)
         {

--- a/src/Components/Telemetry.md
+++ b/src/Components/Telemetry.md
@@ -15,6 +15,8 @@ Aspire.Azure.Messaging.ServiceBus:
   - "Azure.Identity"
   - "Azure.Messaging.ServiceBus"
 - Activity source names:
+  - "Azure.Messaging.ServiceBus"
+  - "Azure.Messaging.ServiceBus.ServiceBusProcessor"
   - "Azure.Messaging.ServiceBus.ServiceBusReceiver"
   - "Azure.Messaging.ServiceBus.ServiceBusSender"
 - Metric names:


### PR DESCRIPTION
- Add Azure.Messaging.ServiceBus and Azure.Messaging.ServiceBus.ServiceBusProcessor activity sources to OTel
- Removing setting the parentId on the custom activity. This is not needed because ServiceBusProcessor will set the static parent activity.
- Update Telemetry.md

Here's what a trace of the sample app "check out" process looks like with the current code.

![image](https://github.com/dotnet/aspire/assets/8291187/4b0e655a-6d81-445d-a100-e750809c095f)
