### PR TITLE
Better log viewing status information

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -6,17 +6,13 @@
 
 <div class="log-overflow">
     <div class="log-container" id="logContainer">
-        <span class="initial-text">@InitialText</span>
+        
     </div>
 </div>
 
 @code {
-    [Parameter]
-    public string InitialText { get; set; } = "";
-
     private List<IEnumerable<LogEntry>> _preRenderQueue = new();
 
-    bool initialMessageCleared = false;
     bool renderComplete = false;
 
     private IJSObjectReference? _jsModule;
@@ -25,7 +21,6 @@
     {
         if (_jsModule is not null)
         {
-            initialMessageCleared = true;
             await _jsModule.InvokeVoidAsync("clearLogs", cancellationToken);
         }
     }
@@ -54,12 +49,6 @@
 
         async Task WritePreRenderQueue()
         {
-            if (!initialMessageCleared)
-            {
-                initialMessageCleared = true;
-                await ClearLogsAsync();
-            }
-
             foreach (var logs in _preRenderQueue)
             {
                 await WriteLogsToDom(logs);
@@ -72,12 +61,6 @@
     {
         if (renderComplete)
         {
-            if (!initialMessageCleared)
-            {
-                initialMessageCleared = true;
-                await ClearLogsAsync();
-            }
-
             await WriteLogsToDom(logs);
         }
         else

--- a/src/Aspire.Dashboard/Components/Pages/ContainerLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ContainerLogs.razor
@@ -11,19 +11,20 @@
 
 <div>
     <FluentStack Orientation="Orientation.Vertical">
-        <FluentToolbar>
+        <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
             <FluentSelect TOption="ContainerViewModel"
                             Items="@Containers"
                             OptionValue="@(c => c.ContainerID)"
-                            OptionText="@(c => c.Name)"
+                            OptionText="GetContainerDisplayText"
                             @bind-SelectedOption="_selectedContainer"
                             @bind-SelectedOption:after="HandleSelectedOptionChangedAsync" />
-        </FluentToolbar>
-        <LogViewer @ref="_logViewer" InitialText="Waiting for logs..." />
+            <FluentLabel Typo="Typography.Body">@_status</FluentLabel>
+        </FluentStack>
+        <LogViewer @ref="_logViewer" />
     </FluentStack>
 </div>
 
-@code {
+    @code {
 
     [Parameter]
     public string? ContainerID { get; set; }
@@ -35,10 +36,12 @@
     private CancellationTokenSource _watchContainersTokenSource = new CancellationTokenSource();
     private CancellationTokenSource? _watchLogsTokenSource;
     private IContainerLogWatcher? _currentWatcher;
-    private bool _pageDisposed;
+    private string _status = ContainerLogStatuses.Initializing;
 
     protected override async Task OnInitializedAsync()
     {
+        _status = ContainerLogStatuses.LoadingContainers;
+
         var initialList = await DashboardViewModelService.GetContainersAsync();
 
         foreach (var result in initialList)
@@ -66,25 +69,23 @@
         });
     }
 
+    private Task ClearLogsAsync()
+        => _logViewer is not null ? _logViewer.ClearLogsAsync() : Task.CompletedTask;
+
     private async Task LoadLogsAsync()
     {
-        if (_selectedContainer is not null && _logViewer is not null)
+        if (_selectedContainer is null)
         {
-            await DisposeCurrentWatcher();
-            await DisposeWatchLogsTokenSource();
-
-            if (_pageDisposed)
-            {
-                // If the page got disposed after this call was started, but before we
-                // set up the _watchLogsTokenSource to a new object below, we would end
-                // up leaving the below tasks running indefinitely.
-                return;
-            }
-
+            _status = ContainerLogStatuses.NoContainerSelected;
+        }
+        else if (_logViewer is null)
+        {
+            _status = ContainerLogStatuses.InitializingLogViewer;
+        }
+        else
+        {
             _watchLogsTokenSource = new CancellationTokenSource();
             _currentWatcher = _selectedContainer.LogSource.GetWatcher();
-
-            await _logViewer.ClearLogsAsync(_watchLogsTokenSource.Token);
 
             if (await _currentWatcher.InitWatchAsync(_watchLogsTokenSource.Token))
             {
@@ -105,6 +106,12 @@
                         await _logViewer.AddLogEntriesAsync(logEntries);
                     }
                 }, _watchLogsTokenSource.Token);
+
+                _status = ContainerLogStatuses.WatchingLogs;
+            }
+            else
+            {
+                _status = ContainerLogStatuses.FailedToInitialize;
             }
         }
     }
@@ -115,7 +122,9 @@
         {
             // Change the URL
             NavigationManager.NavigateTo($"/containerLogs/{_selectedContainer.ContainerID}");
-
+            await DisposeCurrentWatcher();
+            await DisposeWatchLogsTokenSource();
+            await ClearLogsAsync();
             await LoadLogsAsync();
         }
     }
@@ -147,7 +156,6 @@
                 if (_containerNameMapping.Count > 0)
                 {
                     _selectedContainer = Containers.First();
-                    await LoadLogsAsync();
                 }
             }
         }
@@ -155,9 +163,22 @@
         await InvokeAsync(StateHasChanged);
     }
 
+    private static string GetContainerDisplayText(ContainerViewModel container)
+    {
+        string stateText = "";
+        if (string.IsNullOrEmpty(container.State))
+        {
+            stateText = " (Unknown State)";
+        }
+        else if (container.State != "Running")
+        {
+            stateText = $" ({container.State})";
+        }
+        return $"{container.Name}{stateText}";
+    }
+
     public async ValueTask DisposeAsync()
     {
-        _pageDisposed = true;
         await DisposeWatchContainersTokenSource();
         await DisposeWatchLogsTokenSource();
         await DisposeCurrentWatcher();
@@ -182,5 +203,15 @@
             _watchLogsTokenSource.Dispose();
             _watchLogsTokenSource = null;
         }
+    }
+
+    private static class ContainerLogStatuses
+    {
+        public const string FailedToInitialize = "Failed to Initialize";
+        public const string Initializing = "Initializing...";
+        public const string InitializingLogViewer = "Initializing Log Viewer...";
+        public const string LoadingContainers = "Loading Containers...";
+        public const string NoContainerSelected = "No Container Selected";
+        public const string WatchingLogs = "Watching Logs...";
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
@@ -12,19 +12,20 @@
 
 <div>
     <FluentStack Orientation="Orientation.Vertical">
-        <FluentStack Orientation="Orientation.Horizontal">
+        <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
             <FluentSelect TOption="ProjectViewModel"
                             Items="@Projects"
                             OptionValue="@(c => c.Name)"
-                            OptionText="@(c => c.Name)"
+                            OptionText="GetProjectDisplayText"
                             @bind-SelectedOption="_selectedProject"
                             @bind-SelectedOption:after="HandleSelectedOptionChangedAsync" />
+            <FluentLabel Typo="Typography.Body">@_status</FluentLabel>
         </FluentStack>
-        <LogViewer @ref="_logViewer" InitialText="Waiting for logs..." />
+        <LogViewer @ref="_logViewer" />
     </FluentStack>
 </div>
 
-@code {
+    @code {
     [Parameter]
     public string? ProjectName { get; set; }
 
@@ -34,10 +35,12 @@
     private IEnumerable<ProjectViewModel> Projects => _projectNameMapping.Select(kvp => kvp.Value).OrderBy(p => p.Name);
     private CancellationTokenSource _watchProjectsTokenSource = new CancellationTokenSource();
     private CancellationTokenSource? _watchLogsTokenSource;
-    private bool _pageDisposed;
+    private string _status = ProjectLogStatuses.Initializing;
 
     protected override async Task OnInitializedAsync()
     {
+        _status = ProjectLogStatuses.LoadingProjects;
+
         var initialList = await DashboardViewModelService.GetProjectsAsync();
 
         foreach (var result in initialList)
@@ -54,7 +57,7 @@
             _selectedProject = initialList[0].ViewModel;
         }
 
-        await LoadLogsAsync();
+        LoadLogs();
 
         _ = Task.Run(async () =>
         {
@@ -65,32 +68,26 @@
         });
     }
 
-    private async Task HandleSelectedOptionChangedAsync()
+    private Task ClearLogsAsync()
+        => _logViewer is not null ? _logViewer.ClearLogsAsync() : Task.CompletedTask;
+
+    private void LoadLogs()
     {
-        if (_selectedProject is not null)
+        if (_selectedProject is null)
         {
-            NavigationManager.NavigateTo($"/ProjectLogs/{_selectedProject.Name}");
-            await LoadLogsAsync();
+            _status = ProjectLogStatuses.NoProjectSelected;
         }
-    }
-
-    private async Task LoadLogsAsync()
-    {
-        if (_selectedProject?.LogSource?.Available == true && _logViewer is not null)
+        else if (_selectedProject?.LogSource?.Available != true)
         {
-            await DisposeWatchLogsTokenSource();
-
-            if (_pageDisposed)
-            {
-                // If the page got disposed after this call was started, but before we
-                // set up the _watchLogsTokenSource to a new object below, we would end
-                // up leaving the below tasks running indefinitely.
-                return;
-            }
-
+            _status = ProjectLogStatuses.LogsNotYetAvailable;
+        }
+        else if (_logViewer is null)
+        {
+            _status = ProjectLogStatuses.InitializingLogViewer;
+        }
+        else
+        {
             _watchLogsTokenSource = new CancellationTokenSource();
-
-            await _logViewer.ClearLogsAsync(_watchLogsTokenSource.Token);
 
             _ = Task.Run(async () =>
             {
@@ -109,6 +106,19 @@
                     await _logViewer.AddLogEntriesAsync(logEntries);
                 }
             }, _watchLogsTokenSource.Token);
+
+            _status = ProjectLogStatuses.WatchingLogs;
+        }
+    }
+
+    private async Task HandleSelectedOptionChangedAsync()
+    {
+        if (_selectedProject is not null)
+        {
+            NavigationManager.NavigateTo($"/ProjectLogs/{_selectedProject.Name}");
+            await DisposeWatchLogsTokenSource();
+            await ClearLogsAsync();
+            LoadLogs();
         }
     }
 
@@ -123,7 +133,7 @@
                 if (string.IsNullOrEmpty(ProjectName) || string.Equals(ProjectName, projectViewModel.Name, StringComparison.Ordinal))
                 {
                     _selectedProject = projectViewModel;
-                    await LoadLogsAsync();
+                    LoadLogs();
                 }
             }
         }
@@ -138,7 +148,7 @@
 
                 if (!originalSelection!.LogSource.Available && _selectedProject.LogSource.Available)
                 {
-                    await LoadLogsAsync();
+                    LoadLogs();
                 }
             }
         }
@@ -150,7 +160,6 @@
                 if (_projectNameMapping.Count > 0)
                 {
                     _selectedProject = Projects.First();
-                    await LoadLogsAsync();
                 }
             }
         }
@@ -158,9 +167,22 @@
         await InvokeAsync(StateHasChanged);
     }
 
+    private static string GetProjectDisplayText(ProjectViewModel project)
+    {
+        string stateText = "";
+        if (string.IsNullOrEmpty(project.State))
+        {
+            stateText = " (Unknown State)";
+        }
+        else if (project.State != "Running")
+        {
+            stateText = $" ({project.State})";
+        }
+        return $"{project.Name}{stateText}";
+    }
+
     public async ValueTask DisposeAsync()
     {
-        _pageDisposed = true;
         await DisposeWatchProjectsTokenSource();
         await DisposeWatchLogsTokenSource();
     }
@@ -179,5 +201,15 @@
             _watchLogsTokenSource.Dispose();
             _watchLogsTokenSource = null;
         }
+    }
+
+    private static class ProjectLogStatuses
+    {
+        public const string Initializing = "Initializing...";
+        public const string InitializingLogViewer = "Initializing Log Viewer...";
+        public const string LoadingProjects = "Loading Projects...";
+        public const string LogsNotYetAvailable = "Logs Not Yet Available";
+        public const string NoProjectSelected = "No Project Selected";
+        public const string WatchingLogs = "Watching Logs...";
     }
 }

--- a/src/Aspire.Dashboard/Model/LogEntry.cs
+++ b/src/Aspire.Dashboard/Model/LogEntry.cs
@@ -8,7 +8,7 @@ namespace Aspire.Dashboard.Model;
 
 internal sealed partial class LogEntry
 {
-    private static readonly Regex s_rfc3339NanoRegEx = GenerateRfc3339NanoRegEx();
+    private static readonly Regex s_rfc3339RegEx = GenerateRfc3339RegEx();
 
     public string? Content { get; set; }
     public string? Timestamp { get; set; }
@@ -18,11 +18,11 @@ internal sealed partial class LogEntry
     public static LogEntry Create(string s, LogEntryType type)
     {
         var indexOfSpace = s.IndexOf(' ');
-        var possibleTimestamp = s[..indexOfSpace];
+        var possibleTimestamp = indexOfSpace == -1 ? null : s[..indexOfSpace];
 
-        // For right now, we only support RFC3339Nano timestamps, which is what (most) containers generate
+        // For right now, we only support RFC3339 timestamps, which is what (most) containers generate
         // We can tweak this once project/executable log timestamps are finalized
-        if (s_rfc3339NanoRegEx.IsMatch(possibleTimestamp))
+        if (possibleTimestamp is not null && s_rfc3339RegEx.IsMatch(possibleTimestamp))
         {
             return new() { Timestamp = possibleTimestamp, Content = s[(indexOfSpace + 1)..], Type = type };
         }
@@ -62,7 +62,7 @@ internal sealed partial class LogEntry
     //
     // Note: (?:) is a non-capturing group, since we don't care about the values, we are just interested in whether or not there is a match
     [GeneratedRegex("^(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):(?:[0-5][0-9]):(?:[0-5][0-9])(?:\\.\\d{1,9})?(?:Z|(?:[Z+-](?:[01][0-9]|2[0-3]):(?:[0-5][0-9])))?$")]
-    private static partial Regex GenerateRfc3339NanoRegEx();
+    private static partial Regex GenerateRfc3339RegEx();
 }
 
 internal enum LogEntryType


### PR DESCRIPTION
It can be hard to tell what state the Container/Project logs pages are in. Is it actually watching the logs? Is it waiting for the project to start? So this PR takes a first stab at adding some state information here:

1. The State of Projects/Containers are displayed within the dropdown IIF they're not Running.
2. A status message is displayed next to the dropdown with an initial set of statuses as the page loads, containers/projects are discovered, logs become available, log watching starts, etc.
3. The old InitialText from the LogViewer is removed in favor of the above status info.
4. Simplified the Clear/Cancel/Dispose code when the selected container/project changes
5. Fixed a bug in the timestamp detection

Note: There appears to be a bug where the text of the selected item in the FluentSelect doesn't update when the underlying option changes (e.g. when the current selected text changes from "myfrontend (Unknown State)" to "myfrontend", the value of the option in the dropdown list changes, but the displayed selected value does not). I haven't gotten a simple repro of that yet, but will file a bug on it. @vnbaaij FYI on that, I'm not sure if it is in FluentUI-Blazor or in the underlying web components (I think it might be the latter).