### PR TITLE
Support displayOverviewPage in ide.host.json

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/ide.host",
+  "displayOverviewPage": "0",
   "unsupportedHosts": [
     {
       "id": "vs",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/ide.host.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/ide.host",
+  "displayOverviewPage": "0",
   "unsupportedHosts": [
     {
       "id": "vs",


### PR DESCRIPTION
New property to control which project(s) overview pages get opened in Visual Studio

It is a comma delimited zero based index into .*proj files in the primary outputs. primary outputs not ending in .*proj are not considered in the indexed list.