### PR TITLE
Use DCP injected values for OTEL service id and name

### DIFF
--- a/samples/ServiceDefaults/Extensions.cs
+++ b/samples/ServiceDefaults/Extensions.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 public static class Extensions
@@ -40,14 +39,7 @@ public static class Extensions
             logging.IncludeScopes = true;
         });
 
-        // TODO: OTel generates different serviceInstanceId for different telemetry types.
-        // For example, logging, metrics, and tracing all have different serviceInstanceId values.
-        // Explicitly generate serviceInstanceId so the same value is used for all telemetry types.
-        // Is this the right thing to do or is there a bug in OTel?
-        var serviceInstanceId = Guid.NewGuid().ToString();
-
         builder.Services.AddOpenTelemetry()
-            .ConfigureResource(resourceBuilder => resourceBuilder.AddService(builder.Environment.ApplicationName, serviceInstanceId: serviceInstanceId))
             .WithMetrics(metrics =>
             {
                 metrics.AddRuntimeInstrumentation()

--- a/samples/dapr/DevHost/DaprDevHost.csproj
+++ b/samples/dapr/DevHost/DaprDevHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -3,7 +3,9 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
+using Aspire.Hosting.Otlp;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using System.Globalization;
 using System.Net.Sockets;
 using static Aspire.Hosting.Dapr.CommandLineArgs;
@@ -13,6 +15,7 @@ namespace Aspire.Hosting.Dapr;
 internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedApplicationLifecycleHook
 {
     private readonly IConfiguration _configuration;
+    private readonly IHostEnvironment _environment;
     private readonly DaprOptions _options;
     private readonly DaprPortManager _portManager;
 
@@ -22,12 +25,11 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
             : Path.Combine("/usr", "local", "bin", "dapr");
 
     private const int DaprHttpPortStartRange = 50001;
-    private const string DashboardOtlpUrlVariableName = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL";
-    private const string DashboardOtlpUrlDefaultValue = "http://localhost:18889";
 
-    public DaprDistributedApplicationLifecycleHook(IConfiguration configuration, DaprOptions options, DaprPortManager portManager)
+    public DaprDistributedApplicationLifecycleHook(IConfiguration configuration, IHostEnvironment environment, DaprOptions options, DaprPortManager portManager)
     {
         _configuration = configuration;
+        _environment = environment;
         this._options = options;
         this._portManager = portManager;
     }
@@ -139,19 +141,13 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
             // NOTE: Telemetry is enabled by default.
             if (this._options.EnableTelemetry != false)
             {
+                OtlpConfigurationExtensions.AddOtlpEnvironment(component, _configuration, _environment);
+
+                // Explicitly specify OTEL endpoint is insecure and use gRPC to sidecar.
                 component.Annotations.Add(
                     new EnvironmentCallbackAnnotation(
                         env =>
                         {
-
-                            //
-                            // NOTE: Setting OTEL_EXPORTER_OTLP_ENDPOINT will not override any explicit OTLP configuration in a specified Dapr sidecar configuration file.
-                            //       The ambient Dapr sidecar configuration file does not configure an OTLP exporter (but could have been updated by the user to do so).
-                            //
-                            // TODO: It would be nice, at some point, to consolidate determination of the OTLP endpoint as it's now repeated in a few places.
-                            //
-
-                            env["OTEL_EXPORTER_OTLP_ENDPOINT"] = this._configuration[DashboardOtlpUrlVariableName] ?? DashboardOtlpUrlDefaultValue;
                             env["OTEL_EXPORTER_OTLP_INSECURE"] = "true";
                             env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc";
                         }));

--- a/src/Aspire.Hosting/Otlp/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Otlp/OtlpConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting.Otlp;
@@ -11,22 +12,32 @@ public static class OtlpConfigurationExtensions
     private const string DashboardOtlpUrlVariableName = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL";
     private const string DashboardOtlpUrlDefaultValue = "http://localhost:18889";
 
-    public static IDistributedApplicationComponentBuilder<T> ConfigureOtlpEnvironment<T>(this IDistributedApplicationComponentBuilder<T> builder) where T : IDistributedApplicationComponentWithEnvironment
+    public static void AddOtlpEnvironment(IDistributedApplicationComponent component, IConfiguration configuration, IHostEnvironment environment)
     {
         // Configure OpenTelemetry in projects using environment variables.
         // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md
 
-        return builder.WithEnvironment((context) =>
+        component.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
         {
-            context.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = builder.ApplicationBuilder.Configuration[DashboardOtlpUrlVariableName] ?? DashboardOtlpUrlDefaultValue;
+            context.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = configuration[DashboardOtlpUrlVariableName] ?? DashboardOtlpUrlDefaultValue;
+
+            // Set the service name and instance id to the component name and UID. Values are injected by DCP.
+            context.EnvironmentVariables["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id={{- .UID -}}";
+            context.EnvironmentVariables["OTEL_SERVICE_NAME"] = "{{- .Name -}}";
 
             // Set a small batch schedule delay in development.
             // This reduces the delay that OTLP exporter waits to sends telemetry and makes the dashboard telemetry pages responsive.
-            if (builder.ApplicationBuilder.Environment.IsDevelopment())
+            if (environment.IsDevelopment())
             {
                 context.EnvironmentVariables["OTEL_BLRP_SCHEDULE_DELAY"] = "1000"; // milliseconds
                 context.EnvironmentVariables["OTEL_BSP_SCHEDULE_DELAY"] = "1000"; // milliseconds
             }
-        });
+        }));
+    }
+
+    public static IDistributedApplicationComponentBuilder<T> ConfigureOtlpEnvironment<T>(this IDistributedApplicationComponentBuilder<T> builder) where T : IDistributedApplicationComponentWithEnvironment
+    {
+        AddOtlpEnvironment(builder.Component, builder.ApplicationBuilder.Configuration, builder.ApplicationBuilder.Environment);
+        return builder;
     }
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.ServiceDefaults/Extensions.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
@@ -42,10 +41,7 @@ public static class Extensions
             logging.IncludeScopes = true;
         });
 
-        var serviceInstanceId = Guid.NewGuid().ToString();
-
         builder.Services.AddOpenTelemetry()
-            .ConfigureResource(resourceBuilder => resourceBuilder.AddService(builder.Environment.ApplicationName, serviceInstanceId: serviceInstanceId))
             .WithMetrics(metrics =>
             {
                 metrics.AddRuntimeInstrumentation()

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.ServiceDefaults/Extensions.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
@@ -42,10 +41,7 @@ public static class Extensions
             logging.IncludeScopes = true;
         });
 
-        var serviceInstanceId = Guid.NewGuid().ToString();
-
         builder.Services.AddOpenTelemetry()
-            .ConfigureResource(resourceBuilder => resourceBuilder.AddService(builder.Environment.ApplicationName, serviceInstanceId: serviceInstanceId))
             .WithMetrics(metrics =>
             {
                 metrics.AddRuntimeInstrumentation()


### PR DESCRIPTION
This PR makes the OTEL names consistent with DCP names. It fixes the problem of replicas, e.g. `catalogservice`, being duplicated. Now the OTEL name matches what is displayed on the projects page.

![image](https://github.com/dotnet/aspire/assets/303201/4a361831-7455-48d9-a39d-f002c609b052)

I'd like guidance on how this pattern will work when deployed to other environments. Do they ignore/overwrite the env vars set for service id and name and apply their own? Does this PR need to change to reflect that?

~Once this approach is verified as good then port the changes to the template.~

**Note: this change relies on a preview build of DCP that isn't in the workload yet. The right version of DCP should be available in a few days.**