### PR TITLE
Sort logs by timestamp if present

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -31,8 +31,39 @@
     internal Task AddLogEntriesAsync(IEnumerable<LogEntry> logEntries)
         => WriteLogsAsync(logEntries);
 
-    private ValueTask WriteLogsToDom(IEnumerable<LogEntry> logs)
+    private ValueTask WriteLogsToDomAsync(IEnumerable<LogEntry> logs)
         => _jsModule is null ? ValueTask.CompletedTask : _jsModule.InvokeVoidAsync("addLogEntries", logs);
+
+    internal async Task WatchLogsAsync(Func<IAsyncEnumerable<string[]>> watchMethod, LogEntryType logEntryType)
+    {
+        string? parentTimestamp = null;
+        Guid? parentId = null;
+        int lineIndex = 0;
+
+        await foreach (var logs in watchMethod())
+        {
+            var logEntries = new List<LogEntry>(logs.Length);
+            foreach (var log in logs)
+            {
+                var logEntry = LogEntry.Create(log, logEntryType);
+                if (logEntry.IsFirstLine)
+                {
+                    parentTimestamp = logEntry.Timestamp;
+                    parentId = logEntry.Id;
+                    lineIndex = 0;
+                }
+                else if (parentId.HasValue)
+                {
+                    logEntry.ParentTimestamp = parentTimestamp;
+                    logEntry.ParentId = parentId;
+                    logEntry.LineIndex = ++lineIndex;
+                }
+                logEntries.Add(logEntry);
+            }
+
+            await AddLogEntriesAsync(logEntries);
+        }
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -42,16 +73,16 @@
 
             if (_preRenderQueue.Count > 0)
             {
-                await WritePreRenderQueue();
+                await WritePreRenderQueueAsync();
             }
             renderComplete = true;
         }
 
-        async Task WritePreRenderQueue()
+        async Task WritePreRenderQueueAsync()
         {
             foreach (var logs in _preRenderQueue)
             {
-                await WriteLogsToDom(logs);
+                await WriteLogsToDomAsync(logs);
             }
             _preRenderQueue.Clear();
         }
@@ -61,7 +92,7 @@
     {
         if (renderComplete)
         {
-            await WriteLogsToDom(logs);
+            await WriteLogsToDomAsync(logs);
         }
         else
         {

--- a/src/Aspire.Dashboard/Components/Pages/ContainerLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ContainerLogs.razor
@@ -91,21 +91,13 @@
             {
                 _ = Task.Run(async () =>
                 {
-                    await foreach (var logs in _currentWatcher.WatchOutputLogsAsync(_watchLogsTokenSource.Token))
-                    {
-                        var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Default));
-                        await _logViewer.AddLogEntriesAsync(logEntries);
-                    }
-                }, _watchLogsTokenSource.Token);
+                    await _logViewer.WatchLogsAsync(() => _currentWatcher.WatchOutputLogsAsync(_watchLogsTokenSource.Token), LogEntryType.Default);
+                });
 
                 _ = Task.Run(async () =>
                 {
-                    await foreach (var logs in _currentWatcher.WatchErrorLogsAsync(_watchLogsTokenSource.Token))
-                    {
-                        var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Error));
-                        await _logViewer.AddLogEntriesAsync(logEntries);
-                    }
-                }, _watchLogsTokenSource.Token);
+                    await _logViewer.WatchLogsAsync(() => _currentWatcher.WatchErrorLogsAsync(_watchLogsTokenSource.Token), LogEntryType.Error);
+                });
 
                 _status = ContainerLogStatuses.WatchingLogs;
             }

--- a/src/Aspire.Dashboard/Components/Pages/ExecutableLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ExecutableLogs.razor
@@ -91,21 +91,13 @@
 
             _ = Task.Run(async () =>
             {
-                await foreach (var logs in _selectedExecutable.LogSource.WatchOutputLogAsync(_watchLogsTokenSource.Token))
-                {
-                    var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Default));
-                    await _logViewer.AddLogEntriesAsync(logEntries);
-                }
-            }, _watchLogsTokenSource.Token);
+                await _logViewer.WatchLogsAsync(() => _selectedExecutable.LogSource.WatchOutputLogAsync(_watchLogsTokenSource.Token), LogEntryType.Default);
+            });
 
             _ = Task.Run(async () =>
             {
-                await foreach (var logs in _selectedExecutable.LogSource.WatchErrorLogAsync(_watchLogsTokenSource.Token))
-                {
-                    var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Error));
-                    await _logViewer.AddLogEntriesAsync(logEntries);
-                }
-            }, _watchLogsTokenSource.Token);
+                await _logViewer.WatchLogsAsync(() => _selectedExecutable.LogSource.WatchOutputLogAsync(_watchLogsTokenSource.Token), LogEntryType.Error);
+            });
 
             _status = ExecutableLogStatuses.WatchingLogs;
         }

--- a/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ProjectLogs.razor
@@ -91,21 +91,13 @@
 
             _ = Task.Run(async () =>
             {
-                await foreach (var logs in _selectedProject.LogSource.WatchOutputLogAsync(_watchLogsTokenSource.Token))
-                {
-                    var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Default));
-                    await _logViewer.AddLogEntriesAsync(logEntries);
-                }
-            }, _watchLogsTokenSource.Token);
+                await _logViewer.WatchLogsAsync(() => _selectedProject.LogSource.WatchOutputLogAsync(_watchLogsTokenSource.Token), LogEntryType.Default);
+            });
 
             _ = Task.Run(async () =>
             {
-                await foreach (var logs in _selectedProject.LogSource.WatchErrorLogAsync(_watchLogsTokenSource.Token))
-                {
-                    var logEntries = logs.Select(l => LogEntry.Create(l, LogEntryType.Error));
-                    await _logViewer.AddLogEntriesAsync(logEntries);
-                }
-            }, _watchLogsTokenSource.Token);
+                await _logViewer.WatchLogsAsync(() => _selectedProject.LogSource.WatchErrorLogAsync(_watchLogsTokenSource.Token), LogEntryType.Error);
+            });
 
             _status = ProjectLogStatuses.WatchingLogs;
         }
@@ -138,7 +130,7 @@
             }
         }
         else if (changeType == ObjectChangeType.Modified)
-        {          
+        {
             _projectNameMapping[projectViewModel.Name] = projectViewModel;
 
             if (string.Equals(_selectedProject?.Name, projectViewModel.Name, StringComparison.Ordinal))


### PR DESCRIPTION
Currently logs from stdout and stderr can be displayed out of order when the streams (containers) or files (projects and executables) for each are processed and fed into the log viewer.

This PR partially addresses this by doing a couple of things:

1. If a timestamp is present as the first thing on a line, that timestamp is recorded and used to insert the line after any prior (per the timestamp) lines that were already added. The line is also treated as the first line (of potentially many) in a single log entry.
2. If a line instead starts with trce/dbug/info/warn/fail/crit, it is also treated as the first line (of potentially many) in a single log entry. But for inserting it into the log viewer, it is simply appended to the end since there is no timestamp
3. If a line does not meet either of the above conditions, then it is considered a child line relative to the most recent first line that was written to the logs, if any. If there _is_ a prior "first line" then it will be inserted after the last child line (if any) of that log entry. If there isn't, then it is simply appended to the end.

The clearest way to see this in action right now is with the catalog (postgres) container in the repo right now. It has both stdout/stderr logs and they are currently written out of order. With this PR, they're written in order.

If timestamps or log level indicators are present, sorting/grouping will take place. But if they're not present, all log entries will just be written in the order they're received.

Project and executable logs do not currently have timestamps (and are not guaranteed to the way container logs are) but it is simple enough to add. 

Note that for the moment the only timestamp format we support is RFC3339 (including RFC3339Nano used by docker logs). We can add more support in the future as needed.