### PR TITLE
Speed up using TokenCredentials in provisioning

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/JsonExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/JsonExtensions.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Text.Json.Nodes;
+
+namespace Aspire.Hosting.Azure;
+
+internal static class JsonExtensions
+{
+    public static JsonNode Prop(this JsonNode obj, string key)
+    {
+        JsonNode? node = obj[key];
+        if (node is not null)
+        {
+            return node;
+        }
+
+        node = new JsonObject();
+        obj.AsObject().Add(key, node);
+        return node;
+    }
+}

--- a/src/Aspire.Hosting.Azure.Provisioning/UserSecretsPathHelper.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/UserSecretsPathHelper.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure;
+
+// Copied from https://github.com/dotnet/runtime/blob/213833ea99b79a4b494b2935e1ccb10b93cd4cbc/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/PathHelper.cs
+
+public class UserSecretsPathHelper
+{
+    internal const string SecretsFileName = "secrets.json";
+
+    /// <summary>
+    /// <para>
+    /// Returns the path to the JSON file that stores user secrets.
+    /// </para>
+    /// <para>
+    /// This uses the current user profile to locate the secrets file on disk in a location outside of source control.
+    /// </para>
+    /// </summary>
+    /// <param name="userSecretsId">The user secret ID.</param>
+    /// <returns>The full path to the secret file.</returns>
+    public static string GetSecretsPathFromSecretsId(string userSecretsId)
+    {
+        return InternalGetSecretsPathFromSecretsId(userSecretsId, throwIfNoRoot: true);
+    }
+
+    /// <summary>
+    /// <para>
+    /// Returns the path to the JSON file that stores user secrets or throws exception if not found.
+    /// </para>
+    /// <para>
+    /// This uses the current user profile to locate the secrets file on disk in a location outside of source control.
+    /// </para>
+    /// </summary>
+    /// <param name="userSecretsId">The user secret ID.</param>
+    /// <param name="throwIfNoRoot">specifies if an exception should be thrown when no root for user secrets is found</param>
+    /// <returns>The full path to the secret file.</returns>
+    internal static string InternalGetSecretsPathFromSecretsId(string userSecretsId, bool throwIfNoRoot)
+    {
+        const string userSecretsFallbackDir = "DOTNET_USER_SECRETS_FALLBACK_DIR";
+
+        // For backwards compat, this checks env vars first before using Env.GetFolderPath
+        string? appData = Environment.GetEnvironmentVariable("APPDATA");
+        string? root = appData                                                                   // On Windows it goes to %APPDATA%\Microsoft\UserSecrets\
+                   ?? Environment.GetEnvironmentVariable("HOME")                             // On Mac/Linux it goes to ~/.microsoft/usersecrets/
+                   ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+                   ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+                   ?? Environment.GetEnvironmentVariable(userSecretsFallbackDir);            // this fallback is an escape hatch if everything else fails
+
+        if (string.IsNullOrEmpty(root))
+        {
+            if (throwIfNoRoot)
+            {
+                throw new InvalidOperationException($"Missing user secrets location {userSecretsFallbackDir}");
+            }
+
+            return string.Empty;
+        }
+
+        return !string.IsNullOrEmpty(appData)
+            ? Path.Combine(root, "Microsoft", "UserSecrets", userSecretsId, SecretsFileName)
+            : Path.Combine(root, ".microsoft", "usersecrets", userSecretsId, SecretsFileName);
+    }
+}

--- a/src/Aspire.Hosting.Azure.Provisioning/UserSecretsTokenCredential.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/UserSecretsTokenCredential.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text.Json.Nodes;
+using Azure.Core;
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Hosting.Azure;
+
+internal sealed class UserSecretsTokenCredential(IConfiguration configuration, string userSecretsPath, TokenCredential tokenCredential) : TokenCredential
+{
+    public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        return GetTokenAsyncCore(requestContext, sync: true, cancellationToken).AsTask().GetAwaiter().GetResult();
+    }
+
+    public override ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        return GetTokenAsyncCore(requestContext, sync: false, cancellationToken);
+    }
+
+    private async ValueTask<AccessToken> GetTokenAsyncCore(TokenRequestContext requestContext, bool sync, CancellationToken cancellationToken)
+    {
+        // Key the credentials by scope (everything else seems to change)
+        var key = requestContext.Scopes switch
+        {
+            [] => "",
+            [string s] => s,
+            _ => string.Join(",", requestContext.Scopes)
+        };
+
+        var credentials = configuration.GetSection($"Azure:Credentials:{key}");
+
+        var tokenValue = credentials["AccessToken"];
+        var expiresOnValue = credentials["ExpiresOn"];
+
+        DateTimeOffset expiresOn = default;
+
+        if (tokenValue is null || (expiresOnValue is not null && DateTimeOffset.TryParse(expiresOnValue, CultureInfo.InvariantCulture, out expiresOn)
+            && expiresOn < DateTimeOffset.UtcNow))
+        {
+            var accessToken = sync
+                ? tokenCredential.GetToken(requestContext, cancellationToken)
+                : await tokenCredential.GetTokenAsync(requestContext, cancellationToken).ConfigureAwait(false);
+
+            tokenValue = accessToken.Token;
+            expiresOn = accessToken.ExpiresOn;
+
+            var allSecrets = JsonNode.Parse(File.ReadAllText(userSecretsPath))!.AsObject();
+
+            var section = allSecrets.Prop("Azure").Prop("Credentials").Prop(key);
+
+            // REVIEW: Do we need to protect the token at rest?
+            section["AccessToken"] = tokenValue;
+            section["ExpiresOn"] = expiresOn.ToString(CultureInfo.InvariantCulture);
+
+            // Modified secrets with access token
+            File.WriteAllText(userSecretsPath, allSecrets.ToString());
+
+            // Reload configuration
+            (configuration as IConfigurationRoot)?.Reload();
+        }
+
+        return new(tokenValue, expiresOn);
+    }
+}


### PR DESCRIPTION
- Speed up azure provisioning by using user secrets to cache access tokens


PS: I need: 

1. An azure person to tell me if this is OK
2. A security person to tell me if we need to protect the access tokens at rest (though we don't do it for any other user secrets)
