### PR TITLE
Use badge to indicate stderror rather than red text

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -81,10 +81,7 @@
     white-space: pre-wrap;
 }
 
-::deep .content.error {
-    color: red;
-}
-
-::deep .content.warning {
-    color: yellow;
+::deep .content > fluent-badge {
+    margin-right: 1em;
+    user-select: none;
 }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
@@ -1,4 +1,5 @@
 const template = createRowTemplate();
+const stdErrorBadgeTemplate = createStdErrBadgeTemplate();
 
 /**
  * Clears all log entries from the log viewer and resets the
@@ -39,9 +40,7 @@ export function addLogEntries(logEntries) {
             const content = lineArea.lastElementChild;
             content.textContent = logEntry.content;
             if (logEntry.type === "Error") {
-                content.classList.add("error");
-            } else if (logEntry.type === "Warning") {
-                content.classList.add("warning");
+                content.prepend(getStdErrorBadge());
             }
 
             insertSorted(container, rowContainer, logEntry.timestamp, logEntry.parentId, logEntry.lineIndex);
@@ -106,6 +105,14 @@ function getNewRowContainer() {
 }
 
 /**
+ * Clones the stderr badge template for use with a new log entry
+ * @returns
+ */
+function getStdErrorBadge() {
+    return stdErrorBadgeTemplate.cloneNode(true);
+}
+
+/**
  * Creates the initial row container template that will be cloned
  * for each log entry
  * @returns {HTMLElement}
@@ -127,6 +134,18 @@ function createRowTemplate() {
     templateElement.innerHTML = templateString.trim();
     const rowTemplate = templateElement.content.firstChild;
     return rowTemplate;
+}
+
+/**
+ * Creates the initial stderr badge template that will be cloned
+ * for each log entry
+ * @returns {HTMLElement}
+ */
+function createStdErrBadgeTemplate() {
+    const badge = document.createElement("fluent-badge");
+    badge.setAttribute("appearance", "accent");
+    badge.textContent = "stderr";
+    return badge;
 }
 
 /**


### PR DESCRIPTION
Since stderr isn't always used for logs that are considered errors (see prometheus logs, which are 100% stderr, as an example), coloring those logs red doesn't feel right. That said, we still want some indication that they came from stderr as opposed to stdout. 

This PR adds a badge at the front of the log entry to indicate it comes from stderr. The badge is not selectable (so if the user highlights the logs to copy/paste, they won't get the "stderr" text as part of that). 