### PR TITLE
Remove ConnectionString on With methods in Hosting App Model

### DIFF
--- a/src/Aspire.Hosting/IDistributedApplicationComponentBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationComponentBuilder.cs
@@ -5,7 +5,7 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting;
 
-public interface IDistributedApplicationComponentBuilder<T> where T : IDistributedApplicationComponent
+public interface IDistributedApplicationComponentBuilder<out T> where T : IDistributedApplicationComponent
 {
     IDistributedApplicationBuilder ApplicationBuilder { get; }
     T Component { get; }

--- a/src/Aspire.Hosting/Postgres/IPostgresComponent.cs
+++ b/src/Aspire.Hosting/Postgres/IPostgresComponent.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Postgres;
+
+public interface IPostgresComponent : IDistributedApplicationComponent
+{
+    string GetConnectionString(string? databaseName = null);
+}

--- a/src/Aspire.Hosting/Postgres/IPostgresComponent.cs
+++ b/src/Aspire.Hosting/Postgres/IPostgresComponent.cs
@@ -7,5 +7,5 @@ namespace Aspire.Hosting.Postgres;
 
 public interface IPostgresComponent : IDistributedApplicationComponent
 {
-    string GetConnectionString(string? databaseName = null);
+    string? GetConnectionString(string? databaseName = null);
 }

--- a/src/Aspire.Hosting/Postgres/PostgresComponent.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresComponent.cs
@@ -5,9 +5,10 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Postgres;
 
-public class PostgresComponent(string name, string connectionString) : DistributedApplicationComponent(name), IPostgresComponent
+public class PostgresComponent(string name, string? connectionString) : DistributedApplicationComponent(name), IPostgresComponent
 {
-    public string GetConnectionString(string? databaseName = null) =>
+    public string? GetConnectionString(string? databaseName = null) =>
+        connectionString is null ? null :
         databaseName is null ?
             connectionString :
             connectionString.EndsWith(';') ?

--- a/src/Aspire.Hosting/Postgres/PostgresComponent.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresComponent.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Postgres;
+
+public class PostgresComponent(string name, string connectionString) : DistributedApplicationComponent(name), IPostgresComponent
+{
+    public string GetConnectionString(string? databaseName = null) =>
+        databaseName is null ?
+            connectionString :
+            connectionString.EndsWith(';') ?
+                $"{connectionString}Database={databaseName}" :
+                $"{connectionString};Database={databaseName}";
+
+}

--- a/src/Aspire.Hosting/Postgres/PostgresContainerComponent.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresContainerComponent.cs
@@ -5,6 +5,24 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Postgres;
 
-public class PostgresContainerComponent(string name) : ContainerComponent(name)
+public class PostgresContainerComponent(string name) : ContainerComponent(name), IPostgresComponent
 {
+    public string GetConnectionString(string? databaseName = null)
+    {
+        if (!this.TryGetAllocatedEndPoints(out var allocatedEndpoints))
+        {
+            throw new InvalidOperationException("Expected allocated endpoints!");
+        }
+
+        if (!this.TryGetLastAnnotation<PostgresPasswordAnnotation>(out var passwordAnnotation))
+        {
+            throw new InvalidOperationException($"Postgres does not have a password set!");
+        }
+
+        var allocatedEndpoint = allocatedEndpoints.Single(); // We should only have one endpoint for Postgres.
+
+        var baseConnectionString = $"Host={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};Username=postgres;Password={passwordAnnotation.Password};";
+        var connectionString = databaseName is null ? baseConnectionString : $"{baseConnectionString}Database={databaseName};";
+        return connectionString;
+    }
 }

--- a/src/Aspire.Hosting/Postgres/PostgresContainerComponent.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresContainerComponent.cs
@@ -11,12 +11,12 @@ public class PostgresContainerComponent(string name) : ContainerComponent(name),
     {
         if (!this.TryGetAllocatedEndPoints(out var allocatedEndpoints))
         {
-            throw new InvalidOperationException("Expected allocated endpoints!");
+            throw new DistributedApplicationException("Expected allocated endpoints!");
         }
 
         if (!this.TryGetLastAnnotation<PostgresPasswordAnnotation>(out var passwordAnnotation))
         {
-            throw new InvalidOperationException($"Postgres does not have a password set!");
+            throw new DistributedApplicationException($"Postgres does not have a password set!");
         }
 
         var allocatedEndpoint = allocatedEndpoints.Single(); // We should only have one endpoint for Postgres.

--- a/src/Aspire.Hosting/Redis/IRedisComponent.cs
+++ b/src/Aspire.Hosting/Redis/IRedisComponent.cs
@@ -7,5 +7,5 @@ namespace Aspire.Hosting.Redis;
 
 public interface IRedisComponent : IDistributedApplicationComponent
 {
-    string GetConnectionString();
+    string? GetConnectionString();
 }

--- a/src/Aspire.Hosting/Redis/IRedisComponent.cs
+++ b/src/Aspire.Hosting/Redis/IRedisComponent.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Redis;
+
+public interface IRedisComponent : IDistributedApplicationComponent
+{
+    string GetConnectionString();
+}

--- a/src/Aspire.Hosting/Redis/RedisComponent.cs
+++ b/src/Aspire.Hosting/Redis/RedisComponent.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Redis;
+
+public class RedisComponent(string name, string connectionString) : DistributedApplicationComponent(name), IRedisComponent
+{
+    public string GetConnectionString() => connectionString;
+}

--- a/src/Aspire.Hosting/Redis/RedisComponent.cs
+++ b/src/Aspire.Hosting/Redis/RedisComponent.cs
@@ -5,7 +5,7 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Redis;
 
-public class RedisComponent(string name, string connectionString) : DistributedApplicationComponent(name), IRedisComponent
+public class RedisComponent(string name, string? connectionString) : DistributedApplicationComponent(name), IRedisComponent
 {
-    public string GetConnectionString() => connectionString;
+    public string? GetConnectionString() => connectionString;
 }

--- a/src/Aspire.Hosting/Redis/RedisContainerComponent.cs
+++ b/src/Aspire.Hosting/Redis/RedisContainerComponent.cs
@@ -5,6 +5,17 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Redis;
 
-public class RedisContainerComponent(string name) : ContainerComponent(name)
+public class RedisContainerComponent(string name) : ContainerComponent(name), IRedisComponent
 {
+    public string GetConnectionString()
+    {
+        if (!this.TryGetAnnotationsOfType<AllocatedEndpointAnnotation>(out var allocatedEndpoints))
+        {
+            throw new DistributedApplicationException("Redis component does not have endpoint annotation.");
+        }
+
+        // We should only have one endpoint for Redis for local scenarios.
+        var endpoint = allocatedEndpoints.Single();
+        return endpoint.EndPointString;
+    }
 }

--- a/src/Aspire.Hosting/SqlServer/ISqlServerComponent.cs
+++ b/src/Aspire.Hosting/SqlServer/ISqlServerComponent.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.SqlServer;
+
+public interface ISqlServerComponent : IDistributedApplicationComponent
+{
+    string GetConnectionString(string? databaseName = null);
+}

--- a/src/Aspire.Hosting/SqlServer/ISqlServerComponent.cs
+++ b/src/Aspire.Hosting/SqlServer/ISqlServerComponent.cs
@@ -7,5 +7,5 @@ namespace Aspire.Hosting.SqlServer;
 
 public interface ISqlServerComponent : IDistributedApplicationComponent
 {
-    string GetConnectionString(string? databaseName = null);
+    string? GetConnectionString(string? databaseName = null);
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -24,21 +24,32 @@ public static class SqlServerBuilderExtensions
         return componentBuilder;
     }
 
-    public static IDistributedApplicationComponentBuilder<SqlServerComponent> AddSqlServer(this IDistributedApplicationBuilder builder, string name, string connectionString)
+    public static IDistributedApplicationComponentBuilder<SqlServerComponent> AddSqlServer(this IDistributedApplicationBuilder builder, string name, string? connectionString)
     {
-        return builder.AddComponent(new SqlServerComponent(name, connectionString))
-            .WithAnnotation(new ManifestPublishingCallbackAnnotation(WriteSqlServerComponentToManifest));
+        var sqlServer = new SqlServerComponent(name, connectionString);
+
+        return builder.AddComponent(sqlServer)
+            .WithAnnotation(new ManifestPublishingCallbackAnnotation((jsonWriter, cancellationToken) =>
+                WriteSqlServerComponentToManifest(jsonWriter, sqlServer.GetConnectionString(), cancellationToken)));
     }
 
-    private static async Task WriteSqlServerComponentToManifest(Utf8JsonWriter jsonWriter, CancellationToken cancellationToken)
+    private static Task WriteSqlServerComponentToManifest(Utf8JsonWriter jsonWriter, CancellationToken cancellationToken) =>
+        WriteSqlServerComponentToManifest(jsonWriter, null, cancellationToken);
+
+    private static async Task WriteSqlServerComponentToManifest(Utf8JsonWriter jsonWriter, string? connectionString, CancellationToken cancellationToken)
     {
         jsonWriter.WriteString("type", "sqlserver.v1");
+        if (!string.IsNullOrEmpty(connectionString))
+        {
+            jsonWriter.WriteString("connectionString", connectionString);
+        }
         await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public static IDistributedApplicationComponentBuilder<T> WithSqlServer<T>(this IDistributedApplicationComponentBuilder<T> builder, IDistributedApplicationComponentBuilder<SqlServerContainerComponent> sqlBuilder, string? databaseName, string? connectionName = null)
         where T : IDistributedApplicationComponentWithEnvironment
     {
+        var sql = sqlBuilder.Component;
         connectionName = connectionName ?? sqlBuilder.Component.Name;
 
         return builder.WithEnvironment((context) =>
@@ -47,11 +58,15 @@ public static class SqlServerBuilderExtensions
 
             if (context.PublisherName == "manifest")
             {
-                context.EnvironmentVariables[connectionStringName] = $"{{{sqlBuilder.Component.Name}.connectionString}}";
+                context.EnvironmentVariables[connectionStringName] = $"{{{sql.Name}.connectionString}}";
                 return;
             }
 
-            var connectionString = sqlBuilder.Component.GetConnectionString(databaseName);
+            var connectionString = sql.GetConnectionString(databaseName);
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new DistributedApplicationException($"A connection string for SqlServer '{sql.Name}' could not be retrieved.");
+            }
             context.EnvironmentVariables[connectionStringName] = connectionString;
         });
     }

--- a/src/Aspire.Hosting/SqlServer/SqlServerComponent.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerComponent.cs
@@ -5,9 +5,10 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.SqlServer;
 
-public class SqlServerComponent(string name, string connectionString) : DistributedApplicationComponent(name), ISqlServerComponent
+public class SqlServerComponent(string name, string? connectionString) : DistributedApplicationComponent(name), ISqlServerComponent
 {
-    public string GetConnectionString(string? databaseName = null) =>
+    public string? GetConnectionString(string? databaseName = null) =>
+        connectionString is null ? null :
         databaseName is null ?
             connectionString :
             connectionString.EndsWith(';') ?

--- a/src/Aspire.Hosting/SqlServer/SqlServerComponent.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerComponent.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.SqlServer;
+
+public class SqlServerComponent(string name, string connectionString) : DistributedApplicationComponent(name), ISqlServerComponent
+{
+    public string GetConnectionString(string? databaseName = null) =>
+        databaseName is null ?
+            connectionString :
+            connectionString.EndsWith(';') ?
+                $"{connectionString}Database={databaseName}" :
+                $"{connectionString};Database={databaseName}";
+}

--- a/src/Aspire.Hosting/SqlServer/SqlServerContainerComponent.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerContainerComponent.cs
@@ -5,7 +5,7 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.SqlServer;
 
-public class SqlServerContainerComponent : ContainerComponent
+public class SqlServerContainerComponent : ContainerComponent, ISqlServerComponent
 {
     public SqlServerContainerComponent(string name) : base(name)
     {
@@ -13,4 +13,18 @@ public class SqlServerContainerComponent : ContainerComponent
     }
 
     public string GeneratedPassword { get; }
+
+    public string GetConnectionString(string? databaseName = null)
+    {
+        if (!this.TryGetAnnotationsOfType<AllocatedEndpointAnnotation>(out var allocatedEndpoints))
+        {
+            throw new DistributedApplicationException("Sql component does not have endpoint annotation.");
+        }
+
+        var endpoint = allocatedEndpoints.Single();
+
+        // HACK: Use the 127.0.0.1 address because localhost is resolving to [::1] following
+        //       up with DCP on this issue.
+        return $"Server=127.0.0.1,{endpoint.Port};Database={databaseName ?? "master"};User ID=sa;Password={GeneratedPassword};TrustServerCertificate=true;";
+    }
 }


### PR DESCRIPTION
Instead, add new Add overloads that take a connection string to an existing server.

Note - I needed to make `IDistributedApplicationComponentBuilder<out T>` an `out` generic because I need `IDistributedApplicationComponentBuilder<PostgresContainerComponent>` to also be an `IDistributedApplicationComponentBuilder<IPostgresComponent>`.

Fix #62