### PR TITLE
Emit database names in manifest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ node_modules/
 
 # vscode python env files
 .env
+samples/DevHost/aspire-manifest-new.json

--- a/src/Aspire.Hosting/Postgres/PostgresContainerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresContainerBuilderExtensions.cs
@@ -73,7 +73,7 @@ public static class PostgresContainerBuilderExtensions
         {
             if (context.PublisherName == "manifest")
             {
-                var manifestConnectionString = databaseName == null ? $"{postgresBuilder.Component.Name}.connectionString" : $"{postgresBuilder.Component.Name}.databases.{databaseName}.connectionString";
+                var manifestConnectionString = databaseName == null ? $"{{{postgresBuilder.Component.Name}.connectionString}}" : $"{{{postgresBuilder.Component.Name}.databases.{databaseName}.connectionString}}";
                 context.EnvironmentVariables[$"{ConnectionStringEnvironmentName}{connectionName}"] = manifestConnectionString;
                 return;
             }

--- a/src/Aspire.Hosting/Postgres/PostgresDatabaseAnnotation.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresDatabaseAnnotation.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Postgres;
+
+internal sealed class PostgresDatabaseAnnotation(string databaseName) : IDistributedApplicationComponentAnnotation
+{
+    public string DatabaseName { get; } = databaseName;
+}


### PR DESCRIPTION
Minimal implementation of emitting the database names postgres components. This should go in AFTER #84 (will need to react to changes there).

Fix #104 