### PR TITLE
Branding for Preview 2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>8.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview.2</PreReleaseVersionLabel>
     <UseVSTestRunner>true</UseVSTestRunner>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Now that we've branched for release, marking main as Preview 2.

cc: @DamianEdwards @danegsta 