### PR TITLE
Fixing MSB4120 build message

### DIFF
--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -17,8 +17,14 @@
   <Target Name="AddTemplatesToPackageAsContent"
           DependsOnTargets="ReplacePackageVersionOnTemplates">
 
+    <!-- Creating a temporary item instead of defining content items directly in order to avoid MSBuild MSB4120
+    message shown when an item within a target references itself which may cuase unintended expansion. -->
     <ItemGroup>
-      <Content Include="$(IntermediateOutputPath)\content\templates\**\*" PackagePath="content/templates/%(Content.RecursiveDir)" />
+      <_TemplatesForPackage Include="$(IntermediateOutputPath)\content\templates\**\*" />
+    </ItemGroup>
+    <ItemGroup>
+      <Content Include="%(_TemplatesForPackage.Identity)" 
+              PackagePath="content/templates/%(_TemplatesForPackage.RecursiveDir)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixing build message shown on the ProjectTemplates project due to potential unintentional expansion caused by reference from an item to it's own metadata.