### PR TITLE
ANSI Control Sequence parsing and Project Log timestamps

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -1,5 +1,6 @@
 ﻿@namespace Aspire.Dashboard.Components
 @using System.Text
+@using Aspire.Dashboard.ConsoleLogs
 @using Aspire.Dashboard.Model
 @inject IJSRuntime JS
 @implements IAsyncDisposable
@@ -11,10 +12,10 @@
 </div>
 
 @code {
+    private static readonly AnsiParser s_ansiParser = new();
+
     private List<IEnumerable<LogEntry>> _preRenderQueue = new();
-
-    bool renderComplete = false;
-
+    private bool renderComplete = false;
     private IJSObjectReference? _jsModule;
 
     internal async Task ClearLogsAsync(CancellationToken cancellationToken = default)
@@ -39,6 +40,7 @@
         string? parentTimestamp = null;
         Guid? parentId = null;
         int lineIndex = 0;
+        AnsiParser.ParserState? residualState = null;
 
         await foreach (var logs in watchMethod())
         {
@@ -46,6 +48,11 @@
             foreach (var log in logs)
             {
                 var logEntry = LogEntry.Create(log, logEntryType);
+
+                var conversionResult = s_ansiParser.ConvertToHtml(logEntry.Content, residualState);
+                logEntry.Content = conversionResult.ConvertedText;
+                residualState = conversionResult.ResidualState;
+
                 if (logEntry.IsFirstLine)
                 {
                     parentTimestamp = logEntry.Timestamp;

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -2,12 +2,12 @@
     height: calc(100vh - 165px);
     width: 100%;
     overflow: auto;
-    background-color: black;
+    background-color: #0C0C0C;
 }
 
 ::deep .log-container {
-    background: black;
-    color: white;
+    background: #0C0C0C;
+    color: #CCCCCC;
     font-family: 'Cascadia Mono', Consolas, monospace;
     font-size: 0.75rem;
     margin: 16px 0 0 0;
@@ -60,9 +60,8 @@
 }
 
 ::deep .timestamp {
-    color: darkgray;
-    margin-left: 10px;
-    padding-left: 6px;
+    color: gray;
+    margin-left: 1em;
     white-space: nowrap;
 }
 
@@ -72,16 +71,111 @@
 
 ::deep .content {
     word-break: break-all;
-    margin-left: 10px;
+    margin-left: 1em;
     position: relative;
     margin-right: 6px;
     user-select: text;
     cursor: text;
-    padding: 0 6px 0 6px;
     white-space: pre-wrap;
 }
 
 ::deep .content > fluent-badge {
     margin-right: 1em;
     user-select: none;
+}
+
+::deep .ansi-fg-black {
+    color: #0C0C0C;
+}
+
+::deep .ansi-fg-blue {
+    color: #0037DA;
+}
+
+::deep .ansi-fg-cyan {
+    color: #3A96DD;
+}
+
+::deep .ansi-fg-green {
+    color: #13A10E;
+}
+
+::deep .ansi-fg-magenta {
+    color: #881798;
+}
+
+::deep .ansi-fg-red {
+    color: #C50F1F;
+}
+
+::deep .ansi-fg-white {
+    color: #CCCCCC;
+}
+
+::deep .ansi-fg-yellow {
+    color: #C19C00;
+}
+
+::deep .ansi-fg-brightblack {
+    color: #767676;
+}
+
+::deep .ansi-fg-brightblue {
+    color: #3B78FF;
+}
+
+::deep .ansi-fg-brightcyan {
+    color: #61D6D6;
+}
+
+::deep .ansi-fg-brightgreen {
+    color: #16C60C;
+}
+
+::deep .ansi-fg-brightmagenta {
+    color: #B4009E;
+}
+
+::deep .ansi-fg-brightred {
+    color: #E74856;
+}
+
+::deep .ansi-fg-brightwhite {
+    color: #F2F2F2;
+}
+
+::deep .ansi-fg-brightyellow {
+    color: #F9F1A5;
+}
+
+::deep .ansi-bg-black {
+    background-color: #0C0C0C;
+}
+
+::deep .ansi-bg-blue {
+    background-color: #0037DA;
+}
+
+::deep .ansi-bg-cyan {
+    background-color: #3A96DD;
+}
+
+::deep .ansi-bg-green {
+    background-color: #13A10E;
+}
+
+::deep .ansi-bg-magenta {
+    background-color: #881798;
+}
+
+::deep .ansi-bg-red {
+    background-color: #C50F1F;
+}
+
+::deep .ansi-bg-white {
+    background-color: #CCCCCC;
+}
+
+::deep .ansi-bg-yellow {
+    background-color: #C19C00;
 }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
@@ -38,7 +38,11 @@ export function addLogEntries(logEntries) {
                 timestamp.classList.add("missing");
             }
             const content = lineArea.lastElementChild;
-            content.textContent = logEntry.content;
+
+            // logEntry.content should already be HTMLEncoded other than the <span>s produced
+            // by the ANSI Control Sequence Parsing, so it should be safe to set innerHTML here
+            content.innerHTML = logEntry.content;
+            
             if (logEntry.type === "Error") {
                 content.prepend(getStdErrorBadge());
             }

--- a/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
@@ -1,0 +1,262 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Aspire.Dashboard.ConsoleLogs;
+
+public class AnsiParser
+{
+    private const char EscapeChar = '\x1B';
+    private const int ResetCode = 0;
+    private const int IncreasedIntensityCode = 1;
+    private const int NormalIntensityCode = 22;
+    private const int DefaultForegroundCode = 39;
+    private const int DefaultBackgroundCode = 49;
+
+    public ConversionResult ConvertToHtml(string? text, ParserState? priorResidualState = null)
+    {
+        var textStartIndex = -1;
+        var textLength = 0;
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return new(text, default);
+        }
+
+        var span = text.AsSpan();
+
+        ParserState currentState = default;
+        var newState = priorResidualState ?? default;
+
+        var outputBuilder = new StringBuilder(text.Length * 2);
+
+        for (var i = 0; i < span.Length; i++)
+        {
+            if (IsControlSequence(span, i, out var parameter))
+            {
+                // If we have a control sequence, but have found some text already,
+                // we need to write out the new styles (if applicable) and that text
+                // before we continue
+                if (textStartIndex != -1)
+                {
+                    if (newState != currentState)
+                    {
+                        outputBuilder.Append(ProcessStateChange(currentState, newState));
+                        currentState = newState;
+                    }
+                    outputBuilder.Append(text[textStartIndex..(textStartIndex + textLength)]);
+                    textStartIndex = -1;
+                    textLength = 0;
+                }
+
+                ProcessParameter(ref newState, parameter);
+
+                i += (parameter >= 10) ? 4 : 3;
+                continue;
+            }
+
+            // If it wasn't a control sequence, then it must be text, so figure
+            // out how much text before the next control sequence (if any)
+            if (textStartIndex == -1)
+            {
+                textStartIndex = i;
+            }
+            var nextEscapeIndex = -1;
+            if (i < text.Length - 1)
+            {
+                nextEscapeIndex = text.IndexOf(EscapeChar, i + 1);
+            }
+
+            // If there's no more control sequences, capture the text length and we're done
+            if (nextEscapeIndex < 0)
+            {
+                textLength = text.Length - textStartIndex;
+                break;
+            }
+
+            // If there is another control sequence, capture the text length and process it
+            textLength = nextEscapeIndex - textStartIndex;
+            i = nextEscapeIndex - 1;
+        }
+
+        // If we reached the end and have built up a new style, write it out
+        if (newState != currentState)
+        {
+            outputBuilder.Append(ProcessStateChange(currentState, newState));
+            currentState = newState;
+        }
+
+        // If there's any text left, right that out too
+        if (textStartIndex != -1)
+        {
+            outputBuilder.Append(text[textStartIndex..(textStartIndex + textLength)]);
+        }
+
+        // Ensure we always close off the current span. The next log line will
+        // pick up the residual state if necessary
+        outputBuilder.Append(ProcessStateChange(currentState, default));
+
+        return new(outputBuilder.ToString(), currentState);
+    }
+
+    private static void ProcessParameter(ref ParserState newState, int parameter)
+    {
+        if (TryGetForegroundColor(parameter, out var color))
+        {
+            newState.ForegroundColor = color;
+        }
+        else if (TryGetBackgroundColor(parameter, out color))
+        {
+            newState.BackgroundColor = color;
+        }
+        else if (parameter == DefaultBackgroundCode)
+        {
+            newState.BackgroundColor = null;
+        }
+        else if (parameter == DefaultForegroundCode)
+        {
+            newState.ForegroundColor = null;
+        }
+        else if (parameter == NormalIntensityCode)
+        {
+            newState.Bright = false;
+        }
+        else if (parameter == ResetCode)
+        {
+            newState = default;
+        }
+        else if (parameter == IncreasedIntensityCode)
+        {
+            newState.Bright = true;
+        }
+    }
+
+    private static bool IsControlSequence(ReadOnlySpan<char> span, int position, out int parameter)
+    {
+        // If we're at \x1B[ and the span is at least long enough for a single digit parameter
+        if (span[position] == EscapeChar && span.Length >= position + 4 && span[position + 1] == '[')
+        {
+            // If we've got a single digit parameter and the closing m
+            if (span[position + 3] == 'm' && IsDigit(span[position + 2]))
+            {
+                parameter = span[position + 2] - '0';
+                return true;
+            }
+            // If we've got a two digit parameter and the closing m
+            else if (span.Length >= position + 5 && span[position + 4] == 'm' && IsDigit(span[position + 2]) && IsDigit(span[position + 3]))
+            {
+                parameter = (span[position + 2] - '0') * 10 + (span[position + 3] - '0');
+                return true;
+            }
+        }
+
+        parameter = -1;
+        return false;
+    }
+
+    private static string ProcessStateChange(ParserState currentState, ParserState newState)
+    {
+        var closeSpanIfNeeded = "";
+        if (currentState != default)
+        {
+            closeSpanIfNeeded += "</span>";
+        }
+
+        if (newState.ForegroundColor.HasValue && newState.BackgroundColor.HasValue)
+        {
+            return closeSpanIfNeeded + $"<span class=\"{GetForegroundColorClass(newState)} {GetBackgroundColorClass(newState)}\">";
+        }
+        else if (newState.ForegroundColor.HasValue)
+        {
+            return closeSpanIfNeeded + $"<span class=\"{GetForegroundColorClass(newState)}\">";
+        }
+        else if (newState.BackgroundColor.HasValue)
+        {
+            return closeSpanIfNeeded + $"<span class=\"{GetBackgroundColorClass(newState)}\">";
+        }
+        else
+        {
+            return closeSpanIfNeeded;
+        }
+    }
+
+    private static string? GetForegroundColorClass(ParserState state)
+    {
+        return state.ForegroundColor switch
+        {
+            ConsoleColor.Black   => state.Bright ? "ansi-fg-brightblack"   : "ansi-fg-black",
+            ConsoleColor.Blue    => state.Bright ? "ansi-fg-brightblue"    : "ansi-fg-blue",
+            ConsoleColor.Cyan    => state.Bright ? "ansi-fg-brightcyan"    : "ansi-fg-cyan",
+            ConsoleColor.Green   => state.Bright ? "ansi-fg-brightgreen"   : "ansi-fg-green",
+            ConsoleColor.Magenta => state.Bright ? "ansi-fg-brightmagenta" : "ansi-fg-magenta",
+            ConsoleColor.Red     => state.Bright ? "ansi-fg-brightred"     : "ansi-fg-red",
+            ConsoleColor.White   => state.Bright ? "ansi-fg-brightwhite"   : "ansi-fg-white",
+            ConsoleColor.Yellow  => state.Bright ? "ansi-fg-brightyellow"  : "ansi-fg-yellow",
+            _ => ""
+        };
+    }
+
+    private static string? GetBackgroundColorClass(ParserState state)
+    {
+        return state.BackgroundColor switch
+        {
+            ConsoleColor.Black   => "ansi-bg-black",
+            ConsoleColor.Blue    => "ansi-bg-blue",
+            ConsoleColor.Cyan    => "ansi-bg-cyan",
+            ConsoleColor.Green   => "ansi-bg-green",
+            ConsoleColor.Magenta => "ansi-bg-magenta",
+            ConsoleColor.Red     => "ansi-bg-red",
+            ConsoleColor.White   => "ansi-bg-white",
+            ConsoleColor.Yellow  => "ansi-bg-yellow",
+            _ => ""
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsDigit(char c) => (uint)(c - '0') <= ('9' - '0');
+
+    private static bool TryGetForegroundColor(int number, out ConsoleColor? color)
+    {
+        color = number switch
+        {
+            30 => ConsoleColor.Black,
+            31 => ConsoleColor.Red,
+            32 => ConsoleColor.Green,
+            33 => ConsoleColor.Yellow,
+            34 => ConsoleColor.Blue,
+            35 => ConsoleColor.Magenta,
+            36 => ConsoleColor.Cyan,
+            37 => ConsoleColor.White,
+            _ => null
+        };
+        return color != null || number == 39;
+    }
+
+    private static bool TryGetBackgroundColor(int number, out ConsoleColor? color)
+    {
+        color = number switch
+        {
+            40 => ConsoleColor.Black,
+            41 => ConsoleColor.Red,
+            42 => ConsoleColor.Green,
+            43 => ConsoleColor.Yellow,
+            44 => ConsoleColor.Blue,
+            45 => ConsoleColor.Magenta,
+            46 => ConsoleColor.Cyan,
+            47 => ConsoleColor.White,
+            _ => null
+        };
+        return color != null || number == 49;
+    }
+
+    public record struct ParserState
+    {
+        public ConsoleColor? ForegroundColor { get; set; }
+        public ConsoleColor? BackgroundColor { get; set; }
+        public bool Bright { get; set; }
+    }
+
+    public readonly record struct ConversionResult(string? ConvertedText, ParserState ResidualState);
+}

--- a/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
@@ -11,6 +11,10 @@ public static class ConsoleLogsConfigurationExtensions
     {
         return builder.WithEnvironment((context) =>
         {
+            if (context.PublisherName == "Manifest")
+            {
+                return;
+            }
             // Enable ANSI Control Sequences for colors in Output Redirection
             context.EnvironmentVariables["DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION"] = "true";
 

--- a/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Dashboard;
+
+public static class ConsoleLogsConfigurationExtensions
+{
+    public static IDistributedApplicationComponentBuilder<T> ConfigureConsoleLogs<T>(this IDistributedApplicationComponentBuilder<T> builder) where T : IDistributedApplicationComponentWithEnvironment
+    {
+        return builder.WithEnvironment((context) =>
+        {
+            // Enable ANSI Control Sequences for colors in Output Redirection
+            context.EnvironmentVariables["DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION"] = "true";
+
+            // Enable Simple Console Logger Formatting with a UTC timestamp similar to RFC3339Nano that Docker generates
+            context.EnvironmentVariables["LOGGING__CONSOLE__FORMATTERNAME"] = "simple";
+            context.EnvironmentVariables["LOGGING__CONSOLE__FORMATTEROPTIONS__TIMESTAMPFORMAT"] = "yyyy-MM-dd'T'HH:mm:ss.ffffff'Z' ";
+            context.EnvironmentVariables["LOGGING__CONSOLE__FORMATTEROPTIONS__USEUTCTIMESTAMP"] = "true";
+        });
+    }
+}

--- a/src/Aspire.Hosting/ProjectComponentBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectComponentBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Otlp;
 using Aspire.Hosting.Properties;
 
@@ -16,6 +17,7 @@ public static class ProjectComponentBuilderExtensions
         var project = new ProjectComponent(name ?? typeof(TProject).Name.ToLowerInvariant());
         var projectBuilder = builder.AddComponent(project);
         projectBuilder.ConfigureOtlpEnvironment();
+        projectBuilder.ConfigureConsoleLogs();
         var serviceMetadata = new TProject();
         projectBuilder.WithAnnotation(serviceMetadata);
         return projectBuilder;

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/AnsiParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/AnsiParserTests.cs
@@ -1,0 +1,231 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.ConsoleLogs;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.ConsoleLogsTests;
+
+public class AnsiParserTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("This is some text without any codes")]
+    [InlineData("This is some text \x1C with an invalid code")]
+    public void ConvertToHtml_ReturnsInputUnchangedIfNoCodesPresent(string input)
+    {
+        var expectedOutput = input;
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+    }
+
+    [Theory]
+    [InlineData("\x1B[2m", "")]
+    [InlineData("\x1B[23m", "")]
+    [InlineData("\x1B[2m\x1B[23m", "")]
+    [InlineData("Real Text Before\x1B[2m\x1B[23m", "Real Text Before")]
+    [InlineData("\x1B[2m\x1B[23mReal Text After", "Real Text After")]
+    [InlineData("\x1B[2mReal Text Between\x1B[23m", "Real Text Between")]
+    [InlineData("Real Text Before\x1B[2mReal Text Between\x1B[23mReal Text After", "Real Text BeforeReal Text BetweenReal Text After")]
+    public void ConvertToHtml_IgnoresUnsupportedButValidCodes(string input, string expectedOutput)
+    {
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(default, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_ColorOpenedButNotClosed_AutoClosedWithResidualState()
+    {
+        var input = "\x1B[32mThis is some green text";
+        var expectedOutput = "<span class=\"ansi-fg-green\">This is some green text</span>";
+        var expectedResidualState = new AnsiParser.ParserState() { ForegroundColor = ConsoleColor.Green };
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(expectedResidualState, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_ColorOpenedAndClosed()
+    {
+        var input = "\x1B[32mThis is some green text\x1B[39m";
+        var expectedOutput = "<span class=\"ansi-fg-green\">This is some green text</span>";
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(default, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_WithForegroundAndBackgroundSet()
+    {
+        var input = "\x1B[32m\x1B[42mThis is some green text with a green background\x1B[39m\x1B[49m";
+        var expectedOutput = "<span class=\"ansi-fg-green ansi-bg-green\">This is some green text with a green background</span>";
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(default, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_PartiallyFormatted()
+    {
+        var input = "\x1B[32mThis is some green text\x1B[39m and this is some plain text";
+        var expectedOutput = "<span class=\"ansi-fg-green\">This is some green text</span> and this is some plain text";
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(default, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_MultipleDistinctFormats()
+    {
+        var input = "\x1B[32mGreen text\x1B[39m Plain text\x1B[42m Green background\x1B[49m";
+        var expectedOutput = "<span class=\"ansi-fg-green\">Green text</span> Plain text<span class=\"ansi-bg-green\"> Green background</span>";
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(default, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_OverlappingFormats()
+    {
+        var input = "\x1B[32mGreen text\x1B[42m Green text Green background\x1B[39m Green background\x1B[49m";
+        var expectedOutput = "<span class=\"ansi-fg-green\">Green text</span><span class=\"ansi-fg-green ansi-bg-green\"> Green text Green background</span><span class=\"ansi-bg-green\"> Green background</span>";
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(default, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_FormattingAcrossLines()
+    {
+        var input1 = "\x1B[32mThis is some green text";
+        var input2 = "This is some more green text\u001b[39m";
+        var expectedOutput1 = "<span class=\"ansi-fg-green\">This is some green text</span>";
+        var expectedOutput2 = "<span class=\"ansi-fg-green\">This is some more green text</span>";
+        var parser = new AnsiParser();
+        var result1 = parser.ConvertToHtml(input1);
+        var result2 = parser.ConvertToHtml(input2, result1.ResidualState);
+
+        Assert.Equal(expectedOutput1, result1.ConvertedText);
+        Assert.Equal(new AnsiParser.ParserState() { ForegroundColor = ConsoleColor.Green }, result1.ResidualState);
+        Assert.Equal(expectedOutput2, result2.ConvertedText);
+        Assert.Equal(default, result2.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_OverlappingFormattingAcrossLines()
+    {
+        var input1 = "\x1B[32mGreen text\x1B[42m Green text";
+        var input2 = "Green background\x1B[39m Green background\x1B[49m";
+        var expectedOutput1 = "<span class=\"ansi-fg-green\">Green text</span><span class=\"ansi-fg-green ansi-bg-green\"> Green text</span>";
+        var expectedOutput2 = "<span class=\"ansi-fg-green ansi-bg-green\">Green background</span><span class=\"ansi-bg-green\"> Green background</span>";
+        var parser = new AnsiParser();
+        var result1 = parser.ConvertToHtml(input1);
+        var result2 = parser.ConvertToHtml(input2, result1.ResidualState);
+
+        Assert.Equal(expectedOutput1, result1.ConvertedText);
+        Assert.Equal(new AnsiParser.ParserState() { ForegroundColor = ConsoleColor.Green, BackgroundColor = ConsoleColor.Green }, result1.ResidualState);
+        Assert.Equal(expectedOutput2, result2.ConvertedText);
+        Assert.Equal(default, result2.ResidualState);
+    }
+
+    [Theory]
+    [InlineData("\x1B[30mBlack\x1B[39m", "<span class=\"ansi-fg-black\">Black</span>")]
+    [InlineData("\x1B[31mRed\x1B[39m", "<span class=\"ansi-fg-red\">Red</span>")]
+    [InlineData("\x1B[32mGreen\x1B[39m", "<span class=\"ansi-fg-green\">Green</span>")]
+    [InlineData("\x1B[33mYellow\x1B[39m", "<span class=\"ansi-fg-yellow\">Yellow</span>")]
+    [InlineData("\x1B[34mBlue\x1B[39m", "<span class=\"ansi-fg-blue\">Blue</span>")]
+    [InlineData("\x1B[35mMagenta\x1B[39m", "<span class=\"ansi-fg-magenta\">Magenta</span>")]
+    [InlineData("\x1B[36mCyan\x1B[39m", "<span class=\"ansi-fg-cyan\">Cyan</span>")]
+    [InlineData("\x1B[37mWhite\x1B[39m", "<span class=\"ansi-fg-white\">White</span>")]
+    [InlineData("\x1B[1m\x1B[30mBright Black\x1B[22m\x1B[39m", "<span class=\"ansi-fg-brightblack\">Bright Black</span>")]
+    [InlineData("\x1B[1m\x1B[31mBright Red\x1b[22m\x1B[39m", "<span class=\"ansi-fg-brightred\">Bright Red</span>")]
+    [InlineData("\x1B[1m\x1B[32mBright Green\x1B[22m\x1B[39m", "<span class=\"ansi-fg-brightgreen\">Bright Green</span>")]
+    [InlineData("\x1B[1m\x1B[33mBright Yellow\x1B[22m\x1B[39m", "<span class=\"ansi-fg-brightyellow\">Bright Yellow</span>")]
+    [InlineData("\x1B[1m\x1B[34mBright Blue\x1B[22m\x1B[39m", "<span class=\"ansi-fg-brightblue\">Bright Blue</span>")]
+    [InlineData("\x1B[1m\x1B[35mBright Magenta\x1B[22m\x1B[39m", "<span class=\"ansi-fg-brightmagenta\">Bright Magenta</span>")]
+    [InlineData("\x1B[1m\x1B[36mBright Cyan\x1B[22m\x1B[39m", "<span class=\"ansi-fg-brightcyan\">Bright Cyan</span>")]
+    [InlineData("\x1B[1m\x1B[37mBright White\x1B[22m\x1B[39m", "<span class=\"ansi-fg-brightwhite\">Bright White</span>")]
+    public void ConvertToHtml_ForegroundColorSupport(string input, string expectedOutput)
+    {
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(default, result.ResidualState);
+    }
+
+    [Theory]
+    [InlineData("\x1B[40mBlack\x1B[49m", "<span class=\"ansi-bg-black\">Black</span>")]
+    [InlineData("\x1B[41mRed\x1B[49m", "<span class=\"ansi-bg-red\">Red</span>")]
+    [InlineData("\x1B[42mGreen\x1B[49m", "<span class=\"ansi-bg-green\">Green</span>")]
+    [InlineData("\x1B[43mYellow\x1B[49m", "<span class=\"ansi-bg-yellow\">Yellow</span>")]
+    [InlineData("\x1B[44mBlue\x1B[49m", "<span class=\"ansi-bg-blue\">Blue</span>")]
+    [InlineData("\x1B[45mMagenta\x1B[49m", "<span class=\"ansi-bg-magenta\">Magenta</span>")]
+    [InlineData("\x1B[46mCyan\x1B[49m", "<span class=\"ansi-bg-cyan\">Cyan</span>")]
+    [InlineData("\x1B[47mWhite\x1B[49m", "<span class=\"ansi-bg-white\">White</span>")]
+    public void ConvertToHtml_BackgroundColorSupport(string input, string expectedOutput)
+    {
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(default, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_HandlesResetIntensity()
+    {
+        var input = "\x1B[1m\x1B[32m\x1B[42mBright Green Text on Green Background\x1B[22mNo Longer Bright";
+        var expectedOutput = "<span class=\"ansi-fg-brightgreen ansi-bg-green\">Bright Green Text on Green Background</span><span class=\"ansi-fg-green ansi-bg-green\">No Longer Bright</span>";
+        var expectedResidualState = new AnsiParser.ParserState() {  ForegroundColor = ConsoleColor.Green, BackgroundColor = ConsoleColor.Green };
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(expectedResidualState, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_HandlesDefaultForeground()
+    {
+        var input = "\x1B[1m\x1B[32m\x1B[42mBright Green Text on Green Background\x1B[39mNo Longer Green Text";
+        var expectedOutput = "<span class=\"ansi-fg-brightgreen ansi-bg-green\">Bright Green Text on Green Background</span><span class=\"ansi-bg-green\">No Longer Green Text</span>";
+        var expectedResidualState = new AnsiParser.ParserState() { Bright = true, BackgroundColor = ConsoleColor.Green };
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(expectedResidualState, result.ResidualState);
+    }
+
+    [Fact]
+    public void ConvertToHtml_HandlesDefaultBackground()
+    {
+        var input = "\x1B[1m\x1B[32m\x1B[42mBright Green Text on Green Background\x1B[49mNo Longer Green Background";
+        var expectedOutput = "<span class=\"ansi-fg-brightgreen ansi-bg-green\">Bright Green Text on Green Background</span><span class=\"ansi-fg-brightgreen\">No Longer Green Background</span>";
+        var expectedResidualState = new AnsiParser.ParserState() { Bright = true, ForegroundColor = ConsoleColor.Green };
+        var parser = new AnsiParser();
+        var result = parser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+        Assert.Equal(expectedResidualState, result.ResidualState);
+    }
+}


### PR DESCRIPTION
The primary purpose of this PR is enabling ANSI Control Sequence parsing to pass colors through from project logs to the log viewer. It does a few other things along the way, so here's the rundown:

1. Logs are HTML Encoded before being sent to the browser, other than the spans that are added as part of the ANSI parsing
2. The current "theme" of the log colors is based on the default Windows Terminal colors scheme. Fairly easy to change it if we want something else
3. Enabling the colors to be passed through during output redirection is enabled via an environment variable injected into each project when it is run
4. Since we're enabling colors, we also went ahead and enabled timestamps, and specified a format that (roughly) matches what the container logs output so that they're comparable
5. When parsing the ANSI Control Sequences we try to just drop any sequences we recognize don't handle. It's possible we will get some feedback that we missed a class of common sequences that we need to detect and drop.

The formatting of project logs with timestamps enabled looks off. It's clear that lines 2-n of each log entry were indented based on the info/warn/dbug/etc messages in line 1 but NOT anticipating the timestamps. We may want to consider adjusting the indentation ourselves in this case, but I'll save that for another PR after feedback (need to see what would happen with the docker logs in the same scenario as well).

Resolves https://github.com/dotnet/aspire-private-planning/issues/664 and resolves https://github.com/dotnet/aspire-private-planning/issues/610