### PR TITLE
Add View Logs to Executables and fix output bug

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ExecutableLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ExecutableLogs.razor
@@ -92,7 +92,7 @@
 
                 _ = Task.Run(async () =>
                 {
-                    await _logViewer.WatchLogsAsync(() => _selectedExecutable.LogSource.WatchOutputLogAsync(_watchLogsTokenSource.Token), LogEntryType.Error);
+                    await _logViewer.WatchLogsAsync(() => _selectedExecutable.LogSource.WatchErrorLogAsync(_watchLogsTokenSource.Token), LogEntryType.Error);
                 });
 
                 _status = LogStatus.WatchingLogs;

--- a/src/Aspire.Dashboard/Components/Pages/Executables.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Executables.razor
@@ -36,6 +36,9 @@
                                       Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
                                       OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
                     </TemplateColumn>
+                    <TemplateColumn Title="Logs">
+                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ExecutableLogs/{context.Name}")">View</FluentAnchor>
+                    </TemplateColumn>
                 </ChildContent>
                 <EmptyContent>
                     <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;No running executables found


### PR DESCRIPTION
Adds a Logs column to the executables grid to jump straight to the logs for a particular executable (matching the containers and projects pages), and fixes an issue where output was being watched twice rather than stdout/stderr once each.