### PR TITLE
Remove flushing during manifest writing

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureComponentExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureComponentExtensions.cs
@@ -12,13 +12,12 @@ public static class AzureComponentExtensions
     {
         var component = new AzureKeyVaultComponent(name);
         return builder.AddComponent(component)
-                      .WithAnnotation(new ManifestPublishingCallbackAnnotation(WriteAzureKeyVaultComponentToManifestAsync));
+                      .WithAnnotation(new ManifestPublishingCallbackAnnotation(WriteAzureKeyVaultComponentToManifest));
     }
 
-    private static async Task WriteAzureKeyVaultComponentToManifestAsync(Utf8JsonWriter jsonWriter, CancellationToken cancellationToken)
+    private static void WriteAzureKeyVaultComponentToManifest(Utf8JsonWriter jsonWriter)
     {
         jsonWriter.WriteString("type", "azure.keyvault.v1");
-        await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public static IDistributedApplicationComponentBuilder<T> WithAddAzureKeyVault<T>(this IDistributedApplicationComponentBuilder<T> builder, IDistributedApplicationComponentBuilder<AzureKeyVaultComponent> keyVaultBuilder)
@@ -53,10 +52,10 @@ public static class AzureComponentExtensions
         };
 
         return builder.AddComponent(component)
-                      .WithAnnotation(new ManifestPublishingCallbackAnnotation((jsonWriter, cancellationToken) => WriteAzureServiceBusComponentToManifestAsync(component, jsonWriter, cancellationToken)));
+                      .WithAnnotation(new ManifestPublishingCallbackAnnotation(jsonWriter => WriteAzureServiceBusComponentToManifest(component, jsonWriter)));
     }
 
-    private static async Task WriteAzureServiceBusComponentToManifestAsync(AzureServiceBusComponent component,  Utf8JsonWriter jsonWriter, CancellationToken cancellationToken)
+    private static void WriteAzureServiceBusComponentToManifest(AzureServiceBusComponent component, Utf8JsonWriter jsonWriter)
     {
         jsonWriter.WriteString("type", "azure.servicebus.v1");
 
@@ -79,8 +78,6 @@ public static class AzureComponentExtensions
             }
             jsonWriter.WriteEndArray();
         }
-
-        await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public static IDistributedApplicationComponentBuilder<T> WithAzureServiceBus<T>(this IDistributedApplicationComponentBuilder<T> builder, IDistributedApplicationComponentBuilder<AzureServiceBusComponent> serviceBusBuilder)
@@ -110,13 +107,12 @@ public static class AzureComponentExtensions
     {
         var component = new AzureStorageComponent(name);
         return builder.AddComponent(component)
-                      .WithAnnotation(new ManifestPublishingCallbackAnnotation(WriteAzureStorageComponentToManifestAsync));
+                      .WithAnnotation(new ManifestPublishingCallbackAnnotation(WriteAzureStorageComponentToManifest));
     }
 
-    private static async Task WriteAzureStorageComponentToManifestAsync(Utf8JsonWriter jsonWriter, CancellationToken cancellationToken)
+    private static void WriteAzureStorageComponentToManifest(Utf8JsonWriter jsonWriter)
     {
         jsonWriter.WriteString("type", "azure.storage.v1");
-        await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public static IDistributedApplicationComponentBuilder<T> WithAzureStorage<T>(this IDistributedApplicationComponentBuilder<T> builder, IDistributedApplicationComponentBuilder<AzureStorageComponent> storage)

--- a/src/Aspire.Hosting/ApplicationModel/ManifestPublishingCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ManifestPublishingCallbackAnnotation.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 namespace Aspire.Hosting.ApplicationModel;
 
-public class ManifestPublishingCallbackAnnotation(Func<Utf8JsonWriter, CancellationToken, Task> callback) : IDistributedApplicationComponentAnnotation
+public class ManifestPublishingCallbackAnnotation(Action<Utf8JsonWriter> callback) : IDistributedApplicationComponentAnnotation
 {
-    public Func<Utf8JsonWriter, CancellationToken, Task> Callback { get; } = callback;
+    public Action<Utf8JsonWriter> Callback { get; } = callback;
 }

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -37,21 +37,20 @@ public static class PostgresBuilderExtensions
         var postgres = new PostgresComponent(name, connectionString);
 
         return builder.AddComponent(postgres)
-            .WithAnnotation(new ManifestPublishingCallbackAnnotation((jsonWriter, cancellationToken) =>
-                WritePostgresComponentToManifest(jsonWriter, postgres.GetConnectionString(), cancellationToken)));
+            .WithAnnotation(new ManifestPublishingCallbackAnnotation(jsonWriter =>
+                WritePostgresComponentToManifest(jsonWriter, postgres.GetConnectionString())));
     }
 
-    private static Task WritePostgresComponentToManifest(Utf8JsonWriter jsonWriter, CancellationToken cancellationToken) =>
-        WritePostgresComponentToManifest(jsonWriter, null, cancellationToken);
+    private static void WritePostgresComponentToManifest(Utf8JsonWriter jsonWriter) =>
+        WritePostgresComponentToManifest(jsonWriter, null);
 
-    private static async Task WritePostgresComponentToManifest(Utf8JsonWriter jsonWriter, string? connectionString, CancellationToken cancellationToken)
+    private static void WritePostgresComponentToManifest(Utf8JsonWriter jsonWriter, string? connectionString)
     {
         jsonWriter.WriteString("type", "postgres.v1");
         if (!string.IsNullOrEmpty(connectionString))
         {
             jsonWriter.WriteString("connectionString", connectionString);
         }
-        await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
@@ -27,21 +27,20 @@ public static class RedisBuilderExtensions
         var redis = new RedisComponent(name, connectionString);
 
         return builder.AddComponent(redis)
-            .WithAnnotation(new ManifestPublishingCallbackAnnotation((jsonWriter, cancellationToken) =>
-                WriteRedisComponentToManifest(jsonWriter, redis.GetConnectionString(), cancellationToken)));
+            .WithAnnotation(new ManifestPublishingCallbackAnnotation(jsonWriter =>
+                WriteRedisComponentToManifest(jsonWriter, redis.GetConnectionString())));
     }
 
-    private static Task WriteRedisComponentToManifest(Utf8JsonWriter jsonWriter, CancellationToken cancellationToken) =>
-        WriteRedisComponentToManifest(jsonWriter, null, cancellationToken);
+    private static void WriteRedisComponentToManifest(Utf8JsonWriter jsonWriter) =>
+        WriteRedisComponentToManifest(jsonWriter, null);
 
-    private static async Task WriteRedisComponentToManifest(Utf8JsonWriter jsonWriter, string? connectionString, CancellationToken cancellationToken)
+    private static void WriteRedisComponentToManifest(Utf8JsonWriter jsonWriter, string? connectionString)
     {
         jsonWriter.WriteString("type", "redis.v1");
         if (!string.IsNullOrEmpty(connectionString))
         {
             jsonWriter.WriteString("connectionString", connectionString);
         }
-        await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public static IDistributedApplicationComponentBuilder<T> WithRedis<T>(this IDistributedApplicationComponentBuilder<T> builder, IDistributedApplicationComponentBuilder<IRedisComponent> redisBuilder, string? connectionName = null)

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -29,21 +29,20 @@ public static class SqlServerBuilderExtensions
         var sqlServer = new SqlServerComponent(name, connectionString);
 
         return builder.AddComponent(sqlServer)
-            .WithAnnotation(new ManifestPublishingCallbackAnnotation((jsonWriter, cancellationToken) =>
-                WriteSqlServerComponentToManifest(jsonWriter, sqlServer.GetConnectionString(), cancellationToken)));
+            .WithAnnotation(new ManifestPublishingCallbackAnnotation(jsonWriter =>
+                WriteSqlServerComponentToManifest(jsonWriter, sqlServer.GetConnectionString())));
     }
 
-    private static Task WriteSqlServerComponentToManifest(Utf8JsonWriter jsonWriter, CancellationToken cancellationToken) =>
-        WriteSqlServerComponentToManifest(jsonWriter, null, cancellationToken);
+    private static void WriteSqlServerComponentToManifest(Utf8JsonWriter jsonWriter) =>
+        WriteSqlServerComponentToManifest(jsonWriter, null);
 
-    private static async Task WriteSqlServerComponentToManifest(Utf8JsonWriter jsonWriter, string? connectionString, CancellationToken cancellationToken)
+    private static void WriteSqlServerComponentToManifest(Utf8JsonWriter jsonWriter, string? connectionString)
     {
         jsonWriter.WriteString("type", "sqlserver.v1");
         if (!string.IsNullOrEmpty(connectionString))
         {
             jsonWriter.WriteString("connectionString", connectionString);
         }
-        await jsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public static IDistributedApplicationComponentBuilder<T> WithSqlServer<T>(this IDistributedApplicationComponentBuilder<T> builder, IDistributedApplicationComponentBuilder<SqlServerContainerComponent> sqlBuilder, string? databaseName, string? connectionName = null)


### PR DESCRIPTION
We are constantly writing small strings to the disk for every little piece of JSON we are writing. Not only is this inefficient, but it also complicates the code.

Removing the flushing also allows us to remove the CancellationToken and Task everywhere.