### PR TITLE
Don't use batching on GenerateServiceMetadataSources Output

### DIFF
--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -9,7 +9,7 @@
 
   <!-- The purpose of this target is to take a list of the resolved project references and generate a set of items (ServiceMetadataSource) which contain
      code that we want to add to the orchestrator project for each referenced project. The metadata contains pointers to the project/assembly. -->
-  <Target Name="GenerateServiceMetadataSources" DependsOnTargets="FindReferenceAssembliesForReferences" Inputs="@(ReferencePathWithRefAssemblies)" Outputs="%(ReferencePathWithRefAssemblies.Identity)">
+  <Target Name="GenerateServiceMetadataSources" DependsOnTargets="FindReferenceAssembliesForReferences" Inputs="@(ReferencePathWithRefAssemblies)" Outputs="@(ReferencePathWithRefAssemblies)">
     <ItemGroup>
       <ServiceMetadataSource Include="%(ReferencePathWithRefAssemblies.Identity)" Condition="%(ReferencePathWithRefAssemblies.ReferenceSourceTarget) == 'ProjectReference' And %(ReferencePathWithRefAssemblies.ServiceNameOverride) == ''">
         <AssemblyName>$([System.IO.Path]::GetFileNameWithoutExtension(%(ReferencePathWithRefAssemblies.Identity)))</AssemblyName>


### PR DESCRIPTION
Batching on the Outputs of GenerateServiceMetadataSources results in many, many calls to this target. The target itself is working in bulk and isn't doing anything that needs this output batching, so all that's happening is that more time is spent in the build performing needless target calls.

Changing this to return the Item list directly results in one call, with one pass through the `ReferencePathWithRefAssemblies` items.

Before:
![image](https://github.com/dotnet/aspire/assets/573979/73f9faf9-8b4c-4773-bf66-52215422b0d7)

After:
![image](https://github.com/dotnet/aspire/assets/573979/336c8a0d-0af6-476e-8990-f0bf188096d7)

I verified that the generated `ServiceMetadataSource` items were equivalent before and after as well.