### PR TITLE
Add Menu Grouping for Logs

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -8,10 +8,13 @@
             <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Text="Projects" Href="/" />
             <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.BinFull())" Text="Containers" Href="/Containers" />
             <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Text="Executables" Href="/Executables" />
-            <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.SlideText())" Text="Project logs" Href="/ProjectLogs" />
-            <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.SlideText())" Text="Container Logs" Href="/ContainerLogs" />
-            <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.SlideText())" Text="Executable Logs" Href="/ExecutableLogs" />
-            <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Text="Semantic Logs" Href="/SemanticLogs" />
+            <FluentNavMenuGroup Icon="@(new Icons.Regular.Size24.SlideText())" Text="Logs" Expanded="true" OnAction="OnMenuGroupClicked">
+                <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.SlideText())" Text="Project" Href="/ProjectLogs" />
+                <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.SlideText())" Text="Container" Href="/ContainerLogs" />
+                <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.SlideText())" Text="Executable" Href="/ExecutableLogs" />
+                <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Text="Structured" Href="/SemanticLogs" />
+            </FluentNavMenuGroup>
+            
             <FluentNavMenuLink Icon="@(new Icons.Regular.Size24.GanttChart())" Text="Traces" Href="/Traces" />
         </FluentNavMenu>
 
@@ -29,3 +32,11 @@
     <a href="" class="reload">Reload</a>
     <a class="dismiss">🗙</a>
 </div>
+
+@code {
+    // Workaround for bug in current NavMenu when clicking on menu groups
+    private void OnMenuGroupClicked(NavMenuActionArgs args)
+    {
+        args.SetHandled();
+    }
+}

--- a/src/Aspire.Dashboard/Components/Pages/SemanticLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/SemanticLogs.razor
@@ -10,7 +10,7 @@
 @inject IJSRuntime JS
 @implements IDisposable
 
-<h1>Semantic Logs</h1>
+<h1>Structured Logs</h1>
 <div>
     <FluentStack Orientation="Orientation.Vertical">
         <FluentToolbar Orientation="Orientation.Horizontal">


### PR DESCRIPTION
Resolves https://github.com/dotnet/aspire-private-planning/issues/543

Adds a "Logs" menu group and groups the existing log types underneath it. That issue also asked for "Semantic Logs" to be renamed "Structured". I did this on the menu and the title of the page, but didn't change the page name/route and all links to it yet to make sure the name sticks.

There's a bug in the current nav menu where when you click on a menu grouping that doesn't have an href, you get into the flashing menu scenario that we've seen in other cases. I put in a workaround for it that we can remove when we update to the new nav menu coming soon.