### PR TITLE
manifest is lowercase

### DIFF
--- a/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
@@ -11,7 +11,7 @@ public static class ConsoleLogsConfigurationExtensions
     {
         return builder.WithEnvironment((context) =>
         {
-            if (context.PublisherName == "Manifest")
+            if (context.PublisherName == "manifest")
             {
                 return;
             }


### PR DESCRIPTION
Ended up with this:

```JSON
{
  "components": {
    "cache": {
      "type": "redis.v1",
      "connectionString": "localhost:64780"
    },
    "worker": {
      "type": "project.v1",
      "path": "..\\..\\ConsoleApp1\\ConsoleApp1.csproj",
      "env": {
        "DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION": "true",
        "LOGGING__CONSOLE__FORMATTERNAME": "simple",
        "LOGGING__CONSOLE__FORMATTEROPTIONS__TIMESTAMPFORMAT": "yyyy-MM-dd\u0027T\u0027HH:mm:ss.ffffff\u0027Z\u0027 ",
        "LOGGING__CONSOLE__FORMATTEROPTIONS__USEUTCTIMESTAMP": "true",
        "ConnectionStrings__cache": "{cache.connectionString}"
      }
    }
  }
}
```