### PR TITLE
Use the AlwaysOnSampler in development 

### DIFF
--- a/samples/eShopLite/ServiceDefaults/Extensions.cs
+++ b/samples/eShopLite/ServiceDefaults/Extensions.cs
@@ -48,6 +48,12 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
+                if (builder.Environment.IsDevelopment())
+                {
+                    // We want to view all traces in development
+                    tracing.SetSampler(new AlwaysOnSampler());
+                }
+
                 tracing.AddAspNetCoreInstrumentation()
                        .AddGrpcClientInstrumentation()
                        .AddHttpClientInstrumentation();

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.ServiceDefaults/Extensions.cs
@@ -50,6 +50,12 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
+                if (builder.Environment.IsDevelopment())
+                {
+                    // We want to view all traces in development
+                    tracing.SetSampler(new AlwaysOnSampler());
+                }
+
                 tracing.AddAspNetCoreInstrumentation()
                        .AddGrpcClientInstrumentation()
                        .AddHttpClientInstrumentation();

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.ServiceDefaults/Extensions.cs
@@ -50,6 +50,12 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
+                if (builder.Environment.IsDevelopment())
+                {
+                    // We want to view all traces in development
+                    tracing.SetSampler(new AlwaysOnSampler());
+                }
+
                 tracing.AddAspNetCoreInstrumentation()
                        .AddGrpcClientInstrumentation()
                        .AddHttpClientInstrumentation();


### PR DESCRIPTION
- Usually traces are sampled for performance reasons. During development we want to be able to analyze the traces and behavior and sampling makes that very hard. Use the "AlwaysOnSampler" to view all of the traces in development.