### PR TITLE
Add IDistributedApplicationComponentWithConnectionString to app model

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/IConnectionStringProvider.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IConnectionStringProvider.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+public interface IConnectionStringProvider : IDistributedApplicationComponent
+{
+    public string? GetConnectionString();
+}

--- a/src/Aspire.Hosting/ApplicationModel/IDistributedApplicationComponentWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IDistributedApplicationComponentWithConnectionString.cs
@@ -3,7 +3,7 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-public interface IConnectionStringProvider : IDistributedApplicationComponent
+public interface IDistributedApplicationComponentWithConnectionString : IDistributedApplicationComponent
 {
     public string? GetConnectionString();
 }

--- a/src/Aspire.Hosting/ComponentBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ComponentBuilderExtensions.cs
@@ -70,7 +70,7 @@ public static class ComponentBuilderExtensions
 
     public static IDistributedApplicationComponentBuilder<TDestination> WithReference<TDestination, TSource>(this IDistributedApplicationComponentBuilder<TDestination> builder, IDistributedApplicationComponentBuilder<TSource> source)
         where TDestination : IDistributedApplicationComponentWithEnvironment
-        where TSource : IConnectionStringProvider
+        where TSource : IDistributedApplicationComponentWithConnectionString
     {
         var connectionName = $"ConnectionStrings__{source.Component.Name}";
 

--- a/src/Aspire.Hosting/Redis/IRedisComponent.cs
+++ b/src/Aspire.Hosting/Redis/IRedisComponent.cs
@@ -5,6 +5,6 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Redis;
 
-public interface IRedisComponent : IConnectionStringProvider
+public interface IRedisComponent : IDistributedApplicationComponentWithConnectionString
 {
 }

--- a/src/Aspire.Hosting/Redis/IRedisComponent.cs
+++ b/src/Aspire.Hosting/Redis/IRedisComponent.cs
@@ -5,7 +5,6 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Redis;
 
-public interface IRedisComponent : IDistributedApplicationComponent
+public interface IRedisComponent : IConnectionStringProvider
 {
-    string? GetConnectionString();
 }

--- a/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
@@ -9,8 +9,6 @@ namespace Aspire.Hosting.Redis;
 
 public static class RedisBuilderExtensions
 {
-    private const string ConnectionStringEnvironmentName = "ConnectionStrings__";
-
     public static IDistributedApplicationComponentBuilder<RedisContainerComponent> AddRedisContainer(this IDistributedApplicationBuilder builder, string name, int? port = null)
     {
         var redis = new RedisContainerComponent(name);
@@ -46,25 +44,6 @@ public static class RedisBuilderExtensions
     public static IDistributedApplicationComponentBuilder<T> WithRedis<T>(this IDistributedApplicationComponentBuilder<T> builder, IDistributedApplicationComponentBuilder<IRedisComponent> redisBuilder, string? connectionName = null)
         where T : IDistributedApplicationComponentWithEnvironment
     {
-        var redis = redisBuilder.Component;
-        connectionName = connectionName ?? redis.Name;
-
-        return builder.WithEnvironment((context) =>
-        {
-            var connectionStringName = $"{ConnectionStringEnvironmentName}{connectionName}";
-
-            if (context.PublisherName == "manifest")
-            {
-                context.EnvironmentVariables[connectionStringName] = $"{{{redis.Name}.connectionString}}";
-                return;
-            }
-
-            var connectionString = redis.GetConnectionString();
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                throw new DistributedApplicationException($"A connection string for Redis '{redis.Name}' could not be retrieved.");
-            }
-            context.EnvironmentVariables[connectionStringName] = connectionString;
-        });
+        return builder.WithReference(redisBuilder);
     }
 }


### PR DESCRIPTION
- With the latest changes to the app model we have landed on a generic way for resources in the app model to express that they can provide a connection string to a dependency that requests it. This change introduces that abstraction (assuming no extra arguments) and exposes a WithReference method that handles injecting the right connection information based on the component name.

PS: The azure components will get the same treatment once we merge this change https://github.com/dotnet/aspire/pull/65