### PR TITLE
Allow reading connection strings from config

### DIFF
--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Hosting.Postgres;
 
@@ -32,7 +33,7 @@ public static class PostgresBuilderExtensions
                       });
     }
 
-    public static IDistributedApplicationComponentBuilder<PostgresComponent> AddPostgres(this IDistributedApplicationBuilder builder, string name, string? connectionString)
+    public static IDistributedApplicationComponentBuilder<PostgresComponent> AddPostgres(this IDistributedApplicationBuilder builder, string name, string? connectionString = null)
     {
         var postgres = new PostgresComponent(name, connectionString);
 
@@ -72,11 +73,14 @@ public static class PostgresBuilderExtensions
                 return;
             }
 
-            var connectionString = postgres.GetConnectionString(databaseName);
+            var connectionString = postgres.GetConnectionString(databaseName) ??
+                builder.ApplicationBuilder.Configuration.GetConnectionString(postgres.Name);
+
             if (string.IsNullOrEmpty(connectionString))
             {
                 throw new DistributedApplicationException($"A connection string for Postgres '{postgres.Name}' could not be retrieved.");
             }
+
             context.EnvironmentVariables[connectionStringName] = connectionString;
         });
     }

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -61,7 +61,7 @@ public static class PostgresBuilderExtensions
         where T : IDistributedApplicationComponentWithEnvironment
     {
         var postgres = postgresBuilder.Component;
-        connectionName = connectionName ?? postgresBuilder.Component.Name;
+        connectionName ??= postgresBuilder.Component.Name;
 
         return builder.WithEnvironment((context) =>
         {

--- a/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class RedisBuilderExtensions
         return componentBuilder;
     }
 
-    public static IDistributedApplicationComponentBuilder<RedisComponent> AddRedis(this IDistributedApplicationBuilder builder, string name, string? connectionString)
+    public static IDistributedApplicationComponentBuilder<RedisComponent> AddRedis(this IDistributedApplicationBuilder builder, string name, string? connectionString = null)
     {
         var redis = new RedisComponent(name, connectionString);
 
@@ -44,6 +44,6 @@ public static class RedisBuilderExtensions
     public static IDistributedApplicationComponentBuilder<T> WithRedis<T>(this IDistributedApplicationComponentBuilder<T> builder, IDistributedApplicationComponentBuilder<IRedisComponent> redisBuilder, string? connectionName = null)
         where T : IDistributedApplicationComponentWithEnvironment
     {
-        return builder.WithReference(redisBuilder);
+        return builder.WithReference(redisBuilder, connectionName);
     }
 }


### PR DESCRIPTION
- This allows the existing components (postgres, sql, redis) to read from config as a fallback after getting their own connection string.

Contributes to #120

PS: Once we do https://github.com/dotnet/aspire/issues/132, this logic will only exist in a single place.