### PR TITLE
Pin to 8.0.100-rc.2.23472.8

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2",
-    "rollForward": "latestPatch",
+    "version": "8.0.100-rc.2.23472.8",
+    "rollForward": "disable",
     "allowPrerelease": true
   },
   "tools": {


### PR DESCRIPTION
Recent internal VS builds have brought in newer RC.2 SDK builds that are more difficult to use as they require specific internal feeds. This change will pin the repo to the public RC.2 SDK build we know works with the workload. We can move ahead to the released RC.2 build when it goes live on 10/10