### PR TITLE
Removing source index step from the build

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
       publishAssetsImmediately: true
       enablePublishTestResults: true
       testResultsFormat: vstest
-      enableSourceIndex: ${{ and(eq(variables._RunAsInternal, True), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}
+      enableSourceIndex: false
       workspace:
         clean: all
       jobs:


### PR DESCRIPTION
For some time now, the rolling build has been broken due to the fact that it is trying to source index the code in this repo. This is failing because the repo isn't public yet. This change is disabling that so that the rolling build gets fixed.