### PR TITLE
Fix Azure SDK activity sources and minor fixes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,7 +92,7 @@ return await app.RunAsync();
 2. Add the following user-secret to the MyApp orchestrator project (using the unique namespace you created above):
 
 ```shell
-C:\git\aspire\samples\eShopLite\AppHost> dotnet user-secrets set Aspire.Azure.Messaging.ServiceBus:Namespace <ServiceBus namespace host>
+C:\git\aspire\samples\eShopLite\AppHost> dotnet user-secrets set Aspire:Azure:Messaging:ServiceBus:Namespace <ServiceBus namespace host>
 ```
 
 - You can do the same in VS by right-clicking AppHost in the Solution Explorer -> "Manage User Secrets" and add
@@ -103,7 +103,7 @@ C:\git\aspire\samples\eShopLite\AppHost> dotnet user-secrets set Aspire.Azure.Me
 }
 ```
 
-- The `<ServiceBus namespace host>` is labeled in the portal UI as "Host name" and looks similar to "yournamespacename.servicebus.windows.net"
+- The `<ServiceBus namespace host>` is labeled in the portal UI as "Host name". Include host name only and omit "servicebus.windows.net".
 
 ## Load the Sample Application
 

--- a/samples/eShopLite/OrderProcessor/Program.cs
+++ b/samples/eShopLite/OrderProcessor/Program.cs
@@ -11,9 +11,7 @@ if (!builder.Environment.IsDevelopment() || builder.Configuration[AspireServiceB
 }
 
 builder.Services.AddHostedService<OrderProcessingWorker>();
-// ensure the OrderProcessingWorker's Activities participate in tracing
-builder.Services.AddOpenTelemetry()
-    .WithTracing(traceBuilder => traceBuilder.AddSource(OrderProcessingWorker.ActivitySourceName));
+builder.Services.AddOpenTelemetry();
 
 var host = builder.Build();
 host.Run();

--- a/samples/eShopLite/OrderProcessor/Program.cs
+++ b/samples/eShopLite/OrderProcessor/Program.cs
@@ -11,7 +11,6 @@ if (!builder.Environment.IsDevelopment() || builder.Configuration[AspireServiceB
 }
 
 builder.Services.AddHostedService<OrderProcessingWorker>();
-builder.Services.AddOpenTelemetry();
 
 var host = builder.Build();
 host.Run();

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -62,7 +62,7 @@ public static class AspireServiceBusExtensions
 
     private sealed class MessageBusComponent : AzureComponent<AzureMessagingServiceBusSettings, ServiceBusClient, ServiceBusClientOptions>
     {
-        // TODO: Remove "Azure.Messaging.ServiceBus" method when https://github.com/Azure/azure-sdk-for-net/issues/39166 is fixed
+        // TODO: Remove "Azure.Messaging.ServiceBus" source when https://github.com/Azure/azure-sdk-for-net/issues/39166 is fixed
         protected override string[] ActivitySourceNames => ["Azure.Messaging.ServiceBus.*", "Azure.Messaging.ServiceBus"];
 
         protected override IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureMessagingServiceBusSettings settings)

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -62,7 +62,8 @@ public static class AspireServiceBusExtensions
 
     private sealed class MessageBusComponent : AzureComponent<AzureMessagingServiceBusSettings, ServiceBusClient, ServiceBusClientOptions>
     {
-        protected override string[] ActivitySourceNames => ["Azure.Messaging.ServiceBus", "Azure.Messaging.ServiceBus.ServiceBusReceiver", "Azure.Messaging.ServiceBus.ServiceBusSender", "Azure.Messaging.ServiceBus.ServiceBusProcessor"];
+        // TODO: Remove "Azure.Messaging.ServiceBus" method when https://github.com/Azure/azure-sdk-for-net/issues/39166 is fixed
+        protected override string[] ActivitySourceNames => ["Azure.Messaging.ServiceBus.*", "Azure.Messaging.ServiceBus"];
 
         protected override IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureMessagingServiceBusSettings settings)
         {

--- a/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
@@ -61,8 +61,6 @@ public static class AspireBlobStorageExtensions
 
     private sealed class BlobStorageComponent : AzureComponent<AzureStorageBlobsSettings, BlobServiceClient, BlobClientOptions>
     {
-        protected override string[] ActivitySourceNames => ["Azure.Storage.Blobs.*"];
-
         protected override IAzureClientBuilder<BlobServiceClient, BlobClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureStorageBlobsSettings settings)
         {
             var connectionString = settings.ConnectionString;

--- a/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
@@ -61,7 +61,7 @@ public static class AspireBlobStorageExtensions
 
     private sealed class BlobStorageComponent : AzureComponent<AzureStorageBlobsSettings, BlobServiceClient, BlobClientOptions>
     {
-        protected override string[] ActivitySourceNames => ["Azure.Storage.Blobs.BlobContainerClient"];
+        protected override string[] ActivitySourceNames => ["Azure.Storage.Blobs.*"];
 
         protected override IAzureClientBuilder<BlobServiceClient, BlobClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureStorageBlobsSettings settings)
         {

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
@@ -61,8 +61,6 @@ public static class AspireQueueStorageExtensions
 
     private sealed class StorageQueueComponent : AzureComponent<AzureStorageQueuesSettings, QueueServiceClient, QueueClientOptions>
     {
-        protected override string[] ActivitySourceNames => ["Azure.Storage.Queues.*"];
-
         protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings)
         {
             var connectionString = settings.ConnectionString;

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
@@ -61,7 +61,7 @@ public static class AspireQueueStorageExtensions
 
     private sealed class StorageQueueComponent : AzureComponent<AzureStorageQueuesSettings, QueueServiceClient, QueueClientOptions>
     {
-        protected override string[] ActivitySourceNames => ["Azure.Storage.Queues.QueueClient"];
+        protected override string[] ActivitySourceNames => ["Azure.Storage.Queues.*"];
 
         protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings)
         {

--- a/src/Components/Common/AzureComponent.cs
+++ b/src/Components/Common/AzureComponent.cs
@@ -17,7 +17,7 @@ internal abstract class AzureComponent<TSettings, TClient, TClientOptions>
     where TClient : class
     where TClientOptions : class
 {
-    protected virtual string[] ActivitySourceNames => new[] { $"{typeof(TClient).Namespace}.{typeof(TClient).Name}" };
+    protected virtual string[] ActivitySourceNames => new[] { $"{typeof(TClient).Namespace}.*" };
 
     // There would be no need for Get* methods if TSettings had a common base type or if it was implementing a shared interface.
     // TSettings is a public type and we don't have a shared package yet, but we may reconsider the approach in near future.

--- a/src/Components/Telemetry.md
+++ b/src/Components/Telemetry.md
@@ -5,7 +5,7 @@ Aspire.Azure.Data.Tables:
   - "Azure.Core"
   - "Azure.Identity"
 - Activity source names:
-  - "Azure.Data.Tables.TableServiceClient"
+  - "Azure.Data.Tables.*"
 - Metric names:
   - none (currently not supported by the Azure SDK)
 
@@ -15,10 +15,8 @@ Aspire.Azure.Messaging.ServiceBus:
   - "Azure.Identity"
   - "Azure.Messaging.ServiceBus"
 - Activity source names:
+  - "Azure.Messaging.ServiceBus.*"
   - "Azure.Messaging.ServiceBus"
-  - "Azure.Messaging.ServiceBus.ServiceBusProcessor"
-  - "Azure.Messaging.ServiceBus.ServiceBusReceiver"
-  - "Azure.Messaging.ServiceBus.ServiceBusSender"
 - Metric names:
   - none (currently not supported by the Azure SDK)
 

--- a/src/Components/Telemetry.md
+++ b/src/Components/Telemetry.md
@@ -27,7 +27,7 @@ Aspire.Azure.Security.KeyVault:
   - "Azure.Core"
   - "Azure.Identity"
 - Activity source names:
-  - "Azure.Security.KeyVault.Secrets.SecretClient"
+  - "Azure.Security.KeyVault.Secrets.*"
 - Metric names:
   - none (currently not supported by the Azure SDK)
 
@@ -36,7 +36,7 @@ Aspire.Azure.Storage.Blobs:
   - "Azure.Core"
   - "Azure.Identity"
 - Activity source names:
-  - "Azure.Storage.Blobs.BlobContainerClient"
+  - "Azure.Storage.Blobs.*"
 - Metric names:
   - none (currently not supported by the Azure SDK)
 
@@ -45,7 +45,7 @@ Aspire.Azure.Storage.Queues:
   - "Azure.Core"
   - "Azure.Identity"
 - Activity source names:
-  - "Azure.Storage.Queues.QueueClient"
+  - "Azure.Storage.Queues.*"
 - Metric names:
   - none (currently not supported by the Azure SDK)
 

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/ConformanceTests.cs
@@ -21,7 +21,7 @@ public class ConformanceTests : ConformanceTests<SecretClient, AzureSecurityKeyV
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
-    protected override string ActivitySourceName => "Azure.Security.KeyVault.Secrets.SecretClient";
+    protected override string ActivitySourceName => "Azure.Security.KeyVault.Secrets.*";
 
     protected override string[] RequiredLogCategories => new string[] { "Azure.Core" };
 

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/ConformanceTests.cs
@@ -21,7 +21,7 @@ public class ConformanceTests : ConformanceTests<SecretClient, AzureSecurityKeyV
 
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
-    protected override string ActivitySourceName => "Azure.Security.KeyVault.Secrets.*";
+    protected override string ActivitySourceName => "Azure.Security.KeyVault.Secrets.SecretClient";
 
     protected override string[] RequiredLogCategories => new string[] { "Azure.Core" };
 


### PR DESCRIPTION
Azure SDK uses `<packageName>.<clientName>` convention for activity sources and recommends enabling `<packageName>.*` sources by default (to avoid listing multiple possible clients that are not always used directly by developers).

See https://github.com/Azure/azure-sdk-for-net/issues/31921 and https://github.com/Azure/azure-sdk-for-net/issues/39166 for the context.

This change
- updates ActivitySource names to follow convention 
- removes custom processing activity from samples
- updates minor doc issues


Things work just fine:

<img width="1703" alt="image" src="https://github.com/dotnet/aspire/assets/2347409/3751585d-7cea-46c5-9bfe-064701c5f148">
