### PR TITLE
Made azure resources export connection strings

### DIFF
--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -22,7 +22,7 @@ var serviceBus = builder.AddAzureServiceBus("messaging", queueNames: ["orders"])
 
 var basket = builder.AddProject<Projects.BasketService>()
                     .WithRedis(redis)
-                    .WithAzureServiceBus(serviceBus);
+                    .WithReference(serviceBus, optional: true);
 
 builder.AddProject<Projects.MyFrontend>()
        .WithServiceReference(basket)

--- a/samples/eShopLite/BasketService/BasketService.cs
+++ b/samples/eShopLite/BasketService/BasketService.cs
@@ -69,7 +69,7 @@ public class BasketService(IBasketRepository repository, IConfiguration configur
         _serviceBusClient ??= serviceProvider.GetService<ServiceBusClient>();
         if (_serviceBusClient is null)
         {
-            _logger.LogWarning($"Azure ServiceBus is unavailable. Ensure you have configured it - for example in AppHosts's user secrets under {AspireServiceBusExtensions.DefaultNamespaceConfigKey}.");
+            _logger.LogWarning("Azure ServiceBus is unavailable. Ensure you have configured it in AppHosts's config / user secrets under 'ConnectionStrings:messaging'.");
         }
         else
         {

--- a/samples/eShopLite/BasketService/Program.cs
+++ b/samples/eShopLite/BasketService/Program.cs
@@ -9,7 +9,7 @@ builder.AddRedis("basketCache");
 builder.Services.AddTransient<IBasketRepository, RedisBasketRepository>();
 
 // When running for Development, don't fail at startup if the developer hasn't configured ServiceBus yet.
-if (!builder.Environment.IsDevelopment() || builder.Configuration[AspireServiceBusExtensions.DefaultNamespaceConfigKey] is not null)
+if (!builder.Environment.IsDevelopment() || builder.Configuration.GetConnectionString("messaging") is not null)
 {
     builder.AddAzureServiceBus("messaging");
 }

--- a/samples/eShopLite/OrderProcessor/OrderProcessingWorker.cs
+++ b/samples/eShopLite/OrderProcessor/OrderProcessingWorker.cs
@@ -26,7 +26,7 @@ public class OrderProcessingWorker : BackgroundService
     {
         if (_client is null)
         {
-            _logger.LogCritical($"Azure ServiceBus is unavailable. Ensure you have configured it - for example in AppHost's user secrets under '{AspireServiceBusExtensions.DefaultNamespaceConfigKey}'.");
+            _logger.LogCritical("Azure ServiceBus is unavailable. Ensure you have configured it in AppHost's config / user secrets under 'ConnectionStrings:messaging'.");
             return;
         }
 

--- a/samples/eShopLite/OrderProcessor/Program.cs
+++ b/samples/eShopLite/OrderProcessor/Program.cs
@@ -5,7 +5,7 @@ var builder = Host.CreateApplicationBuilder(args);
 builder.AddServiceDefaults();
 
 // When running for Development, don't fail at startup if the developer hasn't configured ServiceBus yet.
-if (!builder.Environment.IsDevelopment() || builder.Configuration[AspireServiceBusExtensions.DefaultNamespaceConfigKey] is not null)
+if (!builder.Environment.IsDevelopment() || builder.Configuration.GetConnectionString("messaging") is not null)
 {
     builder.AddAzureServiceBus("messaging");
 }

--- a/src/Aspire.Hosting.Azure.Provisioning/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/AzureProvisioner.cs
@@ -251,7 +251,7 @@ internal sealed class AzureProvisioner(IConfiguration configuration, IHostEnviro
             logger.LogInformation("Key vault {vaultName} created.", keyVaultResource.Data.Name);
         }
 
-        keyVault.VaultUri = keyVaultResource.Data.Properties.VaultUri.ToString();
+        keyVault.VaultUri = keyVaultResource.Data.Properties.VaultUri;
 
         // Key Vault Administrator
         // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#key-vault-administrator
@@ -384,9 +384,9 @@ internal sealed class AzureProvisioner(IConfiguration configuration, IHostEnviro
             logger.LogInformation("Storage account {accountName} created.", storageAccount.Data.Name);
         }
         
-        component.BlobUri = storageAccount.Data.PrimaryEndpoints.BlobUri.ToString();
-        component.TableUri = storageAccount.Data.PrimaryEndpoints.TableUri.ToString();
-        component.QueueUri = storageAccount.Data.PrimaryEndpoints.QueueUri.ToString();
+        component.BlobUri = storageAccount.Data.PrimaryEndpoints.BlobUri;
+        component.TableUri = storageAccount.Data.PrimaryEndpoints.TableUri;
+        component.QueueUri = storageAccount.Data.PrimaryEndpoints.QueueUri;
 
         // Storage Queue Data Contributor
         // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-queue-data-contributor

--- a/src/Aspire.Hosting.Azure.Provisioning/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/AzureProvisioner.cs
@@ -251,7 +251,7 @@ internal sealed class AzureProvisioner(IConfiguration configuration, IHostEnviro
             logger.LogInformation("Key vault {vaultName} created.", keyVaultResource.Data.Name);
         }
 
-        keyVault.VaultName = keyVaultResource.Data.Name;
+        keyVault.VaultUri = keyVaultResource.Data.Properties.VaultUri.ToString();
 
         // Key Vault Administrator
         // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#key-vault-administrator
@@ -289,7 +289,7 @@ internal sealed class AzureProvisioner(IConfiguration configuration, IHostEnviro
             logger.LogInformation("Service bus namespace {namespace} created.", serviceBusNamespace.Data.Name);
         }
 
-        component.ServiceBusNamespace = serviceBusNamespace.Data.Name;
+        component.ServiceBusEndpoint = serviceBusNamespace.Data.ServiceBusEndpoint;
 
         // Now create the queues
         var queues = serviceBusNamespace.GetServiceBusQueues();
@@ -383,20 +383,10 @@ internal sealed class AzureProvisioner(IConfiguration configuration, IHostEnviro
 
             logger.LogInformation("Storage account {accountName} created.", storageAccount.Data.Name);
         }
-
-        // Our storage component doesn't support connection strings yet
-
-        // Get the storage account key
-        //string accountKey = "";
-        //await foreach (StorageAccountKey key in storageAccount.GetKeysAsync(cancellationToken: cancellationToken))
-        //{
-        //    accountKey = key.Value;
-        //    break;
-        //}
-
-        // component.ConnectionString = $"DefaultEndpointsProtocol=https;AccountName={accountName};AccountKey={accountKey}==;EndpointSuffix=core.windows.net";
-
-        component.AccountName = storageAccount.Data.Name;
+        
+        component.BlobUri = storageAccount.Data.PrimaryEndpoints.BlobUri.ToString();
+        component.TableUri = storageAccount.Data.PrimaryEndpoints.TableUri.ToString();
+        component.QueueUri = storageAccount.Data.PrimaryEndpoints.QueueUri.ToString();
 
         // Storage Queue Data Contributor
         // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-queue-data-contributor

--- a/src/Aspire.Hosting.Azure/AzureKeyVaultComponent.cs
+++ b/src/Aspire.Hosting.Azure/AzureKeyVaultComponent.cs
@@ -7,7 +7,7 @@ namespace Aspire.Hosting.Azure;
 
 public class AzureKeyVaultComponent(string name) : DistributedApplicationComponent(name), IAzureComponent, IDistributedApplicationComponentWithConnectionString
 {
-    public string? VaultUri { get; set; }
+    public Uri? VaultUri { get; set; }
 
-    public string? GetConnectionString() => VaultUri;
+    public string? GetConnectionString() => VaultUri?.ToString();
 }

--- a/src/Aspire.Hosting.Azure/AzureKeyVaultComponent.cs
+++ b/src/Aspire.Hosting.Azure/AzureKeyVaultComponent.cs
@@ -5,7 +5,9 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Azure;
 
-public class AzureKeyVaultComponent(string name) : DistributedApplicationComponent(name), IAzureComponent
+public class AzureKeyVaultComponent(string name) : DistributedApplicationComponent(name), IAzureComponent, IDistributedApplicationComponentWithConnectionString
 {
-    public string? VaultName { get; set; }
+    public string? VaultUri { get; set; }
+
+    public string? GetConnectionString() => VaultUri;
 }

--- a/src/Aspire.Hosting.Azure/AzureServiceBusComponent.cs
+++ b/src/Aspire.Hosting.Azure/AzureServiceBusComponent.cs
@@ -7,6 +7,7 @@ namespace Aspire.Hosting.Azure;
 
 public class AzureServiceBusComponent(string name) : DistributedApplicationComponent(name), IAzureComponent, IDistributedApplicationComponentWithConnectionString
 {
+    // This is the full uri to the service bus namespace e.g https://namespace.servicebus.windows.net
     public string? ServiceBusEndpoint { get; set; }
 
     public string[] QueueNames { get; set; } = [];

--- a/src/Aspire.Hosting.Azure/AzureServiceBusComponent.cs
+++ b/src/Aspire.Hosting.Azure/AzureServiceBusComponent.cs
@@ -5,10 +5,12 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Azure;
 
-public class AzureServiceBusComponent(string name) : DistributedApplicationComponent(name), IAzureComponent
+public class AzureServiceBusComponent(string name) : DistributedApplicationComponent(name), IAzureComponent, IDistributedApplicationComponentWithConnectionString
 {
-    public string ServiceBusNamespace { get; set; } = default!;
+    public string? ServiceBusEndpoint { get; set; }
 
     public string[] QueueNames { get; set; } = [];
     public string[] TopicNames { get; set; } = [];
+
+    public string? GetConnectionString() => ServiceBusEndpoint;
 }

--- a/src/Aspire.Hosting.Azure/AzureStorageComponent.cs
+++ b/src/Aspire.Hosting.Azure/AzureStorageComponent.cs
@@ -7,6 +7,37 @@ namespace Aspire.Hosting.Azure;
 
 public class AzureStorageComponent(string name) : DistributedApplicationComponent(name), IAzureComponent
 {
-    public string? ConnectionString { get; set; }
-    public string? AccountName { get; set; }
+    public string? TableUri { get; set; }
+    public string? QueueUri { get; set; }
+    public string? BlobUri { get; set; }
+}
+
+public class AzureTableStorageComponent(string name, AzureStorageComponent storage) : DistributedApplicationComponent(name),
+    IAzureComponent,
+    IDistributedApplicationComponentWithConnectionString,
+    IDistributedApplicationComponentWithParent<AzureStorageComponent>
+{
+    public AzureStorageComponent Parent => storage;
+
+    public string? GetConnectionString() => Parent.TableUri;
+}
+
+public class AzureBlobStorageComponent(string name, AzureStorageComponent storage) : DistributedApplicationComponent(name),
+    IAzureComponent,
+    IDistributedApplicationComponentWithConnectionString,
+    IDistributedApplicationComponentWithParent<AzureStorageComponent>
+{
+    public AzureStorageComponent Parent => storage;
+
+    public string? GetConnectionString() => Parent.BlobUri;
+}
+
+public class AzureQueueStorageComponent(string name, AzureStorageComponent storage) : DistributedApplicationComponent(name),
+    IAzureComponent,
+    IDistributedApplicationComponentWithConnectionString,
+    IDistributedApplicationComponentWithParent<AzureStorageComponent>
+{
+    public AzureStorageComponent Parent => storage;
+
+    public string? GetConnectionString() => Parent.QueueUri;
 }

--- a/src/Aspire.Hosting.Azure/AzureStorageComponent.cs
+++ b/src/Aspire.Hosting.Azure/AzureStorageComponent.cs
@@ -7,9 +7,9 @@ namespace Aspire.Hosting.Azure;
 
 public class AzureStorageComponent(string name) : DistributedApplicationComponent(name), IAzureComponent
 {
-    public string? TableUri { get; set; }
-    public string? QueueUri { get; set; }
-    public string? BlobUri { get; set; }
+    public Uri? TableUri { get; set; }
+    public Uri? QueueUri { get; set; }
+    public Uri? BlobUri { get; set; }
 }
 
 public class AzureTableStorageComponent(string name, AzureStorageComponent storage) : DistributedApplicationComponent(name),
@@ -19,7 +19,7 @@ public class AzureTableStorageComponent(string name, AzureStorageComponent stora
 {
     public AzureStorageComponent Parent => storage;
 
-    public string? GetConnectionString() => Parent.TableUri;
+    public string? GetConnectionString() => Parent.TableUri?.ToString();
 }
 
 public class AzureBlobStorageComponent(string name, AzureStorageComponent storage) : DistributedApplicationComponent(name),
@@ -29,7 +29,7 @@ public class AzureBlobStorageComponent(string name, AzureStorageComponent storag
 {
     public AzureStorageComponent Parent => storage;
 
-    public string? GetConnectionString() => Parent.BlobUri;
+    public string? GetConnectionString() => Parent.BlobUri?.ToString();
 }
 
 public class AzureQueueStorageComponent(string name, AzureStorageComponent storage) : DistributedApplicationComponent(name),
@@ -39,5 +39,5 @@ public class AzureQueueStorageComponent(string name, AzureStorageComponent stora
 {
     public AzureStorageComponent Parent => storage;
 
-    public string? GetConnectionString() => Parent.QueueUri;
+    public string? GetConnectionString() => Parent.QueueUri?.ToString();
 }

--- a/src/Aspire.Hosting/ComponentBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ComponentBuilderExtensions.cs
@@ -63,7 +63,7 @@ public static class ComponentBuilderExtensions
         };
     }
 
-    public static IDistributedApplicationComponentBuilder<TDestination> WithReference<TDestination, TSource>(this IDistributedApplicationComponentBuilder<TDestination> builder, IDistributedApplicationComponentBuilder<TSource> source, string? connectionName = null)
+    public static IDistributedApplicationComponentBuilder<TDestination> WithReference<TDestination, TSource>(this IDistributedApplicationComponentBuilder<TDestination> builder, IDistributedApplicationComponentBuilder<TSource> source, string? connectionName = null, bool optional = false)
         where TDestination : IDistributedApplicationComponentWithEnvironment
         where TSource : IDistributedApplicationComponentWithConnectionString
     {
@@ -85,6 +85,12 @@ public static class ComponentBuilderExtensions
 
             if (string.IsNullOrEmpty(connectionString))
             {
+                if (optional)
+                {
+                    // This is an optional connection string, so we can just return.
+                    return;
+                }
+
                 throw new DistributedApplicationException($"A connection string for '{component.Name}' could not be retrieved.");
             }
 

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Extensions.Hosting;
 public static class AspireServiceBusExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Azure:Messaging:ServiceBus";
-    private const string NamespaceConfigKeyName = "Namespace";
-    public const string DefaultNamespaceConfigKey = $"{DefaultConfigSectionName}:{NamespaceConfigKeyName}";
 
     /// <summary>
     /// Registers <see cref="ServiceBusClient"/> as a singleton in the services provided by the <paramref name="builder"/>.


### PR DESCRIPTION
- Azure resources now follow the same pattern as the databases. Top level resources can export connection stings and subresources export individual connections.
- Updated the azure provisioner to get connection data directly.
- It's no longer possible to reference azure storage directly, a subresource like blobs, queues or tables must be added as well.
- This also enables connection string lookup based on resource name.

Fixes #132 
Fixes #120 

~PS: One side effect of this change is that the call to AddServiceBus will throw an exception in the sample if there's no connection string specified.~
I've added an optional bool parameter to WithReference. That won't throw if the connection string isn't resolved. I think we should leave this on the low level API only and leave it out of all of the overloads (at least for now).