### PR TITLE
Manifest emitting external flag and http2 transport information.

### DIFF
--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -1,3 +1,4 @@
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Redis;
@@ -21,10 +22,12 @@ var catalog = builder.AddProject<Projects.CatalogService>()
 var serviceBus = builder.AddAzureServiceBus("messaging", queueNames: ["orders"]);
 
 var basket = builder.AddProject<Projects.BasketService>()
+                    .WithServiceBindingForPublisher("manifest", "http", context => context.Binding.AsExternal())
                     .WithRedis(redis)
                     .WithReference(serviceBus, optional: true);
 
 builder.AddProject<Projects.MyFrontend>()
+       .WithServiceBindingForPublisher("manifest", "https", context => context.Binding.AsExternal())
        .WithServiceReference(basket)
        .WithServiceReference(catalog, bindingName: "http")
        .WithEnvironment("GRAFANA_URL", () => grafana.GetEndpoint("grafana-http")?.UriString ?? $"{{{grafana.Component.Name}.bindings.grafana-http}}");

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -16,8 +16,8 @@ var catalogdb = builder.AddPostgresContainer("postgres").AddDatabase("catalog");
 var redis = builder.AddRedisContainer("basketCache");
 
 var catalog = builder.AddProject<Projects.CatalogService>()
-                     .WithPostgres(catalogdb)
-                     .WithReplicas(2);
+                     .WithPostgres(catalogdb);
+//                     .WithReplicas(2);
 
 var serviceBus = builder.AddAzureServiceBus("messaging", queueNames: ["orders"]);
 

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -26,13 +26,6 @@
       "path": "..\\..\\CatalogService\\CatalogService.csproj",
       "env": {
         "ConnectionStrings__catalog": "{catalog.connectionString}"
-      },
-      "bindings": {
-        "http": {
-          "scheme": "http",
-          "protocol": "tcp",
-          "transport": "http"
-        }
       }
     },
     "messaging": {
@@ -52,7 +45,8 @@
         "http": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "external": true
         }
       }
     },
@@ -63,10 +57,11 @@
         "GRAFANA_URL": "{grafana.bindings.grafana-http}"
       },
       "bindings": {
-        "http": {
-          "scheme": "http",
+        "https": {
+          "scheme": "https",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "external": true
         }
       }
     },
@@ -80,14 +75,7 @@
     "apigateway": {
       "type": "project.v1",
       "path": "..\\..\\ApiGateway\\ApiGateway.csproj",
-      "env": {},
-      "bindings": {
-        "http": {
-          "scheme": "http",
-          "protocol": "tcp",
-          "transport": "http"
-        }
-      }
+      "env": {}
     },
     "prometheus": {
       "type": "container.v1",

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -1,4 +1,4 @@
-{
+ {
   "components": {
     "grafana": {
       "type": "container.v1",
@@ -39,7 +39,7 @@
       "path": "..\\..\\BasketService\\BasketService.csproj",
       "env": {
         "ConnectionStrings__basketCache": "{basketCache.connectionString}",
-        "Aspire__Azure__Messaging__ServiceBus__Namespace": "{messaging.connectionString}"
+        "ConnectionStrings__messaging": "{messaging.connectionString}"
       },
       "bindings": {
         "http": {
@@ -69,7 +69,7 @@
       "type": "project.v1",
       "path": "..\\..\\OrderProcessor\\OrderProcessor.csproj",
       "env": {
-        "Aspire__Azure__Messaging__ServiceBus__Namespace": "{messaging.connectionString}"
+        "ConnectionStrings__messaging": "{messaging.connectionString}"
       }
     },
     "apigateway": {

--- a/src/Aspire.Hosting/ApplicationModel/ServiceBindingAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ServiceBindingAnnotation.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 [DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}")]
 public sealed class ServiceBindingAnnotation : IDistributedApplicationComponentAnnotation
 {
-    public ServiceBindingAnnotation(ProtocolType protocol, string? uriScheme = null, string? transport = null, string? name = null, int? port = null, int? containerPort = null)
+    public ServiceBindingAnnotation(ProtocolType protocol, string? uriScheme = null, string? transport = null, string? name = null, int? port = null, int? containerPort = null, bool? isExternal = null)
     {
         // If the URI scheme is null, we'll adopt either udp:// or tcp:// based on the
         // protocol. If the name is null, we'll use the URI scheme as the default. This
@@ -22,22 +22,23 @@ public sealed class ServiceBindingAnnotation : IDistributedApplicationComponentA
         Name = name ?? UriScheme;
         Port = port;
         ContainerPort = containerPort ?? port;
+        IsExternal = isExternal ?? false;
     }
 
     /// <summary>
     ///  Name of the service
     /// </summary>
-    public string Name { get; }
+    public string Name { get; internal set; }
 
     /// <summary>
     /// Network protocol: TCP or UDP are supported today, others possibly in future.
     /// </summary>
-    public ProtocolType Protocol { get; }
+    public ProtocolType Protocol { get; internal set; }
 
     /// <summary>
     /// Desired port for the service
     /// </summary>
-    public int? Port { get; set; }
+    public int? Port { get; internal set; }
 
     /// <summary>
     /// If the binding is used for the container, this is the port the container process is listening on.
@@ -45,15 +46,20 @@ public sealed class ServiceBindingAnnotation : IDistributedApplicationComponentA
     /// <remarks>
     /// Defaults to <see cref="Port"/>. 
     /// </remarks>
-    public int? ContainerPort { get; set; }
+    public int? ContainerPort { get; internal set; }
 
     /// <summary>
     /// If a service is URI-addressable, this will property will contain the URI scheme to use for constructing service URI.
     /// </summary>
-    public string UriScheme { get; }
+    public string UriScheme { get; internal set; }
 
     /// <summary>
     /// Transport that is being used (e.g. http, http2, http3 etc).
     /// </summary>
-    public string Transport { get; }
+    public string Transport { get; internal set; }
+
+    /// <summary>
+    /// Indicates that this service binding should be exposed externally at publish time.
+    /// </summary>
+    public bool IsExternal { get; internal set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ServiceBindingAnnotationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ServiceBindingAnnotationExtensions.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+public static class ServiceBindingAnnotationExtensions
+{
+    public static ServiceBindingAnnotation AsHttp2(this ServiceBindingAnnotation binding)
+    {
+        binding.Transport = "http2";
+        binding.UriScheme = "https";
+        return binding;
+    }
+
+    public static ServiceBindingAnnotation AsExternal(this ServiceBindingAnnotation binding)
+    {
+        binding.IsExternal = true;
+        return binding;
+    }
+
+}

--- a/src/Aspire.Hosting/ApplicationModel/ServiceBindingCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ServiceBindingCallbackAnnotation.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+internal sealed class ServiceBindingCallbackAnnotation(string publisherName, string bindingName, Func<ServiceBindingCallbackContext, ServiceBindingAnnotation>? callback) : IDistributedApplicationComponentAnnotation
+{
+    public string PublisherName { get; } = publisherName;
+    public string BindingName { get; } = bindingName;
+    public Func<ServiceBindingCallbackContext, ServiceBindingAnnotation>? Callback { get; } = callback;
+}

--- a/src/Aspire.Hosting/ApplicationModel/ServiceBindingCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ServiceBindingCallbackContext.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+public class ServiceBindingCallbackContext(string publisherName, ServiceBindingAnnotation binding)
+{
+    public string PublisherName { get; } = publisherName;
+    public ServiceBindingAnnotation Binding { get; } = binding;
+}

--- a/src/Aspire.Hosting/ComponentBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ComponentBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Configuration;
 
@@ -129,5 +130,21 @@ public static class ComponentBuilderExtensions
         }
 
         return builder;
+    }
+
+    public static IDistributedApplicationComponentBuilder<T> WithServiceBinding<T>(this IDistributedApplicationComponentBuilder<T> builder, int? hostPort = null, string? scheme = null, string? name = null) where T : IDistributedApplicationComponent
+    {
+        if (builder.Component.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.Name == name))
+        {
+            throw new DistributedApplicationException($"Service binding with name '{name}' already exists");
+        }
+
+        var annotation = new ServiceBindingAnnotation(ProtocolType.Tcp, scheme, name, port: hostPort);
+        return builder.WithAnnotation(annotation);
+    }
+
+    public static IDistributedApplicationComponentBuilder<T> WithServiceBindingForPublisher<T>(this IDistributedApplicationComponentBuilder<T> builder, string publisherName, string bindingName, Func<ServiceBindingCallbackContext, ServiceBindingAnnotation>? callback = null) where T : IDistributedApplicationComponent
+    {
+        return builder.WithAnnotation(new ServiceBindingCallbackAnnotation(publisherName, bindingName, callback));
     }
 }

--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -77,16 +77,12 @@ public sealed class DcpDistributedApplicationLifecycleHook(IOptions<PublishingOp
 
     private static ServiceBindingAnnotation CreateServiceBindingAnnotation(string bindingName)
     {
-        var uriScheme = bindingName.ToLowerInvariant() switch
+        return bindingName.ToLowerInvariant() switch
         {
-            "http" => "http",
-            "https" => "https",
-            _ => "tcp"
+            "http" => new ServiceBindingAnnotation(ProtocolType.Tcp, uriScheme: "http", containerPort: 80),
+            "https" => new ServiceBindingAnnotation(ProtocolType.Tcp, uriScheme: "https", containerPort: 443),
+            _ => new ServiceBindingAnnotation(ProtocolType.Tcp, name: bindingName)
         };
-
-        // TODO: This is where we might add heuristics to detect container ports etc.
-
-        return new ServiceBindingAnnotation(ProtocolType.Tcp, name: bindingName, uriScheme: uriScheme);
     }
 
     private void PrepareServices(DistributedApplicationModel model)

--- a/src/Aspire.Hosting/ProjectComponentBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectComponentBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Otlp;
@@ -53,16 +52,5 @@ public static class ProjectComponentBuilderExtensions
 
         var launchProfileAnnotation = new LaunchProfileAnnotation(launchProfileName, launchProfile);
         return builder.WithAnnotation(launchProfileAnnotation);
-    }
-
-    public static IDistributedApplicationComponentBuilder<T> WithServiceBinding<T>(this IDistributedApplicationComponentBuilder<T> builder, int? hostPort = null, string? scheme = null, string? name = null) where T : IDistributedApplicationComponent
-    {
-        if (builder.Component.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.Name == name))
-        {
-            throw new DistributedApplicationException($"Service binding with name '{name}' already exists");
-        }
-
-        var annotation = new ServiceBindingAnnotation(ProtocolType.Tcp, scheme, name, port: hostPort);
-        return builder.WithAnnotation(annotation);
     }
 }

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -115,6 +115,12 @@ internal sealed class ManifestPublisher(IOptions<PublishingOptions> options, IHo
                 jsonWriter.WriteString("scheme", serviceBinding.UriScheme);
                 jsonWriter.WriteString("protocol", serviceBinding.Protocol.ToString().ToLowerInvariant());
                 jsonWriter.WriteString("transport", serviceBinding.Transport);
+
+                if (serviceBinding.IsExternal)
+                {
+                    jsonWriter.WriteBoolean("external", serviceBinding.IsExternal);
+                }
+
                 jsonWriter.WriteEndObject();
             }
             jsonWriter.WriteEndObject();


### PR DESCRIPTION
This PR adds the ability for developers to mutate service bindings for specific publishers. Here is an example of the usage:

```csharp
var app = builder.AddProject<Projects.Frontend>("frontend")
                            .WithServiceBindingForPublisher("manifest", "https", context => context.Binding.AsExternal());
```

When hitting F5 to debug locally, this would do nothing because the service bindings are derived from the launch profile. However when publishing a manifest the callback would be invoked and we can mark the binding as external. There is also ```AsHttp2()``` mutator as well. At this point in time the publisher argument is "stringy" but it could be made to be a generic as well.
