### PR TITLE
Fix incorrect logging parameter order in LogInformation call

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/AzureProvisioner.cs
@@ -64,7 +64,7 @@ internal sealed class AzureProvisioner(IConfiguration configuration, IHostEnviro
 
         var subscription = await armClient.GetDefaultSubscriptionAsync(cancellationToken).ConfigureAwait(false);
 
-        logger.LogInformation("Default subscription: {name} ({subscriptionId})", subscription.Id, subscription.Data.DisplayName);
+        logger.LogInformation("Default subscription: {name} ({subscriptionId})", subscription.Data.DisplayName, subscription.Id);
 
         // Name of the resource group to create based on the machine name and application name
         var (resourceGroupName, createIfNoExists) = configuration["Azure:ResourceGroup"] switch


### PR DESCRIPTION
While reading through code to understand how the project works I noticed this `LogInformation` call looked like it has its log parameters in the incorrect order.