### PR TITLE
Refactor Log Parsing

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -59,16 +59,6 @@
     content: counter(line-number);
 }
 
-::deep .timestamp {
-    color: gray;
-    margin-left: 1em;
-    white-space: nowrap;
-}
-
-::deep .timestamp.missing {
-    display: none;
-}
-
 ::deep .content {
     word-break: break-all;
     margin-left: 1em;
@@ -77,6 +67,21 @@
     user-select: text;
     cursor: text;
     white-space: pre-wrap;
+}
+
+::deep .content .timestamp {
+    color: gray;
+}
+
+::deep .content a,
+::deep .content a:active,
+::deep .content a:visited {
+    color: #CCCCCC;
+    text-decoration: none;
+}
+
+::deep .content a:hover {
+    text-decoration: underline;
 }
 
 ::deep .content > fluent-badge {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
@@ -31,12 +31,6 @@ export function addLogEntries(logEntries) {
             rowContainer.setAttribute("data-timestamp", logEntry.timestamp ?? logEntry.parentTimestamp ?? "");
             const lineRow = rowContainer.firstElementChild;
             const lineArea = lineRow.firstElementChild;
-            const timestamp = lineArea.children[1];
-            if (logEntry.timestamp) {
-                timestamp.textContent = logEntry.timestamp;
-            } else {
-                timestamp.classList.add("missing");
-            }
             const content = lineArea.lastElementChild;
 
             // logEntry.content should already be HTMLEncoded other than the <span>s produced
@@ -128,7 +122,6 @@ function createRowTemplate() {
             <div class="line-row">
                 <span class="line-area">
                     <span class="line-number"></span>
-                    <span class="timestamp"></span>
                     <span class="content"></span>
                 </span>
             </div>

--- a/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
@@ -15,7 +15,7 @@ public class AnsiParser
     private const int DefaultForegroundCode = 39;
     private const int DefaultBackgroundCode = 49;
 
-    public ConversionResult ConvertToHtml(string? text, ParserState? priorResidualState = null)
+    public static ConversionResult ConvertToHtml(string? text, ParserState? priorResidualState = null)
     {
         var textStartIndex = -1;
         var textLength = 0;

--- a/src/Aspire.Dashboard/ConsoleLogs/LogEntry.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogEntry.cs
@@ -1,17 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 
 namespace Aspire.Dashboard.Model;
 
 internal sealed partial class LogEntry
 {
-    private static readonly Regex s_rfc3339RegEx = GenerateRfc3339RegEx();
-    private static readonly Regex s_logLevelRegEx = GenerateLogLevelRegEx();
-
     public string? Content { get; set; }
     public string? Timestamp { get; set; }
     [JsonConverter(typeof(JsonStringEnumConverter<LogEntryType>))]
@@ -20,78 +15,7 @@ internal sealed partial class LogEntry
     public Guid? ParentId { get; set; }
     public Guid Id { get; } = Guid.NewGuid();
     public string? ParentTimestamp { get; set; }
-    public bool IsFirstLine { get; private set; }
-
-    private LogEntry() { }
-
-    public static LogEntry Create(string text, LogEntryType type)
-    {
-        var encodedText = WebUtility.HtmlEncode(text);
-
-        var indexOfSpace = encodedText.IndexOf(' ');
-
-        var firstLineIndicator = indexOfSpace == -1 ? null : encodedText[..indexOfSpace];
-
-        // For right now, we only support RFC3339 timestamps, which is what (most) containers generate
-        // We can tweak this once project/executable log timestamps are finalized
-        if (firstLineIndicator is not null && s_rfc3339RegEx.IsMatch(firstLineIndicator))
-        {
-            return new() { Timestamp = firstLineIndicator, Content = encodedText[(indexOfSpace + 1)..], Type = type, IsFirstLine = true };
-        }
-        else if (firstLineIndicator is not null && s_logLevelRegEx.IsMatch(firstLineIndicator))
-        {
-            return new() { Content = encodedText, Type = type, IsFirstLine = true };
-        }
-        else
-        {
-            return new() { Content = encodedText, Type = type };
-        }
-    }
-
-    // Regular Expression for an RFC3339 timestamp, including RFC3339Nano
-    //
-    // Example timestamps:
-    // 2023-10-02T12:56:35.123456789Z
-    // 2023-10-02T13:56:35.123456789+10:00
-    // 2023-10-02T13:56:35.123456789-10:00
-    // 2023-10-02T13:56:35.123456789Z10:00
-    // 2023-10-02T13:56:35.123456Z
-    // 2023-10-02T13:56:35Z
-    //
-    // Explanation:
-    // ^                                                   - Starts the string
-    // (?:\\d{4})                                          - Four digits for the year
-    // -                                                   - Separator for the date
-    // (?:0[1-9]|1[0-2])                                   - Two digits for the month, restricted to 01-12
-    // -                                                   - Separator for the date
-    // (?:0[1-9]|[12][0-9]|3[01])                          - Two digits for the day, restricted to 01-31
-    // [T ]                                                - Literal, separator between date and time, either a T or a space
-    // (?:[01][0-9]|2[0-3])                                - Two digits for the hour, restricted to 00-23
-    // :                                                   - Separator for the time
-    // (?:[0-5][0-9])                                      - Two digits for the minutes, restricted to 00-59
-    // :                                                   - Separator for the time
-    // (?:[0-5][0-9])                                      - Two digits for the seconds, restricted to 00-59
-    // (?:\\.\\d{1,9})                                     - A period and up to nine digits for the partial seconds
-    // Z                                                   - Literal, same as +00:00
-    // (?:[Z+-](?:[01][0-9]|2[0-3]):(?:[0-5][0-9]))        - Time Zone offset, in the form ZHH:MM or +HH:MM or -HH:MM
-    // $                                                   - Ends the string
-    //
-    // Note: (?:) is a non-capturing group, since we don't care about the values, we are just interested in whether or not there is a match
-    [GeneratedRegex("^(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):(?:[0-5][0-9]):(?:[0-5][0-9])(?:\\.\\d{1,9})?(?:Z|(?:[Z+-](?:[01][0-9]|2[0-3]):(?:[0-5][0-9])))?$")]
-    private static partial Regex GenerateRfc3339RegEx();
-
-    // Regular expression that detects log levels used as indicators
-    // of the first line of a log entry, skipping any ANSI control sequences
-    // that may come first
-    //
-    // Explanation:
-    // ^                                 - Starts the string
-    // (?:\x1B\\[\\d{1,2}m)*             - Zero or more ANSI SGR Control Sequences (e.g. \x1B[32m, which means green foreground)
-    // (?:trce|dbug|info|warn|fail|crit) - One of the log level names
-    // :                                 - Literal
-    // $                                 - Ends the string
-    [GeneratedRegex("^(?:\x1B\\[\\d{1,2}m)*(?:trce|dbug|info|warn|fail|crit)(?:\u001b\\[\\d{1,2}m)*:$")]
-    private static partial Regex GenerateLogLevelRegEx();
+    public bool IsFirstLine { get; init; }    
 }
 
 internal enum LogEntryType

--- a/src/Aspire.Dashboard/ConsoleLogs/LogLevelParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogLevelParser.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+
+namespace Aspire.Dashboard.ConsoleLogs;
+
+public static partial class LogLevelParser
+{
+    private static readonly Regex s_logLevelRegEx = GenerateLogLevelRegEx();
+
+    public static bool StartsWithLogLevelHeader(string text)
+     => s_logLevelRegEx.IsMatch(text);
+
+    // Regular expression that detects log levels used as indicators
+    // of the first line of a log entry, skipping any ANSI control sequences
+    // that may come first
+    //
+    // Explanation:
+    // ^                                 - Starts the string
+    // (?:\x1B\\[\\d{1,2}m)*             - Zero or more ANSI SGR Control Sequences (e.g. \x1B[32m, which means green foreground)
+    // (?:trce|dbug|info|warn|fail|crit) - One of the log level names
+    // :                                 - Literal
+    // $                                 - Ends the string
+    [GeneratedRegex("^(?:\x1B\\[\\d{1,2}m)*(?:trce|dbug|info|warn|fail|crit)(?:\u001b\\[\\d{1,2}m)*:")]
+    private static partial Regex GenerateLogLevelRegEx();
+}

--- a/src/Aspire.Dashboard/ConsoleLogs/LogParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogParser.cs
@@ -33,12 +33,11 @@ internal sealed partial class LogParser(LogEntryType logEntryType)
         var isFirstLine = false;
         string? timestamp = null;
 
-        var timestampResult = TimestampParser.TryColorizeTimestamp(content);
-        if (timestampResult.Success)
+        if (TimestampParser.TryColorizeTimestamp(content, out var timestampParseResult))
         {
             isFirstLine = true;
-            content = timestampResult.ModifiedText;
-            timestamp = timestampResult.Timestamp;
+            content = timestampParseResult.ModifiedText;
+            timestamp = timestampParseResult.Timestamp;
         }
         // 3. Parse the content to look for info/warn/dbug header
         else if (LogLevelParser.StartsWithLogLevelHeader(content))
@@ -52,7 +51,7 @@ internal sealed partial class LogParser(LogEntryType logEntryType)
         _residualState = conversionResult.ResidualState;
 
         // 5. Parse the content to look for URLs and make them links if possible
-        if (UrlParser.Parse(content, out var modifiedText))
+        if (UrlParser.TryParse(content, out var modifiedText))
         {
             content = modifiedText;
         }

--- a/src/Aspire.Dashboard/ConsoleLogs/LogParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogParser.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using Aspire.Dashboard.Model;
+
+namespace Aspire.Dashboard.ConsoleLogs;
+
+internal sealed partial class LogParser(LogEntryType logEntryType)
+{
+    private string? _parentTimestamp;
+    private Guid? _parentId;
+    private int _lineIndex;
+    private AnsiParser.ParserState? _residualState;
+
+    public LogEntry CreateLogEntry(string rawText)
+    {
+        // Several steps to do here:
+        //
+        // 1. HTML Encode the raw text for security purposes
+        // 2. Parse the content to look for the timestamp and color it if possible
+        // 3. Parse the content to look for info/warn/dbug header
+        // 4. Parse the content to look for ANSI Control Sequences and color them if possible
+        // 5. Parse the content to look for URLs and make them links if possible
+        // 6. Create the LogEntry to get the ID
+        // 7. Set the relative properties of the log entry (parent/line index/etc)
+        // 8. Return the final result
+
+        // 1. HTML Encode the raw text for security purposes
+        var content = WebUtility.HtmlEncode(rawText);
+
+        // 2. Parse the content to look for the timestamp and color it if possible
+        var isFirstLine = false;
+        string? timestamp = null;
+
+        var timestampResult = TimestampParser.TryColorizeTimestamp(content);
+        if (timestampResult.Success)
+        {
+            isFirstLine = true;
+            content = timestampResult.ModifiedText;
+            timestamp = timestampResult.Timestamp;
+        }
+        // 3. Parse the content to look for info/warn/dbug header
+        else if (LogLevelParser.StartsWithLogLevelHeader(content))
+        {
+            isFirstLine = true;
+        }
+
+        // 4. Parse the content to look for ANSI Control Sequences and color them if possible
+        var conversionResult = AnsiParser.ConvertToHtml(content, _residualState);
+        content = conversionResult.ConvertedText;
+        _residualState = conversionResult.ResidualState;
+
+        // 5. Parse the content to look for URLs and make them links if possible
+        if (UrlParser.Parse(content, out var modifiedText))
+        {
+            content = modifiedText;
+        }
+
+        // 6. Create the LogEntry to get the ID
+        var logEntry = new LogEntry()
+        {
+            Timestamp = timestamp,
+            Content = content,
+            Type = logEntryType,
+            IsFirstLine = isFirstLine
+        };
+
+        // 7. Set the relative properties of the log entry (parent/line index/etc)
+        if (isFirstLine)
+        {
+            _parentTimestamp = logEntry.Timestamp;
+            _parentId = logEntry.Id;
+            _lineIndex = 0;
+        }
+        else if (_parentId.HasValue)
+        {
+            logEntry.ParentTimestamp = _parentTimestamp;
+            logEntry.ParentId = _parentId;
+            logEntry.LineIndex = ++_lineIndex;
+        }
+
+        // 8. Return the final result
+        return logEntry;
+    }
+}

--- a/src/Aspire.Dashboard/ConsoleLogs/TimestampParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/TimestampParser.cs
@@ -8,22 +8,23 @@ public static partial class TimestampParser
 {
     private static readonly Regex s_rfc3339RegEx = GenerateRfc3339RegEx();
 
-    public static TimestampParserResult TryColorizeTimestamp(string text)
+    public static bool TryColorizeTimestamp(string text, out TimestampParserResult result)
     {
         var match = s_rfc3339RegEx.Match(text);
 
-        var span = text.AsSpan();
-
         if (match.Success)
         {
+            var span = text.AsSpan();
             var timestamp = span[match.Index..(match.Index + match.Length)];
             var theRest = match.Index + match.Length >= span.Length ? "" : span[(match.Index + match.Length)..];
 
             var modifiedText = $"<span class=\"timestamp\">{timestamp}</span>{theRest}";
-            return new(true, modifiedText, timestamp.ToString());
+            result = new(modifiedText, timestamp.ToString());
+            return true;
         }
 
-        return new(false, null, null);
+        result = default;
+        return false;
     }
 
     // Regular Expression for an RFC3339 timestamp, including RFC3339Nano
@@ -57,5 +58,5 @@ public static partial class TimestampParser
     [GeneratedRegex("^(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):(?:[0-5][0-9]):(?:[0-5][0-9])(?:\\.\\d{1,9})?(?:Z|(?:[Z+-](?:[01][0-9]|2[0-3]):(?:[0-5][0-9])))?")]
     private static partial Regex GenerateRfc3339RegEx();
 
-    public readonly record struct TimestampParserResult(bool Success, string? ModifiedText, string? Timestamp);
+    public readonly record struct TimestampParserResult(string? ModifiedText, string? Timestamp);
 }

--- a/src/Aspire.Dashboard/ConsoleLogs/TimestampParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/TimestampParser.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+
+namespace Aspire.Dashboard.ConsoleLogs;
+public static partial class TimestampParser
+{
+    private static readonly Regex s_rfc3339RegEx = GenerateRfc3339RegEx();
+
+    public static TimestampParserResult TryColorizeTimestamp(string text)
+    {
+        var match = s_rfc3339RegEx.Match(text);
+
+        var span = text.AsSpan();
+
+        if (match.Success)
+        {
+            var timestamp = span[match.Index..(match.Index + match.Length)];
+            var theRest = match.Index + match.Length >= span.Length ? "" : span[(match.Index + match.Length)..];
+
+            var modifiedText = $"<span class=\"timestamp\">{timestamp}</span>{theRest}";
+            return new(true, modifiedText, timestamp.ToString());
+        }
+
+        return new(false, null, null);
+    }
+
+    // Regular Expression for an RFC3339 timestamp, including RFC3339Nano
+    //
+    // Example timestamps:
+    // 2023-10-02T12:56:35.123456789Z
+    // 2023-10-02T13:56:35.123456789+10:00
+    // 2023-10-02T13:56:35.123456789-10:00
+    // 2023-10-02T13:56:35.123456789Z10:00
+    // 2023-10-02T13:56:35.123456Z
+    // 2023-10-02T13:56:35Z
+    //
+    // Explanation:
+    // ^                                                   - Starts the string
+    // (?:\\d{4})                                          - Four digits for the year
+    // -                                                   - Separator for the date
+    // (?:0[1-9]|1[0-2])                                   - Two digits for the month, restricted to 01-12
+    // -                                                   - Separator for the date
+    // (?:0[1-9]|[12][0-9]|3[01])                          - Two digits for the day, restricted to 01-31
+    // [T ]                                                - Literal, separator between date and time, either a T or a space
+    // (?:[01][0-9]|2[0-3])                                - Two digits for the hour, restricted to 00-23
+    // :                                                   - Separator for the time
+    // (?:[0-5][0-9])                                      - Two digits for the minutes, restricted to 00-59
+    // :                                                   - Separator for the time
+    // (?:[0-5][0-9])                                      - Two digits for the seconds, restricted to 00-59
+    // (?:\\.\\d{1,9})                                     - A period and up to nine digits for the partial seconds
+    // Z                                                   - Literal, same as +00:00
+    // (?:[Z+-](?:[01][0-9]|2[0-3]):(?:[0-5][0-9]))        - Time Zone offset, in the form ZHH:MM or +HH:MM or -HH:MM
+    //
+    // Note: (?:) is a non-capturing group, since we don't care about the values, we are just interested in whether or not there is a match
+    [GeneratedRegex("^(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[01][0-9]|2[0-3]):(?:[0-5][0-9]):(?:[0-5][0-9])(?:\\.\\d{1,9})?(?:Z|(?:[Z+-](?:[01][0-9]|2[0-3]):(?:[0-5][0-9])))?")]
+    private static partial Regex GenerateRfc3339RegEx();
+
+    public readonly record struct TimestampParserResult(bool Success, string? ModifiedText, string? Timestamp);
+}

--- a/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
@@ -11,7 +11,7 @@ public static partial class UrlParser
 {
     private static readonly Regex s_urlRegEx = GenerateUrlRegEx();
 
-    public static bool Parse(string? text, [NotNullWhen(true)] out string? modifiedText)
+    public static bool TryParse(string? text, [NotNullWhen(true)] out string? modifiedText)
     {
         if (text is not null)
         {

--- a/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Aspire.Dashboard.ConsoleLogs;
+public static partial class UrlParser
+{
+    private static readonly Regex s_urlRegEx = GenerateUrlRegEx();
+
+    public static bool Parse(string? text, [NotNullWhen(true)] out string? modifiedText)
+    {
+        if (text is not null)
+        {
+            var urlMatch = s_urlRegEx.Match(text);
+
+            var builder = new StringBuilder(text.Length * 2);
+
+            var nextCharIndex = 0;
+            while (urlMatch.Success)
+            {
+                if (urlMatch.Index > 0)
+                {
+                    builder.Append(text[(nextCharIndex)..urlMatch.Index]);
+                }
+
+                var urlStart = urlMatch.Index;
+                nextCharIndex = urlMatch.Index + urlMatch.Length;
+                var url = text[urlStart..nextCharIndex];
+
+                builder.Append(CultureInfo.InvariantCulture, $"<a target=\"_blank\" href=\"{url}\">{url}</a>");
+                urlMatch = urlMatch.NextMatch();
+            }
+
+            if (builder.Length > 0)
+            {
+                if (nextCharIndex < text.Length)
+                {
+                    builder.Append(text[(nextCharIndex)..]);
+                }
+
+                modifiedText = builder.ToString();
+                return true;
+            }
+        }
+
+        modifiedText = null;
+        return false;
+    }
+
+    // Regular expression that detects http/https URLs in a log entry
+    // Based on the RegEx used in Windows Terminal for the same purpose, but limited
+    // to only http/https URLs
+    //
+    // Explanation:
+    // /b                             - Match must start at a word boundary (after whitespace or at the start of the text)
+    // https?://                      - http:// or https://
+    // [-A-Za-z0-9+&@#/%?=~_|$!:,.;]* - Any character in the list, matched zero or more times.
+    // [A-Za-z0-9+&@#/%=~_|$]         - Any character in the list, matched exactly once
+    [GeneratedRegex("\\bhttps?://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]")]
+    private static partial Regex GenerateUrlRegEx();
+}

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/AnsiParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/AnsiParserTests.cs
@@ -16,8 +16,7 @@ public class AnsiParserTests
     public void ConvertToHtml_ReturnsInputUnchangedIfNoCodesPresent(string input)
     {
         var expectedOutput = input;
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
     }
@@ -32,8 +31,7 @@ public class AnsiParserTests
     [InlineData("Real Text Before\x1B[2mReal Text Between\x1B[23mReal Text After", "Real Text BeforeReal Text BetweenReal Text After")]
     public void ConvertToHtml_IgnoresUnsupportedButValidCodes(string input, string expectedOutput)
     {
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(default, result.ResidualState);
@@ -45,8 +43,7 @@ public class AnsiParserTests
         var input = "\x1B[32mThis is some green text";
         var expectedOutput = "<span class=\"ansi-fg-green\">This is some green text</span>";
         var expectedResidualState = new AnsiParser.ParserState() { ForegroundColor = ConsoleColor.Green };
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(expectedResidualState, result.ResidualState);
@@ -57,8 +54,7 @@ public class AnsiParserTests
     {
         var input = "\x1B[32mThis is some green text\x1B[39m";
         var expectedOutput = "<span class=\"ansi-fg-green\">This is some green text</span>";
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(default, result.ResidualState);
@@ -69,8 +65,7 @@ public class AnsiParserTests
     {
         var input = "\x1B[32m\x1B[42mThis is some green text with a green background\x1B[39m\x1B[49m";
         var expectedOutput = "<span class=\"ansi-fg-green ansi-bg-green\">This is some green text with a green background</span>";
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(default, result.ResidualState);
@@ -81,8 +76,7 @@ public class AnsiParserTests
     {
         var input = "\x1B[32mThis is some green text\x1B[39m and this is some plain text";
         var expectedOutput = "<span class=\"ansi-fg-green\">This is some green text</span> and this is some plain text";
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(default, result.ResidualState);
@@ -93,8 +87,7 @@ public class AnsiParserTests
     {
         var input = "\x1B[32mGreen text\x1B[39m Plain text\x1B[42m Green background\x1B[49m";
         var expectedOutput = "<span class=\"ansi-fg-green\">Green text</span> Plain text<span class=\"ansi-bg-green\"> Green background</span>";
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(default, result.ResidualState);
@@ -105,8 +98,7 @@ public class AnsiParserTests
     {
         var input = "\x1B[32mGreen text\x1B[42m Green text Green background\x1B[39m Green background\x1B[49m";
         var expectedOutput = "<span class=\"ansi-fg-green\">Green text</span><span class=\"ansi-fg-green ansi-bg-green\"> Green text Green background</span><span class=\"ansi-bg-green\"> Green background</span>";
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(default, result.ResidualState);
@@ -119,9 +111,8 @@ public class AnsiParserTests
         var input2 = "This is some more green text\u001b[39m";
         var expectedOutput1 = "<span class=\"ansi-fg-green\">This is some green text</span>";
         var expectedOutput2 = "<span class=\"ansi-fg-green\">This is some more green text</span>";
-        var parser = new AnsiParser();
-        var result1 = parser.ConvertToHtml(input1);
-        var result2 = parser.ConvertToHtml(input2, result1.ResidualState);
+        var result1 = AnsiParser.ConvertToHtml(input1);
+        var result2 = AnsiParser.ConvertToHtml(input2, result1.ResidualState);
 
         Assert.Equal(expectedOutput1, result1.ConvertedText);
         Assert.Equal(new AnsiParser.ParserState() { ForegroundColor = ConsoleColor.Green }, result1.ResidualState);
@@ -136,9 +127,8 @@ public class AnsiParserTests
         var input2 = "Green background\x1B[39m Green background\x1B[49m";
         var expectedOutput1 = "<span class=\"ansi-fg-green\">Green text</span><span class=\"ansi-fg-green ansi-bg-green\"> Green text</span>";
         var expectedOutput2 = "<span class=\"ansi-fg-green ansi-bg-green\">Green background</span><span class=\"ansi-bg-green\"> Green background</span>";
-        var parser = new AnsiParser();
-        var result1 = parser.ConvertToHtml(input1);
-        var result2 = parser.ConvertToHtml(input2, result1.ResidualState);
+        var result1 = AnsiParser.ConvertToHtml(input1);
+        var result2 = AnsiParser.ConvertToHtml(input2, result1.ResidualState);
 
         Assert.Equal(expectedOutput1, result1.ConvertedText);
         Assert.Equal(new AnsiParser.ParserState() { ForegroundColor = ConsoleColor.Green, BackgroundColor = ConsoleColor.Green }, result1.ResidualState);
@@ -165,8 +155,7 @@ public class AnsiParserTests
     [InlineData("\x1B[1m\x1B[37mBright White\x1B[22m\x1B[39m", "<span class=\"ansi-fg-brightwhite\">Bright White</span>")]
     public void ConvertToHtml_ForegroundColorSupport(string input, string expectedOutput)
     {
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(default, result.ResidualState);
@@ -183,8 +172,7 @@ public class AnsiParserTests
     [InlineData("\x1B[47mWhite\x1B[49m", "<span class=\"ansi-bg-white\">White</span>")]
     public void ConvertToHtml_BackgroundColorSupport(string input, string expectedOutput)
     {
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(default, result.ResidualState);
@@ -196,8 +184,7 @@ public class AnsiParserTests
         var input = "\x1B[1m\x1B[32m\x1B[42mBright Green Text on Green Background\x1B[22mNo Longer Bright";
         var expectedOutput = "<span class=\"ansi-fg-brightgreen ansi-bg-green\">Bright Green Text on Green Background</span><span class=\"ansi-fg-green ansi-bg-green\">No Longer Bright</span>";
         var expectedResidualState = new AnsiParser.ParserState() {  ForegroundColor = ConsoleColor.Green, BackgroundColor = ConsoleColor.Green };
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(expectedResidualState, result.ResidualState);
@@ -209,8 +196,7 @@ public class AnsiParserTests
         var input = "\x1B[1m\x1B[32m\x1B[42mBright Green Text on Green Background\x1B[39mNo Longer Green Text";
         var expectedOutput = "<span class=\"ansi-fg-brightgreen ansi-bg-green\">Bright Green Text on Green Background</span><span class=\"ansi-bg-green\">No Longer Green Text</span>";
         var expectedResidualState = new AnsiParser.ParserState() { Bright = true, BackgroundColor = ConsoleColor.Green };
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(expectedResidualState, result.ResidualState);
@@ -222,8 +208,7 @@ public class AnsiParserTests
         var input = "\x1B[1m\x1B[32m\x1B[42mBright Green Text on Green Background\x1B[49mNo Longer Green Background";
         var expectedOutput = "<span class=\"ansi-fg-brightgreen ansi-bg-green\">Bright Green Text on Green Background</span><span class=\"ansi-fg-brightgreen\">No Longer Green Background</span>";
         var expectedResidualState = new AnsiParser.ParserState() { Bright = true, ForegroundColor = ConsoleColor.Green };
-        var parser = new AnsiParser();
-        var result = parser.ConvertToHtml(input);
+        var result = AnsiParser.ConvertToHtml(input);
 
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(expectedResidualState, result.ResidualState);

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogLevelParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogLevelParserTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.ConsoleLogs;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.ConsoleLogsTests;
+
+public class LogLevelParserTests
+{
+    [Theory]
+    [InlineData("", false)]
+    [InlineData(" ", false)]
+    [InlineData("This is some text without any log level", false)]
+    [InlineData("This is some text that does not start with a log level info", false)]
+    [InlineData("crit:", true)]
+    [InlineData("dbug:", true)]
+    [InlineData("fail:", true)]
+    [InlineData("info:", true)]
+    [InlineData("trce:", true)]
+    [InlineData("warn:", true)]
+    [InlineData("\x1B[32minfo\x1B[39m:", true)]
+    public void StartsWithLogLevel_ReturnsCorrectResult(string input, bool expectedResult)
+    {
+        var result = LogLevelParser.StartsWithLogLevelHeader(input);
+
+        Assert.Equal(expectedResult, result);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/TimestampParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/TimestampParserTests.cs
@@ -14,9 +14,9 @@ public class TimestampParserTests
     [InlineData("This is some text without any timestamp")]
     public void TryColorizeTimestamp_DoesNotStartWithTimestamp_ReturnsFalse(string input)
     {
-        var result = TimestampParser.TryColorizeTimestamp(input);
+        var result = TimestampParser.TryColorizeTimestamp(input, out var _);
 
-        Assert.False(result.Success);
+        Assert.False(result);
     }
 
     [Theory]
@@ -26,11 +26,11 @@ public class TimestampParserTests
     [InlineData("With some text before it 2023-10-10T15:05:30.123456789Z", false, null, null)]
     public void TryColorizeTimestamp_ReturnsCorrectResult(string input, bool expectedResult, string? expectedOutput, string? expectedTimestamp)
     {
-        var result = TimestampParser.TryColorizeTimestamp(input);
+        var result = TimestampParser.TryColorizeTimestamp(input, out var parseResult);
 
-        Assert.Equal(expectedResult, result.Success);
-        Assert.Equal(expectedOutput, result.ModifiedText);
-        Assert.Equal(expectedTimestamp, result.Timestamp);
+        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedOutput, parseResult.ModifiedText);
+        Assert.Equal(expectedTimestamp, parseResult.Timestamp);
     }
 
     [Theory]
@@ -49,8 +49,8 @@ public class TimestampParserTests
     [InlineData("2023-10-10T15:05:30.123456789")]
     public void TryColorizeTimestamp_SupportedTimestampFormats(string input)
     {
-        var result = TimestampParser.TryColorizeTimestamp(input);
+        var result = TimestampParser.TryColorizeTimestamp(input, out var _);
 
-        Assert.True(result.Success);
+        Assert.True(result);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/TimestampParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/TimestampParserTests.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.ConsoleLogs;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.ConsoleLogsTests;
+
+public class TimestampParserTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("This is some text without any timestamp")]
+    public void TryColorizeTimestamp_DoesNotStartWithTimestamp_ReturnsFalse(string input)
+    {
+        var result = TimestampParser.TryColorizeTimestamp(input);
+
+        Assert.False(result.Success);
+    }
+
+    [Theory]
+    [InlineData("2023-10-10T15:05:30.123456789Z", true, "<span class=\"timestamp\">2023-10-10T15:05:30.123456789Z</span>", "2023-10-10T15:05:30.123456789Z")]
+    [InlineData("2023-10-10T15:05:30.123456789Z ", true, "<span class=\"timestamp\">2023-10-10T15:05:30.123456789Z</span> ", "2023-10-10T15:05:30.123456789Z")]
+    [InlineData("2023-10-10T15:05:30.123456789Z with some text after it", true, "<span class=\"timestamp\">2023-10-10T15:05:30.123456789Z</span> with some text after it", "2023-10-10T15:05:30.123456789Z")]
+    [InlineData("With some text before it 2023-10-10T15:05:30.123456789Z", false, null, null)]
+    public void TryColorizeTimestamp_ReturnsCorrectResult(string input, bool expectedResult, string? expectedOutput, string? expectedTimestamp)
+    {
+        var result = TimestampParser.TryColorizeTimestamp(input);
+
+        Assert.Equal(expectedResult, result.Success);
+        Assert.Equal(expectedOutput, result.ModifiedText);
+        Assert.Equal(expectedTimestamp, result.Timestamp);
+    }
+
+    [Theory]
+    [InlineData("2023-10-10T15:05:30.123456789Z")]
+    [InlineData("2023-10-10T15:05:30.12345678Z")]
+    [InlineData("2023-10-10T15:05:30.1234567Z")]
+    [InlineData("2023-10-10T15:05:30.123456Z")]
+    [InlineData("2023-10-10T15:05:30.12345Z")]
+    [InlineData("2023-10-10T15:05:30.1234Z")]
+    [InlineData("2023-10-10T15:05:30.123Z")]
+    [InlineData("2023-10-10T15:05:30.12Z")]
+    [InlineData("2023-10-10T15:05:30.1Z")]
+    [InlineData("2023-10-10T15:05:30Z")]
+    [InlineData("2023-10-10T15:05:30.123456789+12:59")]
+    [InlineData("2023-10-10T15:05:30.123456789-12:59")]
+    [InlineData("2023-10-10T15:05:30.123456789")]
+    public void TryColorizeTimestamp_SupportedTimestampFormats(string input)
+    {
+        var result = TimestampParser.TryColorizeTimestamp(input);
+
+        Assert.True(result.Success);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.ConsoleLogs;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.ConsoleLogsTests;
+
+public class UrlParserTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("This is some text without any urls")]
+    public void Parse_NoUrl_ReturnsFalse(string input)
+    {
+        var result = UrlParser.Parse(input, out var _);
+
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("This is some text with a URL at the end: https://bing.com/", true, "This is some text with a URL at the end: <a target=\"_blank\" href=\"https://bing.com/\">https://bing.com/</a>")]
+    [InlineData("https://bing.com/ This is some text with a URL at the beginning", true, "<a target=\"_blank\" href=\"https://bing.com/\">https://bing.com/</a> This is some text with a URL at the beginning")]
+    [InlineData("This is some text with a https://bing.com/ in the middle", true, "This is some text with a <a target=\"_blank\" href=\"https://bing.com/\">https://bing.com/</a> in the middle")]
+    public void Parse_ReturnsCorrectResult(string input, bool expectedResult, string? expectedOutput)
+    {
+        var result = UrlParser.Parse(input, out var modifiedText);
+
+        Assert.Equal(expectedResult, result);
+        Assert.Equal(expectedOutput, modifiedText);
+    }
+
+    [Theory]
+    [InlineData("http://bing.com", "<a target=\"_blank\" href=\"http://bing.com\">http://bing.com</a>")]
+    [InlineData("https://bing.com", "<a target=\"_blank\" href=\"https://bing.com\">https://bing.com</a>")]
+    [InlineData("http://www.bing.com", "<a target=\"_blank\" href=\"http://www.bing.com\">http://www.bing.com</a>")]
+    [InlineData("http://bing.com/", "<a target=\"_blank\" href=\"http://bing.com/\">http://bing.com/</a>")]
+    [InlineData("http://bing.com/dir", "<a target=\"_blank\" href=\"http://bing.com/dir\">http://bing.com/dir</a>")]
+    [InlineData("http://bing.com/index.aspx", "<a target=\"_blank\" href=\"http://bing.com/index.aspx\">http://bing.com/index.aspx</a>")]
+    [InlineData("http://bing", "<a target=\"_blank\" href=\"http://bing\">http://bing</a>")]
+    public void Parse_SupportedUrlFormats(string input, string? expectedOutput)
+    {
+        var result = UrlParser.Parse(input, out var modifiedText);
+
+        Assert.True(result);
+        Assert.Equal(expectedOutput, modifiedText);
+    }
+
+    [Theory]
+    [InlineData("file:///c:/windows/system32/calc.exe")]
+    [InlineData("ftp://ftp.localhost.com/")]
+    [InlineData("ftp://user:pass@ftp.localhost.com/")]
+    public void Parse_UnsupportedUrlFormats(string input)
+    {
+        var result = UrlParser.Parse(input, out var _);
+
+        Assert.False(result);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
@@ -13,9 +13,9 @@ public class UrlParserTests
     [InlineData("")]
     [InlineData(" ")]
     [InlineData("This is some text without any urls")]
-    public void Parse_NoUrl_ReturnsFalse(string input)
+    public void TryParse_NoUrl_ReturnsFalse(string input)
     {
-        var result = UrlParser.Parse(input, out var _);
+        var result = UrlParser.TryParse(input, out var _);
 
         Assert.False(result);
     }
@@ -24,9 +24,9 @@ public class UrlParserTests
     [InlineData("This is some text with a URL at the end: https://bing.com/", true, "This is some text with a URL at the end: <a target=\"_blank\" href=\"https://bing.com/\">https://bing.com/</a>")]
     [InlineData("https://bing.com/ This is some text with a URL at the beginning", true, "<a target=\"_blank\" href=\"https://bing.com/\">https://bing.com/</a> This is some text with a URL at the beginning")]
     [InlineData("This is some text with a https://bing.com/ in the middle", true, "This is some text with a <a target=\"_blank\" href=\"https://bing.com/\">https://bing.com/</a> in the middle")]
-    public void Parse_ReturnsCorrectResult(string input, bool expectedResult, string? expectedOutput)
+    public void TryParse_ReturnsCorrectResult(string input, bool expectedResult, string? expectedOutput)
     {
-        var result = UrlParser.Parse(input, out var modifiedText);
+        var result = UrlParser.TryParse(input, out var modifiedText);
 
         Assert.Equal(expectedResult, result);
         Assert.Equal(expectedOutput, modifiedText);
@@ -40,9 +40,9 @@ public class UrlParserTests
     [InlineData("http://bing.com/dir", "<a target=\"_blank\" href=\"http://bing.com/dir\">http://bing.com/dir</a>")]
     [InlineData("http://bing.com/index.aspx", "<a target=\"_blank\" href=\"http://bing.com/index.aspx\">http://bing.com/index.aspx</a>")]
     [InlineData("http://bing", "<a target=\"_blank\" href=\"http://bing\">http://bing</a>")]
-    public void Parse_SupportedUrlFormats(string input, string? expectedOutput)
+    public void TryParse_SupportedUrlFormats(string input, string? expectedOutput)
     {
-        var result = UrlParser.Parse(input, out var modifiedText);
+        var result = UrlParser.TryParse(input, out var modifiedText);
 
         Assert.True(result);
         Assert.Equal(expectedOutput, modifiedText);
@@ -52,9 +52,9 @@ public class UrlParserTests
     [InlineData("file:///c:/windows/system32/calc.exe")]
     [InlineData("ftp://ftp.localhost.com/")]
     [InlineData("ftp://user:pass@ftp.localhost.com/")]
-    public void Parse_UnsupportedUrlFormats(string input)
+    public void TryParse_UnsupportedUrlFormats(string input)
     {
-        var result = UrlParser.Parse(input, out var _);
+        var result = UrlParser.TryParse(input, out var _);
 
         Assert.False(result);
     }


### PR DESCRIPTION
Resolves #209 

In looking to address #209 it was obvious that the log parsing was becoming more complicated that it should have been at its particular call site. So I split it off into testable classes and added URL parsing as part of that.

The only user-visible change here is the addition of clickable URLs in the logs. 