### PR TITLE
Delay connection validation

### DIFF
--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
@@ -7,7 +7,6 @@ using Azure.Core;
 using Azure.Core.Extensions;
 using Azure.Storage.Queues;
 using HealthChecks.Azure.Storage.Queues;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -61,13 +60,20 @@ public static class AspireQueueStorageExtensions
 
     private sealed class StorageQueueComponent : AzureComponent<AzureStorageQueuesSettings, QueueServiceClient, QueueClientOptions>
     {
-        protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings)
+        protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings, string connectionName, string configurationSectionName)
         {
-            var connectionString = settings.ConnectionString;
+            return azureFactoryBuilder.RegisterClientFactory<QueueServiceClient, QueueClientOptions>((options, cred) =>
+            {
+                var connectionString = settings.ConnectionString;
+                if (string.IsNullOrEmpty(connectionString) && settings.ServiceUri is null)
+                {
+                    throw new InvalidOperationException($"A QueueServiceClient could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{connectionName}' or specify a 'ConnectionString' or 'ServiceUri' in the '{configurationSectionName}' configuration section.");
+                }
 
-            return !string.IsNullOrEmpty(connectionString) ?
-                azureFactoryBuilder.AddQueueServiceClient(connectionString) :
-                azureFactoryBuilder.AddQueueServiceClient(settings.ServiceUri);
+                return !string.IsNullOrEmpty(connectionString) ? new QueueServiceClient(connectionString, options) :
+                    cred is not null ? new QueueServiceClient(settings.ServiceUri, cred, options) :
+                    new QueueServiceClient(settings.ServiceUri, options);
+            }, requiresCredential: false);
         }
 
         protected override IHealthCheck CreateHealthCheck(QueueServiceClient client, AzureStorageQueuesSettings settings)
@@ -81,13 +87,5 @@ public static class AspireQueueStorageExtensions
 
         protected override bool GetTracingEnabled(AzureStorageQueuesSettings settings)
             => settings.Tracing;
-
-        protected override void Validate(AzureStorageQueuesSettings settings, string connectionName, string configurationSectionName)
-        {
-            if (string.IsNullOrEmpty(settings.ConnectionString) && settings.ServiceUri is null)
-            {
-                throw new InvalidOperationException($"A QueueServiceClient could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{connectionName}' or specify a 'ConnectionString' or 'ServiceUri' in the '{configurationSectionName}' configuration section.");
-            }
-        }
     }
 }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AspireSqlServerEFCoreSqlClientExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AspireSqlServerEFCoreSqlClientExtensions.cs
@@ -56,11 +56,6 @@ public static class AspireSqlServerEFCoreSqlClientExtensions
 
         configureSettings?.Invoke(settings);
 
-        if (string.IsNullOrEmpty(settings.ConnectionString))
-        {
-            throw new InvalidOperationException($"ConnectionString is missing. It should be provided in 'ConnectionStrings:{connectionName}' or under the 'ConnectionString' key in '{DefaultConfigSectionName}' or '{typeSpecificSectionName}' configuration section.");
-        }
-
         if (settings.DbContextPooling)
         {
             builder.Services.AddDbContextPool<TContext>(ConfigureDbContext);
@@ -102,6 +97,11 @@ public static class AspireSqlServerEFCoreSqlClientExtensions
             // https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontextoptionsbuilder.useloggerfactory?view=efcore-7.0#remarks
             dbContextOptionsBuilder.UseSqlServer(settings.ConnectionString, builder =>
             {
+                if (string.IsNullOrEmpty(settings.ConnectionString))
+                {
+                    throw new InvalidOperationException($"ConnectionString is missing. It should be provided in 'ConnectionStrings:{connectionName}' or under the 'ConnectionString' key in '{DefaultConfigSectionName}' or '{typeSpecificSectionName}' configuration section.");
+                }
+
                 // Resiliency:
                 // Connection resiliency automatically retries failed database commands
                 if (settings.MaxRetryCount > 0)

--- a/src/Components/Common/AzureComponent.cs
+++ b/src/Components/Common/AzureComponent.cs
@@ -27,9 +27,7 @@ internal abstract class AzureComponent<TSettings, TClient, TClientOptions>
 
     protected abstract TokenCredential? GetTokenCredential(TSettings settings);
 
-    protected abstract void Validate(TSettings settings, string connectionName, string configurationSectionName);
-
-    protected abstract IAzureClientBuilder<TClient, TClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, TSettings settings)
+    protected abstract IAzureClientBuilder<TClient, TClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, TSettings settings, string connectionName, string configurationSectionName)
         where TBuilder : IAzureClientFactoryBuilder, IAzureClientFactoryBuilderWithCredential;
 
     protected abstract IHealthCheck CreateHealthCheck(TClient client, TSettings settings);
@@ -61,8 +59,6 @@ internal abstract class AzureComponent<TSettings, TClient, TClientOptions>
 
         configureSettings?.Invoke(settings);
 
-        Validate(settings, connectionName, configurationSectionName);
-
         if (!string.IsNullOrEmpty(serviceKey))
         {
             // When named client registration is used (.WithName), Microsoft.Extensions.Azure
@@ -77,7 +73,7 @@ internal abstract class AzureComponent<TSettings, TClient, TClientOptions>
 
         builder.Services.AddAzureClients(azureFactoryBuilder =>
         {
-            var secretClientBuilder = AddClient(azureFactoryBuilder, settings);
+            var secretClientBuilder = AddClient(azureFactoryBuilder, settings, connectionName, configurationSectionName);
 
             if (GetTokenCredential(settings) is { } credential)
             {

--- a/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
@@ -353,6 +353,28 @@ public abstract class ConformanceTests<TService, TOptions>
         }
     }
 
+    /// <summary>
+    /// Ensures that when the connection information is missing, an exception isn't thrown before the host
+    /// is built, so any exception can be logged with ILogger.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ConnectionInformationIsDelayValidated(bool useKey)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        string? key = useKey ? "key" : null;
+        RegisterComponent(builder, key: key);
+
+        using var host = builder.Build();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            key is null
+                ? host.Services.GetRequiredService<TService>()
+                : host.Services.GetRequiredKeyedService<TService>(key));
+    }
+
     private static string GetRepoRoot()
     {
         string directory = AppContext.BaseDirectory;

--- a/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
@@ -362,6 +362,8 @@ public abstract class ConformanceTests<TService, TOptions>
     [InlineData(false)]
     public void ConnectionInformationIsDelayValidated(bool useKey)
     {
+        SetupConnectionInformationIsDelayValidated();
+
         var builder = Host.CreateEmptyApplicationBuilder(null);
 
         string? key = useKey ? "key" : null;
@@ -386,6 +388,8 @@ public abstract class ConformanceTests<TService, TOptions>
 
         return directory!;
     }
+
+    protected virtual void SetupConnectionInformationIsDelayValidated() { }
 
     // This method can have side effects (setting AppContext switch, enabling activity source by name).
     // That is why it needs to be executed in a standalone process.

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests_Pooling.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests_Pooling.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using Aspire.Components.Common.Tests;
 using Aspire.Components.ConformanceTests;
 using Microsoft.AspNetCore.Diagnostics;
@@ -106,6 +107,18 @@ public class ConformanceTests_Pooling : ConformanceTests<TestDbContext, NpgsqlEn
         {
             service.Database.EnsureCreated();
         }
+    }
+
+    // workaround https://github.com/npgsql/efcore.pg/issues/2891 by clearing the cache so the test is fresh
+    protected override void SetupConnectionInformationIsDelayValidated()
+    {
+#pragma warning disable EF1001 // Internal EF Core API usage.
+        var cache = (IDictionary)typeof(ServiceProviderCache)
+            .GetField("_configurations", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(ServiceProviderCache.Instance)!;
+#pragma warning restore EF1001 // Internal EF Core API usage.
+
+        cache.Clear();
     }
 
     [Theory]


### PR DESCRIPTION
When an app is deployed to a new environment, it is common for the connection information to be missing initially. When this is the case, the app crashes very early (inline when calling AddXXX for the component). When throwing this early, there isn't an ILogger which can log the exception, and thus the exception is written to stderr/stdout by the .NET runtime. This isn't ideal since certain environments expect stdout logs to be in a certain format.

The fix is to delay the connection validation until the underlying DI service is requested/created. At this point the DI container is built, and the app can log an exception with the configured ILogger.

Fix #185