### PR TITLE
Hide global environment variables by default

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/EnvironmentVariables.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/EnvironmentVariables.razor
@@ -1,11 +1,19 @@
 ﻿@using Aspire.Dashboard.Model
-@implements IDialogContentComponent<List<EnvironmentVariableViewModel>>
+@implements IDialogContentComponent<EnvironmentVariablesDialogViewModel>
 @inject IJSRuntime JS
 
 <FluentDialogBody>
     <div class="GridContainer">
         <FluentStack Orientation="Orientation.Vertical">
             <FluentToolbar Orientation="Orientation.Horizontal">
+                @if (Content?.ShowSpecOnlyToggle == true)
+                {
+                    <FluentButton Appearance="Appearance.Lightweight"
+                                  IconEnd="@(_showAll ? _showSpecOnlyIcon : _showAllIcon)"
+                                  Title="@(_showAll ? "Show Spec Only" : "Show All")"
+                                  OnClick="() => _showAll = !_showAll"
+                                  slot="end" />
+                }
                 <FluentButton Appearance="Appearance.Lightweight"
                               IconEnd="@(_defaultMasked ? _unmaskIcon : _maskIcon)"
                               Title="@(_defaultMasked ? "Show Values" : "Hide Values")"

--- a/src/Aspire.Dashboard/Components/Dialogs/EnvironmentVariables.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/EnvironmentVariables.razor.cs
@@ -11,12 +11,15 @@ public partial class EnvironmentVariables
 {
 
     [Parameter]
-    public List<EnvironmentVariableViewModel>? Content { get; set; }
+    public EnvironmentVariablesDialogViewModel? Content { get; set; }
+
+    private bool _showAll;
 
     private IQueryable<EnvironmentVariableViewModel>? FilteredItems =>
-        Content?.Where(vm =>
-            vm.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) ||
-            vm.Value?.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true
+        Content?.EnvironmentVariables?.Where(vm =>
+            (_showAll || vm.FromSpec) &&
+            (vm.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) ||
+            vm.Value?.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true)
         )?.AsQueryable();
 
     private const string PreCopyText = "Copy to clipboard";
@@ -27,6 +30,8 @@ public partial class EnvironmentVariables
 
     private readonly Icon _maskIcon = new Icons.Regular.Size16.EyeOff();
     private readonly Icon _unmaskIcon = new Icons.Regular.Size16.Eye();
+    private readonly Icon _showSpecOnlyIcon = new Icons.Regular.Size16.DocumentHeader();
+    private readonly Icon _showAllIcon = new Icons.Regular.Size16.DocumentOnePage();
 
     private readonly GridSort<EnvironmentVariableViewModel> _nameSort = GridSort<EnvironmentVariableViewModel>.ByAscending(vm => vm.Name);
     private readonly GridSort<EnvironmentVariableViewModel> _valueSort = GridSort<EnvironmentVariableViewModel>.ByAscending(vm => vm.Value);
@@ -36,7 +41,7 @@ public partial class EnvironmentVariables
         _defaultMasked = !_defaultMasked;
         if (Content is not null)
         {
-            foreach (var vm in Content)
+            foreach (var vm in Content.EnvironmentVariables)
             {
                 vm.IsValueMasked = _defaultMasked;
             }
@@ -66,9 +71,9 @@ public partial class EnvironmentVariables
     {
         if (Content is not null)
         {
-            bool foundMasked = false;
-            bool foundUnmasked = false;
-            foreach (var vm in Content)
+            var foundMasked = false;
+            var foundUnmasked = false;
+            foreach (var vm in Content.EnvironmentVariables)
             {
                 foundMasked |= vm.IsValueMasked;
                 foundUnmasked |= !vm.IsValueMasked;

--- a/src/Aspire.Dashboard/Components/Pages/Containers.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Containers.razor
@@ -65,4 +65,6 @@
         || resource.Image.Contains(filter, StringComparison.CurrentCultureIgnoreCase);
 
     private GridSort<ContainerViewModel> imageSort = GridSort<ContainerViewModel>.ByAscending(c => c.Image);
+
+    protected override bool ShowSpecOnlyToggle => false;
 }

--- a/src/Aspire.Dashboard/Components/Pages/ResourcesListBase.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ResourcesListBase.cs
@@ -22,6 +22,7 @@ public abstract class ResourcesListBase<TResource> : ComponentBase
         IEnumerable<NamespacedName> initialList,
         CancellationToken cancellationToken);
     protected abstract bool Filter(TResource resource);
+    protected virtual bool ShowSpecOnlyToggle => true;
 
     private readonly Dictionary<string, TResource> _resourcesMap = new();
     private readonly CancellationTokenSource _watchTaskCancellationTokenSource = new();
@@ -53,7 +54,11 @@ public abstract class ResourcesListBase<TResource> : ComponentBase
     {
         await EnvironmentVariablesDialogService.ShowDialogAsync(
             source: resource.Name,
-            variables: resource.Environment
+            viewModel: new()
+            {
+                EnvironmentVariables = resource.Environment,
+                ShowSpecOnlyToggle = ShowSpecOnlyToggle
+            }
         );
     }
 

--- a/src/Aspire.Dashboard/Model/EnvironmentVariableViewModel.cs
+++ b/src/Aspire.Dashboard/Model/EnvironmentVariableViewModel.cs
@@ -8,4 +8,5 @@ public sealed class EnvironmentVariableViewModel
     public required string Name { get; init; }
     public string? Value { get; init; }
     public bool IsValueMasked { get; set; } = true;
+    public bool FromSpec { get; set; }
 }

--- a/src/Aspire.Dashboard/Model/EnvironmentVariablesDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/EnvironmentVariablesDialogViewModel.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public class EnvironmentVariablesDialogViewModel
+{
+    public required List<EnvironmentVariableViewModel> EnvironmentVariables { get; init; }
+    public bool ShowSpecOnlyToggle { get; set; }
+}

--- a/src/Aspire.Dashboard/Services/EnvironmentVariablesDialogService.cs
+++ b/src/Aspire.Dashboard/Services/EnvironmentVariablesDialogService.cs
@@ -9,7 +9,7 @@ namespace Aspire.Dashboard.Services;
 
 public sealed class EnvironmentVariablesDialogService(IDialogService dialogService)
 {
-    public async Task ShowDialogAsync(string source, List<EnvironmentVariableViewModel> variables)
+    public async Task ShowDialogAsync(string source, EnvironmentVariablesDialogViewModel viewModel)
     {
         DialogParameters parameters = new()
         {
@@ -23,6 +23,6 @@ public sealed class EnvironmentVariablesDialogService(IDialogService dialogServi
             Height = "auto"
         };
 
-        _ = await dialogService.ShowDialogAsync<EnvironmentVariables>(variables, parameters).ConfigureAwait(true);
+        _ = await dialogService.ShowDialogAsync<EnvironmentVariables>(viewModel, parameters).ConfigureAwait(true);
     }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
@@ -149,7 +149,7 @@ public class DashboardViewModelService : IDashboardViewModelService, IDisposable
 
         if (container.Spec.Env is not null)
         {
-            FillEnvironmentVariables(model.Environment, container.Spec.Env);
+            FillEnvironmentVariables(model.Environment, container.Spec.Env, container.Spec.Env);
         }
 
         return model;
@@ -171,7 +171,7 @@ public class DashboardViewModelService : IDashboardViewModelService, IDisposable
 
         if (executable.Status?.EffectiveEnv is not null)
         {
-            FillEnvironmentVariables(model.Environment, executable.Status.EffectiveEnv);
+            FillEnvironmentVariables(model.Environment, executable.Status.EffectiveEnv, executable.Spec.Env);
         }
 
         return model;
@@ -222,7 +222,7 @@ public class DashboardViewModelService : IDashboardViewModelService, IDisposable
 
         if (executable.Status?.EffectiveEnv is not null)
         {
-            FillEnvironmentVariables(model.Environment, executable.Status.EffectiveEnv);
+            FillEnvironmentVariables(model.Environment, executable.Status.EffectiveEnv, executable.Spec.Env);
         }
 
         return model;
@@ -242,16 +242,17 @@ public class DashboardViewModelService : IDashboardViewModelService, IDisposable
             _ => ObjectChangeType.Other
         };
 
-    private static void FillEnvironmentVariables(List<EnvironmentVariableViewModel> target, List<EnvVar> source)
+    private static void FillEnvironmentVariables(List<EnvironmentVariableViewModel> target, List<EnvVar> effectiveSource, List<EnvVar>? specSource)
     {
-        foreach (var env in source)
+        foreach (var env in effectiveSource)
         {
             if (env.Name is not null)
             {
                 target.Add(new()
                 {
                     Name = env.Name,
-                    Value = env.Value
+                    Value = env.Value,
+                    FromSpec = specSource?.Any(e => string.Equals(e.Name, env.Name, StringComparison.Ordinal)) == true
                 });
             }
         }


### PR DESCRIPTION
1. Adds a flag to the environment variables viewmodel specifying whether it is a spec variable or a global one. Values are always taken from the effective list regardless.
2. By default, environment variables dialog shows only the ones from spec.
3. Adds a toggle at the top of the dialog to switch between spec-only and all. 
4. Hides the toggle on containers, where there's (currently) no difference

Resolves #167 