### PR TITLE
Adding Dependency flow for new DCP versions that are available

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,7 @@
     <BuildArch Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86' ">386</BuildArch>
     <BuildArch Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64' ">arm64</BuildArch>
     <BuildArch Condition=" '$(BuildArch)' == '' ">amd64</BuildArch>
-    <DcpDir>$(NuGetPackageRoot)Microsoft.DeveloperControlPlane.$(BuildOs)-$(BuildArch)/$(_DcpVersion)/tools/</DcpDir>
+    <DcpDir>$(NuGetPackageRoot)Microsoft.DeveloperControlPlane.$(BuildOs)-$(BuildArch)/$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)/tools/</DcpDir>
   </PropertyGroup>
 
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.1.35-rc.0">
+      <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
+      <Sha>2d5f3a1fe63e53b0bf553280f420ee0da9bac3ff</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.1.35-rc.0">
+      <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
+      <Sha>2d5f3a1fe63e53b0bf553280f420ee0da9bac3ff</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.1.35-rc.0">
+      <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
+      <Sha>2d5f3a1fe63e53b0bf553280f420ee0da9bac3ff</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.1.35-rc.0">
+      <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
+      <Sha>2d5f3a1fe63e53b0bf553280f420ee0da9bac3ff</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.1.35-rc.0">
+      <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
+      <Sha>2d5f3a1fe63e53b0bf553280f420ee0da9bac3ff</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.1.35-rc.0">
+      <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
+      <Sha>2d5f3a1fe63e53b0bf553280f420ee0da9bac3ff</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.1.35-rc.0">
+      <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
+      <Sha>2d5f3a1fe63e53b0bf553280f420ee0da9bac3ff</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23463.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,13 @@
   <PropertyGroup>
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rc.1.23422.1</MicrosoftDotnetSdkInternalPackageVersion>
-    <_DcpVersion>0.1.35-rc.0</_DcpVersion>
+    <MicrosoftDeveloperControlPlanedarwinamd64PackageVersion>0.1.35-rc.0</MicrosoftDeveloperControlPlanedarwinamd64PackageVersion>
+    <MicrosoftDeveloperControlPlanedarwinarm64PackageVersion>0.1.35-rc.0</MicrosoftDeveloperControlPlanedarwinarm64PackageVersion>
+    <MicrosoftDeveloperControlPlanelinuxamd64PackageVersion>0.1.35-rc.0</MicrosoftDeveloperControlPlanelinuxamd64PackageVersion>
+    <MicrosoftDeveloperControlPlanelinuxarm64PackageVersion>0.1.35-rc.0</MicrosoftDeveloperControlPlanelinuxarm64PackageVersion>
+    <MicrosoftDeveloperControlPlanewindows386PackageVersion>0.1.35-rc.0</MicrosoftDeveloperControlPlanewindows386PackageVersion>
+    <MicrosoftDeveloperControlPlanewindowsamd64PackageVersion>0.1.35-rc.0</MicrosoftDeveloperControlPlanewindowsamd64PackageVersion>
+    <MicrosoftDeveloperControlPlanewindowsarm64PackageVersion>0.1.35-rc.0</MicrosoftDeveloperControlPlanewindowsarm64PackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>8.0.0-rc.1.23419.3</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftmacOSSdkPackageVersion>13.3.8825-net8-rc1</MicrosoftmacOSSdkPackageVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>8.0.0-beta.23463.1</MicrosoftDotNetBuildTasksPackagingVersion>

--- a/eng/dcppack/dcppack.csproj
+++ b/eng/dcppack/dcppack.csproj
@@ -26,13 +26,13 @@
 
   <!-- Package downloads to DCP packages as we need to repack the binaries from them -->
   <ItemGroup>
-    <PackageDownload Include="Microsoft.DeveloperControlPlane.darwin-amd64" Version="[$(_DcpVersion)]" />
-    <PackageDownload Include="Microsoft.DeveloperControlPlane.darwin-arm64" Version="[$(_DcpVersion)]" />
-    <PackageDownload Include="Microsoft.DeveloperControlPlane.linux-amd64" Version="[$(_DcpVersion)]" />
-    <PackageDownload Include="Microsoft.DeveloperControlPlane.linux-arm64" Version="[$(_DcpVersion)]" />
-    <PackageDownload Include="Microsoft.DeveloperControlPlane.windows-386" Version="[$(_DcpVersion)]" />
-    <PackageDownload Include="Microsoft.DeveloperControlPlane.windows-amd64" Version="[$(_DcpVersion)]" />
-    <PackageDownload Include="Microsoft.DeveloperControlPlane.windows-arm64" Version="[$(_DcpVersion)]" />
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.darwin-amd64" Version="[$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)]" />
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.darwin-arm64" Version="[$(MicrosoftDeveloperControlPlanedarwinarm64PackageVersion)]" />
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.linux-amd64" Version="[$(MicrosoftDeveloperControlPlanelinuxamd64PackageVersion)]" />
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.linux-arm64" Version="[$(MicrosoftDeveloperControlPlanelinuxarm64PackageVersion)]" />
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.windows-386" Version="[$(MicrosoftDeveloperControlPlanewindows386PackageVersion)]" />
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.windows-amd64" Version="[$(MicrosoftDeveloperControlPlanewindowsamd64PackageVersion)]" />
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.windows-arm64" Version="[$(MicrosoftDeveloperControlPlanewindowsarm64PackageVersion)]" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
@@ -40,7 +40,7 @@
   <Target Name="Build" />
 
   <ItemGroup>
-    <None Include="$(NuGetPackageRoot)Microsoft.DeveloperControlPlane.$(DcpPlatform)/$(_DcpVersion)/tools/**/*" Pack="true" PackagePath="tools/" />
+    <None Include="$(NuGetPackageRoot)Microsoft.DeveloperControlPlane.$(DcpPlatform)/$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)/tools/**/*" Pack="true" PackagePath="tools/" />
     <None Include="Sdk.props" Pack="true" PackagePath="Sdk/" />
     <None Include="Sdk.in.targets" PerformTextReplacement="True" Pack="true" PackagePath="Sdk/" />
     <None Include="Aspire.Hosting.Orchestration.props" pack="true" PackagePath="build/$(PackageId).props" />

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -19,7 +19,7 @@
 
   <!-- Download DCP orchestrator components for local development -->
   <ItemGroup>
-    <PackageDownload Include="Microsoft.DeveloperControlPlane.$(BuildOs)-$(BuildArch)" Version="[$(_DcpVersion)]" />
+    <PackageDownload Include="Microsoft.DeveloperControlPlane.$(BuildOs)-$(BuildArch)" Version="[$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)]" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.NET.Sdk.Aspire/Microsoft.NET.Sdk.Aspire.csproj
+++ b/src/Microsoft.NET.Sdk.Aspire/Microsoft.NET.Sdk.Aspire.csproj
@@ -21,7 +21,7 @@
     <TextReplacementValue Include="DotNetAspireManifestVersionBand" NewValue="$(DotNetAspireManifestVersionBand)" />
     <TextReplacementValue Include="ASPIRE_DOTNET_VERSION_MAJOR" NewValue="$(_AspireDotNetVersionMajor)" />
     <TextReplacementValue Include="ASPIRE_DOTNET_VERSION" NewValue="$(_AspireDotNetVersion)" />
-    <TextReplacementValue Include="DCP_VERSION" NewValue="$(_DcpVersion)" />
+    <TextReplacementValue Include="DCP_VERSION" NewValue="$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)" />
   </ItemGroup>
 
   <Target Name="_CopyAdditionalFIles" AfterTargets="Build">


### PR DESCRIPTION
FYI: @dbreshears @danegsta @DamianEdwards @davidfowl @ViktorHofer 

Contributes to #182 

This is onboarding Aspire repo into using dependency flow so that update PRs get automatically created every time there is a new DCP build available. Once this PR goes in, I'll enable the subscription so that flow starts happening.