### PR TITLE
Move reference of Aspire.Hosting into templates

### DIFF
--- a/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
+++ b/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <None Include="..\Aspire.Hosting\build\*.targets" Link="SDK\%(Filename)%(Extension)" Pack="true" PackagePath="Sdk\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Update="SDK\*.props;SDK\*.targets" Pack="true" PackagePath="Sdk\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="SDK\Sdk.in.targets" PerformTextReplacement="true" PackagePath="Sdk\Sdk.targets" />
+    <None Update="SDK\Sdk.targets" Pack="true" PackagePath="Sdk\Sdk.targets" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
@@ -1,15 +1,5 @@
 <Project>
 
-  <PropertyGroup>
-    <!-- Ensure this property is set even if Aspire.Hosting.Sdk was imported directly instead of via the workload targets -->
-    <IsAspireHost>true</IsAspireHost>
-    <AspireHostingVersion Condition=" '$(AspireHostingVersion)' == '' ">@VERSION@</AspireHostingVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" IsImplicitlyDefined="true" Version="$(AspireHostingVersion)" />
-  </ItemGroup>
-
   <!-- *** BEGIN *** -->
 
   <!--

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.AppHost/AspireApplication1.AppHost.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.AppHost/AspireApplication1.AppHost.csproj
@@ -8,4 +8,8 @@
     <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" Version="<REPLACE_WITH_LATEST_VERSION>" />
+  </ItemGroup>
+
 </Project>

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.AppHost/AspireStarterApplication1.AppHost.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.AppHost/AspireStarterApplication1.AppHost.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="..\AspireStarterApplication1.Web\AspireStarterApplication1.Web.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" Version="<REPLACE_WITH_LATEST_VERSION>" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/126

cc: @davidfowl @dbreshears @danegsta @DamianEdwards 

This is removing the reference to the Hosting package from the SDK targets and into the templates instead.