### PR TITLE
Use public gRPC version and remove reference internal feed

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,10 +59,10 @@
     <PackageVersion Include="Dapr.Client" Version="1.12.0-rc01" />
     <PackageVersion Include="DnsClient" Version="1.7.0" />
     <PackageVersion Include="Google.Protobuf" Version="3.23.1" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.58.0-dev202309130702" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.58.0-dev202309130702" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.58.0-dev202309130702" />
-    <PackageVersion Include="Grpc.Net.Server" Version="2.58.0-dev202309130702" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.58.0-pre1" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.58.0-pre1" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.58.0-pre1" />
+    <PackageVersion Include="Grpc.Net.Server" Version="2.58.0-pre1" />
     <PackageVersion Include="Grpc.Tools" Version="2.57.0" />
     <PackageVersion Include="KubernetesClient" Version="11.0.36" />
     <PackageVersion Include="JsonSchema.Net" Version="5.2.5" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,8 +7,6 @@
     <!-- Required as https://github.com/dotnet/runtime/pull/89509 did not get backported to .NET 8 Preview 7 -->
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
-    <!-- Required until Grpc.* 2.58.0 is publically available -->
-    <add key="dotnet-grpc-pre-release" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-grpc-pre-release/nuget/v3/index.json" />
     <add key="dotnet-libraries-internal" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-libraries-internal/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
@@ -16,9 +14,6 @@
       <package pattern="*" />
     </packageSource>
     <packageSource key="dotnet8">
-      <package pattern="*" />
-    </packageSource>
-    <packageSource key="dotnet-grpc-pre-release">
       <package pattern="*" />
     </packageSource>
     <packageSource key="dotnet-libraries">


### PR DESCRIPTION
2.58.0-pre1 is public. Replace the internal build with a public version from dotnet-public.