### PR TITLE
Add Key Vault API to load all secrets into Configuration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
   <ItemGroup>
     <!-- Azure SDK for .NET dependencies -->
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.1" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageVersion Include="Azure.Identity" Version="1.10.0" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.15.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />

--- a/src/Components/Aspire.Azure.Security.KeyVault/Aspire.Azure.Security.KeyVault.csproj
+++ b/src/Components/Aspire.Azure.Security.KeyVault/Aspire.Azure.Security.KeyVault.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Azure.KeyVault.Secrets" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
     <PackageReference Include="Microsoft.Extensions.Azure" />

--- a/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
@@ -5,8 +5,11 @@ using Aspire.Azure.Common;
 using Aspire.Azure.Security.KeyVault;
 using Azure.Core;
 using Azure.Core.Extensions;
+using Azure.Extensions.AspNetCore.Configuration.Secrets;
+using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using HealthChecks.Azure.KeyVault.Secrets;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
@@ -56,6 +59,60 @@ public static class AspireKeyVaultExtensions
         string configurationSectionName = KeyVaultComponent.GetKeyedConfigurationSectionName(name, DefaultConfigSectionName);
 
         new KeyVaultComponent().AddClient(builder, configurationSectionName, configureSettings, configureClientBuilder, connectionName: name, serviceKey: name);
+    }
+
+    /// <summary>
+    /// Adds the Azure KeyVault secrets to be configuration values in the <paramref name="configurationManager"/>.
+    /// </summary>
+    /// <param name="configurationManager">The <see cref="IConfigurationManager"/> to add the secrets to.</param>
+    /// <param name="connectionName">A name used to retrieve the connection string from the ConnectionStrings configuration section.</param>
+    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureSecurityKeyVaultSettings"/>. It's invoked after the settings are read from the configuration.</param>
+    /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="SecretClientOptions"/>.</param>
+    /// <param name="options">An optional <see cref="AzureKeyVaultConfigurationOptions"/> instance to configure the behavior of the configuration provider.</param>
+    public static void AddKeyVaultSecrets(
+        this IConfigurationManager configurationManager,
+        string connectionName,
+        Action<AzureSecurityKeyVaultSettings>? configureSettings = null,
+        Action<SecretClientOptions>? configureClientOptions = null,
+        AzureKeyVaultConfigurationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(configurationManager);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
+        var client = configurationManager.GetSecretClient(connectionName, configureSettings, configureClientOptions);
+        configurationManager.AddAzureKeyVault(client, options ?? new AzureKeyVaultConfigurationOptions());
+    }
+
+    private static SecretClient GetSecretClient(
+        this IConfiguration configuration,
+        string connectionName,
+        Action<AzureSecurityKeyVaultSettings>? configureSettings,
+        Action<SecretClientOptions>? configureOptions)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var configSection = configuration.GetSection(DefaultConfigSectionName);
+
+        var settings = new AzureSecurityKeyVaultSettings();
+        configSection.Bind(settings);
+
+        if (configuration.GetConnectionString(connectionName) is string connectionString)
+        {
+            ((IConnectionStringSettings)settings).ParseConnectionString(connectionString);
+        }
+
+        configureSettings?.Invoke(settings);
+
+        var clientOptions = new SecretClientOptions();
+        configSection.GetSection("ClientOptions").Bind(clientOptions);
+        configureOptions?.Invoke(clientOptions);
+
+        if (settings.VaultUri is null)
+        {
+            throw new InvalidOperationException($"VaultUri is missing. It should be provided in 'ConnectionStrings:{connectionName}' or under the 'VaultUri' key in the '{DefaultConfigSectionName}' configuration section.");
+        }
+
+        return new SecretClient(settings.VaultUri, settings.Credential ?? new DefaultAzureCredential(), clientOptions);
     }
 
     private sealed class KeyVaultComponent : AzureComponent<AzureSecurityKeyVaultSettings, SecretClient, SecretClientOptions>

--- a/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
@@ -89,8 +89,6 @@ public static class AspireKeyVaultExtensions
         Action<AzureSecurityKeyVaultSettings>? configureSettings,
         Action<SecretClientOptions>? configureOptions)
     {
-        ArgumentNullException.ThrowIfNull(configuration);
-
         var configSection = configuration.GetSection(DefaultConfigSectionName);
 
         var settings = new AzureSecurityKeyVaultSettings();

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/AspireKeyVaultExtensionsTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/AspireKeyVaultExtensionsTests.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Text;
+using Azure.Core;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -68,5 +71,104 @@ public class AspireKeyVaultExtensionsTests
             host.Services.GetRequiredService<SecretClient>();
 
         Assert.Equal(new Uri(ConformanceTests.VaultUri), client.VaultUri);
+    }
+
+    [Fact]
+    public void AddsKeyVaultSecretsToConfig()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:secrets", ConformanceTests.VaultUri)
+        ]);
+
+        builder.Configuration.AddKeyVaultSecrets("secrets", configureClientOptions: o =>
+        {
+            o.Transport = new MockTransport(
+                CreateResponse("""
+                    {
+                        "value": [
+                            {
+                                "id": "https://aspiretests.vault.azure.net/secrets/super-secret-1",
+                                "attributes": {
+                                    "enabled": true,
+                                    "created": 1697066435,
+                                    "updated": 1697066435,
+                                    "recoveryLevel": "Recoverable+Purgeable",
+                                    "recoverableDays": 90
+                                }
+                            },
+                            {
+                                "id": "https://aspiretests.vault.azure.net/secrets/super-secret-2",
+                                "attributes": {
+                                    "enabled": true,
+                                    "created": 1692910062,
+                                    "updated": 1692910062,
+                                    "recoveryLevel": "Recoverable+Purgeable",
+                                    "recoverableDays": 90
+                                }
+                            }
+                        ],
+                        "nextLink": null
+                    }
+                    """),
+                CreateResponse("""
+                    {
+                        "value": "Secret 1 Value",
+                        "id": "https://aspiretests.vault.azure.net/secrets/super-secret-1/1a78b8580ee548c3be0d146aab3817e2",
+                        "attributes": {
+                            "enabled": true,
+                            "created": 1697066435,
+                            "updated": 1697066435,
+                            "recoveryLevel": "Recoverable+Purgeable",
+                            "recoverableDays": 90
+                        }
+                    }
+                    """),
+                CreateResponse("""
+                    {
+                        "value": "Secret 2 Value",
+                        "id": "https://aspiretests.vault.azure.net/secrets/super-secret-2/9b8cc4d1ba7941a9b62c3168a17c039f",
+                        "attributes": {
+                            "enabled": true,
+                            "created": 1692910062,
+                            "updated": 1692910062,
+                            "recoveryLevel": "Recoverable+Purgeable",
+                            "recoverableDays": 90
+                        }
+                    }
+                    """));
+        });
+
+        Assert.Equal("Secret 1 Value", builder.Configuration["super-secret-1"]);
+        Assert.Equal("Secret 2 Value", builder.Configuration["super-secret-2"]);
+    }
+
+    private static MockResponse CreateResponse(string content)
+    {
+        var buffer = Encoding.UTF8.GetBytes(content);
+        var response = new MockResponse(200)
+        {
+            ClientRequestId = Guid.NewGuid().ToString(),
+            ContentStream = new MemoryStream(buffer),
+        };
+
+        // Add headers matching current response headers from Key Vault.
+        response.AddHeader(new HttpHeader("Cache-Control", "no-cache"));
+        response.AddHeader(new HttpHeader("Content-Length", buffer.Length.ToString(CultureInfo.InvariantCulture)));
+        response.AddHeader(new HttpHeader("Content-Type", "application/json; charset=utf-8"));
+        response.AddHeader(new HttpHeader("Date", DateTimeOffset.UtcNow.ToString("r", CultureInfo.InvariantCulture)));
+        response.AddHeader(new HttpHeader("Expires", "-1"));
+        response.AddHeader(new HttpHeader("Pragma", "no-cache"));
+        response.AddHeader(new HttpHeader("Server", "Microsoft-IIS/10.0"));
+        response.AddHeader(new HttpHeader("Strict-Transport-Security", "max-age=31536000;includeSubDomains"));
+        response.AddHeader(new HttpHeader("X-AspNet-Version", "4.0.30319"));
+        response.AddHeader(new HttpHeader("X-Content-Type-Options", "nosniff"));
+        response.AddHeader(new HttpHeader("x-ms-keyvault-network-info", "addr=122.117.106.78;act_addr_fam=InterNetwork;"));
+        response.AddHeader(new HttpHeader("x-ms-keyvault-region", "westus"));
+        response.AddHeader(new HttpHeader("x-ms-keyvault-service-version", "1.1.0.875"));
+        response.AddHeader(new HttpHeader("x-ms-request-id", response.ClientRequestId));
+        response.AddHeader(new HttpHeader("X-Powered-By", "ASP.NET"));
+
+        return response;
     }
 }

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/MockTransport.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/MockTransport.cs
@@ -1,0 +1,219 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Azure.Core.Pipeline;
+using Azure.Core;
+using Azure;
+
+namespace Aspire.Azure;
+
+public class MockTransport : HttpPipelineTransport
+{
+    private readonly object _syncObj = new object();
+    private readonly Func<HttpMessage, MockResponse> _responseFactory;
+
+    public List<MockRequest> Requests { get; } = new List<MockRequest>();
+
+    public MockTransport(params MockResponse[] responses)
+    {
+        var requestIndex = 0;
+        _responseFactory = _ =>
+        {
+            lock (_syncObj)
+            {
+                return responses[requestIndex++];
+            }
+        };
+    }
+
+    public MockTransport(Func<MockRequest, MockResponse> responseFactory)
+    {
+        _responseFactory = req => responseFactory((MockRequest)req.Request);
+    }
+
+    public override Request CreateRequest()
+        => new MockRequest();
+
+    public override void Process(HttpMessage message)
+    {
+        ProcessCore(message).GetAwaiter().GetResult();
+    }
+
+    public override async ValueTask ProcessAsync(HttpMessage message)
+    {
+        await ProcessCore(message);
+    }
+
+    private Task ProcessCore(HttpMessage message)
+    {
+        if (!(message.Request is MockRequest request))
+        {
+            throw new InvalidOperationException("the request is not compatible with the transport");
+        }
+
+        message.Response = null!;
+
+        lock (_syncObj)
+        {
+            Requests.Add(request);
+        }
+
+        message.Response = _responseFactory(message);
+
+        message.Response.ClientRequestId = request.ClientRequestId;
+
+        return Task.CompletedTask;
+    }
+}
+
+public class MockRequest : Request
+{
+    public MockRequest()
+    {
+        ClientRequestId = Guid.NewGuid().ToString();
+    }
+
+    private readonly Dictionary<string, List<string>> _headers = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+    public bool IsDisposed { get; private set; }
+
+    protected override void SetHeader(string name, string value) => _headers[name] = [value];
+
+    protected override void AddHeader(string name, string value)
+    {
+        AddHeader(new HttpHeader(name, value));
+    }
+
+    public void AddHeader(HttpHeader header)
+    {
+        if (!_headers.TryGetValue(header.Name, out var values))
+        {
+            _headers[header.Name] = values = new List<string>();
+        }
+
+        values.Add(header.Value);
+
+    }
+
+    protected override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value)
+    {
+        if (_headers.TryGetValue(name, out var values))
+        {
+            value = JoinHeaderValue(values);
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    protected override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => throw new NotImplementedException();
+
+    protected override bool ContainsHeader(string name) => _headers.TryGetValue(name, out _);
+
+    protected override bool RemoveHeader(string name) => _headers.Remove(name);
+
+    protected override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
+
+    public override string ClientRequestId { get; set; }
+
+    public override string ToString() => $"{Method} {Uri}";
+
+    public override void Dispose()
+    {
+        IsDisposed = true;
+    }
+    private static string JoinHeaderValue(IEnumerable<string> values)
+    {
+        return string.Join(",", values);
+    }
+}
+
+public class MockResponse : Response
+{
+    private readonly Dictionary<string, List<string>> _headers = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+    public MockResponse(int status, string? reasonPhrase = null)
+    {
+        Status = status;
+        ReasonPhrase = reasonPhrase!;
+    }
+
+    public override int Status { get; }
+
+    public override string ReasonPhrase { get; }
+
+    public override Stream? ContentStream { get; set; }
+
+    public override string ClientRequestId { get; set; } = string.Empty;
+
+    private bool? _isError;
+    public override bool IsError { get => _isError ?? base.IsError; }
+    public void SetIsError(bool value) => _isError = value;
+
+    public bool IsDisposed { get; private set; }
+
+    public void SetContent(byte[] content)
+    {
+        ContentStream = new MemoryStream(content, 0, content.Length, false, true);
+    }
+
+    public MockResponse SetContent(string content)
+    {
+        SetContent(Encoding.UTF8.GetBytes(content));
+        return this;
+    }
+
+    public MockResponse AddHeader(string name, string value)
+    {
+        return AddHeader(new HttpHeader(name, value));
+    }
+
+    public MockResponse AddHeader(HttpHeader header)
+    {
+        if (!_headers.TryGetValue(header.Name, out var values))
+        {
+            _headers[header.Name] = values = new List<string>();
+        }
+
+        values.Add(header.Value);
+        return this;
+    }
+
+    protected override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value)
+    {
+        if (_headers.TryGetValue(name, out var values))
+        {
+            value = JoinHeaderValue(values);
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    protected override bool TryGetHeaderValues(string name, [NotNullWhen(true)] out IEnumerable<string>? values)
+    {
+        var result = _headers.TryGetValue(name, out var valuesList);
+        values = valuesList;
+        return result;
+    }
+
+    protected override bool ContainsHeader(string name)
+    {
+        return TryGetHeaderValues(name, out _);
+    }
+
+    protected override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
+
+    private static string JoinHeaderValue(IEnumerable<string> values)
+    {
+        return string.Join(",", values);
+    }
+
+    public override void Dispose()
+    {
+        IsDisposed = true;
+    }
+}

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/MockTransport.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/MockTransport.cs
@@ -93,7 +93,6 @@ public class MockRequest : Request
         }
 
         values.Add(header.Value);
-
     }
 
     protected override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value)


### PR DESCRIPTION
Adds a `builder.Configuration.AddKeyVaultSecrets` API.

This API will read all the KeyVault secrets and populate the `builder.Configuration` with the secret values.

Fix #238