### PR TITLE
Remove specific components WithX methods

### DIFF
--- a/docs/specs/manifest-spec.md
+++ b/docs/specs/manifest-spec.md
@@ -13,16 +13,16 @@ using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Redis;
 using Projects = eShopLite.App.Projects;
 
-var builder = CloudApplication.CreateBuilder(args);
+var builder = DistributedApplication.CreateBuilder(args);
 
-var postgres = builder.AddPostgresContainer("postgres");
+var catalogDb = builder.AddPostgresContainer("postgres").AddDatabase("catalogdb");
 var redis = builder.AddRedisContainer("redis");
 
 var catalog = builder.AddProject<Projects.eShopLite_CatalogService>("catalogservice")
-    .WithPostgresDatabase(postgres, databaseName: "catalogdb");
+    .WithReference(catalogDb);
 
 var basket = builder.AddProject<Projects.eShopLite_BasketService>("basketservice")
-    .WithRedis(redis);
+    .WithReference(redis);
 
 builder.AddProject<Projects.eShopLite_Frontend>("frontend")
     .WithServiceReference(basket)
@@ -49,7 +49,7 @@ When ```dotnet publish``` is called on the AppHost project containing the code a
         },
         "catalogservice": {
             "type": "project.v1",
-            "projectPath": "[relative path to]\\eShopLite.BasketService.csproj",
+            "path": "[relative path to]\\eShopLite.BasketService.csproj",
             "env": {
                 "ConnectionStrings__postgres": "{postgres.connectionString}"
             },
@@ -64,7 +64,7 @@ When ```dotnet publish``` is called on the AppHost project containing the code a
         },
         "basketservice": {
             "type": "project.v1",
-            "projectPath": "[relative path to]\\eShopLite.BasketService.csproj",
+            "path": "[relative path to]\\eShopLite.BasketService.csproj",
             "env": {
                 "ConnectionStrings__redis": "{redis.connectionString}"
             },
@@ -79,7 +79,7 @@ When ```dotnet publish``` is called on the AppHost project containing the code a
         },
         "frontend": {
             "type": "project.v1",
-            "projectPath": "[relative path to]\\eShopLite.Frontend.csproj",
+            "path": "[relative path to]\\eShopLite.Frontend.csproj",
             "bindings": {
                 "https": { // Will end up being bound as external on port 443, container port inferred from container image.
                     "scheme": "https",

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -15,14 +15,14 @@ var catalogdb = builder.AddPostgresContainer("postgres").AddDatabase("catalog");
 var redis = builder.AddRedisContainer("basketCache");
 
 var catalog = builder.AddProject<Projects.CatalogService>("catalogservice")
-                     .WithPostgres(catalogdb)
+                     .WithReference(catalogdb)
                      .WithReplicas(2);
 
 var serviceBus = builder.AddAzureServiceBus("messaging", queueNames: ["orders"]);
 
 var basket = builder.AddProject<Projects.BasketService>("basketservice")
                     .WithServiceBindingForPublisher("manifest", "http", context => context.Binding.AsExternal())
-                    .WithRedis(redis)
+                    .WithReference(redis)
                     .WithReference(serviceBus, optional: true);
 
 builder.AddProject<Projects.MyFrontend>("myfrontend")

--- a/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
@@ -20,12 +20,6 @@ public static class AzureResourceExtensions
         jsonWriter.WriteString("type", "azure.keyvault.v1");
     }
 
-    public static IDistributedApplicationResourceBuilder<T> WithAddAzureKeyVault<T>(this IDistributedApplicationResourceBuilder<T> builder, IDistributedApplicationResourceBuilder<AzureKeyVaultResource> keyVaultBuilder, string? connectionName = null)
-        where T : IDistributedApplicationResourceWithEnvironment
-    {
-        return builder.WithReference(keyVaultBuilder, connectionName);
-    }
-
     public static IDistributedApplicationResourceBuilder<AzureServiceBusResource> AddAzureServiceBus(this IDistributedApplicationBuilder builder, string name, string[]? queueNames = null, string[]? topicNames = null)
     {
         var resource = new AzureServiceBusResource(name)
@@ -61,12 +55,6 @@ public static class AzureResourceExtensions
             }
             jsonWriter.WriteEndArray();
         }
-    }
-
-    public static IDistributedApplicationResourceBuilder<T> WithAzureServiceBus<T>(this IDistributedApplicationResourceBuilder<T> builder, IDistributedApplicationResourceBuilder<AzureServiceBusResource> serviceBusBuilder, string? connectionName = null)
-        where T : IDistributedApplicationResourceWithEnvironment
-    {
-        return builder.WithReference(serviceBusBuilder, connectionName);
     }
 
     public static IDistributedApplicationResourceBuilder<AzureStorageResource> AddAzureStorage(this IDistributedApplicationBuilder builder, string name)
@@ -118,23 +106,5 @@ public static class AzureResourceExtensions
     {
         json.WriteString("type", "azure.storage.queue.v1");
         json.WriteString("parent", resource.Parent.Name);
-    }
-
-    public static IDistributedApplicationResourceBuilder<T> WithTableStorage<T>(this IDistributedApplicationResourceBuilder<T> builder, IDistributedApplicationResourceBuilder<AzureTableStorageResource> tableBuilder, string? connectionName = null)
-        where T : IDistributedApplicationResourceWithEnvironment
-    {
-        return builder.WithReference(tableBuilder, connectionName);
-    }
-
-    public static IDistributedApplicationResourceBuilder<T> WithQueueStorage<T>(this IDistributedApplicationResourceBuilder<T> builder, IDistributedApplicationResourceBuilder<AzureQueueStorageResource> queueBuilder, string? connectionName = null)
-        where T : IDistributedApplicationResourceWithEnvironment
-    {
-        return builder.WithReference(queueBuilder, connectionName);
-    }
-
-    public static IDistributedApplicationResourceBuilder<T> WithBlobStorage<T>(this IDistributedApplicationResourceBuilder<T> builder, IDistributedApplicationResourceBuilder<AzureBlobStorageResource> blobBuilder, string? connectionName = null)
-        where T : IDistributedApplicationResourceWithEnvironment
-    {
-        return builder.WithReference(blobBuilder, connectionName);
     }
 }

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -48,15 +48,6 @@ public static class PostgresBuilderExtensions
         json.WriteString("parent", postgresDatabase.Parent.Name);
     }
 
-    /// <summary>
-    /// Sets a connection string for this service. The connection string will be available in the service's environment.
-    /// </summary>
-    public static IDistributedApplicationResourceBuilder<T> WithPostgres<T, TPostgres>(this IDistributedApplicationResourceBuilder<T> builder, IDistributedApplicationResourceBuilder<TPostgres> postgresBuilder, string? connectionName = null) where TPostgres : IPostgresResource
-        where T : IDistributedApplicationResourceWithEnvironment
-    {
-        return builder.WithReference(postgresBuilder, connectionName);
-    }
-
     public static IDistributedApplicationResourceBuilder<PostgresDatabaseResource> AddDatabase(this IDistributedApplicationResourceBuilder<PostgresContainerResource> builder, string name)
     {
         var postgresDatabase = new PostgresDatabaseResource(name, builder.Resource);

--- a/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
@@ -37,10 +37,4 @@ public static class RedisBuilderExtensions
             jsonWriter.WriteString("connectionString", connectionString);
         }
     }
-
-    public static IDistributedApplicationResourceBuilder<T> WithRedis<T>(this IDistributedApplicationResourceBuilder<T> builder, IDistributedApplicationResourceBuilder<IRedisResource> redisBuilder, string? connectionName = null)
-        where T : IDistributedApplicationResourceWithEnvironment
-    {
-        return builder.WithReference(redisBuilder, connectionName);
-    }
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -47,12 +47,6 @@ public static class SqlServerBuilderExtensions
         json.WriteString("parent", sqlServerDatabase.Parent.Name);
     }
 
-    public static IDistributedApplicationResourceBuilder<T> WithSqlServer<T, TSqlServer>(this IDistributedApplicationResourceBuilder<T> builder, IDistributedApplicationResourceBuilder<TSqlServer> sqlServerBuilder, string? connectionName = null) where TSqlServer : ISqlServerResource
-        where T : IDistributedApplicationResourceWithEnvironment
-    {
-        return builder.WithReference(sqlServerBuilder, connectionName);
-    }
-
     public static IDistributedApplicationResourceBuilder<SqlServerDatabaseResource> AddDatabase(this IDistributedApplicationResourceBuilder<SqlServerContainerResource> builder, string name)
     {
         var sqlServerDatabase = new SqlServerDatabaseResource(name, builder.Resource);

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.AppHost/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.AppHost/Program.cs
@@ -12,7 +12,7 @@ var apiservice = builder.AddProject<Projects.AspireStarterApplication1_ApiServic
 
 builder.AddProject<Projects.AspireStarterApplication1_Web>("webfrontend")
 #if UseRedisCache
-    .WithRedis(cache)
+    .WithReference(cache)
 #endif
     .WithServiceReference(apiservice);
 

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
@@ -91,13 +91,13 @@ Also you can pass the `Action<MicrosoftDataSqlClientSettings> configureSettings`
 In your App project, register a SqlServer container and consume the connection using the following methods:
 
 ```cs
-var sql = builder.AddSqlServerContainer("sqldata");
+var sql = builder.AddSqlServerContainer("sql").AddDatabase("sqldata");
 
 var myService = builder.AddProject<YourApp.Projects.MyService>()
-                       .WithSqlServer(sql, "master");
+                       .WithReference(sql);
 ```
 
-`.WithSqlServer` configures a connection in the `MyService` project named `sqldata`. In the `Program.cs` file of `MyService`, the sql connection can be consumed using:
+`.WithReference` configures a connection in the `MyService` project named `sqldata`. In the `Program.cs` file of `MyService`, the sql connection can be consumed using:
 
 ```cs
 builder.AddSqlServerClient("sqldata");

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
@@ -93,13 +93,13 @@ Also you can pass the `Action<MicrosoftEntityFrameworkCoreSqlServerSettings> con
 In your App project, register a SqlServer container and consume the connection using the following methods:
 
 ```cs
-var sql = builder.AddSqlServerContainer("sqldata");
+var sql = builder.AddSqlServerContainer("sql").AddDatabase("sqldata");
 
 var myService = builder.AddProject<YourApp.Projects.MyService>()
-                       .WithSqlServer(sql, "master");
+                       .WithReference(sql);
 ```
 
-`.WithSqlServer` configures a connection in the `MyService` project named `sqldata`. In the `Program.cs` file of `MyService`, the sql connection can be consumed using:
+`.WithReference` configures a connection in the `MyService` project named `sqldata`. In the `Program.cs` file of `MyService`, the sql connection can be consumed using:
 
 ```cs
 builder.AddSqlServerDbContext<MyDbContext>("sqldata");

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
@@ -92,13 +92,13 @@ Also you can pass the `Action<NpgsqlEntityFrameworkCorePostgreSQLSettings> confi
 In your App project, register a Postgres container and consume the connection using the following methods:
 
 ```cs
-var postgres = builder.AddPostgresContainer("postgresdb");
+var postgresdb = builder.AddPostgresContainer("pg").AddDatabase("postgresdb");
 
 var myService = builder.AddProject<YourApp.Projects.MyService>()
-                       .WithPostgresDatabase(postgres, databaseName: "test")
+                       .WithReference(postgresdb);
 ```
 
-`.WithPostgresDatabase` configures a connection in the `MyService` project named `postgresdb`. In the `Program.cs` file of `MyService`, the database connection can be consumed using:
+`.WithReference` configures a connection in the `MyService` project named `postgresdb`. In the `Program.cs` file of `MyService`, the database connection can be consumed using:
 
 ```cs
 builder.AddNpgsqlDbContext<MyDbContext>("postgresdb");

--- a/src/Components/Aspire.Npgsql/README.md
+++ b/src/Components/Aspire.Npgsql/README.md
@@ -87,13 +87,13 @@ Also you can pass the `Action<NpgsqlSettings> configureSettings` delegate to set
 In your App project, register a Postgres container and consume the connection using the following methods:
 
 ```cs
-var postgres = builder.AddPostgresContainer("postgresdb");
+var postgresdb = builder.AddPostgresContainer("pg").AddDatabase("postgresdb");
 
 var myService = builder.AddProject<YourApp.Projects.MyService>()
-                       .WithPostgresDatabase(postgres, databaseName: "test")
+                       .WithReference(postgresdb);
 ```
 
-`.WithPostgresDatabase` configures a connection in the `MyService` project named `postgresdb`. In the `Program.cs` file of `MyService`, the database connection can be consumed using:
+`.WithReference` configures a connection in the `MyService` project named `postgresdb`. In the `Program.cs` file of `MyService`, the database connection can be consumed using:
 
 ```cs
 builder.AddNpgsqlDataSource("postgresdb");

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
@@ -102,10 +102,10 @@ In your App project, register a Redis container and consume the connection using
 var redis = builder.AddRedisContainer("cache");
 
 var myService = builder.AddProject<YourApp.Projects.MyService>()
-                       .WithRedis(redis);
+                       .WithReference(redis);
 ```
 
-`.WithRedis` configures a connection in the `MyService` project named `cache`. In the `Program.cs` file of `MyService`, the redis connection can be consumed using:
+`.WithReference` configures a connection in the `MyService` project named `cache`. In the `Program.cs` file of `MyService`, the redis connection can be consumed using:
 
 ```cs
 builder.AddRedisDistributedCache("cache");

--- a/src/Components/Aspire.StackExchange.Redis.OutputCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.OutputCaching/README.md
@@ -107,10 +107,10 @@ In your App project, register a Redis container and consume the connection using
 var redis = builder.AddRedisContainer("cache");
 
 var myService = builder.AddProject<YourApp.Projects.MyService>()
-                       .WithRedis(redis);
+                       .WithReference(redis);
 ```
 
-`.WithRedis` configures a connection in the `MyService` project named `cache`. In the `Program.cs` file of `MyService`, the redis connection can be consumed using:
+`.WithReference` configures a connection in the `MyService` project named `cache`. In the `Program.cs` file of `MyService`, the redis connection can be consumed using:
 
 ```cs
 builder.AddRedisOutputCache("cache");

--- a/src/Components/Aspire.StackExchange.Redis/README.md
+++ b/src/Components/Aspire.StackExchange.Redis/README.md
@@ -104,10 +104,10 @@ In your App project, register a Redis container and consume the connection using
 var redis = builder.AddRedisContainer("cache");
 
 var myService = builder.AddProject<YourApp.Projects.MyService>()
-                       .WithRedis(redis);
+                       .WithReference(redis);
 ```
 
-`.WithRedis` configures a connection in the `MyService` project named `cache`. In the `Program.cs` file of `MyService`, the redis connection can be consumed using:
+`.WithReference` configures a connection in the `MyService` project named `cache`. In the `Program.cs` file of `MyService`, the redis connection can be consumed using:
 
 ```cs
 builder.AddRedis("cache");


### PR DESCRIPTION
- We've unified the model to either be a connection string reference or a service reference (which injects endpoints). This PR removes all of the special methods in favor of one.

Fixes #193