### PR TITLE
Add Finished State for Logs

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor
@@ -9,7 +9,7 @@
 <div>
     <FluentStack Orientation="Orientation.Vertical">
         <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
-            <FluentSelect @ref="_resourceList" TOption="TResource"
+            <FluentSelect @ref="_resourceSelectComponent" TOption="TResource"
                           Items="@Resources"
                           OptionValue="@(c => c.Name)"
                           OptionText="GetDisplayText"

--- a/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor
@@ -9,7 +9,7 @@
 <div>
     <FluentStack Orientation="Orientation.Vertical">
         <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
-            <FluentSelect TOption="TResource"
+            <FluentSelect @ref="_resourceList" TOption="TResource"
                           Items="@Resources"
                           OptionValue="@(c => c.Name)"
                           OptionText="GetDisplayText"

--- a/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.cs
@@ -31,7 +31,7 @@ public abstract partial class ResourceLogsBase<TResource> : ComponentBase, IAsyn
         IEnumerable<NamespacedName> initialList,
         CancellationToken cancellationToken);
 
-    private FluentSelect<TResource>? _resourceList;
+    private FluentSelect<TResource>? _resourceSelectComponent;
     private TResource? _selectedResource;
     private readonly Dictionary<string, TResource> _resourceNameMapping = new();
     private IEnumerable<TResource> Resources => _resourceNameMapping.Select(kvp => kvp.Value).OrderBy(c => c.Name);
@@ -218,9 +218,9 @@ public abstract partial class ResourceLogsBase<TResource> : ComponentBase, IAsyn
 
     private async Task UpdateResourceListSelectedResourceAsync()
     {
-        if (_resourceList is not null && JS is not null)
+        if (_resourceSelectComponent is not null && JS is not null)
         {
-            await JS.InvokeVoidAsync("updateFluentSelectDisplayValue", _resourceList.Element);
+            await JS.InvokeVoidAsync("updateFluentSelectDisplayValue", _resourceSelectComponent.Element);
         }
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Fast.Components.FluentUI;
 using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Pages;
@@ -30,6 +31,7 @@ public abstract partial class ResourceLogsBase<TResource> : ComponentBase, IAsyn
         IEnumerable<NamespacedName> initialList,
         CancellationToken cancellationToken);
 
+    private FluentSelect<TResource>? _resourceList;
     private TResource? _selectedResource;
     private readonly Dictionary<string, TResource> _resourceNameMapping = new();
     private IEnumerable<TResource> Resources => _resourceNameMapping.Select(kvp => kvp.Value).OrderBy(c => c.Name);
@@ -87,15 +89,20 @@ public abstract partial class ResourceLogsBase<TResource> : ComponentBase, IAsyn
             _watchLogsTokenSource = new CancellationTokenSource();
             if (await _selectedResource.LogSource.StartAsync(_watchLogsTokenSource.Token))
             {
-                _ = Task.Run(async () =>
+                var outputTask = Task.Run(async () =>
                 {
                     await _logViewer.WatchLogsAsync(() => _selectedResource.LogSource.WatchOutputLogAsync(_watchLogsTokenSource.Token), LogEntryType.Default);
                 });
 
-                _ = Task.Run(async () =>
+                var errorTask = Task.Run(async () =>
                 {
                     await _logViewer.WatchLogsAsync(() => _selectedResource.LogSource.WatchErrorLogAsync(_watchLogsTokenSource.Token), LogEntryType.Error);
                 });
+
+                _ = Task.WhenAll(outputTask, errorTask).ContinueWith((task) =>
+                {
+                    _status = LogStatus.FinishedWatchingLogs;
+                }, TaskScheduler.Current);
 
                 _status = LogStatus.WatchingLogs;
             }
@@ -145,6 +152,10 @@ public abstract partial class ResourceLogsBase<TResource> : ComponentBase, IAsyn
                 {
                     await LoadLogsAsync();
                 }
+                else if (!string.Equals(_selectedResource.State, "Running", StringComparison.Ordinal))
+                {
+                    _status = LogStatus.FinishedWatchingLogs;
+                }
             }
         }
         else if (changeType == ObjectChangeType.Deleted)
@@ -161,6 +172,10 @@ public abstract partial class ResourceLogsBase<TResource> : ComponentBase, IAsyn
         }
 
         await InvokeAsync(StateHasChanged);
+
+        // Workaround for issue in fluent-select web component where the display value of the
+        // selected item doesn't update automatically when the item changes
+        await UpdateResourceListSelectedResourceAsync();
     }
 
     private static string GetDisplayText(TResource resource)
@@ -198,6 +213,14 @@ public abstract partial class ResourceLogsBase<TResource> : ComponentBase, IAsyn
             // The token source only gets created if selected resource is not null
             await _selectedResource!.LogSource.StopAsync();
             _watchLogsTokenSource = null;
+        }
+    }
+
+    private async Task UpdateResourceListSelectedResourceAsync()
+    {
+        if (_resourceList is not null && JS is not null)
+        {
+            await JS.InvokeVoidAsync("updateFluentSelectDisplayValue", _resourceList.Element);
         }
     }
 }

--- a/src/Aspire.Dashboard/Model/LogStatus.cs
+++ b/src/Aspire.Dashboard/Model/LogStatus.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Dashboard.Model;
@@ -10,6 +10,7 @@ internal static class LogStatus
     public const string LogsNotYetAvailable = "Logs Not Yet Available";
     public const string WatchingLogs = "Watching Logs...";
     public const string FailedToInitialize = "Failed to Initialize";
+    public const string FinishedWatchingLogs = "Finished Watching Logs";
 
     public const string LoadingProjects = "Loading Projects...";
     public const string NoProjectSelected = "No Project Selected";

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -72,3 +72,9 @@ window.copyTextToClipboard = function (id, text, precopy, postcopy) {
         });
     setTimeout(function () { tooltipDiv.innerText = precopy }, 1500);
 };
+
+window.updateFluentSelectDisplayValue = function (fluentSelect) {
+    if (fluentSelect) {
+        fluentSelect.updateDisplayValue();
+    }
+}


### PR DESCRIPTION
Resolves #66 

Adds a "Finished Watching Logs" status when
- Containers exit and the process underlying the logs exits, or
- Projects move to the finished state

This includes a workaround for an issue in the fluent-select web component where the display value of a select doesn't update when the item underlying the selected value changes.

Note that this does not address #222 as we need to discuss signaling between DCP and the dashboard to coordinate deleting the log files after we stop watching them.

Also note that you need a recent (as of yesterday) build of the workload for this to work properly for projects (there was an issue with notifications when projects exited).