### PR TITLE
Connection strings vary based on the target resource

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
@@ -9,5 +9,5 @@ public class AzureKeyVaultResource(string name) : DistributedApplicationResource
 {
     public Uri? VaultUri { get; set; }
 
-    public string? GetConnectionString() => VaultUri?.ToString();
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource) => VaultUri?.ToString();
 }

--- a/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
@@ -13,5 +13,5 @@ public class AzureServiceBusResource(string name) : DistributedApplicationResour
     public string[] QueueNames { get; set; } = [];
     public string[] TopicNames { get; set; } = [];
 
-    public string? GetConnectionString() => ServiceBusEndpoint;
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource) => ServiceBusEndpoint;
 }

--- a/src/Aspire.Hosting.Azure/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureStorageResource.cs
@@ -19,7 +19,7 @@ public class AzureTableStorageResource(string name, AzureStorageResource storage
 {
     public AzureStorageResource Parent => storage;
 
-    public string? GetConnectionString() => Parent.TableUri?.ToString();
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource) => Parent.TableUri?.ToString();
 }
 
 public class AzureBlobStorageResource(string name, AzureStorageResource storage) : DistributedApplicationResource(name),
@@ -29,7 +29,7 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
 {
     public AzureStorageResource Parent => storage;
 
-    public string? GetConnectionString() => Parent.BlobUri?.ToString();
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource) => Parent.BlobUri?.ToString();
 }
 
 public class AzureQueueStorageResource(string name, AzureStorageResource storage) : DistributedApplicationResource(name),
@@ -39,5 +39,5 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
 {
     public AzureStorageResource Parent => storage;
 
-    public string? GetConnectionString() => Parent.QueueUri?.ToString();
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource) => Parent.QueueUri?.ToString();
 }

--- a/src/Aspire.Hosting/ApplicationModel/IDistributedApplicationResourceWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IDistributedApplicationResourceWithConnectionString.cs
@@ -5,5 +5,5 @@ namespace Aspire.Hosting.ApplicationModel;
 
 public interface IDistributedApplicationResourceWithConnectionString : IDistributedApplicationResource
 {
-    public string? GetConnectionString();
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource);
 }

--- a/src/Aspire.Hosting/Postgres/PostgresConnectionResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresConnectionResource.cs
@@ -9,5 +9,5 @@ public class PostgresConnectionResource(string name, string? connectionString) :
 {
     private readonly string? _connectionString = connectionString;
 
-    public string? GetConnectionString() => _connectionString;
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource = null) => _connectionString;
 }

--- a/src/Aspire.Hosting/Postgres/PostgresContainerResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresContainerResource.cs
@@ -9,7 +9,7 @@ public class PostgresContainerResource(string name, string password) : Container
 {
     public string Password { get; } = password;
 
-    public string? GetConnectionString()
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource = null)
     {
         if (!this.TryGetAllocatedEndPoints(out var allocatedEndpoints))
         {
@@ -18,7 +18,9 @@ public class PostgresContainerResource(string name, string password) : Container
 
         var allocatedEndpoint = allocatedEndpoints.Single(); // We should only have one endpoint for Postgres.
 
-        var connectionString = $"Host={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};Username=postgres;Password={Password};";
+        var host = targetResource is null || !targetResource.IsContainer() ? allocatedEndpoint.Address : "host.docker.internal";
+
+        var connectionString = $"Host={host};Port={allocatedEndpoint.Port};Username=postgres;Password={Password};";
         return connectionString;
     }
 }

--- a/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
@@ -9,9 +9,9 @@ public class PostgresDatabaseResource(string name, PostgresContainerResource pos
 {
     public PostgresContainerResource Parent { get; } = postgresContainer;
 
-    public string? GetConnectionString()
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource)
     {
-        if (Parent.GetConnectionString() is { } connectionString)
+        if (Parent.GetConnectionString(targetResource) is { } connectionString)
         {
             return $"{connectionString}Database={Name}";
         }

--- a/src/Aspire.Hosting/Redis/RedisContainerResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisContainerResource.cs
@@ -7,7 +7,7 @@ namespace Aspire.Hosting.Redis;
 
 public class RedisContainerResource(string name) : ContainerResource(name), IRedisResource
 {
-    public string GetConnectionString()
+    public string GetConnectionString(IDistributedApplicationResource? targetResource)
     {
         if (!this.TryGetAnnotationsOfType<AllocatedEndpointAnnotation>(out var allocatedEndpoints))
         {
@@ -16,6 +16,9 @@ public class RedisContainerResource(string name) : ContainerResource(name), IRed
 
         // We should only have one endpoint for Redis for local scenarios.
         var endpoint = allocatedEndpoints.Single();
-        return endpoint.EndPointString;
+
+        var address = targetResource is null || !targetResource.IsContainer() ? endpoint.Address : "host.docker.internal";
+
+        return $"{address}:{endpoint.Port}";
     }
 }

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -7,5 +7,5 @@ namespace Aspire.Hosting.Redis;
 
 public class RedisResource(string name, string? connectionString) : DistributedApplicationResource(name), IRedisResource
 {
-    public string? GetConnectionString() => connectionString;
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource = null) => connectionString;
 }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -81,7 +81,7 @@ public static class ResourceBuilderExtensions
                 return;
             }
 
-            var connectionString = resource.GetConnectionString() ??
+            var connectionString = resource.GetConnectionString(builder.Resource) ??
                 builder.ApplicationBuilder.Configuration.GetConnectionString(resource.Name);
 
             if (string.IsNullOrEmpty(connectionString))

--- a/src/Aspire.Hosting/SqlServer/SqlServerConnectionResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerConnectionResource.cs
@@ -9,5 +9,5 @@ public class SqlServerConnectionResource(string name, string? connectionString) 
 {
     private readonly string? _connectionString = connectionString;
 
-    public string? GetConnectionString() => _connectionString;
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource = null) => _connectionString;
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
@@ -14,9 +14,9 @@ public class SqlServerDatabaseResource : ContainerResource, ISqlServerResource, 
 
     public SqlServerContainerResource Parent { get; }
 
-    public string? GetConnectionString()
+    public string? GetConnectionString(IDistributedApplicationResource? targetResource)
     {
-        if (Parent.GetConnectionString() is { } connectionString)
+        if (Parent.GetConnectionString(targetResource) is { } connectionString)
         {
             return $"{connectionString}Database={Name}";
         }


### PR DESCRIPTION
- Today connection strings are generated no matter assuming localhost is accessible from service to service. That doesn't work for container to connection comms. This passes the target resource to IDistributedApplicationResourceWithConnectionString so that it can determine the best connection string to return given the target resource.

Related to https://github.com/dotnet/aspire/issues/128

This is a PR to discuss implications on API if we go this route. The other solution would be to always use host.docker.internal for container based connection strings.