### PR TITLE
Add service references to manifests.

### DIFF
--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -1,4 +1,3 @@
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Redis;
@@ -21,12 +20,10 @@ var catalog = builder.AddProject<Projects.CatalogService>("catalogservice")
 var serviceBus = builder.AddAzureServiceBus("messaging", queueNames: ["orders"]);
 
 var basket = builder.AddProject<Projects.BasketService>("basketservice")
-                    .WithServiceBindingForPublisher("manifest", "http", context => context.Binding.AsExternal())
                     .WithReference(redis)
                     .WithReference(serviceBus, optional: true);
 
 builder.AddProject<Projects.MyFrontend>("myfrontend")
-       .WithServiceBindingForPublisher("manifest", "https", context => context.Binding.AsExternal())
        .WithServiceReference(basket)
        .WithServiceReference(catalog, bindingName: "http")
        .WithEnvironment("GRAFANA_URL", () => grafana.GetEndpoint("grafana-http")?.UriString ?? $"{{{grafana.Resource.Name}.bindings.grafana-http}}");

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -32,6 +32,11 @@
           "scheme": "http",
           "protocol": "tcp",
           "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
         }
       }
     },
@@ -53,6 +58,11 @@
           "scheme": "http",
           "protocol": "tcp",
           "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
         }
       }
     },
@@ -62,11 +72,17 @@
       "env": {
         "GRAFANA_URL": "{grafana.bindings.grafana-http}",
         "services__basketservice__0": "{basketservice.bindings.http.url}",
+        "services__basketservice__1": "{basketservice.bindings.https.url}",
         "services__catalogservice__0": "{catalogservice.bindings.http.url}"
       },
       "bindings": {
         "http": {
           "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
           "protocol": "tcp",
           "transport": "http"
         }
@@ -83,6 +99,11 @@
           "scheme": "http",
           "protocol": "tcp",
           "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
         }
       }
     },
@@ -91,11 +112,18 @@
       "path": "..\\ApiGateway\\ApiGateway.csproj",
       "env": {
         "services__basketservice__0": "{basketservice.bindings.http.url}",
-        "services__catalogservice__0": "{catalogservice.bindings.http.url}"
+        "services__basketservice__1": "{basketservice.bindings.https.url}",
+        "services__catalogservice__0": "{catalogservice.bindings.http.url}",
+        "services__catalogservice__1": "{catalogservice.bindings.https.url}"
       },
       "bindings": {
         "http": {
           "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
           "protocol": "tcp",
           "transport": "http"
         }

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -28,13 +28,8 @@
         "ConnectionStrings__catalog": "{catalog.connectionString}"
       },
       "bindings": {
-        "generated-http": {
+        "http": {
           "scheme": "http",
-          "protocol": "tcp",
-          "transport": "http"
-        },
-        "generated-https": {
-          "scheme": "https",
           "protocol": "tcp",
           "transport": "http"
         }
@@ -54,13 +49,8 @@
         "ConnectionStrings__messaging": "{messaging.connectionString}"
       },
       "bindings": {
-        "generated-http": {
+        "http": {
           "scheme": "http",
-          "protocol": "tcp",
-          "transport": "http"
-        },
-        "generated-https": {
-          "scheme": "https",
           "protocol": "tcp",
           "transport": "http"
         }
@@ -70,31 +60,15 @@
       "type": "project.v1",
       "path": "..\\MyFrontend\\MyFrontend.csproj",
       "env": {
-        "GRAFANA_URL": "{grafana.bindings.grafana-http}"
+        "GRAFANA_URL": "{grafana.bindings.grafana-http}",
+        "services__basketservice__0": "{basketservice.bindings.http.url}",
+        "services__catalogservice__0": "{catalogservice.bindings.http.url}"
       },
       "bindings": {
-        "generated-http": {
+        "http": {
           "scheme": "http",
           "protocol": "tcp",
           "transport": "http"
-        },
-        "generated-https": {
-          "scheme": "https",
-          "protocol": "tcp",
-          "transport": "http"
-        }
-      },
-      "references": {
-        "basketservice": {
-          "bindings": [
-            "generated-http",
-            "generated-https"
-          ]
-        },
-        "catalogservice": {
-          "bindings": [
-            "http"
-          ]
         }
       }
     },
@@ -105,13 +79,8 @@
         "ConnectionStrings__messaging": "{messaging.connectionString}"
       },
       "bindings": {
-        "generated-http": {
+        "http": {
           "scheme": "http",
-          "protocol": "tcp",
-          "transport": "http"
-        },
-        "generated-https": {
-          "scheme": "https",
           "protocol": "tcp",
           "transport": "http"
         }
@@ -120,31 +89,15 @@
     "apigateway": {
       "type": "project.v1",
       "path": "..\\ApiGateway\\ApiGateway.csproj",
-      "env": {},
+      "env": {
+        "services__basketservice__0": "{basketservice.bindings.http.url}",
+        "services__catalogservice__0": "{catalogservice.bindings.http.url}"
+      },
       "bindings": {
-        "generated-http": {
+        "http": {
           "scheme": "http",
           "protocol": "tcp",
           "transport": "http"
-        },
-        "generated-https": {
-          "scheme": "https",
-          "protocol": "tcp",
-          "transport": "http"
-        }
-      },
-      "references": {
-        "basketservice": {
-          "bindings": [
-            "generated-http",
-            "generated-https"
-          ]
-        },
-        "catalogservice": {
-          "bindings": [
-            "generated-http",
-            "generated-https"
-          ]
         }
       }
     },

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -26,6 +26,18 @@
       "path": "..\\CatalogService\\CatalogService.csproj",
       "env": {
         "ConnectionStrings__catalog": "{catalog.connectionString}"
+      },
+      "bindings": {
+        "generated-http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "generated-https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
+        }
       }
     },
     "messaging": {
@@ -42,11 +54,15 @@
         "ConnectionStrings__messaging": "{messaging.connectionString}"
       },
       "bindings": {
-        "http": {
+        "generated-http": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http",
-          "external": true
+          "transport": "http"
+        },
+        "generated-https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
         }
       }
     },
@@ -57,11 +73,28 @@
         "GRAFANA_URL": "{grafana.bindings.grafana-http}"
       },
       "bindings": {
-        "https": {
+        "generated-http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "generated-https": {
           "scheme": "https",
           "protocol": "tcp",
-          "transport": "http",
-          "external": true
+          "transport": "http"
+        }
+      },
+      "references": {
+        "basketservice": {
+          "bindings": [
+            "generated-http",
+            "generated-https"
+          ]
+        },
+        "catalogservice": {
+          "bindings": [
+            "http"
+          ]
         }
       }
     },
@@ -70,12 +103,50 @@
       "path": "..\\OrderProcessor\\OrderProcessor.csproj",
       "env": {
         "ConnectionStrings__messaging": "{messaging.connectionString}"
+      },
+      "bindings": {
+        "generated-http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "generated-https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
+        }
       }
     },
     "apigateway": {
       "type": "project.v1",
       "path": "..\\ApiGateway\\ApiGateway.csproj",
-      "env": {}
+      "env": {},
+      "bindings": {
+        "generated-http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "generated-https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
+        }
+      },
+      "references": {
+        "basketservice": {
+          "bindings": [
+            "generated-http",
+            "generated-https"
+          ]
+        },
+        "catalogservice": {
+          "bindings": [
+            "generated-http",
+            "generated-https"
+          ]
+        }
+      }
     },
     "prometheus": {
       "type": "container.v1",

--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -17,72 +17,12 @@ public sealed class DcpDistributedApplicationLifecycleHook(IOptions<PublishingOp
     {
         var publisher = _publishingOptions.Value?.Publisher == null ? "dcp" : _publishingOptions.Value.Publisher;
 
-        // HACK: We only automatically add service bindings when publishing under DCP, but this lifecycle hook
-        //       always runs because we use it to deterministically sequence logic in the lifecycle.
         if (publisher == "dcp")
         {
             PrepareServices(appModel);
         }
 
-        foreach (var resource in appModel.Resources)
-        {
-            // Grab the service bindings we already have for this resource.
-            var serviceBindingsLookup = resource.Annotations
-                .OfType<ServiceBindingAnnotation>()
-                .ToLookup(a => a.Name);
-
-            // Find any callbacks for this specific publisher.
-            var bindingNameGroupedCallbackAnnotations = resource.Annotations
-                .OfType<ServiceBindingCallbackAnnotation>()
-                .Where(a => a.PublisherName == publisher)
-                .ToLookup(a => a.BindingName);
-
-            foreach (var callbackAnnotationsForBinding in bindingNameGroupedCallbackAnnotations)
-            {
-                // For each callback that maps to this publisher and service binding name, find
-                // the existing service binding annotation, and if it doesn't exist create one.
-                ServiceBindingAnnotation inputAnnotation = serviceBindingsLookup.Contains(callbackAnnotationsForBinding.Key)
-                    ? serviceBindingsLookup[callbackAnnotationsForBinding.Key].Single()
-                    : CreateServiceBindingAnnotation(callbackAnnotationsForBinding.Key);
-
-                var callbackAnnotation = callbackAnnotationsForBinding.Single(); // Initially will only support one callback annotation per binding???
-                ServiceBindingAnnotation outputAnnotation = inputAnnotation;
-
-                // If the callback exists, invoke it (sometimes it won't exist if someone is
-                // just using the WithServiceBindingForPublisher(...) to bring a service binding into
-                // existence.
-                if (callbackAnnotation.Callback != null)
-                {
-                    var context = new ServiceBindingCallbackContext(publisher, inputAnnotation);
-                    outputAnnotation = callbackAnnotation.Callback(context);
-                }
-
-                // Currently we support swapping out the existing service binding for a completely
-                // new one. This is done to enable some interesting scenarios in the future around
-                // transparently adding reverse proxies/tunnels.
-                if (resource.Annotations.Contains(inputAnnotation))
-                {
-                    resource.Annotations.Remove(inputAnnotation);
-                }
-
-                if (!resource.Annotations.Contains(outputAnnotation))
-                {
-                    resource.Annotations.Add(outputAnnotation);
-                }
-            }
-        }
-
         return Task.CompletedTask;
-    }
-
-    private static ServiceBindingAnnotation CreateServiceBindingAnnotation(string bindingName)
-    {
-        return bindingName.ToLowerInvariant() switch
-        {
-            "http" => new ServiceBindingAnnotation(ProtocolType.Tcp, uriScheme: "http", containerPort: 80),
-            "https" => new ServiceBindingAnnotation(ProtocolType.Tcp, uriScheme: "https", containerPort: 443),
-            _ => new ServiceBindingAnnotation(ProtocolType.Tcp, name: bindingName)
-        };
     }
 
     private void PrepareServices(DistributedApplicationModel model)

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -40,6 +40,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         // Publishing support
         ConfigurePublishingOptions(args);
+        _innerBuilder.Services.AddLifecycleHook<AutomaticManifestPublisherBindingInjectionHook>();
         _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, ManifestPublisher>("manifest");
         _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, DcpPublisher>("dcp");
     }

--- a/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
+++ b/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
@@ -23,22 +23,20 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
         {
             // TODO: Add logic here that analyzes each project and figures out the best
             //       bindings to automatically add.
-            if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "http"))
+            if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "http" || sb.Name == "http"))
             {
                 var httpBinding = new ServiceBindingAnnotation(
                     System.Net.Sockets.ProtocolType.Tcp,
-                    uriScheme: "http",
-                    name: "generated-http"
+                    uriScheme: "http"
                     );
                 projectResource.Annotations.Add(httpBinding);
             }
 
-            if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "https"))
+            if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "https" || sb.Name == "http"))
             {
                 var httpsBinding = new ServiceBindingAnnotation(
                     System.Net.Sockets.ProtocolType.Tcp,
-                    uriScheme: "https",
-                    name: "generated-https"
+                    uriScheme: "https"
                     );
                 projectResource.Annotations.Add(httpsBinding);
             }

--- a/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
+++ b/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Publishing;
+internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<PublishingOptions> publishingOptions) : IDistributedApplicationLifecycleHook
+{
+    private readonly IOptions<PublishingOptions> _publishingOptions = publishingOptions;
+
+    public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
+    {
+        if (_publishingOptions.Value.Publisher != "manifest")
+        {
+            return Task.CompletedTask;
+        }
+
+        var projectResources = appModel.Resources.OfType<ProjectResource>();
+
+        foreach (var projectResource in projectResources)
+        {
+            // TODO: Add logic here that analyzes each project and figures out the best
+            //       bindings to automatically add.
+            if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "http"))
+            {
+                var httpBinding = new ServiceBindingAnnotation(
+                    System.Net.Sockets.ProtocolType.Tcp,
+                    uriScheme: "http",
+                    name: "generated-http"
+                    );
+                projectResource.Annotations.Add(httpBinding);
+            }
+
+            if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "https"))
+            {
+                var httpsBinding = new ServiceBindingAnnotation(
+                    System.Net.Sockets.ProtocolType.Tcp,
+                    uriScheme: "https",
+                    name: "generated-https"
+                    );
+                projectResource.Annotations.Add(httpsBinding);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
+++ b/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
@@ -32,7 +32,7 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
                 projectResource.Annotations.Add(httpBinding);
             }
 
-            if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "https" || sb.Name == "http"))
+            if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "https" || sb.Name == "https"))
             {
                 var httpsBinding = new ServiceBindingAnnotation(
                     System.Net.Sockets.ProtocolType.Tcp,

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -129,38 +129,6 @@ internal sealed class ManifestPublisher(IOptions<PublishingOptions> options, IHo
         }
     }
 
-    //private static void WriteReferences(IDistributedApplicationResource resource, Utf8JsonWriter jsonWriter)
-    //{
-    //    var serviceReferenceAnnotations = resource.Annotations.OfType<ServiceReferenceAnnotation>();
-
-    //    if (serviceReferenceAnnotations.Any())
-    //    {
-    //        jsonWriter.WriteStartObject("references");
-
-    //        foreach (var serviceReferenceAnnotation in serviceReferenceAnnotations)
-    //        {
-    //            jsonWriter.WriteStartObject(serviceReferenceAnnotation.Resource.Name);
-
-    //            jsonWriter.WriteStartArray("bindings");
-
-    //            var bindingNames = serviceReferenceAnnotation.UseAllBindings
-    //                ? serviceReferenceAnnotation.Resource.Annotations.OfType<ServiceBindingAnnotation>().Select(b => b.Name)
-    //                : serviceReferenceAnnotation.BindingNames;
-
-    //            foreach (var bindingName in bindingNames)
-    //            {
-    //                jsonWriter.WriteStringValue(bindingName);
-    //            }
-
-    //            jsonWriter.WriteEndArray();
-
-    //            jsonWriter.WriteEndObject();
-    //        }
-
-    //        jsonWriter.WriteEndObject();
-    //    }
-    //}
-
     private static void WriteBindings(IDistributedApplicationResource resource, Utf8JsonWriter jsonWriter)
     {
         if (resource.TryGetServiceBindings(out var serviceBindings))

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -142,9 +142,4 @@ public static class ResourceBuilderExtensions
         var annotation = new ServiceBindingAnnotation(ProtocolType.Tcp, scheme, name, port: hostPort);
         return builder.WithAnnotation(annotation);
     }
-
-    public static IDistributedApplicationResourceBuilder<T> WithServiceBindingForPublisher<T>(this IDistributedApplicationResourceBuilder<T> builder, string publisherName, string bindingName, Func<ServiceBindingCallbackContext, ServiceBindingAnnotation>? callback = null) where T : IDistributedApplicationResource
-    {
-        return builder.WithAnnotation(new ServiceBindingCallbackAnnotation(publisherName, bindingName, callback));
-    }
 }


### PR DESCRIPTION
This PR explores an idea around emitting service reference information into the manifest so that it contains all the information needed to support service discovery. On each resource you'll find a ```references``` and ```bindings``` property.

The ```bindings``` property is the list of endpoints that a particular resource exports and its where you get the various bits of protocol information such as TCP/UDP, URI scheme, and transport (e.g. HTTP/2). I've remove the ability to mark an endpoint as being external for now as discussed, selecting which project will be external is someting that the tool processing the manifest does.

The ```references``` property can be thought of a list of endpoints that the service they are attached to need to be able to communicate with. This information is necessary if the tool interpretting the manifest needs to be able to reconstruct service discovery envrionment variables and inject them into the consuming services.

This is something that we do for the inner loop today but it isn't possible for us to pre-compute these values.

Here is what the code looks like after this change:

```csharp
using Aspire.Hosting.Azure;
using Aspire.Hosting.Postgres;
using Aspire.Hosting.Redis;

var builder = DistributedApplication.CreateBuilder(args);

builder.AddAzureProvisioning();

var grafana = builder.AddContainer("grafana", "grafana/grafana")
                     .WithServiceBinding(containerPort: 3000, name: "grafana-http", scheme: "http");

var catalogdb = builder.AddPostgresContainer("postgres").AddDatabase("catalog");

var redis = builder.AddRedisContainer("basketCache");

var catalog = builder.AddProject<Projects.CatalogService>("catalogservice")
                     .WithReference(catalogdb)
                     .WithReplicas(2);

var serviceBus = builder.AddAzureServiceBus("messaging", queueNames: ["orders"]);

var basket = builder.AddProject<Projects.BasketService>("basketservice")
                    .WithReference(redis)
                    .WithReference(serviceBus, optional: true);

builder.AddProject<Projects.MyFrontend>("myfrontend")
       .WithServiceReference(basket)
       .WithServiceReference(catalog, bindingName: "http")
       .WithEnvironment("GRAFANA_URL", () => grafana.GetEndpoint("grafana-http")?.UriString ?? $"{{{grafana.Resource.Name}.bindings.grafana-http}}");

builder.AddProject<Projects.OrderProcessor>("orderprocessor")
       .WithReference(serviceBus, optional: true)
       .WithLaunchProfile("OrderProcessor");

builder.AddProject<Projects.ApiGateway>("apigateway")
       .WithServiceReference(basket)
       .WithServiceReference(catalog);

builder.AddContainer("prometheus", "prom/prometheus")
       .WithVolumeMount("../prometheus", "/etc/prometheus")
       .WithServiceBinding(9090);

builder.Build().Run();
```

And the resulting manifest:

```json
{
  "resources": {
    "grafana": {
      "type": "container.v1",
      "image": "grafana/grafana:latest",
      "bindings": {
        "grafana-http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http"
        }
      }
    },
    "postgres": {
      "type": "postgres.server.v1"
    },
    "catalog": {
      "type": "postgres.database.v1",
      "parent": "postgres"
    },
    "basketCache": {
      "type": "redis.v1"
    },
    "catalogservice": {
      "type": "project.v1",
      "path": "..\\CatalogService\\CatalogService.csproj",
      "env": {
        "ConnectionStrings__catalog": "{catalog.connectionString}"
      },
      "bindings": {
        "generated-http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http"
        },
        "generated-https": {
          "scheme": "https",
          "protocol": "tcp",
          "transport": "http"
        }
      }
    },
    "messaging": {
      "type": "azure.servicebus.v1",
      "queues": [
        "orders"
      ]
    },
    "basketservice": {
      "type": "project.v1",
      "path": "..\\BasketService\\BasketService.csproj",
      "env": {
        "ConnectionStrings__basketCache": "{basketCache.connectionString}",
        "ConnectionStrings__messaging": "{messaging.connectionString}"
      },
      "bindings": {
        "generated-http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http"
        },
        "generated-https": {
          "scheme": "https",
          "protocol": "tcp",
          "transport": "http"
        }
      }
    },
    "myfrontend": {
      "type": "project.v1",
      "path": "..\\MyFrontend\\MyFrontend.csproj",
      "env": {
        "GRAFANA_URL": "{grafana.bindings.grafana-http}"
      },
      "bindings": {
        "generated-http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http"
        },
        "generated-https": {
          "scheme": "https",
          "protocol": "tcp",
          "transport": "http"
        }
      },
      "references": {
        "basketservice": {
          "bindings": [
            "generated-http",
            "generated-https"
          ]
        },
        "catalogservice": {
          "bindings": [
            "http"
          ]
        }
      }
    },
    "orderprocessor": {
      "type": "project.v1",
      "path": "..\\OrderProcessor\\OrderProcessor.csproj",
      "env": {
        "ConnectionStrings__messaging": "{messaging.connectionString}"
      },
      "bindings": {
        "generated-http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http"
        },
        "generated-https": {
          "scheme": "https",
          "protocol": "tcp",
          "transport": "http"
        }
      }
    },
    "apigateway": {
      "type": "project.v1",
      "path": "..\\ApiGateway\\ApiGateway.csproj",
      "env": {},
      "bindings": {
        "generated-http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http"
        },
        "generated-https": {
          "scheme": "https",
          "protocol": "tcp",
          "transport": "http"
        }
      },
      "references": {
        "basketservice": {
          "bindings": [
            "generated-http",
            "generated-https"
          ]
        },
        "catalogservice": {
          "bindings": [
            "generated-http",
            "generated-https"
          ]
        }
      }
    },
    "prometheus": {
      "type": "container.v1",
      "image": "prom/prometheus:latest",
      "bindings": {
        "tcp": {
          "scheme": "tcp",
          "protocol": "tcp",
          "transport": "tcp"
        }
      }
    }
  }
}
```

I am also generating http and https bindings for every project (called ```generated-http``` and ```generated-https``` respectively. This is a sledgehammer right not to get the end-to-end scenario working. Eventually this will be tuned based on whether it is a web project and what is in appsettings.