### PR TITLE
Remove some flash of white in dark mode

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -12,8 +12,9 @@
     <link rel="stylesheet" href="_content/Aspire.Dashboard/Aspire.Dashboard.bundle.scp.css" />
     <HeadOutlet @rendermode="@RenderMode.InteractiveServer" />
     <!-- Make the body background dark if dark mode will be enabled to prevent a flash of white
-         before fully rendered -->
-    <style>@@media (prefers-color-scheme: dark) { body { background-color: #333333; } }</style>
+         before fully rendered. This value is from --neutral-fill-layer-rest, but that custom
+         property isn't available at this point. -->
+    <style>@@media (prefers-color-scheme: dark) { body { background-color: #464646; } }</style>
 </head>
 
 <body class="before-upgrade">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -1,37 +1,39 @@
-@using Aspire.Dashboard.Model
+﻿@using Aspire.Dashboard.Model
 @using Microsoft.AspNetCore.Http
 @inject IDashboardViewModelService dashboardViewModelService
 @inherits LayoutComponentBase
 
-<div @ref="_container">
-    <FluentLayout>
-        <FluentHeader Style="margin-bottom:0px">@dashboardViewModelService.ApplicationName Dashboard</FluentHeader>
-        <FluentStack Orientation="Orientation.Horizontal" Width="100%">
-            <div class="nav-menu-container">
-                <FluentNavMenu Width="250" Collapsible="true">
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Href="/" Match="NavLinkMatch.All">Projects</FluentNavLink>
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.BinFull())" Href="/Containers">Containers</FluentNavLink>
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Href="/Executables">Executables</FluentNavLink>
-                    <FluentNavGroup Title="Logs" Icon="@(new Icons.Regular.Size24.SlideText())" Expanded="true" Gap="10px 0;">
-                        <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ProjectLogs">Project</FluentNavLink>
-                        <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ContainerLogs">Container</FluentNavLink>
-                        <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ExecutableLogs">Executable</FluentNavLink>
-                        <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Href="/StructuredLogs">Structured</FluentNavLink>
-                    </FluentNavGroup>
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces">Traces</FluentNavLink>
-                </FluentNavMenu>
-            </div>
-            <FluentBodyContent Class="custom-body-content">
-                @Body
-            </FluentBodyContent>
+<div>
+    <FluentDesignSystemProvider BaseLayerLuminance="@_baseLayerLuminance">
+        <FluentLayout>
+            <FluentHeader Style="margin-bottom:0px">@dashboardViewModelService.ApplicationName Dashboard</FluentHeader>
+            <FluentStack Orientation="Orientation.Horizontal" Width="100%">
+                <div class="nav-menu-container">
+                    <FluentNavMenu Width="250" Collapsible="true">
+                        <FluentNavLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Href="/" Match="NavLinkMatch.All">Projects</FluentNavLink>
+                        <FluentNavLink Icon="@(new Icons.Regular.Size24.BinFull())" Href="/Containers">Containers</FluentNavLink>
+                        <FluentNavLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Href="/Executables">Executables</FluentNavLink>
+                        <FluentNavGroup Title="Logs" Icon="@(new Icons.Regular.Size24.SlideText())" Expanded="true" Gap="10px 0;">
+                            <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ProjectLogs">Project</FluentNavLink>
+                            <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ContainerLogs">Container</FluentNavLink>
+                            <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ExecutableLogs">Executable</FluentNavLink>
+                            <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Href="/StructuredLogs">Structured</FluentNavLink>
+                        </FluentNavGroup>
+                        <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces">Traces</FluentNavLink>
+                    </FluentNavMenu>
+                </div>
+                <FluentBodyContent Class="custom-body-content">
+                    @Body
+                </FluentBodyContent>
 
-        </FluentStack>
-    </FluentLayout>
-    <FluentDialogProvider />
-    <FluentTooltipProvider />
-    <div id="blazor-error-ui">
-        An unhandled error has occurred.
-        <a href="" class="reload">Reload</a>
-        <a class="dismiss">🗙</a>
-    </div>
+            </FluentStack>
+        </FluentLayout>
+        <FluentDialogProvider />
+        <FluentTooltipProvider />
+        <div id="blazor-error-ui">
+            An unhandled error has occurred.
+            <a href="" class="reload">Reload</a>
+            <a class="dismiss">🗙</a>
+        </div>
+    </FluentDesignSystemProvider>
 </div>


### PR DESCRIPTION
Reverting part of #246 back to using FluentDesignSystemProvider. Even though it's old and not recommended anymore, it seems to work much better for this scenario. We can work to find a replacement for it, but wanted to get rid of (most of) the flash of white. This may not completely remove it, but it comes close.