### PR TITLE
Workaround for Split Panels in .NET 8 RTM

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="_content/Microsoft.Fast.Components.FluentUI/Microsoft.Fast.Components.FluentUI.bundle.scp.css" />
     <link rel="stylesheet" href="_content/Aspire.Dashboard/css/app.css" />
     <link rel="stylesheet" href="_content/Aspire.Dashboard/Aspire.Dashboard.bundle.scp.css" />
+    <link rel="stylesheet" href="_content/Microsoft.Fast.Components.FluentUI/css/Microsoft.Fast.Components.FluentUI.css" />
     <HeadOutlet @rendermode="@RenderMode.InteractiveServer" />
     <!-- Make the body background dark if dark mode will be enabled to prevent a flash of white
          before fully rendered. This value is from --neutral-fill-layer-rest, but that custom
@@ -22,5 +23,6 @@
     <script src="_content/Microsoft.Fast.Components.FluentUI/js/web-components-v2.5.16.min.js" type="module"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/Aspire.Dashboard/js/app.js"></script>
+    <script src="_content/Aspire.Dashboard/js/SplitPanelsWorkaround.js" type="module" async></script>
 </body>
 </html>

--- a/src/Aspire.Dashboard/wwwroot/js/SplitPanelsWorkaround.js
+++ b/src/Aspire.Dashboard/wwwroot/js/SplitPanelsWorkaround.js
@@ -1,0 +1,3 @@
+import { SplitPanels } from "/_content/Microsoft.Fast.Components.FluentUI/js/SplitPanels.js";
+
+customElements.define("split-panels", SplitPanels);


### PR DESCRIPTION
Quick workaround for the lack of blazor initializers at the moment. The FluentSplitter creates its own custom element `split-panels` separate from all the custom elements in the fluent ui web component library. Without the initializers, it wasn't getting defined. This loads the script and defines it outside of the initializer process. When we have a real fix, we can remove this.