### PR TITLE
Workaround for .NET 8 RTM Blazor Initializer Changes

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -19,7 +19,6 @@
 
 <body class="before-upgrade">
     <Routes @rendermode="@RenderMode.InteractiveServer" />
-    <script src="_content/Microsoft.Fast.Components.FluentUI/js/web-components-v2.5.16.min.js" type="module"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/Aspire.Dashboard/js/app.js"></script>
 </body>

--- a/src/Aspire.Dashboard/wwwroot/Aspire.Dashboard.lib.module.js
+++ b/src/Aspire.Dashboard/wwwroot/Aspire.Dashboard.lib.module.js
@@ -1,0 +1,9 @@
+import * as LibraryExports from "/_content/Microsoft.Fast.Components.FluentUI/Microsoft.Fast.Components.FluentUI.lib.module.js";
+
+export function beforeServerStart(blazor) {
+    LibraryExports.beforeStart(blazor);
+}
+
+export function afterServerStarted(blazor) {
+    LibraryExports.afterStarted(blazor);
+}


### PR DESCRIPTION
Blazor in .NET 8 added new initialization concepts for the various render modes. In doing so, it made it such that the Fluent UI Blazor library's initializers don't get called anymore. As a temporary workaround until the library is updated, we create a shim here using our own initializers that call into the library's initializers. 

We will still get a warning in the browser console stating that the library's initializers are being ignored, but that's fine since we're calling them.