### PR TITLE
Move PackageIconFullPath to props file

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,7 @@
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <LangVersion>preview</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIconFullPath>$(MSBuildThisFileDirectory)src/Shared/Aspire_icon_256.png</PackageIconFullPath>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,9 +4,6 @@
     <ReadMePath>$(MSBuildProjectDirectory)\README.md</ReadMePath>
     <ReadMeExists Condition="Exists('$(ReadMePath)')">true</ReadMeExists>
     <PackageReadmeFile Condition="'$(PackageReadmeFile)' == '' And '$(ReadMeExists)' == 'true'">README.md</PackageReadmeFile>
-    <IconPath>$(MSBuildThisFileDirectory)src/Shared/Aspire_icon_256.png</IconPath>
-    <IconExists Condition="Exists('$(IconPath)')">true</IconExists>
-    <PackageIconFullPath Condition="'$(UseAspireIcon)' != 'false' And '$(IconExists)' == 'true'">$(IconPath)</PackageIconFullPath>
   </PropertyGroup>
 
   <Import Condition="'$(SampleProject)' == 'true' or '$(CI)' != 'true' " Project="eng\Versions.dev.targets" />


### PR DESCRIPTION
@DamianEdwards - we should be able to just do this.

And then when an individual .csproj wants to override the icon, they can just set `<PackageIconFullPath>` in their project, and it will overwrite this.