### PR TITLE
Use VS workload rather than SDK workload for visibility

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
@@ -7,5 +7,12 @@
       "id": "vs",
       "version": "(,17.9)"
     }
+  ],
+  "requiredComponents": [
+    {
+      "hostId": "vs",
+      "componentType": "setupComponent",
+      "id": "aspire"
+    }
   ]
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -38,12 +38,6 @@
       ]
     }
   ],
-  "constraints": {
-    "aspire": {
-       "type": "workload",
-       "args": [ "aspire" ]
-    }
-  },
   "symbols": {
     "Framework": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/ide.host.json
@@ -8,6 +8,13 @@
       "version": "(,17.9)"
     }
   ],
+  "requiredComponents": [
+    {
+      "hostId": "vs",
+      "componentType": "setupComponent",
+      "id": "aspire"
+    }
+  ],
   "symbolInfo": [
     {
       "id": "UseRedisCache",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -45,12 +45,6 @@
       ]
     }
   ],
-  "constraints": {
-    "aspire": {
-       "type": "workload",
-       "args": [ "aspire" ]
-    }
-  },
   "symbols": {
     "Framework": {
       "type": "parameter",


### PR DESCRIPTION
There appears to be a bug in the way we determine if a matching SDK is installed in the Workload resolver we use for template constraints.

Reverting to use VS workload to mitigate until underlying issue can be fixed.