### PR TITLE
Fix whitespace issue in component package descriptions

### DIFF
--- a/src/Components/Aspire.Azure.Data.Tables/Aspire.Azure.Data.Tables.csproj
+++ b/src/Components/Aspire.Azure.Data.Tables/Aspire.Azure.Data.Tables.csproj
@@ -4,10 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>$(ComponentAzurePackageTags) tables table</PackageTags>
-    <Description>
-      A client for Azure Table Storage that integrates with Aspire, including
-      health checks, logging, and telemetry.
-    </Description>
+    <Description>A client for Azure Table Storage that integrates with Aspire, including health checks, logging, and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/Aspire.Azure.Messaging.ServiceBus.csproj
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/Aspire.Azure.Messaging.ServiceBus.csproj
@@ -4,10 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>$(ComponentAzurePackageTags) servicebus amqp</PackageTags>
-    <Description>
-      A client for Azure Service Bus that integrates with Aspire, including
-      health checks, logging and telemetry.
-    </Description>
+    <Description>A client for Azure Service Bus that integrates with Aspire, including health checks, logging and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Security.KeyVault/Aspire.Azure.Security.KeyVault.csproj
+++ b/src/Components/Aspire.Azure.Security.KeyVault/Aspire.Azure.Security.KeyVault.csproj
@@ -4,10 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>$(ComponentAzurePackageTags) keyvault secrets</PackageTags>
-    <Description>
-      A client for Azure Key Vault that integrates with Aspire, including health
-      checks, logging and telemetry.
-    </Description>
+    <Description>A client for Azure Key Vault that integrates with Aspire, including health checks, logging and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Storage.Blobs/Aspire.Azure.Storage.Blobs.csproj
+++ b/src/Components/Aspire.Azure.Storage.Blobs/Aspire.Azure.Storage.Blobs.csproj
@@ -4,10 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>$(ComponentAzurePackageTags) storage blobs blob</PackageTags>
-    <Description>
-      A client for Azure Blob Storage that integrates with Aspire, including
-      health checks, logging and telemetry.
-    </Description>
+    <Description>A client for Azure Blob Storage that integrates with Aspire, including health checks, logging and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Storage.Queues/Aspire.Azure.Storage.Queues.csproj
+++ b/src/Components/Aspire.Azure.Storage.Queues/Aspire.Azure.Storage.Queues.csproj
@@ -4,10 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>$(ComponentAzurePackageTags) storage queue queues</PackageTags>
-    <Description>
-      A client for Azure Queue Storage that integrates with Aspire, including
-      health checks, logging and telemetry.
-    </Description>
+    <Description>A client for Azure Queue Storage that integrates with Aspire, including health checks, logging and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/Aspire.Microsoft.Data.SqlClient.csproj
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/Aspire.Microsoft.Data.SqlClient.csproj
@@ -6,10 +6,7 @@
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <IsAotCompatible>true</IsAotCompatible>
     <PackageTags>$(ComponentDatabasePackageTags) sqlserver sql</PackageTags>
-    <Description>
-      A Microsoft SQL Server client that integrates with Aspire, including
-      health checks, metrics and telemetry.
-    </Description>
+    <Description>A Microsoft SQL Server client that integrates with Aspire, including health checks, metrics and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -6,11 +6,7 @@
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <IsAotCompatible>true</IsAotCompatible>
     <PackageTags>$(ComponentEfCorePackageTags) sqlserver sql</PackageTags>
-    <Description>
-      A Microsoft SQL Server provider for Entity Framework Core that integrates
-      with Aspire, including connection pooling, health check, logging, and
-      telemetry.
-    </Description>
+    <Description>A Microsoft SQL Server provider for Entity Framework Core that integrates with Aspire, including connection pooling, health check, logging, and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
@@ -6,11 +6,7 @@
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <IsAotCompatible>true</IsAotCompatible>
     <PackageTags>$(ComponentEfCorePackageTags) postgressql postgres npgsql sql</PackageTags>
-    <Description>
-      A PostgreSQL provider for Entity Framework Core that integrates with
-      Aspire, including connection pooling, health checks, logging, and
-      telemetry.
-    </Description>
+    <Description>A PostgreSQL provider for Entity Framework Core that integrates with Aspire, including connection pooling, health checks, logging, and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Npgsql/Aspire.Npgsql.csproj
+++ b/src/Components/Aspire.Npgsql/Aspire.Npgsql.csproj
@@ -6,10 +6,7 @@
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <IsAotCompatible>true</IsAotCompatible>
     <PackageTags>$(ComponentDatabasePackageTags) postgressql postgres npgsql sql</PackageTags>
-    <Description>
-      A PostgreSQL client that integrates with Aspire, including health checks,
-      metrics, logging, and telemetry.
-    </Description>
+    <Description>A PostgreSQL client that integrates with Aspire, including health checks, metrics, logging, and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/Aspire.StackExchange.Redis.DistributedCaching.csproj
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/Aspire.StackExchange.Redis.DistributedCaching.csproj
@@ -4,10 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>$(ComponentCachePackageTags) distributedcaching distributedcache redis</PackageTags>
-    <Description>
-      A Redis-based implementation for IDistributedCache that integrates with
-      Aspire, including health checks, logging, and telemetry.
-    </Description>
+    <Description>A Redis-based implementation for IDistributedCache that integrates with Aspire, including health checks, logging, and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.StackExchange.Redis.OutputCaching/Aspire.StackExchange.Redis.OutputCaching.csproj
+++ b/src/Components/Aspire.StackExchange.Redis.OutputCaching/Aspire.StackExchange.Redis.OutputCaching.csproj
@@ -4,10 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>$(ComponentCachePackageTags) aspnetcore outputcaching outputcache redis</PackageTags>
-    <Description>
-      A Redis-based implementation for ASP.NET Core Output Caching that
-      integrates with Aspire, including health checks, logging, and telemetry.
-    </Description>
+    <Description>A Redis-based implementation for ASP.NET Core Output Caching that integrates with Aspire, including health checks, logging, and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.StackExchange.Redis/Aspire.StackExchange.Redis.csproj
+++ b/src/Components/Aspire.StackExchange.Redis/Aspire.StackExchange.Redis.csproj
@@ -4,10 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>$(ComponentCachePackageTags) redis</PackageTags>
-    <Description>
-      A generic Redis client that integrates with Aspire, including health
-      checks, logging, and telemetry.
-    </Description>
+    <Description>A generic Redis client that integrates with Aspire, including health checks, logging, and telemetry.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The package manager in VS preserves the original whitespace which was causing oddness with how it is displayed.

<img width="835" alt="image" src="https://github.com/dotnet/aspire/assets/249088/23865a78-6031-406b-b567-858a53cfd8d3">
