### PR TITLE
Really simple approach to combining WithReference and WithServiceRefe…

### DIFF
--- a/samples/dapr/AppHost/aspire-manifest.json
+++ b/samples/dapr/AppHost/aspire-manifest.json
@@ -3,12 +3,36 @@
     "servicea": {
       "type": "project.v1",
       "path": "..\\ServiceA\\DaprServiceA.csproj",
-      "env": {}
+      "env": {},
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
+        }
+      }
     },
     "serviceb": {
       "type": "project.v1",
       "path": "..\\ServiceB\\DaprServiceB.csproj",
-      "env": {}
+      "env": {},
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
+        }
+      }
     },
     "service-a": {
       "type": "executable.v1",

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -20,8 +20,8 @@ var basket = builder.AddProject<Projects.BasketService>("basketservice")
                     .WithReference(serviceBus, optional: true);
 
 builder.AddProject<Projects.MyFrontend>("myfrontend")
-       .WithServiceReference(basket)
-       .WithServiceReference(catalog, bindingName: "http")
+       .WithReference(basket)
+       .WithReference(catalog, bindingName: "http")
        .WithEnvironment("GRAFANA_URL", () => grafana.GetEndpoint("grafana-http")?.UriString ?? $"{{{grafana.Resource.Name}.bindings.grafana-http}}");
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor")
@@ -29,8 +29,8 @@ builder.AddProject<Projects.OrderProcessor>("orderprocessor")
        .WithLaunchProfile("OrderProcessor");
 
 builder.AddProject<Projects.ApiGateway>("apigateway")
-       .WithServiceReference(basket)
-       .WithServiceReference(catalog);
+       .WithReference(basket)
+       .WithReference(catalog);
 
 builder.AddContainer("prometheus", "prom/prometheus")
        .WithVolumeMount("../prometheus", "/etc/prometheus")

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -22,7 +22,7 @@ var basket = builder.AddProject<Projects.BasketService>("basketservice")
 builder.AddProject<Projects.MyFrontend>("myfrontend")
        .WithReference(basket)
        .WithReference(catalog.GetEndpoint("http"))
-       .WithEnvironment("GRAFANA_URL", () => grafana.GetEndpoint("grafana-http").UriStringOrPlaceholder);
+       .WithEnvironment("GRAFANA_URL", () => grafana.GetEndpoint("grafana-http").UriString);
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor")
        .WithReference(serviceBus, optional: true)

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -21,8 +21,8 @@ var basket = builder.AddProject<Projects.BasketService>("basketservice")
 
 builder.AddProject<Projects.MyFrontend>("myfrontend")
        .WithReference(basket)
-       .WithReference(catalog, bindingName: "http")
-       .WithEnvironment("GRAFANA_URL", () => grafana.GetEndpoint("grafana-http")?.UriString ?? $"{{{grafana.Resource.Name}.bindings.grafana-http}}");
+       .WithReference(catalog.GetEndpoint("http"))
+       .WithEnvironment("GRAFANA_URL", () => grafana.GetEndpoint("grafana-http").UriStringOrPlaceholder);
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor")
        .WithReference(serviceBus, optional: true)

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -51,8 +51,7 @@
       "path": "..\\BasketService\\BasketService.csproj",
       "env": {
         "ConnectionStrings__basketCache": "{basketCache.connectionString}",
-        "ConnectionStrings__messaging": "{messaging.connectionString}",
-        "services__basketCache__0": "{basketCache.bindings.tcp.url}"
+        "ConnectionStrings__messaging": "{messaging.connectionString}"
       },
       "bindings": {
         "http": {
@@ -71,7 +70,7 @@
       "type": "project.v1",
       "path": "..\\MyFrontend\\MyFrontend.csproj",
       "env": {
-        "GRAFANA_URL": "grafana.bindings.grafana-http",
+        "GRAFANA_URL": "{grafana.bindings.grafana-http}",
         "services__basketservice__0": "{basketservice.bindings.http.url}",
         "services__basketservice__1": "{basketservice.bindings.https.url}",
         "services__catalogservice__0": "{catalogservice.bindings.http.url}"

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -51,7 +51,8 @@
       "path": "..\\BasketService\\BasketService.csproj",
       "env": {
         "ConnectionStrings__basketCache": "{basketCache.connectionString}",
-        "ConnectionStrings__messaging": "{messaging.connectionString}"
+        "ConnectionStrings__messaging": "{messaging.connectionString}",
+        "services__basketCache__0": "{basketCache.bindings.tcp.url}"
       },
       "bindings": {
         "http": {
@@ -70,7 +71,7 @@
       "type": "project.v1",
       "path": "..\\MyFrontend\\MyFrontend.csproj",
       "env": {
-        "GRAFANA_URL": "{grafana.bindings.grafana-http}",
+        "GRAFANA_URL": "grafana.bindings.grafana-http",
         "services__basketservice__0": "{basketservice.bindings.http.url}",
         "services__basketservice__1": "{basketservice.bindings.https.url}",
         "services__catalogservice__0": "{catalogservice.bindings.http.url}"

--- a/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
@@ -3,6 +3,6 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-public class ContainerResource(string name) : DistributedApplicationResource(name), IDistributedApplicationResourceWithEnvironment
+public class ContainerResource(string name) : DistributedApplicationResource(name), IDistributedApplicationResourceWithEnvironment, IDistributedApplicationResourceWithBindings
 {
 }

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+public sealed class EndpointReference(IDistributedApplicationResourceWithBindings owner, string bindingName)
+{
+    public IDistributedApplicationResourceWithBindings Owner { get; } = owner;
+    public string BindingName { get; } = bindingName;
+
+    public string UriStringOrPlaceholder
+    {
+        get
+        {
+            var allocatedEndpoint = Owner.Annotations.OfType<AllocatedEndpointAnnotation>().SingleOrDefault(a => a.Name == BindingName);
+            return allocatedEndpoint?.UriString ?? $"{Owner.Name}.bindings.{BindingName}";
+        }
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -8,7 +8,7 @@ public sealed class EndpointReference(IDistributedApplicationResourceWithBinding
     public IDistributedApplicationResourceWithBindings Owner { get; } = owner;
     public string BindingName { get; } = bindingName;
 
-    public string UriStringOrPlaceholder
+    public string UriString
     {
         get
         {

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -13,7 +13,7 @@ public sealed class EndpointReference(IDistributedApplicationResourceWithBinding
         get
         {
             var allocatedEndpoint = Owner.Annotations.OfType<AllocatedEndpointAnnotation>().SingleOrDefault(a => a.Name == BindingName);
-            return allocatedEndpoint?.UriString ?? $"{Owner.Name}.bindings.{BindingName}";
+            return allocatedEndpoint?.UriString ?? $"{{{Owner.Name}.bindings.{BindingName}}}";
         }
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -3,7 +3,7 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-public class ExecutableResource(string name, string command, string workingDirectory, string[]? args) : DistributedApplicationResource(name), IDistributedApplicationResourceWithEnvironment
+public class ExecutableResource(string name, string command, string workingDirectory, string[]? args) : DistributedApplicationResource(name), IDistributedApplicationResourceWithEnvironment, IDistributedApplicationResourceWithBindings
 {
     public string Command { get; } = command;
     public string WorkingDirectory { get; } = workingDirectory;

--- a/src/Aspire.Hosting/ApplicationModel/IDistributedApplicationResourceWithBindings.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IDistributedApplicationResourceWithBindings.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+public interface IDistributedApplicationResourceWithBindings : IDistributedApplicationResource
+{
+    public EndpointReference GetEndpoint(string bindingName)
+    {
+        return new EndpointReference(this, bindingName);
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -3,6 +3,6 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-public class ProjectResource(string name) : DistributedApplicationResource(name), IDistributedApplicationResourceWithEnvironment
+public class ProjectResource(string name) : DistributedApplicationResource(name), IDistributedApplicationResourceWithEnvironment, IDistributedApplicationResourceWithBindings
 {
 }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -64,7 +64,19 @@ public static class ResourceBuilderExtensions
         };
     }
 
-    public static IDistributedApplicationResourceBuilder<TDestination> WithReference<TDestination, TSource>(this IDistributedApplicationResourceBuilder<TDestination> builder, IDistributedApplicationResourceBuilder<TSource> source, string? connectionName = null, bool optional = false)
+    public static IDistributedApplicationResourceBuilder<TDestination> WithReference<TDestination, TSource>(this IDistributedApplicationResourceBuilder<TDestination> builder, IDistributedApplicationResourceBuilder<TSource> source, string? connectionName = null, bool optional = false, string? bindingName = null)
+    where TDestination : IDistributedApplicationResourceWithEnvironment
+    where TSource : IDistributedApplicationResource
+    {
+        return source switch
+        {
+            IDistributedApplicationResourceBuilder<IDistributedApplicationResourceWithConnectionString> sourceWithConnectionString => builder.WithReferenceToResource(sourceWithConnectionString, connectionName, optional),
+            IDistributedApplicationResourceBuilder<IDistributedApplicationResource> sourceWithServiceBindings => builder.WithReferenceToService(sourceWithServiceBindings, bindingName),
+            _ => throw new DistributedApplicationException("Cannot add reference to this component.")
+        };
+    }
+
+    private static IDistributedApplicationResourceBuilder<TDestination> WithReferenceToResource<TDestination, TSource>(this IDistributedApplicationResourceBuilder<TDestination> builder, IDistributedApplicationResourceBuilder<TSource> source, string? connectionName = null, bool optional = false)
         where TDestination : IDistributedApplicationResourceWithEnvironment
         where TSource : IDistributedApplicationResourceWithConnectionString
     {
@@ -99,7 +111,7 @@ public static class ResourceBuilderExtensions
         });
     }
 
-    public static IDistributedApplicationResourceBuilder<TDestination> WithServiceReference<TDestination, TSource>(this IDistributedApplicationResourceBuilder<TDestination> builder, IDistributedApplicationResourceBuilder<TSource> bindingSourceBuilder, string? bindingName = null) where TDestination : IDistributedApplicationResourceWithEnvironment where TSource : IDistributedApplicationResource
+    private static IDistributedApplicationResourceBuilder<TDestination> WithReferenceToService<TDestination, TSource>(this IDistributedApplicationResourceBuilder<TDestination> builder, IDistributedApplicationResourceBuilder<TSource> bindingSourceBuilder, string? bindingName = null) where TDestination : IDistributedApplicationResourceWithEnvironment where TSource : IDistributedApplicationResource
     {
         // When adding a service reference we get to see whether there is a ServiceReferencesAnnotation
         // on the resource, if there is then it means we have already been here before and we can just

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.AppHost/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.AppHost/Program.cs
@@ -10,6 +10,6 @@ builder.AddProject<Projects.AspireStarterApplication1_Web>("webfrontend")
 #if UseRedisCache
     .WithReference(cache)
 #endif
-    .WithServiceReference(apiservice);
+    .WithReference(apiservice);
 
 builder.Build().Run();

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Aspire.Hosting.Tests;
 
-public class WithServiceReferenceTests
+public class WithReferenceTests
 {
     [Fact]
     public void ResourceWithSingleServiceBindingProducesSimplifiedEnvironmentVariables()
@@ -25,7 +25,7 @@ public class WithServiceReferenceTests
             ));
 
         // Get the service provider.
-        testProgram.ServiceBBuilder.WithServiceReference(testProgram.ServiceABuilder, "mybinding");
+        testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("mybinding"));
         testProgram.Build();
 
         // Call environment variable callbacks.
@@ -71,11 +71,10 @@ public class WithServiceReferenceTests
             "https"
             ));
 
-        testProgram.ServiceBBuilder.WithServiceReference(testProgram.ServiceABuilder, "mybinding");
-        testProgram.ServiceBBuilder.WithServiceReference(testProgram.ServiceABuilder, "myconflictingbinding");
+        testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("mybinding"));
+        testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("myconflictingbinding"));
 
         // Get the service provider.
-        testProgram.ServiceBBuilder.WithServiceReference(testProgram.ServiceABuilder, "mybinding");
         testProgram.Build();
 
         // Call environment variable callbacks.
@@ -121,11 +120,10 @@ public class WithServiceReferenceTests
             "http"
             ));
 
-        testProgram.ServiceBBuilder.WithServiceReference(testProgram.ServiceABuilder, "mybinding");
-        testProgram.ServiceBBuilder.WithServiceReference(testProgram.ServiceABuilder, "mynonconflictingbinding");
+        testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("mybinding"));
+        testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("mynonconflictingbinding"));
 
         // Get the service provider.
-        testProgram.ServiceBBuilder.WithServiceReference(testProgram.ServiceABuilder, "mybinding");
         testProgram.Build();
 
         // Call environment variable callbacks.


### PR DESCRIPTION
Summary of changes:

* ```WithServiceReference``` combined into ```WithReference``` with type checks to invoke connection string or service discovery environment variable generation as appropriate.
* Introduced ```IDistributedApplicationResourceWithBindings``` interface which contains a ```GetEndpoint(string)``` method. 
* Introduced ```EndpointReference``` type which encapsulates a reference to a particular service binding and provides some helpers (e.g, ```UriStringOrPlaceholder``` to help with rendering endpoint details in environment variables  --- the GRAFANA_URL scenario).
* ```ContainerResource```, ```ProjectResource```, and ```ExecutableResource``` implement ```IDistributedApplicationResourceWithBindings```.

Fixes #194 