### PR TITLE
Allow switching from system theme

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -21,5 +21,6 @@
     <Routes @rendermode="@RenderMode.InteractiveServer" />
     <script src="_framework/blazor.web.js"></script>
     <script src="_content/Aspire.Dashboard/js/app.js"></script>
+    <script src="_content/Aspire.Dashboard/js/theme.js"></script>
 </body>
 </html>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -4,7 +4,7 @@
 @inject IJSRuntime JS
 @implements IDialogContentComponent
 
-<FluentRadioGroup TValue="string" Label="Theme" Value="@_currentSetting" ValueChanged="SettingChangedAsync">
+<FluentRadioGroup TValue="string" Label="Theme" Value="@_currentSetting" ValueChanged="SettingChangedAsync" Orientation="Orientation.Vertical">
     <FluentRadio Value="@ThemeSettingSystem">System</FluentRadio>
     <FluentRadio Value="@ThemeSettingLight">Light</FluentRadio>
     <FluentRadio Value="@ThemeSettingDark">Dark</FluentRadio>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -1,0 +1,11 @@
+﻿@using Microsoft.Fast.Components.FluentUI.DesignTokens
+@inject GlobalState GlobalState
+@inject BaseLayerLuminance BaseLayerLuminance
+@inject IJSRuntime JS
+@implements IDialogContentComponent
+
+<FluentRadioGroup TValue="string" Label="Theme" Value="@_currentSetting" ValueChanged="SettingChangedAsync">
+    <FluentRadio Value="@ThemeSettingSystem">System</FluentRadio>
+    <FluentRadio Value="@ThemeSettingLight">Light</FluentRadio>
+    <FluentRadio Value="@ThemeSettingDark">Dark</FluentRadio>
+</FluentRadioGroup>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Fast.Components.FluentUI;
+using Microsoft.JSInterop;
+
+namespace Aspire.Dashboard.Components.Dialogs;
+
+public partial class SettingsDialog : IDialogContentComponent
+{
+    private const float DarkThemeLuminance = 0.08f;
+    private const float LightThemeLuminance = 1.0f;
+    private const string ThemeSettingSystem = "System";
+    private const string ThemeSettingDark = "Dark";
+    private const string ThemeSettingLight = "Light";
+
+    private string _currentSetting = ThemeSettingSystem;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _currentSetting = await JS.InvokeAsync<string>("getThemeCookieValue");
+            StateHasChanged();
+        }
+    }
+
+    private async Task SettingChangedAsync(string newValue)
+    {
+        var newLuminanceValue = await GetBaseLayerLuminanceForSetting(newValue);
+
+        await BaseLayerLuminance.SetValueFor(GlobalState.Container, newLuminanceValue);
+        await JS.InvokeVoidAsync("setThemeCookie", newValue);
+
+        _currentSetting = newValue;
+    }
+
+    private Task<float> GetBaseLayerLuminanceForSetting(string setting)
+    {
+        if (setting == ThemeSettingLight)
+        {
+            return Task.FromResult(LightThemeLuminance);
+        }
+        else if (setting == ThemeSettingDark)
+        {
+            return Task.FromResult(DarkThemeLuminance);
+        }
+        else // "System"
+        {
+            return GetSystemThemeLuminance();
+        }
+    }
+
+    private async Task<float> GetSystemThemeLuminance()
+    {
+        var systemTheme = await JS.InvokeAsync<string>("getSystemTheme");
+        if (systemTheme == ThemeSettingDark)
+        {
+            return DarkThemeLuminance;
+        }
+        else
+        {
+            return LightThemeLuminance;
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -8,7 +8,14 @@
 
 <div @ref="_container">
     <FluentLayout>
-        <FluentHeader Style="margin-bottom:0px">@dashboardViewModelService.ApplicationName Dashboard</FluentHeader>
+        <FluentHeader Style="margin-bottom:0px">
+            <span>@dashboardViewModelService.ApplicationName Dashboard</span>
+            <div class="header-right">
+                <FluentButton Appearance="Appearance.Stealth" OnClick="LaunchSettings">
+                    <FluentIcon Value="@(new Icons.Regular.Size24.Settings())" Color="@Color.Custom" CustomColor="var(--foreground-on-accent-rest)" />
+                </FluentButton>
+            </div>
+        </FluentHeader>
         <FluentStack Orientation="Orientation.Horizontal" Width="100%">
             <div class="nav-menu-container">
                 <FluentNavMenu Width="250" Collapsible="true" role="menu">
@@ -22,7 +29,6 @@
                         <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Href="/StructuredLogs" role="menuitem">Structured</FluentNavLink>
                     </FluentNavGroup>
                     <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces" role="menuitem">Traces</FluentNavLink>
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.Settings())" OnClick="LaunchSettings">Settings</FluentNavLink>
                 </FluentNavMenu>
             </div>
             <FluentBodyContent Class="custom-body-content">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -1,9 +1,12 @@
-﻿@using Aspire.Dashboard.Model
+﻿@using Aspire.Dashboard.Components.Dialogs
+@using Aspire.Dashboard.Model
 @using Microsoft.AspNetCore.Http
 @inject IDashboardViewModelService dashboardViewModelService
+@inject IDialogService dialogService
+@inject GlobalState GlobalState
 @inherits LayoutComponentBase
 
-<div>
+<div @ref="_container">
     <FluentLayout>
         <FluentHeader Style="margin-bottom:0px">@dashboardViewModelService.ApplicationName Dashboard</FluentHeader>
         <FluentStack Orientation="Orientation.Horizontal" Width="100%">
@@ -19,6 +22,7 @@
                         <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Href="/StructuredLogs" role="menuitem">Structured</FluentNavLink>
                     </FluentNavGroup>
                     <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces" role="menuitem">Traces</FluentNavLink>
+                    <FluentNavLink Icon="@(new Icons.Regular.Size24.Settings())" OnClick="LaunchSettings">Settings</FluentNavLink>
                 </FluentNavMenu>
             </div>
             <FluentBodyContent Class="custom-body-content">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Components.Dialogs;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Fast.Components.FluentUI;
+
+namespace Aspire.Dashboard.Components.Layout;
+
+public partial class MainLayout
+{
+    private ElementReference _container;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            GlobalState.SetContainer(_container);
+        }
+    }
+
+    public async Task LaunchSettings()
+    {
+        DialogParameters parameters = new()
+        {
+            Title = $"Settings",
+            PrimaryAction = "Close",
+            PrimaryActionEnabled = true,
+            SecondaryAction = null,
+            TrapFocus = true,
+            Modal = true,
+            Width = "auto",
+            Height = "auto"
+        };
+
+        _ = await dialogService.ShowDialogAsync<SettingsDialog>(parameters).ConfigureAwait(true);
+    }
+}

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -29,7 +29,7 @@ public partial class MainLayout
             SecondaryAction = null,
             TrapFocus = true,
             Modal = true,
-            Width = "auto",
+            Width = "300px",
             Height = "auto"
         };
 

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -113,3 +113,15 @@ main {
     min-height: calc(100vh - 50px);
     background-color: var(--neutral-fill-stealth-rest);
 }
+
+::deep .header-right {
+    margin-left: auto;
+}
+
+::deep .layout > .header fluent-button[appearance=stealth]::part(control) {
+    background-color: var(--accent-fill-rest);
+}
+
+::deep .layout > .header fluent-button[appearance=stealth]:hover::part(control) {
+    background-color: var(--accent-fill-hover);
+}

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -45,3 +45,21 @@ fluent-toolbar[orientation=horizontal] {
 .custom-body-content {
     margin-right: 10px;
 }
+
+/* The fluent dialog's default fill color is too dark in our current dark theme.
+   Setting it to the floating layer allows it to stand out more and doesn't impact light theme. */
+fluent-dialog::part(control) {
+    background: var(--neutral-layer-floating);
+}
+
+/* Changing the dialog's fill color means stealth buttons on the dialog have the wrong background,
+   so change it to match */
+fluent-dialog fluent-button[appearance=stealth]:not(:hover)::part(control) {
+    background: var(--neutral-layer-floating);
+}
+
+/* But changing the stealth button's background in dialogs means the stealth buttons used as headers for grid cells
+   now have the wrong background. So change that back */
+fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appearance=stealth]:not(:hover)::part(control) {
+    background: var(--fill-layer);
+}

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -2,7 +2,7 @@
 // To avoid Flash of Unstyled Content, the body is hidden by default with
 // the before-upgrade CSS class. Here we'll find the first web component
 // and wait for it to be upgraded. When it is, we'll remove that class
-// from the body. 
+// from the body.
 const firstUndefinedElement = document.body.querySelector(":not(:defined)");
 
 if (firstUndefinedElement) {
@@ -77,12 +77,4 @@ window.updateFluentSelectDisplayValue = function (fluentSelect) {
     if (fluentSelect) {
         fluentSelect.updateDisplayValue();
     }
-}
-
-let matched = window.matchMedia('(prefers-color-scheme: dark)').matches;
-
-if (matched) {
-    window.DefaultBaseLayerLuminance = 0.08;
-} else {
-    window.DefaultBaseLayerLuminance = 1.0;
 }

--- a/src/Aspire.Dashboard/wwwroot/js/theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/theme.js
@@ -1,0 +1,67 @@
+const currentThemeCookieName = "currentTheme";
+const themeSettingSystem = "System";
+const themeSettingDark = "Dark";
+const themeSettingLight = "Light";
+const darkThemeLuminance = 0.08;
+const lightThemeLuminance = 1.0;
+
+/**
+ * Returns the current system theme (Light or Dark)
+ * @returns {string}
+ */
+window.getSystemTheme = function () {
+    let matched = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    if (matched) {
+        return themeSettingDark;
+    } else {
+        return themeSettingLight;
+    }
+}
+
+/**
+ * Sets the currentTheme cookie to the specified value.
+ * @param {string} theme
+ */
+window.setThemeCookie = function (theme) {
+    document.cookie = `${currentThemeCookieName}=${theme}`;
+}
+
+/**
+ * Returns the value of the currentTheme cookie, or System if the cookie is not set.
+ * @returns {string}
+ */
+window.getThemeCookieValue = function () {
+    return getCookieValue(currentThemeCookieName) ?? themeSettingSystem;
+}
+
+/**
+ * Returns the value of the specified cookie, or the empty string if the cookie is not present
+ * @param {string} cookieName
+ * @returns {string}
+ */
+function getCookieValue(cookieName) {
+    const cookiePieces = document.cookie.split(';');
+    for (let index = 0; index < cookiePieces.length; index++) {
+        if (cookiePieces[index].trim().startsWith(cookieName)) {
+            const cookieKeyValue = cookiePieces[index].split('=');
+            if (cookieKeyValue.length > 1) {
+                return cookieKeyValue[1];
+            }
+        }
+    }
+
+    return "";
+}
+
+let theme = window.getThemeCookieValue();
+
+if (theme === themeSettingSystem) {
+    theme = window.getSystemTheme();
+}
+
+if (theme === themeSettingDark) {
+    window.DefaultBaseLayerLuminance = darkThemeLuminance;
+} else /* Light */ {
+    window.DefaultBaseLayerLuminance = lightThemeLuminance;
+}


### PR DESCRIPTION
Currently the dashboard always follows the system theme, but that's not necessarily what everyone wants. This PR does a couple of things:

1. Adds a small settings dialog with these options for theme: System, Light, Dark
2. Modifies the current theme immediately based on the selection in that dialog
3. Sets a cookie based on the selection so that the setting is respected the next time it is launched rather than just defaulting to system theme.
4. Fixes a few small issues with the dark theme in dialogs after #297 