### PR TITLE
Add support for file nesting

### DIFF
--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
@@ -11,6 +11,8 @@
   <ItemGroup>
     <ProjectCapability Include="Aspire" />
     <ProjectCapability Include="AspireHost" />
+    <ProjectCapability Include="DynamicFileNesting" />
+    <ProjectCapability Include="DynamicFileNestingEnabled" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Add 2 capabilities so that files like appsettings.development.json are nested under appsettings.json. These two capabilities enable the default nesting rules in Visual Studio.