### PR TITLE
Fix null ref in dashboard when executable doesn't contain endpoints

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
@@ -317,7 +317,7 @@ public class DashboardViewModelService : IDashboardViewModelService, IDisposable
     private static int GetExpectedEndpointsCount(CustomResource resource, List<Service> services)
     {
         var expectedCount = 0;
-        if (resource.Metadata.Annotations.TryGetValue(CustomResource.ServiceProducerAnnotation, out var servicesProducedAnnotationJson))
+        if (resource.Metadata.Annotations is not null && resource.Metadata.Annotations.TryGetValue(CustomResource.ServiceProducerAnnotation, out var servicesProducedAnnotationJson))
         {
             var serviceProducerAnnotations = JsonSerializer.Deserialize<ServiceProducerAnnotation[]>(servicesProducedAnnotationJson);
             if (serviceProducerAnnotations is not null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/326