### PR TITLE
Default Redis AbortOnConnectFail to false

### DIFF
--- a/samples/eShopLite/BasketService/appsettings.json
+++ b/samples/eShopLite/BasketService/appsettings.json
@@ -13,20 +13,25 @@
     }
   },
   "Aspire": {
-    "Azure:Messaging:ServiceBus": {
-      "OrderQueueName": "orders",
-      "ClientOptions": {
-        "RetryOptions": {
-          "MaxRetries": 2,
-          "Delay": "00:00:01"
+    "Azure": {
+      "Messaging": {
+        "ServiceBus": {
+          "OrderQueueName": "orders",
+          "ClientOptions": {
+            "RetryOptions": {
+              "MaxRetries": 2,
+              "Delay": "00:00:01"
+            }
+          },
+          "Tracing": true
         }
-      },
-      "Tracing": true
+      }
     },
-    "StackExchange:Redis": {
-      "ConfigurationOptions": {
-        "AbortOnConnectFail": false,
-        "ConnectRetry": 2
+    "StackExchange": {
+      "Redis": {
+        "ConfigurationOptions": {
+          "ConnectRetry": 2
+        }
       }
     }
   }

--- a/samples/eShopLite/OrderProcessor/appsettings.json
+++ b/samples/eShopLite/OrderProcessor/appsettings.json
@@ -8,15 +8,19 @@
   },
 
   "Aspire": {
-    "Azure:Messaging:ServiceBus": {
-      "OrderQueueName": "orders",
-      "ClientOptions": {
-        "RetryOptions": {
-          "MaxRetries": 2,
-          "Delay": "00:00:01"
+    "Azure": {
+      "Messaging": {
+        "ServiceBus": {
+          "OrderQueueName": "orders",
+          "ClientOptions": {
+            "RetryOptions": {
+              "MaxRetries": 2,
+              "Delay": "00:00:01"
+            }
+          },
+          "Tracing": true
         }
-      },
-      "Tracing": true
+      }
     }
   }
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.Web/appsettings.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.Web/appsettings.json
@@ -5,15 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  //#if (UseRedisCache)
-  "Aspire": {
-    "StackExchange:Redis": {
-      "ConfigurationOptions": {
-        "AbortOnConnectFail": false,
-        "ConnectRetry": 2
-      }
-    }
-  },
-  //#endif
   "AllowedHosts": "*"
 }

--- a/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 using Xunit;
 
@@ -125,5 +126,59 @@ public class AspireRedisExtensionsTests
         Assert.Contains(AspireRedisHelpers.TestingEndpoint, connection.Configuration);
         // the connection string from config should not be used since it was found in ConnectionStrings
         Assert.DoesNotContain("unused", connection.Configuration);
+    }
+
+    public static IEnumerable<object[]> AbortOnConnectFailData =>
+    [
+        [true, GetDefaultConfiguration(), false],
+        [false, GetDefaultConfiguration(), false],
+
+        [true, GetSetsTrueConfig(true), true],
+        [false, GetSetsTrueConfig(false), true],
+
+        [true, GetConnectionString(abortConnect: true), true],
+        [false, GetConnectionString(abortConnect: true), true],
+        [true, GetConnectionString(abortConnect: false), false],
+        [false, GetConnectionString(abortConnect: false), false],
+    ];
+
+    private static IEnumerable<KeyValuePair<string, string?>> GetDefaultConfiguration() =>
+    [
+        new KeyValuePair<string, string?>("ConnectionStrings:redis", AspireRedisHelpers.TestingEndpoint)
+    ];
+
+    private static IEnumerable<KeyValuePair<string, string?>> GetSetsTrueConfig(bool useKeyed) =>
+    [
+        new KeyValuePair<string, string?>("ConnectionStrings:redis", AspireRedisHelpers.TestingEndpoint),
+        new KeyValuePair<string, string?>(ConformanceTests.CreateConfigKey("Aspire:StackExchange:Redis", useKeyed ? "redis" : null, "ConfigurationOptions:AbortOnConnectFail"), "true")
+    ];
+
+    private static IEnumerable<KeyValuePair<string, string?>> GetConnectionString(bool abortConnect) =>
+    [
+        new KeyValuePair<string, string?>("ConnectionStrings:redis", $"{AspireRedisHelpers.TestingEndpoint},abortConnect={(abortConnect ? "true" : "false")}")
+    ];
+
+    [Theory]
+    [MemberData(nameof(AbortOnConnectFailData))]
+    public void AbortOnConnectFailDefaults(bool useKeyed, IEnumerable<KeyValuePair<string, string?>> configValues, bool expectedAbortOnConnect)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection(configValues);
+
+        if (useKeyed)
+        {
+            builder.AddKeyedRedis("redis");
+        }
+        else
+        {
+            builder.AddRedis("redis");
+        }
+
+        var host = builder.Build();
+        var options = useKeyed ?
+            host.Services.GetRequiredService<IOptionsMonitor<ConfigurationOptions>>().Get("redis") :
+            host.Services.GetRequiredService<IOptions<ConfigurationOptions>>().Value;
+
+        Assert.Equal(expectedAbortOnConnect, options.AbortOnConnectFail);
     }
 }


### PR DESCRIPTION
When using Aspire, we don't want to fail on startup when a Redis server isn't immediately available - for example when the Redis container hasn't had a chance to start yet.

Defaulting AbortOnConnectFail to false, unless otherwise specified.

Fix #207