### PR TITLE
Service Discovery: Refactor DNS & DNS SRV providers into subclasses

### DIFF
--- a/samples/eShopLite/Deployment/basket-service.yml
+++ b/samples/eShopLite/Deployment/basket-service.yml
@@ -22,7 +22,7 @@ spec:
           - containerPort: 8080
           - containerPort: 8443
           env:
-          - name: Aspire.StackExchange.Redis__EndPoints__0
+          - name: ConnectionStrings__basketCache
             value: "redis"
           - name: ASPNETCORE_URLS
             value: "https://+:8443;http://+:8080"

--- a/samples/eShopLite/Deployment/catalog-service.yml
+++ b/samples/eShopLite/Deployment/catalog-service.yml
@@ -22,7 +22,7 @@ spec:
           - containerPort: 8080
           #- containerPort: 443
           env:
-          - name: ConnectionStrings__CatalogDb
+          - name: ConnectionStrings__catalog
             value: "Host=postgres-service;Database=catalog;Username=postgres;Password=postgres"
       terminationGracePeriodSeconds: 180
   minReadySeconds: 60

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
@@ -1,282 +1,42 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Net;
-using DnsClient;
-using DnsClient.Protocol;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
-/// <summary>
-/// A service end point resolver that uses DNS to resolve the service end points.
-/// </summary>
-internal sealed partial class DnsServiceEndPointResolver : IServiceEndPointResolver
+internal sealed partial class DnsServiceEndPointResolver(
+    string serviceName,
+    string hostName,
+    IOptionsMonitor<DnsServiceEndPointResolverOptions> options,
+    ILogger<DnsServiceEndPointResolver> logger,
+    TimeProvider timeProvider) : DnsServiceEndPointResolverBase(serviceName, logger, timeProvider)
 {
-    private readonly object _lock = new();
-    private readonly string _serviceName;
-    private readonly Stopwatch _lastRefreshTimer = new();
-    private readonly IOptionsMonitor<DnsServiceEndPointResolverOptions> _options;
-    private readonly ILogger<DnsServiceEndPointResolver> _logger;
-    private readonly CancellationTokenSource _disposeCancellation = new();
-    private readonly IDnsQuery _dnsClient;
-    private readonly TimeProvider _timeProvider;
-    private Task _resolveTask = Task.CompletedTask;
-    private ResolutionStatus _lastStatus;
-    private IChangeToken? _lastChangeToken;
-    private CancellationTokenSource _lastCollectionCancellation;
-    private List<ServiceEndPoint>? _lastEndPointCollection;
-    private readonly string _addressRecordName;
-    private readonly string _srvRecordName;
-    private readonly int _defaultPort;
-    private TimeSpan _nextRefreshPeriod;
+    protected override double RetryBackOffFactor => options.CurrentValue.RetryBackOffFactor;
+    protected override TimeSpan MinRetryPeriod => options.CurrentValue.MinRetryPeriod;
+    protected override TimeSpan MaxRetryPeriod => options.CurrentValue.MaxRetryPeriod;
+    protected override TimeSpan DefaultRefreshPeriod => options.CurrentValue.DefaultRefreshPeriod;
 
-    /// <summary>
-    /// Initializes a new <see cref="DnsServiceEndPointResolver"/> instance.
-    /// </summary>
-    /// <param name="serviceName">The service name.</param>
-    /// <param name="addressRecordName">The name used to resolve the address of this service.</param>
-    /// <param name="srvRecordName">The name used to resolve this service's SRV record in DNS.</param>
-    /// <param name="defaultPort">The default port to use for endpoints.</param>
-    /// <param name="options">The options.</param>
-    /// <param name="logger">The logger.</param>
-    /// <param name="dnsClient">The DNS client.</param>
-    /// <param name="timeProvider">The time provider.</param>
-    public DnsServiceEndPointResolver(
-        string serviceName,
-        string addressRecordName,
-        string srvRecordName,
-        int defaultPort,
-        IOptionsMonitor<DnsServiceEndPointResolverOptions> options,
-        ILogger<DnsServiceEndPointResolver> logger,
-        IDnsQuery dnsClient,
-        TimeProvider timeProvider)
-    {
-        _serviceName = serviceName;
-        _options = options;
-        _logger = logger;
-        _lastEndPointCollection = null;
-        _addressRecordName = addressRecordName;
-        _srvRecordName = srvRecordName;
-        _defaultPort = defaultPort;
-        _dnsClient = dnsClient;
-        _nextRefreshPeriod = _options.CurrentValue.MinRetryPeriod;
-        _timeProvider = timeProvider;
-        var cancellation = _lastCollectionCancellation = CreateCancellationTokenSource(_options.CurrentValue.DefaultRefreshPeriod);
-        _lastChangeToken = new CancellationChangeToken(cancellation.Token);
-    }
-
-    /// <inheritdoc/>
-    public async ValueTask<ResolutionStatus> ResolveAsync(ServiceEndPointCollectionSource endPoints, CancellationToken cancellationToken)
-    {
-        // Only add endpoints to the collection if a previous provider (eg, a configuration override) did not add them.
-        if (endPoints.EndPoints.Count != 0)
-        {
-            return ResolutionStatus.None;
-        }
-
-        if (ShouldRefresh())
-        {
-            Task resolveTask;
-            lock (_lock)
-            {
-                if (_resolveTask.IsCompleted && ShouldRefresh())
-                {
-                    _resolveTask = ResolveAsyncInternal();
-                }
-
-                resolveTask = _resolveTask;
-            }
-
-            await resolveTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        lock (_lock)
-        {
-            if (_lastEndPointCollection is { Count: > 0 } eps)
-            {
-                foreach (var ep in eps)
-                {
-                    endPoints.EndPoints.Add(ep);
-                }
-            }
-
-            if (_lastChangeToken is not null)
-            {
-                endPoints.AddChangeToken(_lastChangeToken);
-            }
-
-            return _lastStatus;
-        }
-    }
-
-    private bool ShouldRefresh() => _lastEndPointCollection is null || _lastChangeToken is { HasChanged: true } || _lastRefreshTimer.Elapsed >= _nextRefreshPeriod;
-
-    private async Task ResolveAsyncInternal()
+    protected override async Task ResolveAsyncCore()
     {
         var endPoints = new List<ServiceEndPoint>();
-        var options = _options.CurrentValue;
-        var ttl = options.DefaultRefreshPeriod;
-        try
+        var ttl = DefaultRefreshPeriod;
+        Log.AddressQuery(logger, ServiceName, hostName);
+        var addresses = await System.Net.Dns.GetHostAddressesAsync(hostName, ShutdownToken).ConfigureAwait(false);
+        foreach (var address in addresses)
         {
-            if (options.UseSrvQuery)
-            {
-                Log.SrvQuery(_logger, _serviceName, _srvRecordName);
-                var result = await _dnsClient.QueryAsync(_srvRecordName, QueryType.SRV).ConfigureAwait(false);
-                if (result.HasError)
-                {
-                    SetException(CreateException(result.ErrorMessage), ttl);
-                    return;
-                }
-
-                var lookupMapping = new Dictionary<string, DnsResourceRecord>();
-                foreach (var record in result.Additionals)
-                {
-                    ttl = MinTtl(record, ttl);
-                    lookupMapping[record.DomainName] = record;
-                }
-
-                var srvRecords = result.Answers.OfType<SrvRecord>();
-                foreach (var record in srvRecords)
-                {
-                    if (!lookupMapping.TryGetValue(record.Target, out var targetRecord))
-                    {
-                        continue;
-                    }
-
-                    ttl = MinTtl(record, ttl);
-                    if (targetRecord is AddressRecord addressRecord)
-                    {
-                        endPoints.Add(ServiceEndPoint.Create(new IPEndPoint(addressRecord.Address, record.Port)));
-                    }
-                    else if (targetRecord is CNameRecord canonicalNameRecord)
-                    {
-                        endPoints.Add(ServiceEndPoint.Create(new DnsEndPoint(canonicalNameRecord.CanonicalName.Value.TrimEnd('.'), record.Port)));
-                    }
-                }
-            }
-            else
-            {
-                Log.AddressQuery(_logger, _serviceName, _addressRecordName);
-                var addresses = await System.Net.Dns.GetHostAddressesAsync(_addressRecordName, _disposeCancellation.Token).ConfigureAwait(false);
-                foreach (var address in addresses)
-                {
-                    endPoints.Add(ServiceEndPoint.Create(new IPEndPoint(address, _defaultPort)));
-                }
-
-                if (endPoints.Count == 0)
-                {
-                    SetException(CreateException(), ttl);
-                    return;
-                }
-            }
-
-            SetResult(endPoints, ttl);
-        }
-        catch (Exception exception)
-        {
-            SetException(exception, ttl);
-            throw;
+            endPoints.Add(ServiceEndPoint.Create(new IPEndPoint(address, 0)));
         }
 
-        static TimeSpan MinTtl(DnsResourceRecord record, TimeSpan existing)
+        if (endPoints.Count == 0)
         {
-            var candidate = TimeSpan.FromSeconds(record.TimeToLive);
-            return candidate < existing ? candidate : existing;
+            SetException(new InvalidOperationException($"No DNS records were found for service {ServiceName} (DNS name: {hostName})."));
+            return;
         }
 
-        InvalidOperationException CreateException(string? errorMessage = null)
-        {
-            var msg = errorMessage switch
-            {
-                { Length: > 0 } => $"No DNS records were found for service {_serviceName}: {errorMessage}.",
-                _ => $"No DNS records were found for service {_serviceName}."
-            };
-            var exception = new InvalidOperationException(msg);
-            return exception;
-        }
-    }
-
-    private void SetException(Exception exception, TimeSpan validityPeriod) => SetResult(endPoints: null, exception, validityPeriod);
-    private void SetResult(List<ServiceEndPoint> endPoints, TimeSpan validityPeriod) => SetResult(endPoints, exception: null, validityPeriod);
-    private void SetResult(List<ServiceEndPoint>? endPoints, Exception? exception, TimeSpan validityPeriod)
-    {
-        lock (_lock)
-        {
-            var options = _options.CurrentValue;
-            if (exception is not null)
-            {
-                if (_lastStatus.Exception is null)
-                {
-                    _nextRefreshPeriod = options.MinRetryPeriod;
-                }
-                else
-                {
-                    var nextPeriod = TimeSpan.FromTicks((long)(_nextRefreshPeriod.Ticks * options.RetryBackOffFactor));
-                    _nextRefreshPeriod = nextPeriod > options.MaxRetryPeriod ? options.MaxRetryPeriod : nextPeriod;
-                }
-
-                if (_lastEndPointCollection is null)
-                {
-                    // Since end points have never been resolved, use a pending status to indicate that they might appear
-                    // soon and to retry for some period until they do.
-                    _lastStatus = ResolutionStatus.FromPending(exception);
-                }
-                else
-                {
-                    _lastStatus = ResolutionStatus.FromException(exception);
-                }
-            }
-            else
-            {
-                _lastRefreshTimer.Restart();
-                _nextRefreshPeriod = options.DefaultRefreshPeriod;
-                _lastStatus = ResolutionStatus.Success;
-            }
-
-            validityPeriod = validityPeriod > TimeSpan.Zero && validityPeriod < _nextRefreshPeriod ? validityPeriod : _nextRefreshPeriod;
-            _lastCollectionCancellation.Cancel();
-            var cancellation = _lastCollectionCancellation = CreateCancellationTokenSource(validityPeriod);
-            _lastChangeToken = new CancellationChangeToken(cancellation.Token);
-            _lastEndPointCollection = endPoints;
-        }
-
-        if (exception is null)
-        {
-            Debug.Assert(endPoints is not null);
-            Log.DiscoveredEndPoints(_logger, endPoints, _serviceName, validityPeriod);
-        }
-        else
-        {
-            Log.ResolutionFailed(_logger, exception, _serviceName);
-        }
-    }
-
-    /// <inheritdoc/>
-    public async ValueTask DisposeAsync()
-    {
-        _disposeCancellation.Cancel();
-
-        if (_resolveTask is { } task)
-        {
-            await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
-        }
-    }
-
-    private CancellationTokenSource CreateCancellationTokenSource(TimeSpan validityPeriod)
-    {
-        if (validityPeriod <= TimeSpan.Zero)
-        {
-            // Do not invalidate on a timer, but invalidate on refresh.
-            return new CancellationTokenSource();
-        }
-        else
-        {
-            return new CancellationTokenSource(validityPeriod, _timeProvider);
-        }
+        SetResult(endPoints, ttl);
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.Log.cs
@@ -6,9 +6,9 @@ using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
-internal partial class DnsServiceEndPointResolver
+internal partial class DnsServiceEndPointResolverBase
 {
-    private static partial class Log
+    internal static partial class Log
     {
         [LoggerMessage(1, LogLevel.Trace, "Resolving endpoints for service '{ServiceName}' using DNS SRV lookup for name '{RecordName}'.", EventName = "SrvQuery")]
         public static partial void SrvQuery(ILogger logger, string serviceName, string recordName);
@@ -31,10 +31,16 @@ internal partial class DnsServiceEndPointResolver
         [LoggerMessage(3, LogLevel.Debug, "Discovered {Count} endpoints for service '{ServiceName}'. Will refresh in {Ttl}.", EventName = "DiscoveredEndPoints")]
         public static partial void DiscoveredEndPointsCoreDebug(ILogger logger, int count, string serviceName, TimeSpan ttl);
 
-        [LoggerMessage(3, LogLevel.Debug, "Discovered {Count} endpoints for service '{ServiceName}'. Will refresh in {Ttl}. EndPoints: {EndPoints}", EventName = "DiscoveredEndPointsDetailed")]
+        [LoggerMessage(4, LogLevel.Debug, "Discovered {Count} endpoints for service '{ServiceName}'. Will refresh in {Ttl}. EndPoints: {EndPoints}", EventName = "DiscoveredEndPointsDetailed")]
         public static partial void DiscoveredEndPointsCoreTrace(ILogger logger, int count, string serviceName, TimeSpan ttl, string endPoints);
 
-        [LoggerMessage(4, LogLevel.Warning, "Endpoints resolution failed for service '{ServiceName}'.", EventName = "ResolutionFailed")]
+        [LoggerMessage(5, LogLevel.Warning, "Endpoints resolution failed for service '{ServiceName}'.", EventName = "ResolutionFailed")]
         public static partial void ResolutionFailed(ILogger logger, Exception exception, string serviceName);
+
+        [LoggerMessage(6, LogLevel.Debug, "Service name '{ServiceName}' is not a valid URI or DNS name.", EventName = "ServiceNameIsNotUriOrDnsName")]
+        public static partial void ServiceNameIsNotUriOrDnsName(ILogger logger, string serviceName);
+
+        [LoggerMessage(7, LogLevel.Debug, "DNS SRV query cannot be constructed for service name '{ServiceName}' because no DNS namespace was configured or detected.", EventName = "NoDnsSuffixFound")]
+        public static partial void NoDnsSuffixFound(ILogger logger, string serviceName);
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
@@ -1,0 +1,196 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.ServiceDiscovery.Abstractions;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Dns;
+
+/// <summary>
+/// A service end point resolver that uses DNS to resolve the service end points.
+/// </summary>
+internal abstract partial class DnsServiceEndPointResolverBase : IServiceEndPointResolver
+{
+    private readonly object _lock = new();
+    private readonly ILogger _logger;
+    private readonly CancellationTokenSource _disposeCancellation = new();
+    private readonly TimeProvider _timeProvider;
+    private long _lastRefreshTimeStamp;
+    private Task _resolveTask = Task.CompletedTask;
+    private ResolutionStatus _lastStatus;
+    private CancellationChangeToken _lastChangeToken;
+    private CancellationTokenSource _lastCollectionCancellation;
+    private List<ServiceEndPoint>? _lastEndPointCollection;
+    private TimeSpan _nextRefreshPeriod;
+
+    /// <summary>
+    /// Initializes a new <see cref="DnsServiceEndPointResolverBase"/> instance.
+    /// </summary>
+    /// <param name="serviceName">The service name.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="timeProvider">The time provider.</param>
+    public DnsServiceEndPointResolverBase(
+        string serviceName,
+        ILogger logger,
+        TimeProvider timeProvider)
+    {
+        ServiceName = serviceName;
+        _logger = logger;
+        _lastEndPointCollection = null;
+        _timeProvider = timeProvider;
+        _lastRefreshTimeStamp = _timeProvider.GetTimestamp();
+        var cancellation = _lastCollectionCancellation = new CancellationTokenSource();
+        _lastChangeToken = new CancellationChangeToken(cancellation.Token);
+    }
+
+    private TimeSpan ElapsedSinceRefresh => _timeProvider.GetElapsedTime(_lastRefreshTimeStamp);
+
+    protected string ServiceName { get; }
+
+    protected abstract double RetryBackOffFactor { get; }
+    protected abstract TimeSpan MinRetryPeriod { get; }
+    protected abstract TimeSpan MaxRetryPeriod { get; }
+    protected abstract TimeSpan DefaultRefreshPeriod { get; }
+    protected CancellationToken ShutdownToken => _disposeCancellation.Token;
+
+    /// <inheritdoc/>
+    public async ValueTask<ResolutionStatus> ResolveAsync(ServiceEndPointCollectionSource endPoints, CancellationToken cancellationToken)
+    {
+        // Only add endpoints to the collection if a previous provider (eg, a configuration override) did not add them.
+        if (endPoints.EndPoints.Count != 0)
+        {
+            return ResolutionStatus.None;
+        }
+
+        if (ShouldRefresh())
+        {
+            Task resolveTask;
+            lock (_lock)
+            {
+                if (_resolveTask.IsCompleted && ShouldRefresh())
+                {
+                    _resolveTask = ResolveAsyncInternal();
+                }
+
+                resolveTask = _resolveTask;
+            }
+
+            await resolveTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        lock (_lock)
+        {
+            if (_lastEndPointCollection is { Count: > 0 } eps)
+            {
+                foreach (var ep in eps)
+                {
+                    endPoints.EndPoints.Add(ep);
+                }
+            }
+
+            endPoints.AddChangeToken(_lastChangeToken);
+            return _lastStatus;
+        }
+    }
+
+    private bool ShouldRefresh() => _lastEndPointCollection is null || _lastChangeToken is { HasChanged: true } || ElapsedSinceRefresh >= _nextRefreshPeriod;
+
+    protected abstract Task ResolveAsyncCore();
+
+    private async Task ResolveAsyncInternal()
+    {
+        try
+        {
+            await ResolveAsyncCore().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            SetException(exception);
+            throw;
+        }
+
+    }
+
+    protected void SetException(Exception exception) => SetResult(endPoints: null, exception, validityPeriod: TimeSpan.Zero);
+    protected void SetResult(List<ServiceEndPoint> endPoints, TimeSpan validityPeriod) => SetResult(endPoints, exception: null, validityPeriod);
+    private void SetResult(List<ServiceEndPoint>? endPoints, Exception? exception, TimeSpan validityPeriod)
+    {
+        lock (_lock)
+        {
+            if (exception is not null)
+            {
+                _nextRefreshPeriod = GetRefreshPeriod();
+                if (_lastEndPointCollection is null)
+                {
+                    // Since end points have never been resolved, use a pending status to indicate that they might appear
+                    // soon and to retry for some period until they do.
+                    _lastStatus = ResolutionStatus.FromPending(exception);
+                }
+                else
+                {
+                    _lastStatus = ResolutionStatus.FromException(exception);
+                }
+            }
+            else if (endPoints is not { Count: > 0 })
+            {
+                _nextRefreshPeriod = GetRefreshPeriod();
+                validityPeriod = TimeSpan.Zero;
+                _lastStatus = ResolutionStatus.Pending;
+            }
+            else
+            {
+                _lastRefreshTimeStamp = _timeProvider.GetTimestamp();
+                _nextRefreshPeriod = DefaultRefreshPeriod;
+                _lastStatus = ResolutionStatus.Success;
+            }
+
+            if (validityPeriod <= TimeSpan.Zero)
+            {
+                validityPeriod = _nextRefreshPeriod;
+            }
+            else if (validityPeriod > _nextRefreshPeriod)
+            {
+                validityPeriod = _nextRefreshPeriod;
+            }
+
+            _lastCollectionCancellation.Cancel();
+            var cancellation = _lastCollectionCancellation = new CancellationTokenSource(validityPeriod, _timeProvider);
+            _lastChangeToken = new CancellationChangeToken(cancellation.Token);
+            _lastEndPointCollection = endPoints;
+        }
+
+        if (exception is null)
+        {
+            Debug.Assert(endPoints is not null);
+            Log.DiscoveredEndPoints(_logger, endPoints, ServiceName, validityPeriod);
+        }
+        else
+        {
+            Log.ResolutionFailed(_logger, exception, ServiceName);
+        }
+
+        TimeSpan GetRefreshPeriod()
+        {
+            if (_lastStatus.StatusCode is ResolutionStatusCode.Success)
+            {
+                return MinRetryPeriod;
+            }
+
+            var nextPeriod = TimeSpan.FromTicks((long)(_nextRefreshPeriod.Ticks * RetryBackOffFactor));
+            return nextPeriod > MaxRetryPeriod ? MaxRetryPeriod : nextPeriod;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        _disposeCancellation.Cancel();
+
+        if (_resolveTask is { } task)
+        {
+            await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverProvider.cs
@@ -2,148 +2,38 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
-using DnsClient;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.ServiceDiscovery.Abstractions;
+using Microsoft.Extensions.ServiceDiscovery.Internal;
 
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
 /// <summary>
 /// Provides <see cref="IServiceEndPointResolver"/> instances which resolve endpoints from DNS.
 /// </summary>
-internal sealed partial class DnsServiceEndPointResolverProvider : IServiceEndPointResolverProvider
+/// <remarks>
+/// Initializes a new <see cref="DnsServiceEndPointResolverProvider"/> instance.
+/// </remarks>
+/// <param name="options">The options.</param>
+/// <param name="logger">The logger.</param>
+/// <param name="timeProvider">The time provider.</param>
+internal sealed partial class DnsServiceEndPointResolverProvider(
+    IOptionsMonitor<DnsServiceEndPointResolverOptions> options,
+    ILogger<DnsServiceEndPointResolver> logger,
+    TimeProvider timeProvider) : IServiceEndPointResolverProvider
 {
-    private readonly IOptionsMonitor<DnsServiceEndPointResolverOptions> _options;
-    private readonly ILogger<DnsServiceEndPointResolver> _logger;
-    private readonly IDnsQuery _dnsClient;
-    private readonly TimeProvider _timeProvider;
-    private readonly string? _defaultNamespace;
-
-    /// <summary>
-    /// Initializes a new <see cref="DnsServiceEndPointResolverProvider"/> instance.
-    /// </summary>
-    /// <param name="options">The options.</param>
-    /// <param name="logger">The logger.</param>
-    /// <param name="dnsClient">The DNS client.</param>
-    /// <param name="timeProvider">The time provider.</param>
-    public DnsServiceEndPointResolverProvider(
-        IOptionsMonitor<DnsServiceEndPointResolverOptions> options,
-        ILogger<DnsServiceEndPointResolver> logger,
-        IDnsQuery dnsClient,
-        TimeProvider timeProvider)
-    {
-        _options = options;
-        _logger = logger;
-        _dnsClient = dnsClient;
-        _timeProvider = timeProvider;
-        _defaultNamespace = options.CurrentValue.DnsNamespace ?? GetHostNamespace();
-    }
-
-    // RFC 2181
-    // DNS hostnames can consist only of letters, digits, dots, and hyphens.
-    // They must begin with a letter.
-    // They must end with a letter or a digit.
-    // Individual segments (between dots) can be no longer than 63 characters.
-    [GeneratedRegex("^(?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{1,63}$")]
-    private static partial Regex ValidDnsName();
-
-    // Adapted version of Tim Berners Lee's regex from the URI spec: https://stackoverflow.com/a/26766402
-    // Adapted to parse the port into a group and discard groups which we do not care about.
-    [GeneratedRegex("^(?:([^:/?#]+)://)?([^/?#:]*)?(?::([\\d]+))?")]
-    private static partial Regex UriRegex();
-
     /// <inheritdoc/>
     public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointResolver? resolver)
     {
-        // Kubernetes DNS spec: https://github.com/kubernetes/dns/blob/master/docs/specification.md
-        // SRV records are available for headless services with named ports. 
-        // They take the form $"_{portName}._{protocol}.{serviceName}.{namespace}.svc.{zone}"
-        // We can fetch the namespace from /var/run/secrets/kubernetes.io/serviceaccount/namespace
-        // The protocol is assumed to be "tcp".
-        // The portName is the name of the port in the service definition. If the serviceName parses as a URI, we use the scheme as the port name, otherwise "default".
-        var dnsServiceName = serviceName;
-        var dnsNamespace = _defaultNamespace;
-        var portName = "default";
-        var defaultPortNumber = 0;
-
-        // Allow the service name to be expressed as either a URI or a plain DNS name.
-        var uri = UriRegex().Match(serviceName);
-        if (uri.Success)
+        if (!ServiceNameParts.TryParse(serviceName, out var parts))
         {
-            if (uri.Groups[1].ValueSpan is { Length: > 0 } uriPortNameSpan)
-            {
-                // Override the port name if it was specified in the service name
-                portName = uriPortNameSpan.ToString();
-            }
-
-            if (int.TryParse(uri.Groups[3].ValueSpan, out var uriDefaultPort))
-            {
-                // Override the default port if it was specified in the service name
-                defaultPortNumber = uriDefaultPort;
-            }
-
-            // Since the service name was URI-formatted, we should extract the hostname part for resolution.
-            dnsServiceName = uri.Groups[2].Value;
-        }
-        else if (!ValidDnsName().IsMatch(serviceName))
-        {
+            DnsServiceEndPointResolverBase.Log.ServiceNameIsNotUriOrDnsName(logger, serviceName);
             resolver = default;
             return false;
         }
 
-        // If the DNS name is not qualified, and we have a qualifier, apply it.
-        if (!dnsServiceName.Contains('.') && dnsNamespace is not null)
-        {
-            dnsServiceName = $"{dnsServiceName}.{dnsNamespace}";
-        }
-
-        var srvRecordName = $"_{portName}._tcp.{dnsServiceName}";
-        resolver = new DnsServiceEndPointResolver(serviceName, dnsServiceName, srvRecordName, defaultPortNumber, _options, _logger, _dnsClient, _timeProvider);
+        resolver = new DnsServiceEndPointResolver(serviceName, hostName: parts.Host, options, logger, timeProvider);
         return true;
-    }
-
-    private static string? GetHostNamespace() => ReadNamespaceFromKubernetesServiceAccount() ?? ReadQualifiedNamespaceFromResolvConf();
-
-    private static string? ReadNamespaceFromKubernetesServiceAccount()
-    {
-        if (OperatingSystem.IsLinux())
-        {
-            // Read the namespace from the Kubernetes pod's service account.
-            var serviceAccountNamespacePath = Path.Combine($"{Path.DirectorySeparatorChar}var", "run", "secrets", "kubernetes.io", "serviceaccount", "namespace");
-            if (File.Exists(serviceAccountNamespacePath))
-            {
-                return File.ReadAllText(serviceAccountNamespacePath).Trim();
-            }
-        }
-
-        return null;
-    }
-
-    private static string? ReadQualifiedNamespaceFromResolvConf()
-    {
-        if (OperatingSystem.IsLinux())
-        {
-            var resolveConfPath = Path.Combine($"{Path.DirectorySeparatorChar}etc", "resolv.conf");
-            if (File.Exists(resolveConfPath))
-            {
-                var lines = File.ReadAllLines(resolveConfPath);
-                foreach (var line in lines)
-                {
-                    if (line.StartsWith("search "))
-                    {
-                        var components = line.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-
-                        if (components.Length > 1)
-                        {
-                            return components[1];
-                        }
-                    }
-                }
-            }
-        }
-
-        return default;
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using DnsClient;
+using DnsClient.Protocol;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.ServiceDiscovery.Abstractions;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Dns;
+
+internal sealed partial class DnsSrvServiceEndPointResolver(
+    string serviceName,
+    string srvQuery,
+    IOptionsMonitor<DnsSrvServiceEndPointResolverOptions> options,
+    ILogger<DnsSrvServiceEndPointResolver> logger,
+    IDnsQuery dnsClient,
+    TimeProvider timeProvider) : DnsServiceEndPointResolverBase(serviceName, logger, timeProvider)
+{
+    protected override double RetryBackOffFactor => options.CurrentValue.RetryBackOffFactor;
+    protected override TimeSpan MinRetryPeriod => options.CurrentValue.MinRetryPeriod;
+    protected override TimeSpan MaxRetryPeriod => options.CurrentValue.MaxRetryPeriod;
+    protected override TimeSpan DefaultRefreshPeriod => options.CurrentValue.DefaultRefreshPeriod;
+
+    protected override async Task ResolveAsyncCore()
+    {
+        var endPoints = new List<ServiceEndPoint>();
+        var ttl = DefaultRefreshPeriod;
+        Log.SrvQuery(logger, ServiceName, srvQuery);
+        var result = await dnsClient.QueryAsync(srvQuery, QueryType.SRV, cancellationToken: ShutdownToken).ConfigureAwait(false);
+        if (result.HasError)
+        {
+            SetException(CreateException(srvQuery, result.ErrorMessage));
+            return;
+        }
+
+        var lookupMapping = new Dictionary<string, DnsResourceRecord>();
+        foreach (var record in result.Additionals)
+        {
+            ttl = MinTtl(record, ttl);
+            lookupMapping[record.DomainName] = record;
+        }
+
+        var srvRecords = result.Answers.OfType<SrvRecord>();
+        foreach (var record in srvRecords)
+        {
+            if (!lookupMapping.TryGetValue(record.Target, out var targetRecord))
+            {
+                continue;
+            }
+
+            ttl = MinTtl(record, ttl);
+            if (targetRecord is AddressRecord addressRecord)
+            {
+                endPoints.Add(ServiceEndPoint.Create(new IPEndPoint(addressRecord.Address, record.Port)));
+            }
+            else if (targetRecord is CNameRecord canonicalNameRecord)
+            {
+                endPoints.Add(ServiceEndPoint.Create(new DnsEndPoint(canonicalNameRecord.CanonicalName.Value.TrimEnd('.'), record.Port)));
+            }
+        }
+
+        SetResult(endPoints, ttl);
+
+        static TimeSpan MinTtl(DnsResourceRecord record, TimeSpan existing)
+        {
+            var candidate = TimeSpan.FromSeconds(record.TimeToLive);
+            return candidate < existing ? candidate : existing;
+        }
+
+        InvalidOperationException CreateException(string dnsName, string errorMessage)
+        {
+            var msg = errorMessage switch
+            {
+                { Length: > 0 } => $"No DNS records were found for service {ServiceName} (DNS name: {dnsName}): {errorMessage}.",
+                _ => $"No DNS records were found for service {ServiceName} (DNS name: {dnsName})."
+            };
+            return new InvalidOperationException(msg);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverOptions.cs
@@ -4,9 +4,9 @@
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
 /// <summary>
-/// Options for configuring <see cref="DnsServiceEndPointResolver"/>.
+/// Options for configuring <see cref="DnsSrvServiceEndPointResolver"/>.
 /// </summary>
-public class DnsServiceEndPointResolverOptions
+public class DnsSrvServiceEndPointResolverOptions
 {
     /// <summary>
     /// Gets or sets the default refresh period for endpoints resolved from DNS.
@@ -27,4 +27,12 @@ public class DnsServiceEndPointResolverOptions
     /// Gets or sets the retry period growth factor.
     /// </summary>
     public double RetryBackOffFactor { get; set; } = 2;
+
+    /// <summary>
+    /// Gets or sets the default DNS query suffix for services resolved via this provider.
+    /// </summary>
+    /// <remarks>
+    /// If not specified, the provider will attempt to infer the namespace.
+    /// </remarks>
+    public string? QuerySuffix { get; set; }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
@@ -1,0 +1,148 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using DnsClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.ServiceDiscovery.Abstractions;
+using Microsoft.Extensions.ServiceDiscovery.Internal;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Dns;
+
+/// <summary>
+/// Provides <see cref="IServiceEndPointResolver"/> instances which resolve endpoints from DNS using SRV queries.
+/// </summary>
+/// <remarks>
+/// Initializes a new <see cref="DnsSrvServiceEndPointResolverProvider"/> instance.
+/// </remarks>
+/// <param name="options">The options.</param>
+/// <param name="logger">The logger.</param>
+/// <param name="dnsClient">The DNS client.</param>
+/// <param name="timeProvider">The time provider.</param>
+internal sealed partial class DnsSrvServiceEndPointResolverProvider(
+    IOptionsMonitor<DnsSrvServiceEndPointResolverOptions> options,
+    ILogger<DnsSrvServiceEndPointResolver> logger,
+    IDnsQuery dnsClient,
+    TimeProvider timeProvider) : IServiceEndPointResolverProvider
+{
+    private static readonly string s_serviceAccountPath = Path.Combine($"{Path.DirectorySeparatorChar}var", "run", "secrets", "kubernetes.io", "serviceaccount");
+    private static readonly string s_serviceAccountNamespacePath = Path.Combine($"{Path.DirectorySeparatorChar}var", "run", "secrets", "kubernetes.io", "serviceaccount", "namespace");
+    private static readonly string s_resolveConfPath = Path.Combine($"{Path.DirectorySeparatorChar}etc", "resolv.conf");
+    private readonly string? _querySuffix = options.CurrentValue.QuerySuffix ?? GetKubernetesHostDomain();
+
+    /// <inheritdoc/>
+    public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointResolver? resolver)
+    {
+        // If a default namespace is not specified, then this provider will attempt to infer the namespace from the service name, but only when running inside Kubernetes.
+        // Kubernetes DNS spec: https://github.com/kubernetes/dns/blob/master/docs/specification.md
+        // SRV records are available for headless services with named ports. 
+        // They take the form $"_{portName}._{protocol}.{serviceName}.{namespace}.{suffix}"
+        // The suffix (after the service name) can be parsed from /etc/resolv.conf
+        // Otherwise, the namespace can be read from /var/run/secrets/kubernetes.io/serviceaccount/namespace and combined with an assumed suffix of "svc.cluster.local".
+        // The protocol is assumed to be "tcp".
+        // The portName is the name of the port in the service definition. If the serviceName parses as a URI, we use the scheme as the port name, otherwise "default".
+        if (string.IsNullOrWhiteSpace(_querySuffix))
+        {
+            DnsServiceEndPointResolverBase.Log.NoDnsSuffixFound(logger, serviceName);
+            resolver = default;
+            return false;
+        }
+
+        if (!ServiceNameParts.TryParse(serviceName, out var parts))
+        {
+            DnsServiceEndPointResolverBase.Log.ServiceNameIsNotUriOrDnsName(logger, serviceName);
+            resolver = default;
+            return false;
+        }
+
+        var portName = parts.EndPointName ?? "default";
+        var srvQuery = $"_{portName}._tcp.{parts.Host}.{_querySuffix}";
+        resolver = new DnsSrvServiceEndPointResolver(serviceName, srvQuery, options, logger, dnsClient, timeProvider);
+        return true;
+    }
+
+    private static string? GetKubernetesHostDomain()
+    {
+        // Check that we are running in Kubernetes first.
+        if (!IsInKubernetesCluster())
+        {
+            return null;
+        }
+
+        if (!OperatingSystem.IsLinux())
+        {
+            return null;
+        }
+
+        var qualifiedNamespace = ReadQualifiedNamespaceFromResolvConf();
+        if (!string.IsNullOrWhiteSpace(qualifiedNamespace))
+        {
+            return qualifiedNamespace;
+        }
+
+        var serviceAccountNamespace = ReadNamespaceFromKubernetesServiceAccount();
+        if (!string.IsNullOrWhiteSpace(serviceAccountNamespace))
+        {
+            // The zone is assumed to be "cluster.local"
+            return $"{serviceAccountNamespace}.svc.cluster.local";
+        }
+
+        return null;
+    }
+
+    private static string? ReadNamespaceFromKubernetesServiceAccount()
+    {
+        // Read the namespace from the Kubernetes pod's service account.
+        if (File.Exists(s_serviceAccountNamespacePath))
+        {
+            return File.ReadAllText(s_serviceAccountNamespacePath).Trim();
+        }
+
+        return null;
+    }
+
+    private static string? ReadQualifiedNamespaceFromResolvConf()
+    {
+        if (!File.Exists(s_resolveConfPath))
+        {
+            return default;
+        }
+
+        var lines = File.ReadAllLines(s_resolveConfPath);
+        foreach (var line in lines)
+        {
+            if (!line.StartsWith("search "))
+            {
+                continue;
+            }
+
+            var components = line.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+            if (components.Length > 1)
+            {
+                return components[1];
+            }
+        }
+
+        return default;
+    }
+
+    private static bool IsInKubernetesCluster()
+    {
+        var host = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST");
+        var port = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_PORT");
+        if (string.IsNullOrEmpty(host) || string.IsNullOrEmpty(port))
+        {
+            return false;
+        }
+
+        var tokenPath = Path.Combine(s_serviceAccountPath, "token");
+        if (!File.Exists(tokenPath))
+        {
+            return false;
+        }
+
+        var certPath = Path.Combine(s_serviceAccountPath, "ca.crt");
+        return File.Exists(certPath);
+    }
+}

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
@@ -109,6 +109,8 @@ internal sealed partial class DnsSrvServiceEndPointResolverProvider(
             return default;
         }
 
+        // See https://manpages.debian.org/bookworm/manpages/resolv.conf.5.en.html#search for the format of /etc/resolv.conf's search option.
+        // In our case, we are interested in determining the domain name.
         var lines = File.ReadAllLines(s_resolveConfPath);
         foreach (var line in lines)
         {

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/HostingExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/HostingExtensions.cs
@@ -4,7 +4,6 @@
 using DnsClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 using Microsoft.Extensions.ServiceDiscovery.Dns;
 
@@ -25,13 +24,13 @@ public static class HostingExtensions
     /// DNS SRV queries are able to provide port numbers for endpoints and can support multiple named endpoints per service.
     /// However, not all environment support DNS SRV queries, and in some environments, additional configuration may be required.
     /// </remarks>
-    public static IServiceCollection AddDnsSrvServiceEndPointResolver(this IServiceCollection services, Action<OptionsBuilder<DnsSrvServiceEndPointResolverOptions>>? configureOptions = null)
+    public static IServiceCollection AddDnsSrvServiceEndPointResolver(this IServiceCollection services, Action<DnsSrvServiceEndPointResolverOptions>? configureOptions = null)
     {
         services.AddServiceDiscoveryCore();
         services.TryAddSingleton<IDnsQuery, LookupClient>();
         services.AddSingleton<IServiceEndPointResolverProvider, DnsSrvServiceEndPointResolverProvider>();
         var options = services.AddOptions<DnsSrvServiceEndPointResolverOptions>();
-        configureOptions?.Invoke(options);
+        options.Configure(o => configureOptions?.Invoke(o));
         return services;
     }
 
@@ -44,12 +43,12 @@ public static class HostingExtensions
     /// <remarks>
     /// DNS A/AAAA queries are widely available but are not able to provide port numbers for endpoints and cannot support multiple named endpoints per service.
     /// </remarks>
-    public static IServiceCollection AddDnsServiceEndPointResolver(this IServiceCollection services, Action<OptionsBuilder<DnsServiceEndPointResolverOptions>>? configureOptions = null)
+    public static IServiceCollection AddDnsServiceEndPointResolver(this IServiceCollection services, Action<DnsServiceEndPointResolverOptions>? configureOptions = null)
     {
         services.AddServiceDiscoveryCore();
         services.AddSingleton<IServiceEndPointResolverProvider, DnsServiceEndPointResolverProvider>();
         var options = services.AddOptions<DnsServiceEndPointResolverOptions>();
-        configureOptions?.Invoke(options);
+        options.Configure(o => configureOptions?.Invoke(o));
         return services;
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/Microsoft.Extensions.ServiceDiscovery.Dns.csproj
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/Microsoft.Extensions.ServiceDiscovery.Dns.csproj
@@ -1,9 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Microsoft.Extensions.ServiceDiscovery\Internal\ServiceNameParts.cs" Link="Internal\ServiceNameParts.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="DnsClient" />
@@ -17,6 +21,10 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Extensions.ServiceDiscovery.Abstractions\Microsoft.Extensions.ServiceDiscovery.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.Extensions.ServiceDiscovery\Microsoft.Extensions.ServiceDiscovery.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Extensions.ServiceDiscovery.Dns.Tests"/>
   </ItemGroup>
 
 </Project>

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
@@ -14,10 +14,10 @@ using Xunit;
 namespace Microsoft.Extensions.ServiceDiscovery.Dns.Tests;
 
 /// <summary>
-/// Tests for <see cref="DnsServiceEndPointResolver"/> and <see cref="DnsServiceEndPointResolverProvider"/>.
+/// Tests for <see cref="DnsServiceEndPointResolverBase"/> and <see cref="DnsSrvServiceEndPointResolverProvider"/>.
 /// These also cover <see cref="ServiceEndPointResolver"/> and <see cref="ServiceEndPointResolverFactory"/> by extension.
 /// </summary>
-public class DnsServiceEndPointResolverTests
+public class DnsSrvServiceEndPointResolverTests
 {
     private sealed class FakeDnsClient : IDnsQuery
     {
@@ -101,7 +101,7 @@ public class DnsServiceEndPointResolverTests
         var services = new ServiceCollection()
             .AddSingleton<IDnsQuery>(dnsClientMock)
             .AddServiceDiscoveryCore()
-            .AddDnsSrvServiceEndPointResolver()
+            .AddDnsSrvServiceEndPointResolver(optionsBuilder => optionsBuilder.Configure(options => options.QuerySuffix = ".ns"))
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
         ServiceEndPointResolver resolver;
@@ -170,15 +170,15 @@ public class DnsServiceEndPointResolverTests
         if (dnsFirst)
         {
             serviceCollection
-            .AddDnsSrvServiceEndPointResolver()
+            .AddDnsSrvServiceEndPointResolver(optionsBuilder => optionsBuilder.Configure(options => options.QuerySuffix = ".ns"))
             .AddConfigurationServiceEndPointResolver();
         }
         else
         {
             serviceCollection
             .AddConfigurationServiceEndPointResolver()
-            .AddDnsSrvServiceEndPointResolver();
-        }
+            .AddDnsSrvServiceEndPointResolver(optionsBuilder => optionsBuilder.Configure(options => options.QuerySuffix = ".ns"));
+        };
         var services = serviceCollection.BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
         ServiceEndPointResolver resolver;

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
@@ -101,7 +101,7 @@ public class DnsSrvServiceEndPointResolverTests
         var services = new ServiceCollection()
             .AddSingleton<IDnsQuery>(dnsClientMock)
             .AddServiceDiscoveryCore()
-            .AddDnsSrvServiceEndPointResolver(optionsBuilder => optionsBuilder.Configure(options => options.QuerySuffix = ".ns"))
+            .AddDnsSrvServiceEndPointResolver(options => options.QuerySuffix = ".ns")
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
         ServiceEndPointResolver resolver;
@@ -170,14 +170,14 @@ public class DnsSrvServiceEndPointResolverTests
         if (dnsFirst)
         {
             serviceCollection
-            .AddDnsSrvServiceEndPointResolver(optionsBuilder => optionsBuilder.Configure(options => options.QuerySuffix = ".ns"))
+            .AddDnsSrvServiceEndPointResolver(options => options.QuerySuffix = ".ns")
             .AddConfigurationServiceEndPointResolver();
         }
         else
         {
             serviceCollection
             .AddConfigurationServiceEndPointResolver()
-            .AddDnsSrvServiceEndPointResolver(optionsBuilder => optionsBuilder.Configure(options => options.QuerySuffix = ".ns"));
+            .AddDnsSrvServiceEndPointResolver(options => options.QuerySuffix = ".ns");
         };
         var services = serviceCollection.BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();


### PR DESCRIPTION
This PR refactors the DNS resolvers so that they can be added independently. I went back and forth on whether to remove the non-SRV DNS resolver instead of split it out, but I've landed here for now.

It also fixes Kubernetes support in DNS SRV, using the same checks for the Kubernetes environment which KubernetesClient itself uses.