### PR TITLE
Use FluentAnchor for View Trace link

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -67,7 +67,7 @@
                     </TemplateColumn>
                     <PropertyColumn Title="Duration" Property="@(context => DurationFormatter.FormatDuration(context.Duration))" />
                     <TemplateColumn>
-                        <FluentButton Appearance="Appearance.Lightweight" OnClick="() => SelectTraceAsync(context)">View</FluentButton>
+                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/Trace/{context.TraceId}")">View</FluentAnchor>
                     </TemplateColumn>
                 </ChildContent>
                 <EmptyContent>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -108,12 +108,6 @@ public partial class Traces
         }
     }
 
-    private Task SelectTraceAsync(OtlpTrace trace)
-    {
-        NavigationManager.NavigateTo($"/Trace/{trace.TraceId}");
-        return Task.CompletedTask;
-    }
-
     private void HandleFilter(ChangeEventArgs args)
     {
         if (args.Value is string newFilter)


### PR DESCRIPTION
Fixes #353 

Quick fix unless @JamesNK knows there's a reason to keep the code behind navigation. Looks from the history like it originally did more when you clicked that button but no longer does.