### PR TITLE
Rename dimensions to filters in metrics UI

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
@@ -16,7 +16,7 @@
     {
         <div class="metrics-filters-container">
             <div style="margin-left: 10px">
-                <h5>Dimensions</h5>
+                <h5>Filters</h5>
                 <table style="width:100%">
                     @foreach (var item in _viewModel.DimensionFilters)
                     {


### PR DESCRIPTION
The tag values selected here are used to filter dimensions. They aren't dimensions themselves. The average user should probably never even know about dimensions.

![image](https://github.com/dotnet/aspire/assets/303201/34935d06-4742-40e1-ab62-27d108964d34)
