### PR TITLE
Fix the dapr sample

### DIFF
--- a/samples/dapr/ServiceA/Program.cs
+++ b/samples/dapr/ServiceA/Program.cs
@@ -23,8 +23,6 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
-
 var summaries = new[]
 {
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
@@ -36,6 +34,8 @@ app.MapGet("/weatherforecast", (DaprClient client) =>
 })
 .WithName("GetWeatherForecast")
 .WithOpenApi();
+
+app.MapDefaultEndpoints();
 
 app.Run();
 

--- a/samples/dapr/ServiceB/Program.cs
+++ b/samples/dapr/ServiceB/Program.cs
@@ -19,8 +19,6 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
-
 var summaries = new[]
 {
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
@@ -40,6 +38,8 @@ app.MapGet("/weatherforecast", () =>
 })
 .WithName("GetWeatherForecast")
 .WithOpenApi();
+
+app.MapDefaultEndpoints();
 
 app.Run();
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -24,6 +24,7 @@ public class DashboardWebApplication : IHostedService
     private const string DashboardUrlVariableName = "ASPNETCORE_URLS";
     private const string DashboardUrlDefaultValue = "http://localhost:18888";
 
+    private readonly bool _isAllHttps;
     private readonly WebApplication _app;
 
     public DashboardWebApplication(Action<IServiceCollection> configureServices)
@@ -39,6 +40,8 @@ public class DashboardWebApplication : IHostedService
             throw new InvalidOperationException("Only one URL for Aspire dashboard OTLP endpoint is supported.");
         }
 
+        _isAllHttps = dashboardHttpsPort is not null && IsHttps(otlpUris[0]);
+
         builder.WebHost.ConfigureKestrel(kestrelOptions =>
         {
             ConfigureListenAddresses(kestrelOptions, dashboardUris);
@@ -53,7 +56,7 @@ public class DashboardWebApplication : IHostedService
             builder.WebHost.UseStaticWebAssets();
         }
 
-        if (dashboardHttpsPort is not null)
+        if (_isAllHttps)
         {
             // Explicitly configure the HTTPS redirect port as we're possibly listening on multiple HTTPS addresses
             // if the dashboard OTLP URL is configured to use HTTPS too
@@ -86,7 +89,7 @@ public class DashboardWebApplication : IHostedService
             _app.UseExceptionHandler("/Error");
         }
 
-        if (dashboardHttpsPort is not null)
+        if (_isAllHttps)
         {
             _app.UseHttpsRedirection();
         }

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -140,15 +140,6 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
             if (this._options.EnableTelemetry != false)
             {
                 OtlpConfigurationExtensions.AddOtlpEnvironment(resource, _configuration, _environment);
-
-                // Explicitly specify OTEL endpoint is insecure and use gRPC to sidecar.
-                resource.Annotations.Add(
-                    new EnvironmentCallbackAnnotation(
-                        env =>
-                        {
-                            env["OTEL_EXPORTER_OTLP_INSECURE"] = "true";
-                            env["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc";
-                        }));
             }
 
             resource.Annotations.Add(


### PR DESCRIPTION
- HTTPS redirection is too aggressive on the dashboard. It'll only come into play if all endpoints are https (including the OTLP endpoint).
- Remove hardcoded insecure flag from dapr side car impl