### PR TITLE
Update to the 1.7.0-alpha release of otel 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,9 +73,9 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="8.0.0-rc.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.6.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.7" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.EventCounters" Version="1.5.1-alpha.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,7 +72,7 @@
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.0-rc.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="8.0.0-rc.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.6.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1" />

--- a/samples/dapr/AppHost/aspire-manifest.json
+++ b/samples/dapr/AppHost/aspire-manifest.json
@@ -3,7 +3,10 @@
     "servicea": {
       "type": "project.v1",
       "path": "..\\ServiceA\\DaprServiceA.csproj",
-      "env": {},
+      "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true"
+      },
       "bindings": {
         "http": {
           "scheme": "http",
@@ -20,7 +23,10 @@
     "serviceb": {
       "type": "project.v1",
       "path": "..\\ServiceB\\DaprServiceB.csproj",
-      "env": {},
+      "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true"
+      },
       "bindings": {
         "http": {
           "scheme": "http",
@@ -36,10 +42,7 @@
     },
     "service-a": {
       "type": "executable.v1",
-      "env": {
-        "OTEL_EXPORTER_OTLP_INSECURE": "true",
-        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"
-      },
+      "env": {},
       "bindings": {
         "grpc": {
           "scheme": "tcp",
@@ -60,10 +63,7 @@
     },
     "service-b": {
       "type": "executable.v1",
-      "env": {
-        "OTEL_EXPORTER_OTLP_INSECURE": "true",
-        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"
-      },
+      "env": {},
       "bindings": {
         "grpc": {
           "scheme": "tcp",

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -1,16 +1,5 @@
 {
   "resources": {
-    "grafana": {
-      "type": "container.v1",
-      "image": "grafana/grafana:latest",
-      "bindings": {
-        "grafana-http": {
-          "scheme": "http",
-          "protocol": "tcp",
-          "transport": "http"
-        }
-      }
-    },
     "postgres": {
       "type": "postgres.server.v1"
     },
@@ -25,6 +14,8 @@
       "type": "project.v1",
       "path": "..\\CatalogService\\CatalogService.csproj",
       "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "ConnectionStrings__catalog": "{catalog.connectionString}"
       },
       "bindings": {
@@ -50,6 +41,8 @@
       "type": "project.v1",
       "path": "..\\BasketService\\BasketService.csproj",
       "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "ConnectionStrings__basketCache": "{basketCache.connectionString}",
         "ConnectionStrings__messaging": "{messaging.connectionString}"
       },
@@ -70,6 +63,8 @@
       "type": "project.v1",
       "path": "..\\MyFrontend\\MyFrontend.csproj",
       "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "services__basketservice__0": "{basketservice.bindings.http.url}",
         "services__basketservice__1": "{basketservice.bindings.https.url}",
         "services__catalogservice__0": "{catalogservice.bindings.http.url}"
@@ -91,6 +86,8 @@
       "type": "project.v1",
       "path": "..\\OrderProcessor\\OrderProcessor.csproj",
       "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "ConnectionStrings__messaging": "{messaging.connectionString}"
       },
       "bindings": {
@@ -110,6 +107,8 @@
       "type": "project.v1",
       "path": "..\\ApiGateway\\ApiGateway.csproj",
       "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "services__basketservice__0": "{basketservice.bindings.http.url}",
         "services__basketservice__1": "{basketservice.bindings.https.url}",
         "services__catalogservice__0": "{catalogservice.bindings.http.url}",
@@ -125,17 +124,6 @@
           "scheme": "https",
           "protocol": "tcp",
           "transport": "http"
-        }
-      }
-    },
-    "prometheus": {
-      "type": "container.v1",
-      "image": "prom/prometheus:latest",
-      "bindings": {
-        "tcp": {
-          "scheme": "tcp",
-          "protocol": "tcp",
-          "transport": "tcp"
         }
       }
     }

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -14,6 +14,10 @@ public static class ProjectResourceBuilderExtensions
     {
         var project = new ProjectResource(name);
         var projectBuilder = builder.AddResource(project);
+        // We only want to turn these on for .NET projects, ConfigureOtlpEnvironment works for any resource type that
+        // implements IDistributedApplicationResourceWithEnvironment.
+        projectBuilder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES", "true");
+        projectBuilder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES", "true");
         projectBuilder.ConfigureOtlpEnvironment();
         projectBuilder.ConfigureConsoleLogs();
         var serviceMetadata = new TProject();

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.ServiceDefaults/AspireApplication1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication1.ServiceDefaults/AspireApplication1.ServiceDefaults.csproj
@@ -13,8 +13,8 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="<REPLACE_WITH_EXTENSIONS_VERSION>" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="<REPLACE_WITH_LATEST_VERSION>" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.5.1-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.ServiceDefaults/AspireStarterApplication1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication1.ServiceDefaults/AspireStarterApplication1.ServiceDefaults.csproj
@@ -13,8 +13,8 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="<REPLACE_WITH_EXTENSIONS_VERSION>" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="<REPLACE_WITH_LATEST_VERSION>" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.6.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0-alpha.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0-alpha.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.5.1-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.5.1-beta.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.5.1-beta.1" />


### PR DESCRIPTION
- This adds 2 experimental flags to for projects to enable the semantic conventions for event ids and exceptions

Fixes #173

<img width="1147" alt="image" src="https://github.com/dotnet/aspire/assets/95136/7c2341fa-1f4d-40f2-a338-0a3d582bd385">
