### PR TITLE
Add friendly UI when viewing missing trace

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -11,92 +11,101 @@
 
 <PageTitle>@DashboardViewModelService.ApplicationName Traces</PageTitle>
 
-<h1 style="display:inline-block">@(_trace.FirstSpan.Source.ApplicationName): @_trace.FirstSpan.Name</h1>
-<span class="trace-id">@_trace.TraceId.Substring(0, 7)</span>
+@if (_trace != null)
+{
+    <h1 style="display:inline-block">@(_trace.FirstSpan.Source.ApplicationName): @_trace.FirstSpan.Name</h1>
+    <span class="trace-id">@_trace.TraceId.Substring(0, 7)</span>
 
-<div>
-    <FluentStack Orientation="Orientation.Vertical">
-        <FluentToolbar Orientation="Orientation.Horizontal" Class="trace-view-toolbar">
-            <div>
-                Trace Start <strong>@_trace.FirstSpan.StartTime.ToString("MMMM d yyyy"), @OtlpHelpers.FormatTimeStamp(_trace.FirstSpan.StartTime)</strong>
-            </div>
-            <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-            <div>
-                Duration <strong>@DurationFormatter.FormatDuration(_trace.Duration)</strong>
-            </div>
-            <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-            <div>
-                Services <strong>@_trace.Spans.GroupBy(s => s.Source).Count()</strong>
-            </div>
-            <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-            <div>
-                Depth <strong>@_maxDepth</strong>
-            </div>
-            <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-            <div>
-                Total Spans <strong>@_trace.Spans.Count</strong>
-            </div>
-            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?traceId={_trace.TraceId}")">View Logs</FluentAnchor>
-            <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/Traces")">Back</FluentAnchor>
-        </FluentToolbar>
-
-        <FluentDataGrid Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="2fr 6fr">
-            <TemplateColumn Title="Name">
-                <div class="col-long-content" title="@($"{context.Span.Source.ApplicationName}: {context.Span.Name}")">
-                    <span style="@($"margin-left: {(context.Depth - 1) * 15}px; border-left-width: 5px; border-left-style: solid; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(context.Span.Source.ApplicationName)}; padding-left: 5px;")">
-                        @if (context.Span.Status == OtlpSpanStatusCode.Error)
-                        {
-                            <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
-                        }
-                        @context.Span.Source.ApplicationName
-                        @if (!string.IsNullOrEmpty(context.UninstrumentedPeer))
-                        {
-                            <span class="uninstrumented-peer">
-                                <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")" Icon="Icons.Filled.Size16.ArrowCircleRight" Class="uninstrumented-peer-icon" />
-                                @context.UninstrumentedPeer
-                            </span>
-                        }
-                        <span class="span-row-name">@context.Span.Name</span>
-                    </span>
+    <div>
+        <FluentStack Orientation="Orientation.Vertical">
+            <FluentToolbar Orientation="Orientation.Horizontal" Class="trace-view-toolbar">
+                <div>
+                    Trace Start <strong>@_trace.FirstSpan.StartTime.ToString("MMMM d yyyy"), @OtlpHelpers.FormatTimeStamp(_trace.FirstSpan.StartTime)</strong>
                 </div>
-            </TemplateColumn>
-            <TemplateColumn>
-                <HeaderCellItemTemplate>
-                    <div class="ticks">
-                        <div class="tick" style="grid-column: 1;"></div>
-                        <span class="tick-label" style="grid-column: 1;">@DurationFormatter.FormatDuration(TimeSpan.Zero)</span>
+                <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+                <div>
+                    Duration <strong>@DurationFormatter.FormatDuration(_trace.Duration)</strong>
+                </div>
+                <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+                <div>
+                    Services <strong>@_trace.Spans.GroupBy(s => s.Source).Count()</strong>
+                </div>
+                <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+                <div>
+                    Depth <strong>@_maxDepth</strong>
+                </div>
+                <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+                <div>
+                    Total Spans <strong>@_trace.Spans.Count</strong>
+                </div>
+                <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?traceId={_trace.TraceId}")">View Logs</FluentAnchor>
+                <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+                <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/Traces")">Back</FluentAnchor>
+            </FluentToolbar>
 
-                        <div class="tick" style="grid-column: 2;"></div>
-                        <span class="tick-label" style="grid-column: 2;">@DurationFormatter.FormatDuration(_trace.Duration / 4)</span>
-
-                        <div class="tick" style="grid-column: 3;"></div>
-                        <span class="tick-label" style="grid-column: 3;">@DurationFormatter.FormatDuration(_trace.Duration / 4 * 2)</span>
-
-                        <div class="tick" style="grid-column: 4;"></div>
-                        <span class="tick-label" style="grid-column: 4;">@DurationFormatter.FormatDuration(_trace.Duration / 4 * 3)</span>
-
-                        <span class="tick-label end-tick" style="grid-column: 4;">@DurationFormatter.FormatDuration(_trace.Duration)</span>
-                        <div class="tick" style="grid-column: 5;"></div>
+            <FluentDataGrid Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="2fr 6fr">
+                <TemplateColumn Title="Name">
+                    <div class="col-long-content" title="@($"{context.Span.Source.ApplicationName}: {context.Span.Name}")">
+                        <span style="@($"margin-left: {(context.Depth - 1) * 15}px; border-left-width: 5px; border-left-style: solid; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(context.Span.Source.ApplicationName)}; padding-left: 5px;")">
+                            @if (context.Span.Status == OtlpSpanStatusCode.Error)
+                            {
+                                <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
+                            }
+                            @context.Span.Source.ApplicationName
+                            @if (!string.IsNullOrEmpty(context.UninstrumentedPeer))
+                            {
+                                <span class="uninstrumented-peer">
+                                    <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")" Icon="Icons.Filled.Size16.ArrowCircleRight" Class="uninstrumented-peer-icon" />
+                                    @context.UninstrumentedPeer
+                                </span>
+                            }
+                            <span class="span-row-name">@context.Span.Name</span>
+                        </span>
                     </div>
-                </HeaderCellItemTemplate>
-                <ChildContent>
-                    <div class="ticks">
-                        <div class="span-container" style="grid-template-columns: @context.LeftOffset.ToString("F2")% @context.Width.ToString("F2")% min-content;">
-                            <div class="span-bar" @onclick="() => OnShowProperties(context)" style="grid-column: 2; background: @ColorGenerator.Instance.GetColorHexByKey(context.Span.Source.ApplicationName);"></div>
-                            <div class="span-bar-label @(context.LabelIsRight ? "span-bar-label-right" : "span-bar-label-left")" @onclick="() => OnShowProperties(context)">
-                                <span class="span-bar-label-detail">@context.Span.Source.ApplicationName: @context.Span.Name</span>
-                                <span>@DurationFormatter.FormatDuration(context.Span.Duration)</span>
-                            </div>
+                </TemplateColumn>
+                <TemplateColumn>
+                    <HeaderCellItemTemplate>
+                        <div class="ticks">
+                            <div class="tick" style="grid-column: 1;"></div>
+                            <span class="tick-label" style="grid-column: 1;">@DurationFormatter.FormatDuration(TimeSpan.Zero)</span>
+
+                            <div class="tick" style="grid-column: 2;"></div>
+                            <span class="tick-label" style="grid-column: 2;">@DurationFormatter.FormatDuration(_trace.Duration / 4)</span>
+
+                            <div class="tick" style="grid-column: 3;"></div>
+                            <span class="tick-label" style="grid-column: 3;">@DurationFormatter.FormatDuration(_trace.Duration / 4 * 2)</span>
+
+                            <div class="tick" style="grid-column: 4;"></div>
+                            <span class="tick-label" style="grid-column: 4;">@DurationFormatter.FormatDuration(_trace.Duration / 4 * 3)</span>
+
+                            <span class="tick-label end-tick" style="grid-column: 4;">@DurationFormatter.FormatDuration(_trace.Duration)</span>
+                            <div class="tick" style="grid-column: 5;"></div>
                         </div>
-                        <div class="tick" style="grid-column: 1;"></div>
-                        <div class="tick" style="grid-column: 2;"></div>
-                        <div class="tick" style="grid-column: 3;"></div>
-                        <div class="tick" style="grid-column: 4;"></div>
-                        <div class="tick" style="grid-column: 5;"></div>
-                    </div>
-                </ChildContent>
-            </TemplateColumn>
-        </FluentDataGrid>
-    </FluentStack>
-</div>
+                    </HeaderCellItemTemplate>
+                    <ChildContent>
+                        <div class="ticks">
+                            <div class="span-container" style="grid-template-columns: @context.LeftOffset.ToString("F2")% @context.Width.ToString("F2")% min-content;">
+                                <div class="span-bar" @onclick="() => OnShowProperties(context)" style="grid-column: 2; background: @ColorGenerator.Instance.GetColorHexByKey(context.Span.Source.ApplicationName);"></div>
+                                <div class="span-bar-label @(context.LabelIsRight ? "span-bar-label-right" : "span-bar-label-left")" @onclick="() => OnShowProperties(context)">
+                                    <span class="span-bar-label-detail">@context.Span.Source.ApplicationName: @context.Span.Name</span>
+                                    <span>@DurationFormatter.FormatDuration(context.Span.Duration)</span>
+                                </div>
+                            </div>
+                            <div class="tick" style="grid-column: 1;"></div>
+                            <div class="tick" style="grid-column: 2;"></div>
+                            <div class="tick" style="grid-column: 3;"></div>
+                            <div class="tick" style="grid-column: 4;"></div>
+                            <div class="tick" style="grid-column: 5;"></div>
+                        </div>
+                    </ChildContent>
+                </TemplateColumn>
+            </FluentDataGrid>
+        </FluentStack>
+    </div>
+}
+else
+{
+    <div class="empty-content">
+        <FluentIcon Icon="Icons.Regular.Size24.GanttChart" /> &nbsp; Trace &quot;@TraceId&quot; not found
+    </div>
+}

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -1,3 +1,12 @@
+.empty-content {
+    width: 100%;
+    height: 100px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-weight: 600;
+}
+
 ::deep .trace-id {
     color: rgb(136, 136, 136);
     padding-left: 0.5rem;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/125

Add a friendly UI when viewing missing trace. This could happen because a log refers to a trace ID that doesn't exist or isn't loaded in the dashboard yet.

![image](https://github.com/dotnet/aspire/assets/303201/937641fb-3681-44ba-a578-9cf75ee856f7)

Hide whitespace in review to focus on the actual changes.
