### PR TITLE
Fix Signing validation failing to restore due to Package source mapping

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -32,6 +32,7 @@
       <package pattern="Microsoft.DotNet.Maestro.Tasks" />
       <package pattern="Microsoft.DotNet.RemoteExecutor" />
       <package pattern="Microsoft.DotNet.SignTool" />
+      <package pattern="Microsoft.DotNet.SignCheck" />
       <package pattern="Microsoft.DotNet.Tar" />
       <package pattern="Microsoft.DotNet.XliffTasks" />
       <package pattern="Microsoft.DotNet.XUnitExtensions" />


### PR DESCRIPTION
Official builds from release branch are currently failing due to SignCheck package failing to restore due to Package Source mapping. This is fixing that issue.

cc: @danegsta 