### PR TITLE
Onboarding dotnet/aspire repo into source build.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/eng/SourceBuild* @dotnet/source-build-internal

--- a/NuGet.config
+++ b/NuGet.config
@@ -32,6 +32,8 @@
       <package pattern="Microsoft.DotNet.Maestro.Tasks" />
       <package pattern="Microsoft.DotNet.RemoteExecutor" />
       <package pattern="Microsoft.DotNet.SignTool" />
+      <package pattern="Microsoft.DotNet.SourceBuild.Tasks" />
+      <package pattern="Microsoft.SourceBuild.Intermediate.*" />
       <package pattern="Microsoft.DotNet.Tar" />
       <package pattern="Microsoft.DotNet.XliffTasks" />
       <package pattern="Microsoft.DotNet.XUnitExtensions" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,8 +1,4 @@
 <Project>
-  <!--
-  Shared framework projects (sfxproj) can't be added to a solution, so we can't just let Arcade build
-  the root level solution. We instead add this props file to control which projects get built.
-  -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)tests\**\*.csproj"  />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -3,9 +3,13 @@
   Shared framework projects (sfxproj) can't be added to a solution, so we can't just let Arcade build
   the root level solution. We instead add this props file to control which projects get built.
   -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)tests\**\*.csproj"  />
     <ProjectToBuild Include="$(RepoRoot)samples\**\*.csproj" />
+  </ItemGroup>
+  <!-- If we are building for SourceBuild, then we only want to build the Aspire manifest package -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <ProjectToBuild Include="$(RepoRoot)src\Microsoft.NET.Sdk.Aspire\Microsoft.NET.Sdk.Aspire.csproj" />
   </ItemGroup>
 </Project>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>aspire</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+</Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,0 +1,8 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- See https://aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
+
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
+  </IgnorePatterns>
+</UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -33,6 +33,11 @@
       <Uri>https://github.com/dotnet/extensions</Uri>
       <Sha>c02923b759ec596d8d644a9352cdd5122335b5b9</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23516.4">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>b4fa7f2e1e65ef49881be2ab2df27624280a8c55</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23505.1">
@@ -63,6 +68,11 @@
     <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.23505.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>e6be64c3e27aeb29f93f6aa751fad972e4ef2d52</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/xliff-tasks</Uri>
+      <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
+      <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -53,6 +53,7 @@ stages:
       enablePublishUsingPipelines: true
       publishAssetsImmediately: true
       enablePublishTestResults: true
+      enableSourceBuild: true
       testResultsFormat: vstest
       enableSourceIndex: false
       workspace:

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -53,7 +53,7 @@ stages:
       enablePublishUsingPipelines: true
       publishAssetsImmediately: true
       enablePublishTestResults: true
-      enableSourceBuild: true
+      # enableSourceBuild: true   Once the repo is public and we no longer depend on an internal feed, we should uncomment this line in order to enable SourceBuild CI leg.
       testResultsFormat: vstest
       enableSourceIndex: false
       workspace:


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspire-private-planning/issues/584

After these changes, the repo builds source-build clean:
<img width="1445" alt="image" src="https://github.com/dotnet/aspire/assets/13854455/8f1f2ce8-29d0-4352-b5fb-961efd99a939">

Once these changes go in, we will have to go into dotnet/installer in the internal fork to remove the exclusion from source build and to add the relevant details in Version.Details.xml file so that source-build knows how to build the manifest.

cc: @MichaelSimons @eerhardt 