### PR TITLE
Add AsHttp2Service(...) method to builders with binding support.

### DIFF
--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -14,7 +14,8 @@ var serviceBus = builder.AddAzureServiceBus("messaging", queueNames: ["orders"])
 
 var basket = builder.AddProject<Projects.BasketService>("basketservice")
                     .WithReference(redis)
-                    .WithReference(serviceBus, optional: true);
+                    .WithReference(serviceBus, optional: true)
+                    .AsHttp2Service();
 
 builder.AddProject<Projects.MyFrontend>("myfrontend")
        .WithReference(basket)

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -50,12 +50,12 @@
         "http": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http2"
         },
         "https": {
           "scheme": "https",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http2"
         }
       }
     },

--- a/src/Aspire.Hosting/ApplicationModel/Http2ServiceAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Http2ServiceAnnotation.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Internal marker
+/// </summary>
+internal sealed class Http2ServiceAnnotation : IDistributedApplicationResourceAnnotation
+{
+}

--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -30,8 +30,6 @@ public sealed class DcpDistributedApplicationLifecycleHook(IOptions<PublishingOp
         // Automatically add ServiceBindingAnnotations to project resources based on ApplicationUrl set in the launch profile.
         foreach (var projectResource in model.Resources.OfType<ProjectResource>())
         {
-            var isHttp2Service = projectResource.Annotations.OfType<Http2ServiceAnnotation>().Any();
-
             var selectedLaunchProfileName = projectResource.SelectLaunchProfileName();
             if (selectedLaunchProfileName is null)
             {
@@ -59,8 +57,7 @@ public sealed class DcpDistributedApplicationLifecycleHook(IOptions<PublishingOp
                 var generatedServiceBindingAnnotation = new ServiceBindingAnnotation(
                     ProtocolType.Tcp,
                     uriScheme: uri.Scheme,
-                    port: uri.Port,
-                    transport: isHttp2Service ? "http2" : "http"
+                    port: uri.Port
                     );
 
                 projectResource.Annotations.Add(generatedServiceBindingAnnotation);

--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -30,6 +30,7 @@ public sealed class DcpDistributedApplicationLifecycleHook(IOptions<PublishingOp
         // Automatically add ServiceBindingAnnotations to project resources based on ApplicationUrl set in the launch profile.
         foreach (var projectResource in model.Resources.OfType<ProjectResource>())
         {
+            var isHttp2Service = projectResource.Annotations.OfType<Http2ServiceAnnotation>().Any();
 
             var selectedLaunchProfileName = projectResource.SelectLaunchProfileName();
             if (selectedLaunchProfileName is null)
@@ -58,7 +59,8 @@ public sealed class DcpDistributedApplicationLifecycleHook(IOptions<PublishingOp
                 var generatedServiceBindingAnnotation = new ServiceBindingAnnotation(
                     ProtocolType.Tcp,
                     uriScheme: uri.Scheme,
-                    port: uri.Port
+                    port: uri.Port,
+                    transport: isHttp2Service ? "http2" : "http"
                     );
 
                 projectResource.Annotations.Add(generatedServiceBindingAnnotation);

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -41,6 +41,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         // Publishing support
         ConfigurePublishingOptions(args);
         _innerBuilder.Services.AddLifecycleHook<AutomaticManifestPublisherBindingInjectionHook>();
+        _innerBuilder.Services.AddLifecycleHook<Http2TransportMutationHook>();
         _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, ManifestPublisher>("manifest");
         _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, DcpPublisher>("dcp");
     }

--- a/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
+++ b/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
@@ -21,16 +21,13 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
 
         foreach (var projectResource in projectResources)
         {
-            var isHttp2Service = projectResource.Annotations.OfType<Http2ServiceAnnotation>().Any();
-
             // TODO: Add logic here that analyzes each project and figures out the best
             //       bindings to automatically add.
             if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "http" || sb.Name == "http"))
             {
                 var httpBinding = new ServiceBindingAnnotation(
                     System.Net.Sockets.ProtocolType.Tcp,
-                    uriScheme: "http",
-                    transport: isHttp2Service ? "http2" : "http"
+                    uriScheme: "http"
                     );
                 projectResource.Annotations.Add(httpBinding);
             }
@@ -39,8 +36,7 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
             {
                 var httpsBinding = new ServiceBindingAnnotation(
                     System.Net.Sockets.ProtocolType.Tcp,
-                    uriScheme: "https",
-                    transport: isHttp2Service ? "http2" : "http"
+                    uriScheme: "https"
                     );
                 projectResource.Annotations.Add(httpsBinding);
             }

--- a/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
+++ b/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
@@ -21,13 +21,16 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
 
         foreach (var projectResource in projectResources)
         {
+            var isHttp2Service = projectResource.Annotations.OfType<Http2ServiceAnnotation>().Any();
+
             // TODO: Add logic here that analyzes each project and figures out the best
             //       bindings to automatically add.
             if (!projectResource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.UriScheme == "http" || sb.Name == "http"))
             {
                 var httpBinding = new ServiceBindingAnnotation(
                     System.Net.Sockets.ProtocolType.Tcp,
-                    uriScheme: "http"
+                    uriScheme: "http",
+                    transport: isHttp2Service ? "http2" : "http"
                     );
                 projectResource.Annotations.Add(httpBinding);
             }
@@ -36,7 +39,8 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
             {
                 var httpsBinding = new ServiceBindingAnnotation(
                     System.Net.Sockets.ProtocolType.Tcp,
-                    uriScheme: "https"
+                    uriScheme: "https",
+                    transport: isHttp2Service ? "http2" : "http"
                     );
                 projectResource.Annotations.Add(httpsBinding);
             }

--- a/src/Aspire.Hosting/Publishing/Http2TransportMutationHook.cs
+++ b/src/Aspire.Hosting/Publishing/Http2TransportMutationHook.cs
@@ -5,6 +5,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 
 namespace Aspire.Hosting.Publishing;
+
 internal sealed class Http2TransportMutationHook : IDistributedApplicationLifecycleHook
 {
     public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)

--- a/src/Aspire.Hosting/Publishing/Http2TransportMutationHook.cs
+++ b/src/Aspire.Hosting/Publishing/Http2TransportMutationHook.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
+
+namespace Aspire.Hosting.Publishing;
+internal sealed class Http2TransportMutationHook : IDistributedApplicationLifecycleHook
+{
+    public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
+    {
+        foreach (var resource in appModel.Resources)
+        {
+            var isHttp2Service = resource.Annotations.OfType<Http2ServiceAnnotation>().Any();
+            var httpBindings = resource.Annotations.OfType<ServiceBindingAnnotation>().Where(sb => sb.UriScheme == "http" || sb.UriScheme == "https");
+            foreach (var httpBinding in httpBindings)
+            {
+                httpBinding.Transport = isHttp2Service ? "http2" : httpBinding.Transport;
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -154,4 +154,9 @@ public static class ResourceBuilderExtensions
     {
         return builder.Resource.GetEndpoint(name);
     }
+
+    public static IDistributedApplicationResourceBuilder<T> AsHttp2Service<T>(this IDistributedApplicationResourceBuilder<T> builder) where T : IDistributedApplicationResourceWithBindings
+    {
+        return builder.WithAnnotation(new Http2ServiceAnnotation());
+    }
 }

--- a/tests/Aspire.Hosting.Tests/AsHttp2ServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/AsHttp2ServiceTests.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class AsHttp2ServiceTests
+{
+    [Fact]
+    public void Http2TransportIsNotSetWhenHttp2ServiceAnnotationIsNotApplied()
+    {
+        var testProgram = new TestProgram(["--publisher", "manifest"]);
+
+        // Block DCP from actually starting anything up as we don't need it for this test.
+        testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>("manifest");
+
+        testProgram.Build();
+        testProgram.Run();
+
+        var serviceBindingsForAllServices = testProgram.AppBuilder.Resources.SelectMany(
+            r => r.Annotations.OfType<ServiceBindingAnnotation>()
+                              .Where(sb => sb.Transport == "http2")
+            );
+
+        // There should be no service bindings which are set to transport http2.
+        Assert.False(serviceBindingsForAllServices.Any());
+    }
+
+    [Fact]
+    public void Http2TransportIsSetWhenHttp2ServiceAnnotationIsApplied()
+    {
+        var testProgram = new TestProgram(["--publisher", "manifest"]);
+        testProgram.ServiceABuilder.AsHttp2Service();
+
+        // Block DCP from actually starting anything up as we don't need it for this test.
+        testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>("manifest");
+
+        testProgram.Build();
+        testProgram.Run();
+
+        var httpServiceBindings = testProgram.ServiceABuilder.Resource.Annotations.OfType<ServiceBindingAnnotation>().Where(sb => sb.UriScheme == "http" || sb.UriScheme == "https");
+        Assert.Equal(2, httpServiceBindings.Count());
+        Assert.True(httpServiceBindings.All(sb => sb.Transport == "http2"));
+    }
+
+    [Fact]
+    public void Http2TransportIsNotAppliedToNonHttpServiceBindings()
+    {
+        var testProgram = new TestProgram(["--publisher", "manifest"]);
+        testProgram.ServiceABuilder.WithServiceBinding(9999, scheme: "tcp");
+        testProgram.ServiceABuilder.AsHttp2Service();
+
+        // Block DCP from actually starting anything up as we don't need it for this test.
+        testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>("manifest");
+
+        testProgram.Build();
+        testProgram.Run();
+
+        var serviceBindings = testProgram.ServiceABuilder.Resource.Annotations.OfType<ServiceBindingAnnotation>();
+        var tcpBinding = serviceBindings.Single(sb => sb.UriScheme == "tcp");
+        Assert.Equal("tcp", tcpBinding.Transport);
+
+        var httpsBinding = serviceBindings.Single(sb => sb.UriScheme == "https");
+        Assert.Equal("http2", httpsBinding.Transport);
+
+        var httpBinding = serviceBindings.Single(sb => sb.UriScheme == "http");
+        Assert.Equal("http2", httpsBinding.Transport);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Helpers/NoopPublisher.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/NoopPublisher.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.Hosting;
+
+namespace Aspire.Hosting.Tests.Helpers;
+internal sealed class NoopPublisher(IHostApplicationLifetime lifetime) : IDistributedApplicationPublisher
+{
+    private readonly IHostApplicationLifetime _lifetime = lifetime;
+
+    public Task PublishAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
+    {
+        _lifetime.StopApplication();
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Adds a ```AsHttp2Service()``` extension to ```IDistributedApplicationResourceBuilderWithBindings```. It adds a marker annotation so that when we materialize the service bindings for projects we update the transport to ```http2``` if this marker annotaiton is present.