### PR TITLE
Calculate display summary for span

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -45,7 +45,7 @@
 
             <FluentDataGrid Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="2fr 6fr">
                 <TemplateColumn Title="Name">
-                    <div class="col-long-content" title="@($"{context.Span.Source.ApplicationName}: {context.Span.Name}")">
+                    <div class="col-long-content" title="@($"{context.Span.Source.ApplicationName}: {context.GetDisplaySummary()}")">
                         <span style="@($"margin-left: {(context.Depth - 1) * 15}px; border-left-width: 5px; border-left-style: solid; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(context.Span.Source.ApplicationName)}; padding-left: 5px;")">
                             @if (context.Span.Status == OtlpSpanStatusCode.Error)
                             {
@@ -59,7 +59,7 @@
                                     @context.UninstrumentedPeer
                                 </span>
                             }
-                            <span class="span-row-name">@context.Span.Name</span>
+                            <span class="span-row-name">@context.GetDisplaySummary()</span>
                         </span>
                     </div>
                 </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -87,7 +87,7 @@
                             <div class="span-container" style="grid-template-columns: @context.LeftOffset.ToString("F2")% @context.Width.ToString("F2")% min-content;">
                                 <div class="span-bar" @onclick="() => OnShowProperties(context)" style="grid-column: 2; background: @ColorGenerator.Instance.GetColorHexByKey(context.Span.Source.ApplicationName);"></div>
                                 <div class="span-bar-label @(context.LabelIsRight ? "span-bar-label-right" : "span-bar-label-left")" @onclick="() => OnShowProperties(context)">
-                                    <span class="span-bar-label-detail">@context.Span.Source.ApplicationName: @context.Span.Name</span>
+                                    <span class="span-bar-label-detail">@context.Span.Source.ApplicationName: @context.GetDisplaySummary()</span>
                                     <span>@DurationFormatter.FormatDuration(context.Span.Duration)</span>
                                 </div>
                             </div>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -137,7 +137,7 @@ public partial class TraceDetail
 
     private async Task OnShowProperties(SpanWaterfallViewModel viewModel)
     {
-        var entryProperties = viewModel.Span.Attributes
+        var entryProperties = viewModel.Span.AllProperties()
             .Select(kvp => new SpanPropertyViewModel { Name = kvp.Key, Value = kvp.Value })
             .ToList();
 

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Otlp.Model;
+using Grpc.Core;
 
 namespace Aspire.Dashboard.Model.Otlp;
 
@@ -13,4 +14,46 @@ public sealed class SpanWaterfallViewModel
     public required int Depth { get; init; }
     public required bool LabelIsRight { get; init; }
     public required string? UninstrumentedPeer { get; init; }
+
+    public string GetDisplaySummary()
+    {
+        if (Span.Kind == OtlpSpanKind.Client)
+        {
+            if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "rpc.system")))
+            {
+                var rpcSystem = OtlpHelpers.GetValue(Span.Attributes, "rpc.system");
+                var rpcService = OtlpHelpers.GetValue(Span.Attributes, "rpc.service");
+                var rpcMethod = OtlpHelpers.GetValue(Span.Attributes, "rpc.method");
+
+                if (string.Equals(rpcSystem, "grpc", StringComparison.OrdinalIgnoreCase))
+                {
+                    var grpcStatusCode = OtlpHelpers.GetValue(Span.Attributes, "rpc.grpc.status_code");
+
+                    var summary = $"GRPC {rpcService}/{rpcMethod}";
+                    if (!string.IsNullOrEmpty(grpcStatusCode) && Enum.TryParse<StatusCode>(grpcStatusCode, out var statusCode))
+                    {
+                        summary += $" {statusCode}";
+                    }
+                    return summary;
+                }
+
+                return $"RPC {rpcSystem} {rpcService}/{rpcMethod}";
+            }
+            else if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "http.method")))
+            {
+                var httpMethod = OtlpHelpers.GetValue(Span.Attributes, "http.method");
+                var statusCode = OtlpHelpers.GetValue(Span.Attributes, "http.status_code");
+
+                return $"HTTP {httpMethod?.ToUpperInvariant()} {statusCode}";
+            }
+            else if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "db.system")))
+            {
+                var dbSystem = OtlpHelpers.GetValue(Span.Attributes, "db.system");
+
+                return $"DATA {dbSystem?.ToUpperInvariant()} {Span.Name}";
+            }
+        }
+
+        return Span.Name;
+    }
 }

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -17,6 +17,9 @@ public sealed class SpanWaterfallViewModel
 
     public string GetDisplaySummary()
     {
+        // Use attributes on the span to calculate a friendly summary.
+        // Optimize for common cases: HTTP, RPC, DATA, etc.
+        // Fall back to the span name if we can't find anything.
         if (Span.Kind == OtlpSpanKind.Client)
         {
             if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "rpc.system")))

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -22,27 +22,7 @@ public sealed class SpanWaterfallViewModel
         // Fall back to the span name if we can't find anything.
         if (Span.Kind == OtlpSpanKind.Client)
         {
-            if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "rpc.system")))
-            {
-                var rpcSystem = OtlpHelpers.GetValue(Span.Attributes, "rpc.system");
-                var rpcService = OtlpHelpers.GetValue(Span.Attributes, "rpc.service");
-                var rpcMethod = OtlpHelpers.GetValue(Span.Attributes, "rpc.method");
-
-                if (string.Equals(rpcSystem, "grpc", StringComparison.OrdinalIgnoreCase))
-                {
-                    var grpcStatusCode = OtlpHelpers.GetValue(Span.Attributes, "rpc.grpc.status_code");
-
-                    var summary = $"GRPC {rpcService}/{rpcMethod}";
-                    if (!string.IsNullOrEmpty(grpcStatusCode) && Enum.TryParse<StatusCode>(grpcStatusCode, out var statusCode))
-                    {
-                        summary += $" {statusCode}";
-                    }
-                    return summary;
-                }
-
-                return $"RPC {rpcSystem} {rpcService}/{rpcMethod}";
-            }
-            else if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "http.method")))
+            if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "http.method")))
             {
                 var httpMethod = OtlpHelpers.GetValue(Span.Attributes, "http.method");
                 var statusCode = OtlpHelpers.GetValue(Span.Attributes, "http.status_code");
@@ -53,7 +33,35 @@ public sealed class SpanWaterfallViewModel
             {
                 var dbSystem = OtlpHelpers.GetValue(Span.Attributes, "db.system");
 
-                return $"DATA {dbSystem?.ToUpperInvariant()} {Span.Name}";
+                return $"DATA {dbSystem} {Span.Name}";
+            }
+            else if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "rpc.system")))
+            {
+                var rpcSystem = OtlpHelpers.GetValue(Span.Attributes, "rpc.system");
+                var rpcService = OtlpHelpers.GetValue(Span.Attributes, "rpc.service");
+                var rpcMethod = OtlpHelpers.GetValue(Span.Attributes, "rpc.method");
+
+                if (string.Equals(rpcSystem, "grpc", StringComparison.OrdinalIgnoreCase))
+                {
+                    var grpcStatusCode = OtlpHelpers.GetValue(Span.Attributes, "rpc.grpc.status_code");
+
+                    var summary = $"RPC {rpcService}/{rpcMethod}";
+                    if (!string.IsNullOrEmpty(grpcStatusCode) && Enum.TryParse<StatusCode>(grpcStatusCode, out var statusCode))
+                    {
+                        summary += $" {statusCode}";
+                    }
+                    return summary;
+                }
+
+                return $"RPC {rpcSystem} {rpcService}/{rpcMethod}";
+            }
+            else if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "messaging.system")))
+            {
+                var messagingSystem = OtlpHelpers.GetValue(Span.Attributes, "messaging.system");
+                var messagingOperation = OtlpHelpers.GetValue(Span.Attributes, "messaging.operation");
+                var destinationName = OtlpHelpers.GetValue(Span.Attributes, "messaging.destination.name");
+
+                return $"MSG {messagingSystem} {messagingOperation} {destinationName}";
             }
         }
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -60,4 +60,31 @@ public class OtlpSpan
             Events = item.Events
         };
     }
+
+    public Dictionary<string, string> AllProperties()
+    {
+        var props = new Dictionary<string, string>
+        {
+            { "SpanId", SpanId },
+            { "Name", Name },
+            { "Kind", Kind.ToString() },
+        };
+
+        if (Status != OtlpSpanStatusCode.Unset)
+        {
+            props.Add("Status", Status.ToString());
+        }
+
+        if (!string.IsNullOrEmpty(StatusMessage))
+        {
+            props.Add("StatusMessage", StatusMessage);
+        }
+
+        foreach (var kv in Attributes)
+        {
+            props.TryAdd(kv.Key, kv.Value);
+        }
+
+        return props;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/312

![image](https://github.com/dotnet/aspire/assets/303201/6aff4453-06dc-4915-abe2-8cbdb7351095)

Note: There isn't a friendly "statement" for database calls. For example, postgres adds the entire SQL string to the span statement. I used the span name instead.