### PR TITLE
Add ability to suppress manifest generation for resource.

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ManifestPublishingCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ManifestPublishingCallbackAnnotation.cs
@@ -5,7 +5,8 @@ using System.Text.Json;
 
 namespace Aspire.Hosting.ApplicationModel;
 
-public class ManifestPublishingCallbackAnnotation(Action<Utf8JsonWriter> callback) : IDistributedApplicationResourceAnnotation
+public class ManifestPublishingCallbackAnnotation(Action<Utf8JsonWriter>? callback) : IDistributedApplicationResourceAnnotation
 {
-    public Action<Utf8JsonWriter> Callback { get; } = callback;
+    public Action<Utf8JsonWriter>? Callback { get; } = callback;
+    public static ManifestPublishingCallbackAnnotation Ignore { get; } = new ManifestPublishingCallbackAnnotation(null);
 }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -159,4 +159,14 @@ public static class ResourceBuilderExtensions
     {
         return builder.WithAnnotation(new Http2ServiceAnnotation());
     }
+
+    public static IDistributedApplicationResourceBuilder<T> ExcludeFromManifest<T>(this IDistributedApplicationResourceBuilder<T> builder) where T : IDistributedApplicationResource
+    {
+        foreach (var annotation in builder.Resource.Annotations.OfType<ManifestPublishingCallbackAnnotation>())
+        {
+            builder.Resource.Annotations.Remove(annotation);
+        }
+
+        return builder.WithAnnotation(ManifestPublishingCallbackAnnotation.Ignore);
+    }
 }


### PR DESCRIPTION
Add the ability to suppress manifest generation for a particular resource - example usage:

```csharp
var resource = new MyCustomResource(name);
return builder.AddResource(resource)
              .WithAnnotation(ManifestPublishingCallbackAnnotation.Ignore);
```