### PR TITLE
Add --source flag to dotnet workload install commands

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,13 +76,13 @@ Ensure the `.NET Aspire SDK` component is checked in `Individual components`.
 1. The RTM nightly SDK is aware that the Aspire workload exists, but the real manifest is not installed by default. In order to install it, you'll need to update the workload in a directory that has a NuGet.config[^3] with the right feeds configured[^2] so that it can pull the latest manifest. Once you have created the NuGet.config file in your working directory, then you need to run the following command[^1]:
 
     ```shell
-    dotnet workload update --skip-sign-check --interactive
+    dotnet workload update --skip-sign-check --interactive --source https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json
     ```
 
 2. The above command will update the Aspire manifest in your SDK build, meaning it will already be setup for command-line and Visual Studio in-product acquisition (IPA) of the Aspire workload. In order to manually install the workload, you can run the following command[^1]:
 
     ```shell
-    dotnet workload install aspire --skip-sign-check --interactive
+    dotnet workload install aspire --skip-sign-check --interactive --source https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json
     ```
 
 [^1]: The `--skip-sign-check` flag is required because the packages we build out of the Aspire repo are not yet signed.


### PR DESCRIPTION
Since this nuget source isn't required for development, make it explicit in the command line for install rather than adding it to the NuGet.config file.
