### PR TITLE
Use named sources

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,8 +11,8 @@ Add NuGet sources to apply the following feeds
 
 ### Command line instructions
 ```sh
-dotnet nuget add source https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json
-dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json
+dotnet nuget add source --name dotnet-libraries-internal https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-tools-internal/nuget/v3/index.json
+dotnet nuget add source --name dotnet8 https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json
 ```
 
 ## Install the Azure Artifacts Credential Provider for NuGet


### PR DESCRIPTION
Create names for source when adding using `dotnet nuget`. Next steps assumes that the internal source is named `dotnet-libraries-internal`.