### PR TITLE
Producer span types use extra summary detail

### DIFF
--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -20,7 +20,7 @@ public sealed class SpanWaterfallViewModel
         // Use attributes on the span to calculate a friendly summary.
         // Optimize for common cases: HTTP, RPC, DATA, etc.
         // Fall back to the span name if we can't find anything.
-        if (Span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer)
+        if (Span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer or OtlpSpanKind.Consumer)
         {
             if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "http.method")))
             {

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -20,7 +20,7 @@ public sealed class SpanWaterfallViewModel
         // Use attributes on the span to calculate a friendly summary.
         // Optimize for common cases: HTTP, RPC, DATA, etc.
         // Fall back to the span name if we can't find anything.
-        if (Span.Kind == OtlpSpanKind.Client)
+        if (Span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer)
         {
             if (!string.IsNullOrEmpty(OtlpHelpers.GetValue(Span.Attributes, "http.method")))
             {


### PR DESCRIPTION
Client and producer span types are used when making calls to external systems.

cc @davidfowl 