### PR TITLE
Use OnAfterRenderAsync in ResourceLogsBase

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.cs
@@ -43,35 +43,43 @@ public abstract partial class ResourceLogsBase<TResource> : ComponentBase, IAsyn
     private CancellationTokenSource? _watchLogsTokenSource;
     private string _status = LogStatus.Initializing;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         _status = LoadingResourcesMessage;
+    }
 
-        var initialList = await GetResources(DashboardViewModelService);
-
-        foreach (var result in initialList)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
         {
-            _resourceNameMapping[result.Name] = result;
-        }
+            var initialList = await GetResources(DashboardViewModelService);
 
-        if (ResourceName is not null)
-        {
-            _selectedResource = initialList.FirstOrDefault(c => string.Equals(ResourceName, c.Name, StringComparison.Ordinal));
-        }
-        else if (initialList.Count > 0)
-        {
-            _selectedResource = initialList[0];
-        }
-
-        await LoadLogsAsync();
-
-        _ = Task.Run(async () =>
-        {
-            await foreach (var resourceChanged in WatchResources(DashboardViewModelService, initialList.Select(t => t.NamespacedName), _watchContainersTokenSource.Token))
+            foreach (var result in initialList)
             {
-                await OnResourceListChangedAsync(resourceChanged.ObjectChangeType, resourceChanged.Resource);
+                _resourceNameMapping[result.Name] = result;
             }
-        });
+
+            if (ResourceName is not null)
+            {
+                _selectedResource = initialList.FirstOrDefault(c => string.Equals(ResourceName, c.Name, StringComparison.Ordinal));
+            }
+            else if (initialList.Count > 0)
+            {
+                _selectedResource = initialList[0];
+            }
+
+            await LoadLogsAsync();
+
+            _ = Task.Run(async () =>
+            {
+                await foreach (var resourceChanged in WatchResources(DashboardViewModelService, initialList.Select(t => t.NamespacedName), _watchContainersTokenSource.Token))
+                {
+                    await OnResourceListChangedAsync(resourceChanged.ObjectChangeType, resourceChanged.Resource);
+                }
+            });
+
+            StateHasChanged();
+        }
     }
 
     private Task ClearLogsAsync()


### PR DESCRIPTION
After discussions with @SteveSandersonMS and @javiercn about async initialization of blazor components, making a switch to how the streaming logs pages perform their initial loading of data and the first call to LoadLogsAsync. Should be no functional change here, but if upcoming caching changes causes GetResources to not yield in some cases, this change should prevent a failure on first load.