### PR TITLE
Add Aspire OpenTelemetry architecture doc

### DIFF
--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -53,7 +53,7 @@ Aspire F5 debugging workflow:
 
 Aspire deployment environments should configure OTEL environment variables that make sense for their environment. For example, `OTEL_EXPORTER_OTLP_ENDPOINT` should be configured to the environment's local OTLP collector or monitoring service.
 
-OTLP exporting is disabled if `OTEL_EXPORTER_OTLP_ENDPOINT` isn't configured.
+Aspire telemetry works best in environments that support OTLP. OTLP exporting is disabled if `OTEL_EXPORTER_OTLP_ENDPOINT` isn't configured.
 
 ## Non-.NET apps
 

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -40,7 +40,7 @@ Aspire debugging workflow:
 
 * Developer starts the Aspire app with debugging, presses <kbd>F5</kbd>.
 * Aspire dashboard and developer control plane (DCP) start.
-* App configuration is run in the _DevHost_ project.
+* App configuration is run in the _AppHost_ project.
   * OTEL environment variables are automatically added to .NET projects during app configuration.
   * DCP provides the name (`OTEL_SERVICE_NAME`) and ID (`OTEL_RESOURCE_ATTRIBUTES`) of the app in exported telemetry.
   * The OTLP endpoint is an HTTP/2 port started by the dashboard (`OTEL_EXPORTER_OTLP_ENDPOINT`). That tells projects to export telemetry back to the dashboard.

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -1,4 +1,4 @@
-# Aspire OpenTelemetry Architecture
+# Aspire OpenTelemetry architecture
 
 Aspire apps are configured by default to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data.
 

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -1,10 +1,10 @@
 # Aspire OpenTelemetry Architecture
 
-Aspire helps apps configure and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data.
+Aspire apps are configured by default to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data.
 
 ## Telemetry types
 
-There are three kinds of telemetry and values are recorded using .NET APIs by libraries and apps:
+Libraries and apps record values using .NET APIs for three kinds of telemetry:
 
 * Structured logging - Log entries from `ILogger`.
 * Tracing - Distributed tracing from `Activity`.
@@ -12,33 +12,39 @@ There are three kinds of telemetry and values are recorded using .NET APIs by li
 
 ## OpenTelemetry SDK
 
-The .NET OpenTelemetry SDK provides functionality to collect values from the .NET APIs listed above (`ILogger`, `Activity` and `Instrument<T>`) and then export telemetry to a data store or reporting tool. Telemetry is exported using [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/). OTLP is a standard scheme for sending telemetry data using either REST or gRPC.
+The .NET OpenTelemetry SDK provides functionality to collect values from the .NET APIs listed above (`ILogger`, `Activity`, and `Instrument<T>`) and then export telemetry to a data store or reporting tool. Telemetry is exported using [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/). OTLP is a standard scheme for sending telemetry data using REST or gRPC.
 
-The .NET OpenTelemetry SDK is configured in .NET projects in the service defaults project. The service defaults is automatically created by Aspire templates and .NET Aspire apps should use call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
+.NET projects configure the .NET OpenTelemetry SDK using the service defaults project. Aspire templates automatically create the service defaults, and .NET Aspire apps call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
 
 ## OpenTelemetry environment variables
 
-Almost all OTEL settings are configured using environment variables. OTEL has a [list of known environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) that configure most important behavior for collecting and exporting telemetry. OTEL SDK's, including the .NET SDK, support reading these variables.
+Environment variables configure almost all OTEL settings. OTEL has a [list of known environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) that configure the most important behavior for collecting and exporting telemetry. OTEL SDKs, including the .NET SDK, support reading these variables.
 
-Aspire apps are launched with environment variables that configure the name and ID of the app in exported telemetry, and the address endpoint of the OTLP server to export data to. For example:
+Aspire apps launch with environment variables that configure the name and ID of the app in exported telemetry and set the address endpoint of the OTLP server to export data. For example:
 
 * `OTEL_SERVICE_NAME` = myfrontend
 * `OTEL_RESOURCE_ATTRIBUTES` = service.instance.id=1a5f9c1e-e5ba-451b-95ee-ced1ee89c168
 * `OTEL_EXPORTER_OTLP_ENDPOINT` = http://localhost:4318
 
+OTLP exporting is disabled if `OTEL_EXPORTER_OTLP_ENDPOINT` isn't configured.
+
 ## Aspire local development
 
-The Aspire dashboard provides UI for viewing telemetry of apps. Telemetry data is sent to the dashboard using OTLP, and the dashboard implements an OTLP server to receive telemetry data and then store it in-memory. The dashboard UI presents telemetry stored in-memory.
+The Aspire dashboard provides UI for viewing the telemetry of apps. Telemetry data is sent to the dashboard using OTLP, and the dashboard implements an OTLP server to receive telemetry data and store it in memory. The dashboard UI presents telemetry stored in memory.
 
 Aspire F5 debugging workflow:
 
 * Developer starts and Aspire app with debugging
 * Aspire dashboard and developer control plane (DCP) start
 * App configuration is run in the DevHost project.
-  * During app configuration, OTEL environment variables are automatically added to .NET projects.
+  * OTEL environment variables are automatically added to .NET projects during app configuration.
   * The app name and ID from DCP are the name and ID of the app in exported telemetry.
   * The OTLP endpoint is an HTTP/2 port started by the dashboard. That tells projects to export telemetry back to the dashboard.
   * Fast export intervals so data is quickly available in the dashboard.
-* The DCP starts projects, containers, executables.
+* The DCP starts projects, containers, and executables.
 * Once started, apps send telemetry to the dashboard.
 * Dashboard displays near real-time telemetry of all Aspire apps.
+
+## Aspire deployment
+
+Aspire deployment environments should configure OTEL environment variables that make sense for their environment. For example, `OTEL_EXPORTER_OTLP_ENDPOINT` should be configured to the environment's local OTLP collector or monitoring service.

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -42,7 +42,7 @@ Aspire F5 debugging workflow:
   * OTEL environment variables are automatically added to .NET projects during app configuration.
   * DCP provides the name (`OTEL_SERVICE_NAME`) and ID (`OTEL_RESOURCE_ATTRIBUTES`) of the app in exported telemetry.
   * The OTLP endpoint is an HTTP/2 port started by the dashboard (`OTEL_EXPORTER_OTLP_ENDPOINT`). That tells projects to export telemetry back to the dashboard.
-  * Fast export intervals so data is quickly available in the dashboard. Small values are used in local development to prioritize dashboard responsiveness over efficient.
+  * Small export intervals (`OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BLRP_SCHEDULE_DELAY`, `OTEL_METRIC_EXPORT_INTERVAL`) so data is quickly available in the dashboard. Small values are used in local development to prioritize dashboard responsiveness over efficiency.
 * The DCP starts configured projects, containers, and executables.
 * Once started, apps send telemetry to the dashboard.
 * Dashboard displays near real-time telemetry of all Aspire apps.

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -14,7 +14,7 @@ Libraries and apps record values using .NET APIs for three kinds of telemetry:
 
 ## OpenTelemetry SDK
 
-The .NET OpenTelemetry SDK provides functionality to collect values from the .NET APIs listed above (`ILogger`, `Activity`, and `Instrument<T>`) and then export telemetry to a data store or reporting tool. Telemetry is exported using [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/). OTLP is a standard scheme for sending telemetry data using REST or gRPC.
+The .NET OpenTelemetry SDK provides functionality to collect values from the .NET APIs listed above (`ILogger`, `Activity`, and `Meter`/`Instrument<T>`) and then export telemetry to a data store or reporting tool. Telemetry is exported using [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/). OTLP is a standard scheme for sending telemetry data using REST or gRPC.
 
 .NET projects configure the .NET OpenTelemetry SDK using the service defaults project. Aspire templates automatically create the service defaults, and .NET Aspire apps call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
 

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -1,26 +1,28 @@
 # Aspire OpenTelemetry architecture
 
-An Aspire goal is apps are easy to debug and diagnose. Towards this goal, Aspire apps are configured by default to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data.
+An Aspire goal is apps are easy to debug and diagnose. To this end, Aspire apps are configured by default to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data. Telemetry just works and is easy to use.
 
 This document details how OpenTelemtry is used in Aspire apps.
 
 ## Telemetry types
 
-Libraries and apps record values using .NET APIs for three kinds of telemetry:
+OTEL is focused on three kinds of telemetry: structured logging, tracing, and metrics. .NET libraries and apps have APIs for recording each kind of telemetry:
 
 * Structured logging - Log entries from `ILogger`.
 * Tracing - Distributed tracing from `Activity`.
 * Metrics - Numeric values from `Meter`/`Instrument<T>`.
 
+When an OpenTelemetry SDK is configured in an app, it receives data from these APIs.
+
 ## OpenTelemetry SDK
 
-The .NET OpenTelemetry SDK provides functionality to collect values from the .NET APIs listed above (`ILogger`, `Activity`, and `Meter`/`Instrument<T>`) and then export telemetry to a data store or reporting tool. Telemetry is exported using [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/). OTLP is a standard scheme for sending telemetry data using REST or gRPC.
+The [.NET OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-dotnet) provides functionality to collect values from the .NET APIs listed above (`ILogger`, `Activity`, and `Meter`/`Instrument<T>`) and then export telemetry to a data store or reporting tool. Telemetry is exported using [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/). OTLP is a standard scheme for sending telemetry data using REST or gRPC.
 
-.NET projects configure the .NET OpenTelemetry SDK using the service defaults project. Aspire templates automatically create the service defaults, and .NET Aspire apps call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
+.NET projects setup the .NET OpenTelemetry SDK using the service defaults project. Aspire templates automatically create the service defaults, and .NET Aspire apps call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
 
 ## OpenTelemetry environment variables
 
-Environment variables configure almost all OTEL settings. OTEL has a [list of known environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) that configure the most important behavior for collecting and exporting telemetry. OTEL SDKs, including the .NET SDK, support reading these variables.
+OTEL has a [list of known environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) that configure the most important behavior for collecting and exporting telemetry. OTEL SDKs, including the .NET SDK, support reading these variables.
 
 Aspire apps launch with environment variables that configure the name and ID of the app in exported telemetry and set the address endpoint of the OTLP server to export data. For example:
 
@@ -28,7 +30,7 @@ Aspire apps launch with environment variables that configure the name and ID of 
 * `OTEL_RESOURCE_ATTRIBUTES` = service.instance.id=1a5f9c1e-e5ba-451b-95ee-ced1ee89c168
 * `OTEL_EXPORTER_OTLP_ENDPOINT` = http://localhost:4318
 
-OTLP exporting is disabled if `OTEL_EXPORTER_OTLP_ENDPOINT` isn't configured.
+The environment variables are automatically set in local development.
 
 ## Aspire local development
 
@@ -50,3 +52,9 @@ Aspire F5 debugging workflow:
 ## Aspire deployment
 
 Aspire deployment environments should configure OTEL environment variables that make sense for their environment. For example, `OTEL_EXPORTER_OTLP_ENDPOINT` should be configured to the environment's local OTLP collector or monitoring service.
+
+OTLP exporting is disabled if `OTEL_EXPORTER_OTLP_ENDPOINT` isn't configured.
+
+## Non-.NET apps
+
+OTEL isn't limited to .NET projects. Apps and containers that include OTEL can be passed environment variables to configure exporting telemetry. For example, the dapr sidecar (written in golang) includes OTEL and standard OTEL environment variables can be used to enable telemetry.

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -1,0 +1,44 @@
+# Aspire OpenTelemetry Architecture
+
+Aspire helps apps configure and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data.
+
+## Telemetry types
+
+There are three kinds of telemetry and values are recorded using .NET APIs by libraries and apps:
+
+* Structured logging - Log entries from `ILogger`.
+* Tracing - Distributed tracing from `Activity`.
+* Metrics - Numeric values from `Instrument<T>`.
+
+## OpenTelemetry SDK
+
+The .NET OpenTelemetry SDK provides functionality to collect values from the .NET APIs listed above (`ILogger`, `Activity` and `Instrument<T>`) and then export telemetry to a data store or reporting tool. Telemetry is exported using [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/). OTLP is a standard scheme for sending telemetry data using either REST or gRPC.
+
+The .NET OpenTelemetry SDK is configured in .NET projects in the service defaults project. The service defaults is automatically created by Aspire templates and .NET Aspire apps should use call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
+
+## OpenTelemetry environment variables
+
+Almost all OTEL settings are configured using environment variables. OTEL has a [list of known environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) that configure most important behavior for collecting and exporting telemetry. OTEL SDK's, including the .NET SDK, support reading these variables.
+
+Aspire apps are launched with environment variables that configure the name and ID of the app in exported telemetry, and the address endpoint of the OTLP server to export data to. For example:
+
+* `OTEL_SERVICE_NAME` = myfrontend
+* `OTEL_RESOURCE_ATTRIBUTES` = service.instance.id=1a5f9c1e-e5ba-451b-95ee-ced1ee89c168
+* `OTEL_EXPORTER_OTLP_ENDPOINT` = http://localhost:4318
+
+## Aspire local development
+
+The Aspire dashboard provides UI for viewing telemetry of apps. Telemetry data is sent to the dashboard using OTLP, and the dashboard implements an OTLP server to receive telemetry data and then store it in-memory. The dashboard UI presents telemetry stored in-memory.
+
+Aspire F5 debugging workflow:
+
+* Developer starts and Aspire app with debugging
+* Aspire dashboard and developer control plane (DCP) start
+* App configuration is run in the DevHost project.
+  * During app configuration, OTEL environment variables are automatically added to .NET projects.
+  * The app name and ID from DCP are the name and ID of the app in exported telemetry.
+  * The OTLP endpoint is an HTTP/2 port started by the dashboard. That tells projects to export telemetry back to the dashboard.
+  * Fast export intervals so data is quickly available in the dashboard.
+* The DCP starts projects, containers, executables.
+* Once started, apps send telemetry to the dashboard.
+* Dashboard displays near real-time telemetry of all Aspire apps.

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -10,7 +10,7 @@ Libraries and apps record values using .NET APIs for three kinds of telemetry:
 
 * Structured logging - Log entries from `ILogger`.
 * Tracing - Distributed tracing from `Activity`.
-* Metrics - Numeric values from `Instrument<T>`.
+* Metrics - Numeric values from `Meter`/`Instrument<T>`.
 
 ## OpenTelemetry SDK
 

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -36,14 +36,14 @@ The Aspire dashboard provides UI for viewing the telemetry of apps. Telemetry da
 
 Aspire F5 debugging workflow:
 
-* Developer starts and Aspire app with debugging
-* Aspire dashboard and developer control plane (DCP) start
+* Developer starts the Aspire app with debugging.
+* Aspire dashboard and developer control plane (DCP) start.
 * App configuration is run in the DevHost project.
   * OTEL environment variables are automatically added to .NET projects during app configuration.
-  * The app name and ID from DCP are the name and ID of the app in exported telemetry.
-  * The OTLP endpoint is an HTTP/2 port started by the dashboard. That tells projects to export telemetry back to the dashboard.
-  * Fast export intervals so data is quickly available in the dashboard.
-* The DCP starts projects, containers, and executables.
+  * DCP provides the name (`OTEL_SERVICE_NAME`) and ID (`OTEL_RESOURCE_ATTRIBUTES`) of the app in exported telemetry.
+  * The OTLP endpoint is an HTTP/2 port started by the dashboard (`OTEL_EXPORTER_OTLP_ENDPOINT`). That tells projects to export telemetry back to the dashboard.
+  * Fast export intervals so data is quickly available in the dashboard. Small values are used in local development to prioritize dashboard responsiveness over efficient.
+* The DCP starts configured projects, containers, and executables.
 * Once started, apps send telemetry to the dashboard.
 * Dashboard displays near real-time telemetry of all Aspire apps.
 

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -1,6 +1,8 @@
 # Aspire OpenTelemetry architecture
 
-Aspire apps are configured by default to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data.
+An Aspire goal is apps are easy to debug and diagnose. Towards this goal, Aspire apps are configured by default to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data.
+
+This document details how OpenTelemtry is used in Aspire apps.
 
 ## Telemetry types
 

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -1,6 +1,6 @@
 # Aspire OpenTelemetry architecture
 
-An Aspire goal is apps are easy to debug and diagnose. To this end, Aspire apps are configured by default to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data. Telemetry just works and is easy to use.
+One of Aspire's objectives is to ensure that apps are straightforward to debug and diagnose. By default, Aspire apps are configured to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data. Telemetry just works and is easy to use.
 
 This document details how OpenTelemtry is used in Aspire apps.
 
@@ -8,17 +8,17 @@ This document details how OpenTelemtry is used in Aspire apps.
 
 OTEL is focused on three kinds of telemetry: structured logging, tracing, and metrics. .NET libraries and apps have APIs for recording each kind of telemetry:
 
-* Structured logging - Log entries from `ILogger`.
-* Tracing - Distributed tracing from `Activity`.
-* Metrics - Numeric values from `Meter`/`Instrument<T>`.
+* Structured logging: Log entries from `ILogger`.
+* Tracing: Distributed tracing from `Activity`.
+* Metrics: Numeric values from `Meter` and `Instrument<T>`.
 
 When an OpenTelemetry SDK is configured in an app, it receives data from these APIs.
 
 ## OpenTelemetry SDK
 
-The [.NET OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-dotnet) provides functionality to collect values from the .NET APIs listed above (`ILogger`, `Activity`, and `Meter`/`Instrument<T>`) and then export telemetry to a data store or reporting tool. Telemetry is exported using [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/). OTLP is a standard scheme for sending telemetry data using REST or gRPC.
+The [.NET OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-dotnet) offers features for gathering data from several .NET APIs, including `ILogger`, `Activity`, `Meter`, and `Instrument<T>`. It then facilitates the export of this telemetry data to a data store or reporting tool. The telemetry export mechanism relies on the [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/), which serves as a standardized approach for transmitting telemetry data through REST or gRPC.
 
-.NET projects setup the .NET OpenTelemetry SDK using the service defaults project. Aspire templates automatically create the service defaults, and .NET Aspire apps call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
+.NET projects setup the .NET OpenTelemetry SDK using the _service defaults_ project. Aspire templates automatically create the service defaults, and Aspire apps call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
 
 ## OpenTelemetry environment variables
 
@@ -36,11 +36,11 @@ The environment variables are automatically set in local development.
 
 The Aspire dashboard provides UI for viewing the telemetry of apps. Telemetry data is sent to the dashboard using OTLP, and the dashboard implements an OTLP server to receive telemetry data and store it in memory. The dashboard UI presents telemetry stored in memory.
 
-Aspire F5 debugging workflow:
+Aspire debugging workflow:
 
-* Developer starts the Aspire app with debugging.
+* Developer starts the Aspire app with debugging, presses <kbd>F5</kbd>.
 * Aspire dashboard and developer control plane (DCP) start.
-* App configuration is run in the DevHost project.
+* App configuration is run in the _DevHost_ project.
   * OTEL environment variables are automatically added to .NET projects during app configuration.
   * DCP provides the name (`OTEL_SERVICE_NAME`) and ID (`OTEL_RESOURCE_ATTRIBUTES`) of the app in exported telemetry.
   * The OTLP endpoint is an HTTP/2 port started by the dashboard (`OTEL_EXPORTER_OTLP_ENDPOINT`). That tells projects to export telemetry back to the dashboard.

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -43,7 +43,7 @@ Aspire debugging workflow:
 * App configuration is run in the _AppHost_ project.
   * OTEL environment variables are automatically added to .NET projects during app configuration.
   * DCP provides the name (`OTEL_SERVICE_NAME`) and ID (`OTEL_RESOURCE_ATTRIBUTES`) of the app in exported telemetry.
-  * The OTLP endpoint is an HTTP/2 port started by the dashboard (`OTEL_EXPORTER_OTLP_ENDPOINT`). That tells projects to export telemetry back to the dashboard.
+  * The OTLP endpoint is an HTTP/2 port started by the dashboard. This endpoint is set in the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable on each project. That tells projects to export telemetry back to the dashboard.
   * Small export intervals (`OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BLRP_SCHEDULE_DELAY`, `OTEL_METRIC_EXPORT_INTERVAL`) so data is quickly available in the dashboard. Small values are used in local development to prioritize dashboard responsiveness over efficiency.
 * The DCP starts configured projects, containers, and executables.
 * Once started, apps send telemetry to the dashboard.

--- a/samples/eShopLite/MyFrontend/Program.cs
+++ b/samples/eShopLite/MyFrontend/Program.cs
@@ -17,6 +17,8 @@ builder.Services.AddRazorComponents();
 
 var app = builder.Build();
 
+_ = "Hu";
+
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/error", createScopeForErrors: true);

--- a/samples/eShopLite/MyFrontend/Program.cs
+++ b/samples/eShopLite/MyFrontend/Program.cs
@@ -17,8 +17,6 @@ builder.Services.AddRazorComponents();
 
 var app = builder.Build();
 
-_ = "Hu";
-
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/error", createScopeForErrors: true);


### PR DESCRIPTION
Share knowledge of how telemetry works in Aspire.

Also hopefully this is the start of something we can give to cloud providers who want to host Aspire apps with OpenTelemetry nicely configured.

Preview: https://github.com/dotnet/aspire/blob/jamesnk/otel-docs/docs/open-telemetry-architecture.md