### PR TITLE
Add lines to metrics graphs

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -98,6 +98,8 @@ function fixTraceLineRendering(chartDiv) {
     //
     // The fix is to reverse the order of traces so the correct line is on top. There isn't a way to do this
     // with CSS because SVG doesn't support z-index. Node order is what determines the rendering order.
+    //
+    // https://github.com/plotly/plotly.js/issues/6579
     var parent = chartDiv.querySelector(".scatterlayer");
 
     if (parent.childNodes.length > 0) {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -162,7 +162,6 @@ window.initializeChart = function (id, traces, xValues, rangeStartTime, rangeEnd
             name: name,
             text: traces[i].tooltips,
             hoverinfo: 'text',
-            line: { width: 2 },
             stackgroup: "one"
         };
         data.push(t);

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -91,6 +91,22 @@ function getThemeColors() {
     };
 }
 
+function fixTraceLineRendering(chartDiv) {
+    // In stack area charts Plotly orders traces so the top line area overwrites the line of areas below it.
+    // This isn't the effect we want. When the P50, P90 and P99 values are the same, the line displayed is P99
+    // on the P50 area.
+    //
+    // The fix is to reverse the order of traces so the correct line is on top. There isn't a way to do this
+    // with CSS because SVG doesn't support z-index. Node order is what determines the rendering order.
+    var parent = chartDiv.querySelector(".scatterlayer");
+
+    if (parent.childNodes.length > 0) {
+        for (var i = 1; i < parent.childNodes.length; i++) {
+            parent.insertBefore(parent.childNodes[i], parent.firstChild);
+        }
+    }
+}
+
 window.updateChart = function (id, traces, xValues, rangeStartTime, rangeEndTime) {
     var chartContainerDiv = document.getElementById(id);
     var chartDiv = chartContainerDiv.firstChild;
@@ -123,6 +139,8 @@ window.updateChart = function (id, traces, xValues, rangeStartTime, rangeEndTime
     };
 
     Plotly.update(chartDiv, data, layout);
+
+    fixTraceLineRendering(chartDiv);
 };
 
 window.initializeChart = function (id, traces, xValues, rangeStartTime, rangeEndTime) {
@@ -144,7 +162,7 @@ window.initializeChart = function (id, traces, xValues, rangeStartTime, rangeEnd
             name: name,
             text: traces[i].tooltips,
             hoverinfo: 'text',
-            line: { width: 0 },
+            line: { width: 2 },
             stackgroup: "one"
         };
         data.push(t);
@@ -182,5 +200,7 @@ window.initializeChart = function (id, traces, xValues, rangeStartTime, rangeEnd
     var options = { scrollZoom: false, displayModeBar: false };
 
     Plotly.newPlot(chartDiv, data, layout, options);
+
+    fixTraceLineRendering(chartDiv);
 };
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/351

Before, the P99 line would always appear on top in histograms with lines enabled. There would be a blue P50 area and then a green P99 line. Ugly 🤮 

Fortunately, I figured out a little hack to make lines look good 🤓 

Area + line looks better, and it's more accessible. The graph no longer relies on colored areas to differentiate values. Lines show when there are different values. Tooltips are then available to see exact values at each level.

Before:
![image](https://github.com/dotnet/aspire/assets/303201/88f3a288-3edf-4dc0-9b1d-323353375a2e)


After:
![image](https://github.com/dotnet/aspire/assets/303201/65df5a89-ac43-4992-bf4a-b433d5d1c0ac)

![image](https://github.com/dotnet/aspire/assets/303201/ebe8d1f7-241b-40f2-a926-f9acba9867af)

