### PR TITLE
Display first histogram value

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
@@ -199,6 +199,7 @@ public partial class PlotlyChart : ComponentBase
                     var histogramValue = GetHistogramValue(metric);
 
                     // Only use the first recorded entry if it is the beginning of data.
+                    // We can verify the first entry is the beginning of data by checking if the number of buckets equals the total count.
                     if (i == 0 && CountBuckets(histogramValue) != histogramValue.Count)
                     {
                         continue;


### PR DESCRIPTION
Previously, histogram graphs wouldn't use the first value because it needs to diff from the previous value. That means if you visited an app once and then looked at the `http.server.request.duration` graph, nothing would be displayed.

This PR adds a way for the graph to recognize that a single value is the very first one, which means its diff is from zero, and the data point can be displayed in the graph.