### PR TITLE
Remove AspNetCore dependency in Npgsql EF Core component

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,6 @@
     <PackageVersion Include="Azure.ResourceManager.Storage" Version="1.1.1" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.0-beta.1" />
     <!-- ASP.NET Core dependencies -->
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(AspNetCoreVersion)" />

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"/>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.DependencyInjection" />

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AspireEFPostgreSqlExtensions.cs
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AspireEFPostgreSqlExtensions.cs
@@ -67,14 +67,6 @@ public static partial class AspireEFPostgreSqlExtensions
 
         configureSettings?.Invoke(settings);
 
-        if (builder.Environment.IsDevelopment())
-        {
-            // calling UseDeveloperExceptionPage is the responsibility of the app, not Component
-#pragma warning disable IL3050 // TODO: https://github.com/dotnet/aspire/issues/146 should remove this line
-            builder.Services.AddDatabaseDeveloperPageExceptionFilter();
-#pragma warning restore IL3050
-        }
-
         builder.Services.AddNpgsqlDataSource(settings.ConnectionString ?? string.Empty, builder =>
         {
             // delay validating the ConnectionString until the DataSource is requested. This ensures an exception doesn't happen until a Logger is established.

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests_Pooling.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests_Pooling.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using Aspire.Components.Common.Tests;
 using Aspire.Components.ConformanceTests;
-using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -144,21 +143,6 @@ public class ConformanceTests_Pooling : ConformanceTests<TestDbContext, NpgsqlEn
         TestDbContext? dbContext = host.Services.GetService<TestDbContext>();
 
         Assert.NotNull(dbContext);
-    }
-
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void DatabaseDeveloperPageExceptionFilterIsRegisteredOnlyForDevelopmentEnvironment(bool isDevEnv)
-    {
-        HostApplicationBuilderSettings? hostSettings = isDevEnv
-            ? new() { EnvironmentName = Environments.Development }
-            : null;
-
-        using IHost host = CreateHostWithComponent(hostSettings: hostSettings);
-
-        IDeveloperPageExceptionFilter? exceptionPage = host.Services.GetService<IDeveloperPageExceptionFilter>();
-        Assert.Equal(isDevEnv, exceptionPage is not null);
     }
 
     [ConditionalFact]


### PR DESCRIPTION
The Npgsql EF Core component currently adds the EF developer page in development environments. This means the Npgsql EF Core component is dependent on the ASP.NET Core shared framework, which brings more dependencies on it in other app models (ex. Worker apps).

Removing this functionality because this dependency is not desirable and we don't have it in the SQL Server component.

Fix #146