### PR TITLE
Small refactoring to use options

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/AzureProvisinerOptions.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/AzureProvisinerOptions.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Provisioning;
+
+internal sealed class AzureProvisinerOptions
+{
+    public string? SubscriptionId { get; set; }
+
+    public string? ResourceGroup { get; set; }
+
+    public string? Location { get; set; }
+}

--- a/src/Aspire.Hosting.Azure.Provisioning/AzureProvisionerExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/AzureProvisionerExtensions.cs
@@ -24,6 +24,10 @@ public static class AzureProvisionerExtensions
     {
         builder.Services.AddLifecycleHook<AzureProvisioner>();
 
+        // Attempt to read azure configuration from configuration
+        builder.Services.AddOptions<AzureProvisinerOptions>()
+            .BindConfiguration("Azure");
+
         // We're adding 2 because there's no easy way to enumerate all keys and all service types
         builder.AddAzureProvisioner<AzureKeyVaultResource, KeyVaultProvisoner>();
         builder.AddResourceEnumerator(resourceGroup => resourceGroup.GetKeyVaults(), resource => resource.Data.Tags);
@@ -44,7 +48,7 @@ public static class AzureProvisionerExtensions
         where TProvisioner : AzureResourceProvisioner<TResource>
     {
         // This lets us avoid using open generics in the caller, we can use keyed lookup instead
-        builder.Services.AddKeyedSingleton<IAzuresourceProvisioner, TProvisioner>(typeof(TResource));
+        builder.Services.AddKeyedSingleton<IAzureResourceProvisioner, TProvisioner>(typeof(TResource));
         return builder;
     }
 

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureResourceProvisionerOfT.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureResourceProvisionerOfT.cs
@@ -12,7 +12,7 @@ using Azure;
 
 namespace Aspire.Hosting.Azure.Provisioning;
 
-internal interface IAzuresourceProvisioner
+internal interface IAzureResourceProvisioner
 {
     bool ConfigureResource(IConfiguration configuration, IAzureResource resource);
 
@@ -28,13 +28,13 @@ internal interface IAzuresourceProvisioner
         CancellationToken cancellationToken);
 }
 
-internal abstract class AzureResourceProvisioner<TResource> : IAzuresourceProvisioner
+internal abstract class AzureResourceProvisioner<TResource> : IAzureResourceProvisioner
     where TResource : IAzureResource
 {
-    bool IAzuresourceProvisioner.ConfigureResource(IConfiguration configuration, IAzureResource resource) =>
+    bool IAzureResourceProvisioner.ConfigureResource(IConfiguration configuration, IAzureResource resource) =>
         ConfigureResource(configuration, (TResource)resource);
 
-    Task IAzuresourceProvisioner.GetOrCreateResourceAsync(
+    Task IAzureResourceProvisioner.GetOrCreateResourceAsync(
         ArmClient armClient,
         SubscriptionResource subscription,
         ResourceGroupResource resourceGroup,


### PR DESCRIPTION
- Use AzureProvisionerOptions to decouple how the configuration is read. Use config options binding for now (same as we did before).
- Future plans to potentially share configuration with azd or another tool providing this configuration.