### PR TITLE
Service Discovery: Propagate original host name to HttpClient Host header

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Features/IHostNameFeature.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Features/IHostNameFeature.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
+
+/// <summary>
+/// Exposes the host name of the end point.
+/// </summary>
+public interface IHostNameFeature
+{
+    /// <summary>
+    /// Gets the host name of the end point.
+    /// </summary>
+    public string HostName { get; }
+}
+

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -31,7 +31,7 @@ internal abstract partial class DnsServiceEndPointResolverBase : IServiceEndPoin
     /// <param name="serviceName">The service name.</param>
     /// <param name="logger">The logger.</param>
     /// <param name="timeProvider">The time provider.</param>
-    public DnsServiceEndPointResolverBase(
+    protected DnsServiceEndPointResolverBase(
         string serviceName,
         ILogger logger,
         TimeProvider timeProvider)

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
@@ -58,7 +58,7 @@ internal sealed partial class DnsSrvServiceEndPointResolverProvider(
 
         var portName = parts.EndPointName ?? "default";
         var srvQuery = $"_{portName}._tcp.{parts.Host}.{_querySuffix}";
-        resolver = new DnsSrvServiceEndPointResolver(serviceName, srvQuery, options, logger, dnsClient, timeProvider);
+        resolver = new DnsSrvServiceEndPointResolver(serviceName, srvQuery, hostName: parts.Host, options, logger, dnsClient, timeProvider);
         return true;
     }
 

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/ResolvingHttpClientHandler.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/ResolvingHttpClientHandler.cs
@@ -24,6 +24,7 @@ public class ResolvingHttpClientHandler(HttpServiceEndPointResolver resolver) : 
         {
             var result = await _resolver.GetEndpointAsync(request, cancellationToken).ConfigureAwait(false);
             request.RequestUri = ResolvingHttpDelegatingHandler.GetUriWithEndPoint(originalUri, result);
+            request.Headers.Host ??= result.Features.Get<IHostNameFeature>()?.HostName;
             epHealth = result.Features.Get<IEndPointHealthFeature>();
         }
 

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/ResolvingHttpDelegatingHandler.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/ResolvingHttpDelegatingHandler.cs
@@ -44,6 +44,7 @@ public class ResolvingHttpDelegatingHandler : DelegatingHandler
         {
             var result = await _resolver.GetEndpointAsync(request, cancellationToken).ConfigureAwait(false);
             request.RequestUri = GetUriWithEndPoint(originalUri, result);
+            request.Headers.Host ??= result.Features.Get<IHostNameFeature>()?.HostName;
             epHealth = result.Features.Get<IEndPointHealthFeature>();
         }
 

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
@@ -210,6 +210,13 @@ public class DnsSrvServiceEndPointResolverTests
                 Assert.Equal(new DnsEndPoint("localhost", 8080), initialResult.EndPoints[0].EndPoint);
                 Assert.Equal(new DnsEndPoint("remotehost", 9090), initialResult.EndPoints[1].EndPoint);
             }
+
+            Assert.All(initialResult.EndPoints, ep =>
+            {
+                var hostNameFeature = ep.Features.Get<IHostNameFeature>();
+                Assert.NotNull(hostNameFeature);
+                Assert.Equal("basket", hostNameFeature.HostName);
+            });
         }
     }
 

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
@@ -43,6 +43,13 @@ public class ConfigurationServiceEndPointResolverTests
             Assert.Equal(ResolutionStatus.Success, initialResult.Status);
             var ep = Assert.Single(initialResult.EndPoints);
             Assert.Equal(new DnsEndPoint("localhost", 8080), ep.EndPoint);
+
+            Assert.All(initialResult.EndPoints, ep =>
+            {
+                var hostNameFeature = ep.Features.Get<IHostNameFeature>();
+                Assert.NotNull(hostNameFeature);
+                Assert.Equal("basket", hostNameFeature.HostName);
+            });
         }
     }
 
@@ -78,6 +85,13 @@ public class ConfigurationServiceEndPointResolverTests
             Assert.Equal(2, initialResult.EndPoints.Count);
             Assert.Equal(new DnsEndPoint("localhost", 8080), initialResult.EndPoints[0].EndPoint);
             Assert.Equal(new DnsEndPoint("remotehost", 9090), initialResult.EndPoints[1].EndPoint);
+
+            Assert.All(initialResult.EndPoints, ep =>
+            {
+                var hostNameFeature = ep.Features.Get<IHostNameFeature>();
+                Assert.NotNull(hostNameFeature);
+                Assert.Equal("basket", hostNameFeature.HostName);
+            });
         }
     }
 
@@ -115,6 +129,13 @@ public class ConfigurationServiceEndPointResolverTests
             Assert.Equal(2, initialResult.EndPoints.Count);
             Assert.Equal(new DnsEndPoint("localhost", 2222), initialResult.EndPoints[0].EndPoint);
             Assert.Equal(new DnsEndPoint("remotehost", 2222), initialResult.EndPoints[1].EndPoint);
+
+            Assert.All(initialResult.EndPoints, ep =>
+            {
+                var hostNameFeature = ep.Features.Get<IHostNameFeature>();
+                Assert.NotNull(hostNameFeature);
+                Assert.Equal("basket", hostNameFeature.HostName);
+            });
         }
     }
 


### PR DESCRIPTION
Fixes #321

Extracts the original host from the input and propagates it through the `Host` header for HTTP requests.
Eg,
ServiceName = "basket" => Host = "basket"
ServiceName = "_grpc.basket" => Host = "basket"
ServiceName = "https://_grpc.basket" => Host = "basket"