### PR TITLE
Fix conflicting tests

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -12,6 +12,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -30,7 +31,8 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
     private readonly DashboardWebApplication _dashboard;
     private readonly IOptions<PublishingOptions> _publishingOptions;
 
-    public DcpHostService(DistributedApplicationModel applicationModel, ILoggerFactory loggerFactory, IOptions<PublishingOptions> publishingOptions, ApplicationExecutor appExecutor)
+    public DcpHostService(DistributedApplicationModel applicationModel, ILoggerFactory loggerFactory,
+        IOptions<PublishingOptions> publishingOptions, ApplicationExecutor appExecutor, IConfiguration configuration)
     {
         _applicationModel = applicationModel;
         _loggerFactory = loggerFactory;
@@ -42,7 +44,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         {
             serviceCollection.AddSingleton(_applicationModel);
             serviceCollection.AddSingleton<IDashboardViewModelService, DashboardViewModelService>();
-        });
+        }, configuration);
     }
 
     public async Task StartAsync(CancellationToken cancellationToken = default)

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -10,6 +10,8 @@ namespace Aspire.Hosting.Tests;
 
 public class DistributedApplicationTests
 {
+    private static int s_port = 6000;
+
     [Fact]
     public async void RegisteredLifecycleHookIsExecutedWhenRunAsynchronously()
     {
@@ -106,7 +108,8 @@ public class DistributedApplicationTests
         var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMinutes(1));
 
-        var testProgram = new TestProgram([]);
+        var testProgram = new TestProgram([$"ASPNETCORE_URLS=http://localhost:{Interlocked.Increment(ref s_port)}",
+            $"DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:{Interlocked.Increment(ref s_port)}"]);
         var pendingRun = testProgram.RunAsync(cts.Token);
 
         // Make sure each service is running
@@ -128,7 +131,8 @@ public class DistributedApplicationTests
 
         var replicaCount = 3;
 
-        var testProgram = new TestProgram([]);
+        var testProgram = new TestProgram([$"ASPNETCORE_URLS=http://localhost:{Interlocked.Increment(ref s_port)}",
+            $"DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:{Interlocked.Increment(ref s_port)}"]);
         testProgram.ServiceBBuilder.WithReplicas(replicaCount);
 
         var pendingRun = testProgram.RunAsync(cts.Token);

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -10,8 +10,6 @@ namespace Aspire.Hosting.Tests;
 
 public class DistributedApplicationTests
 {
-    private static int s_port = 6000;
-
     [Fact]
     public async void RegisteredLifecycleHookIsExecutedWhenRunAsynchronously()
     {
@@ -108,8 +106,7 @@ public class DistributedApplicationTests
         var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMinutes(1));
 
-        var testProgram = new TestProgram([$"ASPNETCORE_URLS=http://localhost:{Interlocked.Increment(ref s_port)}",
-            $"DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:{Interlocked.Increment(ref s_port)}"]);
+        var testProgram = new TestProgram([]);
         var pendingRun = testProgram.RunAsync(cts.Token);
 
         // Make sure each service is running
@@ -131,8 +128,7 @@ public class DistributedApplicationTests
 
         var replicaCount = 3;
 
-        var testProgram = new TestProgram([$"ASPNETCORE_URLS=http://localhost:{Interlocked.Increment(ref s_port)}",
-            $"DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:{Interlocked.Increment(ref s_port)}"]);
+        var testProgram = new TestProgram([]);
         testProgram.ServiceBBuilder.WithReplicas(replicaCount);
 
         var pendingRun = testProgram.RunAsync(cts.Token);

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -5,8 +5,25 @@ using Aspire.Hosting.ApplicationModel;
 
 public class TestProgram
 {
+    private static int s_port = 6000;
+
     public TestProgram(string[] args)
     {
+        // Avoid port in use errors for tests running in the same process
+        if (!args.Any(s => s.Contains("ASPNETCORE_URLS")))
+        {
+            var newArr = new string[args.Length + 1];
+            Array.Copy(args, newArr, args.Length);
+            newArr[args.Length] = $"ASPNETCORE_URLS=http://localhost:{Interlocked.Increment(ref s_port)}";
+            args = newArr;
+        }
+        if (!args.Any(s => s.Contains("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL")))
+        {
+            var newArr = new string[args.Length + 1];
+            Array.Copy(args, newArr, args.Length);
+            newArr[args.Length] = $"DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:{Interlocked.Increment(ref s_port)}";
+            args = newArr;
+        }
         AppBuilder = DistributedApplication.CreateBuilder(args);
         ServiceABuilder = AppBuilder.AddProject<Projects.ServiceA>("servicea");
         ServiceBBuilder = AppBuilder.AddProject<Projects.ServiceB>("serviceb");


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/172 as far as I understand the issue. Idk what the talk about dcp is since it seems to have no affect on the issue, the problem I could see was that the apps would try running the dashboard on the same URL which causes port conflicts and would fail.

Changed the dashboard to allow passing in config so the tests can change the port being used to avoid conflicts. Very flimsy right now, but could be changed to be automatic inside TestProgram so it's a little less work you need to add to tests. But if tests run in different processes on the same machine they can still hit problems.