### PR TITLE
Rework dashboard layout

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,8 +70,8 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="11.0.36" />
     <PackageVersion Include="JsonSchema.Net" Version="5.2.5" />
-    <PackageVersion Include="Microsoft.Fast.Components.FluentUI" Version="3.2.0" />
-    <PackageVersion Include="Microsoft.Fast.Components.FluentUI.Icons" Version="3.1.1" />
+    <PackageVersion Include="Microsoft.Fast.Components.FluentUI" Version="3.2.1" />
+    <PackageVersion Include="Microsoft.Fast.Components.FluentUI.Icons" Version="3.2.1" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.0-rc.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="8.0.0-rc.2" />

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -1,5 +1,5 @@
 .log-overflow {
-    height: calc(100vh - 165px);
+    height: 100%;
     width: 100%;
     overflow: auto;
     background-color: #0C0C0C;

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -6,40 +6,37 @@
 @inject IDialogService dialogService
 @inherits LayoutComponentBase
 
-<div>
-    <FluentLayout>
-        <FluentHeader>
-            <div class="header-title">
-                <FluentIcon Value="@(new AspireIcons.Size32.Logo())" Style="height: 32px;"></FluentIcon>
-                <span>@dashboardViewModelService.ApplicationName Dashboard</span>
-            </div>
-            <div class="header-right">
-                <FluentButton Appearance="Appearance.Stealth" OnClick="LaunchSettings" IconEnd="@(new Icons.Regular.Size24.Settings())"
-                              Title="Launch Settings" aria-label="Launch Settings" />
-            </div>
-        </FluentHeader>
-        <FluentStack Orientation="Orientation.Horizontal" Width="100%">
-            <div class="nav-menu-container">
-                <FluentNavMenu Width="250" Collapsible="true" role="menu">
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Href="/" Match="NavLinkMatch.All" role="menuitem">Projects</FluentNavLink>
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.BinFull())" Href="/Containers" role="menuitem">Containers</FluentNavLink>
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Href="/Executables" role="menuitem">Executables</FluentNavLink>
-                    <FluentNavGroup Title="Logs" Icon="@(new Icons.Regular.Size24.SlideText())" Expanded="true" Gap="10px 0;" role="menuitem menu">
-                        <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ProjectLogs" role="menuitem">Project</FluentNavLink>
-                        <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ContainerLogs" role="menuitem">Container</FluentNavLink>
-                        <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ExecutableLogs" role="menuitem">Executable</FluentNavLink>
-                        <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Href="/StructuredLogs" role="menuitem">Structured</FluentNavLink>
-                    </FluentNavGroup>
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces" role="menuitem">Traces</FluentNavLink>
-                    <FluentNavLink Icon="@(new Icons.Regular.Size24.ChartMultiple())" Href="/Metrics" role="menuitem">Metrics</FluentNavLink>
-                </FluentNavMenu>
-            </div>
-            <FluentBodyContent Class="custom-body-content">
-                @Body
-            </FluentBodyContent>
+<div class="layout">
+    <FluentHeader>
+        <div class="header-title">
+            <FluentAnchor IconStart="@(new AspireIcons.Size32.Logo())" Appearance="Appearance.Stealth" Href="/">
+                @dashboardViewModelService.ApplicationName Dashboard
+            </FluentAnchor>
+        </div>
+        <div class="header-right">
+            <FluentButton Appearance="Appearance.Stealth" OnClick="LaunchSettings" IconEnd="@(new Icons.Regular.Size24.Settings())"
+                          Title="Launch Settings" aria-label="Launch Settings" />
+        </div>
+    </FluentHeader>
+    <div class="nav-menu-container">
+        <FluentNavMenu Width="250" Collapsible="true" role="menu">
+            <FluentNavLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Href="/" Match="NavLinkMatch.All" role="menuitem">Projects</FluentNavLink>
+            <FluentNavLink Icon="@(new Icons.Regular.Size24.BinFull())" Href="/Containers" role="menuitem">Containers</FluentNavLink>
+            <FluentNavLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Href="/Executables" role="menuitem">Executables</FluentNavLink>
+            <FluentNavGroup Title="Logs" Icon="@(new Icons.Regular.Size24.SlideText())" Expanded="true" Gap="10px 0;" role="menuitem menu">
+                <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ProjectLogs" role="menuitem">Project</FluentNavLink>
+                <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ContainerLogs" role="menuitem">Container</FluentNavLink>
+                <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ExecutableLogs" role="menuitem">Executable</FluentNavLink>
+                <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Href="/StructuredLogs" role="menuitem">Structured</FluentNavLink>
+            </FluentNavGroup>
+            <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces" role="menuitem">Traces</FluentNavLink>
+            <FluentNavLink Icon="@(new Icons.Regular.Size24.ChartMultiple())" Href="/Metrics" role="menuitem">Metrics</FluentNavLink>
+        </FluentNavMenu>
+    </div>
+    <FluentBodyContent Class="custom-body-content">
+        @Body
+    </FluentBodyContent>
 
-        </FluentStack>
-    </FluentLayout>
     <FluentDialogProvider />
     <FluentTooltipProvider />
     <div id="blazor-error-ui">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -1,89 +1,3 @@
-.page {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-}
-
-main {
-    flex: 1;
-}
-
-::deep .fluent-nav-link {
-    width: 100%;
-}
-
-.sidebar {
-    background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
-}
-
-.top-row {
-    background-color: #f7f7f7;
-    border-bottom: 1px solid #d6d5d5;
-    justify-content: flex-end;
-    height: 3.5rem;
-    display: flex;
-    align-items: center;
-}
-
-    .top-row ::deep a, .top-row ::deep .btn-link {
-        white-space: nowrap;
-        margin-left: 1.5rem;
-        text-decoration: none;
-    }
-
-    .top-row ::deep a:hover, .top-row ::deep .btn-link:hover {
-        text-decoration: underline;
-    }
-
-    .top-row ::deep a:first-child {
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-
-@media (max-width: 640.98px) {
-    .top-row:not(.auth) {
-        display: none;
-    }
-
-    .top-row.auth {
-        justify-content: space-between;
-    }
-
-    .top-row ::deep a, .top-row ::deep .btn-link {
-        margin-left: 0;
-    }
-}
-
-@media (min-width: 641px) {
-    .page {
-        flex-direction: row;
-    }
-
-    .sidebar {
-        width: 250px;
-        height: 100vh;
-        position: sticky;
-        top: 0;
-    }
-
-    .top-row {
-        position: sticky;
-        top: 0;
-        z-index: 1;
-    }
-
-    .top-row.auth ::deep a:first-child {
-        flex: 1;
-        text-align: right;
-        width: 0;
-    }
-
-    .top-row, article {
-        padding-left: 2rem !important;
-        padding-right: 1.5rem !important;
-    }
-}
-
 #blazor-error-ui {
     background: lightyellow;
     bottom: 0;
@@ -103,21 +17,42 @@ main {
     top: 0.5rem;
 }
 
-::deep .layout {
-    min-height: 100vh;
+::deep.layout {
+    height: 100vh;
+    width: 100vw;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+        "head head"
+        "nav main";
     background-color: var(--fill-color);
     color: var(--neutral-foreground-rest);
+}
+
+::deep.layout > header {
+    grid-area: head;
+}
+
+::deep.layout > .nav-menu-container {
+    grid-area: nav;
+    overflow-y: auto;
+}
+
+::deep.layout > .body-content {
+    grid-area: main;
 }
 
 ::deep .header-right {
     margin-left: auto;
 }
 
-::deep .layout > .header fluent-button[appearance=stealth]:not(:hover)::part(control) {
+::deep.layout > header fluent-button[appearance=stealth]:not(:hover)::part(control),
+::deep.layout > header fluent-anchor[appearance=stealth]::part(control) {
     background-color: var(--neutral-layer-4);
 }
 
-::deep .layout > .header {
+::deep.layout > header {
     background-color: var(--neutral-layer-4);
     color: var(--accent-fill-rest);
     margin-bottom: 0;
@@ -128,4 +63,9 @@ main {
     align-items: center;
     gap: 10px;
     font-size: var(--type-ramp-plus-2-font-size);
+}
+
+::deep .header-title fluent-anchor {
+    font-size: var(--type-ramp-plus-2-font-size);
+    color: var(--accent-fill-rest);
 }

--- a/src/Aspire.Dashboard/Components/Pages/Containers.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Containers.razor
@@ -6,70 +6,68 @@
 
 <PageTitle>@DashboardViewModelService.ApplicationName Containers</PageTitle>
 
-<div>
-    <FluentStack Orientation="Orientation.Vertical">
-        <FluentToolbar Orientation="Orientation.Horizontal">
-            <h1 slot="label">Containers</h1>
-            <FluentSearch Placeholder="Filter..."
-                          Immediate="true"
-                          @bind-Value="filter"
-                          @oninput="HandleFilter"
-                          AfterBindValue="HandleClear"
-                          slot="end" />
-        </FluentToolbar>
-        <div class="datagrid-overflow-area" tabindex="-1">
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 3fr 1fr 2fr 1fr 1fr">
-                <ChildContent>
-                    <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort">
-                        <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
-                    </TemplateColumn>
-                    <PropertyColumn Property="@(e => e.State)" Sortable="true" />
-                    <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" />
-                    <TemplateColumn Title="Container Image" Sortable="true" SortBy="@imageSort">
-                        <FluentHighlighter HighlightedText="@filter" Text="@context.Image" />
-                    </TemplateColumn>
-                    <TemplateColumn Title="Ports" Sortable="false">
-                        <span>@string.Join(";", context.Ports.Select(e => e.ToString()))</span>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Endpoints" Sortable="false">
-                        <FluentStack Orientation="Orientation.Vertical">
-                            @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
-                            @if (context.Endpoints.Count == 0 && (context.State == FinishedState || context.ExpectedEndpointsCount == 0))
+<div class="content-layout-with-toolbar">
+    <FluentToolbar Orientation="Orientation.Horizontal">
+        <h1 slot="label">Containers</h1>
+        <FluentSearch Placeholder="Filter..."
+                        Immediate="true"
+                        @bind-Value="filter"
+                        @oninput="HandleFilter"
+                        AfterBindValue="HandleClear"
+                        slot="end" />
+    </FluentToolbar>
+    <div class="datagrid-overflow-area" tabindex="-1">
+        <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 3fr 1fr 2fr 1fr 1fr">
+            <ChildContent>
+                <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort">
+                    <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
+                </TemplateColumn>
+                <PropertyColumn Property="@(e => e.State)" Sortable="true" />
+                <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" />
+                <TemplateColumn Title="Container Image" Sortable="true" SortBy="@imageSort">
+                    <FluentHighlighter HighlightedText="@filter" Text="@context.Image" />
+                </TemplateColumn>
+                <TemplateColumn Title="Ports" Sortable="false">
+                    <span>@string.Join(";", context.Ports.Select(e => e.ToString()))</span>
+                </TemplateColumn>
+                <TemplateColumn Title="Endpoints" Sortable="false">
+                    <FluentStack Orientation="Orientation.Vertical">
+                        @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
+                        @if (context.Endpoints.Count == 0 && (context.State == FinishedState || context.ExpectedEndpointsCount == 0))
+                        {
+                            <span>None</span>
+                        }
+                        else
+                        {
+                            @* If we have any, regardless of the state, go ahead and display them *@
+                            foreach (var endpoint in context.Endpoints.OrderBy(e => e))
                             {
-                                <span>None</span>
+                                <a href="@endpoint" target="_blank">@endpoint</a>
                             }
-                            else
+                            @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
+                            if (context.State != FinishedState
+                            && (context.ExpectedEndpointsCount is null || context.ExpectedEndpointsCount > context.Endpoints.Count))
                             {
-                                @* If we have any, regardless of the state, go ahead and display them *@
-                                foreach (var endpoint in context.Endpoints.OrderBy(e => e))
-                                {
-                                    <a href="@endpoint" target="_blank">@endpoint</a>
-                                }
-                                @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
-                                if (context.State != FinishedState
-                                && (context.ExpectedEndpointsCount is null || context.ExpectedEndpointsCount > context.Endpoints.Count))
-                                {
-                                    <span>Starting...</span>
-                                }
+                                <span>Starting...</span>
                             }
-                        </FluentStack>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Environment" Sortable="false">
-                        <FluentButton Appearance="Appearance.Lightweight"
-                                      Disabled="@(!context.Environment.Any())"
-                                      Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
-                                      OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Logs">
-                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/containerLogs/{context.Name}")">View</FluentAnchor>
-                    </TemplateColumn>
-                </ChildContent>
-                <EmptyContent>
-                    <FluentIcon Icon="Icons.Regular.Size24.BinFull" />&nbsp;No running containers found
-                </EmptyContent>
-            </FluentDataGrid>
-        </div>
-    </FluentStack>
+                        }
+                    </FluentStack>
+                </TemplateColumn>
+                <TemplateColumn Title="Environment" Sortable="false">
+                    <FluentButton Appearance="Appearance.Lightweight"
+                                    Disabled="@(!context.Environment.Any())"
+                                    Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
+                                    OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
+                </TemplateColumn>
+                <TemplateColumn Title="Logs">
+                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/containerLogs/{context.Name}")">View</FluentAnchor>
+                </TemplateColumn>
+            </ChildContent>
+            <EmptyContent>
+                <FluentIcon Icon="Icons.Regular.Size24.BinFull" />&nbsp;No running containers found
+            </EmptyContent>
+        </FluentDataGrid>
+    </div>
 </div>
 
 @code {

--- a/src/Aspire.Dashboard/Components/Pages/Executables.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Executables.razor
@@ -6,80 +6,78 @@
 
 <PageTitle>@DashboardViewModelService.ApplicationName Executables</PageTitle>
 
-<div>
-    <FluentStack Orientation="Orientation.Vertical">
-        <FluentToolbar Orientation="Orientation.Horizontal">
-            <h1 slot="label">Executables</h1>
-            <FluentSearch Placeholder="Filter..."
-                          Immediate="true"
-                          @bind-Value="filter"
-                          @oninput="HandleFilter"
-                          AfterBindValue="HandleClear"
-                          slot="end" />
-        </FluentToolbar>
-        <div class="datagrid-overflow-area" tabindex="-1">
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 1fr 4fr 4fr 4fr 2fr 1fr 1fr">
-                <ChildContent>
-                    <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort">
-                        <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
-                    </TemplateColumn>
-                    <PropertyColumn Property="@(e => e.State)" Sortable="true" />
-                    <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" />
-                    <PropertyColumn Property="@(c => c.ProcessId)" Title="Process Id" Sortable="true" />
-                    <TemplateColumn Title="Path" Sortable="true" SortBy="@executablePathSort">
-                        <div class="col-long-content" title="@context.ExecutablePath">
-                            <FluentHighlighter HighlightedText="@filter" Text="@context.ExecutablePath" />
-                        </div>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Working Directory" Sortable="true" SortBy="@workingDirectorySort">
-                        <div class="col-long-content" title="@context.WorkingDirectory">
-                            <FluentHighlighter HighlightedText="@filter" Text="@context.WorkingDirectory" />
-                        </div>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Arguments">
-                        <div class="col-long-content" title="@(context.Arguments != null ? string.Join(" ", context.Arguments) : string.Empty)">
-                            <FluentHighlighter HighlightedText="@filter" Text="@(context.Arguments != null ? string.Join(" ", context.Arguments) : string.Empty)" />
-                        </div>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Endpoints" Sortable="false">
-                        <FluentStack Orientation="Orientation.Vertical">
-                            @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
-                            @if (context.Endpoints.Count == 0 && (context.State == FinishedState || context.ExpectedEndpointsCount == 0))
+<div class="content-layout-with-toolbar">
+    <FluentToolbar Orientation="Orientation.Horizontal">
+        <h1 slot="label">Executables</h1>
+        <FluentSearch Placeholder="Filter..."
+                        Immediate="true"
+                        @bind-Value="filter"
+                        @oninput="HandleFilter"
+                        AfterBindValue="HandleClear"
+                        slot="end" />
+    </FluentToolbar>
+    <div class="datagrid-overflow-area" tabindex="-1">
+        <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 1fr 4fr 4fr 4fr 2fr 1fr 1fr">
+            <ChildContent>
+                <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort">
+                    <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
+                </TemplateColumn>
+                <PropertyColumn Property="@(e => e.State)" Sortable="true" />
+                <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" />
+                <PropertyColumn Property="@(c => c.ProcessId)" Title="Process Id" Sortable="true" />
+                <TemplateColumn Title="Path" Sortable="true" SortBy="@executablePathSort">
+                    <div class="col-long-content" title="@context.ExecutablePath">
+                        <FluentHighlighter HighlightedText="@filter" Text="@context.ExecutablePath" />
+                    </div>
+                </TemplateColumn>
+                <TemplateColumn Title="Working Directory" Sortable="true" SortBy="@workingDirectorySort">
+                    <div class="col-long-content" title="@context.WorkingDirectory">
+                        <FluentHighlighter HighlightedText="@filter" Text="@context.WorkingDirectory" />
+                    </div>
+                </TemplateColumn>
+                <TemplateColumn Title="Arguments">
+                    <div class="col-long-content" title="@(context.Arguments != null ? string.Join(" ", context.Arguments) : string.Empty)">
+                        <FluentHighlighter HighlightedText="@filter" Text="@(context.Arguments != null ? string.Join(" ", context.Arguments) : string.Empty)" />
+                    </div>
+                </TemplateColumn>
+                <TemplateColumn Title="Endpoints" Sortable="false">
+                    <FluentStack Orientation="Orientation.Vertical">
+                        @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
+                        @if (context.Endpoints.Count == 0 && (context.State == FinishedState || context.ExpectedEndpointsCount == 0))
+                        {
+                            <span>None</span>
+                        }
+                        else
+                        {
+                            @* If we have any, regardless of the state, go ahead and display them *@
+                            foreach (var endpoint in context.Endpoints.OrderBy(e => e))
                             {
-                                <span>None</span>
+                                <a href="@endpoint" target="_blank">@endpoint</a>
                             }
-                            else
+                            @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
+                            if (context.State != FinishedState
+                            && (context.ExpectedEndpointsCount is null || context.ExpectedEndpointsCount > context.Endpoints.Count))
                             {
-                                @* If we have any, regardless of the state, go ahead and display them *@
-                                foreach (var endpoint in context.Endpoints.OrderBy(e => e))
-                                {
-                                    <a href="@endpoint" target="_blank">@endpoint</a>
-                                }
-                                @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
-                                if (context.State != FinishedState
-                                && (context.ExpectedEndpointsCount is null || context.ExpectedEndpointsCount > context.Endpoints.Count))
-                                {
-                                    <span>Starting...</span>
-                                }
+                                <span>Starting...</span>
                             }
-                        </FluentStack>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Environment" Sortable="false">
-                        <FluentButton Appearance="Appearance.Lightweight"
-                                      Disabled="@(!context.Environment.Any())"
-                                      Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
-                                      OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Logs">
-                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ExecutableLogs/{context.Name}")">View</FluentAnchor>
-                    </TemplateColumn>
-                </ChildContent>
-                <EmptyContent>
-                    <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;No running executables found
-                </EmptyContent>
-            </FluentDataGrid>
-        </div>
-    </FluentStack>
+                        }
+                    </FluentStack>
+                </TemplateColumn>
+                <TemplateColumn Title="Environment" Sortable="false">
+                    <FluentButton Appearance="Appearance.Lightweight"
+                                    Disabled="@(!context.Environment.Any())"
+                                    Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
+                                    OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
+                </TemplateColumn>
+                <TemplateColumn Title="Logs">
+                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ExecutableLogs/{context.Name}")">View</FluentAnchor>
+                </TemplateColumn>
+            </ChildContent>
+            <EmptyContent>
+                <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;No running executables found
+            </EmptyContent>
+        </FluentDataGrid>
+    </div>
 </div>
 
 @code {

--- a/src/Aspire.Dashboard/Components/Pages/Index.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Index.razor
@@ -6,72 +6,70 @@
 
 <PageTitle>@DashboardViewModelService.ApplicationName Projects</PageTitle>
 
-<div>
-    <FluentStack Orientation="Orientation.Vertical">
-        <FluentToolbar Orientation="Orientation.Horizontal">
-            <h1 slot="label">Projects</h1>
-            <FluentSearch Placeholder="Filter..."
-                          Immediate="true"
-                          @bind-Value="filter"
-                          @oninput="HandleFilter"
-                          AfterBindValue="HandleClear"
-                          slot="end" />
-        </FluentToolbar>
-        <div class="datagrid-overflow-area" tabindex="-1">
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 1fr 4fr 2fr 1fr 1fr">
-                <ChildContent>
-                    <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort">
-                        <div class="col-long-content" title="@context.Name">
-                            <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
-                        </div>
-                    </TemplateColumn>
-                    <PropertyColumn Property="@(e => e.State)" Sortable="true" />
-                    <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" />
-                    <PropertyColumn Property="@(c => c.ProcessId)" Title="Process Id" Sortable="true" />
-                    <TemplateColumn Title="Source Location" Sortable="true" SortBy="@projectPathSort">
-                        <div class="col-long-content" title="@context.ProjectPath">
-                            <FluentHighlighter HighlightedText="@filter" Text="@context.ProjectPath" />
-                        </div>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Endpoints" Sortable="false">
-                        <FluentStack Orientation="Orientation.Vertical">
-                            @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
-                            @if (context.Endpoints.Count == 0 && (context.State == FinishedState || context.ExpectedEndpointsCount == 0))
+<div class="content-layout-with-toolbar">
+    <FluentToolbar Orientation="Orientation.Horizontal">
+        <h1 slot="label">Projects</h1>
+        <FluentSearch Placeholder="Filter..."
+                        Immediate="true"
+                        @bind-Value="filter"
+                        @oninput="HandleFilter"
+                        AfterBindValue="HandleClear"
+                        slot="end" />
+    </FluentToolbar>
+    <div class="datagrid-overflow-area" tabindex="-1">
+        <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 1fr 4fr 2fr 1fr 1fr">
+            <ChildContent>
+                <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort">
+                    <div class="col-long-content" title="@context.Name">
+                        <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
+                    </div>
+                </TemplateColumn>
+                <PropertyColumn Property="@(e => e.State)" Sortable="true" />
+                <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" />
+                <PropertyColumn Property="@(c => c.ProcessId)" Title="Process Id" Sortable="true" />
+                <TemplateColumn Title="Source Location" Sortable="true" SortBy="@projectPathSort">
+                    <div class="col-long-content" title="@context.ProjectPath">
+                        <FluentHighlighter HighlightedText="@filter" Text="@context.ProjectPath" />
+                    </div>
+                </TemplateColumn>
+                <TemplateColumn Title="Endpoints" Sortable="false">
+                    <FluentStack Orientation="Orientation.Vertical">
+                        @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
+                        @if (context.Endpoints.Count == 0 && (context.State == FinishedState || context.ExpectedEndpointsCount == 0))
+                        {
+                            <span>None</span>
+                        }
+                        else
+                        {
+                            @* If we have any, regardless of the state, go ahead and display them *@
+                            foreach (var endpoint in context.Endpoints.OrderBy(e => e))
                             {
-                                <span>None</span>
+                                <a href="@endpoint" target="_blank">@endpoint</a>
                             }
-                            else
+                            @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
+                            if (context.State != FinishedState
+                            && (context.ExpectedEndpointsCount is null || context.ExpectedEndpointsCount > context.Endpoints.Count))
                             {
-                                @* If we have any, regardless of the state, go ahead and display them *@
-                                foreach (var endpoint in context.Endpoints.OrderBy(e => e))
-                                {
-                                    <a href="@endpoint" target="_blank">@endpoint</a>
-                                }
-                                @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
-                                if (context.State != FinishedState
-                                && (context.ExpectedEndpointsCount is null || context.ExpectedEndpointsCount > context.Endpoints.Count))
-                                {
-                                    <span>Starting...</span>
-                                }
+                                <span>Starting...</span>
                             }
-                        </FluentStack>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Environment" Sortable="false">
-                        <FluentButton Appearance="Appearance.Lightweight"
-                                      Disabled="@(!context.Environment.Any())"
-                                      Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
-                                      OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Logs">
-                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ProjectLogs/{context.Name}")">View</FluentAnchor>
-                    </TemplateColumn>
-                </ChildContent>
-                <EmptyContent>
-                    <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;No running projects found
-                </EmptyContent>
-            </FluentDataGrid>
-        </div>
-    </FluentStack>
+                        }
+                    </FluentStack>
+                </TemplateColumn>
+                <TemplateColumn Title="Environment" Sortable="false">
+                    <FluentButton Appearance="Appearance.Lightweight"
+                                    Disabled="@(!context.Environment.Any())"
+                                    Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
+                                    OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
+                </TemplateColumn>
+                <TemplateColumn Title="Logs">
+                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ProjectLogs/{context.Name}")">View</FluentAnchor>
+                </TemplateColumn>
+            </ChildContent>
+            <EmptyContent>
+                <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;No running projects found
+            </EmptyContent>
+        </FluentDataGrid>
+    </div>
 </div>
 
 @code

--- a/src/Aspire.Dashboard/Components/Pages/Index.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Index.razor.css
@@ -5,4 +5,3 @@
 .project-endpoints a {
     margin-right: 0.8em;
 }
-

--- a/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor
@@ -4,20 +4,17 @@
 
 <PageTitle>@DashboardViewModelService.ApplicationName @ResourceType Logs</PageTitle>
 
-<h1>@ResourceType Logs</h1>
-
-<div>
-    <FluentStack Orientation="Orientation.Vertical">
-        <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
-            <FluentSelect @ref="_resourceSelectComponent" TOption="TResource"
-                          Items="@Resources"
-                          OptionValue="@(c => c.Name)"
-                          OptionText="GetDisplayText"
-                          @bind-SelectedOption="_selectedResource"
-                          @bind-SelectedOption:after="HandleSelectedOptionChangedAsync"
-                          AriaLabel="@SelectResourceTitle"/>
-            <FluentLabel Typo="Typography.Body">@_status</FluentLabel>
-            </FluentStack>
-            <LogViewer @ref="_logViewer" />
-        </FluentStack>
-    </div>
+<div class="resource-logs-layout">
+    <h1>@ResourceType Logs</h1>
+    <FluentToolbar Orientation="Orientation.Horizontal">
+        <FluentSelect @ref="_resourceSelectComponent" TOption="TResource"
+                        Items="@Resources"
+                        OptionValue="@(c => c.Name)"
+                        OptionText="GetDisplayText"
+                        @bind-SelectedOption="_selectedResource"
+                        @bind-SelectedOption:after="HandleSelectedOptionChangedAsync"
+                        AriaLabel="@SelectResourceTitle"/>
+        <FluentLabel Typo="Typography.Body">@_status</FluentLabel>
+    </FluentToolbar>
+    <LogViewer @ref="_logViewer" />
+</div>

--- a/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.css
@@ -1,0 +1,22 @@
+::deep.resource-logs-layout {
+    display: grid;
+    grid-template-rows: auto auto 1fr;
+    height: 100%;
+    width: 100%;
+    grid-template-areas:
+        "head"
+        "toolbar"
+        "main";
+}
+
+::deep.resource-logs-layout > h1 {
+    grid-area: head;
+}
+
+::deep.resource-logs-layout > fluent-toolbar {
+    grid-area: toolbar;
+}
+
+::deep.resource-logs-layout > .log-overflow {
+    grid-area: main;
+}

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -1,4 +1,4 @@
-fluent-toolbar fluent-switch,
+ fluent-toolbar fluent-switch,
 fluent-toolbar p {
     margin-inline-end: 15px;
 }
@@ -41,7 +41,7 @@ fluent-toolbar[orientation=horizontal] {
         Height of the browser - static height for other content
         TODO: Is there a better way to do this?
     */
-    height: calc(100vh - 225px);
+    height: 100%;
     width: 100%;
     overflow: auto;
 }
@@ -85,4 +85,23 @@ fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appear
     height: 500px;
     overflow-x: auto;
     overflow-y: auto;
+}
+
+.content-layout-with-toolbar {
+    height: 100%;
+    width: 100%;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+        "toolbar"
+        "main";
+    padding: calc(var(--design-unit) * 2px);
+}
+
+.content-layout-with-toolbar > fluent-toolbar {
+    grid-area: toolbar;
+}
+
+.content-layout-with-toolbar > .datagrid-overflow-area {
+    grid-area: main;
 }


### PR DESCRIPTION
Fixes #449, fixes #397, fixes #346, prep for #454 

We have many content pages in the site where we want a subset of the page to scroll, taking up "the rest" of the content pane beyond some headers/toolbars at the top. We also have upcoming work with a splitter and list/details panes. Both of these scenarios are more easily handled if the overall layout isn't intended to be scrollable beyond the viewport. So we switch to using a CSS grid layout as the root layout. Content pages are then free to choose what layout within the main area they want to use (fully scrollable, scrollable subsection, splitter, etc). The header and nav bar stay in place.

The Projects/Containers/Executables pages are also updated to use a grid layout in anticipation of the details view in #454. The logs pages are also updated to use a grid layout to remove the hackish way we were sizing the height of the log viewer. No changes were made to the Trace/Traces/StructuredLogs page layouts (yet).

This PR also makes the header icon/text a link back to `/`

We also updated the FluentUI Blazor components to 3.2.1, which brings in numerous accessibility fixes, among other things.

No screenshots, because hopefully most of this is transparent to the end user except in edge cases which were bugs anyway.

