### PR TITLE
Limit log and trace telemetry

### DIFF
--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -26,4 +26,8 @@
     <PackageReference Include="Microsoft.Fast.Components.FluentUI.Icons" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Dashboard.Tests"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
@@ -119,25 +119,12 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
     {
         ValidateIndexInRange(index);
 
-        if (IsFull)
+        var internalIndex = InternalIndex(index);
+        _buffer.RemoveAt(internalIndex);
+        if (internalIndex <= _end)
         {
-            var internalIndex = InternalIndex(index);
-            _buffer.RemoveAt(internalIndex);
-            if (internalIndex <= _end)
-            {
-                Decrement(ref _end);
-                _start = _end;
-            }
-        }
-        else
-        {
-            var internalIndex = InternalIndex(index);
-            _buffer.RemoveAt(internalIndex);
-            if (internalIndex <= _end)
-            {
-                Decrement(ref _end);
-                _start = _end;
-            }
+            Decrement(ref _end);
+            _start = _end;
         }
     }
 
@@ -234,12 +221,7 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
 
     private int InternalIndex(int index)
     {
-        var i = _start + index;
-        if (_buffer.Count != 0)
-        {
-            i = i % _buffer.Count;
-        }
-        return i;
+        return (_start + index) % _buffer.Count;
     }
 
     private void Increment(ref int index)

--- a/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
@@ -56,6 +56,7 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
 
     public void Insert(int index, T item)
     {
+        // TODO: There are a lot of branches in this method. Look into simplifying it.
         if (index == Count)
         {
             Add(item);

--- a/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
@@ -1,0 +1,266 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Runtime.InteropServices;
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<T>, IEnumerable
+{
+    // Internal for testing.
+    internal readonly List<T> _buffer;
+    internal int _start;
+    internal int _end;
+
+    public CircularBuffer(int capacity)
+    {
+        if (capacity < 1)
+        {
+            throw new ArgumentException("Circular buffer must have a capacity greater than 0.", nameof(capacity));
+        }
+
+        _buffer = new List<T>();
+        Capacity = capacity;
+        _start = 0;
+        _end = 0;
+    }
+
+    public int Capacity { get; }
+
+    public bool IsFull => Count == Capacity;
+
+    public bool IsEmpty => Count == 0;
+
+    public int Count => _buffer.Count;
+
+    public bool IsReadOnly { get; }
+
+    public bool IsFixedSize { get; } = true;
+
+    public object SyncRoot { get; } = new object();
+
+    public bool IsSynchronized { get; }
+
+    public int IndexOf(T item)
+    {
+        for (var index = 0; index < Count; ++index)
+        {
+            if (Equals(this[index], item))
+            {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    public void Insert(int index, T item)
+    {
+        if (index > Count)
+        {
+            throw new InvalidOperationException($"Cannot access index {index}. Buffer size is {Count}");
+        }
+
+        if (IsFull)
+        {
+            if (index == 0)
+            {
+                // Item inserted at 0 is actually the "last" in the buffer and is removed.
+                return;
+            }
+            var internalIndex = InternalIndex(index);
+
+            var data = CollectionsMarshal.AsSpan(_buffer);
+            // Data is shifted forward so save the last item to copy to the front.
+            var overflowItem = data[data.Length - 1];
+
+            // Shift data after index forward.
+            var changeIndex = _end + index;
+            if (changeIndex != data.Length)
+            {
+                data.Slice(changeIndex, data.Length - changeIndex - 1).CopyTo(data.Slice(changeIndex + 1));
+            }
+
+            // Shift data before index forward and set overflow item to start.
+            data.Slice(0, _end).CopyTo(data.Slice(1));
+            data[0] = overflowItem;
+
+            // Set the actual item.
+            data[internalIndex] = item;
+
+            Increment(ref _end);
+            _start = _end;
+        }
+        else
+        {
+            if (_buffer.Count == 0 && index == 0)
+            {
+                _buffer.Add(item);
+                return;
+            }
+
+            var internalIndex = index + _start;
+            if (internalIndex > _buffer.Count)
+            {
+                internalIndex = internalIndex % _buffer.Count;
+            }
+
+            _buffer.Insert(internalIndex, item);
+            if (internalIndex < _end)
+            {
+                Increment(ref _end);
+                if (_end != _buffer.Count)
+                {
+                    _start = _end;
+                }
+            }
+        }
+    }
+
+    public void RemoveAt(int index)
+    {
+        ValidateIndexInRange(index);
+
+        if (IsFull)
+        {
+            var internalIndex = InternalIndex(index);
+            _buffer.RemoveAt(internalIndex);
+            if (internalIndex <= _end)
+            {
+                Decrement(ref _end);
+                _start = _end;
+            }
+        }
+        else
+        {
+            var internalIndex = InternalIndex(index);
+            _buffer.RemoveAt(internalIndex);
+            if (internalIndex <= _end)
+            {
+                Decrement(ref _end);
+                _start = _end;
+            }
+        }
+    }
+
+    private void ValidateIndexInRange(int index)
+    {
+        if (index >= Count)
+        {
+            throw new InvalidOperationException($"Cannot access index {index}. Buffer size is {Count}");
+        }
+    }
+
+    public bool Remove(T item) => throw new NotImplementedException();
+
+    public T this[int index]
+    {
+        get
+        {
+            ValidateIndexInRange(index);
+            return _buffer[InternalIndex(index)];
+        }
+        set
+        {
+            ValidateIndexInRange(index);
+            _buffer[InternalIndex(index)] = value;
+        }
+    }
+
+    public void Add(T item)
+    {
+        if (IsFull)
+        {
+            _buffer[_end] = item;
+            Increment(ref _end);
+            _start = _end;
+        }
+        else
+        {
+            _buffer.Insert(_end, item);
+            Increment(ref _end);
+            if (_end != _buffer.Count)
+            {
+                _start = _end;
+            }
+        }
+    }
+
+    public void Clear()
+    {
+        _start = 0;
+        _end = 0;
+        _buffer.Clear();
+    }
+
+    public bool Contains(T item) => IndexOf(item) != -1;
+
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        if (array.Length - arrayIndex < Count)
+        {
+            throw new ArgumentException("Array does not contain enough space for items");
+        }
+
+        for (var index = 0; index < Count; ++index)
+        {
+            array[index + arrayIndex] = this[index];
+        }
+    }
+
+    public T[] ToArray()
+    {
+        if (IsEmpty)
+        {
+            return Array.Empty<T>();
+        }
+
+        var array = new T[Count];
+        for (var index = 0; index < Count; ++index)
+        {
+            array[index] = this[index];
+        }
+
+        return array;
+    }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        for (var i = 0; i < Count; ++i)
+        {
+            yield return this[i];
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private int InternalIndex(int index)
+    {
+        var i = _start + index;
+        if (_buffer.Count != 0)
+        {
+            i = i % _buffer.Count;
+        }
+        return i;
+    }
+
+    private void Increment(ref int index)
+    {
+        if (++index < Capacity)
+        {
+            return;
+        }
+
+        index = 0;
+    }
+
+    private void Decrement(ref int index)
+    {
+        if (index <= 0)
+        {
+            index = Capacity - 1;
+        }
+
+        --index;
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
@@ -121,7 +121,7 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
 
         var internalIndex = InternalIndex(index);
         _buffer.RemoveAt(internalIndex);
-        if (internalIndex <= _end)
+        if (internalIndex < _end)
         {
             Decrement(ref _end);
             _start = _end;

--- a/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
@@ -6,6 +6,10 @@ using System.Runtime.InteropServices;
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
+/// <summary>
+/// The circular buffer starts with an empty list and grows to a maximum size.
+/// When the buffer is full, adding or inserting a new item removes the first item in the buffer.
+/// </summary>
 internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<T>, IEnumerable
 {
     // Internal for testing.

--- a/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/CircularBuffer.cs
@@ -56,10 +56,13 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
 
     public void Insert(int index, T item)
     {
-        if (index > Count)
+        if (index == Count)
         {
-            throw new InvalidOperationException($"Cannot access index {index}. Buffer size is {Count}");
+            Add(item);
+            return;
         }
+
+        ValidateIndexInRange(index);
 
         if (IsFull)
         {
@@ -68,6 +71,7 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
                 // Item inserted at 0 is actually the "last" in the buffer and is removed.
                 return;
             }
+
             var internalIndex = InternalIndex(index);
 
             var data = CollectionsMarshal.AsSpan(_buffer);
@@ -93,12 +97,6 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
         }
         else
         {
-            if (_buffer.Count == 0 && index == 0)
-            {
-                _buffer.Add(item);
-                return;
-            }
-
             var internalIndex = index + _start;
             if (internalIndex > _buffer.Count)
             {

--- a/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
+++ b/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
@@ -62,6 +62,27 @@ public class CircularBufferTests
     }
 
     [Fact]
+    public void InsertAtEndUntilFull()
+    {
+        var b = CreateBuffer(5);
+
+        b.Insert(0, "0");
+        b.Insert(1, "1");
+        b.Insert(2, "2");
+        b.Insert(3, "3");
+        b.Insert(4, "4");
+        b.Insert(5, "5");
+        b.Insert(5, "6");
+
+        Assert.Collection(b,
+            i => Assert.Equal("2", i),
+            i => Assert.Equal("3", i),
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("6", i));
+    }
+
+    [Fact]
     public void InsertAtPositionUntilFull()
     {
         var b = CreateBuffer(10);

--- a/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
+++ b/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
@@ -355,6 +355,15 @@ public class CircularBufferTests
             i => Assert.Equal("7", i),
             i => Assert.Equal("7.5", i),
             i => Assert.Equal("11", i));
+
+        b.Insert(5, "12");
+
+        Assert.Collection(b,
+            i => Assert.Equal("6.5", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("7.5", i),
+            i => Assert.Equal("11", i),
+            i => Assert.Equal("12", i));
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
+++ b/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
@@ -243,14 +243,53 @@ public class CircularBufferTests
         b.Add("10");
         b.Add("11");
 
-        b.Insert(1, "7.5");
+        b.Insert(0, "6.5");
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
 
+        b.Insert(1, "7.5");
         Assert.Collection(b,
             i => Assert.Equal("7.5", i),
             i => Assert.Equal("8", i),
             i => Assert.Equal("9", i),
             i => Assert.Equal("10", i),
             i => Assert.Equal("11", i));
+
+        b.Insert(2, "8.5");
+        Assert.Collection(b,
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("8.5", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        b.Insert(3, "9.5");
+        Assert.Collection(b,
+            i => Assert.Equal("8.5", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("9.5", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        b.Insert(4, "10.5");
+        Assert.Collection(b,
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("9.5", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("10.5", i),
+            i => Assert.Equal("11", i));
+
+        b.Insert(5, "11.5");
+        Assert.Collection(b,
+            i => Assert.Equal("9.5", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("10.5", i),
+            i => Assert.Equal("11", i),
+            i => Assert.Equal("11.5", i));
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
+++ b/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
@@ -388,7 +388,7 @@ public class CircularBufferTests
     }
 
     [Fact]
-    public void RemoveAtToZero()
+    public void RemoveAtStartToZero()
     {
         var b = CreateBuffer(5);
 
@@ -406,11 +406,72 @@ public class CircularBufferTests
         b.Add("11");
 
         b.RemoveAt(0);
-        b.RemoveAt(0);
-        b.RemoveAt(0);
-        b.RemoveAt(0);
-        b.RemoveAt(0);
+        Assert.Collection(b,
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
 
+        b.RemoveAt(0);
+        Assert.Collection(b,
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        b.RemoveAt(0);
+        Assert.Collection(b,
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        b.RemoveAt(0);
+        Assert.Collection(b,
+            i => Assert.Equal("11", i));
+
+        b.RemoveAt(0);
+        Assert.Empty(b);
+    }
+
+    [Fact]
+    public void RemoveAtEndToZero()
+    {
+        var b = CreateBuffer(5);
+
+        b.Add("0");
+        b.Add("1");
+        b.Add("2");
+        b.Add("3");
+        b.Add("4");
+        b.Add("5");
+        b.Add("6");
+        b.Add("7");
+        b.Add("8");
+        b.Add("9");
+        b.Add("10");
+        b.Add("11");
+
+        b.RemoveAt(4);
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i));
+
+        b.RemoveAt(3);
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("9", i));
+
+        b.RemoveAt(2);
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("8", i));
+
+        b.RemoveAt(1);
+        Assert.Collection(b,
+            i => Assert.Equal("7", i));
+
+        b.RemoveAt(0);
         Assert.Empty(b);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
+++ b/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
@@ -1,0 +1,386 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Storage;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class CircularBufferTests
+{
+    private static CircularBuffer<string> CreateBuffer(int capacity) => new(capacity);
+
+    [Fact]
+    public void AddUntilFull()
+    {
+        var b = CreateBuffer(5);
+
+        b.Add("0");
+        b.Add("1");
+        b.Add("2");
+        b.Add("3");
+        b.Add("4");
+        b.Add("5");
+        b.Add("6");
+
+        Assert.Collection(b,
+            i => Assert.Equal("2", i),
+            i => Assert.Equal("3", i),
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("6", i));
+
+        Assert.Collection(b._buffer,
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("2", i),
+            i => Assert.Equal("3", i),
+            i => Assert.Equal("4", i));
+        Assert.Equal(2, b._start);
+        Assert.Equal(2, b._end);
+    }
+
+    [Fact]
+    public void InsertAtZeroUntilFull()
+    {
+        var b = CreateBuffer(5);
+
+        b.Insert(0, "0");
+        b.Insert(0, "1");
+        b.Insert(0, "2");
+        b.Insert(0, "3");
+        b.Insert(0, "4");
+        b.Insert(0, "5");
+        b.Insert(0, "6");
+
+        Assert.Collection(b,
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("3", i),
+            i => Assert.Equal("2", i),
+            i => Assert.Equal("1", i),
+            i => Assert.Equal("0", i));
+    }
+
+    [Fact]
+    public void InsertAtPositionUntilFull()
+    {
+        var b = CreateBuffer(10);
+
+        b.Insert(0, "1");
+        b.Insert(1, "2");
+        b.Insert(2, "3");
+        b.Insert(3, "10");
+        b.Insert(3, "9");
+        b.Insert(3, "4");
+        b.Insert(4, "5");
+        b.Insert(5, "7");
+        b.Insert(5, "6");
+        b.Insert(7, "8");
+
+        Assert.Collection(b,
+            i => Assert.Equal("1", i),
+            i => Assert.Equal("2", i),
+            i => Assert.Equal("3", i),
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i));
+    }
+
+    [Fact]
+    public void InsertInMiddleWhileFull()
+    {
+        var b = CreateBuffer(10);
+
+        b.Add("0");
+        b.Add("1");
+        b.Add("2");
+        b.Add("3");
+        b.Add("4");
+        b.Add("5");
+        b.Add("6");
+        b.Add("7");
+        b.Add("8");
+        b.Add("9");
+        b.Add("10");
+        b.Add("11");
+
+        b.Insert(3, "4.5");
+
+        Assert.Collection(b,
+            i => Assert.Equal("3", i),
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("4.5", i),
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        Assert.Collection(b._buffer,
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i),
+            i => Assert.Equal("3", i),
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("4.5", i),
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("8", i));
+        Assert.Equal(3, b._start);
+        Assert.Equal(3, b._end);
+
+        b.Insert(7, "8.5");
+
+        Assert.Collection(b,
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("4.5", i),
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("8.5", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        Assert.Collection(b._buffer,
+            i => Assert.Equal("8.5", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i),
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("4.5", i),
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("8", i));
+        Assert.Equal(4, b._start);
+        Assert.Equal(4, b._end);
+
+        b.Insert(5, "7.5");
+
+        Assert.Collection(b,
+            i => Assert.Equal("4.5", i),
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("7.5", i),
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("8.5", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+    }
+
+    [Fact]
+    public void InsertAfterRemove()
+    {
+        var b = CreateBuffer(5);
+
+        b.Add("0");
+        b.Add("1");
+        b.Add("2");
+        b.Add("3");
+        b.Add("4");
+        b.Add("5");
+        b.Add("6");
+
+        b.RemoveAt(2);
+
+        b.Insert(3, "5.5");
+
+        Assert.Collection(b,
+            i => Assert.Equal("2", i),
+            i => Assert.Equal("3", i),
+            i => Assert.Equal("5", i),
+            i => Assert.Equal("5.5", i),
+            i => Assert.Equal("6", i));
+    }
+
+    [Fact]
+    public void InsertInMiddleLarge()
+    {
+        var b = CreateBuffer(5);
+
+        b.Add("0");
+        b.Add("1");
+        b.Add("2");
+        b.Add("3");
+        b.Add("4");
+        b.Add("5");
+        b.Add("6");
+        b.Add("7");
+        b.Add("8");
+        b.Add("9");
+        b.Add("10");
+        b.Add("11");
+
+        b.Insert(1, "7.5");
+
+        Assert.Collection(b,
+            i => Assert.Equal("7.5", i),
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+    }
+
+    [Fact]
+    public void RemoveAtInMiddleLarge()
+    {
+        var b = CreateBuffer(5);
+
+        b.Add("0");
+        b.Add("1");
+        b.Add("2");
+        b.Add("3");
+        b.Add("4");
+        b.Add("5");
+        b.Add("6");
+        b.Add("7");
+        b.Add("8");
+        b.Add("9");
+        b.Add("10");
+        b.Add("11");
+
+        b.RemoveAt(1);
+
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        b.RemoveAt(1);
+
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        b.RemoveAt(1);
+
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("11", i));
+
+        b.Add("12");
+        b.Add("13");
+        b.Add("14");
+
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("11", i),
+            i => Assert.Equal("12", i),
+            i => Assert.Equal("13", i),
+            i => Assert.Equal("14", i));
+
+        b.Add("15");
+        b.Add("16");
+
+        Assert.Collection(b,
+            i => Assert.Equal("12", i),
+            i => Assert.Equal("13", i),
+            i => Assert.Equal("14", i),
+            i => Assert.Equal("15", i),
+            i => Assert.Equal("16", i));
+    }
+
+    [Fact]
+    public void RemoveAtAndInsertMiddleLarge()
+    {
+        var b = CreateBuffer(5);
+
+        b.Add("0");
+        b.Add("1");
+        b.Add("2");
+        b.Add("3");
+        b.Add("4");
+        b.Add("5");
+        b.Add("6");
+        b.Add("7");
+        b.Add("8");
+        b.Add("9");
+        b.Add("10");
+        b.Add("11");
+
+        b.RemoveAt(1);
+
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("9", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        b.RemoveAt(1);
+
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i));
+
+        b.RemoveAt(1);
+
+        Assert.Collection(b,
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("11", i));
+
+        b.Insert(0, "6");
+
+        Assert.Collection(b,
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("11", i));
+
+        b.Insert(1, "6.5");
+
+        Assert.Collection(b,
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("6.5", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("11", i));
+
+        b.Insert(3, "7.5");
+
+        Assert.Collection(b,
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("6.5", i),
+            i => Assert.Equal("7", i),
+            i => Assert.Equal("7.5", i),
+            i => Assert.Equal("11", i));
+    }
+
+    [Fact]
+    public void RemoveAtToZero()
+    {
+        var b = CreateBuffer(5);
+
+        b.Add("0");
+        b.Add("1");
+        b.Add("2");
+        b.Add("3");
+        b.Add("4");
+        b.Add("5");
+        b.Add("6");
+        b.Add("7");
+        b.Add("8");
+        b.Add("9");
+        b.Add("10");
+        b.Add("11");
+
+        b.RemoveAt(0);
+        b.RemoveAt(0);
+        b.RemoveAt(0);
+        b.RemoveAt(0);
+        b.RemoveAt(0);
+
+        Assert.Empty(b);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -96,6 +96,7 @@ public class TraceTests
                 }
             }
         });
+        Assert.Equal(0, addContext1.FailureCount);
 
         var addContext2 = new AddContext();
         repository.AddTraces(addContext2, new RepeatedField<ResourceSpans>()
@@ -116,6 +117,7 @@ public class TraceTests
                 }
             }
         });
+        Assert.Equal(0, addContext2.FailureCount);
 
         var applications = repository.GetApplications();
         Assert.Collection(applications,
@@ -165,6 +167,7 @@ public class TraceTests
                 }
             }
         });
+        Assert.Equal(0, addContext3.FailureCount);
 
         var traces2 = repository.GetTraces(new GetTracesRequest
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/419

Limit logs and traces to 10,000 items. Not configurable, but would be simple to add in the future.

TODO: Read value from `IConfiguration`.