### PR TITLE
Make sure that projects with no launch profile can still run

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -48,6 +48,16 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model) : I
 {
     private const string DebugSessionPortVar = "DEBUG_SESSION_PORT";
 
+    // These environment variables (coming from/associated with app host launch profile)
+    // never make sense for application service projects.
+    private static readonly string[] s_doNotInheritEnvironmentVars =
+    {
+        "ASPNETCORE_URLS",
+        "DOTNET_LAUNCH_PROFILE",
+        "ASPNETCORE_ENVIRONMENT",
+        "DOTNET_ENVIRONMENT"
+    };
+
     private readonly DistributedApplicationModel _model = model;
     private readonly List<AppResource> _appResources = new();
     private readonly KubernetesService _kubernetesService = new();
@@ -367,6 +377,13 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model) : I
                 if (er.ModelResource is ProjectResource project && project.SelectLaunchProfileName() is { } launchProfileName && project.GetLaunchSettings() is { } launchSettings)
                 {
                     ApplyLaunchProfile(er, config, launchProfileName, launchSettings);
+                } else
+                {
+                    // If there is no launch profile, we want to make sure that certain environment variables are NOT inherited
+                    foreach(var envVar in s_doNotInheritEnvironmentVars)
+                    {
+                        config.Add(envVar, "");
+                    }
                 }
 
                 if (er.ModelResource.TryGetEnvironmentVariables(out var envVarAnnotations))

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -48,8 +48,8 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model) : I
 {
     private const string DebugSessionPortVar = "DEBUG_SESSION_PORT";
 
-    // These environment variables (coming from/associated with app host launch profile)
-    // never make sense for application service projects.
+    // These environment variables should never be inherited from app host;
+    // they only make sense if they come from a launch profile of a service project.
     private static readonly string[] s_doNotInheritEnvironmentVars =
     {
         "ASPNETCORE_URLS",
@@ -377,10 +377,11 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model) : I
                 if (er.ModelResource is ProjectResource project && project.SelectLaunchProfileName() is { } launchProfileName && project.GetLaunchSettings() is { } launchSettings)
                 {
                     ApplyLaunchProfile(er, config, launchProfileName, launchSettings);
-                } else
+                }
+                else
                 {
                     // If there is no launch profile, we want to make sure that certain environment variables are NOT inherited
-                    foreach(var envVar in s_doNotInheritEnvironmentVars)
+                    foreach (var envVar in s_doNotInheritEnvironmentVars)
                     {
                         config.Add(envVar, "");
                     }


### PR DESCRIPTION
This is a fix for [Service application gets dashboard url injected if there's no launch settings](https://github.com/dotnet/aspire/issues/225). I am not super sure if this is the best fix--please chime in if you can think of something else.

I tested this by deleting all launch settings from eShopLite frontend service. Because there is no launch profile, we do not generate a service binding annotation, and as a result, the frontend does not get a clickable "endpoint" in the dashboard. But one can look at the logs and learn the URL for the frontend there. If you navigate to that URL, the application works fine.

Fixes #225