### PR TITLE
Show horiztonal scroll bar if grid resized

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -41,6 +41,7 @@
 
 ::deep.layout > .body-content {
     grid-area: main;
+    overflow-x: auto; /* allow horizontal scrolling */
 }
 
 ::deep .header-right {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -42,7 +42,7 @@ fluent-toolbar[orientation=horizontal] {
         TODO: Is there a better way to do this?
     */
     height: 100%;
-    width: 100%;
+    min-width: 100%;
     overflow: auto;
 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/432

Note that this change is across all grids (projects/containers/exe/structure logs/etc). Resizing trace detail or others allows horizontal scrolling after resizing.

![image](https://github.com/dotnet/aspire/assets/303201/e25bdebf-77cb-4b87-b523-9f31ab14c0b5)
