### PR TITLE
Fix layout regressions in traces/structured logs

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
@@ -1,6 +1,6 @@
 ﻿@namespace Aspire.Dashboard.Components
 
-<div>Total: <strong>@_totalItemCount results found</strong></div>
+<div class="total-items-footer">Total: <strong>@_totalItemCount results found</strong></div>
 
 @code {
     private int _totalItemCount;

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -13,71 +13,69 @@
 
 <PageTitle>@DashboardViewModelService.ApplicationName Structured Logs</PageTitle>
 
-<h1>Structured Logs</h1>
-<div>
-    <FluentStack Orientation="Orientation.Vertical">
-        <FluentToolbar Orientation="Orientation.Horizontal">
-            <FluentSelect TOption="ApplicationViewModel"
-                          Items="@_applications"
-                          OptionValue="@(c => c.Id)"
-                          OptionText="@(c => c.Name)"
-                          @bind-SelectedOption="_selectedApplication"
-                          @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync" />
-            <FluentSearch @bind-Value="_filter"
-                          @oninput="HandleFilter"
-                          AfterBindValue="HandleClear"
-                          Placeholder="Filter..."
-                          slot="end" />
-            @* Temporary workaround for https://github.com/microsoft/fluentui-blazor/issues/811 *@
-            <fluent-divider orientation="vertical" role="separator" aria-orientation="vertical" slot="end"></fluent-divider>
-            <FluentLabel slot="end">Filters: </FluentLabel>
-            @if (ViewModel.Filters.Count == 0)
+<div class="logs-layout">
+    <h1>Structured Logs</h1>
+    <FluentToolbar Orientation="Orientation.Horizontal">
+        <FluentSelect TOption="ApplicationViewModel"
+                      Items="@_applications"
+                      OptionValue="@(c => c.Id)"
+                      OptionText="@(c => c.Name)"
+                      @bind-SelectedOption="_selectedApplication"
+                      @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync" />
+        <FluentSearch @bind-Value="_filter"
+                      @oninput="HandleFilter"
+                      AfterBindValue="HandleClear"
+                      Placeholder="Filter..."
+                      slot="end" />
+        @* Temporary workaround for https://github.com/microsoft/fluentui-blazor/issues/811 *@
+        <fluent-divider orientation="vertical" role="separator" aria-orientation="vertical" slot="end"></fluent-divider>
+        <FluentLabel slot="end">Filters: </FluentLabel>
+        @if (ViewModel.Filters.Count == 0)
+        {
+            <span slot="end">No Filters</span>
+        }
+        else
+        {
+            foreach (var filter in ViewModel.Filters)
             {
-                <span slot="end">No Filters</span>
+                <FluentButton slot="end" Appearance="Appearance.Outline" OnClick="() => OpenFilterAsync(filter)">@filter.FilterText</FluentButton>
             }
-            else
-            {
-                foreach (var filter in ViewModel.Filters)
-                {
-                    <FluentButton slot="end" Appearance="Appearance.Outline" OnClick="() => OpenFilterAsync(filter)">@filter.FilterText</FluentButton>
-                }
-            }
-            <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="Add Filter" OnClick="() => OpenFilterAsync(null)"><FluentIcon Value="@(new Icons.Regular.Size16.Filter())" /></FluentButton>
-        </FluentToolbar>
-        <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
-            <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="48" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
-                <ChildContent>
-                    <TemplateColumn Title="Service">
-                        <div class="col-long-content" title="@context.Application.ApplicationName">
-                            <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(context.Application.ApplicationName));">
-                                @context.Application.ApplicationName
-                            </span>
-                        </div>
-                    </TemplateColumn>
-                    <PropertyColumn Title="Severity" Property="@(context => context.Severity)" />
-                    <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" />
-                    <TemplateColumn Title="Message">
-                        <div class="col-long-content" title="@context.Message">
-                            <FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@context.Message" />
-                        </div>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Trace">
-                        @if (!string.IsNullOrEmpty(context.TraceId))
-                        {
-                            <FluentAnchor Appearance="Appearance.Hypertext" Href="@($"/Trace/{HttpUtility.UrlEncode(context.TraceId)}")">
-                                @OtlpHelpers.ToShortenedId(context.TraceId)
-                            </FluentAnchor>
-                        }
-                    </TemplateColumn>
-                    <TemplateColumn Title="Details">
-                        <FluentButton Appearance="Appearance.Lightweight" OnClick="() => OnShowProperties(context)">View</FluentButton>
-                    </TemplateColumn>
-                </ChildContent>
-                <EmptyContent>
-                    <FluentIcon Icon="Icons.Regular.Size24.SlideTextSparkle" />&nbsp;No structured logs found
-                </EmptyContent>
-            </FluentDataGrid>
-        </div>
-        <TotalItemsFooter @ref="_totalItemsFooter" />
-    </FluentStack>
+        }
+        <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="Add Filter" OnClick="() => OpenFilterAsync(null)"><FluentIcon Value="@(new Icons.Regular.Size16.Filter())" /></FluentButton>
+    </FluentToolbar>
+    <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
+        <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="48" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
+            <ChildContent>
+                <TemplateColumn Title="Service">
+                    <div class="col-long-content" title="@context.Application.ApplicationName">
+                        <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(context.Application.ApplicationName));">
+                            @context.Application.ApplicationName
+                        </span>
+                    </div>
+                </TemplateColumn>
+                <PropertyColumn Title="Severity" Property="@(context => context.Severity)" />
+                <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" />
+                <TemplateColumn Title="Message">
+                    <div class="col-long-content" title="@context.Message">
+                        <FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@context.Message" />
+                    </div>
+                </TemplateColumn>
+                <TemplateColumn Title="Trace">
+                    @if (!string.IsNullOrEmpty(context.TraceId))
+                    {
+                        <FluentAnchor Appearance="Appearance.Hypertext" Href="@($"/Trace/{HttpUtility.UrlEncode(context.TraceId)}")">
+                            @OtlpHelpers.ToShortenedId(context.TraceId)
+                        </FluentAnchor>
+                    }
+                </TemplateColumn>
+                <TemplateColumn Title="Details">
+                    <FluentButton Appearance="Appearance.Lightweight" OnClick="() => OnShowProperties(context)">View</FluentButton>
+                </TemplateColumn>
+            </ChildContent>
+            <EmptyContent>
+                <FluentIcon Icon="Icons.Regular.Size24.SlideTextSparkle" />&nbsp;No structured logs found
+            </EmptyContent>
+        </FluentDataGrid>
+    </div>
+    <TotalItemsFooter @ref="_totalItemsFooter" />
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
@@ -1,0 +1,29 @@
+::deep.logs-layout {
+    display: grid;
+    grid-template-rows: auto auto 1fr auto;
+    height: 100%;
+    width: 100%;
+    grid-template-areas:
+        "head"
+        "toolbar"
+        "main"
+        "foot";
+    gap: calc(var(--design-unit) * 2px);
+    padding-bottom: calc(var(--design-unit) * 2px);
+}
+
+::deep.logs-layout > h1 {
+    grid-area: head;
+}
+
+::deep.logs-layout > fluent-toolbar {
+    grid-area: toolbar;
+}
+
+::deep.logs-layout > .datagrid-overflow-area {
+    grid-area: main;
+}
+
+::deep.logs-layout > .total-items-footer {
+    grid-area: foot;
+}

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -13,36 +13,37 @@
 
 @if (_trace != null)
 {
-    <h1 style="display:inline-block">@(_trace.FirstSpan.Source.ApplicationName): @_trace.FirstSpan.Name</h1>
-    <span class="trace-id">@_trace.TraceId.Substring(0, 7)</span>
+    <div class="trace-detail-layout">
+        <div class="trace-detail-header">
+            <h1 style="display:inline-block">@(_trace.FirstSpan.Source.ApplicationName): @_trace.FirstSpan.Name</h1>
+            <span class="trace-id">@_trace.TraceId.Substring(0, 7)</span>
+        </div>
+        <FluentToolbar Orientation="Orientation.Horizontal">
+            <div>
+                Trace Start <strong>@_trace.FirstSpan.StartTime.ToString("MMMM d yyyy"), @OtlpHelpers.FormatTimeStamp(_trace.FirstSpan.StartTime)</strong>
+            </div>
+            <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+            <div>
+                Duration <strong>@DurationFormatter.FormatDuration(_trace.Duration)</strong>
+            </div>
+            <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+            <div>
+                Services <strong>@_trace.Spans.GroupBy(s => s.Source).Count()</strong>
+            </div>
+            <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+            <div>
+                Depth <strong>@_maxDepth</strong>
+            </div>
+            <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+            <div>
+                Total Spans <strong>@_trace.Spans.Count</strong>
+            </div>
+            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?traceId={_trace.TraceId}")">View Logs</FluentAnchor>
+            <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/Traces")">Back</FluentAnchor>
+        </FluentToolbar>
 
-    <div>
-        <FluentStack Orientation="Orientation.Vertical">
-            <FluentToolbar Orientation="Orientation.Horizontal" Class="trace-view-toolbar">
-                <div>
-                    Trace Start <strong>@_trace.FirstSpan.StartTime.ToString("MMMM d yyyy"), @OtlpHelpers.FormatTimeStamp(_trace.FirstSpan.StartTime)</strong>
-                </div>
-                <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-                <div>
-                    Duration <strong>@DurationFormatter.FormatDuration(_trace.Duration)</strong>
-                </div>
-                <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-                <div>
-                    Services <strong>@_trace.Spans.GroupBy(s => s.Source).Count()</strong>
-                </div>
-                <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-                <div>
-                    Depth <strong>@_maxDepth</strong>
-                </div>
-                <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-                <div>
-                    Total Spans <strong>@_trace.Spans.Count</strong>
-                </div>
-                <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?traceId={_trace.TraceId}")">View Logs</FluentAnchor>
-                <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-                <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/Traces")">Back</FluentAnchor>
-            </FluentToolbar>
-
+        <div class="datagrid-overflow-area">
             <FluentDataGrid Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="2fr 6fr">
                 <TemplateColumn Title="Name">
                     <div class="col-long-content" title="@($"{context.Span.Source.ApplicationName}: {context.GetDisplaySummary()}")">
@@ -100,7 +101,7 @@
                     </ChildContent>
                 </TemplateColumn>
             </FluentDataGrid>
-        </FluentStack>
+        </div>
     </div>
 }
 else

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -133,3 +133,28 @@
     padding-left: 0.5rem;
     font-size: 12px;
 }
+
+::deep.trace-detail-layout {
+    display: grid;
+    grid-template-rows: auto auto 1fr;
+    height: 100%;
+    width: 100%;
+    grid-template-areas:
+        "head"
+        "toolbar"
+        "main";
+    gap: calc(var(--design-unit) * 2px);
+    padding-bottom: calc(var(--design-unit) * 2px);
+}
+
+::deep.trace-detail-layout > .trace-detail-header {
+    grid-area: head;
+}
+
+::deep.trace-detail-layout > fluent-toolbar {
+    grid-area: toolbar;
+}
+
+::deep.trace-detail-layout > .datagrid-overflow-area {
+    grid-area: main;
+}

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -14,67 +14,65 @@
 
 <PageTitle>@DashboardViewModelService.ApplicationName Traces</PageTitle>
 
-<h1>Traces</h1>
 
-<div>
-    <FluentStack Orientation="Orientation.Vertical">
-        <FluentToolbar Orientation="Orientation.Horizontal">
-            <FluentSelect TOption="ApplicationViewModel"
-                          Items="@_applications"
-                          OptionValue="@(c => c.Id)"
-                          OptionText="@(c => c.Name)"
-                          @bind-SelectedOption="_selectedApplication"
-                          @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync"
-                          AriaLabel="Select an Application"/>
-            <FluentSearch @bind-Value="_filter"
-                          @oninput="HandleFilter"
-                          AfterBindValue="HandleClear"
-                          Placeholder="Filter..."
-                          slot="end" />
-        </FluentToolbar>
-        <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
-            <FluentDataGrid Virtualize="true" RowStyle="@GetRowStyle" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="48" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.5fr 0.5fr">
-                <ChildContent>
-                    <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
-                    <TemplateColumn Title="Name">
-                        <div class="col-long-content" title="@($"{context.FullName}: {OtlpHelpers.ToShortenedId(context.TraceId)}")">
-                            <span><FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@(context.FullName)" /></span>
-                            <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
-                        </div>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Spans">
-                        <FluentOverflow>
-                            <ChildContent>
-                                @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Key.ApplicationName))
-                                {
-                                    <FluentOverflowItem>
-                                        <span class="trace-tag trace-service-tag" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(item.Key.ApplicationName));">
-                                            @if (item.Any(s => s.Status == OtlpSpanStatusCode.Error))
-                                            {
-                                                <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
-                                            }
-                                            @item.Key.ApplicationName (@item.Count())
-                                        </span>
-                                    </FluentOverflowItem>
-                                }
-                            </ChildContent>
-                            <MoreButtonTemplate Context="another_name">
-                                <span class="trace-tag">
-                                    @($"+{another_name.ItemsOverflow.Count()}")
-                                </span>
-                            </MoreButtonTemplate>
-                        </FluentOverflow>
-                    </TemplateColumn>
-                    <PropertyColumn Title="Duration" Property="@(context => DurationFormatter.FormatDuration(context.Duration))" />
-                    <TemplateColumn>
-                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/Trace/{context.TraceId}")">View</FluentAnchor>
-                    </TemplateColumn>
-                </ChildContent>
-                <EmptyContent>
-                    <FluentIcon Icon="Icons.Regular.Size24.GanttChart" />&nbsp;No traces found
-                </EmptyContent>
-            </FluentDataGrid>
-        </div>
-        <TotalItemsFooter @ref="_totalItemsFooter" />
-    </FluentStack>
+<div class="traces-layout">
+    <h1>Traces</h1>
+    <FluentToolbar Orientation="Orientation.Horizontal">
+        <FluentSelect TOption="ApplicationViewModel"
+                      Items="@_applications"
+                      OptionValue="@(c => c.Id)"
+                      OptionText="@(c => c.Name)"
+                      @bind-SelectedOption="_selectedApplication"
+                      @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync"
+                      AriaLabel="Select an Application"/>
+        <FluentSearch @bind-Value="_filter"
+                      @oninput="HandleFilter"
+                      AfterBindValue="HandleClear"
+                      Placeholder="Filter..."
+                      slot="end" />
+    </FluentToolbar>
+    <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
+        <FluentDataGrid Virtualize="true" RowStyle="@GetRowStyle" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="48" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.5fr 0.5fr">
+            <ChildContent>
+                <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
+                <TemplateColumn Title="Name">
+                    <div class="col-long-content" title="@($"{context.FullName}: {OtlpHelpers.ToShortenedId(context.TraceId)}")">
+                        <span><FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@(context.FullName)" /></span>
+                        <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
+                    </div>
+                </TemplateColumn>
+                <TemplateColumn Title="Spans">
+                    <FluentOverflow>
+                        <ChildContent>
+                            @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Key.ApplicationName))
+                            {
+                                <FluentOverflowItem>
+                                    <span class="trace-tag trace-service-tag" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(item.Key.ApplicationName));">
+                                        @if (item.Any(s => s.Status == OtlpSpanStatusCode.Error))
+                                        {
+                                            <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
+                                        }
+                                        @item.Key.ApplicationName (@item.Count())
+                                    </span>
+                                </FluentOverflowItem>
+                            }
+                        </ChildContent>
+                        <MoreButtonTemplate Context="another_name">
+                            <span class="trace-tag">
+                                @($"+{another_name.ItemsOverflow.Count()}")
+                            </span>
+                        </MoreButtonTemplate>
+                    </FluentOverflow>
+                </TemplateColumn>
+                <PropertyColumn Title="Duration" Property="@(context => DurationFormatter.FormatDuration(context.Duration))" />
+                <TemplateColumn>
+                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/Trace/{context.TraceId}")">View</FluentAnchor>
+                </TemplateColumn>
+            </ChildContent>
+            <EmptyContent>
+                <FluentIcon Icon="Icons.Regular.Size24.GanttChart" />&nbsp;No traces found
+            </EmptyContent>
+        </FluentDataGrid>
+    </div>
+    <TotalItemsFooter @ref="_totalItemsFooter" />
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -18,3 +18,33 @@
 .trace-service-tag {
     border-left-width: 15px;
 }
+
+::deep.traces-layout {
+    display: grid;
+    grid-template-rows: auto auto 1fr auto;
+    height: 100%;
+    width: 100%;
+    grid-template-areas:
+        "head"
+        "toolbar"
+        "main"
+        "foot";
+    gap: calc(var(--design-unit) * 2px);
+    padding-bottom: calc(var(--design-unit) * 2px);
+}
+
+::deep.traces-layout > h1 {
+    grid-area: head;
+}
+
+::deep.traces-layout > fluent-toolbar {
+    grid-area: toolbar;
+}
+
+::deep.traces-layout > .datagrid-overflow-area {
+    grid-area: main;
+}
+
+::deep.traces-layout > .total-items-footer {
+    grid-area: foot;
+}


### PR DESCRIPTION
#469 was intended to leave the trace and structured logs pages as-is, but failed to do so and left them with unwanted scrolling behavior. This PR goes ahead and updates them to use a layout similar to other pages.