### PR TITLE
Invalidate dashboard cache when calling refresh in browser

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -41,7 +41,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         _dashboard = new DashboardWebApplication(serviceCollection =>
         {
             serviceCollection.AddSingleton(_applicationModel);
-            serviceCollection.AddSingleton<IDashboardViewModelService, DashboardViewModelService>();
+            serviceCollection.AddScoped<IDashboardViewModelService, DashboardViewModelService>();
         });
     }
 


### PR DESCRIPTION
Resolves #480

Turns out our blazor mode initialize service in scope once. Navigating around doesn't change request scope. The new request is only initiated when hitting refresh.