### PR TITLE
Update Aspire Workload SDK Band to 8.0.100

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
-    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rc.1.23422.1</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftDeveloperControlPlanedarwinamd64PackageVersion>0.1.40</MicrosoftDeveloperControlPlanedarwinamd64PackageVersion>
     <MicrosoftDeveloperControlPlanedarwinarm64PackageVersion>0.1.40</MicrosoftDeveloperControlPlanedarwinarm64PackageVersion>
     <MicrosoftDeveloperControlPlanelinuxamd64PackageVersion>0.1.40</MicrosoftDeveloperControlPlanelinuxamd64PackageVersion>

--- a/src/Shared/Workload.targets
+++ b/src/Shared/Workload.targets
@@ -13,7 +13,10 @@
     <DotNetDirectory>$(DotNetOutputPath)dotnet/</DotNetDirectory>
     <DotNetPacksDirectory>$(DotNetDirectory)packs/</DotNetPacksDirectory>
     <VersionBand Condition=" '$(VersionBand)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `^\d+\.\d+\.\d`))00</VersionBand>
-    <DotNetVersionBand Condition=" '$(DotNetPreviewVersionBand)' == '' ">$(VersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `\-(preview|rc|alpha).\d+`))</DotNetVersionBand>
+    <!-- When we are ready to produce Workloads targeting the stable SDK band, set UseStableSdkBand to true. Otherwise, it will match the SDK preview band. -->
+    <UseStableSdkBand>true</UseStableSdkBand>
+    <DotNetVersionBand Condition=" '$(UseStableSdkBand)' != 'true' ">$(VersionBand)$([System.Text.RegularExpressions.Regex]::Match($(MicrosoftDotnetSdkInternalPackageVersion), `\-(preview|rc|alpha|rtm).\d+`))</DotNetVersionBand>
+    <DotNetVersionBand Condition="'$(UseStableSdkBand)' == 'true'">$(VersionBand)</DotNetVersionBand>
     <DotNetSdkManifestsFolder>$(DotNetVersionBand)</DotNetSdkManifestsFolder>
     <DotNetAspireManifestVersionBand>$(DotNetVersionBand)</DotNetAspireManifestVersionBand>
     <_AspireDotNetVersionMajor>8</_AspireDotNetVersionMajor>


### PR DESCRIPTION
This is going to update the Aspire Workload SDK Band to be 8.0.100 instead of 8.0.100-rc.1 as it is currently.

Do note that this change will make it so that updating the workload going forward will require an SDK which has this manifest inserted in it already (The current minimum version noted in this repo only has 8.0.100-rc.1 inserted). After this goes in and we insert this into the SDK, I'll update the instructions in the getting started docs of the repo to point to the new minimum SDK version required for this. There is a workaround in the meantime that can be run once in a machine, and would allow people to continue to update their workload across SDK bands. That workaround will be the one that will need to be used for external folks using the repo (as they won't have access to internal only SDK builds). I will also update the docs once we have a build with these changes to include the workaround instructions.

cc: @dsplaisted @marcpopMSFT @danegsta @DamianEdwards @mhutch 