### PR TITLE
Change span detail dialog header to use custom summary

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -149,7 +149,7 @@ public partial class TraceDetail
 
         var parameters = new DialogParameters
         {
-            Title = viewModel.Span.Name,
+            Title = viewModel.GetDisplaySummary(),
             Width = "auto",
             Height = "auto",
             TrapFocus = true,


### PR DESCRIPTION
![image](https://github.com/dotnet/aspire/assets/303201/ec07dcf9-3fb5-443f-b3a1-66b141234be6)

Span name is still available in the grid.