### PR TITLE
Add initial check for missing Aspire.Hosting package

### DIFF
--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
@@ -21,6 +21,10 @@
 
   <!-- *** END ***  -->
 
+  <Target Name="AspireCapabilityCheck" BeforeTargets="PrepareForBuild">
+    <Error Text="$(MSBuildProjectName) is an Aspire Host project but is missing necessary dependencies. Are you missing a PackageReference to Aspire.Hosting?" Condition="!@(ProjectCapability->AnyHaveMetadataValue('Identity', 'Aspire'))" />
+  </Target>
+
   <!--
   This SDK comes from a workload pack, so normally should only be referenced from
   the WorkloadManifest.targets so as not to cause workload restore to require multiple

--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
@@ -21,8 +21,8 @@
 
   <!-- *** END ***  -->
 
-  <Target Name="AspireCapabilityCheck" BeforeTargets="PrepareForBuild">
-    <Error Text="$(MSBuildProjectName) is an Aspire Host project but is missing necessary dependencies. Are you missing a PackageReference to Aspire.Hosting?" Condition="!@(ProjectCapability->AnyHaveMetadataValue('Identity', 'Aspire'))" />
+  <Target Name="__WarnOnAspireCapabilityMissing" BeforeTargets="PrepareForBuild" Condition="!@(ProjectCapability->AnyHaveMetadataValue('Identity', 'Aspire'))">
+    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire Host project but necessary dependencies aren't present. Are you missing an Aspire.Hosting PackageReference?" />
   </Target>
 
   <!--

--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
@@ -22,7 +22,7 @@
   <!-- *** END ***  -->
 
   <Target Name="__WarnOnAspireCapabilityMissing" BeforeTargets="PrepareForBuild" Condition="!@(ProjectCapability->AnyHaveMetadataValue('Identity', 'Aspire'))">
-    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire Host project but necessary dependencies aren't present. Are you missing an Aspire.Hosting PackageReference?" />
+    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting PackageReference?" />
   </Target>
 
   <!--


### PR DESCRIPTION
This adds a check in the Aspire workload to ensure that the `Aspire.Hosting` package reference is present (by way of the `Aspire` capability which will only be set by `Aspire.Hosting` going forward). The intention is to provide a more helpful error message in the event an AppHost project is missing the package ref than the default `error CS0234: The type or namespace name
'Hosting' does not exist in the namespace 'Aspire' (are you missing an assembly reference?)` message.