### PR TITLE
Disable hot reload and interactive mode with dotnet watch

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -291,18 +291,22 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model) : I
                 exeSpec.ExecutionType = ExecutionType.Process;
                 if (Environment.GetEnvironmentVariable("DOTNET_WATCH") != "1")
                 {
-                    exeSpec.Args = new List<string> {
+                    exeSpec.Args = [
                         "run",
                         "--no-build",
-                        "--project", projectMetadata.ProjectPath,
-                    };
+                        "--project",
+                        projectMetadata.ProjectPath,
+                    ];
                 }
                 else
                 {
-                    exeSpec.Args = new List<string> {
+                    exeSpec.Args = [
                         "watch",
-                        "--project", projectMetadata.ProjectPath
-                    };
+                        "--non-interactive",
+                        "--no-hot-reload",
+                        "--project",
+                        projectMetadata.ProjectPath
+                    ];
                 }
 
                 // We pretty much always want to suppress the normal launch profile handling


### PR DESCRIPTION
- When launching dotnet watch on an aspire project, we invoke watch on each of the projects. There's no way to interactively restart a single project on change so its not possible to force a restart if a hot reload change is ineffective (when changing main).

In the future, we will need to revamp this entire experience so that it works more like the IDE experience (dcp talks to dotnet watch and it launches multiple projects and notifies DCP of those changes).