### PR TITLE
Improvements to span detail dialog

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -8,9 +8,9 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Fast.Components.FluentUI;
 
 namespace Aspire.Dashboard.Components.Dialogs;
+
 public partial class FilterDialog
 {
-
     [CascadingParameter]
     public FluentDialog? Dialog { get; set; }
 
@@ -40,15 +40,7 @@ public partial class FilterDialog
         }
     }
 
-    public List<string> Parameters
-    {
-        get
-        {
-            var result = new List<string> { "Message", "Application", "TraceId", "SpanId", "ParentId", "OriginalFormat" };
-            result.AddRange(Content.LogPropertyKeys);
-            return result;
-        }
-    }
+    public List<string> Parameters => LogFilter.GetAllPropertyNames(Content.LogPropertyKeys);
 
     public Dictionary<FilterCondition, string> Conditions
     {

--- a/src/Aspire.Dashboard/Components/Dialogs/SpanDetailsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SpanDetailsDialog.razor
@@ -3,6 +3,11 @@
 @using Microsoft.Fast.Components.FluentUI;
 @implements IDialogContentComponent<SpanDetailsDialogViewModel>
 
+<FluentDialogHeader>
+    <h3 style="display:inline-block;">@Dialog?.Instance.Parameters.Title</h3>
+    <span class="span-id">@OtlpHelpers.ToShortenedId(Content.Span.SpanId)</span>
+</FluentDialogHeader>
+
 <div>
     <FluentDialogBody>
         <FluentStack Orientation="Orientation.Vertical">

--- a/src/Aspire.Dashboard/Components/Dialogs/SpanDetailsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SpanDetailsDialog.razor.cs
@@ -11,6 +11,9 @@ public partial class SpanDetailsDialog
     [Parameter]
     public SpanDetailsDialogViewModel Content { get; set; } = default!;
 
+    [CascadingParameter]
+    public FluentDialog? Dialog { get; set; }
+
     private IQueryable<SpanPropertyViewModel>? FilteredItems =>
         Content.Properties.Where(vm =>
             vm.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) ||

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -16,7 +16,7 @@
     <div class="trace-detail-layout">
         <div class="trace-detail-header">
             <h1 style="display:inline-block">@(_trace.FirstSpan.Source.ApplicationName): @_trace.FirstSpan.Name</h1>
-            <span class="trace-id">@_trace.TraceId.Substring(0, 7)</span>
+            <span class="trace-id">@OtlpHelpers.ToShortenedId(_trace.TraceId)</span>
         </div>
         <FluentToolbar Orientation="Orientation.Horizontal">
             <div>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -149,7 +149,7 @@ public partial class TraceDetail
 
         var parameters = new DialogParameters
         {
-            Title = viewModel.GetDisplaySummary(),
+            Title = $"{viewModel.Span.Source.ApplicationName}: {viewModel.GetDisplaySummary()}",
             Width = "auto",
             Height = "auto",
             TrapFocus = true,

--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -14,6 +14,13 @@ public class LogFilter
     public string Value { get; set; } = default!;
     public string FilterText => $"{Field} {ConditionToString(Condition)} {Value}";
 
+    public static List<string> GetAllPropertyNames(List<string> propertyKeys)
+    {
+        var result = new List<string> { "Message", "Application", "TraceId", "SpanId", "ParentId", "OriginalFormat" };
+        result.AddRange(propertyKeys);
+        return result;
+    }
+
     public static string ConditionToString(FilterCondition c) =>
         c switch
         {
@@ -75,7 +82,7 @@ public class LogFilter
         return Field switch
         {
             "Message" => x.Message,
-            "Application" => x.Application.UniqueApplicationName,
+            "Application" => x.Application.ApplicationName,
             "TraceId" => x.TraceId,
             "SpanId" => x.SpanId,
             "ParentId" => x.ParentId,

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
@@ -18,7 +18,6 @@ public class OtlpApplication
 
     public string ApplicationName { get; }
     public string InstanceId { get; }
-    public int Suffix { get; }
 
     private readonly ReaderWriterLockSlim _metricsLock = new();
     private readonly Dictionary<string, OtlpMeter> _meters = new();
@@ -60,7 +59,6 @@ public class OtlpApplication
             //
             InstanceId = ApplicationName;
         }
-        Suffix = applications.Where(a => a.Value.ApplicationName == ApplicationName).Count();
         _logger = logger;
     }
 
@@ -77,8 +75,6 @@ public class OtlpApplication
 
         return props;
     }
-
-    public string UniqueApplicationName => $"{ApplicationName}-{Suffix}";
 
     public void AddMetrics(AddContext context, RepeatedField<ScopeMetrics> scopeMetrics)
     {

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -88,7 +88,7 @@ public class OtlpLogEntry
     {
         var props = new Dictionary<string, string>
         {
-            { "Application", Application.UniqueApplicationName },
+            { "Application", Application.ApplicationName },
             { "Severity", Severity.ToString() },
             { "Message", Message },
             { "TraceId", TraceId },

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -80,7 +80,7 @@ public class OtlpSpan
             props.Add("StatusMessage", StatusMessage);
         }
 
-        foreach (var kv in Attributes)
+        foreach (var kv in Attributes.OrderBy(a => a.Key))
         {
             props.TryAdd(kv.Key, kv.Value);
         }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -273,7 +273,7 @@ public class TelemetryRepository
             }
 
             var keys = applicationKeys.Select(keys => keys.PropertyKey).Distinct();
-            return keys.ToList();
+            return keys.OrderBy(k => k).ToList();
         }
         finally
         {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -90,6 +90,10 @@ fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appear
     overflow-y: auto;
 }
 
+.dialog-grid-container h4 {
+    margin: 0.75rem;
+}
+
 .content-layout-with-toolbar {
     height: 100%;
     width: 100%;
@@ -107,4 +111,10 @@ fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appear
 
 .content-layout-with-toolbar > .datagrid-overflow-area {
     grid-area: main;
+}
+
+.span-id {
+    color: rgb(136, 136, 136);
+    padding-left: 0.5rem;
+    font-size: 12px;
 }


### PR DESCRIPTION
The header now matches the trace detail page header (includes app name, has ID):

![image](https://github.com/dotnet/aspire/assets/303201/29d2a6fe-0758-4d0b-998c-bd53bb127897)

There are some other minor improvements to filtering that aren't worth separating into a different PR.