### PR TITLE
Allow creating explicitly named resource groups

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/AzureProvisinerOptions.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/AzureProvisinerOptions.cs
@@ -9,5 +9,7 @@ internal sealed class AzureProvisinerOptions
 
     public string? ResourceGroup { get; set; }
 
+    public bool? CreateResourceGroup { get; set; }
+
     public string? Location { get; set; }
 }

--- a/src/Aspire.Hosting.Azure.Provisioning/AzureProvisinerOptions.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/AzureProvisinerOptions.cs
@@ -9,7 +9,7 @@ internal sealed class AzureProvisinerOptions
 
     public string? ResourceGroup { get; set; }
 
-    public bool? CreateResourceGroup { get; set; }
+    public bool? AllowResourceGroupCreation { get; set; }
 
     public string? Location { get; set; }
 }

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -97,10 +97,10 @@ internal sealed class AzureProvisioner(
         Lazy<Task<(ResourceGroupResource, AzureLocation)>> resourceGroupAndLocationLazy = new(async () =>
         {
             // Name of the resource group to create based on the machine name and application name
-            var (resourceGroupName, createIfNoExists) = _options.ResourceGroup switch
+            var (resourceGroupName, createIfNotExists) = _options.ResourceGroup switch
             {
                 null => ($"{Environment.MachineName.ToLowerInvariant()}-{environment.ApplicationName.ToLowerInvariant()}-rg", true),
-                string rg => (rg, false)
+                string rg => (rg, _options.CreateResourceGroup ?? false)
             };
 
             var subscription = await subscriptionLazy.Value.ConfigureAwait(false);
@@ -118,7 +118,7 @@ internal sealed class AzureProvisioner(
             }
             catch (Exception)
             {
-                if (!createIfNoExists)
+                if (!createIfNotExists)
                 {
                     throw;
                 }

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -97,7 +97,7 @@ internal sealed class AzureProvisioner(
         Lazy<Task<(ResourceGroupResource, AzureLocation)>> resourceGroupAndLocationLazy = new(async () =>
         {
             // Name of the resource group to create based on the machine name and application name
-            var (resourceGroupName, createIfNotExists) = _options.ResourceGroup switch
+            var (resourceGroupName, createIfAbsent) = _options.ResourceGroup switch
             {
                 null => ($"{Environment.MachineName.ToLowerInvariant()}-{environment.ApplicationName.ToLowerInvariant()}-rg", true),
                 string rg => (rg, _options.AllowResourceGroupCreation ?? false)
@@ -118,7 +118,7 @@ internal sealed class AzureProvisioner(
             }
             catch (Exception)
             {
-                if (!createIfNotExists)
+                if (!createIfAbsent)
                 {
                     throw;
                 }

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -100,7 +100,7 @@ internal sealed class AzureProvisioner(
             var (resourceGroupName, createIfNotExists) = _options.ResourceGroup switch
             {
                 null => ($"{Environment.MachineName.ToLowerInvariant()}-{environment.ApplicationName.ToLowerInvariant()}-rg", true),
-                string rg => (rg, _options.CreateResourceGroup ?? false)
+                string rg => (rg, _options.AllowResourceGroupCreation ?? false)
             };
 
             var subscription = await subscriptionLazy.Value.ConfigureAwait(false);


### PR DESCRIPTION
Giving people the ability to create specified resource groups. The biggest problem found thus far (which isn't new) is that changing the resource group will re-create existing resources in the new resource group and will not do clean up in the old resource group. There's no state that keeps track on how resource groups are tied to existing aspire resources, so that's left to the user to clean up.