### PR TITLE
Add background color to structured logs based on severity

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -36,6 +36,7 @@ public partial class SettingsDialog : IDialogContentComponent, IAsyncDisposable
 
             await _jsModule.InvokeVoidAsync("setDefaultBaseLayerLuminance", newLuminanceValue);
             await _jsModule.InvokeVoidAsync("setThemeCookie", newValue);
+            await _jsModule.InvokeVoidAsync("setThemeOnDocument", newValue);
         }
 
         _currentSetting = newValue;

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -27,8 +27,7 @@
                       AfterBindValue="HandleClear"
                       Placeholder="Filter..."
                       slot="end" />
-        @* Temporary workaround for https://github.com/microsoft/fluentui-blazor/issues/811 *@
-        <fluent-divider orientation="vertical" role="separator" aria-orientation="vertical" slot="end"></fluent-divider>
+        <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <FluentLabel slot="end">Filters: </FluentLabel>
         @if (ViewModel.Filters.Count == 0)
         {
@@ -44,7 +43,7 @@
         <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="Add Filter" OnClick="() => OpenFilterAsync(null)"><FluentIcon Value="@(new Icons.Regular.Size16.Filter())" /></FluentButton>
     </FluentToolbar>
     <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
-        <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="48" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
+        <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
             <ChildContent>
                 <TemplateColumn Title="Service">
                     <div class="col-long-content" title="@context.Application.ApplicationName">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -52,7 +52,19 @@
                         </span>
                     </div>
                 </TemplateColumn>
-                <PropertyColumn Title="Severity" Property="@(context => context.Severity)" />
+                <TemplateColumn Title="Severity">
+                    <span>
+                        @if (context.Severity is Microsoft.Extensions.Logging.LogLevel.Error or Microsoft.Extensions.Logging.LogLevel.Critical)
+                        {
+                            <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
+                        }
+                        else if (context.Severity is Microsoft.Extensions.Logging.LogLevel.Warning)
+                        {
+                            <FluentIcon Icon="Icons.Filled.Size16.Warning" Color="Color.Warning" Class="trace-tag-icon" />
+                        }
+                        @context.Severity
+                    </span>
+                </TemplateColumn>
                 <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" />
                 <TemplateColumn Title="Message">
                     <div class="col-long-content" title="@context.Message">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -4,6 +4,7 @@
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Otlp.Storage
+@using Microsoft.Extensions.Logging
 @using Microsoft.Fast.Components.FluentUI
 @using System.Web
 @inject NavigationManager NavigationManager
@@ -53,17 +54,15 @@
                     </div>
                 </TemplateColumn>
                 <TemplateColumn Title="Severity">
-                    <span>
-                        @if (context.Severity is Microsoft.Extensions.Logging.LogLevel.Error or Microsoft.Extensions.Logging.LogLevel.Critical)
-                        {
-                            <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
-                        }
-                        else if (context.Severity is Microsoft.Extensions.Logging.LogLevel.Warning)
-                        {
-                            <FluentIcon Icon="Icons.Filled.Size16.Warning" Color="Color.Warning" Class="trace-tag-icon" />
-                        }
-                        @context.Severity
-                    </span>
+                    @if (context.Severity is LogLevel.Error or LogLevel.Critical)
+                    {
+                        <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="logs-severity-icon" />
+                    }
+                    else if (context.Severity is LogLevel.Warning)
+                    {
+                        <FluentIcon Icon="Icons.Filled.Size16.Warning" Color="Color.Warning" Class="logs-severity-icon" />
+                    }
+                    @context.Severity
                 </TemplateColumn>
                 <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" />
                 <TemplateColumn Title="Message">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -197,6 +197,11 @@ public partial class StructuredLogs
         StateHasChanged();
     }
 
+    private static string GetRowClass(OtlpLogEntry entry)
+    {
+        return $"log-row-{entry.Severity.ToString().ToLowerInvariant()}";
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (_applicationChanged)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
@@ -27,3 +27,15 @@
 ::deep.logs-layout > .total-items-footer {
     grid-area: foot;
 }
+
+::deep .log-row-critical {
+    background-color: var(--log-critical);
+}
+
+::deep .log-row-error {
+    background-color: var(--log-error);
+}
+
+::deep .log-row-warning {
+    background-color: var(--log-warning);
+}

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
@@ -39,3 +39,8 @@
 ::deep .log-row-warning {
     background-color: var(--log-warning);
 }
+
+::deep .logs-severity-icon {
+    vertical-align: text-bottom;
+    margin-right: 3px;
+}

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -32,7 +32,7 @@
                       slot="end" />
     </FluentToolbar>
     <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
-        <FluentDataGrid Virtualize="true" RowStyle="@GetRowStyle" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="48" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.5fr 0.5fr">
+        <FluentDataGrid Virtualize="true" RowStyle="@GetRowStyle" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.5fr 0.5fr">
             <ChildContent>
                 <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
                 <TemplateColumn Title="Name">

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -27,7 +27,15 @@ fluent-toolbar[orientation=horizontal] {
 }
 
 :root {
-    --duration-color: rgb(215, 231, 234);
+    --log-critical: #F8ECEB;
+    --log-error: #F8ECEB;
+    --log-warning: #FBF3DD;
+}
+
+[data-theme="dark"] {
+    --log-critical: #493634;
+    --log-error: #493634;
+    --log-warning: #3F3A2B;
 }
 
 .page-content-area {

--- a/src/Aspire.Dashboard/wwwroot/js/theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/theme.js
@@ -30,12 +30,6 @@ export function getSystemTheme() {
  * @param {string} theme
  */
 export function setThemeCookie(theme) {
-    if (theme === themeSettingDark) {
-        document.documentElement.setAttribute('data-theme', 'dark');
-    } else /* Light */ {
-        document.documentElement.setAttribute('data-theme', 'light');
-    }
-
     document.cookie = `${currentThemeCookieName}=${theme}`;
 }
 

--- a/src/Aspire.Dashboard/wwwroot/js/theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/theme.js
@@ -30,7 +30,25 @@ export function getSystemTheme() {
  * @param {string} theme
  */
 export function setThemeCookie(theme) {
+    if (theme === themeSettingDark) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+    } else /* Light */ {
+        document.documentElement.setAttribute('data-theme', 'light');
+    }
+
     document.cookie = `${currentThemeCookieName}=${theme}`;
+}
+
+/**
+ * Sets the document data-theme attribute to the specified value.
+ * @param {string} theme
+ */
+export function setThemeOnDocument(theme) {
+    if (theme === themeSettingDark) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+    } else /* Light */ {
+        document.documentElement.setAttribute('data-theme', 'light');
+    }
 }
 
 /**
@@ -73,11 +91,11 @@ function setInitialBaseLayerLuminance() {
 
     if (theme === themeSettingDark) {
         baseLayerLuminance.withDefault(darkThemeLuminance);
-        document.documentElement.setAttribute('data-theme', 'dark');
     } else /* Light */ {
         baseLayerLuminance.withDefault(lightThemeLuminance);
-        document.documentElement.setAttribute('data-theme', 'light');
     }
+
+    setThemeOnDocument(theme);
 }
 
 function setInitialAccentColor() {

--- a/src/Aspire.Dashboard/wwwroot/js/theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/theme.js
@@ -73,8 +73,10 @@ function setInitialBaseLayerLuminance() {
 
     if (theme === themeSettingDark) {
         baseLayerLuminance.withDefault(darkThemeLuminance);
+        document.documentElement.setAttribute('data-theme', 'dark');
     } else /* Light */ {
         baseLayerLuminance.withDefault(lightThemeLuminance);
+        document.documentElement.setAttribute('data-theme', 'light');
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/227

Colors are what Chrome/Edge use in the developer console for `console.warn` and `console.error`.

~I don't like how it currently looks.~ Updated screenshots in comments

Light mode:
![image](https://github.com/dotnet/aspire/assets/303201/3d5ed95a-a839-437c-993d-7bdcfe6d577b)

Dark mode:
![image](https://github.com/dotnet/aspire/assets/303201/872c97dd-13bd-468d-a420-780c54ce6d6e)
