### PR TITLE
Center vertical align text with ellipsis

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -11,6 +11,7 @@
 ::deep .cellText {
     text-overflow: ellipsis;
     overflow: hidden;
+    line-height: 30px; /* vertical center align text with button */
 }
 
 ::deep .defaultHidden {

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -11,7 +11,7 @@
 ::deep .cellText {
     text-overflow: ellipsis;
     overflow: hidden;
-    line-height: 30px; /* vertical center align text with button */
+    line-height: 30px; /* vertical center align text */
 }
 
 ::deep .defaultHidden {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -90,7 +90,7 @@
     border-left-width: 5px;
     border-left-style: solid;
     padding-left: 5px;
-    line-height: 16px;
+    line-height: 28px; /* vertical center align text */
 }
 
 ::deep .span-container {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -18,7 +18,9 @@ fluent-toolbar[orientation=horizontal] {
     text-overflow: ellipsis;
     white-space: nowrap;
     height: 100%;
-    display: flex;
+}
+
+fluent-data-grid-row[row-type="default"] {
     align-items: center;
 }
 
@@ -128,6 +130,4 @@ fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appear
 }
 
 .data-grid-cell {
-    display: flex;
-    align-items: center;
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/525

Flexbox and ellipsis overflow don't play well together. There are various ways around the problem, but adding alignment to the row is simple.

In some places, we need to manually size the span with a line height to vertically align text. It's ok because we know the content's height. Duplicating heights doesn't feel that great so a better alternative would be welcome.

`data-grid-cell` doesn't have a purpose anymore. Should it be removed?

I've tested the various pages to confirm that the text is vertically centered and has ellipsis overflow:

![image](https://github.com/dotnet/aspire/assets/303201/970ec60a-fde9-4d20-aeb9-dceb23aad066)

![image](https://github.com/dotnet/aspire/assets/303201/a98a279f-988a-49a1-ae2a-698bc0136c67)

![image](https://github.com/dotnet/aspire/assets/303201/b51e648d-b5ad-4b31-b9e3-c840614b73ca)

![image](https://github.com/dotnet/aspire/assets/303201/4005b84a-1318-46bf-8084-3b16fbcb4bf4)
