### PR TITLE
Fix structured log custom color theme switching

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/js/theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/theme.js
@@ -38,6 +38,11 @@ export function setThemeCookie(theme) {
  * @param {string} theme
  */
 export function setThemeOnDocument(theme) {
+
+    if (!theme || theme === themeSettingSystem) {
+        theme = getSystemTheme();
+    }
+
     if (theme === themeSettingDark) {
         document.documentElement.setAttribute('data-theme', 'dark');
     } else /* Light */ {


### PR DESCRIPTION
The new setThemeOnDocument method didn't handle the scenario when the theme value was set to system (which can't happen on load, because its already translated to light/dark, but can happen on settings change).