### PR TITLE
Provide a target to generate the Aspire manifest

### DIFF
--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -5,12 +5,13 @@
   <PropertyGroup>
     <!-- Similar to ASP.NET Core and Worker apps, set the default CWD of orchestrator projects to be the project directory. -->
     <RunWorkingDirectory Condition=" '$(RunWorkingDirectory)' == '' and '$(EnableDefaultRunWorkingDirectory)' != 'false' ">$(MSBuildProjectDirectory)</RunWorkingDirectory>
+    <_AspireIntermediatePath>$(IntermediateOutputPath)Aspire\</_AspireIntermediatePath>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectCapability Include="Aspire" Condition=" '$(IsAspireHost)' == 'true' " />
   </ItemGroup>
-  
+
   <!-- Generate the data structures for doing the codegen for service references -->
   <Target Name="CreateServiceMetadataSources"
           DependsOnTargets="FindReferenceAssembliesForReferences"
@@ -46,7 +47,7 @@ public class ]]>%(ClassName)<![CDATA[ : IServiceMetadata
     </ItemGroup>
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)Aspire\references\%(ServiceMetadataSource.AssemblyName).ServiceMetadata.g.cs"
+      File="$(_AspireIntermediatePath)references\%(ServiceMetadataSource.AssemblyName).ServiceMetadata.g.cs"
       Overwrite="true"
       Lines="%(ServiceMetadataSource.Source)"
       Encoding="Unicode"
@@ -54,9 +55,9 @@ public class ]]>%(ClassName)<![CDATA[ : IServiceMetadata
       WriteOnlyWhenDifferent="true"
       />
     <ItemGroup>
-      <FileWrites Include="$(IntermediateOutputPath)Aspire\references\%(ServiceMetadataSource.AssemblyName).ServiceMetadata.g.cs" />
+      <FileWrites Include="$(_AspireIntermediatePath)references\%(ServiceMetadataSource.AssemblyName).ServiceMetadata.g.cs" />
       <Compile
-        Include="$(IntermediateOutputPath)Aspire\references\%(ServiceMetadataSource.AssemblyName).ServiceMetadata.g.cs"
+        Include="$(_AspireIntermediatePath)references\%(ServiceMetadataSource.AssemblyName).ServiceMetadata.g.cs"
         Condition="%(ServiceMetadataSource.AssemblyName) != ''"
         />
     </ItemGroup>
@@ -99,5 +100,27 @@ public class ]]>%(ClassName)<![CDATA[ : IServiceMetadata
         <_Parameter2>$(DcpBinPath)</_Parameter2>
       </AssemblyAttribute>
     </ItemGroup>
+  </Target>
+
+  <PropertyGroup>
+    <AspirePublisher Condition="'(AspirePublisher)' == ''">manifest</AspirePublisher>
+    <AspireManifestPublishOutputPath Condition="'$(AspireManifestPublishOutputPath)' == ''">$(_AspireIntermediatePath)manifest.json</AspireManifestPublishOutputPath>
+  </PropertyGroup>
+
+  <!-- Entrypoint to allow for generation of an aspire manifest to a given location -->
+  <Target Name="GenerateAspireManifest" DependsOnTargets="Build" Inputs="$(TargetFileName)" Outputs="$(AspireManifestPublishOutputPath)">
+    <ItemGroup>
+      <_AspireManifestPublishArg Include="%22$(DOTNET_HOST_PATH)%22; %22$(TargetPath)%22;"/>
+      <_AspireManifestPublishArg Include="--publisher; $(AspirePublisher);" />
+      <_AspireManifestPublishArg Include="--output-path; %22$(AspireManifestPublishOutputPath)%22" />
+    </ItemGroup>
+
+    <Exec Command="@(_AspireManifestPublishArg, ' ')"
+      ConsoleToMsBuild="true"
+      IgnoreStandardErrorWarningFormat="true"
+      EchoOff="true"
+      StandardOutputImportance="low"
+      StandardErrorImportance="low"
+      />
   </Target>
 </Project>


### PR DESCRIPTION
This provides a `GenerateAspireManifest` target that azd tooling can call to invoke a given `AspirePublisher` putting the output in a specified `AspireManifestPublishOutputPath`. Tools can cause manifest generation with a command like `dotnet build -t:GenerateAspireManifest -p:AspirePublisher=manifest -p:AspireManifestPublishOutputPath=<some path>`. These properties have sane defaults, and if no explicit path is set can be retrieved with the new `--getProperty` feature of MSBuild like this: `--getProperty=AspireManifestPublishOutputPath`.

I want to talk about the perf here - and this is kind of a philosophical question about the AppHost project.  Right now this target depends on `Build` so that it can actually invoke the AppHost binary. This means that all of the referenced projects for the various services must build. This is non-trivial - on my machine right now the eShop example takes ~8 seconds to do a clean invocation of this new target, and ~4.5 on an incremental build. This is because the current build does _actual builds_ of each of the referenced services. There are a few knobs that a caller can do to make this faster, like passing `--no-restore` to the above build command to skip the restore when you are confident it has already been done - this shaves almost 2 seconds off of my local build. The rest of the time is waiting for the other projects to build.

This can be sidestepped somewhat by doing a design-time build instead, by passing the `-p:BuildingInsideVisualStudio=true` property in the above call. This takes ~2.8s on my machine, _but_ is is not incremental - the `GenerateAspireManifest` target will be run every time. This method can never truly be made incremental because design-time builds are intended to be 'fresh'/up-to-date all of the time, to deliver the most accurate IDE experience.

So the question I have is - would callers prefer to have a potentially-incremental, ~4.5s build for eshop manifest generation, or a non-incremental ~2.5 build for eshop manifest generation? In either case, nothing changes in this PR itself.