### PR TITLE
Text alignment with ellipsis

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -2,6 +2,7 @@
     display: grid;
     grid-template-columns: 1fr auto;
     gap: calc((6 + (var(--design-unit) * var(--density))) * 1px);
+    align-items: center;
 }
 
 .masking-enabled {

--- a/src/Aspire.Dashboard/Components/Pages/Containers.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Containers.razor
@@ -19,47 +19,47 @@
     <div class="datagrid-overflow-area" tabindex="-1">
         <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 3fr 1fr 2fr 1fr 1fr">
             <ChildContent>
-                <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort" Tooltip="true" TooltipText="(c) => c.Name" Class="data-grid-cell">
+                <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort" Tooltip="true" TooltipText="(c) => c.Name">
                     <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
                 </TemplateColumn>
-                <PropertyColumn Property="@(e => e.State)" Sortable="true" Tooltip="true" Class="data-grid-cell" />
-                <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" Tooltip="true" Class="data-grid-cell" />
-                <TemplateColumn Title="Container Image" Sortable="true" SortBy="@imageSort" Tooltip="true" TooltipText="(c) => c.Image" Class="data-grid-cell">
+                <PropertyColumn Property="@(e => e.State)" Sortable="true" Tooltip="true" />
+                <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" Tooltip="true" />
+                <TemplateColumn Title="Container Image" Sortable="true" SortBy="@imageSort" Tooltip="true" TooltipText="(c) => c.Image">
                     <FluentHighlighter HighlightedText="@filter" Text="@context.Image" />
                 </TemplateColumn>
-                <TemplateColumn Title="Ports" Sortable="false" Tooltip="true" TooltipText="@((c) => string.Join(";", c.Ports.Select(e => e.ToString())))" Class="data-grid-cell">
+                <TemplateColumn Title="Ports" Sortable="false" Tooltip="true" TooltipText="@((c) => string.Join(";", c.Ports.Select(e => e.ToString())))">
                     <span>@string.Join(";", context.Ports.Select(e => e.ToString()))</span>
                 </TemplateColumn>
-                <TemplateColumn Title="Endpoints" Sortable="false" Class="data-grid-cell">
+                <TemplateColumn Title="Endpoints" Sortable="false">
                     <FluentStack Orientation="Orientation.Vertical">
                         @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
                         @if (context.Endpoints.Count == 0 && (context.State == FinishedState || context.ExpectedEndpointsCount == 0))
                         {
-                            <span>None</span>
+                            <span class="long-inner-content">None</span>
                         }
                         else
                         {
                             @* If we have any, regardless of the state, go ahead and display them *@
                             foreach (var endpoint in context.Endpoints.OrderBy(e => e))
                             {
-                                <a href="@endpoint" target="_blank">@endpoint</a>
+                                <a href="@endpoint" target="_blank" class="long-inner-content">@endpoint</a>
                             }
                             @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
                             if (context.State != FinishedState
                             && (context.ExpectedEndpointsCount is null || context.ExpectedEndpointsCount > context.Endpoints.Count))
                             {
-                                <span>Starting...</span>
+                                <span class="long-inner-content">Starting...</span>
                             }
                         }
                     </FluentStack>
                 </TemplateColumn>
-                <TemplateColumn Title="Environment" Sortable="false" Class="data-grid-cell">
+                <TemplateColumn Title="Environment" Sortable="false">
                     <FluentButton Appearance="Appearance.Lightweight"
                                     Disabled="@(!context.Environment.Any())"
                                     Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
                                     OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
                 </TemplateColumn>
-                <TemplateColumn Title="Logs" Class="data-grid-cell">
+                <TemplateColumn Title="Logs">
                     <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/containerLogs/{context.Name}")">View</FluentAnchor>
                 </TemplateColumn>
             </ChildContent>

--- a/src/Aspire.Dashboard/Components/Pages/Executables.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Executables.razor
@@ -19,51 +19,51 @@
     <div class="datagrid-overflow-area" tabindex="-1">
         <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 1fr 4fr 4fr 4fr 2fr 1fr 1fr">
             <ChildContent>
-                <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort" Tooltip="true" TooltipText="(e) => e.Name" Class="data-grid-cell">
+                <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort" Tooltip="true" TooltipText="(e) => e.Name">
                     <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
                 </TemplateColumn>
-                <PropertyColumn Property="@(e => e.State)" Sortable="true" Tooltip="true" Class="data-grid-cell" />
-                <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" Tooltip="true" Class="data-grid-cell" />
-                <PropertyColumn Property="@(c => c.ProcessId)" Title="Process Id" Sortable="true" Tooltip="true" Class="data-grid-cell" />
-                <TemplateColumn Title="Path" Sortable="true" SortBy="@executablePathSort" Tooltip="true" TooltipText="(e) => e.ExecutablePath" Class="data-grid-cell">
+                <PropertyColumn Property="@(e => e.State)" Sortable="true" Tooltip="true" />
+                <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" Tooltip="true" />
+                <PropertyColumn Property="@(c => c.ProcessId)" Title="Process Id" Sortable="true" Tooltip="true" />
+                <TemplateColumn Title="Path" Sortable="true" SortBy="@executablePathSort" Tooltip="true" TooltipText="(e) => e.ExecutablePath">
                     <FluentHighlighter HighlightedText="@filter" Text="@context.ExecutablePath" />
                 </TemplateColumn>
-                <TemplateColumn Title="Working Directory" Sortable="true" SortBy="@workingDirectorySort" Tooltip="true" TooltipText="(e) => e.WorkingDirectory" Class="data-grid-cell">
+                <TemplateColumn Title="Working Directory" Sortable="true" SortBy="@workingDirectorySort" Tooltip="true" TooltipText="(e) => e.WorkingDirectory">
                     <FluentHighlighter HighlightedText="@filter" Text="@context.WorkingDirectory" />
                 </TemplateColumn>
-                <TemplateColumn Title="Arguments" Tooltip="true" TooltipText="@((e) => e.Arguments != null ? string.Join(" ", e.Arguments) : string.Empty)" Class="data-grid-cell">
+                <TemplateColumn Title="Arguments" Tooltip="true" TooltipText="@((e) => e.Arguments != null ? string.Join(" ", e.Arguments) : string.Empty)">
                     <FluentHighlighter HighlightedText="@filter" Text="@(context.Arguments != null ? string.Join(" ", context.Arguments) : string.Empty)" />
                 </TemplateColumn>
-                <TemplateColumn Title="Endpoints" Sortable="false" Class="data-grid-cell">
+                <TemplateColumn Title="Endpoints" Sortable="false">
                     <FluentStack Orientation="Orientation.Vertical">
                         @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
                         @if (context.Endpoints.Count == 0 && (context.State == FinishedState || context.ExpectedEndpointsCount == 0))
                         {
-                            <span>None</span>
+                            <span class="long-inner-content">None</span>
                         }
                         else
                         {
                             @* If we have any, regardless of the state, go ahead and display them *@
                             foreach (var endpoint in context.Endpoints.OrderBy(e => e))
                             {
-                                <a href="@endpoint" target="_blank">@endpoint</a>
+                                <a href="@endpoint" target="_blank" class="long-inner-content">@endpoint</a>
                             }
                             @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
                             if (context.State != FinishedState
                             && (context.ExpectedEndpointsCount is null || context.ExpectedEndpointsCount > context.Endpoints.Count))
                             {
-                                <span>Starting...</span>
+                                <span class="long-inner-content">Starting...</span>
                             }
                         }
                     </FluentStack>
                 </TemplateColumn>
-                <TemplateColumn Title="Environment" Sortable="false" Class="data-grid-cell">
+                <TemplateColumn Title="Environment" Sortable="false">
                     <FluentButton Appearance="Appearance.Lightweight"
                                     Disabled="@(!context.Environment.Any())"
                                     Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
                                     OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
                 </TemplateColumn>
-                <TemplateColumn Title="Logs" Class="data-grid-cell">
+                <TemplateColumn Title="Logs">
                     <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ExecutableLogs/{context.Name}")">View</FluentAnchor>
                 </TemplateColumn>
             </ChildContent>

--- a/src/Aspire.Dashboard/Components/Pages/Index.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Index.razor
@@ -19,45 +19,45 @@
     <div class="datagrid-overflow-area" tabindex="-1">
         <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 1fr 4fr 2fr 1fr 1fr" >
             <ChildContent>
-                <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort" Tooltip="true" TooltipText="(p) => p.Name" Class="data-grid-cell">
+                <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort" Tooltip="true" TooltipText="(p) => p.Name">
                     <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
                 </TemplateColumn>
-                <PropertyColumn Property="@(e => e.State)" Sortable="true" Tooltip="true" Class="data-grid-cell" />
-                <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" Tooltip="true" Class="data-grid-cell" />
-                <PropertyColumn Property="@(c => c.ProcessId)" Title="Process Id" Sortable="true" Tooltip="true" Class="data-grid-cell" />
-                <TemplateColumn Title="Source Location" Sortable="true" SortBy="@projectPathSort" Tooltip="true" TooltipText="(p) => p.ProjectPath" Class="data-grid-cell">
+                <PropertyColumn Property="@(e => e.State)" Sortable="true" Tooltip="true" />
+                <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="Start Time" Sortable="true" Tooltip="true" />
+                <PropertyColumn Property="@(c => c.ProcessId)" Title="Process Id" Sortable="true" Tooltip="true" />
+                <TemplateColumn Title="Source Location" Sortable="true" SortBy="@projectPathSort" Tooltip="true" TooltipText="(p) => p.ProjectPath">
                     <FluentHighlighter HighlightedText="@filter" Text="@context.ProjectPath" />
                 </TemplateColumn>
-                <TemplateColumn Title="Endpoints" Sortable="false" Class="data-grid-cell">
+                <TemplateColumn Title="Endpoints" Sortable="false">
                     <FluentStack Orientation="Orientation.Vertical">
                         @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
                         @if (context.Endpoints.Count == 0 && (context.State == FinishedState || context.ExpectedEndpointsCount == 0))
                         {
-                            <span>None</span>
+                            <span class="long-inner-content">None</span>
                         }
                         else
                         {
                             @* If we have any, regardless of the state, go ahead and display them *@
                             foreach (var endpoint in context.Endpoints.OrderBy(e => e))
                             {
-                                <a href="@endpoint" target="_blank">@endpoint</a>
+                                <a href="@endpoint" target="_blank" class="long-inner-content">@endpoint</a>
                             }
                             @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
                             if (context.State != FinishedState
                             && (context.ExpectedEndpointsCount is null || context.ExpectedEndpointsCount > context.Endpoints.Count))
                             {
-                                <span>Starting...</span>
+                                <span class="long-inner-content">Starting...</span>
                             }
                         }
                     </FluentStack>
                 </TemplateColumn>
-                <TemplateColumn Title="Environment" Sortable="false" Class="data-grid-cell">
+                <TemplateColumn Title="Environment" Sortable="false">
                     <FluentButton Appearance="Appearance.Lightweight"
                                     Disabled="@(!context.Environment.Any())"
                                     Title="@(context.Environment.Any() ? "View" : "No Environment Variables")"
                                     OnClick="async() => await ShowEnvironmentVariables(context)">View</FluentButton>
                 </TemplateColumn>
-                <TemplateColumn Title="Logs" Class="data-grid-cell">
+                <TemplateColumn Title="Logs">
                     <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ProjectLogs/{context.Name}")">View</FluentAnchor>
                 </TemplateColumn>
             </ChildContent>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -46,12 +46,10 @@
     <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
         <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
             <ChildContent>
-                <TemplateColumn Title="Service">
-                    <div class="col-long-content" title="@context.Application.ApplicationName">
-                        <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(context.Application.ApplicationName));">
-                            @context.Application.ApplicationName
-                        </span>
-                    </div>
+                <TemplateColumn Title="Service" Tooltip="true" TooltipText="(e) => e.Application.ApplicationName">
+                    <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(context.Application.ApplicationName));">
+                        @context.Application.ApplicationName
+                    </span>
                 </TemplateColumn>
                 <TemplateColumn Title="Severity">
                     @if (context.Severity is LogLevel.Error or LogLevel.Critical)
@@ -64,18 +62,16 @@
                     }
                     @context.Severity
                 </TemplateColumn>
-                <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" />
-                <TemplateColumn Title="Message">
-                    <div class="col-long-content" title="@context.Message">
-                        <FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@context.Message" />
-                    </div>
+                <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" Tooltip="true" />
+                <TemplateColumn Title="Message" Tooltip="true" TooltipText="(e) => e.Message">
+                    <FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@context.Message" />
                 </TemplateColumn>
                 <TemplateColumn Title="Trace">
                     @if (!string.IsNullOrEmpty(context.TraceId))
                     {
-                        <FluentAnchor Appearance="Appearance.Hypertext" Href="@($"/Trace/{HttpUtility.UrlEncode(context.TraceId)}")">
+                        <a href="@($"/Trace/{HttpUtility.UrlEncode(context.TraceId)}")" class="long-inner-content">
                             @OtlpHelpers.ToShortenedId(context.TraceId)
-                        </FluentAnchor>
+                        </a>
                     }
                 </TemplateColumn>
                 <TemplateColumn Title="Details">

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -90,7 +90,7 @@
     border-left-width: 5px;
     border-left-style: solid;
     padding-left: 5px;
-    line-height: 16px;
+    line-height: 28px;
 }
 
 ::deep .span-container {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -35,11 +35,9 @@
         <FluentDataGrid Virtualize="true" RowStyle="@GetRowStyle" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.5fr 0.5fr">
             <ChildContent>
                 <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
-                <TemplateColumn Title="Name">
-                    <div class="col-long-content" title="@($"{context.FullName}: {OtlpHelpers.ToShortenedId(context.TraceId)}")">
-                        <span><FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@(context.FullName)" /></span>
-                        <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
-                    </div>
+                <TemplateColumn Title="Name" Tooltip="true" TooltipText="@((t) => $"{t.FullName}: {OtlpHelpers.ToShortenedId(t.TraceId)}")">
+                    <span><FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@(context.FullName)" /></span>
+                    <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
                 </TemplateColumn>
                 <TemplateColumn Title="Spans">
                     <FluentOverflow>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -18,8 +18,6 @@ fluent-toolbar[orientation=horizontal] {
     text-overflow: ellipsis;
     white-space: nowrap;
     height: 100%;
-    display: flex;
-    align-items: center;
 }
 
 .trace-tag-icon {
@@ -132,7 +130,12 @@ fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appear
     font-size: 12px;
 }
 
-.data-grid-cell {
-    display: flex;
+fluent-data-grid-row {
     align-items: center;
+}
+
+fluent-data-grid-cell .long-inner-content {
+    width: inherit;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }


### PR DESCRIPTION
Fixes #525 

This is an alternative to #528 that doesn't use the line-height for the generic scenario. Still uses line-height for the TraceDetail page, as otherwise the center alignment just wouldn't stick. Removed the `data-grid-cell` css class and its usage too, as proposed in #528 

![image](https://github.com/dotnet/aspire/assets/9613109/609bb6ea-b989-4d35-8947-79706d75ef52)
![image](https://github.com/dotnet/aspire/assets/9613109/3ddb9759-fe92-43e8-ad84-ac1ab08ce647)
![image](https://github.com/dotnet/aspire/assets/9613109/248e1a2e-1526-4942-8820-c91da3eaf104)
![image](https://github.com/dotnet/aspire/assets/9613109/e96781c3-5a8a-4c31-abbd-8b8ae3eccbc1)
