### PR TITLE
Prepare to make Aspire install by default on upgrades for VS web workload

### DIFF
--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -54,9 +54,10 @@
       <!-- Overrides for Visual Studio setup generation. If the workload definition IDs change,
            these must be updated. -->
       <_ComponentResources Include="aspire" Title=".NET Aspire SDK (Preview)"
-                          Description=".NET Aspire SDK (Preview)"/>
+                           Description=".NET Aspire SDK (Preview)"
+                           Advertise="true"/>
       <_ComponentResources Include="aspire-host-runtime" Title=".NET Aspire SDK Hosts"
-                          Description=".NET Aspire SDK Hosts"/>
+                           Description=".NET Aspire SDK Hosts"/>
       <ComponentResources Include="@(_ComponentResources)" Version="$(FileVersion)"/>
     </ItemGroup>
 


### PR DESCRIPTION
Aspire is optional but included by default for the VS Web workload, but on upgrade it needs an additional flag to be installed by default. This takes advantage of newly added Arcade functionality to add the appropriate flag to the VS setup components. This won't do anything until the repo is updated to use the latest version of Arcade.