### PR TITLE
Service Discovery: make host name propagation opt-in

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
@@ -30,13 +30,13 @@ internal sealed partial class DnsServiceEndPointResolver(
         var addresses = await System.Net.Dns.GetHostAddressesAsync(hostName, ShutdownToken).ConfigureAwait(false);
         foreach (var address in addresses)
         {
-            var endPoint = ServiceEndPoint.Create(new IPEndPoint(address, 0));
-            if (options.CurrentValue.AddHostAsMetadata)
+            var serviceEndPoint = ServiceEndPoint.Create(new IPEndPoint(address, 0));
+            if (options.CurrentValue.ApplyHostNameMetadata(serviceEndPoint))
             {
-                endPoint.Features.Set<IHostNameFeature>(this);
+                serviceEndPoint.Features.Set<IHostNameFeature>(this);
             }
 
-            endPoints.Add(endPoint);
+            endPoints.Add(serviceEndPoint);
         }
 
         if (endPoints.Count == 0)

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
@@ -31,7 +31,11 @@ internal sealed partial class DnsServiceEndPointResolver(
         foreach (var address in addresses)
         {
             var endPoint = ServiceEndPoint.Create(new IPEndPoint(address, 0));
-            endPoint.Features.Set<IHostNameFeature>(this);
+            if (options.CurrentValue.AddHostAsMetadata)
+            {
+                endPoint.Features.Set<IHostNameFeature>(this);
+            }
+
             endPoints.Add(endPoint);
         }
 

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverOptions.cs
@@ -27,4 +27,9 @@ public class DnsServiceEndPointResolverOptions
     /// Gets or sets the retry period growth factor.
     /// </summary>
     public double RetryBackOffFactor { get; set; } = 2;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to add the host as metadata to the resolved endpoints. Defaults to <c>false</c>.
+    /// </summary>
+    public bool AddHostAsMetadata { get; set; }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.ServiceDiscovery.Abstractions;
+
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
 /// <summary>
@@ -29,7 +31,7 @@ public class DnsServiceEndPointResolverOptions
     public double RetryBackOffFactor { get; set; } = 2;
 
     /// <summary>
-    /// Gets or sets a value indicating whether to add the host as metadata to the resolved endpoints. Defaults to <c>false</c>.
+    /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint. Defaults to <c>false</c>.
     /// </summary>
-    public bool AddHostAsMetadata { get; set; }
+    public Func<ServiceEndPoint, bool> ApplyHostNameMetadata { get; set; } = _ => false;
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
@@ -85,7 +85,7 @@ internal sealed partial class DnsSrvServiceEndPointResolver(
         ServiceEndPoint CreateEndPoint(EndPoint endPoint)
         {
             var serviceEndPoint = ServiceEndPoint.Create(endPoint);
-            if (options.CurrentValue.AddHostAsMetadata)
+            if (options.CurrentValue.ApplyHostNameMetadata(serviceEndPoint))
             {
                 serviceEndPoint.Features.Set<IHostNameFeature>(this);
             }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
@@ -85,7 +85,11 @@ internal sealed partial class DnsSrvServiceEndPointResolver(
         ServiceEndPoint CreateEndPoint(EndPoint endPoint)
         {
             var serviceEndPoint = ServiceEndPoint.Create(endPoint);
-            serviceEndPoint.Features.Set<IHostNameFeature>(this);
+            if (options.CurrentValue.AddHostAsMetadata)
+            {
+                serviceEndPoint.Features.Set<IHostNameFeature>(this);
+            }
+
             return serviceEndPoint;
         }
     }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverOptions.cs
@@ -35,4 +35,9 @@ public class DnsSrvServiceEndPointResolverOptions
     /// If not specified, the provider will attempt to infer the namespace.
     /// </remarks>
     public string? QuerySuffix { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to add the host as metadata to the resolved endpoints. Defaults to <c>false</c>.
+    /// </summary>
+    public bool AddHostAsMetadata { get; set; }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.ServiceDiscovery.Abstractions;
+
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
 /// <summary>
@@ -37,7 +39,7 @@ public class DnsSrvServiceEndPointResolverOptions
     public string? QuerySuffix { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to add the host as metadata to the resolved endpoints. Defaults to <c>false</c>.
+    /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint. Defaults to <c>false</c>.
     /// </summary>
-    public bool AddHostAsMetadata { get; set; }
+    public Func<ServiceEndPoint, bool> ApplyHostNameMetadata { get; set; } = _ => false;
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.cs
@@ -124,7 +124,11 @@ internal sealed partial class ConfigurationServiceEndPointResolver : IServiceEnd
     private ServiceEndPoint CreateEndPoint(EndPoint endPoint)
     {
         var serviceEndPoint = ServiceEndPoint.Create(endPoint);
-        serviceEndPoint.Features.Set<IHostNameFeature>(this);
+        if (_options.Value.AddHostAsMetadata)
+        {
+            serviceEndPoint.Features.Set<IHostNameFeature>(this);
+        }
+
         return serviceEndPoint;
     }
 

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.cs
@@ -124,7 +124,7 @@ internal sealed partial class ConfigurationServiceEndPointResolver : IServiceEnd
     private ServiceEndPoint CreateEndPoint(EndPoint endPoint)
     {
         var serviceEndPoint = ServiceEndPoint.Create(endPoint);
-        if (_options.Value.AddHostAsMetadata)
+        if (_options.Value.ApplyHostNameMetadata(serviceEndPoint))
         {
             serviceEndPoint.Features.Set<IHostNameFeature>(this);
         }

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverOptions.cs
@@ -12,4 +12,9 @@ public class ConfigurationServiceEndPointResolverOptions
     /// The name of the configuration section which contains service endpoints. Defaults to <c>"Services"</c>.
     /// </summary>
     public string? SectionName { get; set; } = "Services";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to add the host as metadata to the resolved endpoints. Defaults to <c>false</c>.
+    /// </summary>
+    public bool AddHostAsMetadata { get; set; }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverOptions.cs
@@ -14,7 +14,7 @@ public class ConfigurationServiceEndPointResolverOptions
     public string? SectionName { get; set; } = "Services";
 
     /// <summary>
-    /// Gets or sets a value indicating whether to add the host as metadata to the resolved endpoints. Defaults to <c>false</c>.
+    /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint. Defaults to <c>false</c>.
     /// </summary>
-    public bool AddHostAsMetadata { get; set; }
+    public Func<ServiceEndPoint, bool> ApplyHostNameMetadata { get; set; } = _ => false;
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/HostingExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/HostingExtensions.cs
@@ -4,7 +4,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.ServiceDiscovery;
 using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 using Microsoft.Extensions.ServiceDiscovery.Internal;
@@ -60,12 +59,15 @@ public static class HostingExtensions
     /// <param name="configureOptions">The delegate used to configure the provider.</param>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddConfigurationServiceEndPointResolver(this IServiceCollection services, Action<OptionsBuilder<ConfigurationServiceEndPointResolverOptions>>? configureOptions = null)
+    public static IServiceCollection AddConfigurationServiceEndPointResolver(this IServiceCollection services, Action<ConfigurationServiceEndPointResolverOptions>? configureOptions = null)
     {
         services.AddServiceDiscoveryCore();
         services.AddSingleton<IServiceEndPointResolverProvider, ConfigurationServiceEndPointResolverProvider>();
-        var options = services.AddOptions<ConfigurationServiceEndPointResolverOptions>();
-        configureOptions?.Invoke(options);
+        if (configureOptions is not null)
+        {
+            services.Configure(configureOptions);
+        }
+
         return services;
     }
 

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
@@ -120,6 +120,12 @@ public class DnsSrvServiceEndPointResolverTests
             Assert.Equal(new IPEndPoint(IPAddress.Parse("10.10.10.10"), 8888), eps[0].EndPoint);
             Assert.Equal(new IPEndPoint(IPAddress.IPv6Loopback, 9999), eps[1].EndPoint);
             Assert.Equal(new DnsEndPoint("remotehost", 7777), eps[2].EndPoint);
+
+            Assert.All(initialResult.EndPoints, ep =>
+            {
+                var hostNameFeature = ep.Features.Get<IHostNameFeature>();
+                Assert.Null(hostNameFeature);
+            });
         }
     }
 
@@ -170,7 +176,11 @@ public class DnsSrvServiceEndPointResolverTests
         if (dnsFirst)
         {
             serviceCollection
-            .AddDnsSrvServiceEndPointResolver(options => options.QuerySuffix = ".ns")
+            .AddDnsSrvServiceEndPointResolver(options =>
+            {
+                options.QuerySuffix = ".ns";
+                options.AddHostAsMetadata = true;
+            })
             .AddConfigurationServiceEndPointResolver();
         }
         else
@@ -202,6 +212,13 @@ public class DnsSrvServiceEndPointResolverTests
                 Assert.Equal(new IPEndPoint(IPAddress.Parse("10.10.10.10"), 8888), eps[0].EndPoint);
                 Assert.Equal(new IPEndPoint(IPAddress.IPv6Loopback, 9999), eps[1].EndPoint);
                 Assert.Equal(new DnsEndPoint("remotehost", 7777), eps[2].EndPoint);
+
+                Assert.All(initialResult.EndPoints, ep =>
+                {
+                    var hostNameFeature = ep.Features.Get<IHostNameFeature>();
+                    Assert.NotNull(hostNameFeature);
+                    Assert.Equal("basket", hostNameFeature.HostName);
+                });
             }
             else
             {
@@ -209,14 +226,13 @@ public class DnsSrvServiceEndPointResolverTests
                 Assert.Equal(2, initialResult.EndPoints.Count);
                 Assert.Equal(new DnsEndPoint("localhost", 8080), initialResult.EndPoints[0].EndPoint);
                 Assert.Equal(new DnsEndPoint("remotehost", 9090), initialResult.EndPoints[1].EndPoint);
-            }
 
-            Assert.All(initialResult.EndPoints, ep =>
-            {
-                var hostNameFeature = ep.Features.Get<IHostNameFeature>();
-                Assert.NotNull(hostNameFeature);
-                Assert.Equal("basket", hostNameFeature.HostName);
-            });
+                Assert.All(initialResult.EndPoints, ep =>
+                {
+                    var hostNameFeature = ep.Features.Get<IHostNameFeature>();
+                    Assert.Null(hostNameFeature);
+                });
+            }
         }
     }
 

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
@@ -179,7 +179,7 @@ public class DnsSrvServiceEndPointResolverTests
             .AddDnsSrvServiceEndPointResolver(options =>
             {
                 options.QuerySuffix = ".ns";
-                options.AddHostAsMetadata = true;
+                options.ApplyHostNameMetadata = _ => true;
             })
             .AddConfigurationServiceEndPointResolver();
         }

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
@@ -67,7 +67,7 @@ public class ConfigurationServiceEndPointResolverTests
         var services = new ServiceCollection()
             .AddSingleton<IConfiguration>(config.Build())
             .AddServiceDiscoveryCore()
-            .AddConfigurationServiceEndPointResolver(options => options.AddHostAsMetadata = true)
+            .AddConfigurationServiceEndPointResolver(options => options.ApplyHostNameMetadata = _ => true)
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
         ServiceEndPointResolver resolver;

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
@@ -47,8 +47,7 @@ public class ConfigurationServiceEndPointResolverTests
             Assert.All(initialResult.EndPoints, ep =>
             {
                 var hostNameFeature = ep.Features.Get<IHostNameFeature>();
-                Assert.NotNull(hostNameFeature);
-                Assert.Equal("basket", hostNameFeature.HostName);
+                Assert.Null(hostNameFeature);
             });
         }
     }
@@ -68,7 +67,7 @@ public class ConfigurationServiceEndPointResolverTests
         var services = new ServiceCollection()
             .AddSingleton<IConfiguration>(config.Build())
             .AddServiceDiscoveryCore()
-            .AddConfigurationServiceEndPointResolver()
+            .AddConfigurationServiceEndPointResolver(options => options.AddHostAsMetadata = true)
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
         ServiceEndPointResolver resolver;
@@ -133,8 +132,7 @@ public class ConfigurationServiceEndPointResolverTests
             Assert.All(initialResult.EndPoints, ep =>
             {
                 var hostNameFeature = ep.Features.Get<IHostNameFeature>();
-                Assert.NotNull(hostNameFeature);
-                Assert.Equal("basket", hostNameFeature.HostName);
+                Assert.Null(hostNameFeature);
             });
         }
     }


### PR DESCRIPTION
Until we decide on a better approach for when host names should be propagated, we should make this feature opt-in.
In dev scenarios, when using the configuration provider, the host name does not match with the ASP.NET dev cert common name, so it causes HTTPS cert validation errors.