### PR TITLE
Fix Aspire.Npgsql.csproj to be packable

### DIFF
--- a/src/Components/Aspire.Npgsql/Aspire.Npgsql.csproj
+++ b/src/Components/Aspire.Npgsql/Aspire.Npgsql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
-    <IsAotCompatible>true</IsAotCompatible>
+    <IsPackable>true</IsPackable>
     <PackageTags>$(ComponentDatabasePackageTags) postgressql postgres npgsql sql</PackageTags>
     <Description>A PostgreSQL® client that integrates with Aspire, including health checks, metrics, logging, and telemetry.</Description>
     <PackageIconFullPath>$(SharedDir)PostgreSQL_logo.3colors.540x557.png</PackageIconFullPath>


### PR DESCRIPTION
Fixing mistake in https://github.com/dotnet/aspire/commit/b484a8aec9eb163814c4e2130c22e054f7fb7dca#diff-475f0bb5ee20c2e4abb8e419f38c9644934ba615aa073003118f915b7c0e6a9dL5. Should have removed IsAotCompatible and left IsPackable.