### PR TITLE
Support running multiple instances of DAB in the same process

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -5,7 +5,6 @@ using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Model;
 using k8s;
-using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Dcp;
 
@@ -96,18 +95,6 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
         {
             AspireEventSource.Instance.DcpModelCleanupStop();
             _appResources.Clear();
-        }
-    }
-
-    private static async Task LogAllLines(ILogger logger, FileStream fileStream, CancellationToken cancellationToken)
-    {
-        // Log each line separately to avoid losing the line breaks.
-        var streamReader = new StreamReader(fileStream);
-
-        string? line;
-        while ((line = await streamReader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
-        {
-            logger.Log(LogLevel.Information, 0, line, null, (s, e) => s);
         }
     }
 

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -151,7 +151,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         string? dcpExePath = _dcpOptions.CliPath;
         if (!File.Exists(dcpExePath))
         {
-            throw new FileNotFoundException("The Aspire application host is not installed. The application cannot be run without it.", dcpExePath);
+            throw new FileNotFoundException($"The Aspire application host is not installed at \"{dcpExePath}\". The application cannot be run without it.", dcpExePath);
         }
 
         ProcessSpec dcpProcessSpec = new ProcessSpec(dcpExePath)

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -3,6 +3,8 @@
 
 using System.Buffers;
 using System.Collections;
+using System.Diagnostics;
+using System.Globalization;
 using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Text;
@@ -11,7 +13,9 @@ using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp.Process;
+using Aspire.Hosting.Properties;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -27,11 +31,19 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
     private IAsyncDisposable? _dcpRunDisposable;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
-    private readonly DashboardWebApplication _dashboard;
+    private readonly DashboardWebApplication? _dashboard;
     private readonly DcpOptions _dcpOptions;
     private readonly PublishingOptions _publishingOptions;
+    private readonly Locations _locations;
 
-    public DcpHostService(DistributedApplicationModel applicationModel, ILoggerFactory loggerFactory, IOptions<DcpOptions> dcpOptions, IOptions<PublishingOptions> publishingOptions, ApplicationExecutor appExecutor)
+    public DcpHostService(DistributedApplicationModel applicationModel,
+                         DistributedApplicationOptions options,
+                         ILoggerFactory loggerFactory,
+                         IOptions<DcpOptions> dcpOptions,
+                         IOptions<PublishingOptions> publishingOptions,
+                         ApplicationExecutor appExecutor,
+                         Locations locations,
+                         KubernetesService kubernetesService)
     {
         _applicationModel = applicationModel;
         _loggerFactory = loggerFactory;
@@ -39,12 +51,17 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         _dcpOptions = dcpOptions.Value;
         _publishingOptions = publishingOptions.Value;
         _appExecutor = appExecutor;
+        _locations = locations;
 
-        _dashboard = new DashboardWebApplication(serviceCollection =>
+        if (options.DashboardEnabled)
         {
-            serviceCollection.AddSingleton(_applicationModel);
-            serviceCollection.AddScoped<IDashboardViewModelService, DashboardViewModelService>();
-        });
+            _dashboard = new DashboardWebApplication(serviceCollection =>
+            {
+                serviceCollection.AddSingleton(_applicationModel);
+                serviceCollection.AddSingleton(kubernetesService);
+                serviceCollection.AddScoped<IDashboardViewModelService, DashboardViewModelService>();
+            });
+        }
     }
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
@@ -54,9 +71,14 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
             return;
         }
 
+        EnsureDockerIfNecessary();
         EnsureDcpHostRunning();
         await _appExecutor.RunApplicationAsync(cancellationToken).ConfigureAwait(false);
-        await _dashboard.StartAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_dashboard is not null)
+        {
+            await _dashboard.StartAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public async Task StopAsync(CancellationToken cancellationToken = default)
@@ -66,8 +88,13 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
             return;
         }
 
-        await _dashboard.StopAsync(cancellationToken).ConfigureAwait(false);
         await _appExecutor.StopApplicationAsync(cancellationToken).ConfigureAwait(false);
+
+        // Stop the dashboard after the application has stopped
+        if (_dashboard is not null)
+        {
+            await _dashboard.StopAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -88,16 +115,16 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
 
         try
         {
-            var dcpProcessSpec = CreateDcpProcessSpec();
+            var dcpProcessSpec = CreateDcpProcessSpec(_locations);
 
             // Enable Unix Domain Socket based log streaming from DCP
             try
             {
                 AspireEventSource.Instance.DcpLogSocketCreateStart();
-                Socket loggingSocket = CreateLoggingSocket(Locations.DcpLogSocket);
+                Socket loggingSocket = CreateLoggingSocket(_locations.DcpLogSocket);
                 loggingSocket.Listen(LoggingSocketConnectionBacklog);
 
-                dcpProcessSpec.EnvironmentVariables.Add("DCP_LOG_SOCKET", Locations.DcpLogSocket);
+                dcpProcessSpec.EnvironmentVariables.Add("DCP_LOG_SOCKET", _locations.DcpLogSocket);
 
                 _ = Task.Run(() => StartLoggingSocketAsync(loggingSocket), CancellationToken.None);
             }
@@ -119,7 +146,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
 
     }
 
-    private ProcessSpec CreateDcpProcessSpec()
+    private ProcessSpec CreateDcpProcessSpec(Locations locations)
     {
         string? dcpExePath = _dcpOptions.CliPath;
         if (!File.Exists(dcpExePath))
@@ -130,7 +157,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         ProcessSpec dcpProcessSpec = new ProcessSpec(dcpExePath)
         {
             WorkingDirectory = Directory.GetCurrentDirectory(),
-            Arguments = $"start-apiserver --monitor {Environment.ProcessId} --detach --kubeconfig \"{Locations.DcpKubeconfigPath}\"",
+            Arguments = $"start-apiserver --monitor {Environment.ProcessId} --detach --kubeconfig \"{locations.DcpKubeconfigPath}\"",
             OnOutputData = Console.Out.Write,
             OnErrorData = Console.Error.Write,
         };
@@ -159,8 +186,74 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
 
         // Set an environment variable to contain session info that should be deleted when DCP is done
         // Currently this contains the Unix socket for logging and the kubeconfig
-        dcpProcessSpec.EnvironmentVariables.Add("DCP_SESSION_FOLDER", Locations.DcpSessionDir);
+        dcpProcessSpec.EnvironmentVariables.Add("DCP_SESSION_FOLDER", locations.DcpSessionDir);
         return dcpProcessSpec;
+    }
+
+    private const int WaitTimeForDockerTestCommandInSeconds = 10;
+
+    private void EnsureDockerIfNecessary()
+    {
+        // If we don't have any respirces that need a container  then we
+        // don't need to check for Docker.
+        if (!_applicationModel.Resources.Any(c => c.Annotations.OfType<ContainerImageAnnotation>().Any()))
+        {
+            return;
+        }
+
+        AspireEventSource.Instance.DockerHealthCheckStart();
+
+        try
+        {
+            var dockerCommandArgs = "ps --latest --quiet";
+            var dockerStartInfo = new ProcessStartInfo()
+            {
+                FileName = FileUtil.FindFullPathFromPath("docker"),
+                Arguments = dockerCommandArgs,
+                UseShellExecute = true,
+                WindowStyle = ProcessWindowStyle.Hidden
+            };
+            var process = System.Diagnostics.Process.Start(dockerStartInfo);
+            if (process is { } && process.WaitForExit(TimeSpan.FromSeconds(WaitTimeForDockerTestCommandInSeconds)))
+            {
+                if (process.ExitCode != 0)
+                {
+                    Console.Error.WriteLine(string.Format(
+                        CultureInfo.InvariantCulture,
+                        Resources.DockerUnhealthyExceptionMessage,
+                        $"docker {dockerCommandArgs}",
+                        process.ExitCode
+                    ));
+                    Environment.Exit((int)DockerHealthCheckFailures.Unhealthy);
+                }
+            }
+            else
+            {
+                Console.Error.WriteLine(string.Format(
+                    CultureInfo.InvariantCulture,
+                    Resources.DockerUnresponsiveExceptionMessage,
+                    $"docker {dockerCommandArgs}",
+                    WaitTimeForDockerTestCommandInSeconds
+                ));
+                Environment.Exit((int)DockerHealthCheckFailures.Unresponsive);
+            }
+
+            // If we get to here all is good!
+
+        }
+        catch (Exception ex) when (ex is not DistributedApplicationException)
+        {
+            Console.Error.WriteLine(string.Format(
+                    CultureInfo.InvariantCulture,
+                    Resources.DockerPrerequisiteMissingExceptionMessage,
+                    ex.ToString()
+                ));
+            Environment.Exit((int)DockerHealthCheckFailures.PrerequisiteMissing);
+        }
+        finally
+        {
+            AspireEventSource.Instance?.DockerHealthCheckStop();
+        }
     }
 
     private static Socket CreateLoggingSocket(string socketPath)

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -56,7 +56,7 @@ public sealed class DcpOptions
         else
         {
             // Calculate DCP locations from configuration options
-            Assembly? appHostAssembly = Assembly.GetEntryAssembly();
+            var appHostAssembly = Assembly.GetEntryAssembly();
             if (!string.IsNullOrEmpty(appOptions.AssemblyName))
             {
                 try
@@ -75,7 +75,7 @@ public sealed class DcpOptions
             }
 
             
-            IEnumerable<AssemblyMetadataAttribute>? assemblyMetadata = appHostAssembly?.GetCustomAttributes<AssemblyMetadataAttribute>();
+            var assemblyMetadata = appHostAssembly?.GetCustomAttributes<AssemblyMetadataAttribute>();
             CliPath = GetMetadataValue(assemblyMetadata, DcpCliPathMetadataKey);
             ExtensionsPath = GetMetadataValue(assemblyMetadata, DcpExtensionsPathMetadataKey);
             BinPath = GetMetadataValue(assemblyMetadata, DcpBinPathMetadataKey);

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -17,20 +17,13 @@ public enum DcpApiOperationType
     Watch = 4
 }
 
-public class KubernetesService : IDisposable
+internal sealed class KubernetesService(Locations locations) : IDisposable
 {
     private static readonly TimeSpan s_initialRetryDelay = TimeSpan.FromMilliseconds(100);
     private static GroupVersion GroupVersion => Model.Dcp.GroupVersion;
 
     private IKubernetes? _kubernetes;
     private TimeSpan _maxRetryDuration = TimeSpan.FromSeconds(5);
-
-    public KubernetesService(TimeSpan maxRetryDuration)
-    {
-        this.MaxRetryDuration = maxRetryDuration;
-    }
-
-    public KubernetesService() { }
 
     public TimeSpan MaxRetryDuration
     {
@@ -235,7 +228,7 @@ public class KubernetesService : IDisposable
         {
             if (_kubernetes != null) { return; }
 
-            var config = KubernetesClientConfiguration.BuildConfigFromConfigFile(kubeconfigPath: Locations.DcpKubeconfigPath, useRelativePaths: false);
+            var config = KubernetesClientConfiguration.BuildConfigFromConfigFile(kubeconfigPath: locations.DcpKubeconfigPath, useRelativePaths: false);
             _kubernetes = new Kubernetes(config);
         }
     }

--- a/src/Aspire.Hosting/Dcp/Locations.cs
+++ b/src/Aspire.Hosting/Dcp/Locations.cs
@@ -5,19 +5,13 @@ using System.Globalization;
 
 namespace Aspire.Hosting.Dcp;
 
-internal static class Locations
+internal sealed class Locations(string basePath)
 {
-    public static string DcpTempDir
-    {
-        get
-        {
-            return Path.Join(Path.GetTempPath(), "aspire");
-        }
-    }
+    public string DcpTempDir => Path.Join(basePath, "aspire");
 
-    public static string DcpSessionDir => Path.Combine(DcpTempDir, "session", Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+    public string DcpSessionDir => Path.Combine(DcpTempDir, "session", Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
 
-    public static string DcpKubeconfigPath => Path.Combine(DcpSessionDir, "kubeconfig");
+    public string DcpKubeconfigPath => Path.Combine(DcpSessionDir, "kubeconfig");
 
-    public static string DcpLogSocket => Path.Combine(DcpSessionDir, "output.sock");
+    public string DcpLogSocket => Path.Combine(DcpSessionDir, "output.sock");
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -32,11 +32,17 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         // Core things
         _innerBuilder.Services.AddSingleton(sp => new DistributedApplicationModel(Resources));
         _innerBuilder.Services.AddHostedService<DistributedApplicationRunner>();
+        _innerBuilder.Services.AddSingleton(options);
 
         // DCP stuff
         _innerBuilder.Services.AddLifecycleHook<DcpDistributedApplicationLifecycleHook>();
         _innerBuilder.Services.AddSingleton<ApplicationExecutor>();
         _innerBuilder.Services.AddHostedService<DcpHostService>();
+
+        // We need a unique path per application instance
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _innerBuilder.Services.AddSingleton(new Locations(path));
+        _innerBuilder.Services.AddSingleton<KubernetesService>();
 
         // Publishing support
         ConfigurePublishingOptions(options);

--- a/src/Aspire.Hosting/DistributedApplicationOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationOptions.cs
@@ -23,10 +23,5 @@ public sealed class DistributedApplicationOptions
     /// </summary>
     public bool DisableDashboard { get; set; }
 
-    /// <summary>
-    /// Logs each of the service's logs to ILogger on shutdown.
-    /// </summary>
-    public bool WriteLogsToLoggerOnShutdown { get; set; }
-
     internal bool DashboardEnabled => !DisableDashboard;
 }

--- a/src/Aspire.Hosting/DistributedApplicationOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationOptions.cs
@@ -17,4 +17,11 @@ public sealed class DistributedApplicationOptions
     /// The AssemblyName of the AppHost project for loading configuration attributes; if not set defaults to Assembly.GetEntryAssembly().
     /// </summary>
     public string? AssemblyName { get; set; }
+
+    /// <summary>
+    /// Determines whether the dashboard is disabled.
+    /// </summary>
+    public bool DisableDashboard { get; set; }
+
+    internal bool DashboardEnabled => !DisableDashboard;
 }

--- a/src/Aspire.Hosting/DistributedApplicationOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationOptions.cs
@@ -23,5 +23,10 @@ public sealed class DistributedApplicationOptions
     /// </summary>
     public bool DisableDashboard { get; set; }
 
+    /// <summary>
+    /// Logs each of the service's logs to ILogger on shutdown.
+    /// </summary>
+    public bool WriteLogsToLoggerOnShutdown { get; set; }
+
     internal bool DashboardEnabled => !DisableDashboard;
 }

--- a/tests/Aspire.Hosting.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddPostgresTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
-using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -13,7 +12,7 @@ public class AddPostgresTests
     [Fact]
     public void AddPostgresWithDefaultsAddsAnnotationMetadata()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddPostgresContainer("myPostgres");
 
         var app = appBuilder.Build();
@@ -66,7 +65,7 @@ public class AddPostgresTests
     [Fact]
     public void AddPostgresAddsAnnotationMetadata()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddPostgresContainer("myPostgres", 1234, "pass");
 
         var app = appBuilder.Build();
@@ -119,7 +118,7 @@ public class AddPostgresTests
     [Fact]
     public void PostgresCreatesConnectionString()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddPostgresContainer("postgres")
             .WithAnnotation(
             new AllocatedEndpointAnnotation("mybinding",
@@ -142,7 +141,7 @@ public class AddPostgresTests
     [Fact]
     public void PostgresCreatesConnectionStringWithDatabase()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddPostgresContainer("postgres")
             .WithAnnotation(
             new AllocatedEndpointAnnotation("mybinding",
@@ -169,7 +168,7 @@ public class AddPostgresTests
     [Fact]
     public void AddDatabaseToPostgresAddsAnnotationMetadata()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddPostgresContainer("postgres", 1234, "pass").AddDatabase("db");
 
         var app = appBuilder.Build();
@@ -223,7 +222,7 @@ public class AddPostgresTests
     [Fact]
     public void AddPostgresConnectionAddsMetadata()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddPostgresConnection("myPostgres", "endpoint");
 
         var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Tests/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddRedisTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
-using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -13,7 +12,7 @@ public class AddRedisTests
     [Fact]
     public void AddRedisContainerWithDefaultsAddsAnnotationMetadata()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddRedisContainer("myRedis");
 
         var app = appBuilder.Build();
@@ -44,7 +43,7 @@ public class AddRedisTests
     [Fact]
     public void AddRedisContainerAddsAnnotationMetadata()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddRedisContainer("myRedis", 9813);
 
         var app = appBuilder.Build();
@@ -75,7 +74,7 @@ public class AddRedisTests
     [Fact]
     public void RedisCreatesConnectionString()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddRedisContainer("myRedis")
             .WithAnnotation(
             new AllocatedEndpointAnnotation("mybinding",
@@ -97,7 +96,7 @@ public class AddRedisTests
     [Fact]
     public void AddRedisAddsMetadata()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddRedis("myRedis", "endpoint");
 
         var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Tests/AsHttp2ServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/AsHttp2ServiceTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,7 +13,7 @@ public class AsHttp2ServiceTests
     [Fact]
     public void Http2TransportIsNotSetWhenHttp2ServiceAnnotationIsNotApplied()
     {
-        var testProgram = new TestProgram(["--publisher", "manifest"]);
+        var testProgram = CreateTestProgram(["--publisher", "manifest"]);
 
         // Block DCP from actually starting anything up as we don't need it for this test.
         testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>("manifest");
@@ -34,7 +33,7 @@ public class AsHttp2ServiceTests
     [Fact]
     public void Http2TransportIsSetWhenHttp2ServiceAnnotationIsApplied()
     {
-        var testProgram = new TestProgram(["--publisher", "manifest"]);
+        var testProgram = CreateTestProgram(["--publisher", "manifest"]);
         testProgram.ServiceABuilder.AsHttp2Service();
 
         // Block DCP from actually starting anything up as we don't need it for this test.
@@ -51,7 +50,7 @@ public class AsHttp2ServiceTests
     [Fact]
     public void Http2TransportIsNotAppliedToNonHttpServiceBindings()
     {
-        var testProgram = new TestProgram(["--publisher", "manifest"]);
+        var testProgram = CreateTestProgram(["--publisher", "manifest"]);
         testProgram.ServiceABuilder.WithServiceBinding(9999, scheme: "tcp");
         testProgram.ServiceABuilder.AsHttp2Service();
 
@@ -71,4 +70,6 @@ public class AsHttp2ServiceTests
         var httpBinding = serviceBindings.Single(sb => sb.UriScheme == "http");
         Assert.Equal("http2", httpsBinding.Transport);
     }
+
+    private static TestProgram CreateTestProgram(string[] args) => TestProgram.Create<AsHttp2ServiceTests>(args);
 }

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
+    <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.Hosting.Tests/ContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -12,7 +11,7 @@ public class ContainerResourceTests
     [Fact]
     public void AddContainerAddsAnnotationMetadata()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddContainer("container", "none");
 
         var app = appBuilder.Build();
@@ -31,7 +30,7 @@ public class ContainerResourceTests
     [Fact]
     public void AddContainerAddsAnnotationMetadataWithTag()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddContainer("container", "none", "nightly");
 
         var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Tests/Directory.Build.props
+++ b/tests/Aspire.Hosting.Tests/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!-- NOTE: This line is only required because we are using P2P references, not NuGet. It will not exist in real apps. -->
+  <Import Project="..\..\src\Aspire.Hosting\build\Aspire.Hosting.props" />
+
+</Project>

--- a/tests/Aspire.Hosting.Tests/Directory.Build.targets
+++ b/tests/Aspire.Hosting.Tests/Directory.Build.targets
@@ -1,0 +1,8 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!-- NOTE: This line is only required because we are using P2P references, not NuGet. It will not exist in real apps. -->
+  <Import Project="..\..\src\Aspire.Hosting\build\Aspire.Hosting.targets" />
+  
+</Project>

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Publishing;
@@ -18,9 +17,9 @@ public class DistributedApplicationBuilderTests
     {
         var ex = Assert.Throws<DistributedApplicationException>(() =>
         {
-            var testProgram = new TestProgram([]);
-            testProgram.AppBuilder.AddRedisContainer("x");
-            testProgram.AppBuilder.AddPostgresContainer("x");
+            var builder = DistributedApplication.CreateBuilder();
+            builder.AddRedisContainer("x");
+            builder.AddPostgresContainer("x");
         });
 
         Assert.Equal("Cannot add resource of type 'Aspire.Hosting.ApplicationModel.PostgresContainerResource' with name 'x' because resource of type 'Aspire.Hosting.ApplicationModel.RedisContainerResource' with that name already exists.", ex.Message);
@@ -29,7 +28,7 @@ public class DistributedApplicationBuilderTests
     [Fact]
     public void BuilderAddsDefaultServices()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         var app = appBuilder.Build();
 
         Assert.NotNull(app.Services.GetRequiredKeyedService<IDistributedApplicationPublisher>("manifest"));
@@ -51,7 +50,7 @@ public class DistributedApplicationBuilderTests
     [Fact]
     public void BuilderAddsResourceToAddModel()
     {
-        var appBuilder = DistributedApplication.CreateBuilder([]);
+        var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddResource(new TestResource());
         var app = appBuilder.Build();
 

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -5,18 +5,21 @@ using System.Globalization;
 using Aspire.Hosting.Tests.Helpers;
 using Aspire.Hosting.Lifecycle;
 using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests;
 
-public class DistributedApplicationTests
+public class DistributedApplicationTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
     public async void RegisteredLifecycleHookIsExecutedWhenRunAsynchronously()
     {
         var exceptionMessage = "Exception from lifecycle hook to prove it ran!";
 
-        var testProgram = new TestProgram([]);
-        testProgram.AppBuilder.Services.AddLifecycleHook<CallbackLifecycleHook>((sp) =>
+        var testProgram = CreateTestProgram();
+        testProgram.AppBuilder.Services.AddLifecycleHook((sp) =>
         {
             return new CallbackLifecycleHook((appModel, cancellationToken) =>
             {
@@ -43,10 +46,10 @@ public class DistributedApplicationTests
 
         var signal = (FirstHookExecuted: false, SecondHookExecuted: false);
 
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Lifecycle hook 1
-        testProgram.AppBuilder.Services.AddLifecycleHook<CallbackLifecycleHook>((sp) =>
+        testProgram.AppBuilder.Services.AddLifecycleHook((sp) =>
         {
             return new CallbackLifecycleHook((app, cancellationToken) =>
             {
@@ -56,7 +59,7 @@ public class DistributedApplicationTests
         });
 
         // Lifecycle hook 2
-        testProgram.AppBuilder.Services.AddLifecycleHook<CallbackLifecycleHook>((sp) =>
+        testProgram.AppBuilder.Services.AddLifecycleHook((sp) =>
         {
             return new CallbackLifecycleHook((app, cancellationToken) =>
             {
@@ -84,8 +87,8 @@ public class DistributedApplicationTests
     {
         var exceptionMessage = "Exception from lifecycle hook to prove it ran!";
 
-        var testProgram = new TestProgram([]);
-        testProgram.AppBuilder.Services.AddLifecycleHook<CallbackLifecycleHook>((sp) =>
+        var testProgram = CreateTestProgram();
+        testProgram.AppBuilder.Services.AddLifecycleHook((sp) =>
         {
             return new CallbackLifecycleHook((appModel, cancellationToken) =>
             {
@@ -100,45 +103,47 @@ public class DistributedApplicationTests
         Assert.Equal(exceptionMessage, ex.InnerExceptions.First().Message);
     }
 
-    [LocalOnlyFact]
+    [Fact]
     public async void TestProjectStartsAndStopsCleanly()
     {
-        var cts = new CancellationTokenSource();
-        cts.CancelAfter(TimeSpan.FromMinutes(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
 
-        var testProgram = new TestProgram([]);
-        var pendingRun = testProgram.RunAsync(cts.Token);
+        var testProgram = CreateTestProgram();
+        testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
+
+        await using var app = testProgram.Build();
+
+        await app.StartAsync(cts.Token);
 
         // Make sure each service is running
         await testProgram.ServiceABuilder.HttpGetPidAsync("http", cts.Token);
         await testProgram.ServiceBBuilder.HttpGetPidAsync("http", cts.Token);
         await testProgram.ServiceCBuilder.HttpGetPidAsync("http", cts.Token);
-
-        // Shut it all down.
-        cts.Cancel();
-        await pendingRun;
     }
 
-    [LocalOnlyFact]
+    [Fact]
     public async void TestServicesWithMultipleReplicas()
     {
         // Start up the test project.
-        var cts = new CancellationTokenSource();
-        cts.CancelAfter(TimeSpan.FromMinutes(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
 
         var replicaCount = 3;
 
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
+        testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
+
         testProgram.ServiceBBuilder.WithReplicas(replicaCount);
 
-        var pendingRun = testProgram.RunAsync(cts.Token);
+        await using var app = testProgram.Build();
+
+        await app.StartAsync(cts.Token);
 
         // Make sure services A and C are running
         await testProgram.ServiceABuilder.HttpGetPidAsync("http", cts.Token);
         await testProgram.ServiceCBuilder.HttpGetPidAsync("http", cts.Token);
 
         // We should get 3 distinct PIDs from service B
-        Dictionary<int, bool> pids = new();
+        Dictionary<int, bool> pids = [];
         while (true)
         {
             var pid = await testProgram.ServiceBBuilder.HttpGetPidAsync("http", cts.Token);
@@ -152,9 +157,6 @@ public class DistributedApplicationTests
             }
             await Task.Delay(100, cts.Token);
         }
-
-        // Shut it all down.
-        cts.Cancel();
-        await pendingRun;
     }
+    private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<DistributedApplicationTests>(args);
 }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -103,7 +103,7 @@ public class DistributedApplicationTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(exceptionMessage, ex.InnerExceptions.First().Message);
     }
 
-    [Fact]
+    [SkipOnCiOnWindows]
     public async void TestProjectStartsAndStopsCleanly()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
@@ -121,7 +121,7 @@ public class DistributedApplicationTests(ITestOutputHelper testOutputHelper)
         await testProgram.ServiceCBuilder.HttpGetPidAsync("http", cts.Token);
     }
 
-    [Fact]
+    [SkipOnCiOnWindows]
     public async void TestServicesWithMultipleReplicas()
     {
         // Start up the test project.

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -103,7 +103,7 @@ public class DistributedApplicationTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(exceptionMessage, ex.InnerExceptions.First().Message);
     }
 
-    [SkipOnCiOnWindows]
+    [LocalOnlyFact]
     public async void TestProjectStartsAndStopsCleanly()
     {
         var testProgram = CreateTestProgram();
@@ -130,7 +130,7 @@ public class DistributedApplicationTests(ITestOutputHelper testOutputHelper)
         await testProgram.ServiceCBuilder.HttpGetPidAsync(client, "http", cts.Token);
     }
 
-    [SkipOnCiOnWindows]
+    [LocalOnlyFact]
     public async void TestServicesWithMultipleReplicas()
     {
         var replicaCount = 3;

--- a/tests/Aspire.Hosting.Tests/Helpers/AllocatedEndpointAnnotationTestExtensions.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/AllocatedEndpointAnnotationTestExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.ApplicationModel;
-
 namespace Aspire.Hosting.Tests.Helpers;
 public static class AllocatedEndpointAnnotationTestExtensions
 {

--- a/tests/Aspire.Hosting.Tests/Helpers/AllocatedEndpointAnnotationTestExtensions.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/AllocatedEndpointAnnotationTestExtensions.cs
@@ -4,13 +4,8 @@
 namespace Aspire.Hosting.Tests.Helpers;
 public static class AllocatedEndpointAnnotationTestExtensions
 {
-    public static async Task<string> HttpGetPidAsync(this IResourceBuilder<ProjectResource> builder, string bindingName, CancellationToken cancellationToken)
+    public static async Task<string> HttpGetPidAsync(this IResourceBuilder<ProjectResource> builder, HttpClient client, string bindingName, CancellationToken cancellationToken)
     {
-        var client = new HttpClient(new SocketsHttpHandler()
-        {
-            PooledConnectionLifetime = TimeSpan.FromSeconds(5)
-        });
-
         while (true)
         {
             try

--- a/tests/Aspire.Hosting.Tests/Helpers/CallbackLifecycleHook.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/CallbackLifecycleHook.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 
 namespace Aspire.Hosting.Tests.Helpers;

--- a/tests/Aspire.Hosting.Tests/Helpers/LocalOnlyFactAttribute.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/LocalOnlyFactAttribute.cs
@@ -4,6 +4,7 @@
 using Xunit;
 
 namespace Aspire.Hosting.Tests.Helpers;
+
 public class LocalOnlyFactAttribute : FactAttribute
 {
     public override string Skip
@@ -13,6 +14,30 @@ public class LocalOnlyFactAttribute : FactAttribute
             if (Environment.GetEnvironmentVariable("BUILD_BUILDID") != null)
             {
                 return "LocalOnlyFactAttribute tests are not run as part of CI.";
+            }
+
+            return null!;
+        }
+
+        set
+        {
+            // We ignore setting of skip value via attribute usage.
+        }
+    }
+}
+
+public class SkipOnCiOnWindowsAttribute : FactAttribute
+{
+    public override string Skip
+    {
+        get
+        {
+            if (Environment.GetEnvironmentVariable("BUILD_BUILDID") != null)
+            {
+                if (!OperatingSystem.IsWindows())
+                {
+                    return "This test only runs on windows on the CI";
+                }
             }
 
             return null!;

--- a/tests/Aspire.Hosting.Tests/Helpers/LocalOnlyFactAttribute.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/LocalOnlyFactAttribute.cs
@@ -25,27 +25,3 @@ public class LocalOnlyFactAttribute : FactAttribute
         }
     }
 }
-
-public class SkipOnCiOnWindowsAttribute : FactAttribute
-{
-    public override string Skip
-    {
-        get
-        {
-            if (Environment.GetEnvironmentVariable("BUILD_BUILDID") != null)
-            {
-                if (!OperatingSystem.IsWindows())
-                {
-                    return "This test only runs on windows on the CI";
-                }
-            }
-
-            return null!;
-        }
-
-        set
-        {
-            // We ignore setting of skip value via attribute usage.
-        }
-    }
-}

--- a/tests/Aspire.Hosting.Tests/Helpers/NoopPublisher.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/NoopPublisher.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.Hosting;
 

--- a/tests/Aspire.Hosting.Tests/Logging/BeginScopeContext.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/BeginScopeContext.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public class BeginScopeContext
+{
+    public object? Scope { get; set; }
+
+    public string? LoggerName { get; set; }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/ITestSink.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/ITestSink.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public interface ITestSink
+{
+    event Action<WriteContext> MessageLogged;
+
+    event Action<BeginScopeContext> ScopeStarted;
+
+    Func<WriteContext, bool>? WriteEnabled { get; set; }
+
+    Func<BeginScopeContext, bool>? BeginEnabled { get; set; }
+
+    IProducerConsumerCollection<BeginScopeContext> Scopes { get; set; }
+
+    IProducerConsumerCollection<WriteContext> Writes { get; set; }
+
+    void Write(WriteContext context);
+
+    void Begin(BeginScopeContext context);
+}

--- a/tests/Aspire.Hosting.Tests/Logging/LogLevelAttribute.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/LogLevelAttribute.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = false)]
+public class LogLevelAttribute : Attribute
+{
+    public LogLevelAttribute(LogLevel logLevel)
+    {
+        LogLevel = logLevel;
+    }
+
+    public LogLevel LogLevel { get; }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/LogValuesAssert.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/LogValuesAssert.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit.Sdk;
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public static class LogValuesAssert
+{
+    /// <summary>
+    /// Asserts that the given key and value are present in the actual values.
+    /// </summary>
+    /// <param name="key">The key of the item to be found.</param>
+    /// <param name="value">The value of the item to be found.</param>
+    /// <param name="actualValues">The actual values.</param>
+    public static void Contains(
+        string key,
+        object value,
+        IEnumerable<KeyValuePair<string, object>> actualValues)
+    {
+        Contains(new[] { new KeyValuePair<string, object>(key, value) }, actualValues);
+    }
+
+    /// <summary>
+    /// Asserts that all the expected values are present in the actual values by ignoring
+    /// the order of values.
+    /// </summary>
+    /// <param name="expectedValues">Expected subset of values</param>
+    /// <param name="actualValues">Actual set of values</param>
+    public static void Contains(
+        IEnumerable<KeyValuePair<string, object>> expectedValues,
+        IEnumerable<KeyValuePair<string, object>> actualValues)
+    {
+        ArgumentNullException.ThrowIfNull(expectedValues);
+        ArgumentNullException.ThrowIfNull(actualValues);
+
+        var comparer = new LogValueComparer();
+
+        foreach (var expectedPair in expectedValues)
+        {
+            if (!actualValues.Contains(expectedPair, comparer))
+            {
+                throw new EqualException(
+                    expected: GetString(expectedValues),
+                    actual: GetString(actualValues));
+            }
+        }
+    }
+
+    private static string GetString(IEnumerable<KeyValuePair<string, object>> logValues)
+    {
+        return string.Join(",", logValues.Select(kvp => $"[{kvp.Key} {kvp.Value}]"));
+    }
+
+    private sealed class LogValueComparer : IEqualityComparer<KeyValuePair<string, object>>
+    {
+        public bool Equals(KeyValuePair<string, object> x, KeyValuePair<string, object> y)
+        {
+            return string.Equals(x.Key, y.Key) && object.Equals(x.Value, y.Value);
+        }
+
+        public int GetHashCode(KeyValuePair<string, object> obj)
+        {
+            // We are never going to put this KeyValuePair in a hash table,
+            // so this is ok.
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/TestLogger.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/TestLogger.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public class TestLogger : ILogger
+{
+    private object? _scope;
+    private readonly ITestSink _sink;
+    private readonly string _name;
+    private readonly Func<LogLevel, bool> _filter;
+
+    public TestLogger(string name, ITestSink sink, bool enabled)
+        : this(name, sink, _ => enabled)
+    {
+    }
+
+    public TestLogger(string name, ITestSink sink, Func<LogLevel, bool> filter)
+    {
+        _sink = sink;
+        _name = name;
+        _filter = filter;
+    }
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+    {
+        _scope = state;
+
+        _sink.Begin(new BeginScopeContext()
+        {
+            LoggerName = _name,
+            Scope = state,
+        });
+
+        return TestDisposable.Instance;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        _sink.Write(new WriteContext()
+        {
+            LogLevel = logLevel,
+            EventId = eventId,
+            State = state,
+            Exception = exception,
+            Formatter = (s, e) => formatter((TState)s!, e),
+            LoggerName = _name,
+            Scope = _scope
+        });
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return logLevel != LogLevel.None && _filter(logLevel);
+    }
+
+    private sealed class TestDisposable : IDisposable
+    {
+        public static readonly TestDisposable Instance = new TestDisposable();
+
+        public void Dispose()
+        {
+            // intentionally does nothing
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/TestLoggerFactory.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/TestLoggerFactory.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public class TestLoggerFactory : ILoggerFactory
+{
+    private readonly ITestSink _sink;
+    private readonly bool _enabled;
+
+    public TestLoggerFactory(ITestSink sink, bool enabled)
+    {
+        _sink = sink;
+        _enabled = enabled;
+    }
+
+    public ILogger CreateLogger(string name)
+    {
+        return new TestLogger(name, _sink, _enabled);
+    }
+
+    public void AddProvider(ILoggerProvider provider)
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/TestLoggerProvider.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/TestLoggerProvider.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public class TestLoggerProvider : ILoggerProvider
+{
+    private readonly ITestSink _sink;
+
+    public TestLoggerProvider(ITestSink sink)
+    {
+        _sink = sink;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new TestLogger(categoryName, _sink, enabled: true);
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/TestLoggerT.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/TestLoggerT.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public class TestLogger<T> : ILogger<T>
+{
+    private readonly ILogger<T> _logger;
+
+    public TestLogger(TestLoggerFactory factory)
+    {
+        _logger = factory.CreateLogger<T>();
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        return _logger.BeginScope(state);
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return _logger.IsEnabled(logLevel);
+    }
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        _logger.Log(logLevel, eventId, state, exception, formatter);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/TestSink.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/TestSink.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public class TestSink : ITestSink
+{
+    private ConcurrentQueue<BeginScopeContext> _scopes;
+    private ConcurrentQueue<WriteContext> _writes;
+
+    public TestSink(
+        Func<WriteContext, bool>? writeEnabled = null,
+        Func<BeginScopeContext, bool>? beginEnabled = null)
+    {
+        WriteEnabled = writeEnabled;
+        BeginEnabled = beginEnabled;
+
+        _scopes = new ConcurrentQueue<BeginScopeContext>();
+        _writes = new ConcurrentQueue<WriteContext>();
+    }
+
+    public Func<WriteContext, bool>? WriteEnabled { get; set; }
+
+    public Func<BeginScopeContext, bool>? BeginEnabled { get; set; }
+
+    public IProducerConsumerCollection<BeginScopeContext> Scopes { get => _scopes; set => _scopes = new ConcurrentQueue<BeginScopeContext>(value); }
+
+    public IProducerConsumerCollection<WriteContext> Writes { get => _writes; set => _writes = new ConcurrentQueue<WriteContext>(value); }
+
+    public event Action<WriteContext>? MessageLogged;
+
+    public event Action<BeginScopeContext>? ScopeStarted;
+
+    public void Write(WriteContext context)
+    {
+        if (WriteEnabled == null || WriteEnabled(context))
+        {
+            _writes.Enqueue(context);
+        }
+        MessageLogged?.Invoke(context);
+    }
+
+    public void Begin(BeginScopeContext context)
+    {
+        if (BeginEnabled == null || BeginEnabled(context))
+        {
+            _scopes.Enqueue(context);
+        }
+        ScopeStarted?.Invoke(context);
+    }
+
+    public static bool EnableWithTypeName<T>(WriteContext context)
+    {
+        return context.LoggerName?.Equals(typeof(T).FullName) == true;
+    }
+
+    public static bool EnableWithTypeName<T>(BeginScopeContext context)
+    {
+        return context.LoggerName?.Equals(typeof(T).FullName) == true;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/WriteContext.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/WriteContext.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public class WriteContext
+{
+    public LogLevel LogLevel { get; set; }
+
+    public EventId EventId { get; set; }
+
+    public object? State { get; set; }
+
+    public Exception? Exception { get; set; }
+
+    public Func<object?, Exception?, string>? Formatter { get; set; }
+
+    public object? Scope { get; set; }
+
+    public string? LoggerName { get; set; }
+
+    public string? Message
+    {
+        get
+        {
+            return Formatter?.Invoke(State, Exception);
+        }
+    }
+
+    public override string ToString()
+    {
+        return $"{LogLevel} {LoggerName}: {Message}";
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/XunitLoggerFactoryExtensions.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/XunitLoggerFactoryExtensions.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging;
+
+public static class XunitLoggerFactoryExtensions
+{
+    public static ILoggingBuilder AddXunit(this ILoggingBuilder builder, ITestOutputHelper output)
+    {
+        builder.Services.AddSingleton<ILoggerProvider>(new XunitLoggerProvider(output));
+        return builder;
+    }
+
+    public static ILoggingBuilder AddXunit(this ILoggingBuilder builder, ITestOutputHelper output, LogLevel minLevel)
+    {
+        builder.Services.AddSingleton<ILoggerProvider>(new XunitLoggerProvider(output, minLevel));
+        return builder;
+    }
+
+    public static ILoggingBuilder AddXunit(this ILoggingBuilder builder, ITestOutputHelper output, LogLevel minLevel, DateTimeOffset? logStart)
+    {
+        builder.Services.AddSingleton<ILoggerProvider>(new XunitLoggerProvider(output, minLevel, logStart));
+        return builder;
+    }
+
+    public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output)
+    {
+        loggerFactory.AddProvider(new XunitLoggerProvider(output));
+        return loggerFactory;
+    }
+
+    public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output, LogLevel minLevel)
+    {
+        loggerFactory.AddProvider(new XunitLoggerProvider(output, minLevel));
+        return loggerFactory;
+    }
+
+    public static ILoggerFactory AddXunit(this ILoggerFactory loggerFactory, ITestOutputHelper output, LogLevel minLevel, DateTimeOffset? logStart)
+    {
+        loggerFactory.AddProvider(new XunitLoggerProvider(output, minLevel, logStart));
+        return loggerFactory;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Logging/XunitLoggerProvider.cs
+++ b/tests/Aspire.Hosting.Tests/Logging/XunitLoggerProvider.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text;
+using Xunit.Abstractions;
+
+namespace Microsoft.Extensions.Logging.Testing;
+
+public class XunitLoggerProvider : ILoggerProvider
+{
+    private readonly ITestOutputHelper _output;
+    private readonly LogLevel _minLevel;
+    private readonly DateTimeOffset? _logStart;
+
+    public XunitLoggerProvider(ITestOutputHelper output)
+        : this(output, LogLevel.Trace)
+    {
+    }
+
+    public XunitLoggerProvider(ITestOutputHelper output, LogLevel minLevel)
+        : this(output, minLevel, null)
+    {
+    }
+
+    public XunitLoggerProvider(ITestOutputHelper output, LogLevel minLevel, DateTimeOffset? logStart)
+    {
+        _output = output;
+        _minLevel = minLevel;
+        _logStart = logStart;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new XunitLogger(_output, categoryName, _minLevel, _logStart);
+    }
+
+    public void Dispose()
+    {
+    }
+}
+
+public class XunitLogger : ILogger
+{
+    private static readonly string[] s_newLineChars = new[] { Environment.NewLine };
+    private readonly string _category;
+    private readonly LogLevel _minLogLevel;
+    private readonly ITestOutputHelper _output;
+    private readonly DateTimeOffset? _logStart;
+
+    public XunitLogger(ITestOutputHelper output, string category, LogLevel minLogLevel, DateTimeOffset? logStart)
+    {
+        _minLogLevel = minLogLevel;
+        _category = category;
+        _output = output;
+        _logStart = logStart;
+    }
+
+    public void Log<TState>(
+        LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        // Buffer the message into a single string in order to avoid shearing the message when running across multiple threads.
+        var messageBuilder = new StringBuilder();
+
+        var timestamp = _logStart.HasValue ?
+            $"{(DateTimeOffset.UtcNow - _logStart.Value).TotalSeconds.ToString("N3", CultureInfo.InvariantCulture)}s" :
+            DateTimeOffset.UtcNow.ToString("s", CultureInfo.InvariantCulture);
+
+        var firstLinePrefix = $"| [{timestamp}] {_category} {logLevel}: ";
+        var lines = formatter(state, exception).Split(s_newLineChars, StringSplitOptions.RemoveEmptyEntries);
+        messageBuilder.AppendLine(firstLinePrefix + lines.FirstOrDefault() ?? string.Empty);
+
+        var additionalLinePrefix = "|" + new string(' ', firstLinePrefix.Length - 1);
+        foreach (var line in lines.Skip(1))
+        {
+            messageBuilder.AppendLine(additionalLinePrefix + line);
+        }
+
+        if (exception != null)
+        {
+            lines = exception.ToString().Split(s_newLineChars, StringSplitOptions.RemoveEmptyEntries);
+            additionalLinePrefix = "| ";
+            foreach (var line in lines)
+            {
+                messageBuilder.AppendLine(additionalLinePrefix + line);
+            }
+        }
+
+        // Remove the last line-break, because ITestOutputHelper only has WriteLine.
+        var message = messageBuilder.ToString();
+        if (message.EndsWith(Environment.NewLine, StringComparison.Ordinal))
+        {
+            message = message.Substring(0, message.Length - Environment.NewLine.Length);
+        }
+
+        try
+        {
+            _output.WriteLine(message);
+        }
+        catch (Exception)
+        {
+            // We could fail because we're on a background thread and our captured ITestOutputHelper is
+            // busted (if the test "completed" before the background thread fired).
+            // So, ignore this. There isn't really anything we can do but hope the
+            // caller has additional loggers registered
+        }
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+        => logLevel >= _minLogLevel;
+
+    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+        => new NullScope();
+
+    private sealed class NullScope : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Helpers;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
-using Aspire.Hosting.ApplicationModel;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -12,7 +11,7 @@ public class WithEnvironmentTests
     [Fact]
     public void EnvironmentReferencingEndpointPopulatesWithBindingUrl()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Create a binding and its metching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithServiceBinding(1000, 2000, "https", "mybinding");
@@ -47,7 +46,7 @@ public class WithEnvironmentTests
     [Fact]
     public void SimpleEnvironmentWithNameAndValue()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         testProgram.ServiceABuilder.WithEnvironment("myName", "value");
 
@@ -72,7 +71,7 @@ public class WithEnvironmentTests
     [Fact]
     public void EnvironmentCallbackPopulatesValueWhenCalled()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         var environmentValue = "value";
         testProgram.ServiceABuilder.WithEnvironment("myName", () => environmentValue);
@@ -99,7 +98,7 @@ public class WithEnvironmentTests
     [Fact]
     public void ComplexEnvironmentCallbackPopulatesValueWhenCalled()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         var environmentValue = "value";
         testProgram.ServiceABuilder.WithEnvironment((context) =>
@@ -125,4 +124,5 @@ public class WithEnvironmentTests
         Assert.Equal(1, servicesKeysCount);
         Assert.Contains(config, kvp => kvp.Key == "myName" && kvp.Value == "value2");
     }
+    private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithReferenceTests>(args);
 }

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
-using Aspire.Hosting.ApplicationModel;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -12,7 +11,7 @@ public class WithReferenceTests
     [Fact]
     public void ResourceWithSingleServiceBindingProducesSimplifiedEnvironmentVariables()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Create a binding and its metching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithServiceBinding(1000, 2000, "https", "mybinding");
@@ -48,7 +47,7 @@ public class WithReferenceTests
     [Fact]
     public void ResourceWithConflictingServiceBindingsProducesFullyScopedEnvironmentVariables()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Create a binding and its matching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithServiceBinding(1000, 2000, "https", "mybinding");
@@ -97,7 +96,7 @@ public class WithReferenceTests
     [Fact]
     public void ResourceWithNonConflictingServiceBindingsProducesAllVariantsOfEnvironmentVariables()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Create a binding and its matching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithServiceBinding(1000, 2000, "https", "mybinding");
@@ -148,7 +147,7 @@ public class WithReferenceTests
     [Fact]
     public void ResourceWithConflictingBindingsProducesAllBindingsEnvironmentVariables()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Create a binding and its metching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithServiceBinding(1000, 2000, "https", "mybinding");
@@ -193,7 +192,7 @@ public class WithReferenceTests
     [Fact]
     public void ResourceWithBindingsProducesAllBindingsEnvironmentVariables()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Create a binding and its metching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithServiceBinding(1000, 2000, "https", "mybinding");
@@ -240,7 +239,7 @@ public class WithReferenceTests
     [Fact]
     public void ConnectionStringResourceThrowsWhenMissingConnectionString()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Get the service provider.
         var resource = testProgram.AppBuilder.AddResource(new TestResource("resource"));
@@ -265,7 +264,7 @@ public class WithReferenceTests
     [Fact]
     public void ConnectionStringResourceOptionalWithMissingConnectionString()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Get the service provider.
         var resource = testProgram.AppBuilder.AddResource(new TestResource("resource"));
@@ -290,7 +289,7 @@ public class WithReferenceTests
     [Fact]
     public void ConnectionStringResourceWithConnectionString()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Get the service provider.
         var resource = testProgram.AppBuilder.AddResource(new TestResource("resource")
@@ -319,7 +318,7 @@ public class WithReferenceTests
     [Fact]
     public void ConnectionStringResourceWithConnectionStringOverwriteName()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Get the service provider.
         var resource = testProgram.AppBuilder.AddResource(new TestResource("resource")
@@ -348,7 +347,7 @@ public class WithReferenceTests
     [Fact]
     public void ConnectionStringResourceMissingConnectionStringFallbackToConfig()
     {
-        var testProgram = new TestProgram([]);
+        var testProgram = CreateTestProgram();
 
         // Get the service provider.
         var resource = testProgram.AppBuilder.AddResource(new TestResource("resource"));
@@ -371,6 +370,8 @@ public class WithReferenceTests
         Assert.Equal(1, servicesKeysCount);
         Assert.Contains(config, kvp => kvp.Key == "ConnectionStrings__resource" && kvp.Value == "test");
     }
+
+    private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithReferenceTests>(args);
 
     private sealed class TestResource(string name) : IResourceWithConnectionString
     {

--- a/tests/Aspire.Hosting.Tests/WithServiceBindingTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithServiceBindingTests.cs
@@ -12,7 +12,7 @@ public class WithServiceBindingTests
     {
         var ex = Assert.Throws<DistributedApplicationException>(() =>
         {
-            var testProgram = new TestProgram([]);
+            var testProgram = CreateTestProgram();
             testProgram.ServiceABuilder.WithServiceBinding(3000, 1000, scheme: "https", name: "mybinding");
             testProgram.ServiceABuilder.WithServiceBinding(3000, 2000, scheme: "https", name: "mybinding");
         });
@@ -25,11 +25,14 @@ public class WithServiceBindingTests
     {
         var ex = Assert.Throws<DistributedApplicationException>(() =>
         {
-            var testProgram = new TestProgram([]);
+            var testProgram = CreateTestProgram();
             testProgram.ServiceABuilder.WithServiceBinding(1000, scheme: "https", name: "mybinding");
             testProgram.ServiceABuilder.WithServiceBinding(2000, scheme: "https", name: "mybinding");
         });
 
         Assert.Equal("Service binding with name 'mybinding' already exists", ex.Message);
     }
+
+    private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithServiceBindingTests>(args);
+
 }

--- a/tests/testproject/TestProject.AppHost/Program.cs
+++ b/tests/testproject/TestProject.AppHost/Program.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-var testProgram = new TestProgram(args);
+var testProgram = TestProgram.Create<Program>(args);
 await testProgram.RunAsync();

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -7,7 +7,7 @@ public class TestProgram
 {
     private TestProgram(string[] args, Assembly assembly)
     {
-        AppBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { Args = args, DisableDashboard = true, AssemblyName = assembly.FullName, WriteLogsToLoggerOnShutdown = true });
+        AppBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { Args = args, DisableDashboard = true, AssemblyName = assembly.FullName });
         ServiceABuilder = AppBuilder.AddProject<Projects.ServiceA>("servicea");
         ServiceBBuilder = AppBuilder.AddProject<Projects.ServiceB>("serviceb");
         ServiceCBuilder = AppBuilder.AddProject<Projects.ServiceC>("servicec");

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -7,7 +7,7 @@ public class TestProgram
 {
     private TestProgram(string[] args, Assembly assembly)
     {
-        AppBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { Args = args, DisableDashboard = true, AssemblyName = assembly.FullName });
+        AppBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { Args = args, DisableDashboard = true, AssemblyName = assembly.FullName, WriteLogsToLoggerOnShutdown = true });
         ServiceABuilder = AppBuilder.AddProject<Projects.ServiceA>("servicea");
         ServiceBBuilder = AppBuilder.AddProject<Projects.ServiceB>("serviceb");
         ServiceCBuilder = AppBuilder.AddProject<Projects.ServiceC>("servicec");

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -1,15 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection;
+
 public class TestProgram
 {
-    public TestProgram(string[] args)
+    private TestProgram(string[] args, Assembly assembly)
     {
-        AppBuilder = DistributedApplication.CreateBuilder(args);
+        AppBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { Args = args, DisableDashboard = true, AssemblyName = assembly.FullName });
         ServiceABuilder = AppBuilder.AddProject<Projects.ServiceA>("servicea");
         ServiceBBuilder = AppBuilder.AddProject<Projects.ServiceB>("serviceb");
         ServiceCBuilder = AppBuilder.AddProject<Projects.ServiceC>("servicec");
     }
+
+    public static TestProgram Create<T>(string[]? args = null) => new TestProgram(args ?? [], typeof(T).Assembly);
 
     public IDistributedApplicationBuilder AppBuilder { get; private set; }
     public IResourceBuilder<ProjectResource> ServiceABuilder { get; private set; }
@@ -23,12 +27,13 @@ public class TestProgram
         await App.RunAsync(cancellationToken);
     }
 
-    public void Build()
+    public DistributedApplication Build()
     {
         if (App == null)
         {
             App = AppBuilder.Build();
         }
+        return App;
     }
     public void Run()
     {

--- a/tests/testproject/TestProject.AppHost/TestProject.AppHost.csproj
+++ b/tests/testproject/TestProject.AppHost/TestProject.AppHost.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Make each instance of DistributedApplicationBuilder a unique run instead of tying it to the process. Pass in the Kuberenetes service and locations instead of using a shared static.
- Allow disabling the dashboard while running tests to avoid the overhead and avoid port conflicts.
- Stop the dashboard after stoppnig the application executor.
- Moved docker install check to DCP execution logic to speed up entrypoint.
- Added APIs to CreateBuilder with no args for ease of use.
- Clean up DAB implementation.
- Made Aspire.Hosting.Tests an aspire host and added the props and targets.
- Added testing helpers for xunit to see DCP logs in the output.