### PR TITLE
Simple parallel publishing target for SDK containers

### DIFF
--- a/samples/eShopLite/AppHost/AppHost.csproj
+++ b/samples/eShopLite/AppHost/AppHost.csproj
@@ -12,12 +12,12 @@
     <ProjectReference Include="..\..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
     <ProjectReference Include="..\..\..\src\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\..\..\src\Aspire.Hosting.Azure.Provisioning\Aspire.Hosting.Azure.Provisioning.csproj" />
-    <ProjectReference Include="..\ApiGateway\ApiGateway.csproj" />
-    <ProjectReference Include="..\BasketService\BasketService.csproj" />
-    <ProjectReference Include="..\CatalogDb\CatalogDb.csproj" />
-    <ProjectReference Include="..\CatalogService\CatalogService.csproj" />
-    <ProjectReference Include="..\MyFrontend\MyFrontend.csproj" />
-    <ProjectReference Include="..\OrderProcessor\OrderProcessor.csproj" />
+    <ProjectReference Include="..\ApiGateway\ApiGateway.csproj" Containerize="true" />
+    <ProjectReference Include="..\BasketService\BasketService.csproj" Containerize="true"/>
+    <ProjectReference Include="..\CatalogDb\CatalogDb.csproj" Containerize="true"/>
+    <ProjectReference Include="..\CatalogService\CatalogService.csproj" Containerize="true"/>
+    <ProjectReference Include="..\MyFrontend\MyFrontend.csproj" Containerize="true"/>
+    <ProjectReference Include="..\OrderProcessor\OrderProcessor.csproj" Containerize="true"/>
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -129,9 +129,9 @@ public class ]]>%(ClassName)<![CDATA[ : IServiceMetadata
       <_ProjectsToPublish Include="@(ProjectReference)" Condition="'%(ProjectReference.Containerize)' == 'true'" />
     </ItemGroup>
 
+    <!-- Note that we're not publishing _in parallel_ here due to https://github.com/dotnet/sdk-container-builds/issues/344 -->
     <MSBuild
         Projects="@(_ProjectsToPublish)"
-        Targets="Publish;PublishContainer"
-        BuildInParallel="true" />
+        Targets="Publish;PublishContainer" />
   </Target>
 </Project>

--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -123,4 +123,15 @@ public class ]]>%(ClassName)<![CDATA[ : IServiceMetadata
       StandardErrorImportance="low"
       />
   </Target>
+
+  <Target Name="PublishAllReferencedApplications">
+    <ItemGroup>
+      <_ProjectsToPublish Include="@(ProjectReference)" Condition="'%(ProjectReference.Containerize)' == 'true'" />
+    </ItemGroup>
+
+    <MSBuild
+        Projects="@(_ProjectsToPublish)"
+        Targets="Publish;PublishContainer"
+        BuildInParallel="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
Pushed this up as a point of discussion.

The usage is `dotnet build-t:PublishAllReferencedApplications <whatever other parameters you want the publishing applications to have, like arch/os/configuration>`.

Because the `PublishContainer` target isn't available in the _base_ .NET SDK (remember it's only imported by things that support the Publish SDK) we can't just try to call that target on every ProjectReference that the Aspire host app has - if we do this will fail. So we need some kind of marker to know _which_ ProjectReferences are safe to call. Right now this is just a piece of metadata on the ProjectReference, but this could probably also be derived from the generated manifests in some way?

Once we know the set of projects to publish things are fairly straightforward - we can do that in parallel quite easily. Some things to think about:
* Right now we're not returning any outputs from the called targets - would `azd` tooling need some of the existing outputs from the `PublishContainer` target after this target is called? If so we can use the `TargetOutputs` metadata on the `MSBuild` task to grab that.
* The `PublishContainer` target itself isn't amazingly parallelizable - it does everything related to fetching/constructing the container in one Task. This isn't perfectly safe - we don't have locks over some of the file creation we do (e.g. when downloading container base image manifests or layer tarballs). That flakiness alone may be enough to sink this effort for preview. We have some prior reports of this for the container tooling (e.g. https://github.com/dotnet/sdk-container-builds/issues/344) but since folks weren't broadly publishing multiple projects in parallel we deprioritized fixing this.
* when built in this way, the CatalogService sample in eshop fires `NETSDK1152 - Found multiple publish output files with the same relative path: D:\code\aspire\samples\eShopLite\CatalogDb\appsettings.Development.json, D:\code\aspire\samples\eShopLite\CatalogService\appsettings.Development.json, D:\code\aspire\samples\eShopLite\CatalogDb\appsettings.json, D:\code\aspire\samples\eShopLite\CatalogService\appsettings.json`. I haven't investigated why this is, but why are appsettings from CatalogDb being copied as part of CatalogService?