### PR TITLE
Collect and publish code coverage

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-coverage": {
+      "version": "17.8.2",
+      "commands": [
+        "dotnet-coverage"
+      ]
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.1.19",
+      "commands": [
+        "reportgenerator"
+      ]
+    },
+    "PowerShell": {
+      "version": "7.3.3",
+      "commands": [
+        "pwsh"
+      ]
+    }
+  }
+}

--- a/eng/CodeCoverage.config
+++ b/eng/CodeCoverage.config
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <Format>cobertura</Format>
+  <CodeCoverage>
+
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*Aspire\.[^/\\]+\.dll$</ModulePath>
+        <ModulePath>.*Microsoft.Extensions\.[^/\\]+\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <ModulePath>.*tests\.dll</ModulePath>
+        <ModulePath>.*xunit.*</ModulePath>
+        <ModulePath>.*moq.*</ModulePath>
+      </Exclude>
+    </ModulePaths>
+
+    <!-- Match attributes on any code element: -->
+    <Attributes>
+      <Exclude>
+        <!-- Don't forget "Attribute" at the end of the name -->
+        <Attribute>^System\.Diagnostics\.DebuggerHiddenAttribute$</Attribute>
+        <Attribute>^System\.Diagnostics\.DebuggerNonUserCodeAttribute$</Attribute>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+        <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+
+    <!-- When set to True, dynamic native instrumentation will be enabled. -->
+    <EnableDynamicNativeInstrumentation>false</EnableDynamicNativeInstrumentation>
+    <!-- When set to True, instrumented binaries on disk are removed and original files are restored. -->
+    <EnableStaticNativeInstrumentationRestore>false</EnableStaticNativeInstrumentationRestore>
+    <EnableStaticNativeInstrumentation>false</EnableStaticNativeInstrumentation>
+    <UseVerifiableInstrumentation>false</UseVerifiableInstrumentation>
+
+  </CodeCoverage>
+</Configuration>

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -8,6 +8,11 @@ Param(
   [ValidateSet("windows","linux","osx")][string]$os,
   [switch]$testnobuild,
   [ValidateSet("x86","x64","arm","arm64")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
+
+  # Run tests with code coverage
+  [Parameter(ParameterSetName='CommandLine')]
+  [switch] $testCoverage,
+
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -38,6 +43,7 @@ function Get-Help() {
   Write-Host "  -sign                   Sign build outputs."
   Write-Host "  -test (-t)              Incrementally builds and runs tests."
   Write-Host "                          Use in conjunction with -testnobuild to only run tests."
+  Write-Host "  -testCoverage           Run unit tests and capture code coverage information."
   Write-Host ""
 
   Write-Host "Libraries settings:"
@@ -90,6 +96,7 @@ foreach ($argument in $PSBoundParameters.Keys)
 {
   switch($argument)
   {
+    "testCoverage"           { Write-Host "here"; <# this argument is handled in this script only #> }
     "os"                     { $arguments += " /p:TargetOS=$($PSBoundParameters[$argument])" }
     "properties"             { $arguments += " " + $properties }
     "verbosity"              { $arguments += " -$argument " + $($PSBoundParameters[$argument]) }
@@ -103,6 +110,37 @@ if ($env:TreatWarningsAsErrors -eq 'false') {
   $arguments += " -warnAsError 0"
 }
 
+Write-Host "& `"$PSScriptRoot/common/build.ps1`" $arguments"
 Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $arguments"
+
+
+# Perform code coverage as the last operation, this enables the following scenarios:
+#   .\build.cmd -restore -build -c Release -testCoverage
+if ($testCoverage) {
+  try {
+    # Install required toolset
+    . $PSScriptRoot/common/tools.ps1
+    InitializeDotNetCli -install $true | Out-Null
+
+    Push-Location $PSScriptRoot/../
+
+    $testResultPath = "./artifacts/TestResults/$configuration";
+
+    # Run tests and collect code coverage
+    ./.dotnet/dotnet dotnet-coverage collect --settings ./eng/CodeCoverage.config --output $testResultPath/local.cobertura.xml "build.cmd -test -configuration $configuration"
+
+    # Generate the code coverage report and open it in the browser
+    ./.dotnet/dotnet reportgenerator -reports:$testResultPath/*.cobertura.xml -targetdir:$testResultPath/CoverageResultsHtml -reporttypes:HtmlInline_AzurePipelines
+    Start-Process $testResultPath/CoverageResultsHtml/index.html
+  }
+  catch {
+    Write-Host $_.Exception.Message -Foreground "Red"
+    Write-Host $_.ScriptStackTrace -Foreground "DarkGray"
+    exit $global:LASTEXITCODE;
+  }
+  finally {
+    Pop-Location
+  }
+}
 
 exit 0

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -96,7 +96,7 @@ foreach ($argument in $PSBoundParameters.Keys)
 {
   switch($argument)
   {
-    "testCoverage"           { Write-Host "here"; <# this argument is handled in this script only #> }
+    "testCoverage"           { <# this argument is handled in this script only #> }
     "os"                     { $arguments += " /p:TargetOS=$($PSBoundParameters[$argument])" }
     "properties"             { $arguments += " " + $properties }
     "verbosity"              { $arguments += " -$argument " + $($PSBoundParameters[$argument]) }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -41,6 +41,7 @@ usage()
   echo "  --sign                     Sign build outputs."
   echo "  --test (-t)                Incrementally builds and runs tests."
   echo "                             Use in conjunction with --testnobuild to only run tests."
+  echo "  --testCoverage             Run unit tests and capture code coverage information."
   echo ""
 
   echo "Libraries settings:"
@@ -54,6 +55,7 @@ usage()
 
 arguments=''
 extraargs=''
+testCoverage=false
 
 # Check if an action is passed in
 declare -a actions=("b" "build" "r" "restore" "rebuild" "testnobuild" "sign" "publish" "clean")
@@ -136,6 +138,10 @@ while [[ $# > 0 ]]; do
       shift 1
       ;;
 
+    -testcoverage)
+      testCoverage=true
+      ;;
+
      *)
       extraargs="$extraargs $1"
       shift 1
@@ -153,3 +159,24 @@ fi
 
 arguments="$arguments $extraargs"
 "$scriptroot/common/build.sh" $arguments
+
+
+# Perform code coverage as the last operation, this enables the following scenarios:
+#   .\build.sh --restore --build --c Release --testCoverage
+if [[ "$testCoverage" == true ]]; then
+  # Install required toolset
+  . "$DIR/common/tools.sh"
+  InitializeDotNetCli true > /dev/null
+
+  repoRoot=$(realpath $DIR/../)
+  testResultPath="$repoRoot/artifacts/TestResults/$configuration"
+
+  # Run tests and collect code coverage
+  $repoRoot/.dotnet/dotnet 'dotnet-coverage' collect --settings $repoRoot/eng/CodeCoverage.config --output $testResultPath/local.cobertura.xml "$repoRoot/build.sh --test --configuration $configuration"
+
+  # Generate the code coverage report and open it in the browser
+  $repoRoot/.dotnet/dotnet reportgenerator -reports:$testResultPath/*.cobertura.xml -targetdir:$testResultPath/CoverageResultsHtml -reporttypes:HtmlInline_AzurePipelines
+  echo ""
+  echo -e "\e[32mCode coverage results:\e[0m $testResultPath/CoverageResultsHtml/index.html"
+  echo ""
+fi

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -12,19 +12,42 @@ pr:
     - release/*
 
 variables:
-- template: /eng/pipelines/common-variables.yml
-- template: /eng/common/templates/variables/pool-providers.yml
+  - template: /eng/pipelines/common-variables.yml
+  - template: /eng/common/templates/variables/pool-providers.yml
 
-- ${{ if eq(variables['_RunAsPublic'], 'true') }}:
-  - name: _AdditionalBuildArgs
-    value: ''
-  - name: _BuildJobDisplayName
-    value: 'Build and Test'
-- ${{ else }}:
-  - name: _AdditionalBuildArgs
-    value: '/p:Test=false'
-  - name: _BuildJobDisplayName
-    value: 'Build, Sign and Publish'
+  - name: Build.Arcade.ArtifactsPath
+    value: $(Build.SourcesDirectory)/artifacts/
+
+  # Produce test-signed build for PR and Public builds
+  - ${{ if or(eq(variables['_RunAsPublic'], 'true'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+    # needed for darc (dependency flow) publishing
+    - name: _PublishArgs
+      value: ''
+    - name: _OfficialBuildIdArgs
+      value: ''
+    # needed for signing
+    - name: _SignType
+      value: test
+    - name: _SignArgs
+      value: ''
+    - name: _Sign
+      value: false
+
+  # Set up non-PR build from internal project
+  - ${{ if and(ne(variables['_RunAsPublic'], 'true'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+    # needed for darc (dependency flow) publishing
+    - name: _PublishArgs
+      value: >-
+            /p:DotNetPublishUsingPipelines=true
+    - name: _OfficialBuildIdArgs
+      value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+    # needed for signing
+    - name: _SignType
+      value: real
+    - name: _SignArgs
+      value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign) /p:DotNetPublishUsingPipelines=true
+    - name: _Sign
+      value: true
 
 resources:
   containers:
@@ -32,6 +55,10 @@ resources:
     image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
 
 stages:
+
+# ----------------------------------------------------------------
+# This stage performs build, test, packaging
+# ----------------------------------------------------------------
 - stage: build
   displayName: Build
   jobs:
@@ -63,61 +90,67 @@ stages:
         timeoutInMinutes: 60
         pool:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals 1es-windows-2022
-        strategy:
-          matrix:
-            release:
-              _BuildConfig: Release
+          demands: ImageOverride -equals windows.vs2022preview.amd64
+
+        variables:
+          - name: _buildScript
+            value: $(Build.SourcesDirectory)/build.cmd -ci
+          - name: _BuildConfig
+            value: Release
+          - name: Build.Arcade.LogsPath
+            value: $(Build.Arcade.ArtifactsPath)log/$(_BuildConfig)/
+          - name: Build.Arcade.TestResultsPath
+            value: $(Build.Arcade.ArtifactsPath)TestResults/$(_BuildConfig)/
+
         preSteps:
-        - checkout: self
-          fetchDepth: 0
-          clean: true
+          - checkout: self
+            fetchDepth: 1
+            clean: true
+
         steps:
-        - script: eng\common\cibuild.cmd
-            -configuration $(_BuildConfig)
-            -prepareMachine
-            $(_AdditionalBuildArgs)
-            $(_InternalBuildArgs)
-          displayName: $(_BuildJobDisplayName)
-        - script: eng\common\cibuild.cmd
-            -configuration $(_BuildConfig)
-            -projects eng\workloads\workloads.csproj
-            $(_AdditionalBuildArgs)
-            $(_InternalBuildArgs)
-          displayName: Build Workloads
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Package Artifacts
-          inputs:
-            pathToPublish: '$(Build.SourcesDirectory)/artifacts/packages'
-            artifactName: PackageArtifacts
-            artifactType: container
-        - task: PublishBuildArtifacts@1
-          displayName: Publish VSDrop MSIs
-          inputs:
-            pathToPublish: '$(Build.SourcesDirectory)/artifacts/VSSetup/$(_BuildConfig)'
-            artifactName: VSDropInsertion
-            artifactType: container
+          - template: /eng/pipelines/templates/BuildAndTest.yml
+            parameters:
+              runAsPublic: ${{ eq(variables._RunAsPublic, True) }}
+              buildScript: $(_buildScript)
+              buildConfig: $(_BuildConfig)
+              repoLogPath: $(Build.Arcade.LogsPath)
+              repoTestResultsPath: $(Build.Arcade.TestResultsPath)
+              isWindows: true
+
 
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: linux
           timeoutInMinutes: 60
           container: LinuxContainer
           pool:
-            vmImage: ubuntu-latest
-          strategy:
-            matrix:
-              debug:
-                _BuildConfig: Debug
+            name: $(DncEngInternalBuildPool)
+            demands: ImageOverride -equals build.ubuntu.2004.amd64
+
+          variables:
+            - name: _buildScript
+              value: $(Build.SourcesDirectory)/build.sh --ci
+            - name: _BuildConfig
+              value: Debug
+            - name: Build.Arcade.LogsPath
+              value: $(Build.Arcade.ArtifactsPath)log/$(_BuildConfig)/
+            - name: Build.Arcade.TestResultsPath
+              value: $(Build.Arcade.ArtifactsPath)TestResults/$(_BuildConfig)/
+
           preSteps:
-          - checkout: self
-            clean: true
+            - checkout: self
+              fetchDepth: 1
+              clean: true
+
           steps:
-          - script: eng/common/cibuild.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              $(_AdditionalBuildArgs)
-              $(_InternalBuildArgs)
-            displayName: $(_BuildJobDisplayName)
+          - template: /eng/pipelines/templates/BuildAndTest.yml
+            parameters:
+              runAsPublic: ${{ eq(variables._RunAsPublic, True) }}
+              buildScript: $(_buildScript)
+              buildConfig: $(_BuildConfig)
+              repoLogPath: $(Build.Arcade.LogsPath)
+              repoTestResultsPath: $(Build.Arcade.TestResultsPath)
+              isWindows: false
+
 
 - ${{ if eq(variables._RunAsInternal, True) }}:
   - template: /eng/common/templates/post-build/post-build.yml

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -15,8 +15,14 @@ variables:
   - template: /eng/pipelines/common-variables.yml
   - template: /eng/common/templates/variables/pool-providers.yml
 
+  - name: _BuildConfig
+    value: Release
   - name: Build.Arcade.ArtifactsPath
     value: $(Build.SourcesDirectory)/artifacts/
+  - name: Build.Arcade.LogsPath
+    value: $(Build.Arcade.ArtifactsPath)log/$(_BuildConfig)/
+  - name: Build.Arcade.TestResultsPath
+    value: $(Build.Arcade.ArtifactsPath)TestResults/$(_BuildConfig)/
 
   # Produce test-signed build for PR and Public builds
   - ${{ if or(eq(variables['_RunAsPublic'], 'true'), eq(variables['Build.Reason'], 'PullRequest')) }}:
@@ -85,9 +91,12 @@ stages:
       enableSourceIndex: false
       workspace:
         clean: all
+
       jobs:
+
       - job: windows
-        timeoutInMinutes: 60
+        timeoutInMinutes: 30
+
         pool:
           name: $(DncEngInternalBuildPool)
           demands: ImageOverride -equals windows.vs2022preview.amd64
@@ -95,12 +104,6 @@ stages:
         variables:
           - name: _buildScript
             value: $(Build.SourcesDirectory)/build.cmd -ci
-          - name: _BuildConfig
-            value: Release
-          - name: Build.Arcade.LogsPath
-            value: $(Build.Arcade.ArtifactsPath)log/$(_BuildConfig)/
-          - name: Build.Arcade.TestResultsPath
-            value: $(Build.Arcade.ArtifactsPath)TestResults/$(_BuildConfig)/
 
         preSteps:
           - checkout: self
@@ -120,8 +123,8 @@ stages:
 
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: linux
-          timeoutInMinutes: 60
-          container: LinuxContainer
+          timeoutInMinutes: 30
+
           pool:
             name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals build.ubuntu.2004.amd64
@@ -129,12 +132,6 @@ stages:
           variables:
             - name: _buildScript
               value: $(Build.SourcesDirectory)/build.sh --ci
-            - name: _BuildConfig
-              value: Debug
-            - name: Build.Arcade.LogsPath
-              value: $(Build.Arcade.ArtifactsPath)log/$(_BuildConfig)/
-            - name: Build.Arcade.TestResultsPath
-              value: $(Build.Arcade.ArtifactsPath)TestResults/$(_BuildConfig)/
 
           preSteps:
             - checkout: self
@@ -150,6 +147,49 @@ stages:
               repoLogPath: $(Build.Arcade.LogsPath)
               repoTestResultsPath: $(Build.Arcade.TestResultsPath)
               isWindows: false
+
+
+# ----------------------------------------------------------------
+# This stage performs quality gates checks
+# ----------------------------------------------------------------
+- stage: codecoverage
+  displayName: CodeCoverage
+  dependsOn: 
+    - build
+  condition: succeeded('build')
+  variables:
+  - template: /eng/common/templates/variables/pool-providers.yml
+  jobs:
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enableMicrobuild: true
+      enableTelemetry: true
+      runAsPublic: false
+      workspace:
+        clean: all
+
+      # ----------------------------------------------------------------
+      # This stage downloads the code coverage reports from the build jobs,
+      # merges those and validates the combined test coverage.
+      # ----------------------------------------------------------------
+      jobs:
+      - job: CodeCoverageReport
+        timeoutInMinutes: 10
+
+        pool:
+          name: $(DncEngInternalBuildPool)
+          demands: ImageOverride -equals build.ubuntu.2004.amd64
+
+        preSteps:
+          - checkout: self
+            fetchDepth: 1
+            clean: true
+
+        steps:
+        - script: $(Build.SourcesDirectory)/build.sh --ci --restore
+          displayName: Init toolset
+
+        - template: /eng/pipelines/templates/VerifyCoverageReport.yml
 
 
 - ${{ if eq(variables._RunAsInternal, True) }}:
@@ -169,3 +209,4 @@ stages:
           -TsaCodebaseName $(_TsaCodebaseName)
           -TsaOnboard $(_TsaOnboard)
           -TsaPublish $(_TsaPublish)'
+

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -25,12 +25,18 @@ steps:
     displayName: Build
 
   - ${{ if ne(parameters.skipTests, 'true') }}:
-    - script: ${{ parameters.buildScript }}
-              -test
-              -configuration ${{ parameters.buildConfig }}
-              /bl:${{ parameters.repoLogPath }}/tests.binlog
-              $(_OfficialBuildIdArgs)
+    - script: $(Build.SourcesDirectory)/.dotnet/dotnet dotnet-coverage collect
+              --settings $(Build.SourcesDirectory)/eng/CodeCoverage.config
+              --output ${{ parameters.repoTestResultsPath }}/$(Agent.Os)_$(Agent.JobName).cobertura.xml
+              "${{ parameters.buildScript }} -test -configuration ${{ parameters.buildConfig }} /bl:${{ parameters.repoLogPath }}/tests.binlog $(_OfficialBuildIdArgs)"
       displayName: Run tests
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '${{ parameters.repoTestResultsPath }}/$(Agent.Os)_$(Agent.JobName).cobertura.xml'
+        PublishLocation: Container
+        ArtifactName: CodeCoverageResults
+      displayName: Publish coverage results (cobertura.xml)
 
   - ${{ if eq(parameters.isWindows, 'true') }}:
     - script: ${{ parameters.buildScript }}

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -1,0 +1,68 @@
+parameters:
+  - name: runAsPublic
+    type: boolean
+    default: false
+  - name: buildScript
+    type: string
+  - name: buildConfig
+    type: string
+  - name: repoLogPath
+    type: string
+  - name: repoTestResultsPath
+    type: string
+  - name: isWindows
+    type: string
+  - name: skipTests
+    type: boolean
+    default: false
+
+steps:
+  - script: ${{ parameters.buildScript }}
+            -restore -build
+            -configuration ${{ parameters.buildConfig }}
+            /bl:${{ parameters.repoLogPath }}/build.binlog
+            $(_OfficialBuildIdArgs)
+    displayName: Build
+
+  - ${{ if ne(parameters.skipTests, 'true') }}:
+    - script: ${{ parameters.buildScript }}
+              -test
+              -configuration ${{ parameters.buildConfig }}
+              /bl:${{ parameters.repoLogPath }}/tests.binlog
+              $(_OfficialBuildIdArgs)
+      displayName: Run tests
+
+  - ${{ if eq(parameters.isWindows, 'true') }}:
+    - script: ${{ parameters.buildScript }}
+              -pack
+              -sign $(_SignArgs)
+              -publish $(_PublishArgs)
+              -configuration ${{ parameters.buildConfig }}
+              /bl:${{ parameters.repoLogPath }}/pack.binlog
+              /p:Restore=false /p:Build=false
+              $(_OfficialBuildIdArgs)
+      displayName: Pack, Sign, and Publish
+
+    - script: ${{ parameters.buildScript }}
+        -restore -build
+        -pack
+        -sign $(_SignArgs)
+        -publish $(_PublishArgs)
+        -configuration $(_BuildConfig)
+        -projects eng\workloads\workloads.csproj
+        $(_InternalBuildArgs)
+      displayName: Build Workloads
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: '$(Build.SourcesDirectory)/artifacts/packages'
+        artifactName: PackageArtifacts
+        artifactType: container
+      displayName: Publish Package Artifacts
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: '$(Build.SourcesDirectory)/artifacts/VSSetup/$(_BuildConfig)'
+        artifactName: VSDropInsertion
+        artifactType: container
+      displayName: Publish VSDrop MSIs

--- a/eng/pipelines/templates/VerifyCoverageReport.yml
+++ b/eng/pipelines/templates/VerifyCoverageReport.yml
@@ -1,0 +1,28 @@
+steps:
+  - task: DownloadBuildArtifacts@0
+    displayName: Download code coverage reports
+    inputs:
+      artifactName: CodeCoverageResults
+      downloadPath: $(System.DefaultWorkingDirectory)
+
+  - script: $(Build.SourcesDirectory)/.dotnet/dotnet dotnet-coverage merge
+            $(System.DefaultWorkingDirectory)/CodeCoverageResults/*.cobertura.xml
+            --output-format cobertura
+            --output ./merged.cobertura.xml
+    displayName: Merge code coverage reports
+
+  - script: $(Build.SourcesDirectory)/.dotnet/dotnet reportgenerator
+            -reports:./merged.cobertura.xml
+            -targetdir:./CoverageResultsHtml
+            -reporttypes:HtmlInline_AzurePipelines
+    displayName: Generate code coverage report
+
+  - task: PublishCodeCoverageResults@1
+    displayName: Publish coverage report
+    env:
+      DISABLE_COVERAGE_AUTOGENERATE: 'true'
+    inputs:
+      codeCoverageTool: cobertura
+      summaryFileLocation: ./merged.cobertura.xml
+      pathToSources: $(Build.SourcesDirectory)
+      reportDirectory: ./CoverageResultsHtml


### PR DESCRIPTION
Contributes #50

* Restructure the build pipeline definition extracting the common build/test/pack/etc. steps in own template (eng/pipelines/templates/BuildAndTest.yml).
* Split the build pipeline as restore/build, test an pack/sign steps to enable plugging code coverage collection at the "test" step.
* Perform the Ubuntu build on the real agent instead of a Docker container, as the latter doesn't have the required dependencies:
  ```
  No code coverage data available. Profiler was not initialized. Verify that glibc (>=2.27), libxml2 and all .NET dependencies are installed.
  ```
* Perform the Ubuntu build in Release mode (same as the Windows) so that the code coverage is collected from the comparable artifacts.
* The code coverage results from each build stage are then merged and analyzed in a separate stage (see eng/pipelines/templates/VerifyCoverageReport.yml).