### PR TITLE
Various log filter fixes

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -4,19 +4,24 @@
 @using Microsoft.Fast.Components.FluentUI;
 @implements IDialogContentComponent<FilterDialogViewModel>
 
-<FluentStack Orientation="Orientation.Vertical" VerticalGap="8">
-    <FluentCombobox Items=@Parameters @bind-Value="@Parameter" Width="100%" />
+<EditForm EditContext="@EditContext" OnValidSubmit="@Apply">
+    <DataAnnotationsValidator />
 
-    <FluentSelect TOption="FilterCondition" Items="@Conditions.Keys" @bind-SelectedOption="@Condition" OptionText="@(i => Conditions[i])" Width="100%" />
+    <FluentStack Orientation="Orientation.Vertical" VerticalGap="8">
+        <FluentCombobox Placeholder="Field" Items=@Parameters @bind-Value="@_formModel.Parameter" Width="100%" Height="500px" />
 
-    <FluentTextField @bind-Value="Value" Placeholder="Value" />
+        <FluentSelect TOption="SelectViewModel<FilterCondition>" Items="@s_filterConditions" @bind-SelectedOption="@_formModel.Condition" OptionText="@(i => i.Name)" Width="100%" />
 
-    <FluentStack Orientation="Orientation.Horizontal" HorizontalAlignment="HorizontalAlignment.Right">
-        <FluentButton OnClick="Cancel">Cancel</FluentButton>
-        <FluentButton Color="Color.Primary" OnClick="Apply">Apply Filter</FluentButton>
-        @if (Content is { })
-        {
-            <FluentButton Appearance="Appearance.Stealth" aria-label="Remove Filter" OnClick="Delete"><FluentIcon Value="@(new Icons.Regular.Size16.Delete())" /></FluentButton>
-        }
+        <FluentTextField @bind-Value="_formModel.Value" Placeholder="Value" />
+
+        <FluentStack Orientation="Orientation.Horizontal" HorizontalAlignment="HorizontalAlignment.Right">
+            <FluentButton OnClick="Cancel">Cancel</FluentButton>
+            <FluentButton Color="Color.Primary" Type="ButtonType.Submit">Apply Filter</FluentButton>
+            @if (Content.Filter is not null)
+            {
+                <FluentButton Appearance="Appearance.Stealth" aria-label="Remove Filter" OnClick="Delete"><FluentIcon Value="@(new Icons.Regular.Size16.Delete())" /></FluentButton>
+            }
+        </FluentStack>
     </FluentStack>
-</FluentStack>
+
+</EditForm>

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -5,12 +5,24 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Fast.Components.FluentUI;
 
 namespace Aspire.Dashboard.Components.Dialogs;
 
 public partial class FilterDialog
 {
+    private static readonly List<SelectViewModel<FilterCondition>> s_filterConditions = new List<SelectViewModel<FilterCondition>>
+    {
+        CreateFilterSelectViewModel(FilterCondition.Equals),
+        CreateFilterSelectViewModel(FilterCondition.Contains),
+        CreateFilterSelectViewModel(FilterCondition.NotEqual),
+        CreateFilterSelectViewModel(FilterCondition.NotContains),
+    };
+
+    private static SelectViewModel<FilterCondition> CreateFilterSelectViewModel(FilterCondition condition) =>
+        new SelectViewModel<FilterCondition> { Id = condition, Name = LogFilter.ConditionToString(condition) };
+
     [CascadingParameter]
     public FluentDialog? Dialog { get; set; }
 
@@ -20,40 +32,29 @@ public partial class FilterDialog
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; set; }
 
-    private string Parameter { get; set; } = default!;
-    private FilterCondition Condition { get; set; }
-    private string Value { get; set; } = default!;
+    private LogDialogFormModel _formModel = default!;
+    public EditContext EditContext { get; private set; } = default!;
 
     protected override void OnInitialized()
     {
+        _formModel = new LogDialogFormModel();
+        EditContext = new EditContext(_formModel);
+
         if (Content.Filter is { } logFilter)
         {
-            Parameter = logFilter.Field;
-            Condition = logFilter.Condition;
-            Value = logFilter.Value;
+            _formModel.Parameter = logFilter.Field;
+            _formModel.Condition = s_filterConditions.Single(c => c.Id == logFilter.Condition);
+            _formModel.Value = logFilter.Value;
         }
         else
         {
-            Parameter = "Message";
-            Condition = FilterCondition.Contains;
-            Value = "";
+            _formModel.Parameter = "Message";
+            _formModel.Condition = s_filterConditions.Single(c => c.Id == FilterCondition.Contains);
+            _formModel.Value = "";
         }
     }
 
     public List<string> Parameters => LogFilter.GetAllPropertyNames(Content.LogPropertyKeys);
-
-    public Dictionary<FilterCondition, string> Conditions
-    {
-        get
-        {
-            var result = new Dictionary<FilterCondition, string>();
-            foreach (var c in Enum.GetValues<FilterCondition>())
-            {
-                result.Add(c, LogFilter.ConditionToString(c));
-            }
-            return result;
-        }
-    }
 
     private void Cancel()
     {
@@ -69,9 +70,9 @@ public partial class FilterDialog
     {
         if (Content.Filter is { } logFilter)
         {
-            logFilter.Field = Parameter;
-            logFilter.Condition = Condition;
-            logFilter.Value = Value;
+            logFilter.Field = _formModel.Parameter!;
+            logFilter.Condition = _formModel.Condition!.Id;
+            logFilter.Value = _formModel.Value!;
 
             Dialog!.CloseAsync(DialogResult.Ok(new FilterDialogResult() { Filter = logFilter, Delete = false }));
         }
@@ -79,10 +80,11 @@ public partial class FilterDialog
         {
             var filter = new LogFilter
             {
-                Field = Parameter,
-                Condition = Condition,
-                Value = Value
+                Field = _formModel.Parameter!,
+                Condition = _formModel.Condition!.Id,
+                Value = _formModel.Value!
             };
+
             Dialog!.CloseAsync(DialogResult.Ok(new FilterDialogResult() { Filter = filter, Add = true }));
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -49,6 +49,7 @@
             foreach (var filter in ViewModel.Filters)
             {
                 <FluentButton slot="end" Appearance="Appearance.Outline" OnClick="() => OpenFilterAsync(filter)">@filter.FilterText</FluentButton>
+                <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             }
         }
         <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="Add Filter" OnClick="() => OpenFilterAsync(null)"><FluentIcon Value="@(new Icons.Regular.Size16.Filter())" /></FluentButton>

--- a/src/Aspire.Dashboard/Model/Otlp/FilterCondition.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/FilterCondition.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model.Otlp;
+
+public enum FilterCondition
+{
+    Equals,
+    Contains,
+    GreaterThan,
+    LessThan,
+    GreaterThanOrEqual,
+    LessThanOrEqual,
+    NotEqual,
+    NotContains
+}
+

--- a/src/Aspire.Dashboard/Model/Otlp/LogDialogFormModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogDialogFormModel.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Aspire.Dashboard.Model.Otlp;
+
+public class LogDialogFormModel
+{
+    [Required]
+    public string? Parameter { get; set; }
+    [Required]
+    public SelectViewModel<FilterCondition>? Condition { get; set; }
+    [Required]
+    public string? Value { get; set; }
+}

--- a/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
@@ -65,12 +65,12 @@ public class StructuredLogsViewModel
             var filters = Filters.ToList();
             if (!string.IsNullOrWhiteSpace(FilterText))
             {
-                filters.Add(new LogFilter { Field = "Message", Condition = FilterCondition.Contains, Value = FilterText });
+                filters.Add(new LogFilter { Field = nameof(OtlpLogEntry.Message), Condition = FilterCondition.Contains, Value = FilterText });
             }
             // If the log level is set and it is not the bottom level, which has no effect, then add a filter.
             if (_logLevel != null && _logLevel != Microsoft.Extensions.Logging.LogLevel.Trace)
             {
-                filters.Add(new LogFilter { Field = "Severity", Condition = FilterCondition.GreaterThanOrEqual, Value = _logLevel.Value.ToString() });
+                filters.Add(new LogFilter { Field = nameof(OtlpLogEntry.Severity), Condition = FilterCondition.GreaterThanOrEqual, Value = _logLevel.Value.ToString() });
             }
 
             logs = _telemetryRepository.GetLogs(new GetLogsContext

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -17,7 +17,6 @@ public class OtlpLogEntry
     public string Message { get; }
     public string SpanId { get; }
     public string TraceId { get; }
-    public string? ParentId { get; }
     public string? OriginalFormat { get; }
     public OtlpApplication Application { get; }
 
@@ -30,9 +29,6 @@ public class OtlpLogEntry
             {
                 case "{OriginalFormat}":
                     OriginalFormat = kv.Value.GetString();
-                    break;
-                case "ParentId":
-                    ParentId = kv.Value.GetString();
                     break;
                 case "SpanId":
                 case "TraceId":
@@ -89,21 +85,13 @@ public class OtlpLogEntry
         var props = new Dictionary<string, string>
         {
             { "Application", Application.ApplicationName },
-            { "Severity", Severity.ToString() },
-            { "Message", Message },
-            { "TraceId", TraceId },
-            { "SpanId", SpanId }
+            { "Level", Severity.ToString() },
+            { "Message", Message }
         };
 
-        if (ParentId != null)
-        {
-            props.Add("ParentId", ParentId);
-        }
-
-        if (OriginalFormat != null)
-        {
-            props.Add("OriginalFormat", OriginalFormat);
-        }
+        AddOptionalValue("TraceId", TraceId, props);
+        AddOptionalValue("SpanId", SpanId, props);
+        AddOptionalValue("OriginalFormat", OriginalFormat, props);
 
         foreach (var kv in Properties)
         {
@@ -111,6 +99,13 @@ public class OtlpLogEntry
         }
 
         return props;
+
+        static void AddOptionalValue(string name, string? value, Dictionary<string, string> props)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                props.Add(name, value);
+            }
+        }
     }
 }
-

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -60,7 +60,6 @@ public class LogTests
             {
                 Assert.Equal("546573745370616e4964", app.SpanId);
                 Assert.Equal("5465737454726163654964", app.TraceId);
-                Assert.Equal("TestParentId", app.ParentId);
                 Assert.Equal("Test {Log}", app.OriginalFormat);
                 Assert.Equal("Test Value!", app.Message);
                 Assert.Collection(app.Properties,

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
@@ -125,7 +125,6 @@ internal static class TestHelpers
             Attributes =
             {
                 new KeyValue { Key = "{OriginalFormat}", Value = new AnyValue { StringValue = "Test {Log}" } },
-                new KeyValue { Key = "ParentId", Value = new AnyValue { StringValue = "TestParentId" } },
                 new KeyValue { Key = "Log", Value = new AnyValue { StringValue = "Value!" } }
             }
         };


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/499

* Remove less than/greater than filters. Nothing uses them (timestamp isn't an available filter. Can revisit in the future)
* Max height on field combo box
* Space between filters on log pages
* Log filter page validated that field and values are provided