### PR TITLE
Switch to using Path.GetRandomFileName() from uuid

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -83,7 +83,6 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         {
             AspireEventSource.Instance.DistributedApplicationBuildStop();
         }
-
     }
 
     public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -40,7 +40,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddHostedService<DcpHostService>();
 
         // We need a unique path per application instance
-        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         _innerBuilder.Services.AddSingleton(new Locations(path));
         _innerBuilder.Services.AddSingleton<KubernetesService>();
 
@@ -83,7 +83,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         {
             AspireEventSource.Instance.DistributedApplicationBuildStop();
         }
-        
+
     }
 
     public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource


### PR DESCRIPTION
Path.GetRandomFileName() gives us a random path that's only 12 characters long and compatible with Windows, Mac, and Linux. This should resolve https://github.com/dotnet/aspire/issues/585.