### PR TITLE
Increase docker command timeout

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -190,6 +190,8 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         return dcpProcessSpec;
     }
 
+    // Docker goes to into resource saver mode after 5 minutes of not running a container (by default).
+    // While in this mode, the commands we use for the docker check take quite some time
     private const int WaitTimeForDockerTestCommandInSeconds = 25;
 
     private void EnsureDockerIfNecessary()

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -190,7 +190,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         return dcpProcessSpec;
     }
 
-    private const int WaitTimeForDockerTestCommandInSeconds = 10;
+    private const int WaitTimeForDockerTestCommandInSeconds = 25;
 
     private void EnsureDockerIfNecessary()
     {


### PR DESCRIPTION
Docker goes to into resource saver mode after 5 minutes of not running a container (by default). While in this mode, the commands we use for the docker check take quite some time (11+ seconds on my laptop). Increasing the timeout for 25 seconds instead.

Read more here:

https://docs.docker.com/desktop/use-desktop/resource-saver/