### PR TITLE
Update Redis OpenTelemetry to latest version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -94,7 +94,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.5.1-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.10" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.11" />
     <!-- build dependencies -->
     <PackageVersion Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="1.1.87-gba258badda" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Workloads" Version="8.0.0-beta.23371.1" />


### PR DESCRIPTION
This brings in AOT support https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1415

Splitting this from https://github.com/dotnet/aspire/pull/597 to ensure it gets in, if we don't want the Log changes.