### PR TITLE
[release/8.0-preview1] Update Redis OpenTelemetry to latest version (#598)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -93,7 +93,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.5.1-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.10" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.11" />
     <!-- build dependencies -->
     <PackageVersion Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="1.1.87-gba258badda" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Workloads" Version="8.0.0-beta.23371.1" />


### PR DESCRIPTION
Port #598 

This brings in AOT support https://github.com/open-telemetry/opentelemetry-dotnet-contrib/pull/1415

This is needed for eShop to use AOT successfully.