### PR TITLE
Remove unnecessary subfolders from the session temp folder

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -263,7 +263,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         string? directoryName = Path.GetDirectoryName(socketPath);
         if (!string.IsNullOrEmpty(directoryName))
         {
-            Directory.CreateDirectory(directoryName);
+            Directory.CreateDirectory(directoryName, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
         }
 
         Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO.Pipelines;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Text;
 using Aspire.Dashboard;
 using Aspire.Dashboard.Model;
@@ -263,7 +264,14 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         string? directoryName = Path.GetDirectoryName(socketPath);
         if (!string.IsNullOrEmpty(directoryName))
         {
-            Directory.CreateDirectory(directoryName, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Directory.CreateDirectory(directoryName);
+            }
+            else
+            {
+                Directory.CreateDirectory(directoryName, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
+            }
         }
 
         Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);

--- a/src/Aspire.Hosting/Dcp/Locations.cs
+++ b/src/Aspire.Hosting/Dcp/Locations.cs
@@ -7,9 +7,7 @@ namespace Aspire.Hosting.Dcp;
 
 internal sealed class Locations(string basePath)
 {
-    public string DcpTempDir => Path.Join(basePath, "aspire");
-
-    public string DcpSessionDir => Path.Combine(DcpTempDir, "session", Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+    public string DcpSessionDir => basePath;
 
     public string DcpKubeconfigPath => Path.Combine(DcpSessionDir, "kubeconfig");
 

--- a/src/Aspire.Hosting/Dcp/Locations.cs
+++ b/src/Aspire.Hosting/Dcp/Locations.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-
 namespace Aspire.Hosting.Dcp;
 
 internal sealed class Locations(string basePath)


### PR DESCRIPTION
With the new randomized session folder per DCP run, the additional `aspire/session/<pid>` subfolders aren't necessary. This simplifies the folder structure and should keep us from leaving folders behind in temp after a run (assuming normal exit conditions). In the off chance that the session folder wasn't created ahead of time (it should be with the changes in #607), we'll also apply the proper 0700 permissions on Unix just in case.