### PR TITLE
[release/8.0-preview1] Remove unnecessary subfolders from the session temp folder

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO.Pipelines;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Text;
 using Aspire.Dashboard;
 using Aspire.Dashboard.Model;
@@ -263,7 +264,14 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         string? directoryName = Path.GetDirectoryName(socketPath);
         if (!string.IsNullOrEmpty(directoryName))
         {
-            Directory.CreateDirectory(directoryName);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Directory.CreateDirectory(directoryName);
+            }
+            else
+            {
+                Directory.CreateDirectory(directoryName, UnixFileMode.UserExecute | UnixFileMode.UserWrite | UnixFileMode.UserRead);
+            }
         }
 
         Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);

--- a/src/Aspire.Hosting/Dcp/Locations.cs
+++ b/src/Aspire.Hosting/Dcp/Locations.cs
@@ -1,15 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-
 namespace Aspire.Hosting.Dcp;
 
 internal sealed class Locations(string basePath)
 {
-    public string DcpTempDir => Path.Join(basePath, "aspire");
-
-    public string DcpSessionDir => Path.Combine(DcpTempDir, "session", Environment.ProcessId.ToString(CultureInfo.InvariantCulture));
+    public string DcpSessionDir => basePath;
 
     public string DcpKubeconfigPath => Path.Combine(DcpSessionDir, "kubeconfig");
 


### PR DESCRIPTION
Cherry-Pick #615 

* Remove extra subfolders from session temp folder path

* Ensure the session folder is created with appropriate Unix permissions if it doesn't already exist

* Check for Windows for proper CreateDirectory method

* Remove extra using