### PR TITLE
[release/8.0-preview1] Tweak modal sizing

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -164,7 +164,7 @@ public partial class StructuredLogs
         var parameters = new DialogParameters
         {
             Title = "Log Entry Details",
-            Width = "auto",
+            Width = "1000px",
             Height = "auto",
             TrapFocus = true,
             Modal = true,

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -150,7 +150,7 @@ public partial class TraceDetail
         var parameters = new DialogParameters
         {
             Title = $"{viewModel.Span.Source.ApplicationName}: {viewModel.GetDisplaySummary()}",
-            Width = "auto",
+            Width = "1000px",
             Height = "auto",
             TrapFocus = true,
             Modal = true,

--- a/src/Aspire.Dashboard/Services/EnvironmentVariablesDialogService.cs
+++ b/src/Aspire.Dashboard/Services/EnvironmentVariablesDialogService.cs
@@ -19,7 +19,7 @@ public sealed class EnvironmentVariablesDialogService(IDialogService dialogServi
             SecondaryAction = null,
             TrapFocus = true,
             Modal = true,
-            Width = "auto",
+            Width = "1000px",
             Height = "auto"
         };
 

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -92,7 +92,7 @@ fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appear
 }
 
 .dialog-grid-container {
-    width: 1000px;
+    width: 100%;
     height: 500px;
     overflow-x: auto;
     overflow-y: auto;
@@ -151,4 +151,8 @@ fluent-data-grid-cell .long-inner-content {
 .resource-error-badge {
     padding: 0 3px;
     cursor: pointer;
+}
+
+fluent-dialog::part(control) {
+    overflow-x: auto;
 }


### PR DESCRIPTION
Resolves #513. This fix is just for Preview1 since we've already moved on from the modals in main. Making as minimal of a change as possible to address the issue.

Instead of making the dialog width automatic based on its content, and locking the content to a specific width (1000px), we invert that and lock the dialog width to 1000px and set the grid container to size to 100% of its container. This handles the default scenario of resizing the browser window when you have not resized any of the columns in the grid.

There's a second scenario similar to what's shown in the window where you resize the grid columns. This also resizes the grid and allows it to be wider than the dialog. The user can get themselves into a situation where they made the column so large they can't see the resize grab handles anymore to make it smaller again (in addition to the rendering looking like it does in #513). A second variant of this happens when the header text is too wide even after wrapping. For that, we change the dialog to allow horizontal scrolling.
 
If we were keeping the modals, we'd probably want to do more to make the resizing more adaptive to smaller screens. But this is just a small fix to prevent the bad rendering seen in #513.

Without wide header text or grid resizing:
![image](https://github.com/dotnet/aspire/assets/9613109/33f96e3c-ca5c-44d3-a52f-b99f9ccf8ba4)
![image](https://github.com/dotnet/aspire/assets/9613109/5a147ef3-e84b-48a5-9bcd-eef90d9aac5d)
![image](https://github.com/dotnet/aspire/assets/9613109/26a1159f-4324-4a82-ab38-b9d351ff6dbf)

With wide header text:
![image](https://github.com/dotnet/aspire/assets/9613109/a42e7fdb-b310-4e1e-bf8d-36be7b2375eb)

With grid columns resized:
![image](https://github.com/dotnet/aspire/assets/9613109/1d95ce0d-0f2c-4eb5-8636-55d776a171df)
