### PR TITLE
Update trace colors for accessibility

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -8,7 +8,7 @@
 }
 
 ::deep .trace-id {
-    color: rgb(136, 136, 136);
+    color: var(--foreground-subtext-rest);
     padding-left: 0.5rem;
     font-size: 12px;
 }
@@ -110,10 +110,14 @@
 
 ::deep .span-container .span-bar-label {
     font-size: 12px;
-    color: #aaa;
+    color: var(--foreground-subtext-rest);
     padding: 0 0.5em;
     cursor: pointer;
     height: min-content;
+}
+
+::deep fluent-data-grid-row[row-type="default"]:hover .span-container .span-bar-label {
+    color: var(--foreground-subtext-hover);
 }
 
 ::deep .span-container .span-bar-label-detail {
@@ -140,9 +144,13 @@
 }
 
 ::deep .span-row-name {
-    color: rgb(136, 136, 136);
+    color: var(--foreground-subtext-rest);
     padding-left: 0.5rem;
     font-size: 12px;
+}
+
+::deep fluent-data-grid-row[row-type="default"]:hover .span-row-name {
+    color: var(--foreground-subtext-hover);
 }
 
 ::deep.trace-detail-layout {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -1,5 +1,5 @@
 .trace-id {
-    color: rgb(136, 136, 136);
+    color: var(--foreground-subtext-rest);
     padding-left: 0.5rem;
     font-size: 12px;
 }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -30,12 +30,16 @@ fluent-toolbar[orientation=horizontal] {
     --log-warning: #FBF3DD;
     --badge-fill-error: var(--error);
     --badge-color-error: var(--foreground-on-accent-rest);
+    --foreground-subtext-rest: #6F6F6F;
+    --foreground-subtext-hover: #6C6C6C;
 }
 
 [data-theme="dark"] {
     --log-critical: #493634;
     --log-error: #493634;
     --log-warning: #3F3A2B;
+    --foreground-subtext-rest: #8D8D8D;
+    --foreground-subtext-hover: #A1A1A1;
 }
 
 .page-content-area {


### PR DESCRIPTION
Small modifications to the text color in a few areas of the traces and trace details pages. 

This updates the text colors in the following places to ensure proper contrast:

![image](https://github.com/dotnet/aspire/assets/9613109/d5317524-3a94-47ef-a74d-6883d739e96b)
![image](https://github.com/dotnet/aspire/assets/9613109/b3fafac9-8b11-4b77-b831-80ff8ac9e402)
![image](https://github.com/dotnet/aspire/assets/9613109/f4e23b1d-3830-4397-aee2-28b9901223ea)
![image](https://github.com/dotnet/aspire/assets/9613109/d75b1dd2-b9d2-465f-9714-1322fc36795a)

The actual color changes are minimal. In all cases, both light and dark mode, we were close, but not quite. Before/After screenshots don't show any obvious difference unless you look _really_ hard.

These changes impact both light and dark mode even though I've only shown dark mode above. I used the same setup that @jamesnk implemented for the metrics colors to handle the light/dark toggling given we're creating new variables. 

This partially resolves #77, and I'm going to split off the remaining items I found into separate issues because they need more design discussion and potentially a11y team involvement.