### PR TITLE
Disable https in AppHost templates & samples

### DIFF
--- a/samples/dapr/AppHost/Properties/launchSettings.json
+++ b/samples/dapr/AppHost/Properties/launchSettings.json
@@ -22,17 +22,6 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031"
       }
-    },
-    "https": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "dotnetRunMessages": true,
-      "applicationUrl": "https://localhost:17887;http://localhost:15887",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:18032"
-      }
     }
   },
   "$schema": "http://json.schemastore.org/launchsettings.json"

--- a/samples/eShopLite/AppHost/Properties/launchSettings.json
+++ b/samples/eShopLite/AppHost/Properties/launchSettings.json
@@ -22,17 +22,6 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031"
       }
-    },
-    "https": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "dotnetRunMessages": true,
-      "applicationUrl": "https://localhost:17888;http://localhost:15888",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:18031"
-      }
     }
   },
   "$schema": "http://json.schemastore.org/launchsettings.json"

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/dotnetcli.host.json
@@ -15,8 +15,7 @@
         "isHidden": true
       },
       "NoHttps": {
-        "longName": "no-https",
-        "shortName": ""
+        "isHidden": true
       }
     },
     "usageExamples": [ ]

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/ide.host.json
@@ -2,7 +2,6 @@
   "$schema": "https://json.schemastore.org/ide.host",
   "icon": "ide/AspireEmpty.ico",
   "displayOverviewPage": "0",
-  "disableHttpsSymbol": "NoHttps",
   "unsupportedHosts": [
     {
       "id": "vs",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -157,7 +157,7 @@
     "NoHttps": {
       "type": "parameter",
       "datatype": "bool",
-      "defaultValue": "false",
+      "defaultValue": "true",
       "description": "Whether to turn off HTTPS."
     }
   },

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/dotnetcli.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/dotnetcli.host.json
@@ -23,8 +23,7 @@
         "isHidden": true
       },
       "NoHttps": {
-        "longName": "no-https",
-        "shortName": ""
+        "isHidden": true
       },
       "UseRedisCache": {
         "longName": "use-redis-cache",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/ide.host.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/ide.host.json
@@ -2,7 +2,6 @@
   "$schema": "https://json.schemastore.org/ide.host",
   "icon": "ide/AspireStarter.ico",
   "displayOverviewPage": "0",
-  "disableHttpsSymbol": "NoHttps",
   "unsupportedHosts": [
     {
       "id": "vs",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -259,7 +259,7 @@
     "NoHttps": {
       "type": "parameter",
       "datatype": "bool",
-      "defaultValue": "false",
+      "defaultValue": "true",
       "description": "Whether to turn off HTTPS."
     }
   },


### PR DESCRIPTION
Disable the https option in AppHost templates for now as it creates issues if the project is created with https but then run as http as the scheme needs to be specified for across-project API calls. We'll revisit this after preview.1

Workaround for #592

FYI @balachir 