### PR TITLE
Suppress DCP log spew and manifest publishing lifetime logs.

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -350,7 +350,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
             {
                 // loggerFactory.CreateLogger internally caches, but we may as well cache the logger as well as the string
                 // for the lifetime of this socket
-                loggerCache[hashValue] = logger = _loggerFactory.CreateLogger(Encoding.UTF8.GetString(category));
+                loggerCache[hashValue] = logger = _loggerFactory.CreateLogger($"Aspire.Hosting.Dcp.{Encoding.UTF8.GetString(category)}");
             }
 
             return (logger, logLevel, Encoding.UTF8.GetString(message));

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -70,17 +70,10 @@ public class DistributedApplication : IHost, IAsyncDisposable
 
     private void SuppressLifetimeLogsDuringManifestPublishing()
     {
-        if (_host.Services.GetRequiredService<IConfiguration>() is not IConfigurationRoot config)
-        {
-            throw new DistributedApplicationException("IConfiguration service should always be IConfigurationRoot");
-        }
+        var config = (IConfigurationRoot)_host.Services.GetRequiredService<IConfiguration>();
+        var options = _host.Services.GetRequiredService<IOptions<PublishingOptions>>();
 
-        if (_host.Services.GetRequiredService<IOptions<PublishingOptions>>() is not { } publishingOptions)
-        {
-            throw new DistributedApplicationException("Publishing options not registered.");
-        }
-
-        if (publishingOptions.Value?.Publisher != "manifest")
+        if (options.Value?.Publisher != "manifest")
         {
             // If we aren't doing manifest pubilshing we want the logs
             // to be produced as normal.

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -4,12 +4,14 @@
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Publishing;
 
-public class ManifestPublisher(IOptions<PublishingOptions> options, IHostApplicationLifetime lifetime) : IDistributedApplicationPublisher
+public class ManifestPublisher(ILogger<ManifestPublisher> logger, IOptions<PublishingOptions> options, IHostApplicationLifetime lifetime) : IDistributedApplicationPublisher
 {
+    private readonly ILogger<ManifestPublisher> _logger = logger;
     private readonly IOptions<PublishingOptions> _options = options;
     private readonly IHostApplicationLifetime _lifetime = lifetime;
 
@@ -34,6 +36,9 @@ public class ManifestPublisher(IOptions<PublishingOptions> options, IHostApplica
         using var jsonWriter = JsonWriter ?? new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
 
         await WriteManifestAsync(model, jsonWriter, cancellationToken).ConfigureAwait(false);
+
+        var fullyQualifiedPath = Path.GetFullPath(_options.Value.OutputPath);
+        _logger.LogInformation("Published manifest to: {manifestPath}", fullyQualifiedPath);
     }
 
     protected async Task WriteManifestAsync(DistributedApplicationModel model, Utf8JsonWriter jsonWriter, CancellationToken cancellationToken)

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication-1.AppHost/appsettings.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication-1.AppHost/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
     }
   }
 }

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication-1.AppHost/appsettings.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication-1.AppHost/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
     }
   }
 }

--- a/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
@@ -5,11 +5,12 @@ using System.Text.Json;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Tests.Helpers;
 
-internal sealed class JsonDocumentManifestPublisher(IOptions<PublishingOptions> options, IHostApplicationLifetime lifetime) : ManifestPublisher(options, lifetime)
+internal sealed class JsonDocumentManifestPublisher(ILogger<ManifestPublisher> logger, IOptions<PublishingOptions> options, IHostApplicationLifetime lifetime) : ManifestPublisher(logger, options, lifetime)
 {
     protected override async Task PublishInternalAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Fixes #604 (in templates only, remains in samples for debugging purposes) and removes logging noise from _Microsoft.Hosting.Lifetime_ category during manifest publishing.