### PR TITLE
Mark configure console logs internal.

### DIFF
--- a/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
@@ -6,9 +6,9 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Dashboard;
 
-public static class ConsoleLogsConfigurationExtensions
+internal static class ConsoleLogsConfigurationExtensions
 {
-    public static IResourceBuilder<T> ConfigureConsoleLogs<T>(this IResourceBuilder<T> builder) where T : IResourceWithEnvironment
+    internal static IResourceBuilder<T> ConfigureConsoleLogs<T>(this IResourceBuilder<T> builder) where T : IResourceWithEnvironment
     {
         return builder.WithEnvironment((context) =>
         {


### PR DESCRIPTION
Looks like we only using this within _Aspire.Hosting_ and only within `AddProject<T>(...)`.