### PR TITLE
Fix Npgsql Metrics

### DIFF
--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Aspire.Npgsql\NpgsqlCommon.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AspireEFPostgreSqlExtensions.cs
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AspireEFPostgreSqlExtensions.cs
@@ -122,8 +122,7 @@ public static partial class AspireEFPostgreSqlExtensions
                         eventCountersInstrumentationOptions.AddEventSources("Microsoft.EntityFrameworkCore");
                     });
 
-                    // https://github.com/npgsql/npgsql/blob/4c9921de2dfb48fb5a488787fc7422add3553f50/src/Npgsql/MetricsReporter.cs#L48
-                    meterProviderBuilder.AddMeter("Npgsql");
+                    NpgsqlCommon.AddNpgsqlMetrics(meterProviderBuilder);
                 });
         }
 

--- a/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
+++ b/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
@@ -97,11 +97,7 @@ public static class AspirePostgreSqlNpgsqlExtensions
         if (settings.Metrics)
         {
             builder.Services.AddOpenTelemetry()
-                .WithMetrics(meterProviderBuilder =>
-                {
-                    // https://github.com/npgsql/npgsql/blob/4c9921de2dfb48fb5a488787fc7422add3553f50/src/Npgsql/MetricsReporter.cs#L48
-                    meterProviderBuilder.AddMeter("Npgsql");
-                });
+                .WithMetrics(NpgsqlCommon.AddNpgsqlMetrics);
         }
     }
 

--- a/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
+++ b/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
@@ -102,9 +102,6 @@ public static class AspirePostgreSqlNpgsqlExtensions
                 {
                     // https://github.com/npgsql/npgsql/blob/4c9921de2dfb48fb5a488787fc7422add3553f50/src/Npgsql/MetricsReporter.cs#L48
                     meterProviderBuilder.AddMeter("Npgsql");
-
-                    // disable "prepared_ratio" until https://github.com/dotnet/aspire/issues/629 is fixed.
-                    meterProviderBuilder.AddView(instrumentName: "db.client.commands.prepared_ratio", MetricStreamConfiguration.Drop);
                 });
         }
     }

--- a/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
+++ b/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Npgsql;
-using OpenTelemetry.Metrics;
 
 namespace Microsoft.Extensions.Hosting;
 

--- a/src/Components/Aspire.Npgsql/NpgsqlCommon.cs
+++ b/src/Components/Aspire.Npgsql/NpgsqlCommon.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using OpenTelemetry.Metrics;
+
+internal static class NpgsqlCommon
+{
+    public static void AddNpgsqlMetrics(MeterProviderBuilder meterProviderBuilder)
+    {
+        double[] secondsBuckets = [0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10];
+
+        // https://github.com/npgsql/npgsql/blob/4c9921de2dfb48fb5a488787fc7422add3553f50/src/Npgsql/MetricsReporter.cs#L48
+        meterProviderBuilder
+            .AddMeter("Npgsql")
+            // Npgsql's histograms are in seconds, not milliseconds.
+            .AddView("db.client.commands.duration",
+                new ExplicitBucketHistogramConfiguration
+                {
+                    Boundaries = secondsBuckets
+                })
+            .AddView("db.client.connections.create_time",
+                new ExplicitBucketHistogramConfiguration
+                {
+                    Boundaries = secondsBuckets
+                });
+    }
+}


### PR DESCRIPTION
prepared ratio for Npgsql was missed in #648

Addresses #645

Also, Npgsql's histograms are in seconds, not milliseconds. We need an explicit bucket for this to work.

Fix #641 