### PR TITLE
Last round of triple slash, I believe.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@
 ;
 ; Here are some resources for what's supported for .NET/C#
 ; https://kent-boogaart.com/blog/editorconfig-reference-for-c-developers
-; https://learn.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+; https://learn.microsoft.com/visualstudio/ide/editorconfig-code-style-settings-reference
 ;
 ; Be **careful** editing this because some of the rules don't support adding a severity level
 ; For instance if you change to `dotnet_sort_system_directives_first = true:warning` (adding `:warning`)

--- a/Aspire.sln
+++ b/Aspire.sln
@@ -137,9 +137,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CatalogDb", "samples\eShopL
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{991DB378-6CB5-4441-BFC3-657400690FC3}"
 	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-		Directory.Build.props = Directory.Build.props
-		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject

--- a/Aspire.sln
+++ b/Aspire.sln
@@ -137,6 +137,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CatalogDb", "samples\eShopL
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{991DB378-6CB5-4441-BFC3-657400690FC3}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -76,7 +76,7 @@ jobs:
     - name: EnableRichCodeNavigation
       value: 'true'
   # Retry signature validation up to three times, waiting 2 seconds between attempts.
-  # See https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu3028#retry-untrusted-root-failures
+  # See https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu3028#retry-untrusted-root-failures
   - name: NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY
     value: 3,2000
   - ${{ each variable in parameters.variables }}:

--- a/samples/eShopLite/BasketService/Protos/basket.proto
+++ b/samples/eShopLite/BasketService/Protos/basket.proto
@@ -47,7 +47,7 @@ message DeleteCustomerBasketRequest {
 message DeleteCustomerBasketResponse {
 }
 
-// See: https://learn.microsoft.com/en-us/dotnet/architecture/grpc-for-wcf-developers/protobuf-data-types#decimals
+// See: https://learn.microsoft.com/dotnet/architecture/grpc-for-wcf-developers/protobuf-data-types#decimals
 // Example: 12345.6789 -> { units = 12345, nanos = 678900000 }
 message DecimalValue {
 

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -77,7 +77,7 @@ public partial class LogViewer
         }
         catch (JSDisconnectedException)
         {
-            // Per https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/?view=aspnetcore-7.0#javascript-interop-calls-without-a-circuit
+            // Per https://learn.microsoft.com/aspnet/core/blazor/javascript-interoperability/?view=aspnetcore-7.0#javascript-interop-calls-without-a-circuit
             // this is one of the calls that will fail if the circuit is disconnected, and we just need to catch the exception so it doesn't pollute the logs
         }
     }

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -83,7 +83,7 @@ public partial class SettingsDialog : IDialogContentComponent, IAsyncDisposable
         }
         catch (JSDisconnectedException)
         {
-            // Per https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/?view=aspnetcore-7.0#javascript-interop-calls-without-a-circuit
+            // Per https://learn.microsoft.com/aspnet/core/blazor/javascript-interoperability/?view=aspnetcore-7.0#javascript-interop-calls-without-a-circuit
             // this is one of the calls that will fail if the circuit is disconnected, and we just need to catch the exception so it doesn't pollute the logs
         }
     }

--- a/src/Aspire.Hosting.Azure.Provisioning/AzureProvisionerExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/AzureProvisionerExtensions.cs
@@ -16,6 +16,9 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting;
 
+/// <summary>
+/// Provides extension methods for adding support for generating Azure resources dynamically during application startup.
+/// </summary>
 public static class AzureProvisionerExtensions
 {
     /// <summary>
@@ -27,11 +30,11 @@ public static class AzureProvisionerExtensions
         builder.Services.AddLifecycleHook<AzureProvisioner>();
 
         // Attempt to read azure configuration from configuration
-        builder.Services.AddOptions<AzureProvisinerOptions>()
+        builder.Services.AddOptions<AzureProvisionerOptions>()
             .BindConfiguration("Azure");
 
         // We're adding 2 because there's no easy way to enumerate all keys and all service types
-        builder.AddAzureProvisioner<AzureKeyVaultResource, KeyVaultProvisoner>();
+        builder.AddAzureProvisioner<AzureKeyVaultResource, KeyVaultProvisioner>();
         builder.AddResourceEnumerator(resourceGroup => resourceGroup.GetKeyVaults(), resource => resource.Data.Tags);
 
         builder.AddAzureProvisioner<AzureStorageResource, StorageProvisioner>();
@@ -43,7 +46,7 @@ public static class AzureProvisionerExtensions
         builder.AddAzureProvisioner<AzureRedisResource, AzureRedisProvisioner>();
         builder.AddResourceEnumerator(resourceGroup => resourceGroup.GetAllRedis(), resource => resource.Data.Tags);
 
-        builder.AddAzureProvisioner<AzureAppConfigurationResource, AppConfigurationProvisoner>();
+        builder.AddAzureProvisioner<AzureAppConfigurationResource, AppConfigurationProvisioner>();
         builder.AddResourceEnumerator(resourceGroup => resourceGroup.GetAppConfigurationStores(), resource => resource.Data.Tags);
         return builder;
     }

--- a/src/Aspire.Hosting.Azure.Provisioning/AzureProvisionerOptions.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/AzureProvisionerOptions.cs
@@ -3,7 +3,7 @@
 
 namespace Aspire.Hosting.Azure.Provisioning;
 
-internal sealed class AzureProvisinerOptions
+internal sealed class AzureProvisionerOptions
 {
     public string? SubscriptionId { get; set; }
 

--- a/src/Aspire.Hosting.Azure.Provisioning/JsonExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/JsonExtensions.cs
@@ -1,5 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
 using System.Text.Json.Nodes;
 
 namespace Aspire.Hosting.Azure;

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AppConfigurationProvisoner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AppConfigurationProvisoner.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Azure.Provisioning;
 
-internal sealed class AppConfigurationProvisoner(ILogger<AppConfigurationProvisoner> logger) : AzureResourceProvisioner<AzureAppConfigurationResource>
+internal sealed class AppConfigurationProvisioner(ILogger<AppConfigurationProvisioner> logger) : AzureResourceProvisioner<AzureAppConfigurationResource>
 {
     public override bool ConfigureResource(IConfiguration configuration, AzureAppConfigurationResource resource)
     {
@@ -72,7 +72,7 @@ internal sealed class AppConfigurationProvisoner(ILogger<AppConfigurationProviso
         connectionStrings[resource.Name] = resource.Endpoint;
 
         // App Configuration Data Owner
-        // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#app-configuration-data-owner
+        // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#app-configuration-data-owner
         var roleDefinitionId = CreateRoleDefinitionId(subscription, "5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b");
 
         await DoRoleAssignmentAsync(armClient, appConfigurationResource.Id, principalId, roleDefinitionId, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -24,7 +24,7 @@ namespace Aspire.Hosting.Azure;
 
 // Provisions azure resources for development purposes
 internal sealed class AzureProvisioner(
-    IOptions<AzureProvisinerOptions> options,
+    IOptions<AzureProvisionerOptions> options,
     IOptions<PublishingOptions> publishingOptions,
     IConfiguration configuration,
     IHostEnvironment environment,
@@ -34,7 +34,7 @@ internal sealed class AzureProvisioner(
 {
     internal const string AspireResourceNameTag = "aspire-resource-name";
 
-    private readonly AzureProvisinerOptions _options = options.Value;
+    private readonly AzureProvisionerOptions _options = options.Value;
 
     public async Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
@@ -186,21 +186,21 @@ internal sealed class AzureProvisioner(
         {
             usedResources.Add(resource.Name);
 
-            var provisoner = serviceProvider.GetKeyedService<IAzureResourceProvisioner>(resource.GetType());
+            var provisioner = serviceProvider.GetKeyedService<IAzureResourceProvisioner>(resource.GetType());
 
-            if (provisoner is null)
+            if (provisioner is null)
             {
                 logger.LogWarning("No provisioner found for {resourceType} skipping.", resource.GetType().Name);
                 continue;
             }
 
-            if (!provisoner.ShouldProvision(configuration, resource))
+            if (!provisioner.ShouldProvision(configuration, resource))
             {
                 logger.LogInformation("Skipping {resourceName} because it is not configured to be provisioned.", resource.Name);
                 continue;
             }
 
-            if (provisoner.ConfigureResource(configuration, resource))
+            if (provisioner.ConfigureResource(configuration, resource))
             {
                 logger.LogInformation("Using connection information stored in user secrets for {resourceName}.", resource.Name);
 
@@ -217,7 +217,7 @@ internal sealed class AzureProvisioner(
             resourceMap ??= await resourceMapLazy.Value.ConfigureAwait(false);
             principalId ??= await principalIdLazy.Value.ConfigureAwait(false);
 
-            var task = provisoner.GetOrCreateResourceAsync(armClient,
+            var task = provisioner.GetOrCreateResourceAsync(armClient,
                     subscription,
                     resourceGroup,
                     resourceMap,

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/KeyVaultProvisoner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/KeyVaultProvisoner.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Azure.Provisioning;
 
-internal sealed class KeyVaultProvisoner(ILogger<KeyVaultProvisoner> logger) : AzureResourceProvisioner<AzureKeyVaultResource>
+internal sealed class KeyVaultProvisioner(ILogger<KeyVaultProvisioner> logger) : AzureResourceProvisioner<AzureKeyVaultResource>
 {
     public override bool ConfigureResource(IConfiguration configuration, AzureKeyVaultResource resource)
     {
@@ -76,7 +76,7 @@ internal sealed class KeyVaultProvisoner(ILogger<KeyVaultProvisoner> logger) : A
         connectionStrings[keyVault.Name] = keyVault.VaultUri.ToString();
 
         // Key Vault Administrator
-        // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#key-vault-administrator
+        // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#key-vault-administrator
         var roleDefinitionId = CreateRoleDefinitionId(subscription, "00482a5a-887f-4fb3-b363-3b7fe8e74483");
 
         await DoRoleAssignmentAsync(armClient, keyVaultResource.Id, principalId, roleDefinitionId, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/ServiceBusProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/ServiceBusProvisioner.cs
@@ -150,7 +150,7 @@ internal sealed class ServiceBusProvisioner(ILogger<ServiceBusProvisioner> logge
         }
 
         // Azure Service Bus Data Owner
-        // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#azure-service-bus-data-owner
+        // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#azure-service-bus-data-owner
         var roleDefinitionId = CreateRoleDefinitionId(subscription, "090c5cfd-751d-490a-894a-3ce6f1109419");
 
         await DoRoleAssignmentAsync(armClient, serviceBusNamespace.Id, principalId, roleDefinitionId, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/StorageProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/StorageProvisioner.cs
@@ -91,15 +91,15 @@ internal sealed class StorageProvisioner(ILogger<StorageProvisioner> logger) : A
         resourceEntry["QueueUri"] = resource.QueueUri.ToString();
 
         // Storage Queue Data Contributor
-        // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-queue-data-contributor
+        // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#storage-queue-data-contributor
         var storageQueueDataContributorId = CreateRoleDefinitionId(subscription, "974c5e8b-45b9-4653-ba55-5f855dd0fb88");
 
         // Storage Table Data Contributor
-        // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-table-data-contributor
+        // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#storage-table-data-contributor
         var storageDataContributorId = CreateRoleDefinitionId(subscription, "0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3");
 
         // Storage Blob Data Contributor
-        // https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor
+        // https://learn.microsoft.com/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor
         var storageBlobDataContributorId = CreateRoleDefinitionId(subscription, "81a9662b-bebf-436f-a333-f67b29880f12");
 
         var t0 = DoRoleAssignmentAsync(armClient, storageAccount.Id, principalId, storageQueueDataContributorId, cancellationToken);

--- a/src/Aspire.Hosting.Azure.Provisioning/UserSecretsPathHelper.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/UserSecretsPathHelper.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Provides helper methods for working with user secrets in a location outside of source control.
 /// </summary>
-public class UserSecretsPathHelper
+internal class UserSecretsPathHelper
 {
     internal const string SecretsFileName = "secrets.json";
 

--- a/src/Aspire.Hosting.Azure.Provisioning/UserSecretsPathHelper.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/UserSecretsPathHelper.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Provides helper methods for working with user secrets in a location outside of source control.
 /// </summary>
-internal class UserSecretsPathHelper
+internal sealed class UserSecretsPathHelper
 {
     internal const string SecretsFileName = "secrets.json";
 

--- a/src/Aspire.Hosting.Azure.Provisioning/UserSecretsPathHelper.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/UserSecretsPathHelper.cs
@@ -5,6 +5,9 @@ namespace Aspire.Hosting.Azure;
 
 // Copied from https://github.com/dotnet/runtime/blob/213833ea99b79a4b494b2935e1ccb10b93cd4cbc/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/PathHelper.cs
 
+/// <summary>
+/// Provides helper methods for working with user secrets in a location outside of source control.
+/// </summary>
 public class UserSecretsPathHelper
 {
     internal const string SecretsFileName = "secrets.json";

--- a/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
@@ -3,9 +3,20 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
+/// <summary>
+/// Represents an Azure App Configuration resource.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
 public class AzureAppConfigurationResource(string name) : Resource(name), IAzureResource, IResourceWithConnectionString
 {
+    /// <summary>
+    /// Gets or sets the endpoint for the Azure App Configuration resource.
+    /// </summary>
     public string? Endpoint { get; set; }
 
+    /// <summary>
+    /// Gets the connection string for the Azure App Configuration resource.
+    /// </summary>
+    /// <returns>The connection string for the Azure App Configuration resource.</returns>
     public string? GetConnectionString() => Endpoint;
 }

--- a/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a resource that is stored in Azure Blob Storage.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="storage">The <see cref="AzureStorageResource"/> that the resource is stored in.</param>
+public class AzureBlobStorageResource(string name, AzureStorageResource storage) : Resource(name),
+    IAzureResource,
+    IResourceWithConnectionString,
+    IResourceWithParent<AzureStorageResource>
+{
+    /// <summary>
+    /// Gets the parent AzureStorageResource of this AzureBlobStorageResource.
+    /// </summary>
+    public AzureStorageResource Parent => storage;
+
+    /// <summary>
+    /// Gets the connection string for the Azure Blob Storage resource.
+    /// </summary>
+    /// <returns>The connection string for the Azure Blob Storage resource.</returns>
+    public string? GetConnectionString() => Parent.GetBlobConnectionString();
+}

--- a/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
@@ -3,9 +3,20 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
+/// <summary>
+/// Represents an Azure Key Vault resource that can be deployed to an Azure resource group.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
 public class AzureKeyVaultResource(string name) : Resource(name), IAzureResource, IResourceWithConnectionString
 {
+    /// <summary>
+    /// Gets or sets the URI of the Azure Key Vault.
+    /// </summary>
     public Uri? VaultUri { get; set; }
 
+    /// <summary>
+    /// Gets the connection string for the Azure Key Vault resource.
+    /// </summary>
+    /// <returns>The connection string for the Azure Key Vault resource.</returns>
     public string? GetConnectionString() => VaultUri?.ToString();
 }

--- a/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents an Azure Queue Storage resource.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="storage">The <see cref="AzureStorageResource"/> that the resource is stored in.</param>
+public class AzureQueueStorageResource(string name, AzureStorageResource storage) : Resource(name),
+    IAzureResource,
+    IResourceWithConnectionString,
+    IResourceWithParent<AzureStorageResource>
+{
+    /// <summary>
+    /// Gets the parent AzureStorageResource of this AzureQueueStorageResource.
+    /// </summary>
+    public AzureStorageResource Parent => storage;
+
+    /// <summary>
+    /// Gets the connection string for the Azure Queue Storage resource.
+    /// </summary>
+    /// <returns>The connection string for the Azure Queue Storage resource.</returns>
+    public string? GetConnectionString() => Parent.GetQueueConnectionString();
+}

--- a/src/Aspire.Hosting.Azure/AzureRedisResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureRedisResource.cs
@@ -3,9 +3,20 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
+/// <summary>
+/// Represents an Azure Redis resource.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
 public class AzureRedisResource(string name) : Resource(name), IAzureResource, IResourceWithConnectionString
 {
+    /// <summary>
+    /// Gets or sets the connection string for the Azure Redis resource.
+    /// </summary>
     public string? ConnectionString { get; set; }
 
+    /// <summary>
+    /// Gets the connection string for the Azure Redis resource.
+    /// </summary>
+    /// <returns>The connection string for the Azure Redis resource.</returns>
     public string? GetConnectionString() => ConnectionString;
 }

--- a/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
@@ -7,6 +7,9 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting;
 
+/// <summary>
+/// Provides extension methods for adding Azure resources to the application model.
+/// </summary>
 public static class AzureResourceExtensions
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
@@ -3,13 +3,31 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
+/// <summary>
+/// Represents an Azure Service Bus resource.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
 public class AzureServiceBusResource(string name) : Resource(name), IAzureResource, IResourceWithConnectionString
 {
-    // This is the full uri to the service bus namespace e.g namespace.servicebus.windows.net
+    /// <summary>
+    /// Gets or sets the Service Bus endpoint. This is the full uri to the service bus 
+    /// namespace, for example <c>"namespace.servicebus.windows.net"</c>.
+    /// </summary>
     public string? ServiceBusEndpoint { get; set; }
 
+    /// <summary>
+    /// Gets or sets the names of the queues associated with the Azure Service Bus resource.
+    /// </summary>
     public string[] QueueNames { get; set; } = [];
+    
+    /// <summary>
+    /// Gets or sets the names of the topics associated with the Azure Service Bus resource.
+    /// </summary>
     public string[] TopicNames { get; set; } = [];
 
+    /// <summary>
+    /// Gets the connection string for the Azure Service Bus endpoint.
+    /// </summary>
+    /// <returns>The connection string for the Azure Service Bus endpoint.</returns>
     public string? GetConnectionString() => ServiceBusEndpoint;
 }

--- a/src/Aspire.Hosting.Azure/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureStorageResource.cs
@@ -6,12 +6,30 @@ using System.Text;
 
 namespace Aspire.Hosting.ApplicationModel;
 
+/// <summary>
+/// Represents an Azure Storage resource.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
 public class AzureStorageResource(string name) : Resource(name), IAzureResource
 {
+    /// <summary>
+    /// Gets or sets the URI of the Azure Table Storage resource.
+    /// </summary>
     public Uri? TableUri { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the URI of the Azure Storage queue.
+    /// </summary>
     public Uri? QueueUri { get; set; }
+    
+    /// <summary>
+    /// Gets or sets the URI of the blob.
+    /// </summary>
     public Uri? BlobUri { get; set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the Azure Storage resource is running in the local emulator.
+    /// </summary>
     public bool IsEmulator => this.IsContainer();
 
     internal string? GetTableConnectionString() => IsEmulator
@@ -34,39 +52,9 @@ public class AzureStorageResource(string name) : Resource(name), IAzureResource
         ?? throw new DistributedApplicationException($"Azure storage resource does not have endpoint annotation with name '{endpointName}'.");
 }
 
-public class AzureTableStorageResource(string name, AzureStorageResource storage) : Resource(name),
-    IAzureResource,
-    IResourceWithConnectionString,
-    IResourceWithParent<AzureStorageResource>
-{
-    public AzureStorageResource Parent => storage;
-
-    public string? GetConnectionString() => Parent.GetTableConnectionString();
-}
-
-public class AzureBlobStorageResource(string name, AzureStorageResource storage) : Resource(name),
-    IAzureResource,
-    IResourceWithConnectionString,
-    IResourceWithParent<AzureStorageResource>
-{
-    public AzureStorageResource Parent => storage;
-
-    public string? GetConnectionString() => Parent.GetBlobConnectionString();
-}
-
-public class AzureQueueStorageResource(string name, AzureStorageResource storage) : Resource(name),
-    IAzureResource,
-    IResourceWithConnectionString,
-    IResourceWithParent<AzureStorageResource>
-{
-    public AzureStorageResource Parent => storage;
-
-    public string? GetConnectionString() => Parent.GetQueueConnectionString();
-}
-
 static file class AzureStorageEmulatorConnectionString
 {
-    // Use defaults from https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#connect-to-the-emulator-account-using-the-shortcut
+    // Use defaults from https://learn.microsoft.com/azure/storage/common/storage-configure-connection-string#connect-to-the-emulator-account-using-the-shortcut
     private const string ConnectionStringHeader = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;";
     private const string BlobEndpointTemplate = "BlobEndpoint=http://127.0.0.1:{0}/devstoreaccount1;";
     private const string QueueEndpointTemplate = "QueueEndpoint=http://127.0.0.1:{0}/devstoreaccount1;";

--- a/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents an Azure Table Storage resource.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="storage">The <see cref="AzureStorageResource"/> that the resource is stored in.</param>
+public class AzureTableStorageResource(string name, AzureStorageResource storage) : Resource(name),
+    IAzureResource,
+    IResourceWithConnectionString,
+    IResourceWithParent<AzureStorageResource>
+{
+    /// <summary>
+    /// Gets the parent AzureStorageResource of this AzureTableStorageResource.
+    /// </summary>
+    public AzureStorageResource Parent => storage;
+
+    /// <summary>
+    /// Gets the connection string for the Azure Table Storage resource.
+    /// </summary>
+    /// <returns>The connection string for the Azure Table Storage resource.</returns>
+    public string? GetConnectionString() => Parent.GetTableConnectionString();
+}

--- a/src/Aspire.Hosting.Azure/IAzureResource.cs
+++ b/src/Aspire.Hosting.Azure/IAzureResource.cs
@@ -3,7 +3,10 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
+/// <summary>
+/// Represents an Azure resource, as a marker interface for <see cref="IResource"/>'s 
+/// that can be deployed to an Azure resource group.
+/// </summary>
 public interface IAzureResource : IResource
 {
-
 }

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -120,7 +120,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
 
         if (options.Value?.Publisher != "manifest")
         {
-            // If we aren't doing manifest pubilshing we want the logs
+            // If we aren't doing manifest publishing we want the logs
             // to be produced as normal.
             return;
         }
@@ -171,4 +171,3 @@ public class DistributedApplication : IHost, IAsyncDisposable
 
     Task IHost.StopAsync(CancellationToken cancellationToken) => StopAsync(cancellationToken);
 }
-

--- a/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
+++ b/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
@@ -14,6 +14,9 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Provides extension methods for registering <see cref="TableServiceClient"/> as a singleton in the services provided by the <see cref="IHostApplicationBuilder"/>.
+/// </summary>
 public static class AspireTablesExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Azure:Data:Tables";

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -15,6 +15,9 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Provides extension methods for registering <see cref="ServiceBusClient"/> as a singleton in the services provided by the <see cref="IHostApplicationBuilder"/>.
+/// </summary>
 public static class AspireServiceBusExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Azure:Messaging:ServiceBus";

--- a/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
@@ -16,6 +16,9 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Provides extension methods for registering and configuring Azure Key Vault secrets in a .NET Aspire application.
+/// </summary>
 public static class AspireKeyVaultExtensions
 {
     internal const string DefaultConfigSectionName = "Aspire:Azure:Security:KeyVault";

--- a/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
@@ -14,6 +14,9 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Provides extension methods for registering <see cref="BlobServiceClient"/> as a singleton in the services provided by the <see cref="IHostApplicationBuilder"/>.
+/// </summary>
 public static class AspireBlobStorageExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Azure:Storage:Blobs";

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
@@ -14,6 +14,10 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Provides extension methods for registering <see cref="QueueServiceClient"/> as a singleton in the services provided by the <see cref="IHostApplicationBuilder"/>.
+/// Enables retries, corresponding health check, logging and telemetry.
+/// </summary>
 public static class AspireQueueStorageExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Azure:Storage:Queues";

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AspireSqlServerEFCoreSqlClientExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AspireSqlServerEFCoreSqlClientExtensions.cs
@@ -96,7 +96,7 @@ public static class AspireSqlServerEFCoreSqlClientExtensions
         void ConfigureDbContext(DbContextOptionsBuilder dbContextOptionsBuilder)
         {
             // We don't register logger factory, because there is no need to:
-            // https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontextoptionsbuilder.useloggerfactory?view=efcore-7.0#remarks
+            // https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontextoptionsbuilder.useloggerfactory?view=efcore-7.0#remarks
             dbContextOptionsBuilder.UseSqlServer(settings.ConnectionString, builder =>
             {
                 if (string.IsNullOrEmpty(settings.ConnectionString))

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
@@ -1,6 +1,6 @@
 # Aspire.Microsoft.EntityFrameworkCore.SqlServer library
 
-Registers [EntityFrameworkCore](https://learn.microsoft.com/en-us/ef/core/) [DbContext](https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontext) service for connecting Azure SQL, MS SQL server database. Enables connection pooling, health check, logging and telemetry.
+Registers [EntityFrameworkCore](https://learn.microsoft.com/ef/core/) [DbContext](https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontext) service for connecting Azure SQL, MS SQL server database. Enables connection pooling, health check, logging and telemetry.
 
 ## Getting started
 

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AspireEFPostgreSqlExtensions.cs
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AspireEFPostgreSqlExtensions.cs
@@ -11,6 +11,9 @@ using OpenTelemetry.Metrics;
 
 namespace Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Provides extension methods for registering a PostgreSQL database context in an Aspire application.
+/// </summary>
 public static partial class AspireEFPostgreSqlExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Npgsql:EntityFrameworkCore:PostgreSQL";
@@ -114,7 +117,7 @@ public static partial class AspireEFPostgreSqlExtensions
                 .WithMetrics(meterProviderBuilder =>
                 {
                     // Currently EF provides only Event Counters:
-                    // https://learn.microsoft.com/en-us/ef/core/logging-events-diagnostics/event-counters?tabs=windows#counters-and-their-meaning
+                    // https://learn.microsoft.com/ef/core/logging-events-diagnostics/event-counters?tabs=windows#counters-and-their-meaning
                     meterProviderBuilder.AddEventCountersInstrumentation(eventCountersInstrumentationOptions =>
                     {
                         // The magic strings come from:
@@ -130,7 +133,7 @@ public static partial class AspireEFPostgreSqlExtensions
         void ConfigureDbContext(DbContextOptionsBuilder dbContextOptionsBuilder)
         {
             // We don't provide the connection string, it's going to use the pre-registered DataSource.
-            // We don't register logger factory, because there is no need to: https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontextoptionsbuilder.useloggerfactory?view=efcore-7.0#remarks
+            // We don't register logger factory, because there is no need to: https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontextoptionsbuilder.useloggerfactory?view=efcore-7.0#remarks
             dbContextOptionsBuilder.UseNpgsql(builder =>
             {
                 // Resiliency:

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
@@ -1,6 +1,6 @@
 # Aspire.Npgsql.EntityFrameworkCore.PostgreSQL library
 
-Registers [EntityFrameworkCore](https://learn.microsoft.com/en-us/ef/core/) [DbContext](https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontext) in the DI container for connecting PostgreSQL®* database. Enables connection pooling, health check, logging and telemetry.
+Registers [EntityFrameworkCore](https://learn.microsoft.com/ef/core/) [DbContext](https://learn.microsoft.com/dotnet/api/microsoft.entityframeworkcore.dbcontext) in the DI container for connecting PostgreSQL®* database. Enables connection pooling, health check, logging and telemetry.
 
 ## Getting started
 

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
@@ -9,6 +9,9 @@ using StackExchange.Redis;
 
 namespace Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Provides extension methods for adding Redis distributed caching services to an <see cref="IHostApplicationBuilder"/>.
+/// </summary>
 public static class AspireRedisDistributedCacheExtensions
 {
     /// <summary>

--- a/src/Components/Aspire.StackExchange.Redis.OutputCaching/AspireRedisOutputCacheExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis.OutputCaching/AspireRedisOutputCacheExtensions.cs
@@ -8,6 +8,9 @@ using StackExchange.Redis;
 
 namespace Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Provides extension methods for adding Redis output caching services to the <see cref="IHostApplicationBuilder"/>.
+/// </summary>
 public static class AspireRedisOutputCacheExtensions
 {
     /// <summary>

--- a/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
@@ -16,6 +16,9 @@ using StackExchange.Redis.Configuration;
 
 namespace Microsoft.Extensions.Hosting;
 
+/// <summary>
+/// Provides extension methods for registering Redis-related services in an <see cref="IHostApplicationBuilder"/>.
+/// </summary>
 public static class AspireRedisExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:StackExchange:Redis";

--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Features/IEndPointHealthFeature.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Features/IEndPointHealthFeature.cs
@@ -3,10 +3,16 @@
 
 namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
+/// <summary>
+/// Represents a feature that reports the health of an endpoint, for use in triggering internal cache refresh and for use in load balancing.
+/// </summary>
 public interface IEndPointHealthFeature
 {
-    // Reports health of the endpoint, for use in triggering internal cache refresh and for use in load balancing.
-    // Can be a no-op.
+    /// <summary>
+    /// Reports health of the endpoint, for use in triggering internal cache refresh and for use in load balancing. Can be a no-op.
+    /// </summary>
+    /// <param name="responseTime">The response time of the endpoint.</param>
+    /// <param name="exception">An optional exception that occurred while checking the endpoint's health.</param>
     void ReportHealth(TimeSpan responseTime, Exception? exception);
 }
 

--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Features/IEndPointLoadFeature.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Features/IEndPointLoadFeature.cs
@@ -3,9 +3,14 @@
 
 namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
+/// <summary>
+/// Represents a feature that provides information about the current load of an endpoint.
+/// </summary>
 public interface IEndPointLoadFeature
 {
-    // CurrentLoad is some comparable measure of load (queue length, concurrent requests, etc)
+    /// <summary>
+    /// Gets a comparable measure of the current load of the endpoint (e.g. queue length, concurrent requests, etc).
+    /// </summary>
     public double CurrentLoad { get; }
 }
 


### PR DESCRIPTION
I did another round of triple slash additions.

- Fixed typos, in type names, comments, and variables.
- Moved a couple classes into their own file, while adding triple slash for them.
- Remove all `/en-us` locales from learn.microsoft.com links as it's not supposed to be included.