### PR TITLE
Add third party notices

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,6 +6,14 @@
     <PackageReadmeFile Condition="'$(PackageReadmeFile)' == '' And '$(ReadMeExists)' == 'true'">README.md</PackageReadmeFile>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PackageThirdPartyNoticesFile Condition="'$(PackageThirdPartyNoticesFile)' == ''">$(RepoRoot)THIRD-PARTY-NOTICES.TXT</PackageThirdPartyNoticesFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(IsPackable)' == 'true'">
+    <None Include="$(PackageThirdPartyNoticesFile)" Pack="true" PackagePath="." />
+  </ItemGroup>
+
   <Import Condition="'$(SampleProject)' == 'true' or '$(CI)' != 'true' " Project="eng\Versions.dev.targets" />
   <Import Condition="'$(SampleProject)' != 'true' and '$(CI)' == 'true' " Project="eng\Versions.targets" />
 

--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -1,0 +1,34 @@
+Aspire uses third-party libraries or other resources that may be
+distributed under licenses different than the Aspire software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention. Post an issue or email us:
+
+           dotnet@microsoft.com
+
+The attached notices are provided for information only.
+
+License notice for plotly.js
+----------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2021 Plotly, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -19,7 +19,7 @@
   },
   "precedence": "8000",
   "identity": "Aspire.Empty.CSharp.8.0",
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/8.0-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspire/1.0-third-party-notices",
   "groupIdentity": "Aspire.Empty",
   "guids": [
     "F98A6C4E-E01C-44BB-BCC9-4C23F1CD09CD",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -24,7 +24,7 @@
   },
   "precedence": "8000",
   "identity": "Aspire.Starter.CSharp.8.0",
-  "thirdPartyNotices": "https://aka.ms/aspnetcore/8.0-third-party-notices",
+  "thirdPartyNotices": "https://aka.ms/aspire/1.0-third-party-notices",
   "groupIdentity": "Aspire.Starter",
   "guids": [
     "80B24B1B-1E78-4FCB-BDC9-13678F1789F4",


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/191 (excepting creating https://aka.ms/aspire/1.0-third-party-notices that points to https://github.com/dotnet/aspire/blob/main/THIRD-PARTY-NOTICES.TXT when we ship)

The only 3P component that we are distributing in packages/templates is plotly. (Of course we have various dependencies that will be pulled down when our packages are restored.)

1. Add TPN containing plotly license.
2. Add aka.ms link to Aspire templates. We will make this point at the TPN in the repo, exactly as aspnetcore templates do today.
3. Add TPN into root of packages. (Strictly, could just be in the Dashboard package.). Tested by building Dashboard package and verifying it is in there.

This seems like the minimum for preview 1, and we can add more acknowledgements as needed.

Note I could not find a standard Arcade way to include a TPN if present.