### PR TITLE
Fix structured logs layout

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -55,45 +55,49 @@
     </FluentToolbar>
     <SummaryDetailsView DetailsTitle="Log Entry Details" ShowDetails="SelectedLogEntryProperties is not null" OnDismiss="() => SelectedLogEntryProperties = null">
         <Summary>
-            <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
-                <ChildContent>
-                    <TemplateColumn Title="Service" Tooltip="true" TooltipText="(e) => e.Application.ApplicationName">
-                        <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(context.Application.ApplicationName));">
-                            @context.Application.ApplicationName
-                        </span>
-                    </TemplateColumn>
-                    <TemplateColumn Title="Level">
-                        @if (context.Severity is LogLevel.Error or LogLevel.Critical)
-                        {
-                            <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="logs-severity-icon" />
-                        }
-                        else if (context.Severity is LogLevel.Warning)
-                        {
-                            <FluentIcon Icon="Icons.Filled.Size16.Warning" Color="Color.Warning" Class="logs-severity-icon" />
-                        }
-                        @context.Severity
-                    </TemplateColumn>
-                    <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" Tooltip="true" />
-                    <TemplateColumn Title="Message" Tooltip="true" TooltipText="(e) => e.Message">
-                        <FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@context.Message" />
-                    </TemplateColumn>
-                    <TemplateColumn Title="Trace">
-                        @if (!string.IsNullOrEmpty(context.TraceId))
-                        {
-                            <a href="@($"/Trace/{HttpUtility.UrlEncode(context.TraceId)}")" class="long-inner-content">
-                                @OtlpHelpers.ToShortenedId(context.TraceId)
-                            </a>
-                        }
-                    </TemplateColumn>
-                    <TemplateColumn Title="Details">
-                        <FluentButton Appearance="Appearance.Lightweight" OnClick="() => OnShowProperties(context)">View</FluentButton>
-                    </TemplateColumn>
-                </ChildContent>
-                <EmptyContent>
-                    <FluentIcon Icon="Icons.Regular.Size24.SlideTextSparkle" />&nbsp;No structured logs found
-                </EmptyContent>
-            </FluentDataGrid>
-            <TotalItemsFooter @ref="_totalItemsFooter" />
+            <div class="logs-summary-layout">
+                <div class="logs-grid-container continuous-scroll-overflow">
+                    <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
+                        <ChildContent>
+                            <TemplateColumn Title="Service" Tooltip="true" TooltipText="(e) => e.Application.ApplicationName">
+                                <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(context.Application.ApplicationName));">
+                                    @context.Application.ApplicationName
+                                </span>
+                            </TemplateColumn>
+                            <TemplateColumn Title="Level">
+                                @if (context.Severity is LogLevel.Error or LogLevel.Critical)
+                                {
+                                    <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="logs-severity-icon" />
+                                }
+                                else if (context.Severity is LogLevel.Warning)
+                                {
+                                    <FluentIcon Icon="Icons.Filled.Size16.Warning" Color="Color.Warning" Class="logs-severity-icon" />
+                                }
+                                @context.Severity
+                            </TemplateColumn>
+                            <PropertyColumn Title="Timestamp" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" Tooltip="true" />
+                            <TemplateColumn Title="Message" Tooltip="true" TooltipText="(e) => e.Message">
+                                <FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@context.Message" />
+                            </TemplateColumn>
+                            <TemplateColumn Title="Trace">
+                                @if (!string.IsNullOrEmpty(context.TraceId))
+                                {
+                                    <a href="@($"/Trace/{HttpUtility.UrlEncode(context.TraceId)}")" class="long-inner-content">
+                                        @OtlpHelpers.ToShortenedId(context.TraceId)
+                                    </a>
+                                }
+                            </TemplateColumn>
+                            <TemplateColumn Title="Details">
+                                <FluentButton Appearance="Appearance.Lightweight" OnClick="() => OnShowProperties(context)">View</FluentButton>
+                            </TemplateColumn>
+                        </ChildContent>
+                        <EmptyContent>
+                            <FluentIcon Icon="Icons.Regular.Size24.SlideTextSparkle" />&nbsp;No structured logs found
+                        </EmptyContent>
+                    </FluentDataGrid>
+                </div>
+                <TotalItemsFooter @ref="_totalItemsFooter" />
+            </div>
         </Summary>
         <Details>
             <StructuredLogDetails Items="@SelectedLogEntryProperties" />

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
@@ -40,3 +40,23 @@
     vertical-align: text-bottom;
     margin-right: 3px;
 }
+
+::deep .logs-summary-layout {
+    display: grid;
+    grid-template-rows: 1fr auto;
+    height: 100%;
+    width: 100%;
+    grid-template-areas:
+        "main"
+        "foot";
+    gap: calc(var(--design-unit) * 2px);
+}
+
+::deep .logs-summary-layout > .logs-grid-container {
+    grid-area: main;
+    overflow: auto;
+}
+
+::deep .logs-summary-layout > .total-items-footer {
+    grid-area: foot;
+}

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -14,18 +14,6 @@ if (firstUndefinedElement) {
     document.body.classList.remove("before-upgrade");
 }
 
-window.scrollToEndInTextArea = function (classSelector) {
-    let fluentTextAreas = document.querySelectorAll(classSelector);
-    if (fluentTextAreas && fluentTextAreas.length > 0) {
-        for (const fluentTextArea of fluentTextAreas) {
-            if (fluentTextArea && fluentTextArea.shadowRoot) {
-                let textArea = fluentTextArea.shadowRoot.querySelector('textarea');
-                textArea.scrollTop = textArea.scrollHeight;
-            }
-        }
-    }
-};
-
 let isScrolledToContent = false;
 
 window.resetContinuousScrollPosition = function () {


### PR DESCRIPTION
Fixes #697. Structured Logs has the footer _and_ the summary/details view, so it needed to be adjusted in ways other pages (traces, with no summary/details, resource lists, with no footer) did not. Adding a new sub-layout to the page inside the summary view that pins the footer to the bottom. Also looks like the `continuous-scroll-overflow` CSS attribute got dropped on this page, which broke the auto scrolling behavior.

StructuredLogs.razor changes best viewed without whitespace.