### PR TITLE
Update template display strings to say ".NET Aspire"

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -6,9 +6,9 @@
     "Aspire",
     "Cloud"
   ],
-  "name": "Aspire Application",
+  "name": ".NET Aspire Application",
   "defaultName": "AspireApp",
-  "description": "A project template for creating an empty Aspire app.",
+  "description": "A project template for creating an empty .NET Aspire app.",
   "shortName": "aspire",
   "sourceName": "AspireApplication-1",
   "preferNameDirectory": true,

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [
     "Common",
-    "Aspire",
+    ".NET Aspire",
     "Cloud"
   ],
   "name": ".NET Aspire Application",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -3,7 +3,7 @@
   "author": "Microsoft",
   "classifications": [
     "Common",
-    "Aspire",
+    ".NET Aspire",
     "Blazor",
     "Web",
     "Web API",
@@ -11,9 +11,9 @@
     "Service",
     "Cloud"
   ],
-  "name": "Aspire Starter Application",
+  "name": ".NET Aspire Starter Application",
   "defaultName": "AspireApp",
-  "description": "A project template for creating an Aspire app with a Blazor web frontend and web API backend service, optionally using Redis for caching.",
+  "description": "A project template for creating a .NET Aspire app with a Blazor web frontend and web API backend service, optionally using Redis for caching.",
   "shortName": "aspire-starter",
   "sourceName": "AspireStarterApplication-1",
   "preferNameDirectory": false,


### PR DESCRIPTION
Update template name, classification, and description to say ".NET Aspire" instead of "Aspire".