### PR TITLE
Ensure we don't add duplicate Health Checks

### DIFF
--- a/src/Components/Aspire.Azure.Data.Tables/Aspire.Azure.Data.Tables.csproj
+++ b/src/Components/Aspire.Azure.Data.Tables/Aspire.Azure.Data.Tables.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/Aspire.Azure.Messaging.ServiceBus.csproj
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/Aspire.Azure.Messaging.ServiceBus.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Security.KeyVault/Aspire.Azure.Security.KeyVault.csproj
+++ b/src/Components/Aspire.Azure.Security.KeyVault/Aspire.Azure.Security.KeyVault.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Storage.Blobs/Aspire.Azure.Storage.Blobs.csproj
+++ b/src/Components/Aspire.Azure.Storage.Blobs/Aspire.Azure.Storage.Blobs.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Azure.Storage.Queues/Aspire.Azure.Storage.Queues.csproj
+++ b/src/Components/Aspire.Azure.Storage.Queues/Aspire.Azure.Storage.Queues.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <Compile Include="..\Common\AzureComponent.cs" Link="AzureComponent.cs" />
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/Aspire.Microsoft.Data.SqlClient.csproj
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/Aspire.Microsoft.Data.SqlClient.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/AspireSqlServerSqlClientExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/AspireSqlServerSqlClientExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire;
 using Aspire.Microsoft.Data.SqlClient;
 using HealthChecks.SqlServer;
 using Microsoft.Data.SqlClient;
@@ -106,16 +107,15 @@ public static class AspireSqlServerSqlClientExtensions
 
         if (settings.HealthChecks)
         {
-            builder.Services.AddHealthChecks()
-                .Add(new HealthCheckRegistration(
-                    serviceKey is null ? "SqlServer" : $"SqlServer_{connectionName}",
-                    sp => new SqlServerHealthCheck(new SqlServerHealthCheckOptions()
-                    {
-                        ConnectionString = settings.ConnectionString ?? string.Empty
-                    }),
-                    failureStatus: default,
-                    tags: default,
-                    timeout: default));
+            builder.TryAddHealthCheck(new HealthCheckRegistration(
+                serviceKey is null ? "SqlServer" : $"SqlServer_{connectionName}",
+                sp => new SqlServerHealthCheck(new SqlServerHealthCheckOptions()
+                {
+                    ConnectionString = settings.ConnectionString ?? string.Empty
+                }),
+                failureStatus: default,
+                tags: default,
+                timeout: default));
         }
     }
 }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AspireSqlServerEFCoreSqlClientExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AspireSqlServerEFCoreSqlClientExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Aspire;
 using Aspire.Microsoft.EntityFrameworkCore.SqlServer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -90,7 +91,9 @@ public static class AspireSqlServerEFCoreSqlClientExtensions
 
         if (settings.HealthChecks)
         {
-            builder.Services.AddHealthChecks().AddDbContextCheck<TContext>();
+            builder.TryAddHealthCheck(
+                name: typeof(TContext).Name,
+                static hcBuilder => hcBuilder.AddDbContextCheck<TContext>());
         }
 
         void ConfigureDbContext(DbContextOptionsBuilder dbContextOptionsBuilder)

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="..\Aspire.Npgsql\NpgsqlCommon.cs" />
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AspireEFPostgreSqlExtensions.cs
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/AspireEFPostgreSqlExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Aspire;
 using Aspire.Npgsql.EntityFrameworkCore.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -95,7 +96,9 @@ public static partial class AspireEFPostgreSqlExtensions
         if (settings.HealthChecks)
         {
             // calling MapHealthChecks is the responsibility of the app, not Component
-            builder.Services.AddHealthChecks().AddDbContextCheck<TContext>();
+            builder.TryAddHealthCheck(
+                name: typeof(TContext).Name,
+                static hcBuilder => hcBuilder.AddDbContextCheck<TContext>());
         }
 
         if (settings.Tracing)

--- a/src/Components/Aspire.Npgsql/Aspire.Npgsql.csproj
+++ b/src/Components/Aspire.Npgsql/Aspire.Npgsql.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.NpgSql" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />

--- a/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
+++ b/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Data.Common;
+using Aspire;
 using Aspire.Npgsql;
 using HealthChecks.NpgSql;
 using Microsoft.Extensions.Configuration;
@@ -71,18 +72,17 @@ public static class AspirePostgreSqlNpgsqlExtensions
         // https://www.npgsql.org/doc/connection-string-parameters.html#pooling
         if (settings.HealthChecks)
         {
-            builder.Services.AddHealthChecks()
-                .Add(new HealthCheckRegistration(
-                    serviceKey is null ? "PostgreSql" : $"PostgreSql_{connectionName}",
-                    sp => new NpgSqlHealthCheck(new NpgSqlHealthCheckOptions()
-                    {
-                        DataSource = serviceKey is null
-                            ? sp.GetRequiredService<NpgsqlDataSource>()
-                            : sp.GetRequiredKeyedService<NpgsqlDataSource>(serviceKey)
-                    }),
-                    failureStatus: default,
-                    tags: default,
-                    timeout: default));
+            builder.TryAddHealthCheck(new HealthCheckRegistration(
+                serviceKey is null ? "PostgreSql" : $"PostgreSql_{connectionName}",
+                sp => new NpgSqlHealthCheck(new NpgSqlHealthCheckOptions()
+                {
+                    DataSource = serviceKey is null
+                        ? sp.GetRequiredService<NpgsqlDataSource>()
+                        : sp.GetRequiredKeyedService<NpgsqlDataSource>(serviceKey)
+                }),
+                failureStatus: default,
+                tags: default,
+                timeout: default));
         }
 
         if (settings.Tracing)

--- a/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
+++ b/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Net.Sockets;
+using Aspire;
 using Aspire.RabbitMQ.Client;
 using HealthChecks.RabbitMQ;
 using Microsoft.Extensions.Configuration;
@@ -119,9 +120,7 @@ public static class AspireRabbitMQExtensions
 
         if (settings.HealthChecks)
         {
-            var hcBuilder = builder.Services.AddHealthChecks();
-
-            hcBuilder.Add(new HealthCheckRegistration(
+            builder.TryAddHealthCheck(new HealthCheckRegistration(
                 serviceKey is null ? "RabbitMQ.Client" : $"RabbitMQ.Client_{connectionName}",
                 sp =>
                 {

--- a/src/Components/Aspire.StackExchange.Redis/Aspire.StackExchange.Redis.csproj
+++ b/src/Components/Aspire.StackExchange.Redis/Aspire.StackExchange.Redis.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Redis" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />

--- a/src/Components/Common/HealthChecksExtensions.cs
+++ b/src/Components/Common/HealthChecksExtensions.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+
+namespace Aspire;
+
+internal static class HealthChecksExtensions
+{
+    /// <summary>
+    /// Adds a HealthCheckRegistration if one hasn't already been added to the builder.
+    /// </summary>
+    public static void TryAddHealthCheck(this IHostApplicationBuilder builder, HealthCheckRegistration healthCheckRegistration)
+    {
+        builder.TryAddHealthCheck(healthCheckRegistration.Name, hcBuilder => hcBuilder.Add(healthCheckRegistration));
+    }
+
+    /// <summary>
+    /// Invokes the <paramref name="addHealthCheck"/> action if the given <paramref name="name"/> hasn't already been added to the builder.
+    /// </summary>
+    public static void TryAddHealthCheck(this IHostApplicationBuilder builder, string name, Action<IHealthChecksBuilder> addHealthCheck)
+    {
+        var healthCheckKey = $"Aspire.HealthChecks.{name}";
+        if (!builder.Properties.ContainsKey(healthCheckKey))
+        {
+            builder.Properties[healthCheckKey] = true;
+            addHealthCheck(builder.Services.AddHealthChecks());
+        }
+    }
+}

--- a/tests/Aspire.StackExchange.Redis.Tests/Aspire.StackExchange.Redis.Tests.csproj
+++ b/tests/Aspire.StackExchange.Redis.Tests/Aspire.StackExchange.Redis.Tests.csproj
@@ -6,6 +6,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Components\Aspire.StackExchange.Redis\Aspire.StackExchange.Redis.csproj" />
+    <ProjectReference Include="..\..\src\Components\Aspire.StackExchange.Redis.DistributedCaching\Aspire.StackExchange.Redis.DistributedCaching.csproj" />
+    <ProjectReference Include="..\..\src\Components\Aspire.StackExchange.Redis.OutputCaching\Aspire.StackExchange.Redis.OutputCaching.csproj" />
+
     <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
When adding Health Checks, we need to ensure we don't add the same health check twice. ASP.NET will throw an exception if 2 health checks have the same name.

Use the HostApplicationBuilder Properties to ensure an Aspire Component doesn't add the same health check twice.

Fix #705