### PR TITLE
Add entry with workaround for known service startup performance issue in VS 17.9 Preview 1

### DIFF
--- a/docs/tips-and-known-issues.md
+++ b/docs/tips-and-known-issues.md
@@ -20,3 +20,6 @@ ps | where ProcessName -cmatch '(Api)|(Catalog)|(Basket)|(AppHost)|(MyFrontend)|
 ps | where ProcessName -cmatch '(Api)|(Catalog)|(Basket)|(AppHost)|(MyFrontend)|(OrderProcessor)' | % {Write-Output $_.Id; kill $_.Id }
 ```
 
+### Why does it seem to take a long time for my services to reach a ready state when running in Visual Studio?
+
+There's a known performance issue in Visual Studio 2022 17.9 Preview 1 related to a debugger setting which can cause delays during service startup for a .NET Aspire AppHost project with multiple service projects. To work around this issue, go to `Tools > Options > Debugging > General` and uncheck `Enable the External Sources node in Solution Explorer`.

--- a/docs/tips-and-known-issues.md
+++ b/docs/tips-and-known-issues.md
@@ -22,4 +22,4 @@ ps | where ProcessName -cmatch '(Api)|(Catalog)|(Basket)|(AppHost)|(MyFrontend)|
 
 ### Why does it seem to take a long time for my services to reach a ready state when running in Visual Studio?
 
-There's a known performance issue in Visual Studio 2022 17.9 Preview 1 related to a debugger setting which can cause delays during service startup for a .NET Aspire AppHost project with multiple service projects. To work around this issue, go to `Tools > Options > Debugging > General` and uncheck `Enable the External Sources node in Solution Explorer`.
+There is a known performance issue in Visual Studio 2022 17.9 Preview 1 related to a debugger setting which can cause delays during service startup for a .NET Aspire AppHost project with multiple service projects. To work around this issue, go to `Tools > Options > Debugging > General` and uncheck `Enable the External Sources node in Solution Explorer`.


### PR DESCRIPTION
Update the tips-and-known-issues readme with a note on the workaround for the service startup performance issue in 17.9 Preview 1.