### PR TITLE
Add docs link to header

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -9,11 +9,14 @@
 <div class="layout">
     <FluentHeader>
         <div class="header-title">
-            <FluentAnchor IconStart="@(new AspireIcons.Size32.Logo())" Appearance="Appearance.Stealth" Href="/">
+            <FluentAnchor IconStart="@(new AspireIcons.Size32.Logo())" Appearance="Appearance.Stealth" Href="/" Class="logo">
                 @dashboardViewModelService.ApplicationName Dashboard
             </FluentAnchor>
         </div>
         <div class="header-right">
+            <FluentAnchor Appearance="Appearance.Stealth" IconEnd="@(new Icons.Regular.Size24.QuestionCircle())"
+                          Href="https://aka.ms/dotnet/aspire/dashboard" Target="_blank" Rel="noreferrer noopener"
+                          Title="Help" aria-label="Help" />
             <FluentButton Appearance="Appearance.Stealth" OnClick="LaunchSettings" IconEnd="@(new Icons.Regular.Size24.Settings())"
                           Title="Launch Settings" aria-label="Launch Settings" />
         </div>

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -49,7 +49,8 @@
 }
 
 ::deep.layout > header fluent-button[appearance=stealth]:not(:hover)::part(control),
-::deep.layout > header fluent-anchor[appearance=stealth]::part(control) {
+::deep.layout > header fluent-anchor[appearance=stealth]:not(:hover)::part(control),
+::deep.layout > header fluent-anchor[appearance=stealth].logo::part(control) {
     background-color: var(--neutral-layer-4);
 }
 


### PR DESCRIPTION
Adds a link to https://aka.ms/dotnet/aspire/dashboard to the header of the dashboard

![image](https://github.com/dotnet/aspire/assets/9613109/fde4a443-2718-4e54-8ce5-a59a912bbebd)
![image](https://github.com/dotnet/aspire/assets/9613109/7fd709aa-9238-461e-ae34-4333d308d872)
