### PR TITLE
Improve log level filter UI

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -28,7 +28,7 @@
                       slot="end" />
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <div title="Minimum log level filter" slot="end" style="display: flex;align-items: center;">
-            <span>Min level:</span>
+            <span>Min Level:</span>
             <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <FluentSelect TOption="SelectViewModel<LogLevel?>"
                           Items="@_logLevels"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -28,7 +28,7 @@
                       slot="end" />
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <div title="Minimum log level filter" slot="end" style="display: flex;align-items: center;">
-            <span>Min Level:</span>
+            <span>Level:</span>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <FluentSelect TOption="SelectViewModel<LogLevel?>"
                           Items="@_logLevels"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -27,16 +27,17 @@
                       Placeholder="Filter..."
                       slot="end" />
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-        <span slot="end">Level:</span>
-        <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-        <FluentSelect TOption="SelectViewModel<LogLevel?>"
-                      Items="@_logLevels"
-                      OptionText="@(c => c.Name)"
-                      @bind-SelectedOption="_selectedLogLevel"
-                      @bind-SelectedOption:after="HandleSelectedLogLevelChangedAsync"
-                      Width="120px"
-                      Style="min-width: auto;"
-                      slot="end" />
+        <div title="Minimum log level filter" slot="end" style="display: flex;align-items: center;">
+            <span>Min level:</span>
+            <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+            <FluentSelect TOption="SelectViewModel<LogLevel?>"
+                          Items="@_logLevels"
+                          OptionText="@(c => c.Name)"
+                          @bind-SelectedOption="_selectedLogLevel"
+                          @bind-SelectedOption:after="HandleSelectedLogLevelChangedAsync"
+                          Width="120px"
+                          Style="min-width: auto;" />
+        </div>
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <FluentLabel slot="end">Filters: </FluentLabel>
         @if (ViewModel.Filters.Count == 0)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -29,7 +29,7 @@
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <div title="Minimum log level filter" slot="end" style="display: flex;align-items: center;">
             <span>Min Level:</span>
-            <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+            <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <FluentSelect TOption="SelectViewModel<LogLevel?>"
                           Items="@_logLevels"
                           OptionText="@(c => c.Name)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/703

Two changes:

"Level" text is now "Min level":
![image](https://github.com/dotnet/aspire/assets/303201/4c8107e6-d727-4164-a2d6-f23015a4954b)

I don't 100% like this change. `Min level: (All)` is odd.

New tooltip:
![image](https://github.com/dotnet/aspire/assets/303201/b94f8a1b-0e37-4c33-b798-517579409658)
