### PR TITLE
Update FluentUI Blazor Components to 4.0 RC2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,8 +75,8 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="11.0.36" />
     <PackageVersion Include="JsonSchema.Net" Version="5.2.5" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.0.0-preview.2" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.0.0-preview.2" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.0.0-rc.2" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.0.0-rc.2" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.0-rc.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-rc.2" />
     <PackageVersion Include="Polly" Version="8.0.0" />

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -87,10 +87,7 @@ public class DashboardWebApplication : IHostedService
         builder.Services.AddTransient<StructuredLogsViewModel>();
         builder.Services.AddTransient<TracesViewModel>();
 
-        builder.Services.AddFluentUIComponents(options =>
-        {
-            options.HostingModel = BlazorHostingModel.Server;
-        });
+        builder.Services.AddFluentUIComponents();
 
         configureServices(builder.Services);
 

--- a/src/Aspire.Dashboard/wwwroot/Aspire.Dashboard.lib.module.js
+++ b/src/Aspire.Dashboard/wwwroot/Aspire.Dashboard.lib.module.js
@@ -1,9 +1,0 @@
-import * as LibraryExports from "/_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js";
-
-export function beforeServerStart(options, extensions) {
-    LibraryExports.beforeStart(options, extensions);
-}
-
-export function afterServerStarted(blazor) {
-    LibraryExports.afterStarted(blazor);
-}


### PR DESCRIPTION
Fixes #495 

Since this comes with support for the .NET 8 blazor initializers, we can remove our initializer shim and the warning that shows up in the browser console for the classic initializers will be gone.