### PR TITLE
Add link to GitHub Repo in header

### DIFF
--- a/src/Aspire.Dashboard/Components/CustomIcons/AspireIcons.cs
+++ b/src/Aspire.Dashboard/Components/CustomIcons/AspireIcons.cs
@@ -7,6 +7,13 @@ namespace Aspire.Dashboard.Components.CustomIcons;
 
 internal static class AspireIcons
 {
+    internal static class Size24
+    {
+        // The official SVGs from GitHub have a viewbox of 96x96, so we need to scale them down to 20x20 and center them within the 24x24 box to make them match the
+        // other icons we're using. We also need to remove the fill attribute from the SVGs so that we can color them with CSS. 
+        internal sealed class GitHub : Icon { public GitHub() : base("GitHub", IconVariant.Regular, IconSize.Size24, @"<path transform=""scale(0.20833) translate(9.6 9.6)"" fill-rule=""evenodd"" clip-rule=""evenodd"" d=""M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"" />") { } }
+    }
+
     internal static class Size32
     {
         internal sealed class Logo : Icon { public Logo() : base("Aspire", IconVariant.Regular, IconSize.Size32, @"<svg width=""32"" height=""32"" viewBox=""0 0 32 32"" fill=""none"" xmlns=""http://www.w3.org/2000/svg"">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -15,7 +15,7 @@
         </div>
         <div class="header-right">
             <FluentAnchor Appearance="Appearance.Stealth" IconEnd="@(new AspireIcons.Size24.GitHub())"
-                          Href="http://github.com/dotnet/aspire" Target="_blank" Rel="noreferrer noopener"
+                          Href="https://aka.ms/dotnet/aspire/repo" Target="_blank" Rel="noreferrer noopener"
                           Title=".NET Aspire Repo" aria-label=".NET Aspire Repo" />
             <FluentAnchor Appearance="Appearance.Stealth" IconEnd="@(new Icons.Regular.Size24.QuestionCircle())"
                           Href="https://aka.ms/dotnet/aspire/dashboard" Target="_blank" Rel="noreferrer noopener"

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -14,6 +14,9 @@
             </FluentAnchor>
         </div>
         <div class="header-right">
+            <FluentAnchor Appearance="Appearance.Stealth" IconEnd="@(new AspireIcons.Size24.GitHub())"
+                          Href="http://github.com/dotnet/aspire" Target="_blank" Rel="noreferrer noopener"
+                          Title=".NET Aspire Repo" aria-label=".NET Aspire Repo" />
             <FluentAnchor Appearance="Appearance.Stealth" IconEnd="@(new Icons.Regular.Size24.QuestionCircle())"
                           Href="https://aka.ms/dotnet/aspire/dashboard" Target="_blank" Rel="noreferrer noopener"
                           Title="Help" aria-label="Help" />


### PR DESCRIPTION
Goes along #713 and adds a link to the Aspire repo in the header to finish off @IEvangelist 's suggestions

![image](https://github.com/dotnet/aspire/assets/9613109/967b9bf3-2f40-42fe-bc5e-7a129617b3bf)
![image](https://github.com/dotnet/aspire/assets/9613109/bff94661-ff69-4f0b-817d-baeeca0832e4)

It seems less important for the GH link to be an aka.ms link, but should we make it one anyway?

@leslierichardson95 looking for your feedback here specifically to make sure you're fine with the additional icon/link