### PR TITLE
[release/8.0-preview1] Update use of "Aspire" to ".NET Aspire" in .md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET Aspire
 
-## Getting started with Aspire
+## Getting started with .NET Aspire
 
 Follow instructions in [docs/getting-started.md](docs/getting-started.md) to get started using .NET Aspire.
 

--- a/docs/getting-perf-traces.md
+++ b/docs/getting-perf-traces.md
@@ -7,13 +7,13 @@ Collect the trace using PerfView (https://github.com/microsoft/perfview/releases
 1. Increase Circular MB to 8192.
 1. Check the "Thread Time" checkbox.
 1. Expand Advanced Options panel and make sure you have Kernel Base, Cpu Samples, File I/O, .NET, and Task (TPL) options checked.
-1. In "Additional Providers" add `*Microsoft-Aspire-Hosting` (note the asterisk before the Aspire provider name!).
+1. In "Additional Providers" add `*Microsoft-Aspire-Hosting` (note the asterisk before the .NET Aspire provider name!).
 
 Once you are ready, git "Start Collection" button and run your scenario.
 
 When done with the scenario, hit "Stop Collection". Wait for PerfView to finish merging and analyzing data (the "working" status bar stops flashing).
 
-### Verify that the trace contains data Aspire data
+### Verify that the trace contains data .NET Aspire data
 
 This is an optional step, but if you are wondering if your trace has been captured properly, you can check the following:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ it, you need to perform the following steps:
    expiration length:
     [<img width="583" alt="image" src="https://user-images.githubusercontent.com/249088/160220117-7e79822e-a18a-445c-89ff-b3d9ca84892f.png">](https://github.com/settings/tokens/new)
 
-1. At the command line, go to the root of the Aspire repo and run the following
+1. At the command line, go to the root of the .NET Aspire repo and run the following
    commands to add the package feed to your NuGet configuration, replacing the
    `<YOUR_USER_NAME>` and `<YOUR_TOKEN>` placeholders with the relevant values:
    ```text
@@ -61,7 +61,7 @@ it, you need to perform the following steps:
    dotnet nuget add source -u <YOUR_USER_NAME> -p <YOUR_TOKEN> --name dotnet-libraries-internal "https://nuget.pkg.github.com/dotnet/index.json"
    ```
 
-## Install the Aspire dotnet workload
+## Install the .NET Aspire dotnet workload
 
 ### Visual Studio
 
@@ -73,19 +73,19 @@ Ensure the `.NET Aspire SDK` component is checked in `Individual components`.
 
 ### Command line
 
-1. The RTM nightly SDK is aware that the Aspire workload exists, but the real manifest is not installed by default. In order to install it, you'll need to update the workload in a directory that has a NuGet.config[^3] with the right feeds configured[^2] so that it can pull the latest manifest. Once you have created the NuGet.config file in your working directory, then you need to run the following command[^1]:
+1. The RTM nightly SDK is aware that the .NET Aspire workload exists, but the real manifest is not installed by default. In order to install it, you'll need to update the workload in a directory that has a NuGet.config[^3] with the right feeds configured[^2] so that it can pull the latest manifest. Once you have created the NuGet.config file in your working directory, then you need to run the following command[^1]:
 
     ```shell
     dotnet workload update --skip-sign-check --interactive
     ```
 
-2. The above command will update the Aspire manifest in your SDK build, meaning it will already be setup for command-line and Visual Studio in-product acquisition (IPA) of the Aspire workload. In order to manually install the workload, you can run the following command[^1]:
+2. The above command will update the .NET Aspire manifest in your SDK build, meaning it will already be setup for command-line and Visual Studio in-product acquisition (IPA) of the .NET Aspire workload. In order to manually install the workload, you can run the following command[^1]:
 
     ```shell
     dotnet workload install aspire --skip-sign-check --interactive
     ```
 
-[^1]: The `--skip-sign-check` flag is required because the packages we build out of the Aspire repo are not yet signed.
+[^1]: The `--skip-sign-check` flag is required because the packages we build out of the .NET Aspire repo are not yet signed.
 [^2]: If you want to create a separate NuGet.config instead, these are the contents you need:
       ```xml
       <?xml version="1.0" encoding="utf-8"?>
@@ -111,7 +111,7 @@ Ensure the `.NET Aspire SDK` component is checked in `Individual components`.
 
 ## Using command line using workload templates
 
-- To create an empty Aspire project[^3], run the following command::
+- To create an empty .NET Aspire project[^3], run the following command::
 
 ```shell
     dotnet new aspire
@@ -123,7 +123,7 @@ Ensure the `.NET Aspire SDK` component is checked in `Individual components`.
     dotnet new aspire-starter
 ```
 
-[^3]: In order for these commands to work, you must have already installed the Aspire workload by following the steps in #Install-the-Aspire-dotnet-workload section.
+[^3]: In order for these commands to work, you must have already installed the .NET Aspire workload by following the steps in #Install-the-Aspire-dotnet-workload section.
 
 You need to create a `NuGet.config` file in the root directory of your project with the contents above.
 Once that is created you can build with

--- a/docs/open-telemetry-architecture.md
+++ b/docs/open-telemetry-architecture.md
@@ -1,8 +1,8 @@
-# Aspire OpenTelemetry architecture
+# .NET Aspire OpenTelemetry architecture
 
-One of Aspire's objectives is to ensure that apps are straightforward to debug and diagnose. By default, Aspire apps are configured to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, Aspire local development includes UI in the dashboard for viewing OTEL data. Telemetry just works and is easy to use.
+One of .NET Aspire's objectives is to ensure that apps are straightforward to debug and diagnose. By default, .NET Aspire apps are configured to collect and export telemetry using [OpenTelemetry (OTEL)](https://opentelemetry.io/). Additionally, .NET Aspire local development includes UI in the dashboard for viewing OTEL data. Telemetry just works and is easy to use.
 
-This document details how OpenTelemtry is used in Aspire apps.
+This document details how OpenTelemtry is used in .NET Aspire apps.
 
 ## Telemetry types
 
@@ -18,7 +18,7 @@ When an OpenTelemetry SDK is configured in an app, it receives data from these A
 
 The [.NET OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-dotnet) offers features for gathering data from several .NET APIs, including `ILogger`, `Activity`, `Meter`, and `Instrument<T>`. It then facilitates the export of this telemetry data to a data store or reporting tool. The telemetry export mechanism relies on the [OpenTelemetry protocol (OTLP)](https://opentelemetry.io/docs/specs/otel/protocol/), which serves as a standardized approach for transmitting telemetry data through REST or gRPC.
 
-.NET projects setup the .NET OpenTelemetry SDK using the _service defaults_ project. Aspire templates automatically create the service defaults, and Aspire apps call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
+.NET projects setup the .NET OpenTelemetry SDK using the _service defaults_ project. .NET Aspire templates automatically create the service defaults, and .NET Aspire apps call it at startup. The service defaults enable collecting and exporting telemetry for .NET apps.
 
 ## OpenTelemetry environment variables
 
@@ -32,14 +32,14 @@ Aspire apps launch with environment variables that configure the name and ID of 
 
 The environment variables are automatically set in local development.
 
-## Aspire local development
+## .NET Aspire local development
 
-The Aspire dashboard provides UI for viewing the telemetry of apps. Telemetry data is sent to the dashboard using OTLP, and the dashboard implements an OTLP server to receive telemetry data and store it in memory. The dashboard UI presents telemetry stored in memory.
+The .NET Aspire dashboard provides UI for viewing the telemetry of apps. Telemetry data is sent to the dashboard using OTLP, and the dashboard implements an OTLP server to receive telemetry data and store it in memory. The dashboard UI presents telemetry stored in memory.
 
 Aspire debugging workflow:
 
-* Developer starts the Aspire app with debugging, presses <kbd>F5</kbd>.
-* Aspire dashboard and developer control plane (DCP) start.
+* Developer starts the .NET Aspire app with debugging, presses <kbd>F5</kbd>.
+* .NET Aspire dashboard and developer control plane (DCP) start.
 * App configuration is run in the _AppHost_ project.
   * OTEL environment variables are automatically added to .NET projects during app configuration.
   * DCP provides the name (`OTEL_SERVICE_NAME`) and ID (`OTEL_RESOURCE_ATTRIBUTES`) of the app in exported telemetry.
@@ -47,9 +47,9 @@ Aspire debugging workflow:
   * Small export intervals (`OTEL_BSP_SCHEDULE_DELAY`, `OTEL_BLRP_SCHEDULE_DELAY`, `OTEL_METRIC_EXPORT_INTERVAL`) so data is quickly available in the dashboard. Small values are used in local development to prioritize dashboard responsiveness over efficiency.
 * The DCP starts configured projects, containers, and executables.
 * Once started, apps send telemetry to the dashboard.
-* Dashboard displays near real-time telemetry of all Aspire apps.
+* Dashboard displays near real-time telemetry of all .NET Aspire apps.
 
-## Aspire deployment
+## .NET Aspire deployment
 
 Aspire deployment environments should configure OTEL environment variables that make sense for their environment. For example, `OTEL_EXPORTER_OTLP_ENDPOINT` should be configured to the environment's local OTLP collector or monitoring service.
 

--- a/docs/repo-instructions.md
+++ b/docs/repo-instructions.md
@@ -11,7 +11,7 @@ You can launch VS with:
 1. `.\restore.cmd`
 2. `.\startvs.cmd`
 
-# Run the Aspire eShopLite sample
+# Run the .NET Aspire eShopLite sample
 
 ## Enable Azure ServiceBus (optional)
 

--- a/docs/specs/manifest-spec.md
+++ b/docs/specs/manifest-spec.md
@@ -1,12 +1,12 @@
-# Manifest Specification for Aspire's Distributed Application Model
+# Manifest Specification for .NET Aspire's Distributed Application Model
 
-This is a specification for the manifest file for Aspire's Distributed Application Model. The purpose of the manifest file is to allow developers to export definitions of components that comprise their distributed application model and their dependencies so that other tools can process it to facilitate deployment into target runtime environments.
+This is a specification for the manifest file for .NET Aspire's Distributed Application Model. The purpose of the manifest file is to allow developers to export definitions of components that comprise their distributed application model and their dependencies so that other tools can process it to facilitate deployment into target runtime environments.
 
 The format of the manifest file itself does not pre-suppose a particular target environment but this document will make reference to specific cloud providers and technologies for illustrative purposes.
 
 ## Basic model
 
-The Aspire distributed application model is comprised components which are typically deployed together as a unit. For example there may be a front-end ASP.NET Core application which calls into one or more backend services which in turn may depend on relational databases or caches. Consider the following sample (taken from the eShop light example):
+The .NET Aspire distributed application model is comprised components which are typically deployed together as a unit. For example there may be a front-end ASP.NET Core application which calls into one or more backend services which in turn may depend on relational databases or caches. Consider the following sample (taken from the eShop light example):
 
 ```csharp
 using Aspire.Hosting.Postgres;

--- a/docs/tips-and-known-issues.md
+++ b/docs/tips-and-known-issues.md
@@ -6,9 +6,9 @@ We have seen Docker get into weird state on "DevBox" machines that get hibernate
 
 The remedy is to do "Restart Docker" gesture from the Docker icon in system tray.
 
-### If something goes wrong and you are left with a bunch of Aspire eShopLite orphaned processes and containers
+### If something goes wrong and you are left with a bunch of .NET Aspire eShopLite orphaned processes and containers
 
-This will display process IDs of all the Aspire shopping running processes
+This will display process IDs of all the .NET Aspire shopping running processes
 
 ```ps1
 ps | where ProcessName -cmatch '(Api)|(Catalog)|(Basket)|(AppHost)|(MyFrontend)|(OrderProcessor)' | % {Write-Output $_.Id }

--- a/src/Components/Aspire.Azure.Data.Tables/README.md
+++ b/src/Components/Aspire.Azure.Data.Tables/README.md
@@ -11,7 +11,7 @@ Registers [TableServiceClient](https://learn.microsoft.com/dotnet/api/azure.data
 
 ### Install the package
 
-Install the Aspire Azure Table storage library with [NuGet][nuget]:
+Install the .NET Aspire Azure Table storage library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Azure.Data.Tables
@@ -40,7 +40,7 @@ See the [Azure.Data.Tables documentation](https://github.com/Azure/azure-sdk-for
 
 ## Configuration
 
-The Aspire Azure Table storage library provides multiple options to configure the Azure Table connection based on the requirements and conventions of your project. Note that either a `ServiceUri` or a `ConnectionString` is a required to be supplied.
+The .NET Aspire Azure Table storage library provides multiple options to configure the Azure Table connection based on the requirements and conventions of your project. Note that either a `ServiceUri` or a `ConnectionString` is a required to be supplied.
 
 ### Use a connection string
 

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
@@ -11,7 +11,7 @@ Registers a [ServiceBusClient](https://learn.microsoft.com/dotnet/api/azure.mess
 
 ### Install the package
 
-Install the Aspire Azure Service Bus library with [NuGet][nuget]:
+Install the .NET Aspire Azure Service Bus library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Azure.Messaging.ServiceBus
@@ -40,7 +40,7 @@ See the [Azure.Messaging.ServiceBus documentation](https://github.com/Azure/azur
 
 ## Configuration
 
-The Aspire Azure Service Bus library provides multiple options to configure the Azure Service Bus connection based on the requirements and conventions of your project. Note that either a `Namespace` or a `ConnectionString` is a required to be supplied.
+The .NET Aspire Azure Service Bus library provides multiple options to configure the Azure Service Bus connection based on the requirements and conventions of your project. Note that either a `Namespace` or a `ConnectionString` is a required to be supplied.
 
 ### Use a connection string
 
@@ -78,7 +78,7 @@ Alternatively, a connection string can be used.
 
 ### Use configuration providers
 
-The Aspire Azure Service Bus library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureMessagingServiceBusSettings` and `ServiceBusClientOptions` from configuration by using the `Aspire:Azure:Messaging:ServiceBus` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire Azure Service Bus library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureMessagingServiceBusSettings` and `ServiceBusClientOptions` from configuration by using the `Aspire:Azure:Messaging:ServiceBus` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Security.KeyVault/README.md
+++ b/src/Components/Aspire.Azure.Security.KeyVault/README.md
@@ -11,7 +11,7 @@ Retrieves secrets from Azure Key Vault to use in your application. Registers a [
 
 ### Install the package
 
-Install the Aspire Azure Key Vault library with [NuGet][nuget]:
+Install the .NET Aspire Azure Key Vault library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Azure.Security.KeyVault
@@ -59,7 +59,7 @@ See the [Azure.Security.KeyVault.Secrets documentation](https://github.com/Azure
 
 ## Configuration
 
-The Aspire Azure Key Vault library provides multiple options to configure the Azure Key Vault connection based on the requirements and conventions of your project. Note that the `VaultUri` is required to be supplied.
+The .NET Aspire Azure Key Vault library provides multiple options to configure the Azure Key Vault connection based on the requirements and conventions of your project. Note that the `VaultUri` is required to be supplied.
 
 ### Use a connection string
 
@@ -81,7 +81,7 @@ And then the vault URI will be retrieved from the `ConnectionStrings` configurat
 
 ### Use configuration providers
 
-The Aspire Azure Key Vault library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureSecurityKeyVaultSettings` and `SecretClientOptions` from configuration by using the `Aspire:Azure:Security:KeyVault` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire Azure Key Vault library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureSecurityKeyVaultSettings` and `SecretClientOptions` from configuration by using the `Aspire:Azure:Security:KeyVault` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Storage.Blobs/README.md
+++ b/src/Components/Aspire.Azure.Storage.Blobs/README.md
@@ -11,7 +11,7 @@ Registers a [BlobServiceClient](https://learn.microsoft.com/dotnet/api/azure.sto
 
 ### Install the package
 
-Install the Aspire Azure Storage Blobs library with [NuGet][nuget]:
+Install the .NET Aspire Azure Storage Blobs library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Azure.Storage.Blobs
@@ -40,7 +40,7 @@ See the [Azure.Storage.Blobs documentation](https://github.com/Azure/azure-sdk-f
 
 ## Configuration
 
-The Aspire Azure Storage Blobs library provides multiple options to configure the Azure Storage Blob connection based on the requirements and conventions of your project. Note that either a `ServiceUri` or a `ConnectionString` is a required to be supplied.
+The .NET Aspire Azure Storage Blobs library provides multiple options to configure the Azure Storage Blob connection based on the requirements and conventions of your project. Note that either a `ServiceUri` or a `ConnectionString` is a required to be supplied.
 
 ### Use a connection string
 
@@ -78,7 +78,7 @@ Alternatively, an [Azure Storage connection string](https://learn.microsoft.com/
 
 ### Use configuration providers
 
-The Aspire Azure Storage Blobs library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureStorageBlobsSettings` and `BlobClientOptions` from configuration by using the `Aspire:Azure:Storage:Blobs` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire Azure Storage Blobs library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureStorageBlobsSettings` and `BlobClientOptions` from configuration by using the `Aspire:Azure:Storage:Blobs` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.Azure.Storage.Queues/README.md
+++ b/src/Components/Aspire.Azure.Storage.Queues/README.md
@@ -11,7 +11,7 @@ Registers [QueueServiceClient](https://learn.microsoft.com/dotnet/api/azure.stor
 
 ### Install the package
 
-Install the Aspire Azure Storage Queues library with [NuGet][nuget]:
+Install the .NET Aspire Azure Storage Queues library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Azure.Storage.Queues
@@ -40,7 +40,7 @@ See the [Azure.Storage.Queues documentation](https://github.com/Azure/azure-sdk-
 
 ## Configuration
 
-The Aspire Azure Storage Queues library provides multiple options to configure the Azure Storage Queues connection based on the requirements and conventions of your project. Note that either a `ServiceUri` or a `ConnectionString` is a required to be supplied.
+The .NET Aspire Azure Storage Queues library provides multiple options to configure the Azure Storage Queues connection based on the requirements and conventions of your project. Note that either a `ServiceUri` or a `ConnectionString` is a required to be supplied.
 
 ### Use a connection string
 
@@ -78,7 +78,7 @@ Alternatively, an [Azure Storage connection string](https://learn.microsoft.com/
 
 ### Use configuration providers
 
-The Aspire Azure Storage Queues library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureStorageQueuesSettings` and `QueueClientOptions` from configuration by using the `Aspire:Azure:Storage:Queues` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire Azure Storage Queues library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureStorageQueuesSettings` and `QueueClientOptions` from configuration by using the `Aspire:Azure:Storage:Queues` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -11,7 +11,7 @@ Registers [CosmosClient](https://learn.microsoft.com/dotnet/api/microsoft.azure.
 
 ### Install the package
 
-Install the Aspire Microsft Azure Cosmos DB library with [NuGet][nuget]:
+Install the .NET Aspire Microsft Azure Cosmos DB library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Microsoft.Azure.Cosmos
@@ -40,7 +40,7 @@ See the [Azure Cosmos DB documentation](https://learn.microsoft.com/dotnet/api/m
 
 ## Configuration
 
-The Aspire Azure Cosmos DB library provides multiple options to configure the Azure Cosmos DB connection based on the requirements and conventions of your project. Note that either an `AccountEndpoint` or a `ConnectionString` is a required to be supplied.
+The .NET Aspire Azure Cosmos DB library provides multiple options to configure the Azure Cosmos DB connection based on the requirements and conventions of your project. Note that either an `AccountEndpoint` or a `ConnectionString` is a required to be supplied.
 
 ### Use a connection string
 
@@ -78,7 +78,7 @@ Alternatively, an [Azure Cosmos DB connection string](https://learn.microsoft.co
 
 ### Use configuration providers
 
-The Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureCosmosDBSettings` and `QueueClientOptions` from configuration by using the `Aspire:Microsoft:Azure:Cosmos` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureCosmosDBSettings` and `QueueClientOptions` from configuration by using the `Aspire:Microsoft:Azure:Cosmos` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
@@ -10,7 +10,7 @@ Registers 'Scoped' [Microsoft.Data.SqlClient.SqlConnection](https://learn.micros
 
 ### Install the package
 
-Install the Aspire SQL Server SqlClient library with [NuGet][nuget]:
+Install the .NET Aspire SQL Server SqlClient library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Microsoft.Data.SqlClient
@@ -37,7 +37,7 @@ public ProductsController(SqlConnection connection)
 
 ## Configuration
 
-The Aspire SqlClient component provides multiple options to configure the SQL connection based on the requirements and conventions of your project.
+The .NET Aspire SqlClient component provides multiple options to configure the SQL connection based on the requirements and conventions of your project.
 
 ### Use a connection string
 
@@ -61,7 +61,7 @@ See the [ConnectionString documentation](https://learn.microsoft.com/dotnet/api/
 
 ### Use configuration providers
 
-The Aspire SqlClient component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `MicrosoftDataSqlClientSettings` from configuration by using the `Aspire:Microsoft:Data:SqlClient` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire SqlClient component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `MicrosoftDataSqlClientSettings` from configuration by using the `Aspire:Microsoft:Data:SqlClient` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
@@ -10,7 +10,7 @@ Registers [EntityFrameworkCore](https://learn.microsoft.com/en-us/ef/core/) [DbC
 
 ### Install the package
 
-Install the Aspire Microsoft EntityFrameworkCore Cosmos library with [NuGet][nuget]:
+Install the .NET Aspire Microsoft EntityFrameworkCore Cosmos library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Microsoft.EntityFrameworkCore.Cosmos
@@ -37,7 +37,7 @@ public ProductsController(MyDbContext context)
 
 ## Configuration
 
-The Aspire Microsoft EntityFrameworkCore Cosmos component provides multiple options to configure the database connection based on the requirements and conventions of your project.
+The .NET Aspire Microsoft EntityFrameworkCore Cosmos component provides multiple options to configure the database connection based on the requirements and conventions of your project.
 
 ### Use a connection string
 
@@ -61,7 +61,7 @@ See the [ConnectionString documentation](https://learn.microsoft.com/azure/cosmo
 
 ### Use configuration providers
 
-The Aspire Microsoft EntityFrameworkCore Cosmos component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `EntityFrameworkCoreCosmosDBSettings` from configuration by using the `Aspire:Microsaoft:EntityFrameworkCore:Cosmos` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire Microsoft EntityFrameworkCore Cosmos component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `EntityFrameworkCoreCosmosDBSettings` from configuration by using the `Aspire:Microsaoft:EntityFrameworkCore:Cosmos` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
@@ -10,7 +10,7 @@ Registers [EntityFrameworkCore](https://learn.microsoft.com/ef/core/) [DbContext
 
 ### Install the package
 
-Install the Aspire SQL Server EntityFrameworkCore SqlClient library with [NuGet][nuget]:
+Install the .NET Aspire SQL Server EntityFrameworkCore SqlClient library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Microsoft.EntityFrameworkCore.SqlServer
@@ -37,7 +37,7 @@ public ProductsController(MyDbContext context)
 
 ## Configuration
 
-The Aspire SQL Server EntityFrameworkCore SqlClient component provides multiple options to configure the SQL connection based on the requirements and conventions of your project.
+The .NET Aspire SQL Server EntityFrameworkCore SqlClient component provides multiple options to configure the SQL connection based on the requirements and conventions of your project.
 
 ### Use a connection string
 
@@ -61,7 +61,7 @@ See the [ConnectionString documentation](https://learn.microsoft.com/dotnet/api/
 
 ### Use configuration providers
 
-The Aspire SQL Server EntityFrameworkCore SqlClient component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `MicrosoftEntityFrameworkCoreSqlServerSettings` from configuration by using the `Aspire:Microsoft:EntityFrameworkCore:SqlServer` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire SQL Server EntityFrameworkCore SqlClient component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `MicrosoftEntityFrameworkCoreSqlServerSettings` from configuration by using the `Aspire:Microsoft:EntityFrameworkCore:SqlServer` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
@@ -10,7 +10,7 @@ Registers [EntityFrameworkCore](https://learn.microsoft.com/ef/core/) [DbContext
 
 ### Install the package
 
-Install the Aspire PostgreSQL EntityFrameworkCore Npgsql library with [NuGet][nuget]:
+Install the .NET Aspire PostgreSQL EntityFrameworkCore Npgsql library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Npgsql.EntityFrameworkCore.PostgreSQL
@@ -37,7 +37,7 @@ public ProductsController(MyDbContext context)
 
 ## Configuration
 
-The Aspire PostgreSQL EntityFrameworkCore Npgsql component provides multiple options to configure the database connection based on the requirements and conventions of your project.
+The .NET Aspire PostgreSQL EntityFrameworkCore Npgsql component provides multiple options to configure the database connection based on the requirements and conventions of your project.
 
 ### Use a connection string
 
@@ -61,7 +61,7 @@ See the [ConnectionString documentation](https://www.npgsql.org/doc/connection-s
 
 ### Use configuration providers
 
-The Aspire PostgreSQL EntityFrameworkCore Npgsql component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `NpgsqlEntityFrameworkCorePostgreSQLSettings` from configuration by using the `Aspire:Npgsql:EntityFrameworkCore:PostgreSQL` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire PostgreSQL EntityFrameworkCore Npgsql component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `NpgsqlEntityFrameworkCorePostgreSQLSettings` from configuration by using the `Aspire:Npgsql:EntityFrameworkCore:PostgreSQL` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.Npgsql/README.md
+++ b/src/Components/Aspire.Npgsql/README.md
@@ -10,7 +10,7 @@ Registers [NpgsqlDataSource](https://www.npgsql.org/doc/api/Npgsql.NpgsqlDataSou
 
 ### Install the package
 
-Install the Aspire PostgreSQL Npgsql library with [NuGet][nuget]:
+Install the .NET Aspire PostgreSQL Npgsql library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.Npgsql
@@ -37,7 +37,7 @@ public ProductsController(NpgsqlDataSource dataSource)
 
 ## Configuration
 
-The Aspire PostgreSQL Npgsql component provides multiple options to configure the database connection based on the requirements and conventions of your project.
+The .NET Aspire PostgreSQL Npgsql component provides multiple options to configure the database connection based on the requirements and conventions of your project.
 
 ### Use a connection string
 
@@ -61,7 +61,7 @@ See the [ConnectionString documentation](https://www.npgsql.org/doc/connection-s
 
 ### Use configuration providers
 
-The Aspire PostgreSQL Npgsql component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `NpgsqlSettings` from configuration by using the `Aspire:Npgsql` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire PostgreSQL Npgsql component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `NpgsqlSettings` from configuration by using the `Aspire:Npgsql` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.RabbitMQ.Client/README.md
+++ b/src/Components/Aspire.RabbitMQ.Client/README.md
@@ -10,7 +10,7 @@ Registers an [IConnection](https://rabbitmq.github.io/rabbitmq-dotnet-client/api
 
 ### Install the package
 
-Install the Aspire RabbitMQ library with [NuGet][nuget]:
+Install the .NET Aspire RabbitMQ library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.RabbitMQ.Client
@@ -37,7 +37,7 @@ public ProductsController(IConnection connection)
 
 ## Configuration
 
-The Aspire RabbitMQ component provides multiple options to configure the connection based on the requirements and conventions of your project.
+The .NET Aspire RabbitMQ component provides multiple options to configure the connection based on the requirements and conventions of your project.
 
 ### Use a connection string
 
@@ -61,7 +61,7 @@ See the [ConnectionString documentation](https://www.rabbitmq.com/uri-spec.html)
 
 ### Use configuration providers
 
-The Aspire RabbitMQ component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `RabbitMQClientSettings` from configuration by using the `Aspire:RabbitMQ:Client` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire RabbitMQ component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `RabbitMQClientSettings` from configuration by using the `Aspire:RabbitMQ:Client` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
@@ -10,7 +10,7 @@ Registers an [IDistributedCache](https://learn.microsoft.com/dotnet/api/microsof
 
 ### Install the package
 
-Install the Aspire StackExchange Redis Distributed Cache library with [NuGet][nuget]:
+Install the .NET Aspire StackExchange Redis Distributed Cache library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.StackExchange.Redis.DistributedCaching
@@ -37,7 +37,7 @@ public ProductsController(IDistributedCache cache)
 
 ## Configuration
 
-The Aspire StackExchange Redis Distributed Cache component provides multiple options to configure the Redis connection based on the requirements and conventions of your project. Note that at least one host name is required to connect.
+The .NET Aspire StackExchange Redis Distributed Cache component provides multiple options to configure the Redis connection based on the requirements and conventions of your project. Note that at least one host name is required to connect.
 
 ### Use a connection string
 

--- a/src/Components/Aspire.StackExchange.Redis.OutputCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.OutputCaching/README.md
@@ -10,7 +10,7 @@ Registers an [ASP.NET Core Output Caching](https://learn.microsoft.com/aspnet/co
 
 ### Install the package
 
-Install the Aspire StackExchange Redis OutputCache library with [NuGet][nuget]:
+Install the .NET Aspire StackExchange Redis OutputCache library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.StackExchange.Redis.OutputCaching
@@ -42,7 +42,7 @@ For apps with controllers, apply the `[OutputCache]` attribute to the action met
 
 ## Configuration
 
-The Aspire StackExchange Redis OutputCache component provides multiple options to configure the Redis connection based on the requirements and conventions of your project. Note that at least one host name is required to connect.
+The .NET Aspire StackExchange Redis OutputCache component provides multiple options to configure the Redis connection based on the requirements and conventions of your project. Note that at least one host name is required to connect.
 
 ### Use a connection string
 

--- a/src/Components/Aspire.StackExchange.Redis/README.md
+++ b/src/Components/Aspire.StackExchange.Redis/README.md
@@ -10,7 +10,7 @@ Registers an [IConnectionMultiplexer](https://stackexchange.github.io/StackExcha
 
 ### Install the package
 
-Install the Aspire StackExchange Redis library with [NuGet][nuget]:
+Install the .NET Aspire StackExchange Redis library with [NuGet][nuget]:
 
 ```dotnetcli
 dotnet add package Aspire.StackExchange.Redis
@@ -39,7 +39,7 @@ See the [StackExchange.Redis documentation](https://stackexchange.github.io/Stac
 
 ## Configuration
 
-The Aspire StackExchange Redis component provides multiple options to configure the Redis connection based on the requirements and conventions of your project. Note that at least one host name is required to connect.
+The .NET Aspire StackExchange Redis component provides multiple options to configure the Redis connection based on the requirements and conventions of your project. Note that at least one host name is required to connect.
 
 ### Use a connection string
 

--- a/src/Components/Aspire_Components_Progress.md
+++ b/src/Components/Aspire_Components_Progress.md
@@ -1,8 +1,8 @@
-# Aspire Components Progress for November
+# .NET Aspire Components Progress for November
 
-As part of the Aspire November preview, we want to include a set of Aspire Components which help developers build Aspire applications. These components should follow the [Aspire Component Requirements](#aspire-component-requirements). Bellow is a chart that shows the progress of each of the components we intend to ship, and their current stance against each of the requirements.
+As part of the .NET Aspire November preview, we want to include a set of .NET Aspire Components which help developers build .NET Aspire applications. These components should follow the [.NET Aspire Component Requirements](#aspire-component-requirements). Bellow is a chart that shows the progress of each of the components we intend to ship, and their current stance against each of the requirements.
 
-| Aspire Component Name                   | [Contains README](#contains-readme) | [Public API](#public-api) | [Configuration Schema](#json-schemaconfiguration) | [DI Services](#di-services) | [Logging](#logging) | [Tracing](#tracing) | [Metrics](#metrics) | [Health Checks](#health-checks) |
+| .NET Aspire Component Name              | [Contains README](#contains-readme) | [Public API](#public-api) | [Configuration Schema](#json-schemaconfiguration) | [DI Services](#di-services) | [Logging](#logging) | [Tracing](#tracing) | [Metrics](#metrics) | [Health Checks](#health-checks) |
 | --------------------------------------- | :---------------------------------: | :-----------------------: | :----------------------------------------------------: | :-------------------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------------------: |
 | Npgsql                                  |                  ✅                  |             ✅             |                           ✅                            |              ✅              |          ✅          |        ✅            |         ✅           |              ✅                  |
 | Npgsql.EntityFrameworkCore.PostgreSQL   |                  ✅                  |             ✅             |                           ✅                            |              ✅              |          ✅          |        ✅            |         ✅           |              ✅                  |
@@ -27,11 +27,11 @@ Nomenclature used in the table above:
 - (blank) - Requirement hasn't been met yet
 - ❌ - Requirement can't be met
 
-## Aspire Component Requirements
+## .NET Aspire Component Requirements
 
 ### Contains README
 
-Each Aspire component must contain a README.md file which is included in the package. This README should contain the component's main description, usage examples, and basic getting started documentation. The goal of this file is to contain everything a developer will need in the first 5 minutes. Finally, README should have a link pointed back to the full documentation of the component, which will include a list of logging categories used, tracing activity names, and Metric names. For a concrete example of a README file, please look [here](./Aspire.StackExchange.Redis/README.md).
+Each .NET Aspire component must contain a README.md file which is included in the package. This README should contain the component's main description, usage examples, and basic getting started documentation. The goal of this file is to contain everything a developer will need in the first 5 minutes. Finally, README should have a link pointed back to the full documentation of the component, which will include a list of logging categories used, tracing activity names, and Metric names. For a concrete example of a README file, please look [here](./Aspire.StackExchange.Redis/README.md).
 
 ### Public API
 

--- a/src/Components/README.md
+++ b/src/Components/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-Aspire components are classic .NET NuGet packages which are designed as highly usable libraries. Aspire components feature rich production-ready telemetry, health checks, configurability, testability, and documentation. For the current state of the components included in this repo and tracked for Aspire's first preview, please check out the [Aspire Components Progress](./Aspire_Components_Progress.md) page.
+Aspire components are classic .NET NuGet packages which are designed as highly usable libraries. .NET Aspire components feature rich production-ready telemetry, health checks, configurability, testability, and documentation. For the current state of the components included in this repo and tracked for .NET Aspire's first preview, please check out the [.NET Aspire Components Progress](./Aspire_Components_Progress.md) page.
 
 # Best practices for development
 
@@ -174,7 +174,7 @@ Aspire components offer integrated logging, metrics, and tracing using modern .N
 
 ### Security
 
-- If the underlying client library supports passwordless/[RBAC](https://learn.microsoft.com/azure/role-based-access-control/overview) authentication, which Credential to use should be configurable through the Aspire Settings object. For example:
+- If the underlying client library supports passwordless/[RBAC](https://learn.microsoft.com/azure/role-based-access-control/overview) authentication, which Credential to use should be configurable through the .NET Aspire Settings object. For example:
 
 ```csharp
 builder.AddAzureServiceBus(settings =>
@@ -203,7 +203,7 @@ builder.AddAzureServiceBus(settings =>
 }
 ```
 
-- Alternatively, the ConnectionString should be able to be configured through the Aspire Settings object. For example:
+- Alternatively, the ConnectionString should be able to be configured through the .NET Aspire Settings object. For example:
 
 ```csharp
 builder.AddAzureServiceBus(settings =>


### PR DESCRIPTION
Backport of #727

To ensure we're properly referring to the product name.