### PR TITLE
Allow dotnet watch to work with Aspire Dashboard

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -39,7 +39,7 @@ public class DashboardWebApplication : IHostedService
 
         if (dashboardUris.FirstOrDefault() is { } reportedDashboardUri)
         {
-            _logger.LogInformation("Dashboard running at: {dashboardUri}", reportedDashboardUri);
+            _logger.LogInformation("Now listening on: {dashboardUri}", reportedDashboardUri);
         }
 
         var dashboardHttpsPort = dashboardUris.FirstOrDefault(IsHttps)?.Port;

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -39,7 +39,8 @@ public class DashboardWebApplication : IHostedService
 
         if (dashboardUris.FirstOrDefault() is { } reportedDashboardUri)
         {
-            _logger.LogInformation("Now listening on: {dashboardUri}", reportedDashboardUri);
+            // dotnet watch needs the trailing slash removed. See https://github.com/dotnet/sdk/issues/36709
+            _logger.LogInformation("Now listening on: {dashboardUri}", reportedDashboardUri.AbsoluteUri.TrimEnd('/'));
         }
 
         var dashboardHttpsPort = dashboardUris.FirstOrDefault(IsHttps)?.Port;
@@ -52,7 +53,8 @@ public class DashboardWebApplication : IHostedService
 
         if (otlpUris.FirstOrDefault() is { } reportedOtlpUri)
         {
-            _logger.LogInformation("OTLP server running at: {dashboardUri}", reportedOtlpUri);
+            // dotnet watch needs the trailing slash removed. See https://github.com/dotnet/sdk/issues/36709. Conform to dashboard URL format above
+            _logger.LogInformation("OTLP server running at: {dashboardUri}", reportedOtlpUri.AbsoluteUri.TrimEnd('/'));
         }
 
         _isAllHttps = dashboardHttpsPort is not null && IsHttps(otlpUris[0]);


### PR DESCRIPTION
dotnet watch needs the URL message to be of a specific format. Fixing our message to conform.

Fix #711