### PR TITLE
Fix empty content margin in grids

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -62,8 +62,7 @@ fluent-toolbar[orientation=horizontal] {
     overflow: auto;
 }
 
-.datagrid-overflow-area .empty-content {
-    width: 100%;
+fluent-data-grid .empty-content-cell {
     height: 100px;
 }
 
@@ -94,22 +93,6 @@ fluent-dialog fluent-anchor[appearance=lightweight]:not(:hover)::part(control) {
    now have the wrong background. So change that back */
 fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appearance=stealth]:not(:hover)::part(control) {
     background: var(--fill-layer);
-}
-
-.dialog-grid-container {
-    width: 1000px;
-    height: 500px;
-    overflow-x: auto;
-    overflow-y: auto;
-}
-
-.dialog-grid-container .empty-content {
-    width: 100%;
-    height: 46px;
-}
-
-.dialog-grid-container h4 {
-    margin: 0.75rem;
 }
 
 .content-layout-with-toolbar {


### PR DESCRIPTION
Fixes #718 using the same size as used elsewhere for empty content

Also deleted some unused styles from app.css

![image](https://github.com/dotnet/aspire/assets/9613109/93ed9933-0489-4e78-a618-7404e01354af)

Note that the empty content class names changed from `empty-content` to `empty-content-row` and `empty-content-cell` in newer versions of the component library
