### PR TITLE
[release/8.0-preview1] Allow dotnet watch to work with Aspire Dashboard (#731)

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -40,7 +40,8 @@ public class DashboardWebApplication : IHostedService
 
         if (dashboardUris.FirstOrDefault() is { } reportedDashboardUri)
         {
-            _logger.LogInformation("Dashboard running at: {dashboardUri}", reportedDashboardUri);
+            // dotnet watch needs the trailing slash removed. See https://github.com/dotnet/sdk/issues/36709
+            _logger.LogInformation("Now listening on: {dashboardUri}", reportedDashboardUri.AbsoluteUri.TrimEnd('/'));
         }
 
         var dashboardHttpsPort = dashboardUris.FirstOrDefault(IsHttps)?.Port;
@@ -53,7 +54,8 @@ public class DashboardWebApplication : IHostedService
 
         if (otlpUris.FirstOrDefault() is { } reportedOtlpUri)
         {
-            _logger.LogInformation("OTLP server running at: {dashboardUri}", reportedOtlpUri);
+            // dotnet watch needs the trailing slash removed. See https://github.com/dotnet/sdk/issues/36709. Conform to dashboard URL format above
+            _logger.LogInformation("OTLP server running at: {dashboardUri}", reportedOtlpUri.AbsoluteUri.TrimEnd('/'));
         }
 
         _isAllHttps = dashboardHttpsPort is not null && IsHttps(otlpUris[0]);


### PR DESCRIPTION
* Allow dotnet watch to work with Aspire Dashboard

dotnet watch needs the URL message to be of a specific format. Fixing our message to conform.

Fix #711

* Trim trailing slash to allow dotnet watch to work.

Workaround https://github.com/dotnet/sdk/issues/36709