### PR TITLE
Emit container port for containers.

### DIFF
--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -156,7 +156,7 @@ public class ManifestPublisher(ILogger<ManifestPublisher> logger, IOptions<Publi
         }
     }
 
-    private static void WriteBindings(IResource resource, Utf8JsonWriter jsonWriter)
+    private static void WriteBindings(IResource resource, Utf8JsonWriter jsonWriter, bool emitContainerPort = false)
     {
         if (resource.TryGetServiceBindings(out var serviceBindings))
         {
@@ -167,6 +167,11 @@ public class ManifestPublisher(ILogger<ManifestPublisher> logger, IOptions<Publi
                 jsonWriter.WriteString("scheme", serviceBinding.UriScheme);
                 jsonWriter.WriteString("protocol", serviceBinding.Protocol.ToString().ToLowerInvariant());
                 jsonWriter.WriteString("transport", serviceBinding.Transport);
+
+                if (emitContainerPort && serviceBinding.ContainerPort is { } containerPort)
+                {
+                    jsonWriter.WriteNumber("containerPort", containerPort);
+                }
 
                 if (serviceBinding.IsExternal)
                 {
@@ -191,7 +196,7 @@ public class ManifestPublisher(ILogger<ManifestPublisher> logger, IOptions<Publi
         jsonWriter.WriteString("image", image);
 
         WriteEnvironmentVariables(container, jsonWriter);
-        WriteBindings(container, jsonWriter);
+        WriteBindings(container, jsonWriter, emitContainerPort: true);
     }
 
     private void WriteProject(ProjectResource project, Utf8JsonWriter jsonWriter)

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -11,6 +11,28 @@ namespace Aspire.Hosting.Tests;
 public class ManifestGenerationTests
 {
     [Fact]
+    public void EnsureContainerWithServiceBindingsEmitsContainerPort()
+    {
+        var program = CreateTestProgramJsonDocumentManifestPublisher();
+
+        program.AppBuilder.AddContainer("grafana", "grafana/grafana")
+                          .WithServiceBinding(3000, scheme: "http");
+
+        // Build AppHost so that publisher can be resolved.
+        program.Build();
+        var publisher = program.GetManifestPublisher();
+
+        program.Run();
+
+        var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
+
+        var grafana = resources.GetProperty("grafana");
+        var bindings = grafana.GetProperty("bindings");
+        var httpBinding = bindings.GetProperty("http");
+        Assert.Equal(3000, httpBinding.GetProperty("containerPort").GetInt32());
+    }
+
+    [Fact]
     public void EnsureAllRedisManifestTypesHaveVersion0Suffix()
     {
         var program = CreateTestProgramJsonDocumentManifestPublisher();


### PR DESCRIPTION
Emits container ports for manifest - sample output:

```json
{
  "resources": {
    "grafana": {
      "type": "container.v0",
      "image": "grafana/grafana:latest",
      "bindings": {
        "http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http",
          "containerPort": 3000
        }
      }
    }
  }
}
```