### PR TITLE
MongoDB & tool concept exploration.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,5 +99,7 @@
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Workloads" Version="8.0.0-beta.23371.1" />
     <PackageVersion Include="Microsoft.Signed.Wix" Version="1.0.0-v3.14.0.5722" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Installers" Version="8.0.0-beta.23371.1" />
+
+    <PackageVersion Include="MongoDB.Driver" Version="2.19.0" />
   </ItemGroup>
 </Project>

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -2,12 +2,16 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureProvisioning();
 
+var mongo = builder.AddMongoDBContainer("mongodb")
+                   .WithMongoExpress();
+
 var catalogDb = builder.AddPostgresContainer("postgres").AddDatabase("catalogdb");
 
 var basketCache = builder.AddRedisContainer("basketcache");
 
 var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice")
                      .WithReference(catalogDb)
+                     .WithReference(mongo)
                      .WithReplicas(2);
 
 var messaging = builder.AddRabbitMQContainer("messaging");

--- a/samples/eShopLite/AppHost/aspire-manifest.json
+++ b/samples/eShopLite/AppHost/aspire-manifest.json
@@ -1,5 +1,8 @@
 {
   "resources": {
+    "mongodb": {
+      "type": "mongodb.server.v0"
+    },
     "postgres": {
       "type": "postgres.server.v0"
     },
@@ -16,7 +19,8 @@
       "env": {
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "ConnectionStrings__catalogdb": "{catalogdb.connectionString}"
+        "ConnectionStrings__catalogdb": "{catalogdb.connectionString}",
+        "ConnectionStrings__mongodb": "{mongodb.connectionString}"
       },
       "bindings": {
         "http": {

--- a/src/Aspire.Hosting/MongoDB/MongoDBContainerResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBContainerResource.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+public class MongoDBContainerResource(string name, string password) : ContainerResource(name), IResourceWithConnectionString
+{
+    public string Password { get; } = password;
+
+    public string? GetConnectionString()
+    {
+        if (!this.TryGetAnnotationsOfType<AllocatedEndpointAnnotation>(out var allocatedEndpoints))
+        {
+            throw new DistributedApplicationException("Expected allocated endpoints!");
+        }
+
+        var endpoint = allocatedEndpoints.Single();
+
+        return $"mongodb://host.docker.internal:{endpoint.Port}";
+    }
+}

--- a/src/Aspire.Hosting/MongoDB/MongoDBExtensions.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBExtensions.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Net.Sockets;
+using System.Text.Json;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+public static class MongoDBExtensions
+{
+    public static IResourceBuilder<MongoDBContainerResource> AddMongoDBContainer(this IDistributedApplicationBuilder builder, string name, string? password = null)
+    {
+        password = password ?? Guid.NewGuid().ToString("N");
+        var mongo = new MongoDBContainerResource(name, password);
+        return builder.AddResource(mongo)
+                      .WithAnnotation(new ManifestPublishingCallbackAnnotation(WriteMongoDBContainerToManifest))
+                      .WithAnnotation(new ServiceBindingAnnotation(ProtocolType.Tcp, containerPort: 27017))
+                      .WithAnnotation(new ContainerImageAnnotation { Image = "mongo", Tag = "latest" });
+    }
+
+    public static IResourceBuilder<MongoDBContainerResource> WithMongoExpress(this IResourceBuilder<MongoDBContainerResource> builder)
+    {
+        builder.ApplicationBuilder.AddContainer("mongo-express", "mongo-express", "latest")
+                                  .WithServiceBinding(8081, 8081, scheme: "http")
+                                  .WithEnvironment((context) =>
+                                  {
+                                      if (builder.Resource.GetConnectionString() is not { } connectionString)
+                                      {
+                                          throw new DistributedApplicationException($"MongoDBContainer resource '{builder.Resource.Name}' did not return a connection string.");
+                                      }
+
+                                      var connectionStringUri = new Uri(connectionString);
+                                      context.EnvironmentVariables.Add("ME_CONFIG_MONGODB_SERVER", connectionStringUri.Host);
+                                      context.EnvironmentVariables.Add("ME_CONFIG_MONGODB_PORT", connectionStringUri.Port.ToString(CultureInfo.InvariantCulture));
+                                  });
+
+        return builder;
+    }
+
+    private static void WriteMongoDBContainerToManifest(Utf8JsonWriter jsonWriter)
+    {
+        jsonWriter.WriteString("type", "mongodb.server.v0");
+    }
+}

--- a/src/Aspire.Hosting/MongoDB/MongoDBExtensions.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBExtensions.cs
@@ -24,6 +24,7 @@ public static class MongoDBExtensions
     {
         builder.ApplicationBuilder.AddContainer("mongo-express", "mongo-express", "latest")
                                   .WithServiceBinding(8081, 8081, scheme: "http")
+                                  .WithAnnotation(ManifestPublishingCallbackAnnotation.Ignore)
                                   .WithEnvironment((context) =>
                                   {
                                       if (builder.Resource.GetConnectionString() is not { } connectionString)


### PR DESCRIPTION
This PR adds a MongoDB resource to the app model (no Aspire client components yet). In addition I am exploring the idea of adding developer debugging tooling to the app model. Here is an example:

```csharp
var builder = DistributedApplication.CreateBuilder(args);
var mongo = builder.AddMongoDBContainer("mongo")
                   .WithMongoExpress();
```

The idea is that by using the ```WithMongoExpression()``` extension method we inject a ```mongo-express``` container in to the app model which is configured to point to the ```mongo``` instance. This PR is not complete, some further things that need to be done:

1. Add the Aspire client components (maybe a follow-up PR).
2. Explore adding a ToolAnnotation which can be used by the dashboard to provide an insitu link to "tools" like Mongo express which are mapped to a specific resource (the tooling annotation would have a tool tip, icon, and hyperlink).

Checklist before merging:

- [ ] Move mongo express container creation logic into lifecycle hook
- [ ] Make sure lifecycle hook creation is safe for multiple calls
- [ ] XML DOC comments!
- [ ] Document need for host.docker.internal for container to container comms.