### PR TITLE
Fix Trim warning in ServiceDiscovery

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/ServiceEndPointCollection.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/ServiceEndPointCollection.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 /// Represents an immutable collection of service endpoints.
 /// </summary>
 [DebuggerDisplay("{ToString(),nq}")]
-[DebuggerTypeProxy(nameof(ServiceEndPointCollectionDebuggerView))]
+[DebuggerTypeProxy(typeof(ServiceEndPointCollectionDebuggerView))]
 public class ServiceEndPointCollection : IReadOnlyList<ServiceEndPoint>
 {
     private readonly List<ServiceEndPoint>? _endpoints;


### PR DESCRIPTION
When PublishTrimmed=true in an app that uses ServiceDiscovery, we get a warning that says:

_ILLink : warning IL2105: Microsoft.Extensions.ServiceDiscovery.Abstractions.ServiceEndPointCollection: Type 'ServiceEndPointCollectionDebuggerView' was not found in the caller assembly nor in the base library. Type name strings used for dynamically accessing a type should be assembly qualified._

Fix this warning by using `typeof` instead of `nameof`.