### PR TITLE
Suppress exceptions from DeleteResourcesAsync on shutdown.

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Model;
 using k8s;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Dcp;
 
@@ -44,7 +45,7 @@ internal sealed class ServiceAppResource : AppResource
     }
 }
 
-internal sealed class ApplicationExecutor(DistributedApplicationModel model, KubernetesService kubernetesService)
+internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger, DistributedApplicationModel model, KubernetesService kubernetesService)
 {
     private const string DebugSessionPortVar = "DEBUG_SESSION_PORT";
 
@@ -58,6 +59,7 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
         "DOTNET_ENVIRONMENT"
     };
 
+    private readonly ILogger<ApplicationExecutor> _logger = logger;
     private readonly DistributedApplicationModel _model = model;
     private readonly List<AppResource> _appResources = new();
 
@@ -634,7 +636,7 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Could not stop {resourceName} '{res.Metadata.Name}': {ex}");
+                _logger.LogInformation("Could not stop {resourceName} '{res.Metadata.Name}': {ex}", resourceName, res.Metadata.Name, ex);
             }
         }
     }


### PR DESCRIPTION
Fixes #603 
Fixes #73 

We still get this error if we CTRL-C whilst the host is still starting up though:

```
PS > dotnet run
Building...
info: Aspire.Dashboard.DashboardWebApplication[0]
      Now listening on: http://localhost:15888
info: Aspire.Dashboard.DashboardWebApplication[0]
      OTLP server running at: http://localhost:16031
info: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
fail: Microsoft.Extensions.Hosting.Internal.Host[11]
      Hosting failed to start
      System.Threading.Tasks.TaskCanceledException: A task was canceled.
         at Aspire.Hosting.Dcp.KubernetesService.ExecuteWithRetry[TResult](DcpApiOperationType operationType, String resourceType, Func`2 operation, CancellationToken cancellationToken) in C:\Code\dotnet\aspire\src\Aspire.Hosting\Dcp\KubernetesService.cs:line 208
         at Aspire.Hosting.Dcp.ApplicationExecutor.CreateResourcesAsync[RT](CancellationToken cancellationToken) in C:\Code\dotnet\aspire\src\Aspire.Hosting\Dcp\ApplicationExecutor.cs:line 619
         at Aspire.Hosting.Dcp.ApplicationExecutor.CreateServicesAsync(CancellationToken cancellationToken) in C:\Code\dotnet\aspire\src\Aspire.Hosting\Dcp\ApplicationExecutor.cs:line 111
         at Aspire.Hosting.Dcp.ApplicationExecutor.RunApplicationAsync(CancellationToken cancellationToken) in C:\Code\dotnet\aspire\src\Aspire.Hosting\Dcp\ApplicationExecutor.cs:line 75
         at Aspire.Hosting.Dcp.DcpHostService.StartAsync(CancellationToken cancellationToken) in C:\Code\dotnet\aspire\src\Aspire.Hosting\Dcp\DcpHostService.cs:line 78
         at Microsoft.Extensions.Hosting.Internal.Host.<StartAsync>b__15_1(IHostedService service, CancellationToken token)
         at Microsoft.Extensions.Hosting.Internal.Host.ForeachService[T](IEnumerable`1 services, CancellationToken token, Boolean concurrent, Boolean abortOnFirstException, List`1 exceptions, Func`3 operation)
Unhandled exception. System.AggregateException: One or more errors occurred. (A task was canceled.)
 ---> System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Threading.Tasks.Task.GetExceptions(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Aspire.Hosting.DistributedApplication.Run() in C:\Code\dotnet\aspire\src\Aspire.Hosting\DistributedApplication.cs:line 147
   at Program.<Main>$(String[] args) in C:\Code\dotnet\aspire\samples\eShopLite\AppHost\Program.cs:line 34
--- End of stack trace from previous location ---

   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Aspire.Hosting.DistributedApplication.Run() in C:\Code\dotnet\aspire\src\Aspire.Hosting\DistributedApplication.cs:line 147
   at Program.<Main>$(String[] args) in C:\Code\dotnet\aspire\samples\eShopLite\AppHost\Program.cs:line 34
```

I'm not sure supressing that error is a good idea.