### PR TITLE
Removing internal feed since it is no longer needed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -31,6 +31,7 @@
     </packageSource>
     <packageSource key="dotnet-libraries">
       <package pattern="Yarp.ReverseProxy" />
+      <package pattern="Microsoft.DeveloperControlPlane*" />
     </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="MicroBuild.Core.Sentinel" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -15,7 +15,6 @@
     <!-- Required as https://github.com/dotnet/runtime/pull/89509 did not get backported to .NET 8 Preview 7 -->
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
-    <add key="dotnet-libraries-internal" value="https://pkgs.dev.azure.com/dnceng/internal/_packaging/dotnet-libraries-internal/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="darc-pub-dotnet-runtime-488a8a3">
@@ -32,9 +31,6 @@
     </packageSource>
     <packageSource key="dotnet-libraries">
       <package pattern="Yarp.ReverseProxy" />
-    </packageSource>
-    <packageSource key="dotnet-libraries-internal">
-      <package pattern="Microsoft.DeveloperControlPlane*" />
     </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="MicroBuild.Core.Sentinel" />

--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -22,7 +22,7 @@ Alternatively, if you are using Visual Studio, you can [Install and manage packa
 This will actually get Aspire components.
 
 ```shell
-dotnet workload install aspire --skip-sign-check --interactive --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json
+dotnet workload install aspire --skip-sign-check --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json
 # To update it later if you wish
 # dotnet workload update --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json
 ```

--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -20,7 +20,6 @@ variables:
     # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
     # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
     # DotNet-HelixApi-Access provides: HelixApiAccessToken
-    - group: DotNet-Blob-Feed
     - group: Publish-Build-Assets
     - group: DotNet-HelixApi-Access
     - group: SDL_Settings


### PR DESCRIPTION
Staging this PR here. We will be able to merge it as soon as the DCP packages are in a public feed. We'll need to merge this in before we make the repo public.