### PR TITLE
Add markdown lint

### DIFF
--- a/.github/workflows/markdownlint-problem-matcher.json
+++ b/.github/workflows/markdownlint-problem-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "markdownlint",
+            "pattern": [
+                {
+                    "regexp": "^([^:]*):(\\d+):?(\\d+)?\\s([\\w-\\/]*)\\s(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "code": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,29 @@
+name: Markdownlint
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".markdownlint.json"
+      - ".github/workflows/markdownlint.yml"
+      - ".github/workflows/markdownlint-problem-matcher.json"
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 16.x
+    - name: Run Markdownlint
+      run: |
+        echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
+        npm i -g markdownlint-cli
+        markdownlint "**/*.md"

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -23,4 +23,4 @@ jobs:
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
         npm i -g markdownlint-cli
-        markdownlint "**/*.md"
+        markdownlint --ignore '.dotnet/' '**/*.md'

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -3,13 +3,10 @@ name: Markdownlint
 permissions:
   contents: read
 
+# run even on changes without markdown changes, so that we can
+# make it in GitHub a required check for PR's
 on:
   pull_request:
-    paths:
-      - "**/*.md"
-      - ".markdownlint.json"
-      - ".github/workflows/markdownlint.yml"
-      - ".github/workflows/markdownlint-problem-matcher.json"
 
 jobs:
   lint:
@@ -17,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 16.x
     - name: Run Markdownlint

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "default": false,
+    "MD009": {
+        "br_spaces": 0
+    },
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,13 +6,13 @@
     "blanks-around-headings":          false,
     "no-duplicate-heading":            { "siblings_only": true },
     "no-trailing-punctuation":         false,
-    "ol-prefix":                       { "one_or_ordered": true },
     "blanks-around-fences":            false,
     "blanks-around-lists":             false,
-    "no-inline-html":                 { "allowed_elements": [ "summary", "details" ]},
+    "no-inline-html":                  { "allowed_elements": [ "summary", "details", "kbd" ]},
     "no-bare-urls":                    false,
     "single-trailing-newline":         false,
     "emphasis-style":                  false,
+    "reference-links-images":          false, // temporary until we figure out NuGet-nuget
 
     // rule settings and options are documented in https://github.com/DavidAnson/markdownlint
     // feel free to disable more low value rules in here; get rule name from the error message.

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,20 @@
 {
-    "default": false,
-    "MD009": {
-        "br_spaces": 0
-    },
+    "default": true,
+    "ul-indent":                       false,
+    "no-trailing-spaces":              false,
+    "line-length":                     false,
+    "blanks-around-headings":          false,
+    "no-duplicate-heading":            { "siblings_only": true },
+    "no-trailing-punctuation":         false,
+    "ol-prefix":                       { "one_or_ordered": true },
+    "blanks-around-fences":            false,
+    "blanks-around-lists":             false,
+    "no-inline-html":                 { "allowed_elements": [ "summary", "details" ]},
+    "no-bare-urls":                    false,
+    "single-trailing-newline":         false,
+    "emphasis-style":                  false,
+
+    // rule settings and options are documented in https://github.com/DavidAnson/markdownlint
+    // feel free to disable more low value rules in here; get rule name from the error message.
+    // the purpose of the linter is to catch significant issues like broken links.
 }

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+# This is for editors; keep .github/workflows/markdownlint.yml in sync
+.dotnet/
+**/README.md

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,3 +1,2 @@
 # This is for editors; keep .github/workflows/markdownlint.yml in sync
 .dotnet/
-**/README.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,4 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V0.0.6 BLOCK -->
-
-## Security
+# Security
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
@@ -14,7 +12,7 @@ Instead, please report them to the Microsoft Security Response Center (MSRC) at 
 
 If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 
 Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,7 +9,6 @@ See [machine-requirements.md](machine-requirements.md).
 ## Build the repo
 `.\build.cmd` (Windows) or `.\build.sh` (macOS and Linux)
 
-
 ## Run eShopLite
 
 This will confirm that you're all set up.

--- a/docs/getting-perf-traces.md
+++ b/docs/getting-perf-traces.md
@@ -1,6 +1,6 @@
-## Wall-clock time investigations
+# Wall-clock time investigations
 
-### Collect the trace
+## Collect the trace
 Collect the trace using PerfView (https://github.com/microsoft/perfview/releases). Use Collect menu, then Collect again, to open the collection dialog and make the following changes from defaults:
 
 1. If you do not intend to share the trace with anyone, uncheck the "Zip" and "Merge" option.
@@ -13,9 +13,8 @@ Once you are ready, git "Start Collection" button and run your scenario.
 
 When done with the scenario, hit "Stop Collection". Wait for PerfView to finish merging and analyzing data (the "working" status bar stops flashing).
 
-### Verify that the trace contains data .NET Aspire data
+## Verify that the trace contains data .NET Aspire data
 
 This is an optional step, but if you are wondering if your trace has been captured properly, you can check the following:
 
 1. Open the trace (usually named PerfViewData.etl, if you haven't changed the name) and double click Events view. Verify you have a bunch of events from Microsoft-Aspire-Hosting provider.
-

--- a/docs/tips-and-known-issues.md
+++ b/docs/tips-and-known-issues.md
@@ -1,12 +1,12 @@
 # Tips and known issues
 
-### My containers aren't being created at all
+## My containers aren't being created at all
 
 We have seen Docker get into weird state on "DevBox" machines that get hibernated every evening. You can check if you got into this state by opening a command window and doing "docker ps". If it hangs forever without error, that is it.
 
 The remedy is to do "Restart Docker" gesture from the Docker icon in system tray.
 
-### If something goes wrong and you are left with a bunch of .NET Aspire eShopLite orphaned processes and containers
+## If something goes wrong and you are left with a bunch of .NET Aspire eShopLite orphaned processes and containers
 
 This will display process IDs of all the .NET Aspire shopping running processes
 
@@ -20,6 +20,6 @@ ps | where ProcessName -cmatch '(Api)|(Catalog)|(Basket)|(AppHost)|(MyFrontend)|
 ps | where ProcessName -cmatch '(Api)|(Catalog)|(Basket)|(AppHost)|(MyFrontend)|(OrderProcessor)' | % {Write-Output $_.Id; kill $_.Id }
 ```
 
-### Why does it seem to take a long time for my services to reach a ready state when running in Visual Studio?
+## Why does it seem to take a long time for my services to reach a ready state when running in Visual Studio?
 
 There is a known performance issue in Visual Studio 2022 17.9 Preview 1 related to a debugger setting which can cause delays during service startup for a .NET Aspire AppHost project with multiple service projects. To work around this issue, go to `Tools > Options > Debugging > General` and uncheck `Enable the External Sources node in Solution Explorer`.

--- a/samples/eShopLite/README.md
+++ b/samples/eShopLite/README.md
@@ -1,15 +1,15 @@
-## Instructions for running in Kubernetes locally
+# Instructions for running in Kubernetes locally
 
 * Install Docker Desktop
 * Enable Kubernetes support in Docker Desktop
 * Start a local image repository
 
-```
+```sh
 > docker run -d -p 5001:5000 --restart always --name registry registry:2
 ```
 
 * Build the containers, pushing them to the local repository, and deploy to kubernetes
 
-```
+```sh
 > ./deploy.cmd
 ```

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
@@ -137,4 +137,3 @@ builder.AddAzureServiceBus("sb");
 ## Feedback & contributing
 
 https://github.com/dotnet/aspire
-

--- a/src/Components/Aspire_Components_Progress.md
+++ b/src/Components/Aspire_Components_Progress.md
@@ -1,6 +1,6 @@
 # .NET Aspire Components Progress for November
 
-As part of the .NET Aspire November preview, we want to include a set of .NET Aspire Components which help developers build .NET Aspire applications. These components should follow the [.NET Aspire Component Requirements](#aspire-component-requirements). Bellow is a chart that shows the progress of each of the components we intend to ship, and their current stance against each of the requirements.
+As part of the .NET Aspire November preview, we want to include a set of .NET Aspire Components which help developers build .NET Aspire applications. These components should follow the [.NET Aspire Component Requirements](#net-aspire-component-requirements). Bellow is a chart that shows the progress of each of the components we intend to ship, and their current stance against each of the requirements.
 
 | .NET Aspire Component Name              | [Contains README](#contains-readme) | [Public API](#public-api) | [Configuration Schema](#json-schemaconfiguration) | [DI Services](#di-services) | [Logging](#logging) | [Tracing](#tracing) | [Metrics](#metrics) | [Health Checks](#health-checks) |
 | --------------------------------------- | :---------------------------------: | :-----------------------: | :----------------------------------------------------: | :-------------------------: | :-----------------: | :-----------------: | :-----------------: | :-----------------------------: |


### PR DESCRIPTION
Fixes #783.

This will make it impossible for me to break markdown links again.

Temporarily disabling `"reference-links-images"` rule until we resolve these apparently unresolvable references
https://github.com/danmoseley/aspire/blob/603b4a7b68980da908a3d1f6565057ec13d8925d/src/Components/Aspire.RabbitMQ.Client/README.md?plain=1#L13