### PR TITLE
Use FluentSplitter for Summary/Details View

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -1,23 +1,26 @@
-﻿<div class="summary-details-container" data-orientation="@Orientation" data-show-details="@ShowDetails">
-    <div class="summary-container">
-        @Summary
-    </div>
-    @if (ShowDetails)
-    {
-        <div class="details-container">
-            <FluentHeader Style="height: auto;">
-                @DetailsTitle
-                <div class="header-right">
-                    <FluentButton Appearance="Appearance.Stealth"
-                                  IconEnd="@(Orientation == Orientation.Horizontal ? _splitVerticalIcon : _splitHorizontalIcon)"
-                                  OnClick="HandleToggleOrientation"
-                                  Title="@(Orientation == Orientation.Horizontal ? "Split Vertical" : "Split Horizontal")"
-                                  aria-label="@(Orientation == Orientation.Horizontal ? "Split Vertical" : "Split Horizontal")" />
-                    <FluentButton Appearance="Appearance.Stealth" IconEnd="@(new Icons.Regular.Size16.Dismiss())"
-                                  OnClick="HandleDismissAsync" Title="Close" aria-label="Close" />
-                </div>
-            </FluentHeader>
-            @Details
-        </div>
-    }
+﻿<div class="summary-details-container">
+    <FluentSplitter Orientation="@Orientation" Collapsed="@(!ShowDetails)" OnResized="HandleSplitterResize" Panel1Size="@_panel1Size" Panel2Size="@_panel2Size">
+        <Panel1>
+            <div class="summary-container">
+                @Summary
+            </div>
+        </Panel1>
+        <Panel2>
+            <div class="details-container">
+                <FluentHeader Style="height: auto;">
+                    @DetailsTitle
+                    <div class="header-right">
+                        <FluentButton Appearance="Appearance.Stealth"
+                                      IconEnd="@(Orientation == Orientation.Horizontal ? _splitHorizontalIcon : _splitVerticalIcon)"
+                                      OnClick="HandleToggleOrientation"
+                                      Title="@(Orientation == Orientation.Horizontal ? "Split Horizontal" : "Split Vertical")"
+                                      aria-label="@(Orientation == Orientation.Horizontal ? "Split Horizontal" : "Split Vertical")" />
+                        <FluentButton Appearance="Appearance.Stealth" IconEnd="@(new Icons.Regular.Size16.Dismiss())"
+                                      OnClick="HandleDismissAsync" Title="Close" aria-label="Close" />
+                    </div>
+                </FluentHeader>
+                @Details
+            </div>
+        </Panel2>
+    </FluentSplitter>
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components.Controls;
@@ -21,20 +22,64 @@ public partial class SummaryDetailsView
     public required string DetailsTitle { get; set; }
 
     [Parameter]
-    public Orientation Orientation { get; set; } = Orientation.Horizontal;
+    public Orientation Orientation { get; set; } = Orientation.Vertical;
 
     [Parameter]
     public EventCallback OnDismiss { get; set; }
 
+    [Parameter]
+    public bool RememberSize { get; set; } = true;
+
+    [Parameter]
+    public bool RememberOrientation { get; set; } = true;
+
+    /// <summary>
+    /// Overrides the default key used to store the splitter size and orientation in local storage.
+    /// By default, the key is based on the current URL. If you have multiple instances of this control
+    /// on a page or want to share the same settings across multiple pages, you can set this property
+    /// </summary>
+    [Parameter]
+    public string? ViewKey { get; set; }
+
+    [Inject]
+    public required ProtectedLocalStorage ProtectedLocalStore { get; set; }
+
+    [Inject]
+    public required NavigationManager NavigationManager { get; set; }
+
     private readonly Icon _splitHorizontalIcon = new Icons.Regular.Size16.SplitHorizontal();
     private readonly Icon _splitVerticalIcon = new Icons.Regular.Size16.SplitVertical();
+
+    private string _panel1Size { get; set; } = "1fr";
+    private string _panel2Size { get; set; } = "1fr";
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (RememberOrientation)
+        {
+            var orientationResult = await ProtectedLocalStore.GetAsync<Orientation>(GetOrientationStorageKey());
+            if (orientationResult.Success)
+            {
+                Orientation = orientationResult.Value;
+            }
+        }
+
+        if (RememberSize)
+        {
+            var panel1FractionResult = await ProtectedLocalStore.GetAsync<float>(GetSizeStorageKey());
+            if (panel1FractionResult.Success)
+            {
+                SetPanelSizes(panel1FractionResult.Value);
+            }
+        }
+    }
 
     private async Task HandleDismissAsync()
     {
         await OnDismiss.InvokeAsync();
     }
 
-    private void HandleToggleOrientation()
+    private async void HandleToggleOrientation()
     {
         if (Orientation == Orientation.Horizontal)
         {
@@ -44,5 +89,76 @@ public partial class SummaryDetailsView
         {
             Orientation = Orientation.Horizontal;
         }
+
+        if (RememberOrientation)
+        {
+            await ProtectedLocalStore.SetAsync(GetOrientationStorageKey(), Orientation);
+        }
+
+        if (RememberSize)
+        {
+            var panel1FractionResult = await ProtectedLocalStore.GetAsync<float>(GetSizeStorageKey());
+            if (panel1FractionResult.Success)
+            {
+                SetPanelSizes(panel1FractionResult.Value);
+                
+            }
+            else
+            {
+                ResetPanelSizes();
+            }
+        }
+        else
+        {
+            ResetPanelSizes();
+        }
+
+        // The FluentSplitter control will render during the async calls above, but with the wrong values.
+        // We need to force a re-render to get the correct values.
+        StateHasChanged();
+    }
+
+    private async Task HandleSplitterResize(SplitterResizedEventArgs args)
+    {
+        if (!RememberSize)
+        {
+            return;
+        }
+
+        var totalSize = (float)(args.Panel1Size + args.Panel2Size);
+
+        var panel1Fraction = (args.Panel1Size / totalSize);
+
+        SetPanelSizes(panel1Fraction);
+
+        if (RememberSize)
+        {
+            await ProtectedLocalStore.SetAsync(GetSizeStorageKey(), panel1Fraction);
+        }
+    }
+
+    private void ResetPanelSizes()
+    {
+        _panel1Size = "1fr";
+        _panel2Size = "1fr";
+    }
+
+    private void SetPanelSizes(float panel1Fraction)
+    {
+        _panel1Size = $"{panel1Fraction:F3}fr";
+        _panel2Size = $"{(1 - panel1Fraction):F3}fr";
+    }
+
+    private string GetSizeStorageKey()
+    {
+        var viewKey = ViewKey ?? NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        return $"SplitterSize_{Orientation}_{viewKey}";
+    }
+
+    private string GetOrientationStorageKey()
+    {
+        var viewKey = ViewKey ?? NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        return $"SplitterOrientation_{viewKey}";
     }
 }
+

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
@@ -1,41 +1,19 @@
-::deep.summary-details-container {
-    display: grid;
-    grid-template-areas:
-        "summary";
-    gap: calc(var(--design-unit) * 2px);
+.summary-details-container {
     overflow: auto;
 }
 
-::deep.summary-details-container:not([data-orientation=Vertical]) {
-    grid-template-rows: 1fr;
+::deep split-panels {
+    height: 100%;
+    width: 100%;
 }
 
-::deep.summary-details-container[data-orientation=Vertical] {
-    grid-template-columns: 1fr;
-}
-
-::deep.summary-details-container[data-show-details]:not([data-orientation=Vertical]) {
-    grid-template-rows: 1fr 1fr;
-    grid-template-areas:
-        "summary"
-        "details";
-}
-
-::deep.summary-details-container[data-show-details][data-orientation=Vertical] {
-    grid-template-columns: 1fr 1fr;
-    grid-template-areas:
-        "summary details";
-}
-
-::deep > .summary-container {
-    grid-area: summary;
+::deep .summary-container {
     height: 100%;
     min-width: 100%;
     overflow: auto;
 }
 
-::deep > .details-container {
-    grid-area: details;
+::deep .details-container {
     overflow: auto;
     display: grid;
     grid-template-rows: auto 1fr;
@@ -44,22 +22,18 @@
         "main";
 }
 
-::deep.summary-details-container[data-orientation=Vertical] > .details-container {
-    border-left: solid 1px var(--neutral-layer-4);
-}
-
-::deep > .details-container > header {
+::deep .details-container > header {
     height: auto;
     grid-row-start: 1;
     background-color: var(--neutral-layer-4);
     color: var(--neutral-foreground-rest);
 }
 
-::deep > .details-container > header fluent-button[appearance=stealth]:not(:hover)::part(control) {
+::deep .details-container > header fluent-button[appearance=stealth]:not(:hover)::part(control) {
     background-color: var(--neutral-layer-4);
 }
 
-::deep > .details-container > *:last-child {
+::deep .details-container > *:last-child {
     grid-row-start: 2;
 }
 

--- a/src/Aspire.Dashboard/Components/Pages/Containers.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Containers.razor
@@ -17,7 +17,8 @@
     </FluentToolbar>
     <SummaryDetailsView DetailsTitle="@($"Environment Variables for {SelectedResourceName}")"
                         ShowDetails="@(SelectedEnvironmentVariables is not null)"
-                        OnDismiss="() => SelectedEnvironmentVariables = null">
+                        OnDismiss="() => ClearSelectedResource()"
+                        ViewKey="ResourcesList">
         <Summary>
             <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 2fr 2fr 2fr 2fr 1fr 2fr 1fr 1fr">
                 <ChildContent>

--- a/src/Aspire.Dashboard/Components/Pages/Executables.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Executables.razor
@@ -17,7 +17,8 @@
     </FluentToolbar>
     <SummaryDetailsView DetailsTitle="@($"Environment Variables for {SelectedResourceName}")"
                         ShowDetails="@(SelectedEnvironmentVariables is not null)"
-                        OnDismiss="() => SelectedEnvironmentVariables = null">
+                        OnDismiss="() => ClearSelectedResource()"
+                        ViewKey="ResourcesList">
         <Summary>
             <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1fr 2fr 1fr 4fr 4fr 4fr 2fr 1fr 1fr">
                 <ChildContent>

--- a/src/Aspire.Dashboard/Components/Pages/Index.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Index.razor
@@ -17,7 +17,8 @@
     </FluentToolbar>
     <SummaryDetailsView DetailsTitle="@($"Environment Variables for {SelectedResourceName}")"
                         ShowDetails="@(SelectedEnvironmentVariables is not null)"
-                        OnDismiss="() => SelectedEnvironmentVariables = null">
+                        OnDismiss="() => ClearSelectedResource()"
+                        ViewKey="ResourcesList">
         <Summary>
             <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1.2fr 2fr 1fr 4fr 2fr 1fr 1fr" >
                 <ChildContent>

--- a/src/Aspire.Dashboard/Components/Pages/ResourcesListBase.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ResourcesListBase.cs
@@ -90,8 +90,21 @@ public abstract class ResourcesListBase<TResource> : ComponentBase, IDisposable
 
     protected void ShowEnvironmentVariables(TResource resource)
     {
-        SelectedEnvironmentVariables = resource.Environment;
-        SelectedResourceName = resource.Name;
+        if (SelectedEnvironmentVariables == resource.Environment)
+        {
+            ClearSelectedResource();
+        }
+        else
+        {
+            SelectedEnvironmentVariables = resource.Environment;
+            SelectedResourceName = resource.Name;
+        }
+    }
+
+    protected void ClearSelectedResource()
+    {
+        SelectedEnvironmentVariables = null;
+        SelectedResourceName = null;
     }
 
     private async Task OnResourceListChanged(ObjectChangeType objectChangeType, TResource resource)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -56,7 +56,7 @@
         }
         <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="Add Filter" OnClick="() => OpenFilterAsync(null)"><FluentIcon Value="@(new Icons.Regular.Size16.Filter())" /></FluentButton>
     </FluentToolbar>
-    <SummaryDetailsView DetailsTitle="Log Entry Details" ShowDetails="SelectedLogEntryProperties is not null" OnDismiss="() => SelectedLogEntryProperties = null">
+    <SummaryDetailsView DetailsTitle="Log Entry Details" ShowDetails="SelectedLogEntryProperties is not null" OnDismiss="() => ClearSelectedLogEntry()">
         <Summary>
             <div class="logs-summary-layout">
                 <div class="logs-grid-container continuous-scroll-overflow">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -53,6 +53,7 @@ public partial class StructuredLogs
     public string? LogLevelText { get; set; }
 
     public IEnumerable<LogEntryPropertyViewModel>? SelectedLogEntryProperties { get; set; }
+    private OtlpLogEntry? _selectedLogEntry;
 
     private ValueTask<GridItemsProviderResult<OtlpLogEntry>> GetData(GridItemsProviderRequest<OtlpLogEntry> request)
     {
@@ -159,10 +160,23 @@ public partial class StructuredLogs
 
     private void OnShowProperties(OtlpLogEntry entry)
     {
-        SelectedLogEntryProperties = entry.AllProperties()
-                                          .Select(kvp => new LogEntryPropertyViewModel { Name = kvp.Key, Value = kvp.Value })
-                                          .ToList();
+        if (_selectedLogEntry == entry)
+        {
+            ClearSelectedLogEntry();
+        }
+        else
+        {
+            _selectedLogEntry = entry;
+            SelectedLogEntryProperties = entry.AllProperties()
+                                              .Select(kvp => new LogEntryPropertyViewModel { Name = kvp.Key, Value = kvp.Value })
+                                              .ToList();
+        }
+    }
 
+    private void ClearSelectedLogEntry()
+    {
+        _selectedLogEntry = null;
+        SelectedLogEntryProperties = null;
     }
 
     private async Task OpenFilterAsync(LogFilter? entry)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -43,7 +43,7 @@
             <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/Traces")">Back</FluentAnchor>
         </FluentToolbar>
 
-        <SummaryDetailsView DetailsTitle="@(SelectedSpan?.Title)" ShowDetails="SelectedSpan is not null" OnDismiss="() => SelectedSpan = null">
+        <SummaryDetailsView DetailsTitle="@(SelectedSpan?.Title)" ShowDetails="SelectedSpan is not null" OnDismiss="() => ClearSelectedSpan()">
             <Summary>
                 <FluentDataGrid Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="2fr 6fr">
                     <TemplateColumn Title="Name">

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -144,18 +144,30 @@ public partial class TraceDetail
 
     private void OnShowProperties(SpanWaterfallViewModel viewModel)
     {
-        var entryProperties = viewModel.Span.AllProperties()
-            .Select(kvp => new SpanPropertyViewModel { Name = kvp.Key, Value = kvp.Value })
-            .ToList();
-
-        var spanDetailsViewModel = new SpanDetailsViewModel
+        if (SelectedSpan?.Span == viewModel.Span)
         {
-            Span = viewModel.Span,
-            Properties = entryProperties,
-            Title = $"{viewModel.Span.Source.ApplicationName}: {viewModel.GetDisplaySummary()} {OtlpHelpers.ToShortenedId(viewModel.Span.SpanId)}"
-        };
+            ClearSelectedSpan();
+        }
+        else
+        {
+            var entryProperties = viewModel.Span.AllProperties()
+                .Select(kvp => new SpanPropertyViewModel { Name = kvp.Key, Value = kvp.Value })
+                .ToList();
 
-        SelectedSpan = spanDetailsViewModel;
+            var spanDetailsViewModel = new SpanDetailsViewModel
+            {
+                Span = viewModel.Span,
+                Properties = entryProperties,
+                Title = $"{viewModel.Span.Source.ApplicationName}: {viewModel.GetDisplaySummary()} {OtlpHelpers.ToShortenedId(viewModel.Span.SpanId)}"
+            };
+
+            SelectedSpan = spanDetailsViewModel;
+        }
+    }
+
+    private void ClearSelectedSpan()
+    {
+        SelectedSpan = null;
     }
 
     public void Dispose()


### PR DESCRIPTION
This partially addresses #590. Once this goes in, I'll split off the remaining work from that issue into separate issues that can be picked up by anyone.

1. The Summary/Details View uses the FluentSplitter, taking advantage of the new Collapsed functionality that was just added in RC3 of the library.
2. The orientation is remembered between loads of a page and runs of the dashboard
3. The size is remembered between loads of a page and runs of the dashboard
4. For 2 and 3, the storage is done with a configurable key. By default this uses the url of the page. But it can be overridden if a) you have multiple summary/details views on one page or b) you want to share the settings between pages. We currently use this so that the three resource list pages (Projects, Containers, Executables) all share the same settings, but Structured Logs and Trace Details have their own (since the summary pane is visibly different for those two from the other three). We can adjust that if we want so that they all share a default, all have their own or any other combination. 
5. All five pages with the Summary/Details View are now toggleable. If you click View (or click on the span in Trace Details), and then click on the _same_ one again, the details view will collapse. If you click on a different one, it'll switch the details to that new selection. 

Screenshot with the splitter (only real visible change is the gray splitter bar):
![image](https://github.com/dotnet/aspire/assets/9613109/8ddb7353-7722-48aa-b835-666d0087163d)


