### PR TITLE
Fix NuGet Package Icons

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,10 @@
     <LangVersion>preview</LangVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <SharedDir>$(MSBuildThisFileDirectory)/src/Shared/</SharedDir>
+    <!-- Capture PackageIconFullPath into DefaultDotnetIconFullPath before we overwrite PackageIconFullPath. -->
+    <!-- DefaultDotnetIconFullPath is only needed for the ServiceDisovery packages. The property can be removed when these libraries move. See https://github.com/dotnet/aspire/issues/170 -->
+    <DefaultDotnetIconFullPath>$(PackageIconFullPath)</DefaultDotnetIconFullPath>
+    <PackageIconFullPath>$(SharedDir)Aspire_icon_256.png</PackageIconFullPath>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,8 +4,6 @@
     <ReadMePath>$(MSBuildProjectDirectory)\README.md</ReadMePath>
     <ReadMeExists Condition="Exists('$(ReadMePath)')">true</ReadMeExists>
     <PackageReadmeFile Condition="'$(PackageReadmeFile)' == '' And '$(ReadMeExists)' == 'true'">README.md</PackageReadmeFile>
-
-    <PackageIconFullPath Condition="'$(SuppressAspireIcon)' != 'true'">$(SharedDir)Aspire_icon_256.png</PackageIconFullPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Microsoft.Extensions.ServiceDiscovery.Abstractions.csproj
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Microsoft.Extensions.ServiceDiscovery.Abstractions.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Provides abstractions for service discovery. Interfaces defined in this package are implemented in Microsoft.Extensions.ServiceDiscovery and other service discovery packages.</Description>
-    <SuppressAspireIcon>true</SuppressAspireIcon>
+    <PackageIconFullPath>$(DefaultDotnetIconFullPath)</PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/Microsoft.Extensions.ServiceDiscovery.Dns.csproj
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/Microsoft.Extensions.ServiceDiscovery.Dns.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Provides extensions to HttpClient to resolve well-known hostnames to concrete endpoints based on DNS records. Useful for service resolution in orchestrators such as Kubernetes.</Description>
-    <SuppressAspireIcon>true</SuppressAspireIcon>
+    <PackageIconFullPath>$(DefaultDotnetIconFullPath)</PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.ServiceDiscovery.Yarp/Microsoft.Extensions.ServiceDiscovery.Yarp.csproj
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Yarp/Microsoft.Extensions.ServiceDiscovery.Yarp.csproj
@@ -7,7 +7,7 @@
     <IsPackable>true</IsPackable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Provides extensions for service discovery for the YARP reverse proxy.</Description>
-    <SuppressAspireIcon>true</SuppressAspireIcon>
+    <PackageIconFullPath>$(DefaultDotnetIconFullPath)</PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.ServiceDiscovery/Microsoft.Extensions.ServiceDiscovery.csproj
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Microsoft.Extensions.ServiceDiscovery.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Provides extensions to HttpClient that enable service discovery based on configuration.</Description>
-    <SuppressAspireIcon>true</SuppressAspireIcon>
+    <PackageIconFullPath>$(DefaultDotnetIconFullPath)</PackageIconFullPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Move setting PackageIconFullPath back to Directory.Build.props so it is set by default at the top of the project.

Capture Arcade's default PackageIconFullPath into a new property DefaultDotnetIconFullPath and use this in the ServiceDiscovery packages.

Fix #810

Here are the packages from my local build:

![image](https://github.com/dotnet/aspire/assets/8291187/df66bbe5-b7d2-40f9-a7e5-866855b2c452)

![image](https://github.com/dotnet/aspire/assets/8291187/536c1b34-8035-44ca-aea8-98fffef4cc2f)

![image](https://github.com/dotnet/aspire/assets/8291187/8563731e-b27f-4655-af95-d2370067b7cd)

![image](https://github.com/dotnet/aspire/assets/8291187/4ac9e800-6f96-4ad9-842d-6735a1a734b9)
