### PR TITLE
Add a small footer

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -29,7 +29,8 @@
         @Body
     </FluentBodyContent>
     <FluentFooter>
-       &copy; Microsoft, 2023
+       <div class="runtimeinfo">Powered by @(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)</div>
+       <div class="copyright">&copy; Microsoft, 2023</div
     </FluentFooter>
 
     <FluentDialogProvider />

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -28,6 +28,9 @@
     <FluentBodyContent Class="custom-body-content">
         @Body
     </FluentBodyContent>
+    <FluentFooter>
+       &copy; Microsoft, 2023
+    </FluentFooter>
 
     <FluentDialogProvider />
     <FluentTooltipProvider />

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -22,10 +22,11 @@
     width: 100vw;
     display: grid;
     grid-template-columns: auto 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto 1fr auto;
     grid-template-areas:
         "head head"
-        "nav main";
+        "nav main"
+        "footer footer";
     background-color: var(--fill-color);
     color: var(--neutral-foreground-rest);
 }
@@ -70,4 +71,16 @@
 ::deep .header-title fluent-anchor {
     font-size: var(--type-ramp-plus-2-font-size);
     color: var(--accent-fill-rest);
+}
+
+::deep.layout > footer {
+    grid-area: footer;
+    height: 20px;
+    background-color: var(--neutral-layer-4);
+    color: var(--accent-fill-rest);
+    margin-bottom: 0;
+    justify-content: right;
+    align-content: center;
+    padding-right: 10px;
+    font-size: smaller;
 }

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -74,13 +74,23 @@
 }
 
 ::deep.layout > footer {
+    display: grid;
+    grid-template-columns: auto auto;
     grid-area: footer;
     height: 20px;
     background-color: var(--neutral-layer-4);
     color: var(--accent-fill-rest);
     margin-bottom: 0;
-    justify-content: right;
     align-content: center;
-    padding-right: 10px;
+    padding: 0 10px;
     font-size: smaller;
+}
+
+::deep.layout .runtimeinfo {
+    display: grid;
+    justify-content: start;
+}
+::deep.layout .copyright {
+    display: grid;
+    justify-content: end;
 }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
@@ -49,7 +49,7 @@
     grid-template-areas:
         "main"
         "foot";
-    gap: calc(var(--design-unit) * 2px);
+    gap: calc(var(--design-unit) * 2px) calc(var(--design-unit) * 2px) 0;
 }
 
 ::deep .logs-summary-layout > .logs-grid-container {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
@@ -49,7 +49,7 @@
     grid-template-areas:
         "main"
         "foot";
-    gap: calc(var(--design-unit) * 2px) calc(var(--design-unit) * 2px) 0;
+    gap: calc(var(--design-unit) * 2px) 0 0 calc(var(--design-unit) * 2px);
 }
 
 ::deep .logs-summary-layout > .logs-grid-container {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -163,7 +163,7 @@
         "toolbar"
         "main";
     gap: calc(var(--design-unit) * 2px);
-    padding: calc(var(--design-unit) * 2px) calc(var(--design-unit) * 2px) 0 ;
+    padding: calc(var(--design-unit) * 2px) 0 0 calc(var(--design-unit) * 2px);
 }
 
 ::deep.trace-detail-layout > .trace-detail-header {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -163,7 +163,7 @@
         "toolbar"
         "main";
     gap: calc(var(--design-unit) * 2px);
-    padding: calc(var(--design-unit) * 2px);
+    padding: calc(var(--design-unit) * 2px) calc(var(--design-unit) * 2px) 0 ;
 }
 
 ::deep.trace-detail-layout > .trace-detail-header {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -103,7 +103,7 @@ fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appear
     grid-template-areas:
         "toolbar"
         "main";
-    padding: calc(var(--design-unit) * 2px) calc(var(--design-unit) * 2px) 0;
+    padding: calc(var(--design-unit) * 2px) 0 0 calc(var(--design-unit) * 2px);
 }
 
 .content-layout-with-toolbar > fluent-toolbar {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -103,7 +103,7 @@ fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appear
     grid-template-areas:
         "toolbar"
         "main";
-    padding: calc(var(--design-unit) * 2px);
+    padding: calc(var(--design-unit) * 2px) calc(var(--design-unit) * 2px) 0;
 }
 
 .content-layout-with-toolbar > fluent-toolbar {


### PR DESCRIPTION
With the new summary/details view, text seems to disappear into the abys at the bottom of the window. I feel adding a small footer helps to make that less apparent. I also remove the bottom padding from various pages to make the text/splitter stop at the footer and not above it

Text displayed in the footer can of course be adjusted.
Before:
![image](https://github.com/dotnet/aspire/assets/1761079/6a54008d-d52a-4233-bde8-df5b8cd6b785)

After:
![image](https://github.com/dotnet/aspire/assets/1761079/66e9d402-e538-4e06-b545-0b2aef869df9)
