### PR TITLE
Remove check for dotnet.exe from startvs.cmd.

### DIFF
--- a/startvs.cmd
+++ b/startvs.cmd
@@ -20,9 +20,4 @@ IF "%sln%"=="" (
     SET sln=%~dp0Aspire.sln
 )
 
-IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
-    echo .NET Core has not yet been installed. Run `%~dp0restore.cmd` to install tools
-    exit /b 1
-)
-
 start "" "%sln%"


### PR DESCRIPTION
This check is not helpful. At points in time where we are running against stable bits (like 8.0.100 RTM) the `.\restore.cmd` script won't actually install a repo local copy of .NET, and so this path will never exist. We may as well ditch the check.