### PR TITLE
Fix for endpoint not having correct port.

### DIFF
--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -17,24 +17,7 @@ var basketService = builder.AddProject<Projects.BasketService>("basketservice")
 
 builder.AddProject<Projects.MyFrontend>("frontend")
        .WithReference(basketService)
-       .WithReference(catalogService.GetEndpoint("http"))
-       .WithEnvironment("TESTVALUE_X", catalogService.GetEndpoint("http"))
-       .WithEnvironment(context =>
-       {
-           if (!catalogService.Resource.TryGetServiceBindings(out var serviceBindings))
-           {
-               return;
-           }
-
-           var binding = serviceBindings.FirstOrDefault(b => b.Name == "http");
-
-           if (binding is null)
-           {
-               return;
-           }
-
-           context.EnvironmentVariables["TESTVALUE_Y"] = binding.UriScheme + "://localhost:" + binding.Port;
-       });
+       .WithReference(catalogService.GetEndpoint("http"));
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor")
        .WithReference(messaging)

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -7,7 +7,8 @@ var catalogDb = builder.AddPostgresContainer("postgres").AddDatabase("catalogdb"
 var basketCache = builder.AddRedisContainer("basketcache");
 
 var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice")
-                     .WithReference(catalogDb);
+                     .WithReference(catalogDb)
+                     .WithReplicas(2);
 
 var messaging = builder.AddRabbitMQContainer("messaging");
 

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -7,8 +7,7 @@ var catalogDb = builder.AddPostgresContainer("postgres").AddDatabase("catalogdb"
 var basketCache = builder.AddRedisContainer("basketcache");
 
 var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice")
-                     .WithReference(catalogDb)
-                     .WithReplicas(2);
+                     .WithReference(catalogDb);
 
 var messaging = builder.AddRabbitMQContainer("messaging");
 
@@ -18,7 +17,24 @@ var basketService = builder.AddProject<Projects.BasketService>("basketservice")
 
 builder.AddProject<Projects.MyFrontend>("frontend")
        .WithReference(basketService)
-       .WithReference(catalogService.GetEndpoint("http"));
+       .WithReference(catalogService.GetEndpoint("http"))
+       .WithEnvironment("TESTVALUE_X", catalogService.GetEndpoint("http"))
+       .WithEnvironment(context =>
+       {
+           if (!catalogService.Resource.TryGetServiceBindings(out var serviceBindings))
+           {
+               return;
+           }
+
+           var binding = serviceBindings.FirstOrDefault(b => b.Name == "http");
+
+           if (binding is null)
+           {
+               return;
+           }
+
+           context.EnvironmentVariables["TESTVALUE_Y"] = binding.UriScheme + "://localhost:" + binding.Port;
+       });
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor")
        .WithReference(messaging)

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -167,7 +167,7 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
                     sp.ServiceBindingAnnotation.Name,
                     PortProtocol.ToProtocolType(svc.Spec.Protocol),
                     svc.AllocatedAddress!,
-                    (int)(sp.ServiceBindingAnnotation.Port! ?? svc.AllocatedPort!), // Checked by HasCompleteAddress above.
+                    (int)(sp.ServiceBindingAnnotation.Port ?? svc.AllocatedPort!), // Checked by HasCompleteAddress above.
                     sp.ServiceBindingAnnotation.UriScheme
                     );
 

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -167,7 +167,7 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
                     sp.ServiceBindingAnnotation.Name,
                     PortProtocol.ToProtocolType(svc.Spec.Protocol),
                     svc.AllocatedAddress!,
-                    (int)svc.AllocatedPort!,
+                    (int)(sp.ServiceBindingAnnotation.Port! ?? svc.AllocatedPort!), // Checked by HasCompleteAddress above.
                     sp.ServiceBindingAnnotation.UriScheme
                     );
 

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -131,6 +131,82 @@ public class DistributedApplicationTests(ITestOutputHelper testOutputHelper)
     }
 
     [LocalOnlyFact]
+    public async void TestPortOnServiceBindingAnnotationAndAllocatedEndpointAnnotationMatch()
+    {
+        var testProgram = CreateTestProgram();
+        testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
+
+        testProgram.AppBuilder.Services
+            .AddHttpClient()
+            .ConfigureHttpClientDefaults(b =>
+            {
+                b.UseSocketsHttpHandler((handler, sp) => handler.PooledConnectionLifetime = TimeSpan.FromSeconds(5));
+            });
+
+        await using var app = testProgram.Build();
+
+        var client = app.Services.GetRequiredService<IHttpClientFactory>().CreateClient();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+
+        await app.StartAsync(cts.Token);
+
+        // Make sure each service is running
+        await testProgram.ServiceABuilder.HttpGetPidAsync(client, "http", cts.Token);
+        await testProgram.ServiceBBuilder.HttpGetPidAsync(client, "http", cts.Token);
+        await testProgram.ServiceCBuilder.HttpGetPidAsync(client, "http", cts.Token);
+
+        foreach (var projectBuilders in testProgram.ServiceProjectBuilders)
+        {
+            var serviceBinding = projectBuilders.Resource.Annotations.OfType<ServiceBindingAnnotation>().Single();
+            var allocatedEndpoint = projectBuilders.Resource.Annotations.OfType<AllocatedEndpointAnnotation>().Single();
+
+            Assert.Equal(serviceBinding.Port, allocatedEndpoint.Port);
+        }
+    }
+
+    [LocalOnlyFact]
+    public async void TestPortOnServiceBindingAnnotationAndAllocatedEndpointAnnotationMatchForReplicatedServices()
+    {
+        var testProgram = CreateTestProgram();
+
+        foreach (var serviceBuilder in testProgram.ServiceProjectBuilders)
+        {
+            serviceBuilder.WithReplicas(2);
+        }
+
+        testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
+
+        testProgram.AppBuilder.Services
+            .AddHttpClient()
+            .ConfigureHttpClientDefaults(b =>
+            {
+                b.UseSocketsHttpHandler((handler, sp) => handler.PooledConnectionLifetime = TimeSpan.FromSeconds(5));
+            });
+
+        await using var app = testProgram.Build();
+
+        var client = app.Services.GetRequiredService<IHttpClientFactory>().CreateClient();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+
+        await app.StartAsync(cts.Token);
+
+        // Make sure each service is running
+        await testProgram.ServiceABuilder.HttpGetPidAsync(client, "http", cts.Token);
+        await testProgram.ServiceBBuilder.HttpGetPidAsync(client, "http", cts.Token);
+        await testProgram.ServiceCBuilder.HttpGetPidAsync(client, "http", cts.Token);
+
+        foreach (var projectBuilders in testProgram.ServiceProjectBuilders)
+        {
+            var serviceBinding = projectBuilders.Resource.Annotations.OfType<ServiceBindingAnnotation>().Single();
+            var allocatedEndpoint = projectBuilders.Resource.Annotations.OfType<AllocatedEndpointAnnotation>().Single();
+
+            Assert.Equal(serviceBinding.Port, allocatedEndpoint.Port);
+        }
+    }
+
+    [LocalOnlyFact]
     public async void TestServicesWithMultipleReplicas()
     {
         var replicaCount = 3;

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -21,6 +21,8 @@ public class TestProgram
     public IResourceBuilder<ProjectResource> ServiceCBuilder { get; private set; }
     public DistributedApplication? App { get; private set; }
 
+    public List<IResourceBuilder<ProjectResource>> ServiceProjectBuilders => [ServiceABuilder, ServiceBBuilder, ServiceCBuilder];
+
     public async Task RunAsync(CancellationToken cancellationToken = default)
     {
         App = AppBuilder.Build();


### PR DESCRIPTION
Fixes #692

I think this issue was ultimately a very simple bug in the way that we were constructing the allocated endpoint annotation. Whenever the port is specified it should be what is allocated. If it isn't specified then we should take the port allocated.

Note putting this PR up for review ... will remove cruft from sample app host and create a test around this but wanted to get it in front of @karolz-ms especially since this seemed less involved than what he specified in the issue.