### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+registries:
+  public-nuget:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    registries:
+      - public-nuget
+    schedule:
+      interval: daily
+      time: "18:54"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 25
+    groups:
+      Azure:
+        patterns:
+          - "Azure.*"
+          - "Microsoft.Azure.*"
+          - "Microsoft.Extensions.Azure"
+      AspNetCoreHealthChecks:
+        patterns:
+          - "AspNetCore.HealthChecks.*"
+      AspNetCore:
+        patterns:
+          - "Microsoft.AspNetCore.*"
+          - "Microsoft.Extensions.Features"
+      MicrosoftExtensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      EntityFrameworkCore:
+        patterns:
+          - "Microsoft.EntityFrameworkCore.*"
+      FluentUi:
+        patterns:
+          - "Microsoft.FluentUI.*"
+      OpenTelemetry:
+        patterns:
+          - "OpenTelemetry.*"
+      Npgsql:
+        patterns:
+          - "Npgsql.*"
+      MicrosoftDotNet:
+        patterns:
+          - "Microsoft.DotNet.*"
+      Grpc:
+        patterns:
+          - "Grpc.*"
+    labels:
+      - "area-codeflow"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       - public-nuget
     schedule:
       interval: daily
-      time: "18:54"
+      time: "07:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 25
     groups:


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/182

`url: https://api.nuget.org/v3/index.json` in the dependabot.yml makes it look at nuget.org, even though we do not have that feed in our nuget.config: we mirror packages selectively.

This is very helpful, because it will trigger updates even when the package version is not on the mirror yet. The build will break, and then someone with rights to queue a dnceng build needs to go [update the mirror for the version needed](https://github.com/dotnet/arcade/blob/main/Documentation/MirroringPackages.md) and then rerun validation.

eg., I had to do this for Polly, JsonSchema.Net, Dapr.AspNetCore and KubernetesClient to restore successfully after dependabot ran in my fork.