### PR TITLE
Use old array initializer in templates for older IDEs

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication-1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication-1.ServiceDefaults/Extensions.cs
@@ -89,7 +89,7 @@ public static class Extensions
     {
         builder.Services.AddHealthChecks()
             // Add a default liveness check to ensure app is responsive
-            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+            .AddCheck("self", () => HealthCheckResult.Healthy(), new[]{ "live" });
 
         return builder;
     }

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication-1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication-1.ServiceDefaults/Extensions.cs
@@ -89,7 +89,7 @@ public static class Extensions
     {
         builder.Services.AddHealthChecks()
             // Add a default liveness check to ensure app is responsive
-            .AddCheck("self", () => HealthCheckResult.Healthy(), ["live"]);
+            .AddCheck("self", () => HealthCheckResult.Healthy(), new[]{ "live" });
 
         return builder;
     }


### PR DESCRIPTION
Unfortunately not all IDEs support C# 12 yet (JetBrains Rider and ReSharper, I'm looking at you).

This small PR alters the templates so that developers using those tools don't get a broken build by default.