### PR TITLE
Service Discovery: fix shutdown blocking indefinitely in some cases

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
@@ -122,7 +122,7 @@ public class HttpServiceEndPointResolver(ServiceEndPointResolverFactory resolver
     {
         lock (_lock)
         {
-            if (_cleanupTask is { IsCompleted: true })
+            if (_cleanupTask is null or { IsCompleted: true })
             {
                 _cleanupTask = CleanupResolversAsyncCore();
             }
@@ -159,7 +159,7 @@ public class HttpServiceEndPointResolver(ServiceEndPointResolverFactory resolver
     {
         private readonly ServiceEndPointResolver _resolver;
         private readonly IServiceEndPointSelector _selector;
-        private const ulong CountMask = unchecked((ulong)-1);
+        private const ulong CountMask = ~(RecentUseFlag | DisposingFlag);   
         private const ulong RecentUseFlag = 1UL << 61;
         private const ulong DisposingFlag = 1UL << 62;
         private ulong _status;

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
@@ -160,8 +160,8 @@ public class HttpServiceEndPointResolver(ServiceEndPointResolverFactory resolver
         private readonly ServiceEndPointResolver _resolver;
         private readonly IServiceEndPointSelector _selector;
         private const ulong CountMask = ~(RecentUseFlag | DisposingFlag);
-        private const ulong RecentUseFlag = 1UL << 61;
-        private const ulong DisposingFlag = 1UL << 62;
+        private const ulong RecentUseFlag = 1UL << 62;
+        private const ulong DisposingFlag = 1UL << 63;
         private ulong _status;
         private TaskCompletionSource? _onDisposed;
 

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
@@ -159,7 +159,7 @@ public class HttpServiceEndPointResolver(ServiceEndPointResolverFactory resolver
     {
         private readonly ServiceEndPointResolver _resolver;
         private readonly IServiceEndPointSelector _selector;
-        private const ulong CountMask = ~(RecentUseFlag | DisposingFlag);   
+        private const ulong CountMask = ~(RecentUseFlag | DisposingFlag);
         private const ulong RecentUseFlag = 1UL << 61;
         private const ulong DisposingFlag = 1UL << 62;
         private ulong _status;

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverRegistry.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverRegistry.cs
@@ -121,7 +121,7 @@ public sealed class ServiceEndPointResolverRegistry(ServiceEndPointResolverFacto
     {
         lock (_lock)
         {
-            if (_cleanupTask is { IsCompleted: true })
+            if (_cleanupTask is null or { IsCompleted: true })
             {
                 _cleanupTask = CleanupResolversAsyncCore();
             }
@@ -155,7 +155,7 @@ public sealed class ServiceEndPointResolverRegistry(ServiceEndPointResolverFacto
     private sealed class ResolverEntry(ServiceEndPointResolver resolver) : IAsyncDisposable
     {
         private readonly ServiceEndPointResolver _resolver = resolver;
-        private const ulong CountMask = unchecked((ulong)-1);
+        private const ulong CountMask = ~(RecentUseFlag | DisposingFlag);
         private const ulong RecentUseFlag = 1UL << 61;
         private const ulong DisposingFlag = 1UL << 62;
         private ulong _status;

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverRegistry.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverRegistry.cs
@@ -156,8 +156,8 @@ public sealed class ServiceEndPointResolverRegistry(ServiceEndPointResolverFacto
     {
         private readonly ServiceEndPointResolver _resolver = resolver;
         private const ulong CountMask = ~(RecentUseFlag | DisposingFlag);
-        private const ulong RecentUseFlag = 1UL << 61;
-        private const ulong DisposingFlag = 1UL << 62;
+        private const ulong RecentUseFlag = 1UL << 62;
+        private const ulong DisposingFlag = 1UL << 63;
         private ulong _status;
         private TaskCompletionSource? _onDisposed;
 


### PR DESCRIPTION
The logic used to determine when it was safe to dispose was not triggering because we added an additional flag which was not covered by the count mask.