### PR TITLE
Fix async void in SummaryDetailsView

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
@@ -80,7 +80,7 @@ public partial class SummaryDetailsView
         await OnDismiss.InvokeAsync();
     }
 
-    private async void HandleToggleOrientation()
+    private async Task HandleToggleOrientation()
     {
         if (Orientation == Orientation.Horizontal)
         {


### PR DESCRIPTION
Looks like when I added the `await`s in HandleToggleOrientation, VS helpfully added `async` for me but then I forgot to go back and _also_ change `void` to `Task`.