### PR TITLE
Support proxyless singleton containers

### DIFF
--- a/src/Aspire.Hosting/AspireEventSource.cs
+++ b/src/Aspire.Hosting/AspireEventSource.cs
@@ -262,4 +262,22 @@ internal sealed class AspireEventSource : EventSource
             WriteEvent(28);
         }
     }
+
+    [Event(29, Level = EventLevel.Informational, Message = "DCP version check is starting...")]
+    public void DcpVersionCheckStart()
+    {
+        if (IsEnabled())
+        {
+            WriteEvent(29);
+        }
+    }
+
+    [Event(30, Level = EventLevel.Informational, Message = "DCP version check completed")]
+    public void DcpVersionCheckStop()
+    {
+        if (IsEnabled())
+        {
+            WriteEvent(30);
+        }
+    }
 }

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -77,8 +77,7 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
         var dockerHealthCheckTask = EnsureDockerIfNecessaryAsync(cancellationToken);
         var dcpVersionCheckTask = EnsureDcpVersionAsync(cancellationToken);
 
-        await dockerHealthCheckTask.ConfigureAwait(false);
-        await dcpVersionCheckTask.ConfigureAwait(false);
+        await Task.WhenAll(dockerHealthCheckTask, dcpVersionCheckTask).ConfigureAwait(false);
 
         EnsureDcpHostRunning();
         await _appExecutor.RunApplicationAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -347,7 +347,8 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
                 {
                     Console.Error.WriteLine(string.Format(
                         CultureInfo.InvariantCulture,
-                        Resources.DcpVersionCheckTooHighMessage
+                        Resources.DcpVersionCheckTooHighMessage,
+                        DcpVersion.MinimumVersionInclusive.ToString()
                     ));
                     Environment.Exit((int)DcpVersionCheckFailures.DcpVersionIncompatible);
                 }

--- a/src/Aspire.Hosting/Dcp/DcpVersion.cs
+++ b/src/Aspire.Hosting/Dcp/DcpVersion.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Dcp;
+
+public static class DcpVersion
+{
+    public static Version MinimumVersionInclusive = new Version(0, 1, 43);
+    public static Version MaximumVersionExclusive = new Version(0, 2, 0);
+}

--- a/src/Aspire.Hosting/Dcp/DcpVersion.cs
+++ b/src/Aspire.Hosting/Dcp/DcpVersion.cs
@@ -3,7 +3,7 @@
 
 namespace Aspire.Hosting.Dcp;
 
-public static class DcpVersion
+internal static class DcpVersion
 {
     public static Version MinimumVersionInclusive = new Version(0, 1, 43);
     public static Version MaximumVersionExclusive = new Version(0, 2, 0);

--- a/src/Aspire.Hosting/Dcp/Model/Service.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Service.cs
@@ -23,7 +23,7 @@ internal sealed class ServiceSpec
 
     // The mode for address allocation
     [JsonPropertyName("addressAllocationMode")]
-    public string AddressAllocationMode = AddressAllocationModes.Localhost;
+    public string AddressAllocationMode { get; set; } = AddressAllocationModes.Localhost;
 }
 
 internal sealed class ServiceStatus : V1Status
@@ -63,6 +63,9 @@ internal static class AddressAllocationModes
 
     // Bind to "localhost", which is all loopback devices on the machine.
     public const string Localhost = "Localhost";
+
+    // Don't use a proxy, instead bind to the first Endpoint.
+    public const string Proxyless = "Proxyless";
 }
 
 internal sealed class Service : CustomResource<ServiceSpec, ServiceStatus>

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -30,6 +30,14 @@ internal enum DockerHealthCheckFailures : int
     PrerequisiteMissing = 127
 }
 
+internal enum DcpVersionCheckFailures: int
+{
+    /// <summary>
+    /// Represents the exit code indicating that the version of DCP is too low or too high.
+    /// </summary>
+    DcpVersionIncompatible = 128,
+}
+
 /// <summary>
 /// Represents a distributed application that implements the <see cref="IHost"/> and <see cref="IAsyncDisposable"/> interfaces.
 /// </summary>

--- a/src/Aspire.Hosting/Properties/Resources.Designer.cs
+++ b/src/Aspire.Hosting/Properties/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace Aspire.Hosting.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The application orchestrator version could not be determined. Continuing..
+        /// </summary>
+        internal static string DcpVersionCheckFailedMessage {
+            get {
+                return ResourceManager.GetString("DcpVersionCheckFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The application orchestrator version is too high. Lorem ipsum how did you even get here..
+        /// </summary>
+        internal static string DcpVersionCheckTooHighMessage {
+            get {
+                return ResourceManager.GetString("DcpVersionCheckTooHighMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The application orchestrator version is too low. Run `lorem ipsum` to upgrade..
+        /// </summary>
+        internal static string DcpVersionCheckTooLowMessage {
+            get {
+                return ResourceManager.GetString("DcpVersionCheckTooLowMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Docker could not be found. The error from Docker invocation was: {0}.
         /// </summary>
         internal static string DockerPrerequisiteMissingExceptionMessage {

--- a/src/Aspire.Hosting/Properties/Resources.Designer.cs
+++ b/src/Aspire.Hosting/Properties/Resources.Designer.cs
@@ -70,7 +70,7 @@ namespace Aspire.Hosting.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The application orchestrator version is too high. Lorem ipsum how did you even get here..
+        ///   Looks up a localized string similar to Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application)..
         /// </summary>
         internal static string DcpVersionCheckTooHighMessage {
             get {
@@ -79,7 +79,7 @@ namespace Aspire.Hosting.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The application orchestrator version is too low. Run `lorem ipsum` to upgrade..
+        ///   Looks up a localized string similar to Newer version of .NET Aspire workload is required to run the application. Run &apos;dotnet workload update&apos; to get it..
         /// </summary>
         internal static string DcpVersionCheckTooLowMessage {
             get {

--- a/src/Aspire.Hosting/Properties/Resources.resx
+++ b/src/Aspire.Hosting/Properties/Resources.resx
@@ -121,10 +121,10 @@
     <value>The application orchestrator version could not be determined. Continuing.</value>
   </data>
   <data name="DcpVersionCheckTooHighMessage" xml:space="preserve">
-    <value>The application orchestrator version is too high. Lorem ipsum how did you even get here.</value>
+    <value>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</value>
   </data>
   <data name="DcpVersionCheckTooLowMessage" xml:space="preserve">
-    <value>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</value>
+    <value>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</value>
   </data>
   <data name="DockerPrerequisiteMissingExceptionMessage" xml:space="preserve">
     <value>Docker could not be found. The error from Docker invocation was: {0}</value>

--- a/src/Aspire.Hosting/Properties/Resources.resx
+++ b/src/Aspire.Hosting/Properties/Resources.resx
@@ -117,6 +117,15 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DcpVersionCheckFailedMessage" xml:space="preserve">
+    <value>The application orchestrator version could not be determined. Continuing.</value>
+  </data>
+  <data name="DcpVersionCheckTooHighMessage" xml:space="preserve">
+    <value>The application orchestrator version is too high. Lorem ipsum how did you even get here.</value>
+  </data>
+  <data name="DcpVersionCheckTooLowMessage" xml:space="preserve">
+    <value>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</value>
+  </data>
   <data name="DockerPrerequisiteMissingExceptionMessage" xml:space="preserve">
     <value>Docker could not be found. The error from Docker invocation was: {0}</value>
   </data>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.cs.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.cs.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.cs.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.cs.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.de.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.de.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.de.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.de.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.es.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.es.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.es.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.es.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.fr.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.fr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.fr.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.fr.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.it.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.it.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.it.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.it.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.ja.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.ja.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.ja.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.ja.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.ko.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.ko.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.ko.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.ko.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.pl.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.pl.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.pl.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.pl.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.pt-BR.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.ru.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.ru.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.ru.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.ru.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.tr.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.tr.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.tr.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.tr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.zh-Hans.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>

--- a/src/Aspire.Hosting/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.zh-Hant.xlf
@@ -8,13 +8,13 @@
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooHighMessage">
-        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
-        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <source>Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</source>
+        <target state="new">Found incompatible version of .NET Aspire workload (need application orchestrator version {0} to run the application).</target>
         <note />
       </trans-unit>
       <trans-unit id="DcpVersionCheckTooLowMessage">
-        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
-        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <source>Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</source>
+        <target state="new">Newer version of .NET Aspire workload is required to run the application. Run 'dotnet workload update' to get it.</target>
         <note />
       </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">

--- a/src/Aspire.Hosting/Properties/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Hosting/Properties/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="DcpVersionCheckFailedMessage">
+        <source>The application orchestrator version could not be determined. Continuing.</source>
+        <target state="new">The application orchestrator version could not be determined. Continuing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooHighMessage">
+        <source>The application orchestrator version is too high. Lorem ipsum how did you even get here.</source>
+        <target state="new">The application orchestrator version is too high. Lorem ipsum how did you even get here.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DcpVersionCheckTooLowMessage">
+        <source>The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</source>
+        <target state="new">The application orchestrator version is too low. Run `lorem ipsum` to upgrade.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DockerPrerequisiteMissingExceptionMessage">
         <source>Docker could not be found. The error from Docker invocation was: {0}</source>
         <target state="new">Docker could not be found. The error from Docker invocation was: {0}</target>


### PR DESCRIPTION
/cc @karolz-ms

This change works with a corresponding change in DCP to support proxyless aka headless services. The `ApplicationExecutor` will choose containers which consume no services and start them up without a proxy in front. The `Service` object assumes the address and port of the container itself and no proxy process is started.