### PR TITLE
Add support for comment handling in launchSettings.json

### DIFF
--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
@@ -40,6 +40,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Tests"/>
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting/Utils/LaunchProfileExtensions.cs
+++ b/src/Aspire.Hosting/Utils/LaunchProfileExtensions.cs
@@ -145,6 +145,7 @@ internal static class LaunchProfileExtensions
 internal delegate bool LaunchProfileSelector(ProjectResource project, out string? launchProfile);
 
 [JsonSerializable(typeof(LaunchSettings))]
+[JsonSourceGenerationOptions(ReadCommentHandling = JsonCommentHandling.Skip)]
 internal sealed partial class LaunchSetttingsSerializerContext : JsonSerializerContext
 {
 

--- a/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
+++ b/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+public class LaunchSettingsSerializerContextTests
+{
+    [Fact]
+    public void CommentsInLaunchSettingsJsonDoesNotThrow()
+    {
+        const string launchSettingsJson = """
+        {
+          "$schema": "http://json.schemastore.org/launchsettings.json",
+          "profiles": {
+            // comment
+            "http": {
+              "commandName": "Project",
+              "dotnetRunMessages": true,
+              "launchBrowser": true,
+              "applicationUrl": "http://localhost:5261",
+              "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+              }
+            }
+          }
+        }
+        """;
+        var exception = Record.Exception(() => JsonSerializer.Deserialize(launchSettingsJson, LaunchSetttingsSerializerContext.Default.LaunchSettings));
+        Assert.Null(exception);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
+++ b/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
+
 public class LaunchSettingsSerializerContextTests
 {
     [Fact]

--- a/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
+++ b/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
@@ -27,7 +27,8 @@ public class LaunchSettingsSerializerContextTests
           }
         }
         """;
-        var exception = Record.Exception(() => JsonSerializer.Deserialize(launchSettingsJson, LaunchSetttingsSerializerContext.Default.LaunchSettings));
-        Assert.Null(exception);
+
+        // should not throw
+        JsonSerializer.Deserialize(launchSettingsJson, LaunchSetttingsSerializerContext.Default.LaunchSettings));
     }
 }

--- a/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
+++ b/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
@@ -30,6 +30,6 @@ public class LaunchSettingsSerializerContextTests
         """;
 
         // should not throw
-        JsonSerializer.Deserialize(launchSettingsJson, LaunchSetttingsSerializerContext.Default.LaunchSettings));
+        JsonSerializer.Deserialize(launchSettingsJson, LaunchSetttingsSerializerContext.Default.LaunchSettings);
     }
 }


### PR DESCRIPTION
Closes #772 by adding `[JsonSourceGenerationOptions(ReadCommentHandling = JsonCommentHandling.Skip)]` to `LaunchSetttingsSerializerContext`