### PR TITLE
Use ExecutableReplicaSet uniformly for running projects

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Index.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Index.razor
@@ -22,8 +22,8 @@
         <Summary>
             <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="2fr 1.2fr 2fr 1fr 4fr 2fr 1fr 1fr" >
                 <ChildContent>
-                    <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort" Tooltip="true" TooltipText="(p) => p.Name">
-                        <FluentHighlighter HighlightedText="@filter" Text="@context.Name" />
+                    <TemplateColumn Title="Name" Sortable="true" SortBy="@nameSort" Tooltip="true" TooltipText="(p) => p.DisplayName ?? p.Name">
+                        <FluentHighlighter HighlightedText="@filter" Text="@(context.DisplayName ?? context.Name)" />
                     </TemplateColumn>
                     <TemplateColumn Title="State" Sortable="true" SortBy="@stateSort">
                         <div class="resource-state-container">

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -105,7 +105,11 @@ public partial class Metrics : IDisposable
 
     private void UpdateApplications()
     {
-        _applications = TelemetryRepository.GetApplications().Select(a => new SelectViewModel<string> { Id = a.InstanceId, Name = a.ApplicationName }).ToList();
+        _applications = TelemetryRepository.GetApplications().Select(a =>
+        {
+            var applicationName = NamingUtil.TryGetReplicaDisplayName(a.ApplicationName) ?? a.ApplicationName;
+            return new SelectViewModel<string> { Id = a.InstanceId, Name = applicationName };
+        }).ToList();
         _applications.Insert(0, s_selectApplication);
         UpdateSubscription();
     }

--- a/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.cs
@@ -218,7 +218,7 @@ public abstract partial class ResourceLogsBase<TResource> : ComponentBase, IAsyn
         {
             stateText = $" ({resource.State})";
         }
-        return $"{resource.Name}{stateText}";
+        return $"{resource.DisplayName ?? resource.Name}{stateText}";
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -124,7 +124,11 @@ public partial class StructuredLogs
 
     private void UpdateApplications()
     {
-        _applications = TelemetryRepository.GetApplications().Select(a => new SelectViewModel<string> { Id = a.InstanceId, Name = a.ApplicationName }).ToList();
+        _applications = TelemetryRepository.GetApplications().Select(a =>
+        {
+            var applicationName = NamingUtil.TryGetReplicaDisplayName(a.ApplicationName) ?? a.ApplicationName;
+            return new SelectViewModel<string> { Id = a.InstanceId, Name = applicationName };
+        }).ToList();
         _applications.Insert(0, s_allApplication);
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -96,7 +96,6 @@ public partial class Traces
 
     private void UpdateApplications()
     {
-        
         _applications = TelemetryRepository.GetApplications().Select(a =>
         {
             var applicationName = NamingUtil.TryGetReplicaDisplayName(a.ApplicationName) ?? a.ApplicationName;

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -96,7 +96,12 @@ public partial class Traces
 
     private void UpdateApplications()
     {
-        _applications = TelemetryRepository.GetApplications().Select(a => new SelectViewModel<string> { Id = a.InstanceId, Name = a.ApplicationName }).ToList();
+        
+        _applications = TelemetryRepository.GetApplications().Select(a =>
+        {
+            var applicationName = NamingUtil.TryGetReplicaDisplayName(a.ApplicationName) ?? a.ApplicationName;
+            return new SelectViewModel<string> { Id = a.InstanceId, Name = applicationName };
+        }).ToList();
         _applications.Insert(0, s_allApplication);
         UpdateSubscription();
     }

--- a/src/Aspire.Dashboard/Model/NamingUtil.cs
+++ b/src/Aspire.Dashboard/Model/NamingUtil.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public static class NamingUtil
+{
+    public static string? TryGetReplicaDisplayName(string candidate)
+    {
+        if (candidate.Length < 3)
+        {
+            return null;
+        }
+
+        var nameParts = candidate.Split('-');
+        if (nameParts.Length == 2 && nameParts[0].Length > 0 && nameParts[1].Length > 0)
+        {
+            return $"{nameParts[0]} ({nameParts[1]})";
+        }
+
+        return null;
+    }
+}

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -6,6 +6,7 @@ namespace Aspire.Dashboard.Model;
 public abstract class ResourceViewModel
 {
     public required string Name { get; init; }
+    public string? DisplayName { get; init; }
     public required string Uid { get; init; }
     public required NamespacedName NamespacedName { get; init; }
     public string? State { get; init; }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -399,7 +399,7 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
         var launchProfile = launchSettings.Profiles[launchProfileName];
         if (!string.IsNullOrWhiteSpace(launchProfile.ApplicationUrl))
         {
-            if (executableResource.ServicesProduced.Any())
+            if (executableResource.DcpResource is ExecutableReplicaSet)
             {
                 var urls = executableResource.ServicesProduced.Select(sar =>
                 {
@@ -553,8 +553,11 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
 
                 sp.DcpServiceProducerAnnotation.Port = sp.ServiceBindingAnnotation.ContainerPort;
             }
-            else if (sp.ServiceBindingAnnotation.Port is not null)
+            else if (sp.ServiceBindingAnnotation.Port is not null && sp.ModelResource is not ProjectResource)
             {
+                // Project resources do not use ServiceBindingAnnotation port because they will have port auto-allocated by the orchestrator.
+                // The port specified by the ServiceBindingAnnotation will be applied to the Service objects and injected into clients instead.
+
                 sp.DcpServiceProducerAnnotation.Port = sp.ServiceBindingAnnotation.Port;
             }
 

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -544,6 +544,10 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
         var servicesProduced = _appResources.OfType<ServiceAppResource>().Where(r => r.ModelResource == modelResource);
         foreach (var sp in servicesProduced)
         {
+            // Projects/Executables have their ports auto-allocated; the the port specified by the ServiceBindingAnnotation
+            // is applied to the Service objects and used by clients.
+            // Containers use the port from the ServiceBindingAnnotation directly.
+
             if (modelResource.IsContainer())
             {
                 if (sp.ServiceBindingAnnotation.ContainerPort is null)
@@ -552,13 +556,6 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
                 }
 
                 sp.DcpServiceProducerAnnotation.Port = sp.ServiceBindingAnnotation.ContainerPort;
-            }
-            else if (sp.ServiceBindingAnnotation.Port is not null && sp.ModelResource is not ProjectResource)
-            {
-                // Project resources do not use ServiceBindingAnnotation port because they will have port auto-allocated by the orchestrator.
-                // The port specified by the ServiceBindingAnnotation will be applied to the Service objects and injected into clients instead.
-
-                sp.DcpServiceProducerAnnotation.Port = sp.ServiceBindingAnnotation.Port;
             }
 
             dcpResource.AnnotateAsObjectList(CustomResource.ServiceProducerAnnotation, sp.DcpServiceProducerAnnotation);


### PR DESCRIPTION
This change removes the dichotomy between single-replica projects and multi-replica projects and positions us well to enable service scale up and scale down at development time.

Augments https://github.com/dotnet/aspire/pull/860 and completes https://github.com/dotnet/aspire/issues/692

Large portion of this change is to make Project names readable in the dashboard. Since every Project visible in the dashboard is a replica now, the names were kind of ugly originally (coming straight from the model like `basketservice-e3gth7a`). I changed them to be easier on the eyes by separating replica id suffix from the service name (e.g. the same service shows up now as `basketservice (e3gth7a)`).