### PR TITLE
Make DurationFormater use CultureInfo.InvariantCulture for decimal values

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/DurationFormatter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/DurationFormatter.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+
 namespace Aspire.Dashboard.Otlp.Model;
 
 public static class DurationFormatter
@@ -31,7 +33,7 @@ public static class DurationFormatter
         if (primaryUnit.IsDecimal)
         {
             // If the unit is decimal based, display as a decimal
-            return $"{ticks / primaryUnit.Ticks:0.##}{primaryUnit.Unit}";
+            return $"{(ticks / primaryUnit.Ticks).ToString("0.##", CultureInfo.InvariantCulture)}{primaryUnit.Unit}";
         }
 
         var primaryValue = Math.Floor(ticks / primaryUnit.Ticks);

--- a/tests/Aspire.Dashboard.Tests/DurationFormatterTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DurationFormatterTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Dashboard.Otlp.Model;
 using Xunit;
 
@@ -26,6 +27,25 @@ public class DurationFormatterTests
     {
         var input = 2 * TimeSpan.TicksPerDay + 5 * TimeSpan.TicksPerMinute;
         Assert.Equal("2d", DurationFormatter.FormatDuration(TimeSpan.FromTicks(input)));
+    }
+
+    [Theory]
+    [InlineData("pt-BR")]
+    [InlineData("fr-FR")]
+    public void FormatDuration_MustBeCultureInvariant(string commaDecimalSeparatorCulture)
+    {
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo(commaDecimalSeparatorCulture);
+            var input = 2 * TimeSpan.TicksPerSecond + 357 * TimeSpan.TicksPerMillisecond;
+            Assert.Equal("2.36s", DurationFormatter.FormatDuration(TimeSpan.FromTicks(input)));
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
     }
 
     [Fact]


### PR DESCRIPTION
DurationFormatter tests fail when run on machines that do not have the decimal separator being "."