### PR TITLE
Remove padding around content pane

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -70,7 +70,6 @@
         "toolbar"
         "main";
     gap: calc(var(--design-unit) * 2px);
-    padding: calc(var(--design-unit) * 2px);
 }
 
 ::deep.metrics-layout > h1 {
@@ -84,4 +83,10 @@
 
 ::deep.metrics-layout > .page-content-area {
     grid-area: main;
+}
+
+.page-content-area {
+    height: 100%;
+    width: 100%;
+    overflow: auto;
 }

--- a/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/ResourceLogsBase.razor.css
@@ -7,7 +7,6 @@
         "head"
         "toolbar"
         "main";
-    padding: calc(var(--design-unit) * 2px);
 }
 
 ::deep.resource-logs-layout > h1 {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
@@ -8,7 +8,6 @@
         "toolbar"
         "main";
     gap: calc(var(--design-unit) * 2px);
-    padding: calc(var(--design-unit) * 2px);
 }
 
 ::deep.logs-layout > h1 {
@@ -59,4 +58,5 @@
 
 ::deep .logs-summary-layout > .total-items-footer {
     grid-area: foot;
+    padding-bottom: calc(var(--design-unit) * 2px);
 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -163,7 +163,6 @@
         "toolbar"
         "main";
     gap: calc(var(--design-unit) * 2px);
-    padding: calc(var(--design-unit) * 2px);
 }
 
 ::deep.trace-detail-layout > .trace-detail-header {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -30,7 +30,6 @@
         "main"
         "foot";
     gap: calc(var(--design-unit) * 2px);
-    padding: calc(var(--design-unit) * 2px);
 }
 
 ::deep.traces-layout > h1 {
@@ -48,4 +47,5 @@
 
 ::deep.traces-layout > .total-items-footer {
     grid-area: foot;
+    padding-bottom: calc(var(--design-unit) * 2px);
 }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -42,15 +42,6 @@ fluent-toolbar[orientation=horizontal] {
     --foreground-subtext-hover: #A1A1A1;
 }
 
-.page-content-area {
-    /*
-        Height of the browser - static height for other content
-        TODO: Is there a better way to do this?
-    */
-    height: calc(100vh - 175px);
-    width: 100%;
-}
-
 .datagrid-overflow-area,
 .parent-details-container {
     /*
@@ -103,7 +94,6 @@ fluent-dialog fluent-data-grid-cell[cell-type=columnheader] fluent-button[appear
     grid-template-areas:
         "toolbar"
         "main";
-    padding: calc(var(--design-unit) * 2px);
 }
 
 .content-layout-with-toolbar > fluent-toolbar {


### PR DESCRIPTION
Fixes #867.

Since #823 hasn't been settled, I went ahead and addressed this one. Removing the padding from the content pane on all pages cleaned things up considerably. I added a little padding back to the total items footer to pull that text away from the bottom. I don't think the removal of padding made anything else too dense.

Screenshots don't really do it justice since its now mostly aligned with the edge, but here they are.
![image](https://github.com/dotnet/aspire/assets/9613109/f569867d-7e09-4667-b1d3-86a2d93fc135)
![image](https://github.com/dotnet/aspire/assets/9613109/d52a3a6a-b810-45d7-a9cd-83a80a1dd05a)
![image](https://github.com/dotnet/aspire/assets/9613109/d3fb65fa-36d9-4250-80ef-74763a45d9ea)
![image](https://github.com/dotnet/aspire/assets/9613109/76638720-a302-4537-813d-b20c8875bf44)
![image](https://github.com/dotnet/aspire/assets/9613109/c0232041-9f01-4d21-a6c7-5a655a72a266)
