### PR TITLE
Add unique project capability to workload SDK

### DIFF
--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectCapability Include="DynamicFileNesting" />
     <ProjectCapability Include="DynamicFileNestingEnabled" />
+    <ProjectCapability Include="AspireOrchestration" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Adding a unique project capability to the Aspire.Hosting.Sdk workload SDK to allow tooling to identify Aspire projects before project restore.