### PR TITLE
Details Header Layout adjustments

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -7,16 +7,16 @@
         </Panel1>
         <Panel2>
             <div class="details-container">
-                <FluentHeader Style="height: auto;">
+                <header Style="height: auto;">
                     @if (DetailsTitle is not null)
                     {
-                        @DetailsTitle
+                        <div class="details-header-title" title="@DetailsTitle">@DetailsTitle</div>
                     }
                     else if (DetailsTitleTemplate is not null)
                     {
-                        @DetailsTitleTemplate
+                        <div class="details-header-title">@DetailsTitleTemplate</div>
                     }
-                    <div class="header-right">
+                    <div class="header-actions">
                         <FluentButton Appearance="Appearance.Stealth"
                                       IconEnd="@(Orientation == Orientation.Horizontal ? _splitHorizontalIcon : _splitVerticalIcon)"
                                       OnClick="HandleToggleOrientation"
@@ -25,7 +25,7 @@
                         <FluentButton Appearance="Appearance.Stealth" IconEnd="@(new Icons.Regular.Size16.Dismiss())"
                                       OnClick="HandleDismissAsync" Title="Close" aria-label="Close" />
                     </div>
-                </FluentHeader>
+                </header>
                 @Details
             </div>
         </Panel2>

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
@@ -28,6 +28,11 @@
     grid-row-start: 1;
     background-color: var(--neutral-layer-4);
     color: var(--neutral-foreground-rest);
+    padding: calc(var(--design-unit) * 2px) calc(var(--design-unit) * 3px);
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas: "title actions";
+    align-items: center;
 }
 
 ::deep .details-container > header fluent-button[appearance=stealth]:not(:hover)::part(control) {
@@ -38,6 +43,16 @@
     grid-row-start: 2;
 }
 
-::deep .header-right {
-    margin-left: auto;
+::deep .details-container > header > .details-header-title {
+    grid-area: title;
+    font-size: var(--type-ramp-plus-1-font-size);
+    font-weight: bold;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+::deep .details-container > header > .header-actions {
+    white-space: nowrap;
+    grid-area: actions;
 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -45,9 +45,10 @@
 
         <SummaryDetailsView ShowDetails="SelectedSpan is not null" OnDismiss="() => ClearSelectedSpan()" ViewKey="TraceDetail">
             <DetailsTitleTemplate>
-                <div class="span-details-title">
+                @{ var shortedSpanId = OtlpHelpers.ToShortenedId(SelectedSpan!.Span.SpanId); }
+                <div class="span-details-title" title="@($"{SelectedSpan!.Title} ({shortedSpanId})")">
                     @SelectedSpan!.Title
-                    <span class="span-id">@OtlpHelpers.ToShortenedId(SelectedSpan!.Span.SpanId)</span>
+                    <span class="span-id">@shortedSpanId</span>
                 </div>
             </DetailsTitleTemplate>
             <Summary>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -45,7 +45,7 @@
 
         <SummaryDetailsView ShowDetails="SelectedSpan is not null" OnDismiss="() => ClearSelectedSpan()" ViewKey="TraceDetail">
             <DetailsTitleTemplate>
-                <div>
+                <div class="span-details-title">
                     @SelectedSpan!.Title
                     <span class="span-id">@OtlpHelpers.ToShortenedId(SelectedSpan!.Span.SpanId)</span>
                 </div>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -177,3 +177,9 @@
 ::deep.trace-detail-layout > .summary-details-container {
     grid-area: main;
 }
+
+::deep .span-details-title {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}


### PR DESCRIPTION
Fixes #871 

1. Prevent the buttons wrapping on top of each other
2. Removed the large margins from both sides of the header
3. Prevent the text from wrapping on top of each other, adding the ellipsis to the text when it overflows
4. Added tooltip to the header text for the cases where it overflows
5. All of the above was for the default view, but modified the Trace Details details pane to do the same as well since it has custom display as of #960.

![image](https://github.com/dotnet/aspire/assets/9613109/234a4651-2dec-41fb-a5d2-aac44b65544e)
