### PR TITLE
Fixing a bug in SQL AppHost resource & add end to end integration test

### DIFF
--- a/Aspire.sln
+++ b/Aspire.sln
@@ -156,6 +156,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspire.MySqlConnector", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspire.MySqlConnector.Tests", "tests\Aspire.MySqlConnector.Tests\Aspire.MySqlConnector.Tests.csproj", "{C8079F06-304F-49B1-A0C1-45AA3782A923}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestProject.IntegrationServiceA", "tests\testproject\TestProject.IntegrationServiceA\TestProject.IntegrationServiceA.csproj", "{DCF2D47A-921A-4900-B5B2-CF97B3531CE8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -418,6 +420,10 @@ Global
 		{C8079F06-304F-49B1-A0C1-45AA3782A923}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8079F06-304F-49B1-A0C1-45AA3782A923}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8079F06-304F-49B1-A0C1-45AA3782A923}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCF2D47A-921A-4900-B5B2-CF97B3531CE8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCF2D47A-921A-4900-B5B2-CF97B3531CE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCF2D47A-921A-4900-B5B2-CF97B3531CE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCF2D47A-921A-4900-B5B2-CF97B3531CE8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -491,6 +497,7 @@ Global
 		{165411FE-755E-4869-A756-F87F455860AC} = {4981B3A5-4AFD-4191-BF7D-8692D9783D60}
 		{CA283D7F-EB95-4353-B196-C409965D2B42} = {27381127-6C45-4B4C-8F18-41FF48DFE4B2}
 		{C8079F06-304F-49B1-A0C1-45AA3782A923} = {4981B3A5-4AFD-4191-BF7D-8692D9783D60}
+		{DCF2D47A-921A-4900-B5B2-CF97B3531CE8} = {975F6F41-B455-451D-A312-098DE4A167B6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6DCEDFEC-988E-4CB3-B45B-191EB5086E0C}

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class SqlServerBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{SqlServerContainerResource}"/>.</returns>
     public static IResourceBuilder<SqlServerContainerResource> AddSqlServerContainer(this IDistributedApplicationBuilder builder, string name, string? password = null, int? port = null)
     {
-        password = password ?? Guid.NewGuid().ToString("N");
+        password = password ?? Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N").ToUpper();
         var sqlServer = new SqlServerContainerResource(name, password);
 
         return builder.AddResource(sqlServer)

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -251,5 +251,37 @@ public class DistributedApplicationTests(ITestOutputHelper testOutputHelper)
             await Task.Delay(100, cts.Token);
         }
     }
-    private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<DistributedApplicationTests>(args);
+
+    [LocalOnlyFact]
+    public async void VerifyHealthyOnIntegrationServiceA()
+    {
+        var testProgram = CreateTestProgram(includeIntegrationServices: true);
+        testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
+
+        testProgram.AppBuilder.Services
+            .AddHttpClient()
+            .ConfigureHttpClientDefaults(b =>
+            {
+                b.UseSocketsHttpHandler((handler, sp) => handler.PooledConnectionLifetime = TimeSpan.FromSeconds(5));
+            });
+
+        await using var app = testProgram.Build();
+
+        var client = app.Services.GetRequiredService<IHttpClientFactory>().CreateClient();
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+
+        await app.StartAsync(cts.Token);
+
+        // Make sure all services are running
+        await testProgram.ServiceABuilder.HttpGetPidAsync(client, "http", cts.Token);
+        await testProgram.ServiceBBuilder.HttpGetPidAsync(client, "http", cts.Token);
+        await testProgram.ServiceCBuilder.HttpGetPidAsync(client, "http", cts.Token);
+        await testProgram.IntegrationServiceA!.HttpGetPidAsync(client, "http", cts.Token);
+
+        // We wait until timeout for the /health endpoint to return successfully. We assume
+        // that components wired up into this project have health checks enabled.
+        await testProgram.IntegrationServiceA!.WaitForHealthyStatus(client, "http", cts.Token);
+    }
+    private static TestProgram CreateTestProgram(string[]? args = null, bool includeIntegrationServices = false) => TestProgram.Create<DistributedApplicationTests>(args, includeIntegrationServices);
 }

--- a/tests/Aspire.Hosting.Tests/Helpers/AllocatedEndpointAnnotationTestExtensions.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/AllocatedEndpointAnnotationTestExtensions.cs
@@ -4,19 +4,43 @@
 namespace Aspire.Hosting.Tests.Helpers;
 public static class AllocatedEndpointAnnotationTestExtensions
 {
+    public static async Task<string> HttpGetAsync(this IResourceBuilder<ProjectResource> builder, HttpClient client, string bindingName, string path, CancellationToken cancellationToken)
+    {
+        // We have to get the allocated endpoint each time through the loop
+        // because it may not be populated yet by the time we get here.
+        var allocatedEndpoint = builder.Resource.Annotations.OfType<AllocatedEndpointAnnotation>().Single(a => a.Name == bindingName);
+        var url = $"{allocatedEndpoint.UriString}{path}";
+
+        var response = await client.GetStringAsync(url, cancellationToken);
+        return response;
+    }
+
+    public static async Task<string> WaitForHealthyStatus(this IResourceBuilder<ProjectResource> builder, HttpClient client, string bindingName, CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            try
+            {
+                return await builder.HttpGetAsync(client, bindingName, "/health", cancellationToken);
+            }
+            catch (HttpRequestException ex)
+            {
+                Console.WriteLine(ex);
+            }
+            catch
+            {
+                await Task.Delay(100, cancellationToken);
+            }
+        }
+    }
+
     public static async Task<string> HttpGetPidAsync(this IResourceBuilder<ProjectResource> builder, HttpClient client, string bindingName, CancellationToken cancellationToken)
     {
         while (true)
         {
             try
             {
-                // We have to get the allocated endpoint each time through the loop
-                // because it may not be populated yet by the time we get here.
-                var allocatedEndpoint = builder.Resource.Annotations.OfType<AllocatedEndpointAnnotation>().Single(a => a.Name == bindingName);
-                var url = $"{allocatedEndpoint.UriString}/pid";
-
-                var response = await client.GetStringAsync(url, cancellationToken);
-                return response;
+                return await builder.HttpGetAsync(client, bindingName, "/pid", cancellationToken);
             }
             catch (HttpRequestException ex)
             {

--- a/tests/testproject/TestProject.AppHost/Program.cs
+++ b/tests/testproject/TestProject.AppHost/Program.cs
@@ -1,5 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-var testProgram = TestProgram.Create<Program>(args);
+var testProgram = TestProgram.Create<Program>(args, includeIntegrationServices: true, disableDashboard: false);
 await testProgram.RunAsync();

--- a/tests/testproject/TestProject.AppHost/TestProject.AppHost.csproj
+++ b/tests/testproject/TestProject.AppHost/TestProject.AppHost.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
+    <ProjectReference Include="..\TestProject.IntegrationServiceA\TestProject.IntegrationServiceA.csproj" ServiceNameOverride="IntegrationServiceA" />
     <ProjectReference Include="..\TestProject.ServiceA\TestProject.ServiceA.csproj" ServiceNameOverride="ServiceA" />
     <ProjectReference Include="..\TestProject.ServiceB\TestProject.ServiceB.csproj" ServiceNameOverride="ServiceB" />
     <ProjectReference Include="..\TestProject.ServiceC\TestProject.ServiceC.csproj" ServiceNameOverride="ServiceC" />

--- a/tests/testproject/TestProject.IntegrationServiceA/Program.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Program.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+var builder = WebApplication.CreateBuilder(args);
+builder.AddSqlServerClient("sql");
+
+var app = builder.Build();
+
+app.MapHealthChecks("/health");
+app.MapGet("/", () => "Hello World!");
+app.MapGet("/pid", () => Environment.ProcessId);
+app.Run();

--- a/tests/testproject/TestProject.IntegrationServiceA/Properties/launchSettings.json
+++ b/tests/testproject/TestProject.IntegrationServiceA/Properties/launchSettings.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:37455",
+      "sslPort": 44334
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5281",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7038;http://localhost:5281",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tests/testproject/TestProject.IntegrationServiceA/TestProject.IntegrationServiceA.csproj
+++ b/tests/testproject/TestProject.IntegrationServiceA/TestProject.IntegrationServiceA.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.Data.SqlClient\Aspire.Microsoft.Data.SqlClient.csproj" />
+    <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.EntityFrameworkCore.SqlServer\Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/testproject/TestProject.IntegrationServiceA/appsettings.Development.json
+++ b/tests/testproject/TestProject.IntegrationServiceA/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tests/testproject/TestProject.IntegrationServiceA/appsettings.json
+++ b/tests/testproject/TestProject.IntegrationServiceA/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
This test adds a smoke test which calls the health endpoint on a new test project that we'll wire every component up to. Basically, we spin on the health endpoint until it times out or returns healthy.

Fixes #971
Related https://github.com/dotnet/aspire/issues/937