### PR TITLE
Suggested fix for #1000: not passing Command Line Args to dotnet projects, when launching from Visual Studio's debugger

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -284,6 +284,21 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(DebugSessionPortVar)))
             {
                 exeSpec.ExecutionType = ExecutionType.IDE;
+
+                string? launchProfileName = project.SelectLaunchProfileName();
+                if (!string.IsNullOrEmpty(launchProfileName))
+                {
+                    var launchProfile = project.GetEffectiveLaunchProfile();
+                    if (launchProfile is not null && !string.IsNullOrWhiteSpace(launchProfile.CommandLineArgs))
+                    {
+                        var cmdArgs = launchProfile.CommandLineArgs.Split((string?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                        if (cmdArgs is not null && cmdArgs.Length > 0)
+                        {
+                            exeSpec.Args = [];
+                            exeSpec.Args.AddRange(cmdArgs);
+                        }
+                    }
+                }
             }
             else
             {


### PR DESCRIPTION
For issue #1000 

As mentioned in the issue:
 - When **not debugging**, ApplicationExecutor.cs PrepareProjectExecutables() will construct the command line arguments from the launchProfile. 
 - It looks like this logic is either missing in Aspire **when debugging**, or dotnet.exe is supposed to be picking up the launch profile some other way (DOTNET_LAUNCH_PROFILE?) but it's not working for me.
 - This code works for my particular use case, but I'm not sure if there needs to be a "dotnet run" or "--" or whatnot to properly submit the args to the project.