### PR TITLE
Add 'Back to Traces' Button in Structured Logs

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -16,11 +16,7 @@
 <div class="logs-layout">
     <h1>Structured Logs</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
-        @if (!string.IsNullOrEmpty(TraceId))
-        {
-            <FluentButton Appearance="Appearance.Accent" OnClick="@GoBackToTrace">Back to Traces</FluentButton>
-        }
-        <FluentSelect TOption="SelectViewModel<string>"
+               <FluentSelect TOption="SelectViewModel<string>"
                       Items="@_applications"
                       OptionText="@(c => c.Name)"
                       @bind-SelectedOption="_selectedApplication"
@@ -60,6 +56,10 @@
             }
         }
         <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="Add Filter" OnClick="() => OpenFilterAsync(null)"><FluentIcon Value="@(new Icons.Regular.Size16.Filter())" /></FluentButton>
+        @if (!string.IsNullOrEmpty(TraceId))
+        {
+            <FluentButton slot="end" Appearance="Appearance.Stealth" OnClick="@GoBackToTrace">Back</FluentButton>
+        }
         </FluentToolbar>
     <SummaryDetailsView DetailsTitle="Log Entry Details" ShowDetails="SelectedLogEntryProperties is not null" OnDismiss="() => ClearSelectedLogEntry()">
         <Summary>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -18,7 +18,7 @@
     <FluentToolbar Orientation="Orientation.Horizontal">
         @if (!string.IsNullOrEmpty(TraceId))
         {
-            <FluentButton OnClick="@GoBackToTrace">Back to Traces</FluentButton>
+            <FluentButton Appearance="Appearance.Accent" OnClick="@GoBackToTrace">Back to Traces</FluentButton>
         }
         <FluentSelect TOption="SelectViewModel<string>"
                       Items="@_applications"
@@ -60,7 +60,7 @@
             }
         }
         <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="Add Filter" OnClick="() => OpenFilterAsync(null)"><FluentIcon Value="@(new Icons.Regular.Size16.Filter())" /></FluentButton>
-    </FluentToolbar>
+        </FluentToolbar>
     <SummaryDetailsView DetailsTitle="Log Entry Details" ShowDetails="SelectedLogEntryProperties is not null" OnDismiss="() => ClearSelectedLogEntry()">
         <Summary>
             <div class="logs-summary-layout">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -16,6 +16,10 @@
 <div class="logs-layout">
     <h1>Structured Logs</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
+        @if (!string.IsNullOrEmpty(TraceId))
+        {
+            <FluentButton OnClick="@GoBackToTrace">Back to Traces</FluentButton>
+        }
         <FluentSelect TOption="SelectViewModel<string>"
                       Items="@_applications"
                       OptionText="@(c => c.Name)"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -282,8 +282,7 @@ public partial class StructuredLogs
 
     private void GoBackToTrace()
     {
-        var url = $"/Trace/{TraceId}";
-        NavigationManager.NavigateTo(url);
+        NavigationManager.NavigateTo($"/Trace/{TraceId}");
     }
 
     public void Dispose()

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -280,6 +280,12 @@ public partial class StructuredLogs
         }
     }
 
+    private void GoBackToTrace()
+    {
+        var url = $"/Trace/{TraceId}";
+        NavigationManager.NavigateTo(url);
+    }
+
     public void Dispose()
     {
         _applicationsSubscription?.Dispose();


### PR DESCRIPTION
## Description:
This pull request introduces a new feature in the StructuredLogs component, providing enhanced navigation for users. A "Back to Traces" button has been added, which is dynamically displayed when a TraceId is present in the URL. Clicking this button will navigate the user back to the corresponding Trace page, improving the overall user experience by providing a quick and intuitive way to return to the Trace view.


## Rationale
The addition of this button addresses a usability concern where users viewing structured logs had to manually adjust the URL or use the browser's back button to return to the Trace page. With this feature, navigation becomes more seamless and intuitive, enhancing the user experience.

## User Can Format
A user can go into a specific trace. That user can then see all of the traces and see a 'view logs' button. A user can then click on that button and go to the structured logs page with just the logs from the trace. Then a user can click on the 'go back to traces'  button in which they are navigated back to the view trace page.  