### PR TITLE
Fix variable naming inconsistency in  aspire-starter template

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.AppHost/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.AppHost/Program.cs
@@ -4,12 +4,12 @@ var builder = DistributedApplication.CreateBuilder(args);
 var cache = builder.AddRedisContainer("cache");
 
 #endif
-var apiservice = builder.AddProject<Projects.AspireStarterApplication__1_ApiService>("apiservice");
+var apiService = builder.AddProject<Projects.AspireStarterApplication__1_ApiService>("apiservice");
 
 builder.AddProject<Projects.AspireStarterApplication__1_Web>("webfrontend")
 #if UseRedisCache
     .WithReference(cache)
 #endif
-    .WithReference(apiservice);
+    .WithReference(apiService);
 
 builder.Build().Run();


### PR DESCRIPTION
Fixes: #1020 by renaming local variable `apiservice` to the more proper camel-cased `apiService` in _aspire-starter_ `.Host` template.