### PR TITLE
 Enhancement of Navigation Menu Consistency

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -1,9 +1,8 @@
 ﻿@using Aspire.Dashboard.Components.Dialogs
-@using Aspire.Dashboard.Components.CustomIcons;
+@using Aspire.Dashboard.Components.CustomIcons
 @using Aspire.Dashboard.Model
 @using Microsoft.AspNetCore.Http
 @inject IDashboardViewModelService dashboardViewModelService
-@inject IDialogService dialogService
 @inherits LayoutComponentBase
 
 <div class="layout">
@@ -20,8 +19,6 @@
             <FluentAnchor Appearance="Appearance.Stealth" IconEnd="@(new Icons.Regular.Size24.QuestionCircle())"
                           Href="https://aka.ms/dotnet/aspire/dashboard" Target="_blank" Rel="noreferrer noopener"
                           Title="Help" aria-label="Help" />
-            <FluentButton Appearance="Appearance.Stealth" OnClick="LaunchSettings" IconEnd="@(new Icons.Regular.Size24.Settings())"
-                          Title="Launch Settings" aria-label="Launch Settings" />
         </div>
     </FluentHeader>
     <NavMenu />

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -37,6 +37,16 @@
 ::deep.layout > .nav-menu-container {
     grid-area: nav;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    border-right: 1px solid #d3d3d3;
+}
+
+::deep.layout > .nav-menu-container > .fluent-nav-menu {
+    flex-grow: 1; /* Make the nav menu grow to occupy available space */
+    display: flex;
+    flex-direction: column;
 }
 
 ::deep.layout > .body-content {

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -44,7 +44,7 @@
 }
 
 ::deep.layout > .nav-menu-container > .fluent-nav-menu {
-    flex-grow: 1; /* Make the nav menu grow to occupy available space */
+    flex-grow: 1;
     display: flex;
     flex-direction: column;
 }

--- a/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
@@ -1,9 +1,10 @@
-﻿<div class="nav-menu-container">
-    <FluentNavMenu Width="250" Collapsible="true">
+﻿@using Aspire.Dashboard.Components.Dialogs
+@inject IDialogService dialogService
+
+<div class="nav-menu-container">
+    <FluentNavMenu Width="250" Collapsible="false" @bind-SidebarExpanded="@SidebarExpanded">
         <FluentNavLink Icon="@(new Icons.Regular.Size24.AppFolder())" Href="/" Match="NavLinkMatch.All">Resources</FluentNavLink>
-        @* <FluentNavLink Icon="@(new Icons.Regular.Size24.BinFull())" Href="/Containers">Containers</FluentNavLink>
-        <FluentNavLink Icon="@(new Icons.Regular.Size24.AppGeneric())" Href="/Executables">Executables</FluentNavLink> *@
-        <FluentNavGroup Title="Logs" Icon="@(new Icons.Regular.Size24.SlideText())" Expanded="true" Gap="10px 0;">
+        <FluentNavGroup Title="Logs" Icon="@(new Icons.Regular.Size24.SlideText())" SidebarExpanded="true" Gap="10px 0;">
             <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ProjectLogs">Project</FluentNavLink>
             <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ContainerLogs">Container</FluentNavLink>
             <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ExecutableLogs">Executable</FluentNavLink>
@@ -11,5 +12,12 @@
         </FluentNavGroup>
         <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces">Traces</FluentNavLink>
         <FluentNavLink Icon="@(new Icons.Regular.Size24.ChartMultiple())" Href="/Metrics">Metrics</FluentNavLink>
+        <!-- Spacer div to push the settings button to the bottom -->
+        <FluentSpacer></FluentSpacer>
+        <FluentDivider></FluentDivider>
+        <FluentNavLink Icon="@ToggleSidebarIcon" @onclick="ToggleSidebarExpansion">
+            @ToggleSidebarText
+        </FluentNavLink>
+        <FluentNavLink Icon="@(new Icons.Regular.Size24.Settings())" @onclick="LaunchSettings">Settings</FluentNavLink>
     </FluentNavMenu>
 </div>

--- a/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
@@ -2,7 +2,7 @@
 @inject IDialogService dialogService
 
 <div class="nav-menu-container">
-    <FluentNavMenu Width="250" Collapsible="false" @bind-SidebarExpanded="@SidebarExpanded">
+    <FluentNavMenu Width="250" Collapsible="false" @bind-Expanded="@SidebarExpanded">
         <FluentNavLink Icon="@(new Icons.Regular.Size24.AppFolder())" Href="/" Match="NavLinkMatch.All">Resources</FluentNavLink>
         <FluentNavGroup Title="Logs" Icon="@(new Icons.Regular.Size24.SlideText())" SidebarExpanded="true" Gap="10px 0;">
             <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ProjectLogs">Project</FluentNavLink>
@@ -12,7 +12,6 @@
         </FluentNavGroup>
         <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces">Traces</FluentNavLink>
         <FluentNavLink Icon="@(new Icons.Regular.Size24.ChartMultiple())" Href="/Metrics">Metrics</FluentNavLink>
-        <!-- Spacer div to push the settings button to the bottom -->
         <FluentSpacer></FluentSpacer>
         <FluentDivider></FluentDivider>
         <FluentNavLink Icon="@ToggleSidebarIcon" @onclick="ToggleSidebarExpansion">

--- a/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
@@ -2,7 +2,7 @@
 @inject IDialogService dialogService
 
 <div class="nav-menu-container">
-    <FluentNavMenu Width="250" Collapsible="false" @bind-Expanded="@SidebarExpanded">
+    <FluentNavMenu Width="250" Collapsible="true">
         <FluentNavLink Icon="@(new Icons.Regular.Size24.AppFolder())" Href="/" Match="NavLinkMatch.All">Resources</FluentNavLink>
         <FluentNavGroup Title="Logs" Icon="@(new Icons.Regular.Size24.SlideText())" SidebarExpanded="true" Gap="10px 0;">
             <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ProjectLogs">Project</FluentNavLink>
@@ -14,9 +14,6 @@
         <FluentNavLink Icon="@(new Icons.Regular.Size24.ChartMultiple())" Href="/Metrics">Metrics</FluentNavLink>
         <FluentSpacer></FluentSpacer>
         <FluentDivider></FluentDivider>
-        <FluentNavLink Icon="@ToggleSidebarIcon" @onclick="ToggleSidebarExpansion">
-            @ToggleSidebarText
-        </FluentNavLink>
         <FluentNavLink Icon="@(new Icons.Regular.Size24.Settings())" @onclick="LaunchSettings">Settings</FluentNavLink>
     </FluentNavMenu>
 </div>

--- a/src/Aspire.Dashboard/Components/Layout/NavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/NavMenu.razor.cs
@@ -12,7 +12,7 @@ public partial class NavMenu
     {
         DialogParameters parameters = new()
         {
-            Title = $"Settings",
+            Title = "Settings",
             PrimaryAction = "Close",
             PrimaryActionEnabled = true,
             SecondaryAction = null,
@@ -25,27 +25,5 @@ public partial class NavMenu
 
         _ = await dialogService.ShowPanelAsync<SettingsDialog>(parameters).ConfigureAwait(true);
     }
-
-    private bool SidebarExpanded { get; set; }
-
-    private void ToggleSidebarExpansion()
-    {
-        SidebarExpanded = !SidebarExpanded;
-    }
-
-    private string ToggleSidebarText
-    {
-        get
-        {
-            return SidebarExpanded ? "Show Less Information" : "Show More Information";
-        }
-    }
-
-    private Icon ToggleSidebarIcon
-    {
-        get
-        {
-            return SidebarExpanded ? new Icons.Regular.Size24.ArrowLeft() : new Icons.Regular.Size24.ArrowRight();
-        }
-    }
 }
+

--- a/src/Aspire.Dashboard/Components/Layout/NavMenu.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/NavMenu.razor.cs
@@ -6,7 +6,7 @@ using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components.Layout;
 
-public partial class MainLayout
+public partial class NavMenu
 {
     public async Task LaunchSettings()
     {
@@ -24,5 +24,28 @@ public partial class MainLayout
         };
 
         _ = await dialogService.ShowPanelAsync<SettingsDialog>(parameters).ConfigureAwait(true);
+    }
+
+    private bool SidebarExpanded { get; set; }
+
+    private void ToggleSidebarExpansion()
+    {
+        SidebarExpanded = !SidebarExpanded;
+    }
+
+    private string ToggleSidebarText
+    {
+        get
+        {
+            return SidebarExpanded ? "Show Less Information" : "Show More Information";
+        }
+    }
+
+    private Icon ToggleSidebarIcon
+    {
+        get
+        {
+            return SidebarExpanded ? new Icons.Regular.Size24.ArrowLeft() : new Icons.Regular.Size24.ArrowRight();
+        }
     }
 }


### PR DESCRIPTION
Upon reviewing the existing navigation menu implementation, it became apparent that the design consistency and user experience were not aligned with established patterns, especially when compared to the navigation menu utilized within Azure DevOps. The visual cohesion and functional clarity present in the DevOps menu, as depicted in the reference image below, served as an inspiration for the proposed enhancements.

Reference Image from Azure DevOps:

![image](https://github.com/dotnet/aspire/assets/47674962/b5971bf6-5395-4007-9184-c159083a9c79)

To address this, I have repositioned the settings button and the sidebar toggle to the lower end of the navigation menu, emulating the intuitive layout found in DevOps. The current structure of the `NavMenuLink` component presents certain constraints that prevent the combination of multiple icons within a single button or row. Nevertheless, I managed to circumvent this limitation by introducing two distinct buttons at the bottom of the menu. This adjustment has resulted in a more streamlined and user-friendly navigation interface.

Here is the new interface:

NavMenu Expanded:

![image](https://github.com/dotnet/aspire/assets/47674962/42751eb6-f0ac-4731-a04d-faf2bef33998)

NavMenu Closed:

![image](https://github.com/dotnet/aspire/assets/47674962/41174ac2-ccc1-4c5a-b3f6-f8f7b1afc1c8)