### PR TITLE
refactor : Remove twice reading of launchProfile

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -30,11 +30,11 @@ internal sealed class DcpDistributedApplicationLifecycleHook(IOptions<Publishing
         // Automatically add ServiceBindingAnnotations to project resources based on ApplicationUrl set in the launch profile.
         foreach (var projectResource in model.Resources.OfType<ProjectResource>())
         {
-            var selectedLaunchProfileName = projectResource.SelectLaunchProfileName();
-            if (selectedLaunchProfileName is null)
-            {
-                continue;
-            }
+            //var selectedLaunchProfileName = projectResource.SelectLaunchProfileName();
+            //if (selectedLaunchProfileName is null)
+            //{
+            //    continue;
+            //}
 
             var launchProfile = projectResource.GetEffectiveLaunchProfile();
             if (launchProfile is null)

--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -30,12 +30,6 @@ internal sealed class DcpDistributedApplicationLifecycleHook(IOptions<Publishing
         // Automatically add ServiceBindingAnnotations to project resources based on ApplicationUrl set in the launch profile.
         foreach (var projectResource in model.Resources.OfType<ProjectResource>())
         {
-            //var selectedLaunchProfileName = projectResource.SelectLaunchProfileName();
-            //if (selectedLaunchProfileName is null)
-            //{
-            //    continue;
-            //}
-
             var launchProfile = projectResource.GetEffectiveLaunchProfile();
             if (launchProfile is null)
             {


### PR DESCRIPTION
Under the hood `GetEffectiveLaunchProfile` does call `SelectLaunchProfileName`, so we don't need to call it.

Found this while exploring the internal codebase of Aspire. 😊