### PR TITLE
Tracing UI displays resource name for outgoing resources

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -16,6 +16,7 @@ public partial class TraceDetail
     private OtlpTrace? _trace;
     private OtlpSpan? _span;
     private Subscription? _tracesSubscription;
+    private IDisposable? _peerChangesSubscription;
     private List<SpanWaterfallViewModel>? _spanWaterfallViewModels;
     private int _maxDepth;
 
@@ -30,6 +31,15 @@ public partial class TraceDetail
 
     [Inject]
     public required IOutgoingPeerResolver OutgoingPeerResolver { get; set; }
+
+    protected override void OnInitialized()
+    {
+        _peerChangesSubscription = OutgoingPeerResolver.OnPeerChanges(async () =>
+        {
+            UpdateDetailViewData();
+            await InvokeAsync(StateHasChanged);
+        });
+    }
 
     private ValueTask<GridItemsProviderResult<SpanWaterfallViewModel>> GetData(GridItemsProviderRequest<SpanWaterfallViewModel> request)
     {
@@ -179,6 +189,7 @@ public partial class TraceDetail
 
     public void Dispose()
     {
+        _peerChangesSubscription?.Dispose();
         _tracesSubscription?.Dispose();
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -28,6 +28,9 @@ public partial class TraceDetail
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; set; }
 
+    [Inject]
+    public required IOutgoingPeerResolver OutgoingPeerResolver { get; set; }
+
     private ValueTask<GridItemsProviderResult<SpanWaterfallViewModel>> GetData(GridItemsProviderRequest<SpanWaterfallViewModel> request)
     {
         Debug.Assert(_spanWaterfallViewModels != null);
@@ -39,34 +42,34 @@ public partial class TraceDetail
         });
     }
 
-    private static List<SpanWaterfallViewModel> CreateSpanWaterfallViewModels(OtlpTrace trace)
+    private static List<SpanWaterfallViewModel> CreateSpanWaterfallViewModels(OtlpTrace trace, IOutgoingPeerResolver outgoingPeerResolver)
     {
         var orderedSpans = new List<SpanWaterfallViewModel>();
         // There should be one root span but just in case, we'll add them all.
         foreach (var rootSpan in trace.Spans.Where(s => string.IsNullOrEmpty(s.ParentSpanId)).OrderBy(s => s.StartTime))
         {
-            AddSelfAndChildren(orderedSpans, rootSpan, depth: 1, CreateViewModel);
+            AddSelfAndChildren(orderedSpans, rootSpan, depth: 1, outgoingPeerResolver, CreateViewModel);
         }
         // Unparented spans.
         foreach (var unparentedSpan in trace.Spans.Where(s => !string.IsNullOrEmpty(s.ParentSpanId) && s.GetParentSpan() == null).OrderBy(s => s.StartTime))
         {
-            AddSelfAndChildren(orderedSpans, unparentedSpan, depth: 1, CreateViewModel);
+            AddSelfAndChildren(orderedSpans, unparentedSpan, depth: 1, outgoingPeerResolver, CreateViewModel);
         }
 
         return orderedSpans;
 
-        static void AddSelfAndChildren(List<SpanWaterfallViewModel> orderedSpans, OtlpSpan span, int depth, Func<OtlpSpan, int, SpanWaterfallViewModel> createViewModel)
+        static void AddSelfAndChildren(List<SpanWaterfallViewModel> orderedSpans, OtlpSpan span, int depth, IOutgoingPeerResolver outgoingPeerResolver, Func<OtlpSpan, int, IOutgoingPeerResolver, SpanWaterfallViewModel> createViewModel)
         {
-            orderedSpans.Add(createViewModel(span, depth));
+            orderedSpans.Add(createViewModel(span, depth, outgoingPeerResolver));
             depth++;
 
             foreach (var child in span.GetChildSpans().OrderBy(s => s.StartTime))
             {
-                AddSelfAndChildren(orderedSpans, child, depth, createViewModel);
+                AddSelfAndChildren(orderedSpans, child, depth, outgoingPeerResolver, createViewModel);
             }
         }
 
-        static SpanWaterfallViewModel CreateViewModel(OtlpSpan span, int depth)
+        static SpanWaterfallViewModel CreateViewModel(OtlpSpan span, int depth, IOutgoingPeerResolver outgoingPeerResolver)
         {
             var traceStart = span.Trace.FirstSpan.StartTime;
             var relativeStart = span.StartTime - traceStart;
@@ -82,6 +85,13 @@ public partial class TraceDetail
             // A span may indicate a call to another service but the service isn't instrumented.
             var hasPeerService = span.Attributes.Any(a => a.Key == OtlpSpan.PeerServiceAttributeKey);
             var isUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
+            var uninstrumentedPeer = isUninstrumentedPeer
+                ? OtlpHelpers.GetValue(span.Attributes, OtlpSpan.PeerServiceAttributeKey)
+                : null;
+            if (uninstrumentedPeer != null)
+            {
+                uninstrumentedPeer = outgoingPeerResolver.ResolvePeerName(uninstrumentedPeer);
+            }
 
             var viewModel = new SpanWaterfallViewModel
             {
@@ -90,7 +100,7 @@ public partial class TraceDetail
                 Width = width,
                 Depth = depth,
                 LabelIsRight = labelIsRight,
-                UninstrumentedPeer = isUninstrumentedPeer ? OtlpHelpers.GetValue(span.Attributes, OtlpSpan.PeerServiceAttributeKey) : null
+                UninstrumentedPeer = uninstrumentedPeer
             };
             return viewModel;
         }
@@ -111,7 +121,7 @@ public partial class TraceDetail
             _trace = TelemetryRepository.GetTrace(TraceId);
             if (_trace != null)
             {
-                _spanWaterfallViewModels = CreateSpanWaterfallViewModels(_trace);
+                _spanWaterfallViewModels = CreateSpanWaterfallViewModels(_trace, OutgoingPeerResolver);
                 _maxDepth = _spanWaterfallViewModels.Max(s => s.Depth);
 
                 if (_tracesSubscription is null || _tracesSubscription.ApplicationId != _trace.FirstSpan.Source.InstanceId)

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -86,6 +86,7 @@ public class DashboardWebApplication : IHostedService
         // OTLP services.
         builder.Services.AddGrpc();
         builder.Services.AddSingleton<TelemetryRepository>();
+        builder.Services.AddSingleton<IOutgoingPeerResolver, ResourceOutgoingPeerResolver>();
         builder.Services.AddTransient<StructuredLogsViewModel>();
         builder.Services.AddTransient<TracesViewModel>();
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -86,7 +86,7 @@ public class DashboardWebApplication : IHostedService
         // OTLP services.
         builder.Services.AddGrpc();
         builder.Services.AddSingleton<TelemetryRepository>();
-        builder.Services.AddSingleton<IOutgoingPeerResolver, ResourceOutgoingPeerResolver>();
+        builder.Services.AddScoped<IOutgoingPeerResolver, ResourceOutgoingPeerResolver>();
         builder.Services.AddTransient<StructuredLogsViewModel>();
         builder.Services.AddTransient<TracesViewModel>();
 

--- a/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
@@ -6,4 +6,5 @@ namespace Aspire.Dashboard.Model;
 public interface IOutgoingPeerResolver
 {
     string ResolvePeerName(string networkAddress);
+    IDisposable OnPeerChanges(Func<Task> callback);
 }

--- a/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public interface IOutgoingPeerResolver
+{
+    string ResolvePeerName(string networkAddress);
+}

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -28,7 +28,7 @@ public sealed class SpanWaterfallViewModel
         }
         if (HasUninstrumentedPeer)
         {
-            tooltip += Environment.NewLine + $"Outgoing call to peer {UninstrumentedPeer}";
+            tooltip += Environment.NewLine + $"Outgoing call to {UninstrumentedPeer}";
         }
 
         return tooltip;

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsyncDisposable
+{
+    private readonly IDashboardViewModelService _dashboardViewModelService;
+    private readonly Dictionary<string, ResourceViewModel> _resourceNameMapping = new();
+    private readonly CancellationTokenSource _watchContainersTokenSource = new();
+    private readonly Task _watchTask;
+    private readonly object _lock = new object();
+
+    public ResourceOutgoingPeerResolver(IDashboardViewModelService dashboardViewModelService)
+    {
+        _dashboardViewModelService = dashboardViewModelService;
+
+        var viewModelMonitor = _dashboardViewModelService.GetResources();
+        var initialList = viewModelMonitor.Snapshot;
+        var watch = viewModelMonitor.Watch;
+
+        foreach (var result in initialList)
+        {
+            _resourceNameMapping[result.Name] = result;
+        }
+
+        _watchTask = Task.Run(async () =>
+        {
+            await foreach (var resourceChanged in watch.WithCancellation(_watchContainersTokenSource.Token))
+            {
+                OnResourceListChanged(resourceChanged.ObjectChangeType, resourceChanged.Resource);
+            }
+        });
+    }
+
+    private void OnResourceListChanged(ObjectChangeType changeType, ResourceViewModel resourceViewModel)
+    {
+        lock (_lock)
+        {
+            if (changeType == ObjectChangeType.Added)
+            {
+                _resourceNameMapping[resourceViewModel.Name] = resourceViewModel;
+            }
+            else if (changeType == ObjectChangeType.Modified)
+            {
+                _resourceNameMapping[resourceViewModel.Name] = resourceViewModel;
+            }
+            else if (changeType == ObjectChangeType.Deleted)
+            {
+                _resourceNameMapping.Remove(resourceViewModel.Name);
+            }
+        }
+    }
+
+    public string ResolvePeerName(string networkAddress)
+    {
+        lock (_lock)
+        {
+            foreach (var resource in _resourceNameMapping.Values)
+            {
+                foreach (var service in resource.Services)
+                {
+                    if (service.AddressAndPort == networkAddress)
+                    {
+                        return resource.Name;
+                    }
+                }
+            }
+        }
+
+        return networkAddress;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _watchContainersTokenSource.Cancel();
+        _watchContainersTokenSource.Dispose();
+
+        try
+        {
+            await _watchTask.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -13,8 +13,17 @@ public abstract class ResourceViewModel
     public List<EnvironmentVariableViewModel> Environment { get; } = new();
     public required ILogSource LogSource { get; init; }
     public List<string> Endpoints { get; } = new();
+    public List<ResourceService> Services { get; } = new();
     public int? ExpectedEndpointsCount { get; init; }
     public abstract string ResourceType { get; }
+}
+
+public sealed class ResourceService(string name, string? allocatedAddress, int? allocatedPort)
+{
+    public string Name { get; } = name;
+    public string? AllocatedAddress { get; } = allocatedAddress;
+    public int? AllocatedPort { get; } = allocatedPort;
+    public string AddressAndPort { get; } = $"{allocatedAddress}:{allocatedPort}";
 }
 
 public sealed record NamespacedName(string Name, string? Namespace);

--- a/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
@@ -473,6 +473,31 @@ internal sealed partial class DashboardViewModelService : IDashboardViewModelSer
                 resourceViewModel.Endpoints.Add(endpointString);
             }
         }
+
+        var resourceApplicationModel = applicationModel.Resources.FirstOrDefault(r => r.Name == resourceViewModel.Name);
+        if (resourceApplicationModel?.TryGetAllocatedEndPoints(out var allocatedEndPoints) ?? false)
+        {
+            if (allocatedEndPoints.Count() == 1)
+            {
+                var service = services.FirstOrDefault(s => s.Metadata.Name == resourceViewModel.Name);
+                if (service != null)
+                {
+                    resourceViewModel.Services.Add(new ResourceService(service.Metadata.Name, service.AllocatedAddress, service.AllocatedPort));
+                }
+            }
+            else
+            {
+                foreach (var allocatedEndPoint in allocatedEndPoints)
+                {
+                    var serviceName = resourceApplicationModel.Name + "_" + allocatedEndPoint.Name;
+                    var service = services.FirstOrDefault(s => s.Metadata.Name == serviceName);
+                    if (service != null)
+                    {
+                        resourceViewModel.Services.Add(new ResourceService(service.Metadata.Name, service.AllocatedAddress, service.AllocatedPort));
+                    }
+                }
+            }
+        }
     }
 
     private static int? GetExpectedEndpointsCount(IEnumerable<Service> services, CustomResource resource)

--- a/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
@@ -269,11 +269,6 @@ internal sealed partial class DashboardViewModelService : IDashboardViewModelSer
             return;
         }
 
-        if (!service.UsesHttpProtocol(out _))
-        {
-            return;
-        }
-
         foreach (var kvp in _resourceAssociatedServicesMap.Where(e => e.Value.Contains(service.Metadata.Name)))
         {
             var (resourceKind, resourceName) = kvp.Key;

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -62,7 +62,7 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
             {
                 serviceCollection.AddSingleton(_applicationModel);
                 serviceCollection.AddSingleton(kubernetesService);
-                serviceCollection.AddScoped<IDashboardViewModelService, DashboardViewModelService>();
+                serviceCollection.AddSingleton<IDashboardViewModelService, DashboardViewModelService>();
             });
         }
     }

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -62,7 +62,7 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
             {
                 serviceCollection.AddSingleton(_applicationModel);
                 serviceCollection.AddSingleton(kubernetesService);
-                serviceCollection.AddSingleton<IDashboardViewModelService, DashboardViewModelService>();
+                serviceCollection.AddScoped<IDashboardViewModelService, DashboardViewModelService>();
             });
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1052

I had an idea to improve tracing.

**Before:**
![image](https://github.com/dotnet/aspire/assets/303201/6eca4e62-4022-45b2-bb32-e1b07500cef1)

**After:**
![image](https://github.com/dotnet/aspire/assets/303201/335ab7a5-05d4-42e3-b0df-8f8214c337ce)

**Background:**
Distributed tracing commonly has a client recording it is making a call, and the peer recording receiving it. However, sometimes the peer doesn't log anything to OTEL. For example, the redis client records that it calls redis, but redis itself doesn't send data to OTEL. Internally this is called an outgoing peer. When it happens, the tracing UI shows an arrow and the peer address (e.g. redis address).

Aspire has a unique opportunity. It combines defining resources, starting resources, and displaying telemetry for resources. Aspire knows the relationship between addresses and resources. That allows the tracing UI to use the outgoing peer address to lookup the resource name.

For example, there is an outgoing peer call to address `localhost:69322`. The `redis` container has a service with that address. The tracing UI links the address and the service together and therefore displays `redis`.

This PR adds some coupling between telemetry and hosting. I've placed all logic inside `IOutgoingPeerResolver`. A dummy resolver that just returns the address back can be used by the UI if hosting isn't available.

Note: The IP address continues to be available in the detail view:
![image](https://github.com/dotnet/aspire/assets/303201/990c6448-0c56-48dd-84d3-0d5ab1ab6ac1)
