### PR TITLE
Use invariant culture when generating CSS numeric values

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -7,6 +7,7 @@
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Otlp.Storage
 @using System.Diagnostics
+@using System.Globalization
 @inject IDashboardViewModelService DashboardViewModelService
 
 <PageTitle>@DashboardViewModelService.ApplicationName Traces</PageTitle>
@@ -93,7 +94,7 @@
                         </HeaderCellItemTemplate>
                         <ChildContent>
                             <div class="ticks" @onclick="() => OnShowProperties(context)">
-                                <div class="span-container" style="grid-template-columns: @context.LeftOffset.ToString("F2")% @context.Width.ToString("F2")% min-content;">
+                                <div class="span-container" style="grid-template-columns: @context.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)% @context.Width.ToString("F2", CultureInfo.InvariantCulture)% min-content;">
                                     <div class="span-bar" style="grid-column: 2; background: @ColorGenerator.Instance.GetColorHexByKey(context.Span.Source.ApplicationName);"></div>
                                     <div class="span-bar-label @(context.LabelIsRight ? "span-bar-label-right" : "span-bar-label-left")">
                                         <span class="span-bar-label-detail">@context.Span.Source.ApplicationName: @context.GetDisplaySummary()</span>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
@@ -43,7 +44,7 @@ public partial class Traces
             percentage = trace.Duration / ViewModel.MaxDuration * 100.0;
         }
 
-        return $"background: linear-gradient(to right, var(--neutral-fill-input-alt-active) {percentage:0.##}%, transparent {percentage:0.##}%);";
+        return string.Create(CultureInfo.InvariantCulture, $"background: linear-gradient(to right, var(--neutral-fill-input-alt-active) {percentage:0.##}%, transparent {percentage:0.##}%);");
     }
 
     private static string GetTooltip(IGrouping<OtlpApplication, OtlpSpan> applicationSpans)


### PR DESCRIPTION
Fixes #841 

It looks like the cause of this issue was the CSS numeric values being localized to include commas instead of decimal point. CSS requires it be a decimal point, but by default both `ToString()` and string interpolation will use the current culture. 

I changed the one line that appears to be the culprit in `TraceDetail.razor` and one more in `TraceDetail.razor.cs` that could be generating invalid values. For the latter, it was string interpolation, where [the guidance in .NET 6+ is to use `string.Create`](https://learn.microsoft.com/en-us/dotnet/csharp/tutorials/string-interpolation#how-to-create-a-culture-specific-result-string-with-string-interpolation).

I added #1048 to discuss the long term issues here because I think the string interpolation variant of this issue may not be as easy to solve.