### PR TITLE
Show correct end point when launchUrl is absolute URL

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
@@ -467,7 +467,22 @@ internal sealed partial class DashboardViewModelService : IDashboardViewModelSer
                     && project.GetEffectiveLaunchProfile() is LaunchProfile launchProfile
                     && launchProfile.LaunchUrl is string launchUrl)
                 {
-                    endpointString += $"/{launchUrl}";
+                    if (!launchUrl.Contains("://"))
+                    {
+                        // This is relative URL
+                        endpointString += $"/{launchUrl}";
+                    }
+                    else
+                    {
+                        // For absolute URL we need to update the port value if possible
+                        if (launchProfile.ApplicationUrl is string applicationUrl
+                            && launchUrl.StartsWith(applicationUrl))
+                        {
+                            endpointString = launchUrl.Replace(applicationUrl, endpointString);
+                        }
+                    }
+
+                    // If we cannot process launchUrl then we just show endpoint string
                 }
 
                 resourceViewModel.Endpoints.Add(endpointString);


### PR DESCRIPTION
Fixes #812

We generate end point URL from applicationUrl so port is correct when replicas are used or a different port is assigned by orchestrator. We use launchUrl in following way to generate final end point URL
- Endpoint URL if launchUrl is null or empty.
- Endpoint URL suffixed with launchUrl if launchUrl is relative.
- Endpoint URL replacing the applicationUrl in launchUrl if launchUrl is absolute and applicationUrl is prefix.
- Endpoint URL if none of above matches.