### PR TITLE
change dependabot to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     registries:
       - public-nuget
     schedule:
-      interval: daily
+      interval: weekly
+      day: "sunday"
       time: "07:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 15
@@ -47,5 +48,11 @@ updates:
       Grpc:
         patterns:
           - "Grpc.*"
+      Yarp:
+        patterns:
+          - "Yarp.*"
+      Misc:
+        patterns:
+          - "*"
     labels:
       - "area-codeflow"


### PR DESCRIPTION
1. change to every Sunday
2. group misc packages to reduce number of PR's

Note, dependabot is currently already broken in dotnet/aspire apparently due to a dependabot upgrade today. I have reported this here: https://github.com/dependabot/dependabot-core/issues/8490 ... we can't merge this until it's fixed.

edit: looks like it was https://github.com/dependabot/dependabot-core/pull/8179