### PR TITLE
Resolve outgoing peer browserlink call in trace UI

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -118,7 +118,7 @@ public partial class TraceDetail : ComponentBase
         // Attempt to resolve uninstrumented peer to a friendly name from the span.
         foreach (var resolver in outgoingPeerResolvers)
         {
-            if (resolver.TryResolvePeerName(span, out var name))
+            if (resolver.TryResolvePeerName(span.Attributes, out var name))
             {
                 return name;
             }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -11,7 +11,7 @@ using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components.Pages;
 
-public partial class TraceDetail
+public partial class TraceDetail : ComponentBase
 {
     private OtlpTrace? _trace;
     private OtlpSpan? _span;
@@ -30,15 +30,18 @@ public partial class TraceDetail
     public required TelemetryRepository TelemetryRepository { get; set; }
 
     [Inject]
-    public required IOutgoingPeerResolver OutgoingPeerResolver { get; set; }
+    public required IEnumerable<IOutgoingPeerResolver> OutgoingPeerResolvers { get; set; }
 
     protected override void OnInitialized()
     {
-        _peerChangesSubscription = OutgoingPeerResolver.OnPeerChanges(async () =>
+        foreach (var resolver in OutgoingPeerResolvers)
         {
-            UpdateDetailViewData();
-            await InvokeAsync(StateHasChanged);
-        });
+            _peerChangesSubscription = resolver.OnPeerChanges(async () =>
+            {
+                UpdateDetailViewData();
+                await InvokeAsync(StateHasChanged);
+            });
+        }
     }
 
     private ValueTask<GridItemsProviderResult<SpanWaterfallViewModel>> GetData(GridItemsProviderRequest<SpanWaterfallViewModel> request)
@@ -52,34 +55,34 @@ public partial class TraceDetail
         });
     }
 
-    private static List<SpanWaterfallViewModel> CreateSpanWaterfallViewModels(OtlpTrace trace, IOutgoingPeerResolver outgoingPeerResolver)
+    private static List<SpanWaterfallViewModel> CreateSpanWaterfallViewModels(OtlpTrace trace, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
     {
         var orderedSpans = new List<SpanWaterfallViewModel>();
         // There should be one root span but just in case, we'll add them all.
         foreach (var rootSpan in trace.Spans.Where(s => string.IsNullOrEmpty(s.ParentSpanId)).OrderBy(s => s.StartTime))
         {
-            AddSelfAndChildren(orderedSpans, rootSpan, depth: 1, outgoingPeerResolver, CreateViewModel);
+            AddSelfAndChildren(orderedSpans, rootSpan, depth: 1, outgoingPeerResolvers, CreateViewModel);
         }
         // Unparented spans.
         foreach (var unparentedSpan in trace.Spans.Where(s => !string.IsNullOrEmpty(s.ParentSpanId) && s.GetParentSpan() == null).OrderBy(s => s.StartTime))
         {
-            AddSelfAndChildren(orderedSpans, unparentedSpan, depth: 1, outgoingPeerResolver, CreateViewModel);
+            AddSelfAndChildren(orderedSpans, unparentedSpan, depth: 1, outgoingPeerResolvers, CreateViewModel);
         }
 
         return orderedSpans;
 
-        static void AddSelfAndChildren(List<SpanWaterfallViewModel> orderedSpans, OtlpSpan span, int depth, IOutgoingPeerResolver outgoingPeerResolver, Func<OtlpSpan, int, IOutgoingPeerResolver, SpanWaterfallViewModel> createViewModel)
+        static void AddSelfAndChildren(List<SpanWaterfallViewModel> orderedSpans, OtlpSpan span, int depth, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers, Func<OtlpSpan, int, IEnumerable<IOutgoingPeerResolver>, SpanWaterfallViewModel> createViewModel)
         {
-            orderedSpans.Add(createViewModel(span, depth, outgoingPeerResolver));
+            orderedSpans.Add(createViewModel(span, depth, outgoingPeerResolvers));
             depth++;
 
             foreach (var child in span.GetChildSpans().OrderBy(s => s.StartTime))
             {
-                AddSelfAndChildren(orderedSpans, child, depth, outgoingPeerResolver, createViewModel);
+                AddSelfAndChildren(orderedSpans, child, depth, outgoingPeerResolvers, createViewModel);
             }
         }
 
-        static SpanWaterfallViewModel CreateViewModel(OtlpSpan span, int depth, IOutgoingPeerResolver outgoingPeerResolver)
+        static SpanWaterfallViewModel CreateViewModel(OtlpSpan span, int depth, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
         {
             var traceStart = span.Trace.FirstSpan.StartTime;
             var relativeStart = span.StartTime - traceStart;
@@ -95,13 +98,7 @@ public partial class TraceDetail
             // A span may indicate a call to another service but the service isn't instrumented.
             var hasPeerService = span.Attributes.Any(a => a.Key == OtlpSpan.PeerServiceAttributeKey);
             var isUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
-            var uninstrumentedPeer = isUninstrumentedPeer
-                ? OtlpHelpers.GetValue(span.Attributes, OtlpSpan.PeerServiceAttributeKey)
-                : null;
-            if (uninstrumentedPeer != null)
-            {
-                uninstrumentedPeer = outgoingPeerResolver.ResolvePeerName(uninstrumentedPeer);
-            }
+            var uninstrumentedPeer = isUninstrumentedPeer ? ResolveUninstrumentedPeerName(span, outgoingPeerResolvers) : null;
 
             var viewModel = new SpanWaterfallViewModel
             {
@@ -114,6 +111,19 @@ public partial class TraceDetail
             };
             return viewModel;
         }
+    }
+
+    private static string? ResolveUninstrumentedPeerName(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+    {
+        foreach (var resolver in outgoingPeerResolvers)
+        {
+            if (resolver.TryResolvePeerName(span, out var name))
+            {
+                return name;
+            }
+        }
+
+        return OtlpHelpers.GetValue(span.Attributes, OtlpSpan.PeerServiceAttributeKey);
     }
 
     protected override void OnParametersSet()
@@ -131,7 +141,7 @@ public partial class TraceDetail
             _trace = TelemetryRepository.GetTrace(TraceId);
             if (_trace != null)
             {
-                _spanWaterfallViewModels = CreateSpanWaterfallViewModels(_trace, OutgoingPeerResolver);
+                _spanWaterfallViewModels = CreateSpanWaterfallViewModels(_trace, OutgoingPeerResolvers);
                 _maxDepth = _spanWaterfallViewModels.Max(s => s.Depth);
 
                 if (_tracesSubscription is null || _tracesSubscription.ApplicationId != _trace.FirstSpan.Source.InstanceId)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -13,10 +13,10 @@ namespace Aspire.Dashboard.Components.Pages;
 
 public partial class TraceDetail : ComponentBase
 {
+    private readonly List<IDisposable> _peerChangesSubscriptions = new();
     private OtlpTrace? _trace;
     private OtlpSpan? _span;
     private Subscription? _tracesSubscription;
-    private IDisposable? _peerChangesSubscription;
     private List<SpanWaterfallViewModel>? _spanWaterfallViewModels;
     private int _maxDepth;
 
@@ -36,11 +36,11 @@ public partial class TraceDetail : ComponentBase
     {
         foreach (var resolver in OutgoingPeerResolvers)
         {
-            _peerChangesSubscription = resolver.OnPeerChanges(async () =>
+            _peerChangesSubscriptions.Add(resolver.OnPeerChanges(async () =>
             {
                 UpdateDetailViewData();
                 await InvokeAsync(StateHasChanged);
-            });
+            }));
         }
     }
 
@@ -199,7 +199,10 @@ public partial class TraceDetail : ComponentBase
 
     public void Dispose()
     {
-        _peerChangesSubscription?.Dispose();
+        foreach (var subscription in _peerChangesSubscriptions)
+        {
+            subscription.Dispose();
+        }
         _tracesSubscription?.Dispose();
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -115,6 +115,7 @@ public partial class TraceDetail : ComponentBase
 
     private static string? ResolveUninstrumentedPeerName(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
     {
+        // Attempt to resolve uninstrumented peer to a friendly name from the span.
         foreach (var resolver in outgoingPeerResolvers)
         {
             if (resolver.TryResolvePeerName(span, out var name))
@@ -123,6 +124,7 @@ public partial class TraceDetail : ComponentBase
             }
         }
 
+        // Fallback to the peer address.
         return OtlpHelpers.GetValue(span.Attributes, OtlpSpan.PeerServiceAttributeKey);
     }
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -86,9 +87,10 @@ public class DashboardWebApplication : IHostedService
         // OTLP services.
         builder.Services.AddGrpc();
         builder.Services.AddSingleton<TelemetryRepository>();
-        builder.Services.AddScoped<IOutgoingPeerResolver, ResourceOutgoingPeerResolver>();
         builder.Services.AddTransient<StructuredLogsViewModel>();
         builder.Services.AddTransient<TracesViewModel>();
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Scoped<IOutgoingPeerResolver, ResourceOutgoingPeerResolver>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Scoped<IOutgoingPeerResolver, BrowserLinkOutgoingPeerResolver>());
 
         builder.Services.AddFluentUIComponents();
 

--- a/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
@@ -22,6 +22,13 @@ public sealed class BrowserLinkOutgoingPeerResolver : IOutgoingPeerResolver
 
     public bool TryResolvePeerName(OtlpSpan span, [NotNullWhen(true)] out string? name)
     {
+        // There isn't a good way to identify the HTTP request the BrowserLink middleware makes to
+        // the IDE to get the script tag. The logic below looks at the host and URL and identifies
+        // the HTTP request by its shape. There is the chance future BrowserLink changes to make this
+        // detection invalid. Also, it's possible to mis-identify a HTTP request.
+        //
+        // A long term improvement here is to add tags to the BrowserLink client and then detect the
+        // values in the span's attributes.
         var url = OtlpHelpers.GetValue(span.Attributes, "http.url");
         if (url != null && Uri.TryCreate(url, UriKind.Absolute, out var uri))
         {

--- a/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
@@ -24,8 +24,11 @@ public sealed class BrowserLinkOutgoingPeerResolver : IOutgoingPeerResolver
     {
         // There isn't a good way to identify the HTTP request the BrowserLink middleware makes to
         // the IDE to get the script tag. The logic below looks at the host and URL and identifies
-        // the HTTP request by its shape. There is the chance future BrowserLink changes to make this
-        // detection invalid. Also, it's possible to mis-identify a HTTP request.
+        // the HTTP request by its shape.
+        // Example URL: http://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag
+        //
+        // There is the chance future BrowserLink changes make this detection invalid.
+        // Also, it's possible to misidentify a HTTP request.
         //
         // A long term improvement here is to add tags to the BrowserLink client and then detect the
         // values in the span's attributes.

--- a/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Dashboard.Otlp.Model;
+
+namespace Aspire.Dashboard.Model;
+
+public sealed class BrowserLinkOutgoingPeerResolver : IOutgoingPeerResolver
+{
+    public IDisposable OnPeerChanges(Func<Task> callback)
+    {
+        return new NullSubscription();
+    }
+
+    private sealed class NullSubscription : IDisposable
+    {
+        public void Dispose()
+        {
+        }
+    }
+
+    public bool TryResolvePeerName(OtlpSpan span, [NotNullWhen(true)] out string? name)
+    {
+        var url = OtlpHelpers.GetValue(span.Attributes, "http.url");
+        if (url != null && Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            if (string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                var parts = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2)
+                {
+                    if (Guid.TryParse(parts[0], out _) && string.Equals(parts[1], "getScriptTag", StringComparison.OrdinalIgnoreCase))
+                    {
+                        name = "browserlink";
+                        return true;
+                    }
+                }
+            }
+        }
+
+        name = null;
+        return false;
+    }
+}

--- a/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
@@ -1,12 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Otlp.Model;
-
 namespace Aspire.Dashboard.Model;
 
 public interface IOutgoingPeerResolver
 {
-    bool TryResolvePeerName(OtlpSpan span, out string? name);
+    bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, out string? name);
     IDisposable OnPeerChanges(Func<Task> callback);
 }

--- a/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/IOutgoingPeerResolver.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Otlp.Model;
+
 namespace Aspire.Dashboard.Model;
 
 public interface IOutgoingPeerResolver
 {
-    string ResolvePeerName(string networkAddress);
+    bool TryResolvePeerName(OtlpSpan span, out string? name);
     IDisposable OnPeerChanges(Func<Task> callback);
 }

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -57,9 +57,9 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
         await RaisePeerChangesAsync().ConfigureAwait(false);
     }
 
-    public bool TryResolvePeerName(OtlpSpan span, [NotNullWhen(true)] out string? name)
+    public bool TryResolvePeerName(KeyValuePair<string, string>[] attributes, [NotNullWhen(true)] out string? name)
     {
-        var address = OtlpHelpers.GetValue(span.Attributes, OtlpSpan.PeerServiceAttributeKey);
+        var address = OtlpHelpers.GetValue(attributes, OtlpSpan.PeerServiceAttributeKey);
         if (address != null)
         {
             foreach (var (resourceName, resource) in _resourceNameMapping)

--- a/tests/Aspire.Dashboard.Tests/BrowserLinkOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/BrowserLinkOutgoingPeerResolverTests.cs
@@ -1,0 +1,113 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class BrowserLinkOutgoingPeerResolverTests
+{
+    [Fact]
+    public void EmptyAttributes_NoMatch()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.False(resolver.TryResolvePeerName([], out var name));
+    }
+
+    [Fact]
+    public void EmptyUrlAttribute_NoMatch()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "")], out var name));
+    }
+
+    [Fact]
+    public void NullUrlAttribute_NoMatch()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create<string, string>("http.url", null!)], out var name));
+    }
+
+    // http://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag
+
+    [Fact]
+    public void RelativeUrlAttribute_NoMatch()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out var name));
+    }
+
+    [Fact]
+    public void NonLocalHostUrlAttribute_NoMatch()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://dummy:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out var name));
+    }
+
+    [Fact]
+    public void NoPathGuidUrlAttribute_NoMatch()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://localhost:59267/getScriptTag")], out var name));
+    }
+
+    [Fact]
+    public void InvalidUrlAttribute_NoMatch()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "ht$tp://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out var name));
+    }
+
+    [Fact]
+    public void NoPathUrlAttribute_Match()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://localhost:59267/")], out var name));
+    }
+
+    [Fact]
+    public void GuidPathUrlAttribute_NoMatch()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://localhost:59267/not-a-guid/getScriptTag")], out var name));
+    }
+
+    [Fact]
+    public void LocalHostAndPathUrlAttribute_Match()
+    {
+        // Arrange
+        var resolver = new BrowserLinkOutgoingPeerResolver();
+
+        // Act & Assert
+        Assert.True(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out var name));
+        Assert.Equal("Browser Link", name);
+    }
+}


### PR DESCRIPTION
* Can now register multiple `IOutgoingPeerResolver` implementations
* Added resolver for labeling `browserlink` request that an app makes to VS. The resolver looks at the shape of the HTTP request.

![image](https://github.com/dotnet/aspire/assets/303201/88933c4a-4fab-4c7d-a573-d1f8dc91af95)
