### PR TITLE
The sample no longer uses it

### DIFF
--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -1,7 +1,5 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureProvisioning();
-
 var catalogDb = builder.AddPostgresContainer("postgres").AddDatabase("catalogdb");
 
 var basketCache = builder.AddRedisContainer("basketcache");


### PR DESCRIPTION
This pull request removes the code for adding Azure provisioning from the `Program.cs` file in the `samples/eShopLite/AppHost` directory.

Main change:

* <a href="diffhunk://#diff-4f439a6aa6aad1c9bb819effe331e96a1efb0cbca80c1a334a9f3ad48e9fa6f2L3-L4">`samples/eShopLite/AppHost/Program.cs`</a>: Removed the code for adding Azure provisioning.