### PR TITLE
Change AddLifecycleHook to use TryAddEnumerable

### DIFF
--- a/src/Aspire.Hosting/Lifecycle/LifecycleHookServiceCollectionExtensions.cs
+++ b/src/Aspire.Hosting/Lifecycle/LifecycleHookServiceCollectionExtensions.cs
@@ -18,6 +18,16 @@ public static class LifecycleHookServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to add the distributed application lifecycle hook to.</param>
     public static void AddLifecycleHook<T>(this IServiceCollection services) where T : class, IDistributedApplicationLifecycleHook
     {
+        services.AddSingleton<IDistributedApplicationLifecycleHook, T>();
+    }
+
+    /// <summary>
+    /// Attempts to add a distributed application lifecycle hook to the service collection.
+    /// </summary>
+    /// <typeparam name="T">The type of the distributed application lifecycle hook to add.</typeparam>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add the distributed application lifecycle hook to.</param>
+    public static void TryAddLifecycleHook<T>(this IServiceCollection services) where T : class, IDistributedApplicationLifecycleHook
+    {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDistributedApplicationLifecycleHook, T>());
     }
 
@@ -28,6 +38,17 @@ public static class LifecycleHookServiceCollectionExtensions
     /// <param name="services">The service collection to add the hook to.</param>
     /// <param name="implementationFactory">A factory function that creates the hook implementation.</param>
     public static void AddLifecycleHook<T>(this IServiceCollection services, Func<IServiceProvider, T> implementationFactory) where T : class, IDistributedApplicationLifecycleHook
+    {
+        services.AddSingleton<IDistributedApplicationLifecycleHook, T>(implementationFactory);
+    }
+
+    /// <summary>
+    /// Attempts to add a distributed application lifecycle hook to the service collection. 
+    /// </summary>
+    /// <typeparam name="T">The type of the distributed application lifecycle hook.</typeparam>
+    /// <param name="services">The service collection to add the hook to.</param>
+    /// <param name="implementationFactory">A factory function that creates the hook implementation.</param>
+    public static void TryAddLifecycleHook<T>(this IServiceCollection services, Func<IServiceProvider, T> implementationFactory) where T : class, IDistributedApplicationLifecycleHook
     {
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IDistributedApplicationLifecycleHook, T>(implementationFactory));
     }

--- a/src/Aspire.Hosting/Lifecycle/LifecycleHookServiceCollectionExtensions.cs
+++ b/src/Aspire.Hosting/Lifecycle/LifecycleHookServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Aspire.Hosting.Lifecycle;
 
@@ -17,7 +18,7 @@ public static class LifecycleHookServiceCollectionExtensions
     /// <param name="services">The <see cref="IServiceCollection"/> to add the distributed application lifecycle hook to.</param>
     public static void AddLifecycleHook<T>(this IServiceCollection services) where T : class, IDistributedApplicationLifecycleHook
     {
-        services.AddSingleton<IDistributedApplicationLifecycleHook, T>();
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDistributedApplicationLifecycleHook, T>());
     }
 
     /// <summary>
@@ -28,6 +29,6 @@ public static class LifecycleHookServiceCollectionExtensions
     /// <param name="implementationFactory">A factory function that creates the hook implementation.</param>
     public static void AddLifecycleHook<T>(this IServiceCollection services, Func<IServiceProvider, T> implementationFactory) where T : class, IDistributedApplicationLifecycleHook
     {
-        services.AddSingleton<IDistributedApplicationLifecycleHook, T>(implementationFactory);
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDistributedApplicationLifecycleHook, T>(implementationFactory));
     }
 }


### PR DESCRIPTION
This pull request modifies the `AddLifecycleHook` method in `LifecycleHookServiceCollectionExtensions.cs` to allow multiple implementations of `IDistributedApplicationLifecycleHook` to be registered. The `TryAddEnumerable` method is used to add the service descriptor as a singleton if it doesn't already exist in the service collection.

* <a href="diffhunk://#diff-c17979f860f24e1f32d61e60a3b113a74760fa8923f07eb911bfcf62b5d4ecfdL20-R21">`src/Aspire.Hosting/Lifecycle/LifecycleHookServiceCollectionExtensions.cs`</a>: Modified the `AddLifecycleHook` method to allow multiple implementations of `IDistributedApplicationLifecycleHook` to be registered. <a href="diffhunk://#diff-c17979f860f24e1f32d61e60a3b113a74760fa8923f07eb911bfcf62b5d4ecfdL20-R21">[1]</a> <a href="diffhunk://#diff-c17979f860f24e1f32d61e60a3b113a74760fa8923f07eb911bfcf62b5d4ecfdL31-R32">[2]</a>