### PR TITLE
Added AddProject overload that takes a project path

### DIFF
--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -12,7 +12,7 @@ var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice
 
 var messaging = builder.AddRabbitMQContainer("messaging");
 
-var basketService = builder.AddProject<Projects.BasketService>("basketservice")
+var basketService = builder.AddProject("basketservice", "..\\BasketService\\BasketService.csproj")
                     .WithReference(basketCache)
                     .WithReference(messaging);
 

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -12,7 +12,7 @@ var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice
 
 var messaging = builder.AddRabbitMQContainer("messaging");
 
-var basketService = builder.AddProject("basketservice", "..\\BasketService\\BasketService.csproj")
+var basketService = builder.AddProject("basketservice", @"..\BasketService\BasketService.csproj")
                     .WithReference(basketCache)
                     .WithReference(messaging);
 

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -44,7 +44,7 @@ internal sealed class ServiceAppResource : AppResource
     }
 }
 
-internal sealed class ApplicationExecutor(DistributedApplicationModel model, KubernetesService kubernetesService, DistributedApplicationOptions options)
+internal sealed class ApplicationExecutor(DistributedApplicationModel model, KubernetesService kubernetesService)
 {
     private const string DebugSessionPortVar = "DEBUG_SESSION_PORT";
 
@@ -60,8 +60,6 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
 
     private readonly DistributedApplicationModel _model = model;
     private readonly List<AppResource> _appResources = new();
-
-    private readonly string? _appHostProjectDirectory = options.ProjectDirectory;
 
     public async Task RunApplicationAsync(CancellationToken cancellationToken = default)
     {
@@ -248,9 +246,7 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model, Kub
             var exe = Executable.Create(exeName, exePath);
 
             // The working directory is always relative to the app host project directory (if it exists).
-            exe.Spec.WorkingDirectory = _appHostProjectDirectory is null ?
-                executable.WorkingDirectory :
-                Path.GetFullPath(Path.Combine(_appHostProjectDirectory, executable.WorkingDirectory));
+            exe.Spec.WorkingDirectory = executable.WorkingDirectory;
             exe.Spec.Args = executable.Args?.ToList();
             exe.Spec.ExecutionType = ExecutionType.Process;
 

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -29,6 +29,9 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     public IServiceCollection Services => _innerBuilder.Services;
 
     /// <inheritdoc />
+    public string ProjectDirectory { get; }
+
+    /// <inheritdoc />
     public IResourceCollection Resources { get; } = new ResourceCollection();
 
     /// <summary>
@@ -39,6 +42,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     {
         _args = options.Args ?? [];
         _innerBuilder = new HostApplicationBuilder();
+
+        ProjectDirectory = options.ProjectDirectory ?? _innerBuilder.Environment.ContentRootPath;
 
         // Core things
         _innerBuilder.Services.AddSingleton(sp => new DistributedApplicationModel(Resources));

--- a/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class ExecutableResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{ExecutableResource}"/>.</returns>
     public static IResourceBuilder<ExecutableResource> AddExecutable(this IDistributedApplicationBuilder builder, string name, string command, string workingDirectory, params string[]? args)
     {
-        workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.ProjectDirectory, workingDirectory);
+        workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.ProjectDirectory, workingDirectory));
 
         var executable = new ExecutableResource(name, command, workingDirectory, args);
         return builder.AddResource(executable);

--- a/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -21,7 +22,7 @@ public static class ExecutableResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{ExecutableResource}"/>.</returns>
     public static IResourceBuilder<ExecutableResource> AddExecutable(this IDistributedApplicationBuilder builder, string name, string command, string workingDirectory, params string[]? args)
     {
-        workingDirectory = Path.GetFullPath(Path.Combine(builder.ProjectDirectory, workingDirectory));
+        workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.ProjectDirectory, workingDirectory);
 
         var executable = new ExecutableResource(name, command, workingDirectory, args);
         return builder.AddResource(executable);

--- a/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
@@ -21,6 +21,8 @@ public static class ExecutableResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{ExecutableResource}"/>.</returns>
     public static IResourceBuilder<ExecutableResource> AddExecutable(this IDistributedApplicationBuilder builder, string name, string command, string workingDirectory, params string[]? args)
     {
+        workingDirectory = Path.GetFullPath(Path.Combine(builder.ProjectDirectory, workingDirectory));
+
         var executable = new ExecutableResource(name, command, workingDirectory, args);
         return builder.AddResource(executable);
     }

--- a/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Properties;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -40,7 +41,7 @@ public static class ProjectResourceBuilderExtensions
     {
         var project = new ProjectResource(name);
 
-        projectPath = Path.GetFullPath(Path.Combine(builder.ProjectDirectory, projectPath));
+        projectPath = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.ProjectDirectory, projectPath));
 
         return builder.AddResource(project)
                       .WithProjectDefaults()

--- a/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
@@ -24,16 +24,38 @@ public static class ProjectResourceBuilderExtensions
     public static IResourceBuilder<ProjectResource> AddProject<TProject>(this IDistributedApplicationBuilder builder, string name) where TProject : IServiceMetadata, new()
     {
         var project = new ProjectResource(name);
-        var projectBuilder = builder.AddResource(project);
+        return builder.AddResource(project)
+                      .WithProjectDefaults()
+                      .WithAnnotation(new TProject());
+    }
+
+    /// <summary>
+    /// Adds a .NET project to the application model. 
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the resource. This name will be used for service discovery when referenced in a dependency.</param>
+    /// <param name="projectPath">The path to the project file.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{ProjectResource}"/>.</returns>
+    public static IResourceBuilder<ProjectResource> AddProject(this IDistributedApplicationBuilder builder, string name, string projectPath)
+    {
+        var project = new ProjectResource(name);
+
+        projectPath = Path.GetFullPath(Path.Combine(builder.ProjectDirectory, projectPath));
+
+        return builder.AddResource(project)
+                      .WithProjectDefaults()
+                      .WithAnnotation(new ServiceMetadata(projectPath));
+    }
+
+    private static IResourceBuilder<ProjectResource> WithProjectDefaults(this IResourceBuilder<ProjectResource> builder)
+    {
         // We only want to turn these on for .NET projects, ConfigureOtlpEnvironment works for any resource type that
         // implements IDistributedApplicationResourceWithEnvironment.
-        projectBuilder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES", "true");
-        projectBuilder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES", "true");
-        projectBuilder.WithOtlpExporter();
-        projectBuilder.ConfigureConsoleLogs();
-        var serviceMetadata = new TProject();
-        projectBuilder.WithAnnotation(serviceMetadata);
-        return projectBuilder;
+        builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES", "true");
+        builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES", "true");
+        builder.WithOtlpExporter();
+        builder.ConfigureConsoleLogs();
+        return builder;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
@@ -16,6 +16,11 @@ public interface IDistributedApplicationBuilder
     /// <inheritdoc cref="HostApplicationBuilder.Configuration" />
     public ConfigurationManager Configuration { get; }
 
+    /// <summary>
+    /// Directory of the project where the app host is located. Defaults to the content root if there's no project.
+    /// </summary>
+    public string ProjectDirectory { get; }
+
     /// <inheritdoc cref="HostApplicationBuilder.Environment" />
     public IHostEnvironment Environment { get; }
 

--- a/src/Aspire.Hosting/IServiceMetadata.cs
+++ b/src/Aspire.Hosting/IServiceMetadata.cs
@@ -25,3 +25,12 @@ public interface IServiceMetadata : IResourceAnnotation
     /// </summary>
     public string ProjectPath { get; }
 }
+
+internal class ServiceMetadata(string projectPath) : IServiceMetadata
+{
+    public string AssemblyName => throw new NotImplementedException();
+
+    public string AssemblyPath => throw new NotImplementedException();
+
+    public string ProjectPath { get; } = projectPath;
+}

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -11,13 +11,11 @@ namespace Aspire.Hosting.Publishing;
 
 public class ManifestPublisher(ILogger<ManifestPublisher> logger,
                                IOptions<PublishingOptions> options,
-                               IHostApplicationLifetime lifetime,
-                               DistributedApplicationOptions applicationOptions) : IDistributedApplicationPublisher
+                               IHostApplicationLifetime lifetime) : IDistributedApplicationPublisher
 {
     private readonly ILogger<ManifestPublisher> _logger = logger;
     private readonly IOptions<PublishingOptions> _options = options;
     private readonly IHostApplicationLifetime _lifetime = lifetime;
-    private readonly string? _appHostProjectDirectory = applicationOptions.ProjectDirectory;
 
     public Utf8JsonWriter? JsonWriter { get; set; }
 
@@ -247,12 +245,7 @@ public class ManifestPublisher(ILogger<ManifestPublisher> logger,
         var manifestPath = _options.Value.OutputPath ?? throw new DistributedApplicationException("Output path not specified");
         var fullyQualifiedManifestPath = Path.GetFullPath(manifestPath);
         var manifestDirectory = Path.GetDirectoryName(fullyQualifiedManifestPath) ?? throw new DistributedApplicationException("Could not get directory name of output path");
-
-        var fullPath = _appHostProjectDirectory is null
-            ? Path.GetFullPath(executable.WorkingDirectory)
-            : Path.GetFullPath(Path.Combine(_appHostProjectDirectory, executable.WorkingDirectory));
-
-        var relativePathToProjectFile = Path.GetRelativePath(manifestDirectory, fullPath);
+        var relativePathToProjectFile = Path.GetRelativePath(manifestDirectory, executable.WorkingDirectory);
         jsonWriter.WriteString("workingDirectory", relativePathToProjectFile);
 
         jsonWriter.WriteString("command", executable.Command);

--- a/src/Aspire.Hosting/Utils/PathNormalizer.cs
+++ b/src/Aspire.Hosting/Utils/PathNormalizer.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Utils;
+
+internal static class PathNormalizer
+{
+    public static string NormalizePathForCurrentPlatform(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        // Fix slashes
+        path = path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+
+        return Path.GetFullPath(path);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
@@ -13,8 +13,7 @@ namespace Aspire.Hosting.Tests.Helpers;
 internal sealed class JsonDocumentManifestPublisher(
     ILogger<ManifestPublisher> logger,
     IOptions<PublishingOptions> options,
-    IHostApplicationLifetime lifetime,
-    DistributedApplicationOptions distributedApplicationOptions) : ManifestPublisher(logger, options, lifetime, distributedApplicationOptions)
+    IHostApplicationLifetime lifetime) : ManifestPublisher(logger, options, lifetime)
 {
     protected override async Task PublishInternalAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -8,7 +8,10 @@ public class TestProgram
     private TestProgram(string[] args, Assembly assembly, bool includeIntegrationServices = false, bool disableDashboard = true, bool includeNodeApp = false)
     {
         AppBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { Args = args, DisableDashboard = disableDashboard, AssemblyName = assembly.FullName });
-        ServiceABuilder = AppBuilder.AddProject<Projects.ServiceA>("servicea");
+
+        var serviceAPath = Path.Combine(Projects.TestProject_AppHost.ProjectPath, @"..\TestProject.ServiceA\TestProject.ServiceA.csproj");
+
+        ServiceABuilder = AppBuilder.AddProject("servicea", serviceAPath);
         ServiceBBuilder = AppBuilder.AddProject<Projects.ServiceB>("serviceb");
         ServiceCBuilder = AppBuilder.AddProject<Projects.ServiceC>("servicec");
         WorkerABuilder = AppBuilder.AddProject<Projects.WorkerA>("workera");


### PR DESCRIPTION
- To enable out of solution projects to be added trivially, added an overload of AddProject that takes the project path.
- Exposed ProjectDirectory on the builder to enable resources to resolve physical paths earlier. This cleans up lots of code from having to understand if paths of fully qualified or not.

Fixes #1065