### PR TITLE
Shorten paths in resources grid

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -37,7 +37,7 @@
                         OnDismiss="() => ClearSelectedResource()"
                         ViewKey="ResourcesList">
         <Summary>
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1fr 2fr 6fr 2fr 1fr 1fr" >
+            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1fr 2fr 3fr 2fr 1fr 1fr" >
                 <ChildContent>
                     <PropertyColumn Property="@(c => c.ResourceType)" Title="Type" Sortable="true" />
                     <TemplateColumn Title="Name" Sortable="true" SortBy="@_nameSort">

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -1,16 +1,17 @@
 ﻿@using Aspire.Dashboard.Model
+@using Aspire.Dashboard.Extensions
 
 @if (Resource is ProjectViewModel projectViewModel)
 {
-    <span title="@projectViewModel.ProjectPath">@projectViewModel.ProjectPath</span>
+    <span title="@projectViewModel.ProjectPath" aria-label="@projectViewModel.ProjectPath">@projectViewModel.ProjectPath.TrimMiddle(50)</span>
 }
 else if (Resource is ExecutableViewModel executableViewModel)
 {
     var arguments = string.Join(" ", executableViewModel.Arguments ?? []);
     var fullCommandLine = $"{executableViewModel.ExecutablePath} {arguments}";
 
-    <div class="ellipsis-overflow" title="@fullCommandLine">@executableViewModel.ExecutablePath <span class="subtext">@arguments</span></div>
-    <div class="ellipsis-overflow" title="@executableViewModel.WorkingDirectory">Working Dir: @executableViewModel.WorkingDirectory</div>
+    <div class="ellipsis-overflow" title="@fullCommandLine" aria-label="@fullCommandLine">@executableViewModel.ExecutablePath?.TrimMiddle(35) <span class="subtext">@arguments</span></div>
+    <div class="ellipsis-overflow" title="@executableViewModel.WorkingDirectory" aria-label="@executableViewModel.WorkingDirectory">Working Dir: @executableViewModel.WorkingDirectory?.TrimMiddle(35)</div>
 }
 else if (Resource is ContainerViewModel containerViewModel)
 {

--- a/src/Aspire.Dashboard/Extensions/StringExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/StringExtensions.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Extensions;
+
+internal static class StringExtensions
+{
+    /// <summary>
+    /// Shortens a string by replacing the middle with an ellipsis.
+    /// </summary>
+    /// <param name="text">The string to shorten</param>
+    /// <param name="maxLength">The max length of the result</param>
+    public static string TrimMiddle(this string text, int maxLength)
+    {
+        if (text.Length <= maxLength)
+        {
+            return text;
+        }
+
+        var firstPart = (maxLength - 1) / 2;
+        var lastPart = firstPart + ((maxLength - 1) % 2);
+
+        return $"{text[..firstPart]}…{text[^lastPart..]}";
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/StringExtensionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/StringExtensionsTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Extensions;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineData("/usr", 5, "/usr")]
+    [InlineData("~/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 5, "~/…oj")]
+    [InlineData("~/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 25, "~/src/repos/…MyApp.csproj")]
+    [InlineData("~/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 26, "~/src/repos/…/MyApp.csproj")]
+    [InlineData("/home/username/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 5, "/h…oj")]
+    [InlineData("/home/username/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 38, "/home/username/src…/MyApp/MyApp.csproj")]
+    [InlineData("/home/username/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 39, "/home/username/src/…/MyApp/MyApp.csproj")]
+    [InlineData("c:\\", 5, "c:\\")]
+    [InlineData("c:\\src\\repos\\AspireStarterProject\\MyApp\\MyApp.csproj", 5, "c:…oj")]
+    [InlineData("c:\\src\\repos\\AspireStarterProject\\MyApp\\MyApp.csproj", 32, "c:\\src\\repos\\As…App\\MyApp.csproj")]
+    [InlineData("c:\\src\\repos\\AspireStarterProject\\MyApp\\MyApp.csproj", 33, "c:\\src\\repos\\Asp…App\\MyApp.csproj")]
+    [InlineData("c:\\src\\repos\\AspireStarterProject\\MyApp\\MyApp.csproj", 48, "c:\\src\\repos\\AspireStar…oject\\MyApp\\MyApp.csproj")]
+    public void TrimMiddle(string path, int targetLength, string expectedResult)
+    {
+        var actual = StringExtensions.TrimMiddle(path, targetLength);
+
+        Assert.Equal(expectedResult, actual);
+    }
+}


### PR DESCRIPTION
This is a simple implementation of a fix for the Source column being way too big in the new combined Resources page. I added a _very_ basic "middle trimming" implementation and used it on the project path, executable path and working directory, then cut the default size of the Source column from 6/16ths to 3/13ths. Tooltips remain so you can see the whole value and narrator reads the whole value

Added a few tests mostly to document what it looks like, not really to enforce future compliance with this implementation. 

I don't really intend this as a fix for #999 necessarily unless people are happy with it. Just wanted to get that large column a little under control before Preview 2.

Before
![image](https://github.com/dotnet/aspire/assets/9613109/e63291bf-2f43-42ca-beaa-0136f9553f6d)
After
![image](https://github.com/dotnet/aspire/assets/9613109/3460d22b-4599-4481-8009-4233f9354c6b)
