### PR TITLE
Default Azure SDK tracing bool to the true if the environment variable or runtime config is set

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageVersion Include="Azure.Identity" Version="1.10.4" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0-beta.2" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.17.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.37.0" />

--- a/src/Components/Aspire.Azure.Data.Tables/AzureDataTablesSettings.cs
+++ b/src/Components/Aspire.Azure.Data.Tables/AzureDataTablesSettings.cs
@@ -41,14 +41,9 @@ public sealed class AzureDataTablesSettings : IConnectionStringSettings
 
     /// <summary>
     /// <para>Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.</para>
-    /// <para>Disabled by default.</para>
+    /// <para>Enabled by default.</para>
     /// </summary>
-    /// <remarks>
-    /// ActivitySource support in Azure SDK is experimental, the shape of Activities may change in the future without notice.
-    /// It can be enabled by setting "Azure.Experimental.EnableActivitySource" <see cref="AppContext"/> switch to true.
-    /// Or by setting "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE" environment variable to "true".
-    /// </remarks>
-    public bool Tracing { get; set; }
+    public bool Tracing { get; set; } = true;
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AzureMessagingServiceBusSettings.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AzureMessagingServiceBusSettings.cs
@@ -11,6 +11,8 @@ namespace Aspire.Azure.Messaging.ServiceBus;
 /// </summary>
 public sealed class AzureMessagingServiceBusSettings : IConnectionStringSettings
 {
+    private bool? _tracing;
+
     /// <summary>
     /// Gets or sets the connection string used to connect to the Service Bus namespace. 
     /// </summary>
@@ -44,14 +46,35 @@ public sealed class AzureMessagingServiceBusSettings : IConnectionStringSettings
 
     /// <summary>
     /// <para>Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.</para>
-    /// <para>Disabled by default.</para>
     /// </summary>
     /// <remarks>
-    /// ActivitySource support in Azure SDK is experimental, the shape of Activities may change in the future without notice.
+    /// ServiceBus ActivitySource support in Azure SDK is experimental, the shape of Activities may change in the future without notice.
     /// It can be enabled by setting "Azure.Experimental.EnableActivitySource" <see cref="AppContext"/> switch to true.
     /// Or by setting "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE" environment variable to "true".
     /// </remarks>
-    public bool Tracing { get; set; }
+    public bool Tracing
+    {
+        get { return _tracing ??= GetTracingDefaultValue(); }
+        set { _tracing = value; }
+    }
+
+    // default Tracing to true if the experimental switch is set
+    // TODO: remove this when ActivitySource support is no longer experimental
+    private static bool GetTracingDefaultValue()
+    {
+        if (AppContext.TryGetSwitch("Azure.Experimental.EnableActivitySource", out var enabled))
+        {
+            return enabled;
+        }
+
+        var envVar = Environment.GetEnvironmentVariable("AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE");
+        if (envVar is not null && (envVar.Equals("true", StringComparison.OrdinalIgnoreCase) || envVar.Equals("1")))
+        {
+            return true;
+        }
+
+        return false;
+    }
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
@@ -32,14 +32,9 @@ public sealed class AzureSecurityKeyVaultSettings : IConnectionStringSettings
 
     /// <summary>
     /// <para>Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.</para>
-    /// <para>Disabled by default.</para>
+    /// <para>Enabled by default.</para>
     /// </summary>
-    /// <remarks>
-    /// ActivitySource support in Azure SDK is experimental, the shape of Activities may change in the future without notice.
-    /// It can be enabled by setting "Azure.Experimental.EnableActivitySource" <see cref="AppContext"/> switch to true.
-    /// Or by setting "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE" environment variable to "true".
-    /// </remarks>
-    public bool Tracing { get; set; }
+    public bool Tracing { get; set; } = true;
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Storage.Blobs/AzureStorageBlobsSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AzureStorageBlobsSettings.cs
@@ -42,14 +42,9 @@ public sealed class AzureStorageBlobsSettings : IConnectionStringSettings
 
     /// <summary>
     /// <para>Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.</para>
-    /// <para>Disabled by default.</para>
+    /// <para>Enabled by default.</para>
     /// </summary>
-    /// <remarks>
-    /// ActivitySource support in Azure SDK is experimental, the shape of Activities may change in the future without notice.
-    /// It can be enabled by setting "Azure.Experimental.EnableActivitySource" <see cref="AppContext"/> switch to true.
-    /// Or by setting "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE" environment variable to "true".
-    /// </remarks>
-    public bool Tracing { get; set; }
+    public bool Tracing { get; set; } = true;
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
@@ -42,7 +42,7 @@ public sealed class AzureStorageQueuesSettings : IConnectionStringSettings
 
     /// <summary>
     /// <para>Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.</para>
-    /// <para>Disabled by default.</para>
+    /// <para>Enabled by default.</para>
     /// </summary>
     public bool Tracing { get; set; } = true;
 

--- a/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
@@ -44,12 +44,7 @@ public sealed class AzureStorageQueuesSettings : IConnectionStringSettings
     /// <para>Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.</para>
     /// <para>Disabled by default.</para>
     /// </summary>
-    /// <remarks>
-    /// ActivitySource support in Azure SDK is experimental, the shape of Activities may change in the future without notice.
-    /// It can be enabled by setting "Azure.Experimental.EnableActivitySource" <see cref="AppContext"/> switch to true.
-    /// Or by setting "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE" environment variable to "true".
-    /// </remarks>
-    public bool Tracing { get; set; }
+    public bool Tracing { get; set; } = true;
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AzureMessagingServiceBusSettingsTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AzureMessagingServiceBusSettingsTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace Aspire.Azure.Messaging.ServiceBus.Tests;
+
+public class AzureMessagingServiceBusSettingsTests
+{
+    [Fact]
+    public void TracingIsEnabledWhenAzureSwitchIsSet()
+    {
+        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(false)).Dispose();
+        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(true), ConformanceTests.EnableTracingForAzureSdk()).Dispose();
+    }
+
+    private static void EnsureTracingIsEnabledWhenAzureSwitchIsSet(bool expectedValue)
+    {
+        Assert.Equal(expectedValue, new AzureMessagingServiceBusSettings().Tracing);
+    }
+}

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Components.ConformanceTests;
 using Azure.Identity;
 using Azure.Messaging.ServiceBus;
+using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -91,4 +92,10 @@ public abstract class ConformanceTests : ConformanceTests<ServiceBusClient, Azur
 
     protected override void SetTracing(AzureMessagingServiceBusSettings options, bool enabled)
         => options.Tracing = enabled;
+
+    public static RemoteInvokeOptions EnableTracingForAzureSdk()
+        => new()
+        {
+            RuntimeConfigurationOptions = { { "Azure.Experimental.EnableActivitySource", true } }
+        };
 }

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/ConfigurationTests.cs
@@ -16,6 +16,6 @@ public class ConfigurationTests
         => Assert.True(new AzureSecurityKeyVaultSettings().HealthChecks);
 
     [Fact]
-    public void TracingIsDisabledByDefault()
-        => Assert.False(new AzureSecurityKeyVaultSettings().Tracing);
+    public void TracingIsEnabledByDefault()
+        => Assert.True(new AzureSecurityKeyVaultSettings().Tracing);
 }

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/ConformanceTests.cs
@@ -104,11 +104,11 @@ public class ConformanceTests : ConformanceTests<SecretClient, AzureSecurityKeyV
 
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null), EnableTracingForAzureSdk()).Dispose();
+        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key"), EnableTracingForAzureSdk()).Dispose();
+        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
 
     private static bool GetCanConnect()
     {

--- a/tests/Aspire.Azure.Storage.Blobs.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Blobs.Tests/ConformanceTests.cs
@@ -113,11 +113,11 @@ public class ConformanceTests : ConformanceTests<BlobServiceClient, AzureStorage
 
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null), EnableTracingForAzureSdk()).Dispose();
+        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key"), EnableTracingForAzureSdk()).Dispose();
+        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
 
     private static bool GetCanConnect()
     {

--- a/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
@@ -115,11 +115,11 @@ public class ConformanceTests : ConformanceTests<QueueServiceClient, AzureStorag
 
     [Fact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null), EnableTracingForAzureSdk()).Dispose();
+        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: null)).Dispose();
 
     [Fact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key"), EnableTracingForAzureSdk()).Dispose();
+        => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
 
     private static bool GetCanConnect()
     {

--- a/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Text.Json.Nodes;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -504,12 +503,6 @@ public abstract class ConformanceTests<TService, TOptions>
 
     public static string CreateConfigKey(string prefix, string? key, string suffix)
         => string.IsNullOrEmpty(key) ? $"{prefix}:{suffix}" : $"{prefix}:{key}:{suffix}";
-
-    protected static RemoteInvokeOptions EnableTracingForAzureSdk()
-        => new()
-        {
-            RuntimeConfigurationOptions = { { "Azure.Experimental.EnableActivitySource", true } }
-        };
 
     protected HostApplicationBuilder CreateHostBuilder(HostApplicationBuilderSettings? hostSettings = null, string? key = null)
     {


### PR DESCRIPTION
With the recent update to the new Azure SDK, the tracing is no longer experimental and can be enabled without the environment variable / AppContext switch. So enable Tracing by default for all Azure components except for ServiceBus. ServiceBus tracing is still experimental. So default the Tracing value based on whether the switch is enabled. This allows users to just set 1 setting - the Azure switch - to turn on tracing for ServiceBus.

Fix #742

fyi - @lmolkova @jsquire @tg-msft 