### PR TITLE
Update eShopLite to not call basket checkout if no current basket

### DIFF
--- a/samples/eShopLite/MyFrontend/Components/Cart.razor
+++ b/samples/eShopLite/MyFrontend/Components/Cart.razor
@@ -4,12 +4,12 @@
 <div class="justify-content-end">
     @if (basketIsAvailable)
     {
-        <EditForm action="@Navigation.ToAbsolutePath(Navigation.Uri)" Model="this" FormName="checkout" OnSubmit="HandleCheckout" data-enhance>
+        <EditForm Model="this" FormName="checkout" OnSubmit="HandleCheckout" data-enhance>
             <button type="submit" class="align-content-end cart-button">
                 <span class="fa-stack fa-lg cart-stack pa-4">
                     <i class="fa fa-shopping-cart fa-stack-4x"></i>
                     <i class="fa fa-stack-1x badge">
-                        @itemsInCart
+                        @(customerBasket?.TotalItemCount ?? 0)
                     </i>
                 </span>
             </button>
@@ -18,27 +18,25 @@
 </div>
 
 @code {
+    CustomerBasket? customerBasket;
     bool basketIsAvailable;
-    int itemsInCart = 0;
 
     [Parameter]
     public EventCallback<bool> BasketAvailabilityChanged { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
-        var (basket, isAvailable) = await BasketClient.GetBasketAsync("user");
+        (customerBasket, basketIsAvailable) = await BasketClient.GetBasketAsync("user");
 
-        if (basket is not null)
-        {
-            itemsInCart = basket.TotalItemCount;
-        }
-        basketIsAvailable = isAvailable;
         await BasketAvailabilityChanged.InvokeAsync(basketIsAvailable);
     }
 
     private async Task HandleCheckout()
     {
-        await BasketClient.CheckoutBasketAsync("user");
+        if (customerBasket is not null)
+        {
+            await BasketClient.CheckoutBasketAsync("user");
+        }
 
         // Preserve query string
         Navigation.NavigateTo($"/{new Uri(Navigation.Uri).Query}");


### PR DESCRIPTION
Tweak to not attempt to call the checkout basket service if the call to get the basket returned null (meaning there's no current user basket).

Port of dotnet/aspire-samples#51

This started happening when #361 was merged I think.