### PR TITLE
Add classifications to aspire-empty template

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -4,7 +4,11 @@
   "classifications": [
     "Common",
     ".NET Aspire",
-    "Cloud"
+    "Cloud",
+    "Web",
+    "Web API",
+    "API",
+    "Service"
   ],
   "name": ".NET Aspire Application",
   "defaultName": "AspireApp",


### PR DESCRIPTION
Fix #1096 by adding a few more classifications. These are missing and thus this template doesn't show in IDE filters that key off this info. These are in the aspire-starter one (in addition to Blazor but omitting that here)