### PR TITLE
Hack around resolving projects by path

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
@@ -442,7 +442,7 @@ internal sealed partial class DashboardViewModelService : IDashboardViewModelSer
 
                 // For project look into launch profile to append launch url
                 if (resourceViewModel is ProjectViewModel projectViewModel
-                    && _applicationModel.TryGetProjectWithPath(projectViewModel.ProjectPath, out var project)
+                    && _applicationModel.TryGetProjectWithPath(projectViewModel.Name, projectViewModel.ProjectPath, out var project)
                     && project.GetEffectiveLaunchProfile() is LaunchProfile launchProfile
                     && launchProfile.LaunchUrl is string launchUrl)
                 {


### PR DESCRIPTION
- Use the name as input for disambiguating the project resource. This is a workaround until we rewrite the dashboard view model to use the DistributedApplicationModel as the source of truth

Fixes #1072

<img width="1166" alt="image" src="https://github.com/dotnet/aspire/assets/95136/baf20bde-0431-41f6-924e-2e35df90f6d2">
