### PR TITLE
Add matching project template classifications to Aspire Empty to match Aspire Starter template

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -4,6 +4,10 @@
   "classifications": [
     "Common",
     ".NET Aspire",
+    "Web",
+    "Web API",
+    "API",
+    "Service",
     "Cloud"
   ],
   "name": ".NET Aspire Application",


### PR DESCRIPTION
Fixes: #1096
Adds `Web`, `Web API`, `API`, and `Service` to the _aspire-empty_ project template's classifications.