### PR TITLE
Remove default selection on console logs page

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -7,11 +7,11 @@
 <div class="resource-logs-layout">
     <h1>Console Logs</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <FluentSelect @ref="_resourceSelectComponent" TOption="ResourceViewModel"
+        <FluentSelect @ref="_resourceSelectComponent" TOption="Option<string>"
                       Items="@Resources"
-                      OptionValue="@(c => c.Name)"
-                      OptionText="GetDisplayText"
-                      @bind-SelectedOption="_selectedResource"
+                      OptionText="(o) => o.Text"
+                      OptionValue="(o) => o.Value"
+                      @bind-SelectedOption="_selectedOption"
                       @bind-SelectedOption:after="HandleSelectedOptionChangedAsync"
                       AriaLabel="Select a Resource"/>
         <FluentLabel Typo="Typography.Body">@_status</FluentLabel>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -26,54 +26,90 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
     private static ViewModelMonitor<ResourceViewModel> GetViewModelMonitor(IDashboardViewModelService dashboardViewModelService)
         => dashboardViewModelService.GetResources();
 
-    private FluentSelect<ResourceViewModel>? _resourceSelectComponent;
+    private FluentSelect<Option<string>>? _resourceSelectComponent;
+    private Option<string>? _selectedOption;
     private ResourceViewModel? _selectedResource;
     private readonly Dictionary<string, ResourceViewModel> _resourceNameMapping = new();
-    private IEnumerable<ResourceViewModel> Resources => _resourceNameMapping.Select(kvp => kvp.Value).OrderBy(c => c.Name);
+    private List<Option<string>>? Resources { get; set; }
     private LogViewer? _logViewer;
     private readonly CancellationTokenSource _watchContainersTokenSource = new();
     private CancellationTokenSource? _watchLogsTokenSource;
     private string _status = LogStatus.Initializing;
 
+    private readonly TaskCompletionSource _renderCompleted = new();
+
+    private readonly Option<string> _noSelection = new() { Value = null, Text = "(Select a resource)" };
+
     protected override void OnInitialized()
     {
         _status = LogStatus.LoadingResources;
+
+        var viewModelMonitor = GetViewModelMonitor(DashboardViewModelService);
+        var initialList = viewModelMonitor.Snapshot;
+        var watch = viewModelMonitor.Watch;
+
+        foreach (var result in initialList)
+        {
+            _resourceNameMapping[result.Name] = result;
+        }
+
+        UpdateResourcesList();
+
+        _ = Task.Run(async () =>
+        {
+            await foreach (var resourceChanged in watch.WithCancellation(_watchContainersTokenSource.Token))
+            {
+                await OnResourceListChangedAsync(resourceChanged.ObjectChangeType, resourceChanged.Resource);
+            }
+        });
+
+        StateHasChanged();
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    protected override void OnAfterRender(bool firstRender)
     {
         if (firstRender)
         {
-            var viewModelMonitor = GetViewModelMonitor(DashboardViewModelService);
-            var initialList = viewModelMonitor.Snapshot;
-            var watch = viewModelMonitor.Watch;
-
-            foreach (var result in initialList)
-            {
-                _resourceNameMapping[result.Name] = result;
-            }
-
-            if (ResourceName is not null)
-            {
-                _selectedResource = initialList.FirstOrDefault(c => string.Equals(ResourceName, c.Name, StringComparison.Ordinal));
-            }
-            else if (initialList.Count > 0)
-            {
-                _selectedResource = initialList[0];
-            }
-
-            await LoadLogsAsync();
-
-            _ = Task.Run(async () =>
-            {
-                await foreach (var resourceChanged in watch.WithCancellation(_watchContainersTokenSource.Token))
-                {
-                    await OnResourceListChangedAsync(resourceChanged.ObjectChangeType, resourceChanged.Resource);
-                }
-            });
-
-            StateHasChanged();
+            // Let anyone waiting know that the render is complete so we have access to the underlying log viewer
+            _renderCompleted.SetResult();
         }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Resources is not null && ResourceName is not null)
+        {
+            _selectedOption = Resources.FirstOrDefault(c => string.Equals(ResourceName, c.Value, StringComparison.Ordinal)) ?? _noSelection;
+            _selectedResource = _selectedOption.Value is null ? null : _resourceNameMapping[_selectedOption.Value];
+            await LoadLogsAsync();
+        }
+        else
+        {
+            await StopWatchingLogsAsync();
+            await ClearLogsAsync();
+            _selectedOption = _noSelection;
+            _selectedResource = null;
+            _status = LogStatus.NoResourceSelected;
+        }
+    }
+
+    private static Option<string> GetOption(ResourceViewModel resource)
+    {
+        return new Option<string>()
+        {
+            Value = resource.Name,
+            Text = GetDisplayText(resource)
+        };
+    }
+
+    private void UpdateResourcesList()
+    {
+        Resources = _resourceNameMapping.Values
+            .OrderBy(c => c.Name)
+            .Select(GetOption)
+            .ToList();
+
+        Resources.Insert(0, _noSelection);
     }
 
     private Task ClearLogsAsync()
@@ -81,6 +117,9 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
 
     private async ValueTask LoadLogsAsync()
     {
+        // Wait for the first render to complete so that the log viewer is available
+        await _renderCompleted.Task;
+
         if (_selectedResource is null)
         {
             _status = LogStatus.NoResourceSelected;
@@ -148,14 +187,9 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
 
     private async Task HandleSelectedOptionChangedAsync()
     {
-        if (_selectedResource is not null)
-        {
-            // Change the URL
-            NavigationManager.NavigateTo($"/ConsoleLogs/{_selectedResource.Name}");
-            await StopWatchingLogsAsync();
-            await ClearLogsAsync();
-            await LoadLogsAsync();
-        }
+        await StopWatchingLogsAsync();
+        await ClearLogsAsync();
+        NavigationManager.NavigateTo($"/ConsoleLogs/{_selectedOption?.Value}");
     }
 
     private async Task OnResourceListChangedAsync(ObjectChangeType changeType, ResourceViewModel resourceViewModel)
@@ -163,15 +197,6 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
         if (changeType == ObjectChangeType.Added)
         {
             _resourceNameMapping[resourceViewModel.Name] = resourceViewModel;
-
-            if (_selectedResource is null)
-            {
-                if (string.IsNullOrEmpty(ResourceName) || string.Equals(ResourceName, resourceViewModel.Name, StringComparison.Ordinal))
-                {
-                    _selectedResource = resourceViewModel;
-                    await LoadLogsAsync();
-                }
-            }
         }
         else if (changeType == ObjectChangeType.Modified)
         {
@@ -195,13 +220,12 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
             _resourceNameMapping.Remove(resourceViewModel.Name);
             if (string.Equals(_selectedResource?.Name, resourceViewModel.Name, StringComparison.Ordinal))
             {
-                if (_resourceNameMapping.Count > 0)
-                {
-                    _selectedResource = Resources.First();
-                    await HandleSelectedOptionChangedAsync();
-                }
+                _selectedOption = _noSelection;
+                await HandleSelectedOptionChangedAsync();
             }
         }
+
+        UpdateResourcesList();
 
         await InvokeAsync(StateHasChanged);
 
@@ -242,8 +266,10 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
         {
             await _watchLogsTokenSource.CancelAsync();
             _watchLogsTokenSource.Dispose();
-            // The token source only gets created if selected resource is not null
-            await _selectedResource!.LogSource.StopAsync();
+            if (_selectedResource?.LogSource is not null)
+            {
+                await _selectedResource.LogSource.StopAsync();
+            }
             _watchLogsTokenSource = null;
         }
     }

--- a/src/Aspire.Dashboard/Model/LogStatus.cs
+++ b/src/Aspire.Dashboard/Model/LogStatus.cs
@@ -6,11 +6,11 @@ namespace Aspire.Dashboard.Model;
 internal static class LogStatus
 {
     public const string Initializing = "Initializing...";
-    public const string InitializingLogViewer = "Initializing Log Viewer...";
-    public const string LogsNotYetAvailable = "Logs Not Yet Available";
-    public const string WatchingLogs = "Watching Logs...";
-    public const string FailedToInitialize = "Failed to Initialize";
-    public const string FinishedWatchingLogs = "Finished Watching Logs";
-    public const string LoadingResources = "Loading Resources ...";
-    public const string NoResourceSelected = "No Resource Selected";
+    public const string InitializingLogViewer = "Initializing log viewer...";
+    public const string LogsNotYetAvailable = "Logs not yet available";
+    public const string WatchingLogs = "Watching logs...";
+    public const string FailedToInitialize = "Failed to initialize";
+    public const string FinishedWatchingLogs = "Finished watching logs";
+    public const string LoadingResources = "Loading resources ...";
+    public const string NoResourceSelected = "No resource selected";
 }


### PR DESCRIPTION
Resolves #1055 

- Change the binding for the `FluentSelect` to be a list of `Option<string>` instead of directly using `ResourceViewModel`
- Insert a default `(Select a resource)` entry in the list (see first screenshot)
- If you hit the page directly (either by typing in the `/ConsoleLogs` url or using the menu, logs won't start automatically and you'll get the view in the second screenshot below
- If there is no selection and a new resource shows up, we do not automatically select it
- Switching between log sources is the same as before this change
- Changed all statuses to sentence casing per UX board suggestion

Screenshots:
![image](https://github.com/dotnet/aspire/assets/9613109/a68f84ee-aa1f-41fc-86fe-c5c3ad823862)
![image](https://github.com/dotnet/aspire/assets/9613109/a67601d8-0733-4bcb-aeb4-a5e052883ba2)