### PR TITLE
Make Copy tooltip text configurable

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -34,5 +34,5 @@
                   Class="defaultHidden"
                   @onclick="@(() => CopyTextToClipboardAsync(Value, @_anchorId))"
                   aria-label="Copy to Clipboard" />
-    <FluentTooltip Anchor="@_anchorId" Position="TooltipPosition.Top">@PreCopyText</FluentTooltip>
+    <FluentTooltip Anchor="@_anchorId" Position="TooltipPosition.Top">@PreCopyToolTip</FluentTooltip>
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
@@ -42,8 +42,11 @@ public partial class GridValue
     [Parameter]
     public string? ToolTip { get; set; }
 
-    private const string PreCopyText = "Copy to clipboard";
-    private const string PostCopyText = "Copied!";
+    [Parameter]
+    public string PreCopyToolTip { get; set; } = "Copy to clipboard";
+
+    [Parameter]
+    public string PostCopyToolTip { get; set; } = "Copied!";
 
     private readonly Icon _maskIcon = new Icons.Regular.Size16.EyeOff();
     private readonly Icon _unmaskIcon = new Icons.Regular.Size16.Eye();
@@ -56,7 +59,7 @@ public partial class GridValue
         => await IsMaskedChanged.InvokeAsync(!IsMasked);
 
     private async Task CopyTextToClipboardAsync(string? text, string id)
-        => await JS.InvokeVoidAsync("copyTextToClipboard", id, text, PreCopyText, PostCopyText);
+        => await JS.InvokeVoidAsync("copyTextToClipboard", id, text, PreCopyToolTip, PostCopyToolTip);
 
     private static string TrimLength(string? text)
         => text?.Length > 8 ? text.Substring(0, 8) : text ?? string.Empty;

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -13,7 +13,7 @@
             <GridValue Value="@containerViewModel.ContainerId"
                        MaxDisplayLength="8"
                        EnableHighlighting="false"
-                       PreCopyToolTip="Copy Container Id to Clipboard"
+                       PreCopyToolTip="Copy container ID to clipboard"
                        ToolTip="@($"Container Id: {containerViewModel.ContainerId}")"/>
         </div>
     }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -13,6 +13,7 @@
             <GridValue Value="@containerViewModel.ContainerId"
                        MaxDisplayLength="8"
                        EnableHighlighting="false"
+                       PreCopyToolTip="Copy Container Id to Clipboard"
                        ToolTip="@($"Container Id: {containerViewModel.ContainerId}")"/>
         </div>
     }


### PR DESCRIPTION
This came up during the UX board meeting today. It was suggested that the tooltip here should indicate _what_ it is going to copy, since there are two distinct pieces of information in the cell where the copy button lives. So this text makes the Pre/Post copy text configurable and then changes it for that one usage, leaving it the default in all other uses.

![image](https://github.com/dotnet/aspire/assets/9613109/be10272c-198e-4e02-becf-13f23e29b89d)
