### PR TITLE
Password escaping for MySql, Postgres, and SQL Server

### DIFF
--- a/src/Aspire.Hosting/MySql/MySqlContainerResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlContainerResource.cs
@@ -25,7 +25,12 @@ public class MySqlContainerResource(string name, string password) : ContainerRes
 
         var allocatedEndpoint = allocatedEndpoints.Single(); // We should only have one endpoint for MySQL.
 
-        var connectionString = $"Server={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};User ID=root;Password={Password};";
+        var connectionString = $"Server={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};User ID=root;Password=\"{EscapedPassword(Password)}\";";
         return connectionString;
+    }
+
+    internal static string EscapedPassword(string password)
+    {
+        return password.Replace("\"", "\"\"");
     }
 }

--- a/src/Aspire.Hosting/MySql/MySqlContainerResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlContainerResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Utils;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -25,12 +27,7 @@ public class MySqlContainerResource(string name, string password) : ContainerRes
 
         var allocatedEndpoint = allocatedEndpoints.Single(); // We should only have one endpoint for MySQL.
 
-        var connectionString = $"Server={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};User ID=root;Password=\"{EscapedPassword(Password)}\";";
+        var connectionString = $"Server={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};User ID=root;Password=\"{PasswordUtil.EscapePassword(Password)}\";";
         return connectionString;
-    }
-
-    internal static string EscapedPassword(string password)
-    {
-        return password.Replace("\"", "\"\"");
     }
 }

--- a/src/Aspire.Hosting/Postgres/PostgresContainerResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresContainerResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Utils;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -25,7 +27,7 @@ public class PostgresContainerResource(string name, string password) : Container
 
         var allocatedEndpoint = allocatedEndpoints.Single(); // We should only have one endpoint for Postgres.
 
-        var connectionString = $"Host={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};Username=postgres;Password={Password};";
+        var connectionString = $"Host={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};Username=postgres;Password={PasswordUtil.EscapePassword(Password)};";
         return connectionString;
     }
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerContainerResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerContainerResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Utils;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -30,11 +32,6 @@ public class SqlServerContainerResource(string name, string password) : Containe
 
         // HACK: Use the 127.0.0.1 address because localhost is resolving to [::1] following
         //       up with DCP on this issue.
-        return $"Server=127.0.0.1,{endpoint.Port};User ID=sa;Password={EscapedPassword(Password)};TrustServerCertificate=true;";
-    }
-
-    internal static string EscapedPassword(string password)
-    {
-        return password.Replace("\"", "\"\"");
+        return $"Server=127.0.0.1,{endpoint.Port};User ID=sa;Password={PasswordUtil.EscapePassword(Password)};TrustServerCertificate=true;";
     }
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerContainerResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerContainerResource.cs
@@ -30,6 +30,11 @@ public class SqlServerContainerResource(string name, string password) : Containe
 
         // HACK: Use the 127.0.0.1 address because localhost is resolving to [::1] following
         //       up with DCP on this issue.
-        return $"Server=127.0.0.1,{endpoint.Port};User ID=sa;Password={Password};TrustServerCertificate=true;";
+        return $"Server=127.0.0.1,{endpoint.Port};User ID=sa;Password={EscapedPassword(Password)};TrustServerCertificate=true;";
+    }
+
+    internal static string EscapedPassword(string password)
+    {
+        return password.Replace("\"", "\"\"");
     }
 }

--- a/src/Aspire.Hosting/Utils/PasswordUtil.cs
+++ b/src/Aspire.Hosting/Utils/PasswordUtil.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Utils;
+
+internal static class PasswordUtil
+{
+    internal static string EscapePassword(string password) => password.Replace("\"", "\"\"");
+}

--- a/tests/Aspire.Hosting.Tests/MySql/MySqlContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/MySqlContainerResourceTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using MySqlConnector;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.MySql;
+
+public class MySqlContainerResourceTests
+{
+    [Theory()]
+    [InlineData(["password", "Server=myserver;Port=1000;User ID=root;Password=\"password\";"])]
+    [InlineData(["mypasswordwitha\"inthemiddle", "Server=myserver;Port=1000;User ID=root;Password=\"mypasswordwitha\"\"inthemiddle\";"])]
+    [InlineData(["mypasswordwitha\"attheend\"", "Server=myserver;Port=1000;User ID=root;Password=\"mypasswordwitha\"\"attheend\"\"\";"])]
+    [InlineData(["\"mypasswordwitha\"atthestart", "Server=myserver;Port=1000;User ID=root;Password=\"\"\"mypasswordwitha\"\"atthestart\";"])]
+    [InlineData(["mypasswordwitha'inthemiddle", "Server=myserver;Port=1000;User ID=root;Password=\"mypasswordwitha'inthemiddle\";"])]
+    [InlineData(["mypasswordwitha'attheend'", "Server=myserver;Port=1000;User ID=root;Password=\"mypasswordwitha'attheend'\";"])]
+    [InlineData(["'mypasswordwitha'atthestart", "Server=myserver;Port=1000;User ID=root;Password=\"'mypasswordwitha'atthestart\";"])]
+    public void TestEscapeSequencesForPassword(string password, string expectedConnectionString)
+    {
+        var connectionStringTemplate = "Server=myserver;Port=1000;User ID=root;Password=\"{0}\";";
+        var escapedPassword = MySqlContainerResource.EscapedPassword(password);
+        var actualConnectionString = string.Format(CultureInfo.InvariantCulture, connectionStringTemplate, escapedPassword);
+
+        var builder = new MySqlConnectionStringBuilder(actualConnectionString);
+        Assert.Equal(password, builder.Password);
+        Assert.Equal(expectedConnectionString, actualConnectionString);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/MySql/MySqlContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/MySqlContainerResourceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Hosting.Utils;
 using MySqlConnector;
 using Xunit;
 
@@ -20,7 +21,7 @@ public class MySqlContainerResourceTests
     public void TestEscapeSequencesForPassword(string password, string expectedConnectionString)
     {
         var connectionStringTemplate = "Server=myserver;Port=1000;User ID=root;Password=\"{0}\";";
-        var escapedPassword = MySqlContainerResource.EscapedPassword(password);
+        var escapedPassword = PasswordUtil.EscapePassword(password);
         var actualConnectionString = string.Format(CultureInfo.InvariantCulture, connectionStringTemplate, escapedPassword);
 
         var builder = new MySqlConnectionStringBuilder(actualConnectionString);

--- a/tests/Aspire.Hosting.Tests/Postgres/PostgresContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/PostgresContainerResourceTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Hosting.Utils;
+using Npgsql;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Postgres;
+
+public class PostgresContainerResourceTests
+{
+    [Theory()]
+    [InlineData(["password", "Host=myserver;Port=1000;Username=postgres;Password=\"password\";"])]
+    [InlineData(["mypasswordwitha\"inthemiddle", "Host=myserver;Port=1000;Username=postgres;Password=\"mypasswordwitha\"\"inthemiddle\";"])]
+    [InlineData(["mypasswordwitha\"attheend\"", "Host=myserver;Port=1000;Username=postgres;Password=\"mypasswordwitha\"\"attheend\"\"\";"])]
+    [InlineData(["\"mypasswordwitha\"atthestart", "Host=myserver;Port=1000;Username=postgres;Password=\"\"\"mypasswordwitha\"\"atthestart\";"])]
+    [InlineData(["mypasswordwitha'inthemiddle", "Host=myserver;Port=1000;Username=postgres;Password=\"mypasswordwitha'inthemiddle\";"])]
+    [InlineData(["mypasswordwitha'attheend'", "Host=myserver;Port=1000;Username=postgres;Password=\"mypasswordwitha'attheend'\";"])]
+    [InlineData(["'mypasswordwitha'atthestart", "Host=myserver;Port=1000;Username=postgres;Password=\"'mypasswordwitha'atthestart\";"])]
+    public void TestEscapeSequencesForPassword(string password, string expectedConnectionString)
+    {
+        var connectionStringTemplate = "Host=myserver;Port=1000;Username=postgres;Password=\"{0}\";";
+        var escapedPassword = PasswordUtil.EscapePassword(password);
+        var actualConnectionString = string.Format(CultureInfo.InvariantCulture, connectionStringTemplate, escapedPassword);
+
+        var builder = new NpgsqlConnectionStringBuilder(actualConnectionString);
+        Assert.Equal(password, builder.Password);
+        Assert.Equal(expectedConnectionString, actualConnectionString);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/SqlServer/SqlServerContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/SqlServerContainerResourceTests.cs
@@ -22,7 +22,9 @@ public class SqlServerContainerResourceTests
         var connectionStringTemplate = "Server=myserver;User ID=sa;Password=\"{0}\";";
         var escapedPassword = SqlServerContainerResource.EscapedPassword(password);
         var actualConnectionString = string.Format(CultureInfo.InvariantCulture, connectionStringTemplate, escapedPassword);
-        using var connection = new SqlConnection(actualConnectionString);
+
+        var builder = new SqlConnectionStringBuilder(actualConnectionString);
+        Assert.Equal(password, builder.Password);
         Assert.Equal(expectedConnectionString, actualConnectionString);
     }
 }

--- a/tests/Aspire.Hosting.Tests/SqlServer/SqlServerContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/SqlServerContainerResourceTests.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.SqlServer;
+
+public class SqlServerContainerResourceTests
+{
+    [Theory()]
+    [InlineData(["password", "Server=myserver;User ID=sa;Password=\"password\";"])]
+    [InlineData(["mypasswordwitha\"inthemiddle", "Server=myserver;User ID=sa;Password=\"mypasswordwitha\"\"inthemiddle\";"])]
+    [InlineData(["mypasswordwitha\"attheend\"", "Server=myserver;User ID=sa;Password=\"mypasswordwitha\"\"attheend\"\"\";"])]
+    [InlineData(["\"mypasswordwitha\"atthestart", "Server=myserver;User ID=sa;Password=\"\"\"mypasswordwitha\"\"atthestart\";"])]
+    [InlineData(["mypasswordwitha'inthemiddle", "Server=myserver;User ID=sa;Password=\"mypasswordwitha'inthemiddle\";"])]
+    [InlineData(["mypasswordwitha'attheend'", "Server=myserver;User ID=sa;Password=\"mypasswordwitha'attheend'\";"])]
+    [InlineData(["'mypasswordwitha'atthestart", "Server=myserver;User ID=sa;Password=\"'mypasswordwitha'atthestart\";"])]
+    public void TestEscapeSequencesForPassword(string password, string expectedConnectionString)
+    {
+        var connectionStringTemplate = "Server=myserver;User ID=sa;Password=\"{0}\";";
+        var escapedPassword = SqlServerContainerResource.EscapedPassword(password);
+        var actualConnectionString = string.Format(CultureInfo.InvariantCulture, connectionStringTemplate, escapedPassword);
+        using var connection = new SqlConnection(actualConnectionString);
+        Assert.Equal(expectedConnectionString, actualConnectionString);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/SqlServer/SqlServerContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/SqlServerContainerResourceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Hosting.Utils;
 using Microsoft.Data.SqlClient;
 using Xunit;
 
@@ -20,7 +21,7 @@ public class SqlServerContainerResourceTests
     public void TestEscapeSequencesForPassword(string password, string expectedConnectionString)
     {
         var connectionStringTemplate = "Server=myserver;User ID=sa;Password=\"{0}\";";
-        var escapedPassword = SqlServerContainerResource.EscapedPassword(password);
+        var escapedPassword = PasswordUtil.EscapePassword(password);
         var actualConnectionString = string.Format(CultureInfo.InvariantCulture, connectionStringTemplate, escapedPassword);
 
         var builder = new SqlConnectionStringBuilder(actualConnectionString);


### PR DESCRIPTION
Fixes #1131 

Will need similar approaches for other connection strings, ~~but the rules are slightly different for say MySQL or Postgres.~~

Turns out that Postgres, MySql and SQL Server appear to support the same escaping mechanism.