### PR TITLE
Throw from `GetEndpoint` if the service binding does not exist

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithBindings.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithBindings.cs
@@ -14,8 +14,14 @@ public interface IResourceWithBindings : IResource
     /// <param name="bindingName">The name of the binding.</param>
     /// <returns>An <see cref="EndpointReference"/> object representing the endpoint reference 
     /// for the specified binding.</returns>
+    /// <exception cref="DistributedApplicationException">Throws an exception if the a binding with the name <paramref name="bindingName"/> does not exist on the specified resource.</exception>
     public EndpointReference GetEndpoint(string bindingName)
     {
+        if (!Annotations.OfType<ServiceBindingAnnotation>().Any(a => a.Name == bindingName))
+        {
+            throw new DistributedApplicationException($"Service binding with name '{bindingName}' does not exist on the specified resource");
+        }
+
         return new EndpointReference(this, bindingName);
     }
 }

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -257,6 +257,7 @@ public static class ResourceBuilderExtensions
     /// <param name="builder">The the resource builder.</param>
     /// <param name="name">The name of the service binding.</param>
     /// <returns>An <see cref="EndpointReference"/> that can be used to resolve the address of the endpoint after resource allocation has occurred.</returns>
+    /// <exception cref="DistributedApplicationException">Throws an exception if the a binding with the name <paramref name="name"/> does not exist on the specified resource.</exception>
     public static EndpointReference GetEndpoint<T>(this IResourceBuilder<T> builder, string name) where T : IResourceWithBindings
     {
         return builder.Resource.GetEndpoint(name);

--- a/tests/Aspire.Hosting.Tests/WithServiceBindingTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithServiceBindingTests.cs
@@ -33,6 +33,29 @@ public class WithServiceBindingTests
         Assert.Equal("Service binding with name 'mybinding' already exists", ex.Message);
     }
 
+    [Fact]
+    public void GetEndpointReturnsEndpointMatchingServiceBinding()
+    {
+        var testProgram = CreateTestProgram();
+        testProgram.ServiceABuilder.WithServiceBinding(1000, scheme: "https", name: "mybinding");
+
+        var endpoint = testProgram.ServiceABuilder.GetEndpoint("mybinding");
+
+        Assert.Equal("mybinding", endpoint.BindingName);
+    }
+
+    [Fact]
+    public void GetEndpointWithoutMatchingServiceBindingThrows()
+    {
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+        {
+            var testProgram = CreateTestProgram();
+            testProgram.ServiceABuilder.GetEndpoint("not-exist");
+        });
+
+        Assert.Equal("Service binding with name 'not-exist' does not exist on the specified resource", ex.Message);
+    }
+
     private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithServiceBindingTests>(args);
 
 }


### PR DESCRIPTION
Fixes #609 