### PR TITLE
Small layout tweaks

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -5,7 +5,7 @@
 <PageTitle>@DashboardViewModelService.ApplicationName Console Logs</PageTitle>
 
 <div class="resource-logs-layout">
-    <h1>Console Logs</h1>
+    <h1 class="page-header">Console Logs</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect @ref="_resourceSelectComponent" TOption="ResourceViewModel"
                       Items="@Resources"

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.css
@@ -7,11 +7,12 @@
         "head"
         "toolbar"
         "main";
+    gap: calc(var(--design-unit) * 2px);
 }
 
 ::deep.resource-logs-layout > h1 {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px);
+    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.resource-logs-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.css
@@ -12,7 +12,6 @@
 
 ::deep.resource-logs-layout > h1 {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.resource-logs-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -8,7 +8,7 @@
 <PageTitle>@DashboardViewModelService.ApplicationName Metrics</PageTitle>
 
 <div class="metrics-layout">
-    <h1>Metrics</h1>
+    <h1 class="page-header">Metrics</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect TOption="SelectViewModel<string>"
                       Items="@_applications"

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -74,7 +74,7 @@
 
 ::deep.metrics-layout > h1 {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px);
+    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.metrics-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -74,7 +74,6 @@
 
 ::deep.metrics-layout > h1 {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.metrics-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -8,3 +8,7 @@
     padding: 0 3px;
     cursor: pointer;
 }
+
+::deep fluent-toolbar > h1 {
+    padding-left: calc(var(--design-unit) * 1px);
+}

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -14,7 +14,7 @@
 <PageTitle>@DashboardViewModelService.ApplicationName Structured Logs</PageTitle>
 
 <div class="logs-layout">
-    <h1>Structured Logs</h1>
+    <h1 class="page-header">Structured Logs</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect TOption="SelectViewModel<string>"
                       Items="@_applications"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
@@ -12,7 +12,7 @@
 
 ::deep.logs-layout > h1 {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px);
+    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.logs-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.css
@@ -12,7 +12,6 @@
 
 ::deep.logs-layout > h1 {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.logs-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -15,7 +15,7 @@
 @if (_trace != null)
 {
     <div class="trace-detail-layout">
-        <div class="trace-detail-header">
+        <div class="trace-detail-header page-header">
             <h1 style="display:inline-block">@(_trace.FirstSpan.Source.ApplicationName): @_trace.FirstSpan.Name</h1>
             <span class="trace-id">@OtlpHelpers.ToShortenedId(_trace.TraceId)</span>
         </div>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -167,7 +167,7 @@
 
 ::deep.trace-detail-layout > .trace-detail-header {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px);
+    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.trace-detail-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -167,7 +167,6 @@
 
 ::deep.trace-detail-layout > .trace-detail-header {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.trace-detail-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -15,7 +15,7 @@
 
 
 <div class="traces-layout">
-    <h1>Traces</h1>
+    <h1 class="page-header">Traces</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect TOption="SelectViewModel<string>"
                       Items="@_applications"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -34,7 +34,6 @@
 
 ::deep.traces-layout > h1 {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.traces-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -34,7 +34,7 @@
 
 ::deep.traces-layout > h1 {
     grid-area: head;
-    padding: calc(var(--design-unit) * 1px);
+    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
 }
 
 ::deep.traces-layout > fluent-toolbar {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -150,3 +150,7 @@ fluent-data-grid-cell .long-inner-content {
 .validation-message {
     color: var(--error);
 }
+
+.page-header {
+    padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
+}


### PR DESCRIPTION
Fixes #1128 as well as something that came up during UX Board (that the titles and selects weren't quite aligned).

Console Logs was missing the gap value for the css grid layout.
The selects inside of the toolbar by default get a double padding effect (padding of the toolbar + padding that acts as a margin for the select itself). So I moved the title over to match that. 

I did a bit of an overlay image to try to show the alignment across all the main pages. The selects are aligned now (that was #1128) and the titles and selects line up, minus general text kerning differences):

![image](https://github.com/dotnet/aspire/assets/9613109/261f7ec1-443d-4607-9519-d05fa8b758a0)
