### PR TITLE
Make the manifest file clickable in terminal

### DIFF
--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -37,8 +37,8 @@ public class ManifestPublisher(ILogger<ManifestPublisher> logger, IOptions<Publi
 
         await WriteManifestAsync(model, jsonWriter, cancellationToken).ConfigureAwait(false);
 
-        var fullyQualifiedPath = Path.GetFullPath(_options.Value.OutputPath);
-        _logger.LogInformation("Published manifest to: {manifestPath}", fullyQualifiedPath);
+        var fullyQualifiedPath = Path.GetFullPath(_options.Value.OutputPath).Replace("\\", "/");
+        _logger.LogInformation("Published manifest to: file://{manifestPath}", fullyQualifiedPath);
     }
 
     protected async Task WriteManifestAsync(DistributedApplicationModel model, Utf8JsonWriter jsonWriter, CancellationToken cancellationToken)


### PR DESCRIPTION
I'm lazy 😅 ! I thought it would be a good feature to be able to click on the generated manifest file in the terminal and open it instead of copy and paste the path.
Old:
![image](https://github.com/dotnet/aspire/assets/19396090/dab38194-9306-40b4-8ab2-79c234ea3993)
New:
![image](https://github.com/dotnet/aspire/assets/19396090/4af29a5c-1d8a-4ce3-b6e7-bfe9199fde98)
