### PR TITLE
Update FluentUI packages to 4.1.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,8 +69,8 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="12.1.1" />
     <PackageVersion Include="JsonSchema.Net" Version="5.4.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.0.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.0.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.1.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.1" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,7 +69,7 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="12.1.1" />
     <PackageVersion Include="JsonSchema.Net" Version="5.4.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.1.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.1.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.1" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.0" />

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -1,5 +1,8 @@
 ﻿<div class="summary-details-container">
-    <FluentSplitter Orientation="@Orientation" Collapsed="@(!ShowDetails)" OnResized="HandleSplitterResize" Panel1Size="@_panel1Size" Panel2Size="@_panel2Size">
+    <FluentSplitter Orientation="@Orientation" Collapsed="@(!ShowDetails)"
+                    OnResized="HandleSplitterResize"
+                    Panel1Size="@_panel1Size" Panel2Size="@_panel2Size"
+                    Panel1MinSize="150px" Panel2MinSize="150px">
         <Panel1>
             <div class="summary-container">
                 @Summary

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
@@ -56,22 +56,3 @@
     white-space: nowrap;
     grid-area: actions;
 }
-
-
-/* Workaround until https://github.com/microsoft/fluentui-blazor/pull/1046 (or similar) is available
-   Note that this locks us to 8px bar size for the moment and BarSize parameter on FluentSplitter will
-   be ignored
-*/
-::deep split-panels[direction=row]::part(median) {
-    inline-size: 8px !important;
-    block-size: unset !important;
-}
-
-/* Workaround until https://github.com/microsoft/fluentui-blazor/pull/1046 (or similar) is available
-   Note that this locks us to 8px bar size for the moment and BarSize parameter on FluentSplitter will
-   be ignored
-*/
-::deep split-panels[direction=column]::part(median) {
-    block-size: 8px !important;
-    inline-size: unset !important;
-}

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
@@ -56,3 +56,22 @@
     white-space: nowrap;
     grid-area: actions;
 }
+
+
+/* Workaround until https://github.com/microsoft/fluentui-blazor/pull/1046 (or similar) is available
+   Note that this locks us to 8px bar size for the moment and BarSize parameter on FluentSplitter will
+   be ignored
+*/
+::deep split-panels[direction=row]::part(median) {
+    inline-size: 8px !important;
+    block-size: unset !important;
+}
+
+/* Workaround until https://github.com/microsoft/fluentui-blazor/pull/1046 (or similar) is available
+   Note that this locks us to 8px bar size for the moment and BarSize parameter on FluentSplitter will
+   be ignored
+*/
+::deep split-panels[direction=column]::part(median) {
+    block-size: 8px !important;
+    inline-size: unset !important;
+}


### PR DESCRIPTION
Fixes #865, Fixes #866

Added minimum widths of 150px to each part of the Summary/Details view now that that support is available per the original suggestion in #865. I think we can get feedback on whether those are appropriate values or whether they should be configurable but it is a good start to clean up the interface.

~There's a bug in the FluentSplitter implementation here that causes the splitter bar to not be rendered properly. I put a workaround in that we can remove once https://github.com/microsoft/fluentui-blazor/pull/1046 (or a similar PR fixing that issue) is available to us.~