### PR TITLE
Make behavior of IHttpClientBuilder.UseServiceDiscovery overloads consistent

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpClientBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpClientBuilderExtensions.cs
@@ -34,6 +34,10 @@ public static class HttpClientBuilderExtensions
             return new ResolvingHttpDelegatingHandler(registry);
         });
 
+        // Configure the HttpClient to disable gRPC load balancing.
+        // This is done on all HttpClient instances but only impacts gRPC clients.
+        AddDisableGrpcLoadBalancingFilter(httpClientBuilder.Services, httpClientBuilder.Name);
+
         return httpClientBuilder;
     }
 


### PR DESCRIPTION
Fixes #1158