### PR TITLE
Fix PostgreSQL mention in RabbitMQ project

### DIFF
--- a/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
@@ -162,7 +162,7 @@
                 },
                 "ConnectionString": {
                   "type": "string",
-                  "description": "Gets or sets the connection string of the Postgre SQL database to connect to."
+                  "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
                 },
                 "MaxConnectRetryCount": {
                   "type": "integer",

--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQClientSettings.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQClientSettings.cs
@@ -9,7 +9,7 @@ namespace Aspire.RabbitMQ.Client;
 public sealed class RabbitMQClientSettings
 {
     /// <summary>
-    /// The connection string of the RabbitMQ server to connect to.
+    /// Gets or sets the connection string of the RabbitMQ server to connect to.
     /// </summary>
     public string? ConnectionString { get; set; }
 


### PR DESCRIPTION
This pull request includes changes related to the configuration and comments of the RabbitMQ client in the codebase. The most important changes include updating the description of the "ConnectionString" property in the "ConfigurationSchema.json" file and updating the comment for the "ConnectionString" property in "RabbitMQClientSettings.cs" to reflect that it both gets and sets the connection string.

Main configuration and comment changes:

* <a href="diffhunk://#diff-5621fc8d343809b6b06bdd1f11b7d4841152196d0ddf7c625c927d6fa9dc39caL165-R165">`src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json`</a>: Updated the description of the "ConnectionString" property to mention a RabbitMQ server instead of a Postgre SQL database.
* <a href="diffhunk://#diff-b44eefccae2e95a9b3b308554c61c913c6f79aaaf77dc3a0e9c21463fbd8dc1aL12-R12">`src/Components/Aspire.RabbitMQ.Client/RabbitMQClientSettings.cs`</a>: Updated the comment for the "ConnectionString" property to reflect that it both gets and sets the connection string.