### PR TITLE
Workaround container networking limitations

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -79,7 +79,7 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model,
             // await CreateContainerSingletonsAsync(cancellationToken).ConfigureAwait(false);
 
             await CreateServicesAsync(cancellationToken).ConfigureAwait(false);
-            
+
             await CreateContainersAndExecutablesAsync(cancellationToken).ConfigureAwait(false);
         }
         finally

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -74,12 +74,12 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model,
             PrepareServices();
             PrepareContainers();
             PrepareExecutables();
-            PrepareProxylessServices();
+            // PrepareProxylessServices();
 
-            await CreateContainerSingletonsAsync(cancellationToken).ConfigureAwait(false);
+            // await CreateContainerSingletonsAsync(cancellationToken).ConfigureAwait(false);
 
             await CreateServicesAsync(cancellationToken).ConfigureAwait(false);
-
+            
             await CreateContainersAndExecutablesAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
@@ -166,7 +166,7 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model,
             await lifecycleHook.AfterEndpointsAllocatedAsync(_model, cancellationToken).ConfigureAwait(false);
         }
 
-        await CreateContainersAsync(toCreate.Where(ar => ar.DcpResource is Container && ar.ServicesConsumed.Any()), cancellationToken).ConfigureAwait(false);
+        await CreateContainersAsync(toCreate.Where(ar => ar.DcpResource is Container), cancellationToken).ConfigureAwait(false);
         await CreateExecutablesAsync(toCreate.Where(ar => ar.DcpResource is Executable || ar.DcpResource is ExecutableReplicaSet), cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -66,9 +66,9 @@ public static class ResourceBuilderExtensions
     {
         return builder.WithAnnotation(new EnvironmentCallbackAnnotation(name, () =>
         {
-            var replaceLocalhostWithMachineHost = builder.Resource is ContainerResource && endpointReference.Owner is ContainerResource;
+            var replaceLocalhostWithContainerHost = builder.Resource is ContainerResource;
 
-            return replaceLocalhostWithMachineHost
+            return replaceLocalhostWithContainerHost
             ? HostNameResolver.ReplaceLocalhostWithContainerHost(endpointReference.UriString, builder.ApplicationBuilder.Configuration)
             : endpointReference.UriString;
         }));
@@ -105,21 +105,21 @@ public static class ResourceBuilderExtensions
 
             var containsAmbiguousEndpoints = ContainsAmbiguousEndpoints(allocatedEndPoints);
 
-            var replaceLocalhostWithMachineHost = builder.Resource is ContainerResource && serviceReferencesAnnotation.Resource is ContainerResource;
+            var replaceLocalhostWithContainerHost = builder.Resource is ContainerResource;
             var configuration = builder.ApplicationBuilder.Configuration;
 
             var i = 0;
             foreach (var allocatedEndPoint in allocatedEndPoints)
             {
                 var bindingNameQualifiedUriStringKey = $"services__{name}__{i++}";
-                context.EnvironmentVariables[bindingNameQualifiedUriStringKey] = replaceLocalhostWithMachineHost
+                context.EnvironmentVariables[bindingNameQualifiedUriStringKey] = replaceLocalhostWithContainerHost
                 ? HostNameResolver.ReplaceLocalhostWithContainerHost(allocatedEndPoint.BindingNameQualifiedUriString, configuration)
                 : allocatedEndPoint.BindingNameQualifiedUriString;
 
                 if (!containsAmbiguousEndpoints)
                 {
                     var uriStringKey = $"services__{name}__{i++}";
-                    context.EnvironmentVariables[uriStringKey] = replaceLocalhostWithMachineHost
+                    context.EnvironmentVariables[uriStringKey] = replaceLocalhostWithContainerHost
                     ? HostNameResolver.ReplaceLocalhostWithContainerHost(allocatedEndPoint.UriString, configuration)
                     : allocatedEndPoint.UriString;
                 }
@@ -176,7 +176,7 @@ public static class ResourceBuilderExtensions
                 throw new DistributedApplicationException($"A connection string for '{resource.Name}' could not be retrieved.");
             }
 
-            if (builder.Resource is ContainerResource && resource is ContainerResource)
+            if (builder.Resource is ContainerResource)
             {
                 connectionString = HostNameResolver.ReplaceLocalhostWithContainerHost(connectionString, builder.ApplicationBuilder.Configuration);
             }

--- a/src/Aspire.Hosting/Otlp/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Otlp/OtlpConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -34,7 +35,10 @@ public static class OtlpConfigurationExtensions
                 return;
             }
 
-            context.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = configuration[DashboardOtlpUrlVariableName] ?? DashboardOtlpUrlDefaultValue;
+            var url = configuration[DashboardOtlpUrlVariableName] ?? DashboardOtlpUrlDefaultValue;
+            context.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = resource is ContainerResource
+                ? HostNameResolver.ReplaceLocalhostWithContainerHost(url, configuration)
+                : url;
 
             // Set the service name and instance id to the resource name and UID. Values are injected by DCP.
             context.EnvironmentVariables["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id={{- .UID -}}";

--- a/src/Aspire.Hosting/Utils/HostNameResolver.cs
+++ b/src/Aspire.Hosting/Utils/HostNameResolver.cs
@@ -16,8 +16,8 @@ internal class HostNameResolver
         // This configuration value is a workaround for the fact that host.docker.internal is not available on Linux by default.
         var hostName = configuration["AppHost:ContainerHostname"] ?? "host.docker.internal";
 
-        // REVIEW: Handle IPV6?
         return value.Replace("localhost", hostName, StringComparison.OrdinalIgnoreCase)
-                    .Replace("127.0.0.1", hostName);
+                    .Replace("127.0.0.1", hostName)
+                    .Replace("[::1]", hostName);
     }
 }

--- a/src/Aspire.Hosting/Utils/HostNameResolver.cs
+++ b/src/Aspire.Hosting/Utils/HostNameResolver.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+
+namespace Aspire.Hosting.Utils;
+
+internal class HostNameResolver
+{
+    // HACK: When the destination resource is a container, we need to replace the localhost with host.docker.internal
+    // so the container can access the other container via the host's IP address.
+    internal static string ReplaceLocalhostWithContainerHost(string value, IConfiguration configuration)
+    {
+        // https://stackoverflow.com/a/43541732/45091
+
+        // This configuration value is a workaround for the fact that host.docker.internal is not available on Linux by default.
+        var hostName = configuration["AppHost:ContainerHostname"] ?? "host.docker.internal";
+
+        // REVIEW: Handle IPV6?
+        return value.Replace("localhost", hostName, StringComparison.OrdinalIgnoreCase)
+                    .Replace("127.0.0.1", hostName);
+    }
+}


### PR DESCRIPTION
- Until we setup container networking, make sure containers can talk to other containers when using WithReference. This won't work when using raw strings/urls.

Preview2 mitigation for https://github.com/dotnet/aspire/issues/128

Fixes https://github.com/dotnet/aspire/issues/1197