### PR TITLE
Add command & args to container source column

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -23,6 +23,8 @@ else if (Resource is ContainerViewModel containerViewModel)
             var title = $"Port{(containerViewModel.Ports.Count > 1 ? "s" : string.Empty)}: {ports}";
             <span class="subtext" title="@title" aria-label="@title">@ports</span>
         }
+    </FluentStack>
+    <FluentStack Orientation="Orientation.Horizontal">
         @if (containerViewModel.Command is not null)
         {
             <div class="ellipsis-overflow" title="Container command" aria-label="Container command">Command: @containerViewModel.Command</div>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -23,6 +23,15 @@ else if (Resource is ContainerViewModel containerViewModel)
             var title = $"Port{(containerViewModel.Ports.Count > 1 ? "s" : string.Empty)}: {ports}";
             <span class="subtext" title="@title" aria-label="@title">@ports</span>
         }
+        @if (containerViewModel.Command is not null)
+        {
+            <div class="ellipsis-overflow" title="Container command" aria-label="Container command">Command: @containerViewModel.Command</div>
+        }
+        @if (containerViewModel.Args is not null)
+        {
+            var args = string.Join(" ", containerViewModel.Args);
+            <div class="ellipsis-overflow" title="Container args" aria-label="Container args">@args</div>
+        }
     </FluentStack>
 }
 

--- a/src/Aspire.Dashboard/Model/ContainerViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ContainerViewModel.cs
@@ -9,4 +9,6 @@ public class ContainerViewModel : ResourceViewModel
     public string? ContainerId { get; init; }
     public required string Image { get; init; }
     public List<int> Ports { get; } = new();
+    public string? Command { get; init; }
+    public List<string>? Args { get; init; }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardViewModelService.cs
@@ -345,7 +345,9 @@ internal sealed partial class DashboardViewModelService : IDashboardViewModelSer
             Image = container.Spec.Image!,
             LogSource = new DockerContainerLogSource(container.Status!.ContainerId!),
             State = container.Status?.State,
-            ExpectedEndpointsCount = GetExpectedEndpointsCount(_servicesMap.Values, container)
+            ExpectedEndpointsCount = GetExpectedEndpointsCount(_servicesMap.Values, container),
+            Command = container.Spec.Command,
+            Args = container.Spec.Args
         };
 
         if (container.Spec.Ports != null)


### PR DESCRIPTION
Show container command and args in the source column on resources tab if they have been set. As args will be more common than command, command is prefixed with `Command: {command}`.

<img width="645" alt="image" src="https://github.com/dotnet/aspire/assets/20359921/4834ef0b-c704-4021-80fa-b2d28e37a081">

Fixes #1122