### PR TITLE
Improve dashboard version display

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -70,7 +70,7 @@ public partial class SettingsDialog : IDialogContentComponent, IAsyncDisposable
                 return version[..plusIndex];
             }
 
-            // Version was not in the expected format so just continue on.
+            return version;
         }
 
         // Fallback to the file version, which is based on the CI build number, and then fallback to the assembly version, which is

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection;
+using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -18,7 +18,7 @@ public partial class SettingsDialog : IDialogContentComponent, IAsyncDisposable
     private const string ThemeSettingLight = "Light";
 
     private string _currentSetting = ThemeSettingSystem;
-    private static readonly string? s_version = GetVersionFromAssembly();
+    private static readonly string? s_version = typeof(SettingsDialog).Assembly.GetDisplayVersion();
 
     private IJSObjectReference? _jsModule;
 
@@ -51,34 +51,6 @@ public partial class SettingsDialog : IDialogContentComponent, IAsyncDisposable
 
         _currentSetting = newValue;
         await ThemeManager.RaiseThemeChangedAsync(newValue);
-    }
-
-    private static string? GetVersionFromAssembly()
-    {
-        // The package version is stamped into the assembly's AssemblyInformationalVersionAttribute at build time, followed by a '+' and
-        // the commit hash, e.g.:
-        // [assembly: AssemblyInformationalVersion("8.0.0-preview.2.23604.7+e7762a46d31842884a0bc72c92e07ba700c99bf5")]
-
-        var version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-
-        if (version is not null)
-        {
-            var plusIndex = version.IndexOf('+');
-
-            if (plusIndex > 0)
-            {
-                return version[..plusIndex];
-            }
-
-            return version;
-        }
-
-        // Fallback to the file version, which is based on the CI build number, and then fallback to the assembly version, which is
-        // product stable version, e.g. 8.0.0.0
-        version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version
-            ?? Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyVersionAttribute>()?.Version;
-
-        return version;
     }
 
     private Task<float> GetBaseLayerLuminanceForSetting(string setting)

--- a/src/Aspire.Dashboard/Extensions/AssemblyExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+
+namespace Aspire.Dashboard.Extensions;
+
+internal static class AssemblyExtensions
+{
+    public static string? GetDisplayVersion(this Assembly assembly)
+    {
+        // The package version is stamped into the assembly's AssemblyInformationalVersionAttribute at build time, followed by a '+' and
+        // the commit hash, e.g.:
+        // [assembly: AssemblyInformationalVersion("8.0.0-preview.2.23604.7+e7762a46d31842884a0bc72c92e07ba700c99bf5")]
+
+        var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        if (version is not null)
+        {
+            var plusIndex = version.IndexOf('+');
+
+            if (plusIndex > 0)
+            {
+                return version[..plusIndex];
+            }
+
+            return version;
+        }
+
+        // Fallback to the file version, which is based on the CI build number, and then fallback to the assembly version, which is
+        // product stable version, e.g. 8.0.0.0
+        version = assembly.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version
+            ?? assembly.GetCustomAttribute<AssemblyVersionAttribute>()?.Version;
+
+        return version;
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/AssemblyExtensionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/AssemblyExtensionsTests.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Aspire.Dashboard.Extensions;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class AssemblyExtensionsTests
+{
+    [Theory]
+    [InlineData("8.0.0-preview.1", "8.0.0-preview.1")]
+    [InlineData("8.0.0-preview.1+asdlkjfdijee", "8.0.0-preview.1")]
+    [InlineData("8.0.0-preview.1+asdlkjfdijee+someothersuffix", "8.0.0-preview.1")]
+    [InlineData("8.0.0", "8.0.0")]
+    [InlineData("Plain old text", "Plain old text")]
+    [InlineData("", "")]
+    [InlineData(null, null)]
+    public void GetDisplayVersionUsesInformationalVersionWhenPresent(string? attributeValue, string? expectedDisplayVersion)
+    {
+        var assembly = new TestingAssembly();
+        if (attributeValue is not null)
+        {
+            assembly.AddCustomAttribute(new AssemblyInformationalVersionAttribute(attributeValue));
+            assembly.AddCustomAttribute(new AssemblyFileVersionAttribute("This should never be used"));
+            assembly.AddCustomAttribute(new AssemblyVersionAttribute("1.1.1.1"));
+        }
+
+        var actualDisplayVersion = assembly.GetDisplayVersion();
+
+        Assert.Equal(expectedDisplayVersion, actualDisplayVersion);
+    }
+
+    [Theory]
+    [InlineData("8.0.0.1", "8.0.0.1")]
+    [InlineData("8.0.0.1+asdlkjfdijee", "8.0.0.1+asdlkjfdijee")]
+    [InlineData("Plain old text", "Plain old text")]
+    [InlineData("", "")]
+    [InlineData(null, null)]
+    public void GetDisplayVersionUsesFileVersionWhenPresentAndInformationalVersionIsMissing(string? attributeValue, string? expectedDisplayVersion)
+    {
+        var assembly = new TestingAssembly();
+        if (attributeValue is not null)
+        {
+            assembly.AddCustomAttribute(new AssemblyFileVersionAttribute(attributeValue));
+            assembly.AddCustomAttribute(new AssemblyVersionAttribute("1.1.1.1"));
+        }
+
+        var actualDisplayVersion = assembly.GetDisplayVersion();
+
+        Assert.Equal(expectedDisplayVersion, actualDisplayVersion);
+    }
+
+    [Theory]
+    [InlineData("8.0.0.1", "8.0.0.1")]
+    [InlineData("8.0.0.1+asdlkjfdijee", "8.0.0.1+asdlkjfdijee")]
+    [InlineData("Plain old text", "Plain old text")]
+    [InlineData("", "")]
+    [InlineData(null, null)]
+    public void GetDisplayVersionUsesAssemblyVersionWhenPresentAndInformationalVersionAndFileVersionAreaMissing(string? attributeValue, string? expectedDisplayVersion)
+    {
+        var assembly = new TestingAssembly();
+        if (attributeValue is not null)
+        {
+            assembly.AddCustomAttribute(new AssemblyVersionAttribute(attributeValue));
+        }
+
+        var actualDisplayVersion = assembly.GetDisplayVersion();
+
+        Assert.Equal(expectedDisplayVersion, actualDisplayVersion);
+    }
+}
+
+internal sealed class TestingAssembly : Assembly
+{
+    private readonly List<Attribute> _customAttributes = [];
+
+    public void AddCustomAttribute(Attribute attribute)
+    {
+        _customAttributes.Add(attribute);
+    }
+
+    public override object[] GetCustomAttributes(bool inherit)
+    {
+        return base.GetCustomAttributes(inherit);
+    }
+
+    public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+    {
+        return _customAttributes.Where(a => a.GetType() == attributeType).ToArray();
+    }
+}


### PR DESCRIPTION
Use the package version for the version displayed on the dashboard, if available, otherwise fallback to file version, followed by assembly version.

Example from running locally:

<img width="212" alt="image" src="https://github.com/dotnet/aspire/assets/249088/2af05387-c243-4017-9435-d01f8015df1e">


Fixes #1206