### PR TITLE
Add log category name to structured logs

### DIFF
--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -18,7 +18,7 @@ public class LogFilter
 
     public static List<string> GetAllPropertyNames(List<string> propertyKeys)
     {
-        var result = new List<string> { "Message", "Application", "TraceId", "SpanId", "OriginalFormat" };
+        var result = new List<string> { "Message", "Category", "Application", "TraceId", "SpanId", "OriginalFormat" };
         result.AddRange(propertyKeys);
         return result;
     }
@@ -88,6 +88,7 @@ public class LogFilter
             "TraceId" => x.TraceId,
             "SpanId" => x.SpanId,
             "OriginalFormat" => x.OriginalFormat,
+            "Category" => x.Scope.ScopeName,
             _ => x.Properties.GetValue(Field)
         };
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -19,8 +19,9 @@ public class OtlpLogEntry
     public string TraceId { get; }
     public string? OriginalFormat { get; }
     public OtlpApplication Application { get; }
+    public OtlpScope Scope { get; }
 
-    public OtlpLogEntry(LogRecord record, OtlpApplication logApp)
+    public OtlpLogEntry(LogRecord record, OtlpApplication logApp, OtlpScope scope)
     {
         var properties = new List<KeyValuePair<string, string>>();
         foreach (var kv in record.Attributes)
@@ -49,6 +50,7 @@ public class OtlpLogEntry
         SpanId = record.SpanId.ToHexString();
         TraceId = record.TraceId.ToHexString();
         Application = logApp;
+        Scope = scope;
     }
 
     private static LogLevel MapSeverity(SeverityNumber severityNumber) => severityNumber switch
@@ -82,13 +84,12 @@ public class OtlpLogEntry
 
     public Dictionary<string, string> AllProperties()
     {
-        var props = new Dictionary<string, string>
-        {
-            { "Application", Application.ApplicationName },
-            { "Level", Severity.ToString() },
-            { "Message", Message }
-        };
+        var props = new Dictionary<string, string>();
 
+        AddOptionalValue("Application", Application.ApplicationName, props);
+        AddOptionalValue("Category", Scope.ScopeName, props);
+        AddOptionalValue("Level", Severity.ToString(), props);
+        AddOptionalValue("Message", Message, props);
         AddOptionalValue("TraceId", TraceId, props);
         AddOptionalValue("SpanId", SpanId, props);
         AddOptionalValue("OriginalFormat", OriginalFormat, props);

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
@@ -10,12 +10,21 @@ namespace Aspire.Dashboard.Otlp.Model;
 /// </summary>
 public class OtlpScope
 {
+    public static readonly OtlpScope Empty = new OtlpScope();
+
     public string ScopeName { get; }
     public string Version { get; }
 
     public KeyValuePair<string, string>[] Properties { get; }
 
     public string ServiceProperties => Properties.ConcatProperties();
+
+    private OtlpScope()
+    {
+        ScopeName = string.Empty;
+        Properties = Array.Empty<KeyValuePair<string, string>>();
+        Version = string.Empty;
+    }
 
     public OtlpScope(InstrumentationScope scope)
     {

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
@@ -8,7 +8,7 @@ namespace Aspire.Dashboard.Otlp.Model;
 /// <summary>
 /// The Scope of a TraceSource, maps to the name of the ActivitySource in .NET
 /// </summary>
-public class OtlpTraceScope
+public class OtlpScope
 {
     public string ScopeName { get; }
     public string Version { get; }
@@ -17,7 +17,7 @@ public class OtlpTraceScope
 
     public string ServiceProperties => Properties.ConcatProperties();
 
-    public OtlpTraceScope(InstrumentationScope scope)
+    public OtlpScope(InstrumentationScope scope)
     {
         ScopeName = scope.Name;
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -35,7 +35,7 @@ public class OtlpTrace
 
     public List<OtlpSpan> Spans { get; } = new List<OtlpSpan>();
 
-    public OtlpTraceScope TraceScope { get; }
+    public OtlpScope TraceScope { get; }
 
     public int CalculateDepth(OtlpSpan span)
     {
@@ -93,7 +93,7 @@ public class OtlpTrace
         }
     }
 
-    public OtlpTrace(ReadOnlyMemory<byte> traceId, OtlpTraceScope traceScope)
+    public OtlpTrace(ReadOnlyMemory<byte> traceId, OtlpScope traceScope)
     {
         Key = traceId;
         TraceId = OtlpHelpers.ToHexString(traceId);

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -270,6 +270,9 @@ public class TelemetryRepository
                 OtlpScope? scope;
                 try
                 {
+                    // The instrumentation scope information for the spans in this message.
+                    // Semantically when InstrumentationScope isn't set, it is equivalent with
+                    // an empty instrumentation scope name (unknown).
                     var name = sl.Scope?.Name ?? string.Empty;
                     if (!_logScopes.TryGetValue(name, out scope))
                     {
@@ -543,10 +546,14 @@ public class TelemetryRepository
                 OtlpScope? scope;
                 try
                 {
-                    if (!_traceScopes.TryGetValue(scopeSpan.Scope.Name, out scope))
+                    // The instrumentation scope information for the spans in this message.
+                    // Semantically when InstrumentationScope isn't set, it is equivalent with
+                    // an empty instrumentation scope name (unknown).
+                    var name = scopeSpan.Scope?.Name ?? string.Empty;
+                    if (!_traceScopes.TryGetValue(name, out scope))
                     {
-                        scope = new OtlpScope(scopeSpan.Scope);
-                        _traceScopes.Add(scopeSpan.Scope.Name, scope);
+                        scope = (scopeSpan.Scope != null) ? new OtlpScope(scopeSpan.Scope) : OtlpScope.Empty;
+                        _traceScopes.Add(name, scope);
                     }
                 }
                 catch (Exception ex)

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -270,10 +270,11 @@ public class TelemetryRepository
                 OtlpScope? scope;
                 try
                 {
-                    if (!_logScopes.TryGetValue(sl.Scope.Name, out scope))
+                    var name = sl.Scope?.Name ?? string.Empty;
+                    if (!_logScopes.TryGetValue(name, out scope))
                     {
-                        scope = new OtlpScope(sl.Scope);
-                        _logScopes.Add(sl.Scope.Name, scope);
+                        scope = (sl.Scope != null) ? new OtlpScope(sl.Scope) : OtlpScope.Empty;
+                        _logScopes.Add(name, scope);
                     }
                 }
                 catch (Exception ex)

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -31,12 +31,13 @@ public class TelemetryRepository
     private readonly ConcurrentDictionary<string, OtlpApplication> _applications = new();
 
     private readonly ReaderWriterLockSlim _logsLock = new();
+    private readonly Dictionary<string, OtlpScope> _logScopes = new();
     private readonly CircularBuffer<OtlpLogEntry> _logs;
     private readonly HashSet<(OtlpApplication Application, string PropertyKey)> _logPropertyKeys = new();
     private readonly Dictionary<OtlpApplication, int> _applicationUnviewedErrorLogs = new();
 
     private readonly ReaderWriterLockSlim _tracesLock = new();
-    private readonly Dictionary<string, OtlpTraceScope> _traceScopes = new();
+    private readonly Dictionary<string, OtlpScope> _traceScopes = new();
     private readonly CircularBuffer<OtlpTrace> _traces;
 
     public TelemetryRepository(IConfiguration config, ILoggerFactory loggerFactory)
@@ -266,14 +267,27 @@ public class TelemetryRepository
         {
             foreach (var sl in scopeLogs)
             {
-                // Instrumentation Scope isn't commonly used for logs.
-                // Skip it for now until there is feedback that it has useful information.
+                OtlpScope? scope;
+                try
+                {
+                    if (!_logScopes.TryGetValue(sl.Scope.Name, out scope))
+                    {
+                        scope = new OtlpScope(sl.Scope);
+                        _logScopes.Add(sl.Scope.Name, scope);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    context.FailureCount += sl.LogRecords.Count;
+                    _logger.LogInformation(ex, "Error adding scope.");
+                    continue;
+                }
 
                 foreach (var record in sl.LogRecords)
                 {
                     try
                     {
-                        var logEntry = new OtlpLogEntry(record, application);
+                        var logEntry = new OtlpLogEntry(record, application, scope);
 
                         // Insert log entry in the correct position based on timestamp.
                         // Logs can be added out of order by different services.
@@ -525,13 +539,13 @@ public class TelemetryRepository
         {
             foreach (var scopeSpan in scopeSpans)
             {
-                OtlpTraceScope? traceScope;
+                OtlpScope? scope;
                 try
                 {
-                    if (!_traceScopes.TryGetValue(scopeSpan.Scope.Name, out traceScope))
+                    if (!_traceScopes.TryGetValue(scopeSpan.Scope.Name, out scope))
                     {
-                        traceScope = new OtlpTraceScope(scopeSpan.Scope);
-                        _traceScopes.Add(scopeSpan.Scope.Name, traceScope);
+                        scope = new OtlpScope(scopeSpan.Scope);
+                        _traceScopes.Add(scopeSpan.Scope.Name, scope);
                     }
                 }
                 catch (Exception ex)
@@ -557,7 +571,7 @@ public class TelemetryRepository
                         }
                         else if (!TryGetTraceById(_traces, span.TraceId.Memory, out trace))
                         {
-                            trace = new OtlpTrace(span.TraceId.Memory, traceScope);
+                            trace = new OtlpTrace(span.TraceId.Memory, scope);
                             newTrace = true;
                         }
 

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -31,6 +31,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords = { CreateLogRecord() }
                     }
                 }
@@ -62,6 +63,7 @@ public class LogTests
                 Assert.Equal("5465737454726163654964", app.TraceId);
                 Assert.Equal("Test {Log}", app.OriginalFormat);
                 Assert.Equal("Test Value!", app.Message);
+                Assert.Equal("TestLogger", app.Scope.ScopeName);
                 Assert.Collection(app.Properties,
                     p =>
                     {
@@ -92,6 +94,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords =
                         {
                             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "1"),
@@ -150,6 +153,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords =
                         {
                             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "1", severity: SeverityNumber.Trace),
@@ -169,6 +173,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords =
                         {
                             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "1", severity: SeverityNumber.Fatal)
@@ -224,6 +229,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords =
                         {
                             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "1", severity: SeverityNumber.Error),
@@ -238,6 +244,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords =
                         {
                             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "1", severity: SeverityNumber.Fatal)
@@ -274,6 +281,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords =
                         {
                             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "1", severity: SeverityNumber.Error),
@@ -288,6 +296,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords =
                         {
                             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "1", severity: SeverityNumber.Fatal)
@@ -325,6 +334,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords =
                         {
                             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "1", severity: SeverityNumber.Error),
@@ -399,6 +409,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords = { CreateLogRecord() }
                     }
                 }
@@ -435,6 +446,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords = { CreateLogRecord() }
                     }
                 }
@@ -482,6 +494,7 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
+                        Scope = CreateScope("TestLogger"),
                         LogRecords = { CreateLogRecord() }
                     }
                 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -94,7 +94,6 @@ public class LogTests
                 {
                     new ScopeLogs
                     {
-                        Scope = CreateScope("TestLogger"),
                         LogRecords =
                         {
                             CreateLogRecord(time: s_testTime.AddMinutes(1), message: "1"),
@@ -124,7 +123,11 @@ public class LogTests
             Filters = []
         });
         Assert.Collection(logs.Items,
-            l => Assert.Equal("1", l.Message),
+            l =>
+            {
+                Assert.Equal("1", l.Message);
+                Assert.Equal("", l.Scope.ScopeName);
+            },
             l => Assert.Equal("2", l.Message),
             l => Assert.Equal("3", l.Message),
             l => Assert.Equal("4", l.Message),

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -87,7 +87,6 @@ public class TraceTests
                 {
                     new ScopeSpans
                     {
-                        Scope = CreateScope(),
                         Spans =
                         {
                             CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(5), endTime: s_testTime.AddMinutes(10), parentSpanId: "1-1")
@@ -108,7 +107,6 @@ public class TraceTests
                 {
                     new ScopeSpans
                     {
-                        Scope = CreateScope(),
                         Spans =
                         {
                             CreateSpan(traceId: "2", spanId: "2-1", startTime: s_testTime.AddMinutes(3), endTime: s_testTime.AddMinutes(10))
@@ -140,12 +138,14 @@ public class TraceTests
                 AssertId("2", trace.TraceId);
                 AssertId("2-1", trace.FirstSpan.SpanId);
                 AssertId("2-1", trace.RootSpan!.SpanId);
+                Assert.Equal("", trace.TraceScope.ScopeName);
             },
             trace =>
             {
                 AssertId("1", trace.TraceId);
                 AssertId("1-2", trace.FirstSpan.SpanId);
                 Assert.Null(trace.RootSpan);
+                Assert.Equal("", trace.TraceScope.ScopeName);
             });
 
         var addContext3 = new AddContext();
@@ -158,7 +158,6 @@ public class TraceTests
                 {
                     new ScopeSpans
                     {
-                        Scope = CreateScope(),
                         Spans =
                         {
                             CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10))
@@ -181,13 +180,17 @@ public class TraceTests
             {
                 AssertId("1", trace.TraceId);
                 AssertId("1-1", trace.FirstSpan.SpanId);
+                AssertId("", trace.FirstSpan.ScopeName);
                 AssertId("1-1", trace.RootSpan!.SpanId);
+                Assert.Equal("", trace.TraceScope.ScopeName);
             },
             trace =>
             {
                 AssertId("2", trace.TraceId);
                 AssertId("2-1", trace.FirstSpan.SpanId);
+                AssertId("", trace.FirstSpan.ScopeName);
                 AssertId("2-1", trace.RootSpan!.SpanId);
+                Assert.Equal("", trace.TraceScope.ScopeName);
             });
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1200

I haven't added it to the grid because I don't think there is real estate.

Added to details view:
![image](https://github.com/dotnet/aspire/assets/303201/11094a95-65ab-4c6b-8605-ba948cc7c5c4)

Support filtering:
![image](https://github.com/dotnet/aspire/assets/303201/9dabce20-2a9f-409a-ba10-11985be163bf)