### PR TITLE
Add spelling exclusion file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,7 @@ indent_style = space
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+spelling_exclusion_path = spelling.dic
 
 [*.cs]
 indent_size = 4

--- a/Aspire.sln
+++ b/Aspire.sln
@@ -146,6 +146,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{991DB378-6CB5-4441-BFC3-657400690FC3}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Packages.props = Directory.Packages.props
+		spelling.dic = spelling.dic
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspire.RabbitMQ.Client", "src\Components\Aspire.RabbitMQ.Client\Aspire.RabbitMQ.Client.csproj", "{4D8A92AB-4E77-4965-AD8E-8E206DCE66A4}"

--- a/spelling.dic
+++ b/spelling.dic
@@ -1,0 +1,6 @@
+grpc
+kubernetes
+oninput
+otlp
+protoc
+uris


### PR DESCRIPTION
This allows setting repo-specific terms for the VS spell checker to ignore, reducing noise in the IDE.