### PR TITLE
Remove redundant JSInterop injection

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -6,7 +6,6 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
-using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Pages;
 
@@ -21,8 +20,6 @@ public partial class Resources : ComponentBase, IDisposable
     public required TelemetryRepository TelemetryRepository { get; init; }
     [Inject]
     public required NavigationManager NavigationManager { get; set; }
-    [Inject]
-    public required IJSRuntime JS { get; set; }
 
     private IEnumerable<EnvironmentVariableViewModel>? SelectedEnvironmentVariables { get; set; }
     private string? SelectedResourceName { get; set; }


### PR DESCRIPTION
This dependency was added in ea05b9a5b370bb43cc6327a481cdaed62ea4dc5d and the usage of it was removed in 28c2ef056cf92a571741ca0c2f924845117ddb60.