### PR TITLE
Show template items in Solution Explorer and Find in Files

### DIFF
--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -13,6 +13,10 @@
     <Description>.NET Aspire Template Pack for Microsoft Template Engine</Description>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Include="templates\**\*" />
+  </ItemGroup>
+
   <!-- When building a package, this target will run to copy all the templates into the intermediate directory, 
        replaces the package versions, and adds them to the package.-->
   <Target Name="AddTemplatesToPackageAsContent"


### PR DESCRIPTION
This change adds template files as `None` items. This causes the contents of the `Aspire.ProjectTemplates` project to:

1. Appear in solution explorer
2. Participate in find-in-files

The templates include C# source code, but because they're included as `None` items (not `Compile`) items, they're shown in the IDE but ignored during build.

## Before

![image](https://github.com/dotnet/aspire/assets/350947/31823081-c6cc-4089-84f5-54a41990e437)

## After

![image](https://github.com/dotnet/aspire/assets/350947/626f0728-af30-4123-9bd0-7b319ff4c367)
