### PR TITLE
Fixed dapr sidecar resolution when app in container

### DIFF
--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -144,6 +144,17 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                 new EnvironmentCallbackAnnotation(
                     env =>
                     {
+                        if (resource is ContainerResource)
+                        {
+                            // By default, the Dapr sidecar will listen on localhost, which is not accessible from the container.
+
+                            var grpcEndpoint = $"http://localhost:{{{{- portFor \"{daprSideCarResourceName}_grpc\" -}}}}";
+                            var httpEndpoint = $"http://localhost:{{{{- portFor \"{daprSideCarResourceName}_http\" -}}}}";
+
+                            env.TryAdd("DAPR_GRPC_ENDPOINT", HostNameResolver.ReplaceLocalhostWithContainerHost(grpcEndpoint, _configuration));
+                            env.TryAdd("DAPR_HTTP_ENDPOINT", HostNameResolver.ReplaceLocalhostWithContainerHost(httpEndpoint, _configuration));
+                        }
+
                         env.TryAdd("DAPR_GRPC_PORT", $"{{{{- portFor \"{daprSideCarResourceName}_grpc\" -}}}}");
                         env.TryAdd("DAPR_HTTP_PORT", $"{{{{- portFor \"{daprSideCarResourceName}_http\" -}}}}");
                     }));

--- a/src/Aspire.Hosting/Utils/HostNameResolver.cs
+++ b/src/Aspire.Hosting/Utils/HostNameResolver.cs
@@ -5,11 +5,18 @@ using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Hosting.Utils;
 
-internal class HostNameResolver
+/// <summary>
+/// Helpers to resolve host names when running in a containers.
+/// </summary>
+public class HostNameResolver
 {
-    // HACK: When the destination resource is a container, we need to replace the localhost with host.docker.internal
-    // so the container can access the other container via the host's IP address.
-    internal static string ReplaceLocalhostWithContainerHost(string value, IConfiguration configuration)
+    /// <summary>
+    /// Resolves the "localhost" with the container host name.
+    /// </summary>
+    /// <param name="value">The value that contains the localhost</param>
+    /// <param name="configuration">The configuration object.</param>
+    /// <returns>A new value with localhost replaced with the container host name</returns>
+    public static string ReplaceLocalhostWithContainerHost(string value, IConfiguration configuration)
     {
         // https://stackoverflow.com/a/43541732/45091
 


### PR DESCRIPTION
- When the app is in a container we need to tell it to communicate over the container host instead of local host. Not all SDKs support this new env variable, but we set it anyways (.NET works).