### PR TITLE
Use instance ID throughout dashboard UI for disambiguation

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -245,15 +245,7 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
         return $"{GetResourceName(resource)}{stateText}";
     }
 
-    private string GetResourceName(ResourceViewModel resource)
-    {
-        if (_resourceNameMapping.Count(kvp => kvp.Value.DisplayName == resource.DisplayName) >= 2)
-        {
-            return ResourceFormatter.GetName(resource.DisplayName, resource.Uid);
-        }
-
-        return resource.DisplayName;
-    }
+    private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceNameMapping.Values);
 
     public async ValueTask DisposeAsync()
     {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -37,8 +37,6 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
 
     private readonly Option<string> _noSelection = new() { Value = null, Text = "(Select a resource)" };
 
-    private const int InstanceIdHintLimit = 8;
-
     protected override void OnInitialized()
     {
         _status = LogStatus.LoadingResources;
@@ -92,7 +90,7 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
         }
     }
 
-    private static Option<string> GetOption(ResourceViewModel resource)
+    private Option<string> GetOption(ResourceViewModel resource)
     {
         return new Option<string>()
         {
@@ -233,7 +231,7 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
         await UpdateResourceListSelectedResourceAsync();
     }
 
-    private static string GetDisplayText(ResourceViewModel resource)
+    private string GetDisplayText(ResourceViewModel resource)
     {
         var stateText = "";
         if (string.IsNullOrEmpty(resource.State))
@@ -244,23 +242,17 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
         {
             stateText = $" ({resource.State})";
         }
-        var resourceName = resource.DisplayName;
-        switch (resource)
+        return $"{GetResourceName(resource)}{stateText}";
+    }
+
+    private string GetResourceName(ResourceViewModel resource)
+    {
+        if (_resourceNameMapping.Count(kvp => kvp.Value.DisplayName == resource.DisplayName) >= 2)
         {
-            case ExecutableViewModel evm:
-                resourceName += $" ({evm.Uid.Substring(0, Math.Min(evm.Uid.Length, InstanceIdHintLimit))})";
-                break;
-            case ProjectViewModel pvm:
-                resourceName += $" ({pvm.Uid.Substring(0, Math.Min(pvm.Uid.Length, InstanceIdHintLimit))})";
-                break;
-            case ContainerViewModel cvm:
-                if (cvm.ContainerId is not null)
-                {
-                    resourceName += $" (container ID: {cvm.ContainerId.Substring(0, Math.Min(cvm.ContainerId.Length, 8))})";
-                }
-                break;
+            return ResourceFormatter.GetName(resource.DisplayName, resource.Uid);
         }
-        return $"{resourceName}{stateText}";
+
+        return resource.DisplayName;
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -37,6 +37,8 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
 
     private readonly Option<string> _noSelection = new() { Value = null, Text = "(Select a resource)" };
 
+    private const int InstanceIdHintLimit = 8;
+
     protected override void OnInitialized()
     {
         _status = LogStatus.LoadingResources;
@@ -246,16 +248,10 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
         switch (resource)
         {
             case ExecutableViewModel evm:
-                if (evm.ProcessId is not null)
-                {
-                    resourceName += $" (PID: {evm.ProcessId})";
-                }
+                resourceName += $" ({evm.Uid.Substring(0, Math.Min(evm.Uid.Length, InstanceIdHintLimit))})";
                 break;
             case ProjectViewModel pvm:
-                if (pvm.ProcessId is not null)
-                {
-                    resourceName += $" (PID: {pvm.ProcessId})";
-                }
+                resourceName += $" ({pvm.Uid.Substring(0, Math.Min(pvm.Uid.Length, InstanceIdHintLimit))})";
                 break;
             case ContainerViewModel cvm:
                 if (cvm.ContainerId is not null)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -43,7 +43,7 @@
                 <ChildContent>
                     <PropertyColumn Property="@(c => c.ResourceType)" Title="Type" Sortable="true" />
                     <TemplateColumn Title="Name" Sortable="true" SortBy="@_nameSort">
-                        <ResourceNameDisplay Resource="context" FilterText="@_filter" />
+                        <ResourceNameDisplay Resource="context" FilterText="@_filter" FormatName="GetResourceName" />
                     </TemplateColumn>
                     <TemplateColumn Title="State" Sortable="true" SortBy="@_stateSort">
                         <div class="resource-state-container">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -34,7 +34,7 @@
                         @bind-Value:after="HandleClear"
                         slot="end" />
     </FluentToolbar>
-    <SummaryDetailsView DetailsTitle="@($"Environment Variables for {SelectedResourceName}")"
+    <SummaryDetailsView DetailsTitle="@($"Environment Variables for {((SelectedResource != null) ? GetResourceName(SelectedResource) : null)}")"
                         ShowDetails="@(SelectedEnvironmentVariables is not null)"
                         OnDismiss="() => ClearSelectedResource()"
                         ViewKey="ResourcesList">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -164,15 +164,7 @@ public partial class Resources : ComponentBase, IDisposable
         await InvokeAsync(StateHasChanged);
     }
 
-    private string GetResourceName(ResourceViewModel resource)
-    {
-        if (_resourcesMap.Count(kvp => kvp.Value.DisplayName == resource.DisplayName) >= 2)
-        {
-            return ResourceFormatter.GetName(resource.DisplayName, resource.Uid);
-        }
-
-        return resource.DisplayName;
-    }
+    private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourcesMap.Values);
 
     protected virtual void Dispose(bool disposing)
     {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -25,7 +25,7 @@ public partial class Resources : ComponentBase, IDisposable
     public required IJSRuntime JS { get; set; }
 
     private IEnumerable<EnvironmentVariableViewModel>? SelectedEnvironmentVariables { get; set; }
-    private string? SelectedResourceName { get; set; }
+    private ResourceViewModel? SelectedResource { get; set; }
 
     private static ViewModelMonitor<ResourceViewModel> GetViewModelMonitor(IDashboardViewModelService dashboardViewModelService)
         => dashboardViewModelService.GetResources();
@@ -134,14 +134,14 @@ public partial class Resources : ComponentBase, IDisposable
         else
         {
             SelectedEnvironmentVariables = resource.Environment;
-            SelectedResourceName = resource.Name;
+            SelectedResource = resource;
         }
     }
 
     private void ClearSelectedResource()
     {
         SelectedEnvironmentVariables = null;
-        SelectedResourceName = null;
+        SelectedResource = null;
     }
 
     private async Task OnResourceListChanged(ObjectChangeType objectChangeType, ResourceViewModel resource)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -164,6 +164,16 @@ public partial class Resources : ComponentBase, IDisposable
         await InvokeAsync(StateHasChanged);
     }
 
+    private string GetResourceName(ResourceViewModel resource)
+    {
+        if (_resourcesMap.Count(kvp => kvp.Value.DisplayName == resource.DisplayName) >= 2)
+        {
+            return ResourceFormatter.GetName(resource.DisplayName, resource.Uid);
+        }
+
+        return resource.DisplayName;
+    }
+
     protected virtual void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -63,9 +63,9 @@
                 <div class="logs-grid-container continuous-scroll-overflow">
                     <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
                         <ChildContent>
-                            <TemplateColumn Title="Resource" Tooltip="true" TooltipText="(e) => e.Application.ApplicationName">
+                            <TemplateColumn Title="Resource" Tooltip="true" TooltipText="@(e => $"{e.Application.ApplicationName} ({e.Application.InstanceId.Substring(0, Math.Min(e.Application.InstanceId.Length, 8))})")">
                                 <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(context.Application.ApplicationName));">
-                                    @context.Application.ApplicationName
+                                    @($"{context.Application.ApplicationName} ({context.Application.InstanceId.Substring(0, Math.Min(context.Application.InstanceId.Length, 8))})")
                                 </span>
                             </TemplateColumn>
                             <TemplateColumn Title="Level">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -17,7 +17,7 @@
     <h1 class="page-header">Structured Logs</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect TOption="SelectViewModel<string>"
-                      Items="@_applications"
+                      Items="@_applicationViewModels"
                       OptionText="@(c => c.Name)"
                       @bind-SelectedOption="_selectedApplication"
                       @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync"
@@ -63,9 +63,9 @@
                 <div class="logs-grid-container continuous-scroll-overflow">
                     <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
                         <ChildContent>
-                            <TemplateColumn Title="Resource" Tooltip="true" TooltipText="@(e => $"{e.Application.ApplicationName} ({e.Application.InstanceId.Substring(0, Math.Min(e.Application.InstanceId.Length, 8))})")">
-                                <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(context.Application.ApplicationName));">
-                                    @($"{context.Application.ApplicationName} ({context.Application.InstanceId.Substring(0, Math.Min(context.Application.InstanceId.Length, 8))})")
+                            <TemplateColumn Title="Resource" Tooltip="true" TooltipText="@(e => GetResourceName(e.Application))">
+                                <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Application)));">
+                                    @GetResourceName(context.Application)
                                 </span>
                             </TemplateColumn>
                             <TemplateColumn Title="Level">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -18,7 +18,8 @@ public partial class StructuredLogs
     private static readonly SelectViewModel<string> s_allApplication = new SelectViewModel<string> { Id = null, Name = "(All)" };
 
     private TotalItemsFooter _totalItemsFooter = default!;
-    private List<SelectViewModel<string>> _applications = default!;
+    private List<OtlpApplication> _applications = default!;
+    private List<SelectViewModel<string>> _applicationViewModels = default!;
     private List<SelectViewModel<LogLevel?>> _logLevels = default!;
     private SelectViewModel<string> _selectedApplication = s_allApplication;
     private SelectViewModel<LogLevel?> _selectedLogLevel = default!;
@@ -106,7 +107,7 @@ public partial class StructuredLogs
 
     protected override void OnParametersSet()
     {
-        _selectedApplication = _applications.SingleOrDefault(e => e.Id == ApplicationInstanceId) ?? s_allApplication;
+        _selectedApplication = _applicationViewModels.SingleOrDefault(e => e.Id == ApplicationInstanceId) ?? s_allApplication;
         ViewModel.ApplicationServiceId = _selectedApplication.Id;
 
         if (LogLevelText != null && Enum.TryParse<LogLevel>(LogLevelText, ignoreCase: true, out var logLevel))
@@ -124,8 +125,9 @@ public partial class StructuredLogs
 
     private void UpdateApplications()
     {
-        _applications = SelectViewModelFactory.CreateApplicationsSelectViewModel(TelemetryRepository.GetApplications());
-        _applications.Insert(0, s_allApplication);
+        _applications = TelemetryRepository.GetApplications();
+        _applicationViewModels = SelectViewModelFactory.CreateApplicationsSelectViewModel(_applications);
+        _applicationViewModels.Insert(0, s_allApplication);
     }
 
     private Task HandleSelectedApplicationChangedAsync()
@@ -241,6 +243,8 @@ public partial class StructuredLogs
         ViewModel.FilterText = string.Empty;
         StateHasChanged();
     }
+
+    private string GetResourceName(OtlpApplication app) => OtlpApplication.GetResourceName(app, _applications);
 
     private void NavigateTo(string? applicationId, LogLevel? level)
     {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -16,7 +16,7 @@
 {
     <div class="trace-detail-layout">
         <div class="trace-detail-header page-header">
-            <h1 style="display:inline-block">@(_trace.FirstSpan.Source.ApplicationName): @_trace.FirstSpan.Name</h1>
+            <h1 style="display:inline-block">@GetResourceName(_trace.FirstSpan.Source): @_trace.FirstSpan.Name</h1>
             <span class="trace-id">@OtlpHelpers.ToShortenedId(_trace.TraceId)</span>
         </div>
         <FluentToolbar Orientation="Orientation.Horizontal">
@@ -56,12 +56,12 @@
                 <FluentDataGrid Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="2fr 6fr">
                     <TemplateColumn Title="Name">
                         <div class="col-long-content" title="@context.GetTooltip()" @onclick="() => OnShowProperties(context)">
-                            <span class="span-name-container" style="@($"margin-left: {(context.Depth - 1) * 15}px; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(context.Span.Source.ApplicationName)};")">
+                            <span class="span-name-container" style="@($"margin-left: {(context.Depth - 1) * 15}px; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))};")">
                                 @if (context.IsError)
                                 {
                                     <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
                                 }
-                                @($"{context.Span.Source.ApplicationName} ({context.Span.Source.InstanceId.Substring(0, Math.Min(context.Span.Source.InstanceId.Length, 8))})")
+                                @GetResourceName(context.Span.Source)
                                 @if (context.HasUninstrumentedPeer)
                                 {
                                     <span class="uninstrumented-peer">
@@ -95,9 +95,9 @@
                         <ChildContent>
                             <div class="ticks" @onclick="() => OnShowProperties(context)">
                                 <div class="span-container" style="grid-template-columns: @context.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)% @context.Width.ToString("F2", CultureInfo.InvariantCulture)% min-content;">
-                                    <div class="span-bar" style="grid-column: 2; background: @ColorGenerator.Instance.GetColorHexByKey(context.Span.Source.ApplicationName);"></div>
+                                    <div class="span-bar" style="grid-column: 2; background: @ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source));"></div>
                                     <div class="span-bar-label @(context.LabelIsRight ? "span-bar-label-right" : "span-bar-label-left")">
-                                        <span class="span-bar-label-detail">@context.Span.Source.ApplicationName: @context.GetDisplaySummary()</span>
+                                        <span class="span-bar-label-detail">@GetResourceName(context.Span.Source): @context.GetDisplaySummary()</span>
                                         <span>@DurationFormatter.FormatDuration(context.Span.Duration)</span>
                                     </div>
                                 </div>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -61,7 +61,7 @@
                                 {
                                     <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
                                 }
-                                @context.Span.Source.ApplicationName
+                                @($"{context.Span.Source.ApplicationName} ({context.Span.Source.InstanceId.Substring(0, Math.Min(context.Span.Source.InstanceId.Length, 8))})")
                                 @if (context.HasUninstrumentedPeer)
                                 {
                                     <span class="uninstrumented-peer">

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -19,6 +19,7 @@ public partial class TraceDetail : ComponentBase
     private Subscription? _tracesSubscription;
     private List<SpanWaterfallViewModel>? _spanWaterfallViewModels;
     private int _maxDepth;
+    private List<OtlpApplication> _applications = default!;
 
     [Parameter]
     public required string TraceId { get; set; }
@@ -135,6 +136,8 @@ public partial class TraceDetail : ComponentBase
 
     private void UpdateDetailViewData()
     {
+        _applications = TelemetryRepository.GetApplications();
+
         _trace = null;
         _span = null;
 
@@ -187,7 +190,7 @@ public partial class TraceDetail : ComponentBase
             {
                 Span = viewModel.Span,
                 Properties = entryProperties,
-                Title = $"{viewModel.Span.Source.ApplicationName}: {viewModel.GetDisplaySummary()}"
+                Title = $"{GetResourceName(viewModel.Span.Source)}: {viewModel.GetDisplaySummary()}"
             };
 
             SelectedSpan = spanDetailsViewModel;
@@ -198,6 +201,8 @@ public partial class TraceDetail : ComponentBase
     {
         SelectedSpan = null;
     }
+
+    private string GetResourceName(OtlpApplication app) => OtlpApplication.GetResourceName(app, _applications);
 
     public void Dispose()
     {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -18,7 +18,7 @@
     <h1 class="page-header">Traces</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect TOption="SelectViewModel<string>"
-                      Items="@_applications"
+                      Items="@_applicationViewModels"
                       OptionValue="@(c => c.Id)"
                       OptionText="@(c => c.Name)"
                       @bind-SelectedOption="_selectedApplication"
@@ -45,12 +45,12 @@
                             @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Key.ApplicationName))
                             {
                                 <FluentOverflowItem>
-                                    <span class="trace-tag trace-service-tag" title="@(GetTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(item.Key.ApplicationName));">
+                                    <span class="trace-tag trace-service-tag" title="@(GetTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(item.Key)));">
                                         @if (item.Any(s => s.Status == OtlpSpanStatusCode.Error))
                                         {
                                             <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
                                         }
-                                        @item.Key.ApplicationName (@item.Count())
+                                        @GetResourceName(item.Key) (@item.Count())
                                     </span>
                                 </FluentOverflowItem>
                             }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -1,12 +1,11 @@
 ﻿@using Aspire.Dashboard.Model
 
 <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
-    <span><FluentHighlighter HighlightedText="@FilterText" Text="@Resource.DisplayName" /></span>
+    <span><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)" /></span>
     @if (Resource is ProjectViewModel projectViewModel)
     {
-        var content = projectViewModel.Uid.Substring(0, Math.Min(projectViewModel.Uid.Length, 8));
-        var title = $"({content})";
-        <span class="subtext" title="@title" aria-label="@title">@content</span>
+        var title = $"PID: {projectViewModel.ProcessId}";
+        <span class="subtext" title="@title" aria-label="@title">@projectViewModel.ProcessId</span>
     }
     else if (Resource is ContainerViewModel containerViewModel)
     {
@@ -20,15 +19,17 @@
     }
     else if (Resource is ExecutableViewModel executableViewModel)
     {
-        var content = executableViewModel.Uid.Substring(0, Math.Min(executableViewModel.Uid.Length, 8));
-        var title = $"({content})";
-        <span class="subtext" title="@title" aria-label="@title">@content</span>
+        var title = $"PID: {executableViewModel.ProcessId}";
+        <span class="subtext" title="@title" aria-label="@title">@executableViewModel.ProcessId</span>
     }
 </FluentStack>
 
 @code {
     [Parameter, EditorRequired]
     public required ResourceViewModel Resource { get; set; }
+
+    [Parameter, EditorRequired]
+    public required Func<ResourceViewModel, string> FormatName { get; set; }
 
     [Parameter, EditorRequired]
     public required string FilterText { get; set; }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -4,8 +4,9 @@
     <span><FluentHighlighter HighlightedText="@FilterText" Text="@Resource.DisplayName" /></span>
     @if (Resource is ProjectViewModel projectViewModel)
     {
-        var title = $"PID: {projectViewModel.ProcessId}";
-        <span class="subtext" title="@title" aria-label="@title">@projectViewModel.ProcessId</span>
+        var content = projectViewModel.Uid.Substring(0, Math.Min(projectViewModel.Uid.Length, 8));
+        var title = $"({content})";
+        <span class="subtext" title="@title" aria-label="@title">@content</span>
     }
     else if (Resource is ContainerViewModel containerViewModel)
     {
@@ -19,8 +20,9 @@
     }
     else if (Resource is ExecutableViewModel executableViewModel)
     {
-        var title = $"PID: {executableViewModel.ProcessId}";
-        <span class="subtext" title="@title" aria-label="@title">@executableViewModel.ProcessId</span>
+        var content = executableViewModel.Uid.Substring(0, Math.Min(executableViewModel.Uid.Length, 8));
+        var title = $"({content})";
+        <span class="subtext" title="@title" aria-label="@title">@content</span>
     }
 </FluentStack>
 

--- a/src/Aspire.Dashboard/Model/Otlp/SelectViewModelFactory.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SelectViewModelFactory.cs
@@ -9,12 +9,9 @@ public class SelectViewModelFactory
 {
     public static List<SelectViewModel<string>> CreateApplicationsSelectViewModel(List<OtlpApplication> applications)
     {
-        var byInstanceCount = applications.GroupBy(a => a.ApplicationName).ToDictionary(g => g.Key, g => g.Count());
         var retval = applications.Select(a =>
         {
-            var name = byInstanceCount[a.ApplicationName] > 1 ?
-                $"{a.ApplicationName} ({a.InstanceId.Substring(0, Math.Min(a.InstanceId.Length, 8))})"
-                : a.ApplicationName;
+        var name = $"{a.ApplicationName} ({a.InstanceId.Substring(0, Math.Min(a.InstanceId.Length, 8))})";
             return new SelectViewModel<string> { Id = a.InstanceId, Name = name };
         }).ToList();
         return retval;

--- a/src/Aspire.Dashboard/Model/Otlp/SelectViewModelFactory.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SelectViewModelFactory.cs
@@ -9,11 +9,10 @@ public class SelectViewModelFactory
 {
     public static List<SelectViewModel<string>> CreateApplicationsSelectViewModel(List<OtlpApplication> applications)
     {
-        var retval = applications.Select(a =>
+        return applications.Select(a => new SelectViewModel<string>
         {
-        var name = $"{a.ApplicationName} ({a.InstanceId.Substring(0, Math.Min(a.InstanceId.Length, 8))})";
-            return new SelectViewModel<string> { Id = a.InstanceId, Name = name };
+            Id = a.InstanceId,
+            Name = OtlpApplication.GetResourceName(a, applications)
         }).ToList();
-        return retval;
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceFormatter.cs
+++ b/src/Aspire.Dashboard/Model/ResourceFormatter.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public static class ResourceFormatter
+{
+    public static string GetName(string name, string uid)
+    {
+        return $"{name}-{uid.Substring(0, Math.Min(uid.Length, 7))}";
+    }
+}

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -17,6 +17,24 @@ public abstract class ResourceViewModel
     public List<ResourceService> Services { get; } = new();
     public int? ExpectedEndpointsCount { get; init; }
     public abstract string ResourceType { get; }
+
+    public static string GetResourceName(ResourceViewModel resource, IEnumerable<ResourceViewModel> allResources)
+    {
+        var count = 0;
+        foreach (var item in allResources)
+        {
+            if (item.DisplayName == resource.DisplayName)
+            {
+                count++;
+                if (count >= 2)
+                {
+                    return ResourceFormatter.GetName(resource.DisplayName, resource.Uid);
+                }
+            }
+        }
+
+        return resource.DisplayName;
+    }
 }
 
 public sealed class ResourceService(string name, string? allocatedAddress, int? allocatedPort)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Dashboard.Model;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Proto.Common.V1;
@@ -176,5 +177,23 @@ public class OtlpApplication
         {
             _metricsLock.ExitReadLock();
         }
+    }
+
+    public static string GetResourceName(OtlpApplication app, List<OtlpApplication> allApplications)
+    {
+        var count = 0;
+        foreach (var item in allApplications)
+        {
+            if (item.ApplicationName == app.ApplicationName)
+            {
+                count++;
+                if (count >= 2)
+                {
+                    return ResourceFormatter.GetName(app.ApplicationName, app.InstanceId);
+                }
+            }
+        }
+
+        return app.ApplicationName;
     }
 }


### PR DESCRIPTION
Resource names on resource and telemetry pages:
* Display the resource name if there is one resource with a name
* Display the resource name + 7 chars of UID if there are multiple resources with a name. I changed the UI to display the old format, e.g. `frontend-sdfgdg`, because there are existing places that have trailing parentheses and it doesn't look good. e.g. `frontend (sdfsdf) (1)`

The decision for adding the UID is based on checking if there is more than one resource with a name. This feels a little hacky. It could be improved by the dashboard having knowledge about whether a resource is part of a replicaset and the replicaset count.
* Resources and console logs could check to see if the resource belongs to a replicaset with multiple instances.
* OpenTelemetry pages have to look at instance id vs application name. An improvement could come from linking the OTEL instance id to the hosting UID, then looking at replicaset.

Before:
![image](https://github.com/dotnet/aspire/assets/303201/4a5a9ad6-6834-4c29-a17f-76a28966f505)

![image](https://github.com/dotnet/aspire/assets/303201/594992a3-97de-450d-9738-2531b0689078)

![image](https://github.com/dotnet/aspire/assets/303201/62d37c67-e36d-4168-92fd-9358f266b805)

After:
![image](https://github.com/dotnet/aspire/assets/303201/d4dea482-d781-44b2-985d-c7d0593d0997)

![image](https://github.com/dotnet/aspire/assets/303201/3e04acef-e81b-4605-8e3d-f0431789c349)

![image](https://github.com/dotnet/aspire/assets/303201/dc84536a-b4ea-4cf4-824f-baf1490f2090)
