### PR TITLE
Add method WithPersistentVolume

### DIFF
--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting;
 
@@ -63,6 +64,24 @@ public static class ContainerResourceBuilderExtensions
             containerPort: containerPort);
 
         return builder.WithAnnotation(annotation);
+    }
+
+    /// <summary>
+    /// Adds a named volume mount to the container resource where the name is generated from
+    /// the <see cref="IHostEnvironment.ApplicationName"/> and <see cref="Resource.Name"/>.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="target">The target path in the container.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithPersistentVolume<T>(
+        this IResourceBuilder<T> builder,
+        string target)
+        where T : ContainerResource
+    {
+        var source = $"{builder.ApplicationBuilder.Environment.ApplicationName}.{builder.Resource.Name}.data";
+
+        return builder.WithVolumeMount(source, target, type: VolumeMountType.Named, isReadOnly: false);
     }
 
     /// <summary>


### PR DESCRIPTION
#1132 

Add an extension method as described in issue:

```csharp
var database = builder.AddSqlServerContainer("sqlserver", "abcdefg123_78")
    .WithPersistentVolume("/var/opt/mssql")
    .AddDatabase("appdb");
```
> The method `WithPersistentVolume` would be a shortcut to `WithVolumeMount(string source, string target, VolumeMountType type, bool isReadOnly)` with `source` being generated from the application name and resource name, e.g. `$"{builder.Environment.ApplicationName}.{resourceName}.data`", and `type` being `VolumeMountType.Named` and `isReadOnly` being `false`.

### Testing

Manually tested in eShopLite sample app:

```csharp
var catalogDb =
    builder
        .AddPostgresContainer("postgres")
        .WithEnvironment("PGDATA", "/var/lib/postgresql/data/pgdata")
        .WithPersistentVolume("/var/lib/postgresql/data")
        .AddDatabase("catalogdb");
```

![image](https://github.com/dotnet/aspire/assets/1190907/66b52bfb-1b1b-4773-81bc-433b46700c88)
