### PR TITLE
Highlight selected rows

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -39,7 +39,7 @@
                         OnDismiss="() => ClearSelectedResource()"
                         ViewKey="ResourcesList">
         <Summary>
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1fr 2fr 3fr 2fr 1fr 1fr" >
+            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1fr 2fr 3fr 2fr 1fr 1fr" RowClass="GetRowClass" >
                 <ChildContent>
                     <PropertyColumn Property="@(c => c.ResourceType)" Title="Type" Sortable="true" />
                     <TemplateColumn Title="Name" Sortable="true" SortBy="@_nameSort">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -39,7 +39,7 @@
                         OnDismiss="() => ClearSelectedResource()"
                         ViewKey="ResourcesList">
         <Summary>
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1fr 2fr 3fr 2fr 1fr 1fr" RowClass="GetRowClass" >
+            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1fr 2fr 3fr 2fr 1fr 1fr" RowClass="GetRowClass">
                 <ChildContent>
                     <PropertyColumn Property="@(c => c.ResourceType)" Title="Type" Sortable="true" />
                     <TemplateColumn Title="Name" Sortable="true" SortBy="@_nameSort">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -197,4 +197,7 @@ public partial class Resources : ComponentBase, IDisposable
     {
         NavigationManager.NavigateTo($"/StructuredLogs/{resource.Uid}?level=error");
     }
+
+    private string? GetRowClass(ResourceViewModel resource)
+        => string.Equals(resource.Name, SelectedResourceName, StringComparison.Ordinal) ? "selected-row" : null;
 }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -262,9 +262,16 @@ public partial class StructuredLogs
         NavigationManager.NavigateTo(url);
     }
 
-    private static string GetRowClass(OtlpLogEntry entry)
+    private string GetRowClass(OtlpLogEntry entry)
     {
-        return $"log-row-{entry.Severity.ToString().ToLowerInvariant()}";
+        if (entry == _selectedLogEntry)
+        {
+            return "selected-row";
+        }
+        else
+        {
+            return $"log-row-{entry.Severity.ToString().ToLowerInvariant()}";
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -166,7 +166,14 @@ public partial class TraceDetail : ComponentBase
 
     private string GetRowClass(SpanWaterfallViewModel viewModel)
     {
-        return (viewModel.Span.SpanId == _span?.SpanId) ? "selected-span" : string.Empty;
+        if (viewModel.Span == SelectedSpan?.Span)
+        {
+            return "selected-row";
+        }
+        else
+        {
+            return (viewModel.Span.SpanId == _span?.SpanId) ? "selected-span" : string.Empty;
+        }
     }
 
     public SpanDetailsViewModel? SelectedSpan { get; set; }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -116,10 +116,6 @@
     height: min-content;
 }
 
-::deep fluent-data-grid-row[row-type="default"]:hover .span-container .span-bar-label {
-    color: var(--foreground-subtext-hover);
-}
-
 ::deep .span-container .span-bar-label-detail {
     display: none;
 }
@@ -149,8 +145,13 @@
     font-size: 12px;
 }
 
-::deep fluent-data-grid-row[row-type="default"]:hover .span-row-name {
-    color: var(--foreground-subtext-hover);
+::deep .selected-row .span-row-name,
+::deep .selected-row fluent-data-grid-row[row-type="default"]:hover .span-row-name,
+::deep fluent-data-grid-row[row-type="default"]:hover .span-row-name,
+::deep .selected-row .span-container .span-bar-label,
+::deep .selected-row fluent-data-grid-row[row-type="default"]:hover .span-container .span-bar-label,
+::deep fluent-data-grid-row[row-type="default"]:hover .span-container .span-bar-label {
+    color: var(--neutral-foreground-rest);
 }
 
 ::deep.trace-detail-layout {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -147,10 +147,25 @@ fluent-data-grid-cell .long-inner-content {
     color: var(--foreground-subtext-rest);
 }
 
+.selected-row .subtext {
+    color: var(--neutral-foreground-rest);
+}
+
 .validation-message {
     color: var(--error);
 }
 
 .page-header {
     padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
+}
+
+.selected-row,
+.selected-row fluent-button[appearance=lightweight]:not(:hover)::part(control),
+.selected-row fluent-anchor[appearance=lightweight]:not(:hover)::part(control) {
+    background-color: var(--neutral-fill-secondary-rest); /* Same color as the menu hover */
+}
+
+.selected-row fluent-button[appearance=lightweight]:hover::part(control),
+.selected-row fluent-anchor[appearance=lightweight]:hover::part(control){
+    background-color: var(--neutral-fill-stealth-rest); /* Essentially inverts the hover compared to an unselected row */
 }


### PR DESCRIPTION
Addresses part of #1081.

This adds some highlighting (using the same color as used for the menu hover to ensure contrast) to the various grid rows when they're selected in a Summary/Details view. Also, at the suggestion of various UI/UX/Accessibility folks I changed the subtext color to not be "ghosted" when hovered/highlighted. That avoids the issue of having to thread the needle of contrast with two foreground colors and two (or three) background colors.

The remainder of #1081 is around how we do selection (full row vs buttons, etc) and this PR doesn't address that.

![image](https://github.com/dotnet/aspire/assets/9613109/987db100-9975-4c1a-bb7c-3f6230926a7b)
![image](https://github.com/dotnet/aspire/assets/9613109/8d9f75ce-0b9b-4556-98f1-48d6c0932260)
![image](https://github.com/dotnet/aspire/assets/9613109/99359f07-7caf-4052-a11e-dc55e99397d2)
![image](https://github.com/dotnet/aspire/assets/9613109/d68a61d3-7d3b-4f62-8775-76a4296b10a5)
![image](https://github.com/dotnet/aspire/assets/9613109/160bbcfe-3708-49e1-86d4-10e6733981d9)
![image](https://github.com/dotnet/aspire/assets/9613109/5b49f5c7-9150-4367-8252-4d5775368326)

