### PR TITLE
Only show file name in dashboard resources page

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -39,7 +39,7 @@
                         OnDismiss="() => ClearSelectedResource()"
                         ViewKey="ResourcesList">
         <Summary>
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1fr 2fr 3fr 2fr 1fr 1fr" RowClass="GetRowClass">
+            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1fr 2fr 2.5fr 2fr 1fr 1fr" RowClass="GetRowClass">
                 <ChildContent>
                     <PropertyColumn Property="@(c => c.ResourceType)" Title="Type" Sortable="true" />
                     <TemplateColumn Title="Name (ID)" Sortable="true" SortBy="@_nameSort">

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -3,14 +3,14 @@
 
 @if (Resource is ProjectViewModel projectViewModel)
 {
-    <span title="@projectViewModel.ProjectPath" aria-label="@projectViewModel.ProjectPath">@projectViewModel.ProjectPath.TrimMiddle(50)</span>
+    <span title="@projectViewModel.ProjectPath" aria-label="@projectViewModel.ProjectPath">@Path.GetFileName(projectViewModel.ProjectPath)</span>
 }
 else if (Resource is ExecutableViewModel executableViewModel)
 {
     var arguments = string.Join(" ", executableViewModel.Arguments ?? []);
     var fullCommandLine = $"{executableViewModel.ExecutablePath} {arguments}";
 
-    <div class="ellipsis-overflow" title="@fullCommandLine" aria-label="@fullCommandLine">@executableViewModel.ExecutablePath?.TrimMiddle(35) <span class="subtext">@arguments</span></div>
+    <div class="ellipsis-overflow" title="@fullCommandLine" aria-label="@fullCommandLine">@Path.GetFileName(executableViewModel.ExecutablePath) <span class="subtext">@arguments</span></div>
     <div class="ellipsis-overflow" title="@executableViewModel.WorkingDirectory" aria-label="@executableViewModel.WorkingDirectory">Working Dir: @executableViewModel.WorkingDirectory?.TrimMiddle(35)</div>
 }
 else if (Resource is ContainerViewModel containerViewModel)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1216
Fixes https://github.com/dotnet/aspire/issues/1273

Only display the project/exe name in the dashboard. This is the most important piece of information and only showing the name prevents it from being trimmed in lower resolutions. See before screenshots below to see this happening.

Full paths are available in the tool tip.

Opinions on the UI change? I think it is better, but I want some consensus before merging.

## eShop

**Before:**
![image](https://github.com/dotnet/aspire/assets/303201/07c5d337-9860-4ef2-b692-9db5a882dcfe)

**After:**
![image](https://github.com/dotnet/aspire/assets/303201/f94a18d8-2eb9-44c6-a968-0ba2c971be57)

## darp

**Before:**
![image](https://github.com/dotnet/aspire/assets/303201/64983f82-7273-4647-b3fa-d636304aa649)

**After:**
![image](https://github.com/dotnet/aspire/assets/303201/94e727b3-1212-4958-9fb6-07ed2ca8df1e)
