### PR TITLE
Use destructuring

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -24,9 +24,6 @@ public partial class Resources : ComponentBase, IDisposable
     private IEnumerable<EnvironmentVariableViewModel>? SelectedEnvironmentVariables { get; set; }
     private string? SelectedResourceName { get; set; }
 
-    private static ViewModelMonitor<ResourceViewModel> GetViewModelMonitor(IDashboardViewModelService dashboardViewModelService)
-        => dashboardViewModelService.GetResources();
-
     private bool Filter(ResourceViewModel resource)
         => ((resource.ResourceType == "Project" && _areProjectsVisible) ||
             (resource.ResourceType == "Container" && _areContainersVisible) ||
@@ -78,19 +75,19 @@ public partial class Resources : ComponentBase, IDisposable
     protected override void OnInitialized()
     {
         _applicationUnviewedErrorCounts = TelemetryRepository.GetApplicationUnviewedErrorLogsCount();
-        var viewModelMonitor = GetViewModelMonitor(DashboardViewModelService);
-        var resources = viewModelMonitor.Snapshot;
-        var watch = viewModelMonitor.Watch;
-        foreach (var resource in resources)
+
+        var (snapshot, subscription) = DashboardViewModelService.GetResources();
+
+        foreach (var resource in snapshot)
         {
             _resourcesMap.Add(resource.Name, resource);
         }
 
         _ = Task.Run(async () =>
         {
-            await foreach (var resourceChanged in watch.WithCancellation(_watchTaskCancellationTokenSource.Token))
+            await foreach (var (changeType, resource) in subscription.WithCancellation(_watchTaskCancellationTokenSource.Token))
             {
-                await OnResourceListChanged(resourceChanged.ObjectChangeType, resourceChanged.Resource);
+                await OnResourceListChanged(changeType, resource);
             }
         });
 


### PR DESCRIPTION
This language feature tidies up quite a few call sites. When code prefers use of var, there's no loss of type information.