### PR TITLE
Override fluentui-blazor error hex, darken trace duration background

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,8 +72,8 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="12.1.1" />
     <PackageVersion Include="JsonSchema.Net" Version="5.4.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.1.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.1.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.2.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.22.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.3.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.1" />

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -38,6 +38,7 @@ fluent-toolbar[orientation=horizontal] {
     --log-critical: #493634;
     --log-error: #493634;
     --log-warning: #3F3A2B;
+    --error: #F8040A;
     --foreground-subtext-rest: #8D8D8D;
     --foreground-subtext-hover: #A1A1A1;
 }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -38,7 +38,7 @@ fluent-toolbar[orientation=horizontal] {
     --log-critical: #493634;
     --log-error: #493634;
     --log-warning: #3F3A2B;
-    --error: #F8040A;
+    --error: #F8040A !important;
     --foreground-subtext-rest: #8D8D8D;
     --foreground-subtext-hover: #A1A1A1;
 }

--- a/src/Aspire.Dashboard/wwwroot/js/theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/theme.js
@@ -2,7 +2,7 @@ import {
     accentBaseColor,
     baseLayerLuminance,
     SwatchRGB
-} from "/_content/Microsoft.FluentUI.AspNetCore.Components/js/web-components-v2.5.16.min.js";
+} from "/_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js";
 
 const currentThemeCookieName = "currentTheme";
 const themeSettingSystem = "System";


### PR DESCRIPTION
Fixes #690 and #689 

For #689, I darkened the background color, which looks like this on light and dark theme:
![image](https://github.com/dotnet/aspire/assets/20359921/18935e47-cdd7-4c55-a95d-cd544d0c290d)
![image](https://github.com/dotnet/aspire/assets/20359921/f926af92-1b88-49a8-a8b3-6c2efc0d614b)

Both contrasts meet WCAG guidelines for text on background, and between the row and package backgrounds. Other color suggestions are welcome as well. This is ##938989

For #690, I override --error to be more red, as this is an issue in the three places that `Color.Error` shows up. We _could_ ask to change the default in fluentui-blazor. This is one of the lightest possible shades we can choose, with a dark theme contrast of ~3.0.

![image](https://github.com/dotnet/aspire/assets/20359921/062f004a-d018-404a-a8f9-0431f010b5c1)
