### PR TITLE
Fix build break after merge conflict

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -120,6 +120,7 @@ stages:
           - template: /eng/pipelines/templates/BuildAndTest.yml
             parameters:
               runAsPublic: ${{ eq(variables._RunAsPublic, True) }}
+              dotnetScript: $(Build.SourcesDirectory)/dotnet.cmd
               buildScript: $(_buildScript)
               buildConfig: $(_BuildConfig)
               repoLogPath: $(Build.Arcade.LogsPath)
@@ -152,6 +153,7 @@ stages:
           - template: /eng/pipelines/templates/BuildAndTest.yml
             parameters:
               runAsPublic: ${{ eq(variables._RunAsPublic, True) }}
+              dotnetScript: $(Build.SourcesDirectory)/dotnet.sh
               buildScript: $(_buildScript)
               buildConfig: $(_BuildConfig)
               repoLogPath: $(Build.Arcade.LogsPath)

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -12,6 +12,8 @@ parameters:
     type: string
   - name: isWindows
     type: string
+  - name: dotnetScript
+    type: string
   - name: skipTests
     type: boolean
     default: false
@@ -25,7 +27,7 @@ steps:
     displayName: Build
 
   - ${{ if ne(parameters.skipTests, 'true') }}:
-    - script: $(Build.SourcesDirectory)/dotnet.cmd dotnet-coverage collect
+    - script: ${{ parameters.dotnetScript }} dotnet-coverage collect
               --settings $(Build.SourcesDirectory)/eng/CodeCoverage.config
               --output ${{ parameters.repoTestResultsPath }}/$(Agent.Os)_$(Agent.JobName).cobertura.xml
               "${{ parameters.buildScript }} -test -configuration ${{ parameters.buildConfig }} /bl:${{ parameters.repoLogPath }}/tests.binlog $(_OfficialBuildIdArgs)"

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -25,7 +25,7 @@ steps:
     displayName: Build
 
   - ${{ if ne(parameters.skipTests, 'true') }}:
-    - script: $(Build.SourcesDirectory)/.dotnet/dotnet dotnet-coverage collect
+    - script: $(Build.SourcesDirectory)/dotnet.cmd dotnet-coverage collect
               --settings $(Build.SourcesDirectory)/eng/CodeCoverage.config
               --output ${{ parameters.repoTestResultsPath }}/$(Agent.Os)_$(Agent.JobName).cobertura.xml
               "${{ parameters.buildScript }} -test -configuration ${{ parameters.buildConfig }} /bl:${{ parameters.repoLogPath }}/tests.binlog $(_OfficialBuildIdArgs)"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -198,5 +198,5 @@ public partial class Resources : ComponentBase, IDisposable
     }
 
     private string? GetRowClass(ResourceViewModel resource)
-        => string.Equals(resource.Name, SelectedResourceName, StringComparison.Ordinal) ? "selected-row" : null;
+        => resource == SelectedResource ? "selected-row" : null;
 }


### PR DESCRIPTION
When I merged #1231 I didn't realize that #1229 was merged a couple hours before and it removed `SelectedResourceName` in favor of `SelectedResource`.  Small fix to use `SelectedResource` instead.