### PR TITLE
[release/8.0-preview2] Revert "Enable Redis Logging (#597)" (#1242)

### DIFF
--- a/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
@@ -3,6 +3,7 @@
 
 global using System.Net.Security; // needed to work around https://github.com/dotnet/runtime/issues/94065
 
+using System.Text;
 using Aspire;
 using Aspire.StackExchange.Redis;
 using Microsoft.Extensions.Configuration;
@@ -88,12 +89,12 @@ public static class AspireRedisExtensions
         if (serviceKey is null)
         {
             builder.Services.AddSingleton<IConnectionMultiplexer>(
-                sp => ConnectionMultiplexer.Connect(GetConfigurationOptions(sp, connectionName, configurationSectionName, optionsName)));
+                sp => ConnectionMultiplexer.Connect(GetConfigurationOptions(sp, connectionName, configurationSectionName, optionsName), CreateLogger(sp)));
         }
         else
         {
             builder.Services.AddKeyedSingleton<IConnectionMultiplexer>(serviceKey,
-                (sp, key) => ConnectionMultiplexer.Connect(GetConfigurationOptions(sp, connectionName, configurationSectionName, optionsName)));
+                (sp, key) => ConnectionMultiplexer.Connect(GetConfigurationOptions(sp, connectionName, configurationSectionName, optionsName), CreateLogger(sp)));
         }
 
         if (settings.Tracing)
@@ -119,6 +120,11 @@ public static class AspireRedisExtensions
                     connectionMultiplexerFactory: sp => serviceKey is null ? sp.GetRequiredService<IConnectionMultiplexer>() : sp.GetRequiredKeyedService<IConnectionMultiplexer>(serviceKey),
                     healthCheckName));
         }
+
+        static TextWriter? CreateLogger(IServiceProvider serviceProvider)
+            => serviceProvider.GetService<ILoggerFactory>() is { } loggerFactory
+                ? new LoggingTextWriter(loggerFactory.CreateLogger("Aspire.StackExchange.Redis"))
+                : null;
     }
 
     private static ConfigurationOptions GetConfigurationOptions(IServiceProvider serviceProvider, string connectionName, string configurationSectionName, string? optionsName)
@@ -132,9 +138,6 @@ public static class AspireRedisExtensions
             throw new InvalidOperationException($"No endpoints specified. Ensure a valid connection string was provided in 'ConnectionStrings:{connectionName}' or for the '{configurationSectionName}:ConnectionString' configuration key.");
         }
 
-        // ensure the LoggerFactory is initialized if someone hasn't already set it.
-        configurationOptions.LoggerFactory ??= serviceProvider.GetService<ILoggerFactory>();
-
         return configurationOptions;
     }
 
@@ -144,6 +147,13 @@ public static class AspireRedisExtensions
         configurationOptionsSection.Bind(options);
 
         return options;
+    }
+
+    private sealed class LoggingTextWriter(ILogger logger) : TextWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(string? value) => logger.LogTrace(value);
     }
 
     /// <summary>

--- a/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
+++ b/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
@@ -2,7 +2,7 @@
   "definitions": {
     "logLevel": {
       "properties": {
-        "StackExchange.Redis": {
+        "Aspire.StackExchange.Redis": {
           "$ref": "#/definitions/logLevelThreshold"
         }
       }

--- a/src/Components/Telemetry.md
+++ b/src/Components/Telemetry.md
@@ -233,7 +233,7 @@ Aspire.RabbitMQ.Client:
 
 Aspire.StackExchange.Redis:
 - Log categories:
-  - "StackExchange.Redis"
+  - "Aspire.StackExchange.Redis" (this name is defined by our component, we can change it)
 - Activity source names:
   - "OpenTelemetry.Instrumentation.StackExchangeRedis"
 - Metric names:

--- a/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
@@ -20,7 +20,7 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override string[] RequiredLogCategories => new string[] { "StackExchange.Redis" };
+    protected override string[] RequiredLogCategories => new string[] { "Aspire.StackExchange.Redis" };
 
     // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/e4cb523a4a3592e1a1adf30f3596025bfd8978e3/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs#L34
     protected override string ActivitySourceName => "OpenTelemetry.Instrumentation.StackExchangeRedis";


### PR DESCRIPTION
This reverts commit d9e8e958253469884ca197b12b08c9dcbd43d811.

With https://github.com/dotnet/aspire/commit/a3ed2b5d202f55179cb9c3985663c0995fb8e0a2, the proxyless container changes were reverted. Redis logging relied on these changes for a decent user experience.

Reverting back to preview1 behavior until the proxyless container changes can be made again.