### PR TITLE
Add instructions to install builds from release branch

### DIFF
--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -12,7 +12,14 @@ If you want to install the latest build from the main branch, then skip this sec
 
 If you want to use the latest .NET Aspire build from release branches, you can use the scripts in this repo to install the latest .NET Aspire build from those. The reason why we provide scripts for builds from release branches but not for main, is that when working with dotnet workloads, it is not easy to specify exactly which version of the workload you want to install, and instead you get the latest NuGet package version that the SDK is able to find in your configured NuGet feeds. For release branches though, this will not work as main branch produces packages like 8.0.0-preview.x, while release branches produce packages like 8.0.0-preview.(x-1). For example, when main produces packages with version 8.0.0-preview.3, release branches produce packages with version 8.0.0-preview.2.
 
-The scripts to install these builds, are [installLatestFromReleaseBranch.ps1](../eng/installLatestFromReleaseBranch.ps1) for Windows, and [installLatestFromReleaseBranch.sh](../eng/installLatestFromReleaseBranch.sh) for Linux and macOS. These scripts will use rollback files, which at this time is the only way to specify which exact version of a workload you want to install. They will query the feed that contains all of the builds from the release branch, get the latest version, and generate a rollback file to be used for the installation. Finally, it will run the workload `update` and `install` commands for you, using the rollback file.
+The scripts to install these builds, are [installLatestFromReleaseBranch.ps1](../eng/installLatestFromReleaseBranch.ps1) for Windows, and [installLatestFromReleaseBranch.sh](../eng/installLatestFromReleaseBranch.sh) for Linux and macOS. These scripts will use rollback files, which at this time is the only way to specify which exact version of a workload you want to install. They will query the feed that contains all of the builds from the release branch, get the latest version, and generate a rollback file to be used for the installation. Finally, it will run the workload `update` and `install` commands for you, using the rollback file. Note that these scripts will work even if you already have a different version of the workload installed, independently of whether it is an older or newer version, and it will override it with the one calculated from the script. 
+
+### Troubleshooting
+
+Potential issues that may happen when using these scripts:
+
+- On Windows, there is a known issue with workloads when using rollback files, where the commands may fail with un-authorized permissions. This issue has been fixed in 8.0.2xx SDK, but if you are using 8.0.1xx SDK you will likely need to run the script as admin.
+- On Linux and macOS, you may need to install `jq` utility which is used by the script to parse the json response from the NuGet feed. You can install it using `sudo apt-get install jq` on Ubuntu, or `brew install jq` on macOS.
 
 ## Add necessary NuGet feeds
 

--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -6,21 +6,6 @@ These instructions will get you set up with the latest build of Aspire. If you j
 
 See [machine-requirements.md](machine-requirements.md).
 
-## [Optional] Using scripts to install the latest .NET Aspire build from release branches
-
-If you want to install the latest build from the main branch, then skip this section and continue with: [Add necessary NuGet feeds](#add-necessary-nuget-feeds).
-
-If you want to use the latest .NET Aspire build from release branches, you can use the scripts in this repo to install the latest .NET Aspire build from those. The reason why we provide scripts for builds from release branches but not for main, is that when working with dotnet workloads, it is not easy to specify exactly which version of the workload you want to install, and instead you get the latest NuGet package version that the SDK is able to find in your configured NuGet feeds. For release branches though, this will not work as main branch produces packages like 8.0.0-preview.x, while release branches produce packages like 8.0.0-preview.(x-1). For example, when main produces packages with version 8.0.0-preview.3, release branches produce packages with version 8.0.0-preview.2.
-
-The scripts to install these builds, are [installLatestFromReleaseBranch.ps1](../eng/installLatestFromReleaseBranch.ps1) for Windows, and [installLatestFromReleaseBranch.sh](../eng/installLatestFromReleaseBranch.sh) for Linux and macOS. These scripts will use rollback files, which at this time is the only way to specify which exact version of a workload you want to install. They will query the feed that contains all of the builds from the release branch, get the latest version, and generate a rollback file to be used for the installation. Finally, it will run the workload `update` and `install` commands for you, using the rollback file. Note that these scripts will work even if you already have a different version of the workload installed, independently of whether it is an older or newer version, and it will override it with the one calculated from the script. 
-
-### Troubleshooting
-
-Potential issues that may happen when using these scripts:
-
-- On Windows, there is a known issue with workloads when using rollback files, where the commands may fail with un-authorized permissions. This issue has been fixed in 8.0.2xx SDK, but if you are using 8.0.1xx SDK you will likely need to run the script as admin.
-- On Linux and macOS, you may need to install `jq` utility which is used by the script to parse the json response from the NuGet feed. You can install it using `sudo apt-get install jq` on Ubuntu, or `brew install jq` on macOS.
-
 ## Add necessary NuGet feeds
 
 The latest builds are pushed to a special feed, which you need to add:
@@ -74,3 +59,20 @@ dotnet run --project "<directoryname>.AppHost"
 ```
 
 Alternatively, if you are using Visual Studio, you can instead create a new Blazor Web App project and check the `Enlist in Aspire orchestration` box while creating it. Then use <kbd>F5</kbd> to debug or <kbd>Ctrl+F5</kbd> to launch without debugging.
+
+## [Optional] Using scripts to install the latest .NET Aspire build from release branches
+
+If you want to install the latest build from the main branch, then you shouldn't follow the next steps, and instead check out: [Add necessary NuGet feeds](#add-necessary-nuget-feeds).
+
+If you want to use the latest .NET Aspire build from release branches, you can use the scripts in this repo to install the latest .NET Aspire build from those. The reason why we provide scripts for builds from release branches but not for main, is that when working with dotnet workloads, it is not easy to specify exactly which version of the workload you want to install, and instead you get the latest NuGet package version that the SDK is able to find in your configured NuGet feeds. For release branches though, this will not work as main branch produces packages like 8.0.0-preview.x, while release branches produce packages like 8.0.0-preview.(x-1). For example, when main produces packages with version 8.0.0-preview.3, release branches produce packages with version 8.0.0-preview.2.
+
+The scripts to install these builds, are [installLatestFromReleaseBranch.ps1](../eng/installLatestFromReleaseBranch.ps1) for Windows, and [installLatestFromReleaseBranch.sh](../eng/installLatestFromReleaseBranch.sh) for Linux and macOS. These scripts will use rollback files, which at this time is the only way to specify which exact version of a workload you want to install. They will query the feed that contains all of the builds from the release branch, get the latest version, and generate a rollback file to be used for the installation. Finally, it will run the workload `update` and `install` commands for you, using the rollback file. Note that these scripts will work even if you already have a different version of the workload installed, independently of whether it is an older or newer version, and it will override it with the one calculated from the script. 
+
+### Troubleshooting
+
+Potential issues that may happen when using these scripts:
+
+- If you are also using other workloads locally (for example, Maui or wasm), then you probably will want to update and install those other workloads first, before running these scripts. The reason is that if you run the scripts first, then the commands that update and install Maui or wasm may interfere with the .NET Aspire workload and bump it to a different (newer) version. For this reason, we recommend that you run the scripts last, after you have installed all other workloads that you want to use.
+- On Windows, there is a known issue with workloads when using rollback files, where the commands may fail with un-authorized permissions. This issue has been fixed in 8.0.2xx SDK, but if you are using 8.0.1xx SDK you will likely need to run the script as admin.
+- On Windows, also keep in mind that the powershell script is not signed, so it may require you to allow running unsigned scripts. You can do this by running `Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser` in powershell.
+- On Linux and macOS, you may need to install `jq` utility which is used by the script to parse the json response from the NuGet feed. You can install it using `sudo apt-get install jq` on Ubuntu, or `brew install jq` on macOS.

--- a/docs/using-latest-daily.md
+++ b/docs/using-latest-daily.md
@@ -6,6 +6,14 @@ These instructions will get you set up with the latest build of Aspire. If you j
 
 See [machine-requirements.md](machine-requirements.md).
 
+## [Optional] Using scripts to install the latest .NET Aspire build from release branches
+
+If you want to install the latest build from the main branch, then skip this section and continue with: [Add necessary NuGet feeds](#add-necessary-nuget-feeds).
+
+If you want to use the latest .NET Aspire build from release branches, you can use the scripts in this repo to install the latest .NET Aspire build from those. The reason why we provide scripts for builds from release branches but not for main, is that when working with dotnet workloads, it is not easy to specify exactly which version of the workload you want to install, and instead you get the latest NuGet package version that the SDK is able to find in your configured NuGet feeds. For release branches though, this will not work as main branch produces packages like 8.0.0-preview.x, while release branches produce packages like 8.0.0-preview.(x-1). For example, when main produces packages with version 8.0.0-preview.3, release branches produce packages with version 8.0.0-preview.2.
+
+The scripts to install these builds, are [installLatestFromReleaseBranch.ps1](../eng/installLatestFromReleaseBranch.ps1) for Windows, and [installLatestFromReleaseBranch.sh](../eng/installLatestFromReleaseBranch.sh) for Linux and macOS. These scripts will use rollback files, which at this time is the only way to specify which exact version of a workload you want to install. They will query the feed that contains all of the builds from the release branch, get the latest version, and generate a rollback file to be used for the installation. Finally, it will run the workload `update` and `install` commands for you, using the rollback file.
+
 ## Add necessary NuGet feeds
 
 The latest builds are pushed to a special feed, which you need to add:

--- a/eng/installLatestFromReleaseBranch.ps1
+++ b/eng/installLatestFromReleaseBranch.ps1
@@ -1,0 +1,39 @@
+# NuGet Feed URL
+$nugetUrl = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+
+# Package name to search for
+$packageName = "Microsoft.NET.Sdk.Aspire.Manifest-8.0.100"
+
+# Fetch the feed data
+$feedData = Invoke-RestMethod -Uri $nugetUrl
+
+# Extract resources and find the first package's metadata URL using substring comparison
+$metadataUrl = $feedData.resources | Where-Object { $_.'@type' -like '*RegistrationsBaseUrl*' } | Select-Object -First 1 -ExpandProperty '@id'
+
+# Fetch the package data
+$packageData = Invoke-RestMethod -Uri "$metadataUrl$packageName/index.json"
+
+# Get the latest version
+$latestVersion = $packageData.items[-1].upper
+
+# Create the content for the rollback file
+$fileContent = @"
+{
+  `"microsoft.net.sdk.aspire`": `"$latestVersion/8.0.100`"
+}
+"@
+
+# Write to file
+$fileContent | Out-File -FilePath "aspire-rollback.txt"
+
+# Run dotnet workload update command
+dotnet workload update --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --from-rollback-file .\aspire-rollback.txt
+
+# Run dotnet workload install command
+dotnet workload install aspire --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --from-rollback-file .\aspire-rollback.txt
+
+# Delete the rollback file as it is no longer needed.
+Remove-Item "aspire-rollback.txt" -Force
+
+# Output the latest version
+Write-Output "Installed Latest version of aspire produced from the release branch. Version installed was $latestVersion."

--- a/eng/installLatestFromReleaseBranch.ps1
+++ b/eng/installLatestFromReleaseBranch.ps1
@@ -27,10 +27,10 @@ $fileContent = @"
 $fileContent | Out-File -FilePath "aspire-rollback.txt"
 
 # Run dotnet workload update command
-dotnet workload update --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --from-rollback-file .\aspire-rollback.txt
+dotnet workload update --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --skip-sign-check --from-rollback-file .\aspire-rollback.txt
 
 # Run dotnet workload install command
-dotnet workload install aspire --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --from-rollback-file .\aspire-rollback.txt
+dotnet workload install aspire --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --skip-sign-check --from-rollback-file .\aspire-rollback.txt
 
 # Delete the rollback file as it is no longer needed.
 Remove-Item "aspire-rollback.txt" -Force

--- a/eng/installLatestFromReleaseBranch.sh
+++ b/eng/installLatestFromReleaseBranch.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# NuGet Feed URL
+nugetUrl="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+
+# Package name to search for
+packageName="Microsoft.NET.Sdk.Aspire.Manifest-8.0.100"
+
+# Fetch the feed data
+feedData=$(curl -s $nugetUrl)
+
+# Extract resources and find the first package's metadata URL using jq
+metadataUrl=$(echo $feedData | jq -r '.resources[] | select(."@type" | contains("RegistrationsBaseUrl")) | ."@id"' | head -1)
+
+# Fetch the package data
+packageData=$(curl -s "${metadataUrl}${packageName}/index.json")
+
+# Get the latest version
+latestVersion=$(echo $packageData | jq -r '.items[-1].upper')
+
+# Create the content for the rollback file
+fileContent=$(cat <<-END
+{
+  "microsoft.net.sdk.aspire": "$latestVersion/8.0.100"
+}
+END
+)
+
+# Write to file
+echo "$fileContent" > aspire-rollback.txt
+
+# Run dotnet workload update command
+dotnet workload update --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --from-rollback-file ./aspire-rollback.txt
+
+# Run dotnet workload install command
+dotnet workload install aspire --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --from-rollback-file ./aspire-rollback.txt
+
+# Delete the rollback file as it is no longer needed.
+rm -f ./aspire-rollback.txt
+
+# Output the latest version
+echo "Installed Latest version of aspire produced from the release branch. Version installed was $latestVersion."

--- a/eng/installLatestFromReleaseBranch.sh
+++ b/eng/installLatestFromReleaseBranch.sh
@@ -30,10 +30,10 @@ END
 echo "$fileContent" > aspire-rollback.txt
 
 # Run dotnet workload update command
-dotnet workload update --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --from-rollback-file ./aspire-rollback.txt
+dotnet workload update --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --skip-sign-check --from-rollback-file ./aspire-rollback.txt
 
 # Run dotnet workload install command
-dotnet workload install aspire --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --from-rollback-file ./aspire-rollback.txt
+dotnet workload install aspire --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" --skip-sign-check --from-rollback-file ./aspire-rollback.txt
 
 # Delete the rollback file as it is no longer needed.
 rm -f ./aspire-rollback.txt

--- a/eng/installLatestFromReleaseBranch.sh
+++ b/eng/installLatestFromReleaseBranch.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Check if jq is installed
+if ! command -v jq &> /dev/null
+then
+    echo "Error: jq is not installed. Please install jq to run this script."
+    echo "On Ubuntu/Debian: sudo apt-get install jq"
+    echo "On macOS: brew install jq"
+    exit 1
+fi
+
 # NuGet Feed URL
 nugetUrl="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
 


### PR DESCRIPTION
cc: @balachir 

Adding scripts and instructions to be used for installing .NET Aspire latest builds from the release branch. Today, this means that these scripts can help you install latest builds of preview 2, since main branch has now started to produce preview 3 versions.

Marking this PR as a draft for now as I still have to actually validate that the scripts work as I haven't yet tried the full end-to-end.