### PR TITLE
Option on metrics histograms to show count

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
@@ -43,6 +43,14 @@ else
                             </tr>
                         }
                     </table>
+
+                    @if (_instrument.Type == OtlpInstrumentType.Histogram)
+                    {
+                        <h5>@Loc[ControlsStrings.ChartContainerOptionsHeader]</h5>
+                        <div>
+                            <FluentSwitch Label="@Loc[ControlsStrings.ChartContainerOptionsShowCountLabel]" @bind-Value="_showCount" @bind-Value:after="ShowCountChanged" />
+                        </div>
+                    }
                 </div>
             </div>
         }

--- a/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
@@ -46,9 +46,9 @@ else
 
                     @if (_instrument.Type == OtlpInstrumentType.Histogram)
                     {
-                        <h5>@Loc[ControlsStrings.ChartContainerOptionsHeader]</h5>
+                        <h5>Options</h5>
                         <div>
-                            <FluentSwitch Label="@Loc[ControlsStrings.ChartContainerOptionsShowCountLabel]" @bind-Value="_showCount" @bind-Value:after="ShowCountChanged" />
+                            <FluentSwitch Label="Show count" @bind-Value="_showCount" @bind-Value:after="ShowCountChanged" />
                         </div>
                     }
                 </div>

--- a/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor.cs
@@ -21,6 +21,7 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
     private int _renderedDimensionsCount;
     private string? _previousMeterName;
     private string? _previousInstrumentName;
+    private bool _showCount;
     private readonly InstrumentViewModel _instrumentViewModel = new InstrumentViewModel();
 
     [Parameter, EditorRequired]
@@ -241,5 +242,10 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
         }
 
         return filters;
+    }
+
+    private void ShowCountChanged()
+    {
+        _instrumentViewModel.ShowCount = _showCount;
     }
 }

--- a/src/Aspire.Dashboard/Model/InstrumentViewModel.cs
+++ b/src/Aspire.Dashboard/Model/InstrumentViewModel.cs
@@ -13,6 +13,7 @@ public class InstrumentViewModel
 
     public Func<Task>? OnDataUpdate { get; set; }
     public string? Theme { get; set; }
+    public bool ShowCount { get; set; }
 
     public async Task UpdateDataAsync(OtlpInstrument instrument, List<DimensionScope> matchedDimensions)
     {

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrumentKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrumentKey.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Dashboard.Otlp.Model;


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/965

Adds a switch to histogram charts to display the count of the instrument, e.g. the number of HTTP requests.

Demo:
![metrics-show-count](https://github.com/dotnet/aspire/assets/303201/89f77a52-7d5f-4eb0-aadf-85ce60a1f51a)
