### PR TITLE
Rename view models in hosting layer

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -2,7 +2,7 @@
 @using Aspire.Dashboard.Components.CustomIcons;
 @using Aspire.Dashboard.Model
 @using Microsoft.AspNetCore.Http
-@inject IDashboardViewModelService dashboardViewModelService
+@inject IResourceService resourceService
 @inject IDialogService dialogService
 @inherits LayoutComponentBase
 
@@ -10,7 +10,7 @@
     <FluentHeader>
         <div class="header-title">
             <FluentAnchor IconStart="@(new AspireIcons.Size32.Logo())" Appearance="Appearance.Stealth" Href="/" Class="logo">
-                @dashboardViewModelService.ApplicationName Dashboard
+                @resourceService.ApplicationName Dashboard
             </FluentAnchor>
         </div>
         <div class="header-right">

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -2,7 +2,7 @@
 @namespace Aspire.Dashboard.Components.Pages
 @using Aspire.Dashboard.Model
 
-<PageTitle>@DashboardViewModelService.ApplicationName Console Logs</PageTitle>
+<PageTitle>@ResourceService.ApplicationName Console Logs</PageTitle>
 
 <div class="resource-logs-layout">
     <h1 class="page-header">Console Logs</h1>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -12,7 +12,7 @@ namespace Aspire.Dashboard.Components.Pages;
 public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
 {
     [Inject]
-    public required IDashboardViewModelService DashboardViewModelService { get; init; }
+    public required IResourceService ResourceService { get; init; }
     [Inject]
     public required IJSRuntime JS { get; init; }
     [Inject]
@@ -41,7 +41,7 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
     {
         _status = LogStatus.LoadingResources;
 
-        var (snapshot, subscription) = DashboardViewModelService.GetResources();
+        var (snapshot, subscription) = ResourceService.GetResources();
 
         foreach (var resource in snapshot)
         {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -41,7 +41,7 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
     {
         _status = LogStatus.LoadingResources;
 
-        var (snapshot, subscription) = ResourceService.GetResources();
+        var (snapshot, subscription) = ResourceService.Subscribe();
 
         foreach (var resource in snapshot)
         {

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -5,7 +5,7 @@
 
 @using Aspire.Dashboard.Model.Otlp
 
-<PageTitle>@DashboardViewModelService.ApplicationName Metrics</PageTitle>
+<PageTitle>@ResourceService.ApplicationName Metrics</PageTitle>
 
 <div class="metrics-layout">
     <h1 class="page-header">Metrics</h1>

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -55,7 +55,7 @@ public partial class Metrics : IDisposable
     public required NavigationManager NavigationManager { get; set; }
 
     [Inject]
-    public required IDashboardViewModelService DashboardViewModelService { get; set; }
+    public required IResourceService ResourceService { get; set; }
 
     [Inject]
     public required ProtectedSessionStorage ProtectedSessionStore { get; set; }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -3,7 +3,7 @@
 @using Aspire.Dashboard.Components.ResourcesGridColumns
 @implements IDisposable
 
-<PageTitle>@DashboardViewModelService.ApplicationName Resources</PageTitle>
+<PageTitle>@ResourceService.ApplicationName Resources</PageTitle>
 
 <div class="content-layout-with-toolbar">
     <FluentToolbar Orientation="Orientation.Horizontal">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -17,7 +17,7 @@ public partial class Resources : ComponentBase, IDisposable
     private Dictionary<OtlpApplication, int>? _applicationUnviewedErrorCounts;
 
     [Inject]
-    public required IDashboardViewModelService DashboardViewModelService { get; init; }
+    public required IResourceService ResourceService { get; init; }
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
     [Inject]
@@ -89,7 +89,7 @@ public partial class Resources : ComponentBase, IDisposable
     {
         _applicationUnviewedErrorCounts = TelemetryRepository.GetApplicationUnviewedErrorLogsCount();
 
-        var (snapshot, subscription) = DashboardViewModelService.GetResources();
+        var (snapshot, subscription) = ResourceService.GetResources();
 
         foreach (var resource in snapshot)
         {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -89,7 +89,7 @@ public partial class Resources : ComponentBase, IDisposable
     {
         _applicationUnviewedErrorCounts = TelemetryRepository.GetApplicationUnviewedErrorLogsCount();
 
-        var (snapshot, subscription) = ResourceService.GetResources();
+        var (snapshot, subscription) = ResourceService.Subscribe();
 
         foreach (var resource in snapshot)
         {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -7,11 +7,11 @@
 @using Microsoft.Extensions.Logging
 @using System.Web
 @inject NavigationManager NavigationManager
-@inject IDashboardViewModelService DashboardViewModelService
+@inject IResourceService resourceService
 @inject IJSRuntime JS
 @implements IDisposable
 
-<PageTitle>@DashboardViewModelService.ApplicationName Structured Logs</PageTitle>
+<PageTitle>@resourceService.ApplicationName Structured Logs</PageTitle>
 
 <div class="logs-layout">
     <h1 class="page-header">Structured Logs</h1>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -8,9 +8,9 @@
 @using Aspire.Dashboard.Otlp.Storage
 @using System.Diagnostics
 @using System.Globalization
-@inject IDashboardViewModelService DashboardViewModelService
+@inject IResourceService dashboardService
 
-<PageTitle>@DashboardViewModelService.ApplicationName Traces</PageTitle>
+<PageTitle>@dashboardService.ApplicationName Traces</PageTitle>
 
 @if (_trace != null)
 {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -7,11 +7,11 @@
 @using Aspire.Dashboard.Otlp.Storage
 @using System.Web
 @inject NavigationManager NavigationManager
-@inject IDashboardViewModelService DashboardViewModelService
+@inject IResourceService resourceService
 @inject IJSRuntime JS
 @implements IDisposable
 
-<PageTitle>@DashboardViewModelService.ApplicationName Traces</PageTitle>
+<PageTitle>@resourceService.ApplicationName Traces</PageTitle>
 
 
 <div class="traces-layout">

--- a/src/Aspire.Dashboard/Model/IResourceService.cs
+++ b/src/Aspire.Dashboard/Model/IResourceService.cs
@@ -10,9 +10,12 @@ public interface IResourceService
 {
     string ApplicationName { get; }
 
-    ViewModelMonitor GetResources();
+    /// <summary>
+    /// Gets the current set of resources and a stream of updates.
+    /// </summary>
+    ResourceSubscription Subscribe();
 }
 
-public record ViewModelMonitor(
+public record ResourceSubscription(
     List<ResourceViewModel> Snapshot,
-    IAsyncEnumerable<ResourceChange> Watch);
+    IAsyncEnumerable<ResourceChange> Subscription);

--- a/src/Aspire.Dashboard/Model/IResourceService.cs
+++ b/src/Aspire.Dashboard/Model/IResourceService.cs
@@ -16,6 +16,6 @@ public interface IResourceService
     ResourceSubscription Subscribe();
 }
 
-public record ResourceSubscription(
+public sealed record ResourceSubscription(
     List<ResourceViewModel> Snapshot,
     IAsyncEnumerable<ResourceChange> Subscription);

--- a/src/Aspire.Dashboard/Model/IResourceService.cs
+++ b/src/Aspire.Dashboard/Model/IResourceService.cs
@@ -3,7 +3,10 @@
 
 namespace Aspire.Dashboard.Model;
 
-public interface IDashboardViewModelService
+/// <summary>
+/// Provides data about active resources to external components, such as the dashboard.
+/// </summary>
+public interface IResourceService
 {
     string ApplicationName { get; }
 

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -9,19 +9,15 @@ namespace Aspire.Dashboard.Model;
 
 public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsyncDisposable
 {
-    private readonly IResourceService _resourceService;
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceNameMapping = new();
     private readonly CancellationTokenSource _watchContainersTokenSource = new();
     private readonly Task _watchTask;
-    private readonly List<ModelSubscription> _subscriptions;
-    private readonly object _lock = new object();
+    private readonly List<ModelSubscription> _subscriptions = [];
+    private readonly object _lock = new();
 
     public ResourceOutgoingPeerResolver(IResourceService resourceService)
     {
-        _resourceService = resourceService;
-        _subscriptions = new List<ModelSubscription>();
-
-        var (snapshot, subscription) = _resourceService.Subscribe();
+        var (snapshot, subscription) = resourceService.Subscribe();
 
         foreach (var resource in snapshot)
         {

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -21,7 +21,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
         _resourceService = resourceService;
         _subscriptions = new List<ModelSubscription>();
 
-        var (snapshot, subscription) = _resourceService.GetResources();
+        var (snapshot, subscription) = _resourceService.Subscribe();
 
         foreach (var resource in snapshot)
         {

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -9,19 +9,19 @@ namespace Aspire.Dashboard.Model;
 
 public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsyncDisposable
 {
-    private readonly IDashboardViewModelService _dashboardViewModelService;
+    private readonly IResourceService _resourceService;
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceNameMapping = new();
     private readonly CancellationTokenSource _watchContainersTokenSource = new();
     private readonly Task _watchTask;
     private readonly List<ModelSubscription> _subscriptions;
     private readonly object _lock = new object();
 
-    public ResourceOutgoingPeerResolver(IDashboardViewModelService dashboardViewModelService)
+    public ResourceOutgoingPeerResolver(IResourceService resourceService)
     {
-        _dashboardViewModelService = dashboardViewModelService;
+        _resourceService = resourceService;
         _subscriptions = new List<ModelSubscription>();
 
-        var (snapshot, subscription) = _dashboardViewModelService.GetResources();
+        var (snapshot, subscription) = _resourceService.GetResources();
 
         foreach (var resource in snapshot)
         {

--- a/src/Aspire.Hosting/Dashboard/ResourceCollection.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceCollection.cs
@@ -7,7 +7,7 @@ using Aspire.Dashboard.Model;
 
 namespace Aspire.Hosting.Dashboard;
 
-internal sealed class ViewModelProcessor
+internal sealed class ResourceCollection
 {
     private readonly object _syncLock = new();
     private readonly Channel<ResourceChange> _incomingChannel;
@@ -15,7 +15,7 @@ internal sealed class ViewModelProcessor
     private readonly Dictionary<string, ResourceViewModel> _snapshot = [];
     private ImmutableHashSet<Channel<ResourceChange>> _outgoingChannels = [];
 
-    public ViewModelProcessor(Channel<ResourceChange> incomingChannel, CancellationToken cancellationToken)
+    public ResourceCollection(Channel<ResourceChange> incomingChannel, CancellationToken cancellationToken)
     {
         _incomingChannel = incomingChannel;
         _cancellationToken = cancellationToken;

--- a/src/Aspire.Hosting/Dashboard/ResourceCollection.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceCollection.cs
@@ -7,6 +7,11 @@ using Aspire.Dashboard.Model;
 
 namespace Aspire.Hosting.Dashboard;
 
+/// <summary>
+/// Builds a collection of resources by integrating incoming changes from a channel,
+/// and allowing multiple subscribers to receive the current resource snapshot and future
+/// updates.
+/// </summary>
 internal sealed class ResourceCollection
 {
     private readonly object _syncLock = new();

--- a/src/Aspire.Hosting/Dashboard/ResourceService.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceService.cs
@@ -23,7 +23,6 @@ internal sealed partial class ResourceService : IResourceService, IAsyncDisposab
 {
     private const string AppHostSuffix = ".AppHost";
 
-    private readonly string _applicationName;
     private readonly KubernetesService _kubernetesService;
     private readonly DistributedApplicationModel _applicationModel;
     private readonly ILogger _logger;
@@ -50,7 +49,7 @@ internal sealed partial class ResourceService : IResourceService, IAsyncDisposab
     {
         _applicationModel = applicationModel;
         _kubernetesService = kubernetesService;
-        _applicationName = ComputeApplicationName(hostEnvironment.ApplicationName);
+        ApplicationName = ComputeApplicationName(hostEnvironment.ApplicationName);
         _logger = loggerFactory.CreateLogger<ResourceService>();
         _cancellationToken = _cancellationTokenSource.Token;
 
@@ -67,7 +66,7 @@ internal sealed partial class ResourceService : IResourceService, IAsyncDisposab
         _resourceViewModelProcessor = new ViewModelProcessor(_resourceViewModelChangesChannel, _cancellationToken);
     }
 
-    public string ApplicationName => _applicationName;
+    public string ApplicationName { get; }
 
     public ViewModelMonitor GetResources() => _resourceViewModelProcessor.GetMonitor();
 

--- a/src/Aspire.Hosting/Dashboard/ResourceService.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceService.cs
@@ -21,8 +21,6 @@ namespace Aspire.Hosting.Dashboard;
 
 internal sealed partial class ResourceService : IResourceService, IAsyncDisposable
 {
-    private const string AppHostSuffix = ".AppHost";
-
     private readonly KubernetesService _kubernetesService;
     private readonly DistributedApplicationModel _applicationModel;
     private readonly ILogger _logger;
@@ -64,6 +62,18 @@ internal sealed partial class ResourceService : IResourceService, IAsyncDisposab
         Task.Run(ProcessKubernetesChanges);
 
         _resourceViewModelProcessor = new ViewModelProcessor(_resourceViewModelChangesChannel, _cancellationToken);
+
+        static string ComputeApplicationName(string applicationName)
+        {
+            const string AppHostSuffix = ".AppHost";
+
+            if (applicationName.EndsWith(AppHostSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                applicationName = applicationName[..^AppHostSuffix.Length];
+            }
+
+            return applicationName;
+        }
     }
 
     public string ApplicationName { get; }
@@ -609,16 +619,6 @@ internal sealed partial class ResourceService : IResourceService, IAsyncDisposab
         // right now. We don't have to clean anything up for the channels.
 
         await _cancellationTokenSource.CancelAsync().ConfigureAwait(false);
-    }
-
-    private static string ComputeApplicationName(string applicationName)
-    {
-        if (applicationName.EndsWith(AppHostSuffix, StringComparison.OrdinalIgnoreCase))
-        {
-            applicationName = applicationName[..^AppHostSuffix.Length];
-        }
-
-        return applicationName;
     }
 
     private static string ComputeExecutableDisplayName(Executable executable)

--- a/src/Aspire.Hosting/Dashboard/ResourceService.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceService.cs
@@ -78,7 +78,7 @@ internal sealed partial class ResourceService : IResourceService, IAsyncDisposab
 
     public string ApplicationName { get; }
 
-    public ViewModelMonitor GetResources() => _resourceViewModelProcessor.GetMonitor();
+    public ResourceSubscription Subscribe() => _resourceViewModelProcessor.Subscribe();
 
     private void RunWatchTask<T>()
             where T : CustomResource

--- a/src/Aspire.Hosting/Dashboard/ResourceService.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceService.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Dashboard;
 
-internal sealed partial class DashboardViewModelService : IDashboardViewModelService, IAsyncDisposable
+internal sealed partial class ResourceService : IResourceService, IAsyncDisposable
 {
     private const string AppHostSuffix = ".AppHost";
 
@@ -45,13 +45,13 @@ internal sealed partial class DashboardViewModelService : IDashboardViewModelSer
 
     private readonly ViewModelProcessor _resourceViewModelProcessor;
 
-    public DashboardViewModelService(
+    public ResourceService(
         DistributedApplicationModel applicationModel, KubernetesService kubernetesService, IHostEnvironment hostEnvironment, ILoggerFactory loggerFactory)
     {
         _applicationModel = applicationModel;
         _kubernetesService = kubernetesService;
         _applicationName = ComputeApplicationName(hostEnvironment.ApplicationName);
-        _logger = loggerFactory.CreateLogger<DashboardViewModelService>();
+        _logger = loggerFactory.CreateLogger<ResourceService>();
         _cancellationToken = _cancellationTokenSource.Token;
 
         _kubernetesChangesChannel = Channel.CreateUnbounded<(WatchEventType, string, CustomResource?)>();
@@ -436,7 +436,7 @@ internal sealed partial class DashboardViewModelService : IDashboardViewModelSer
                 var service = _servicesMap.Values.FirstOrDefault(s => s.Metadata.Name == resourceViewModel.Name);
                 if (service != null)
                 {
-                    resourceViewModel.Services.Add(new ResourceService(service.Metadata.Name, service.AllocatedAddress, service.AllocatedPort));
+                    resourceViewModel.Services.Add(new Aspire.Dashboard.Model.ResourceService(service.Metadata.Name, service.AllocatedAddress, service.AllocatedPort));
                 }
             }
         }

--- a/src/Aspire.Hosting/Dashboard/ViewModelProcessor.cs
+++ b/src/Aspire.Hosting/Dashboard/ViewModelProcessor.cs
@@ -23,7 +23,7 @@ internal sealed class ViewModelProcessor
         Task.Run(ProcessChanges, cancellationToken);
     }
 
-    public ViewModelMonitor GetMonitor()
+    public ResourceSubscription Subscribe()
     {
         lock (_syncLock)
         {
@@ -31,9 +31,9 @@ internal sealed class ViewModelProcessor
 
             ImmutableInterlocked.Update(ref _outgoingChannels, static (set, channel) => set.Add(channel), channel);
 
-            return new ViewModelMonitor(
+            return new ResourceSubscription(
                 Snapshot: _snapshot.Values.ToList(),
-                Watch: new ChangeEnumerable(channel, RemoveChannel));
+                Subscription: new ChangeEnumerable(channel, RemoveChannel));
         }
 
         void RemoveChannel(Channel<ResourceChange> channel)

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -12,7 +12,6 @@ using System.Text.RegularExpressions;
 using Aspire.Dashboard;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp.Process;
 using Aspire.Hosting.Properties;
 using Aspire.Hosting.Publishing;
@@ -21,6 +20,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using ResourceService = Aspire.Hosting.Dashboard.ResourceService;
 
 namespace Aspire.Hosting.Dcp;
 
@@ -62,7 +62,7 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
             {
                 serviceCollection.AddSingleton(_applicationModel);
                 serviceCollection.AddSingleton(kubernetesService);
-                serviceCollection.AddScoped<IDashboardViewModelService, DashboardViewModelService>();
+                serviceCollection.AddScoped<IResourceService, ResourceService>();
             });
         }
     }


### PR DESCRIPTION
There will be a gRPC connection between `Aspire.Hosting` and `Aspire.Dashboard`. On the hosting side, there'll be no concept of view models any more.

This change applies some renaming to better match the shape of APIs to come, reduce the size of the future PR that splits them across that boundary.