### PR TITLE
Delegate filtering logic to implementation

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -21,16 +21,10 @@ public partial class Resources : ComponentBase, IDisposable
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
     [Inject]
-    public required NavigationManager NavigationManager { get; set; }
+    public required NavigationManager NavigationManager { get; init; }
 
     private IEnumerable<EnvironmentVariableViewModel>? SelectedEnvironmentVariables { get; set; }
     private ResourceViewModel? SelectedResource { get; set; }
-
-    private bool Filter(ResourceViewModel resource)
-        => _visibleResourceTypes.Contains(resource.ResourceType) &&
-           (resource.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) ||
-            (resource is ContainerViewModel containerViewModel &&
-             containerViewModel.Image.Contains(_filter, StringComparison.CurrentCultureIgnoreCase)));
 
     private readonly CancellationTokenSource _watchTaskCancellationTokenSource = new();
     private readonly Dictionary<string, ResourceViewModel> _resourcesMap = [];
@@ -44,6 +38,8 @@ public partial class Resources : ComponentBase, IDisposable
     {
         _visibleResourceTypes = new HashSet<string>(_allResourceTypes, StringComparers.ResourceType);
     }
+
+    private bool Filter(ResourceViewModel resource) => _visibleResourceTypes.Contains(resource.ResourceType) && (_filter.Length == 0 || resource.MatchesFilter(_filter));
 
     protected void OnResourceTypeVisibilityChanged(string resourceType, bool isVisible)
     {

--- a/src/Aspire.Dashboard/Extensions/StringComparers.cs
+++ b/src/Aspire.Dashboard/Extensions/StringComparers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Dashboard.Extensions;
@@ -6,4 +6,11 @@ namespace Aspire.Dashboard.Extensions;
 internal static class StringComparers
 {
     public static StringComparer ResourceType => StringComparer.Ordinal;
+    public static StringComparer UserTextSearch => StringComparer.CurrentCultureIgnoreCase;
+}
+
+internal static class StringComparisons
+{
+    public static StringComparison ResourceType => StringComparison.Ordinal;
+    public static StringComparison UserTextSearch => StringComparison.CurrentCultureIgnoreCase;
 }

--- a/src/Aspire.Dashboard/Model/ContainerViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ContainerViewModel.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Extensions;
+
 namespace Aspire.Dashboard.Model;
 
 public class ContainerViewModel : ResourceViewModel
@@ -11,4 +13,9 @@ public class ContainerViewModel : ResourceViewModel
     public List<int> Ports { get; } = new();
     public string? Command { get; init; }
     public List<string>? Args { get; init; }
+
+    internal override bool MatchesFilter(string filter)
+    {
+        return base.MatchesFilter(filter) || Image.Contains(filter, StringComparisons.UserTextSearch);
+    }
 }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Extensions;
+
 namespace Aspire.Dashboard.Model;
 
 public abstract class ResourceViewModel
@@ -33,6 +35,11 @@ public abstract class ResourceViewModel
         }
 
         return resource.DisplayName;
+    }
+
+    internal virtual bool MatchesFilter(string filter)
+    {
+        return Name.Contains(filter, StringComparisons.UserTextSearch);
     }
 }
 


### PR DESCRIPTION
Avoids having a special check for a specific type.

Once we move to a truly generic form for resources, we'll have to check extension data values, possibly adding metadata to control which items participate in search.