### PR TITLE
Add support for Dapr `--runtime-path` option.

### DIFF
--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -129,6 +129,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         ModelNamedArg("--placement-host-address", sidecarOptions?.PlacementHostAddress),
                         ModelNamedArg("--resources-path", aggregateResourcesPaths),
                         ModelNamedArg("--run-file", NormalizePath(sidecarOptions?.RunFile)),
+                        ModelNamedArg("--runtime-path", NormalizePath(sidecarOptions?.RuntimePath)),
                         ModelNamedArg("--unix-domain-socket", sidecarOptions?.UnixDomainSocket),
                         PostOptionsArgs(Args(sidecarOptions?.Command)));
 
@@ -230,6 +231,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         context.Writer.TryWriteNumber("profilePort", sidecarOptions?.ProfilePort);
                         context.Writer.TryWriteStringArray("resourcesPath", sidecarOptions?.ResourcesPaths.Select(path => context.GetManifestRelativePath(path)));
                         context.Writer.TryWriteString("runFile", context.GetManifestRelativePath(sidecarOptions?.RunFile));
+                        context.Writer.TryWriteString("runtimePath", context.GetManifestRelativePath(sidecarOptions?.RuntimePath));
                         context.Writer.TryWriteString("unixDomainSocket", sidecarOptions?.UnixDomainSocket);
 
                         context.Writer.WriteEndObject();

--- a/src/Aspire.Hosting.Dapr/DaprSidecarOptions.cs
+++ b/src/Aspire.Hosting.Dapr/DaprSidecarOptions.cs
@@ -148,6 +148,11 @@ public sealed record DaprSidecarOptions
     public string? RunFile { get; init; }
 
     /// <summary>
+    /// Gets or sets the directory of the Dapr runtime (i.e. daprd).
+    /// </summary>
+    public string? RuntimePath { get; init; }
+
+    /// <summary>
     /// Gets or sets the path to a Unix Domain Socket (UDS) directory.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
The Dapr CLI has a global `--runtime-path` to enable using an alternative Dapr runtime (i.e. `daprd`), such as a locally built version in order to test runtime changes.  This PR adds a corresponding, optional `RuntimePath` property to the `DaprSidecarOptions` type as well as pushes the property into the Aspire manifest (if specified).