### PR TITLE
Set dashboards refresh rate

### DIFF
--- a/src/Grafana/dashboards/aspnetcore-endpoint.json
+++ b/src/Grafana/dashboards/aspnetcore-endpoint.json
@@ -818,7 +818,7 @@
       "type": "stat"
     }
   ],
-  "refresh": "",
+  "refresh": "10s",
   "revision": 1,
   "schemaVersion": 38,
   "tags": [

--- a/src/Grafana/dashboards/aspnetcore.json
+++ b/src/Grafana/dashboards/aspnetcore.json
@@ -1270,7 +1270,7 @@
       "type": "table"
     }
   ],
-  "refresh": "",
+  "refresh": "10s",
   "revision": 1,
   "schemaVersion": 38,
   "tags": [


### PR DESCRIPTION
Allow the metric dashboards to auto refresh.
Makes it easier to follow traffic when the auto fetch is activated in the blazor project.