### PR TITLE
Metrics filter layout

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
@@ -12,47 +12,47 @@
 }
 else
 {
-    <div class="metrics-chart" style="max-width: 1100px;">
-        <div class="metrics-chart-header" style="grid-column-end: span 2;">
+    <div class="metrics-chart">
+        <div class="metrics-chart-header">
             <h3>@_instrument.Name</h3>
             <p>@_instrument.Description</p>
         </div>
         <div class="metrics-chart-container">
             <PlotlyChart InstrumentViewModel="_instrumentViewModel" Duration="Duration" />
-        </div>
-        @if (_viewModel.DimensionFilters.Count > 0)
-        {
-            <div class="metrics-filters-container">
-                <div style="margin-left: 10px">
-                    <h5>@Loc[ControlsStrings.ChartContainerFiltersHeader]</h5>
-                    <table style="width:100%">
-                        @foreach (var item in _viewModel.DimensionFilters)
-                        {
-                            <tr>
-                                <td class="dimension-name" title="@item.Name">@item.Name</td>
-                                <td class="dimension-values" title="@string.Join(", ", item.SelectedValues.Select(v => v.Name))">
-                                    <FluentAutocomplete TOption="DimensionValueViewModel"
-                                                        Width="250px"
-                                                        Placeholder="@Loc[ControlsStrings.ChartContainerSelectFilters]"
-                                                        AriaLabel="@Loc[ControlsStrings.ChartContainerSelectFilters]"
-                                                        OnOptionsSearch="item.OnSearchAsync"
-                                                        OptionText="@(item => item.Name)"
-                                                        @bind-SelectedOptions="item.SelectedValues"
-                                                        @bind-SelectedOptions:after="async () => await DimensionValuesChangedAsync(item)" />
-                                </td>
-                            </tr>
-                        }
-                    </table>
+            @if (_viewModel.DimensionFilters.Count > 0)
+            {
+                <div class="metrics-filters-container">
+                    <div>
+                        <h4>@Loc[ControlsStrings.ChartContainerFiltersHeader]</h4>
+                        <table style="width:100%">
+                            @foreach (var item in _viewModel.DimensionFilters)
+                            {
+                                <tr>
+                                    <td class="dimension-name" title="@item.Name">@item.Name</td>
+                                    <td class="dimension-values" title="@string.Join(", ", item.SelectedValues.Select(v => v.Name))">
+                                        <FluentAutocomplete TOption="DimensionValueViewModel"
+                                                            Width="250px"
+                                                            Placeholder="@Loc[ControlsStrings.ChartContainerSelectFilters]"
+                                                            AriaLabel="@Loc[ControlsStrings.ChartContainerSelectFilters]"
+                                                            OnOptionsSearch="item.OnSearchAsync"
+                                                            OptionText="@(item => item.Name)"
+                                                            @bind-SelectedOptions="item.SelectedValues"
+                                                            @bind-SelectedOptions:after="async () => await DimensionValuesChangedAsync(item)" />
+                                    </td>
+                                </tr>
+                            }
+                        </table>
 
-                    @if (_instrument.Type == OtlpInstrumentType.Histogram)
-                    {
-                        <h5>Options</h5>
-                        <div>
-                            <FluentSwitch Label="Show count" @bind-Value="_showCount" @bind-Value:after="ShowCountChanged" />
-                        </div>
-                    }
+                        @if (_instrument.Type == OtlpInstrumentType.Histogram)
+                        {
+                            <h5>Options</h5>
+                            <div>
+                                <FluentSwitch Label="Show count" @bind-Value="_showCount" @bind-Value:after="ShowCountChanged" />
+                            </div>
+                        }
+                    </div>
                 </div>
-            </div>
-        }
+            }
+        </div>
     </div>
 }

--- a/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor
@@ -2,4 +2,4 @@
 @namespace Aspire.Dashboard.Components
 @inject IStringLocalizer<ControlsStrings> Loc
 
-<div id="plotly-chart-container" style="width:650px; height:400px"></div>
+<div id="plotly-chart-container" style="width:650px; height:450px"></div>

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -24,6 +24,7 @@
         "chart";
     width: 100%;
     gap: calc(var(--design-unit) * 4px);
+    padding-left: 40px;
 }
 
 ::deep .metrics-chart-header {
@@ -86,4 +87,8 @@
     height: 100%;
     width: 100%;
     overflow: auto;
+}
+
+::deep #plotly-chart-container {
+    margin-left: -40px;
 }

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -18,27 +18,25 @@
 
 ::deep .metrics-chart {
     display: grid;
-    grid-template-columns: min-content auto;
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+        "header"
+        "chart";
+    width: 100%;
+    gap: calc(var(--design-unit) * 4px);
 }
 
 ::deep .metrics-chart-header {
-    margin-left: 40px;
+    grid-area: header;
 }
 
 ::deep .metrics-chart-container {
-    grid-column: 1;
-    margin-bottom: 60px;
-}
-
-::deep .metrics-filters-container {
-    grid-column: 2;
-}
-
-@media (max-width: 1700px) {
-    ::deep .metrics-filters-container {
-        grid-column: 1;
-        margin-left: 40px;
-    }
+    grid-area: chart;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    row-gap: calc(var(--design-unit) * 4px);
+    column-gap: calc(var(--design-unit) * 4px);
 }
 
 ::deep .metrics-filters-container td.dimension-name {


### PR DESCRIPTION
Resolves #1258 

Uses flexbox layout rather than the `@media` and `max-width` method. 

This also allows it to wrap when you move the slider, which didn't work before (it only wrapped if you changed the browser window size).

One thing I changed here is that I got rid of the left margin for the main header and the filter (when wrapped). You can see this below. There's no CSS-only way to detect that an item has wrapped to another line in flexbox, so I couldn't easily conditionally add it to the filters. I think it still looks fine, but we could do a general UX pass on the metrics page overall separate from this issue if we wanted.

Before:
![MetricsFilterWrap-Before](https://github.com/dotnet/aspire/assets/9613109/06eadcee-b2b2-473e-9e34-39f259adc7b0)

After:
![MetricsFilterWrap-After](https://github.com/dotnet/aspire/assets/9613109/9676439c-6a15-4bfb-b8cd-0f12fc176893)

Note: ignore whitespace to see the actual changes in `ChartContainer.razor`.