### PR TITLE
Disable "spec only" button when it doesn't do anything

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/EnvironmentVariables.razor
+++ b/src/Aspire.Dashboard/Components/Controls/EnvironmentVariables.razor
@@ -8,6 +8,7 @@
         @if (ShowSpecOnlyToggle)
         {
             <FluentButton Appearance="Appearance.Lightweight"
+                          Disabled="IsSpecOnlyToggleDisabled"
                           IconEnd="@(_showAll ? _showSpecOnlyIcon : _showAllIcon)"
                           Title="@(_showAll ? Loc[ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly] : ControlsStrings.EnvironmentVariablesFilterToggleShowAll)"
                           aria-label="@(_showAll ? Loc[ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly] : ControlsStrings.EnvironmentVariablesFilterToggleShowAll)"

--- a/src/Aspire.Dashboard/Components/Controls/EnvironmentVariables.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/EnvironmentVariables.razor.cs
@@ -9,12 +9,10 @@ namespace Aspire.Dashboard.Components.Controls;
 
 public partial class EnvironmentVariables
 {
-
     [Parameter, EditorRequired]
     public IEnumerable<EnvironmentVariableViewModel>? Items { get; set; }
 
-    [Parameter]
-    public bool ShowSpecOnlyToggle { get; set; }
+    public bool ShowSpecOnlyToggle => Items?.Any(i => i.FromSpec == false) == true;
 
     private bool _showAll;
 

--- a/src/Aspire.Dashboard/Components/Controls/EnvironmentVariables.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/EnvironmentVariables.razor.cs
@@ -12,7 +12,10 @@ public partial class EnvironmentVariables
     [Parameter, EditorRequired]
     public IEnumerable<EnvironmentVariableViewModel>? Items { get; set; }
 
-    public bool ShowSpecOnlyToggle => Items?.Any(i => i.FromSpec == false) == true;
+    [Parameter]
+    public bool ShowSpecOnlyToggle { get; set; }
+
+    private bool IsSpecOnlyToggleDisabled => Items?.Any(i => i.FromSpec == false) is false or null;
 
     private bool _showAll;
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -81,7 +81,7 @@
             </FluentDataGrid>
         </Summary>
         <Details>
-            <EnvironmentVariables Items="SelectedEnvironmentVariables" ShowSpecOnlyToggle="true" />
+            <EnvironmentVariables Items="SelectedEnvironmentVariables" />
         </Details>
     </SummaryDetailsView>
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -81,7 +81,7 @@
             </FluentDataGrid>
         </Summary>
         <Details>
-            <EnvironmentVariables Items="SelectedEnvironmentVariables" />
+            <EnvironmentVariables Items="SelectedEnvironmentVariables" ShowSpecOnlyToggle="true" />
         </Details>
     </SummaryDetailsView>
 </div>


### PR DESCRIPTION
The environment variables window has a toggle button that controls whether only "from spec" variables are shown.

This change disables the button in the case that all items _are_ from the spec, in which case toggling it would have no visible effect.

![image](https://github.com/dotnet/aspire/assets/350947/ea3f707d-09db-4bc9-99ba-29973c946db5)

![image](https://github.com/dotnet/aspire/assets/350947/7e4d603b-6766-4120-bace-9476cba7a062)



