### PR TITLE
Add Resource Management automation for issue and PR Triage

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -12,14 +12,14 @@ configuration:
         if:
           - payloadType: Issues
           - isAction:
-            action: Opened
+              action: Opened
         then:
           - addLabel:
-            label: untriaged
+              label: untriaged
       - description: Add CodeFlow link to new PRs
         if:
           - payloadType: Pull_Request
           - isAction:
-            action: Opened
+              action: Opened
         then:
           - addCodeFlowLink

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -1,0 +1,22 @@
+name: New Issues
+description: Adds untriaged label to new issues
+resource: repository
+
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Add untriaged to new issues
+        if:
+          - payloadType: Issues
+          - isAction:
+            action: Opened
+        then:
+          - addLabel:
+            label: untriaged
+      - description: Add CodeFlow link to new PRs
+        if:
+          - payloadType: Pull_Request
+          - isAction:
+              action: Opened
+        then:
+          - addCodeFlowLink

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -20,6 +20,6 @@ configuration:
         if:
           - payloadType: Pull_Request
           - isAction:
-              action: Opened
+            action: Opened
         then:
           - addCodeFlowLink

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -1,7 +1,10 @@
+id: labelManagement.issueOpened
 name: New Issues
 description: Adds untriaged label to new issues
+owner:
 resource: repository
-
+disabled: false
+where:
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -14,20 +14,20 @@ configuration:
             - payloadType: Issue_Comment
             - payloadType: Issues
           - not:
-            - isAction:
-              action: Closed
+              isAction:
+                action: Closed
           - hasLabel:
-            label: no-recent-activity
+              label: no-recent-activity
         then:
           - removeLabel:
-            label: no-recent-activity
+              label: no-recent-activity
       - description: Remove needs-author-action label from issues when an author replies
         if:
           - payloadType: Issue_Comment
           - isActivitySender:
-            issueAuthor: true
+              issueAuthor: true
           - hasLabel:
-            label: needs-author-action
+              label: needs-author-action
         then:
           - removeLabel:
-            label: needs-author-action
+              label: needs-author-action

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -1,0 +1,30 @@
+name: Issue Activity Responder
+description: Adds/Removes labels from issues based on activity
+resource: repository
+
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Remove no-recent-activity label from issues after an update
+        if:
+          - or:
+            - payloadType: Issue_Comment
+            - payloadType: Issues
+          - not:
+            - isAction:
+              action: Closed
+          - hasLabel:
+            label: no-recent-activity
+        then:
+          - removeLabel:
+            label: no-recent-activity
+      - description: Remove needs-author-action label from issues when an author replies
+        if:
+          - payloadType: Issue_Comment
+          - isActivitySender:
+            issueAuthor: true
+          - hasLabel:
+            label: needs-author-action
+        then:
+          - removeLabel:
+            label: needs-author-action

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -1,7 +1,10 @@
+id: labelManagement.issueUpdated
 name: Issue Activity Responder
 description: Adds/Removes labels from issues based on activity
+owner:
 resource: repository
-
+disabled: false
+where:
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:

--- a/.github/policies/labelManagement.prUpdated.yml
+++ b/.github/policies/labelManagement.prUpdated.yml
@@ -1,7 +1,10 @@
+id: labelManagement.prUpdated
 name: PR Activity Responder
 description: Adds/Removes labels from PRs based on activity
+owner:
 resource: repository
-
+disabled: false
+where:
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:

--- a/.github/policies/labelManagement.prUpdated.yml
+++ b/.github/policies/labelManagement.prUpdated.yml
@@ -12,37 +12,37 @@ configuration:
         if:
           - payloadType: Pull_Request_Review
           - isAction:
-            action: Submitted
+              action: Submitted
           - isReviewState:
-            state: Changes_requested
+              reviewState: Changes_requested
         then:
           - addLabel:
-            label: needs-author-action
+              label: needs-author-action
       - description: Remove needs-author-action label from PRs when an author updates the PR
         if:
           - or:
             - payloadType: Pull_Request_Review
             - payloadType: Pull_Request_Review_Comment
           - not:
-            - isAction:
-              action: Closed
+              isAction:
+                action: Closed
           - isActivitySender:
-            issueAuthor: true
+              issueAuthor: true
           - hasLabel:
-            label: needs-author-action
+              label: needs-author-action
         then:
           - removeLabel:
-            label: needs-author-action
-        - description: Remove no-recent-activity label from PRs after an update
+              label: needs-author-action
+      - description: Remove no-recent-activity label from PRs after an update
         if:
           - or:
             - payloadType: Pull_Request_Review
             - payloadType: Pull_Request_Review_Comment
           - not:
-            - isAction:
-              action: Closed
+              isAction:
+                action: Closed
           - hasLabel:
-            label: no-recent-activity
+              label: no-recent-activity
         then:
           - removeLabel:
-            label: no-recent-activity
+              label: no-recent-activity

--- a/.github/policies/labelManagement.prUpdated.yml
+++ b/.github/policies/labelManagement.prUpdated.yml
@@ -1,0 +1,45 @@
+name: PR Activity Responder
+description: Adds/Removes labels from PRs based on activity
+resource: repository
+
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Add needs-author-action label when changes are requested
+        if:
+          - payloadType: Pull_Request_Review
+          - isAction:
+            action: Submitted
+          - isReviewState:
+            state: Changes_requested
+        then:
+          - addLabel:
+            label: needs-author-action
+      - description: Remove needs-author-action label from PRs when an author updates the PR
+        if:
+          - or:
+            - payloadType: Pull_Request_Review
+            - payloadType: Pull_Request_Review_Comment
+          - not:
+            - isAction:
+              action: Closed
+          - isActivitySender:
+            issueAuthor: true
+          - hasLabel:
+            label: needs-author-action
+        then:
+          - removeLabel:
+            label: needs-author-action
+        - description: Remove no-recent-activity label from PRs after an update
+        if:
+          - or:
+            - payloadType: Pull_Request_Review
+            - payloadType: Pull_Request_Review_Comment
+          - not:
+            - isAction:
+              action: Closed
+          - hasLabel:
+            label: no-recent-activity
+        then:
+          - removeLabel:
+            label: no-recent-activity

--- a/.github/policies/scheduledSearch.closeStaleIssuesAndPrs.yml
+++ b/.github/policies/scheduledSearch.closeStaleIssuesAndPrs.yml
@@ -1,7 +1,10 @@
+id: scheduledSearch.closeStaleIssuesAndPrs
 name: Close Stale Issues and PRs
 description: Closes issues and PRs that have not been updated in a while
+owner:
 resource: repository
-
+disabled: false
+where:
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:

--- a/.github/policies/scheduledSearch.closeStaleIssuesAndPrs.yml
+++ b/.github/policies/scheduledSearch.closeStaleIssuesAndPrs.yml
@@ -1,0 +1,24 @@
+name: Close Stale Issues and PRs
+description: Closes issues and PRs that have not been updated in a while
+resource: repository
+
+configuration:
+  resourceManagementConfiguration:
+    scheduledSearches:
+      - description: Close issues and PRs that have not been updated in a while
+        frequencies:
+          - hourly:
+            hour: 12
+        filters:
+          - or:
+            - isPullRequest
+            - isIssue
+          - isOpen
+          - hasLabel:
+            label: needs-author-action
+          - hasLabel:
+            label: no-recent-activity
+          - noActivitySince:
+            days: 7
+        actions:
+          - closeIssue

--- a/.github/policies/scheduledSearch.closeStaleIssuesAndPrs.yml
+++ b/.github/policies/scheduledSearch.closeStaleIssuesAndPrs.yml
@@ -11,17 +11,14 @@ configuration:
       - description: Close issues and PRs that have not been updated in a while
         frequencies:
           - hourly:
-            hour: 12
+              hour: 12
         filters:
-          - or:
-            - isPullRequest
-            - isIssue
           - isOpen
           - hasLabel:
-            label: needs-author-action
+              label: needs-author-action
           - hasLabel:
-            label: no-recent-activity
+              label: no-recent-activity
           - noActivitySince:
-            days: 7
+              days: 7
         actions:
           - closeIssue

--- a/.github/policies/scheduledSearch.markNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.markNoRecentActivity.yml
@@ -1,7 +1,10 @@
+id: scheduledSearch.markNoRecentActivity
 name: No Recent Activity Monitor
 description: Adds no-recent-activity label to issues and PRs that have not been updated in a while
+owner:
 resource: repository
-
+disabled: false
+where:
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:

--- a/.github/policies/scheduledSearch.markNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.markNoRecentActivity.yml
@@ -1,0 +1,30 @@
+name: No Recent Activity Monitor
+description: Adds no-recent-activity label to issues and PRs that have not been updated in a while
+resource: repository
+
+configuration:
+  resourceManagementConfiguration:
+    scheduledSearches:
+      - description: Add no-recent-activity label to issues and PRs that have not been updated in a while
+        frequencies:
+          - hourly:
+            hour: 3
+        filters:
+          - or:
+            - isPullRequest
+            - isIssue
+          - isOpen
+          - isNotLabeledWith:
+            label: no-recent-activity
+          - hasLabel:
+            label: needs-author-action
+          - noActivitySince:
+            days: 14
+        actions:
+          - addLabel:
+            label: no-recent-activity
+          - addReply:
+            reply: >-
+              This submission has been automatically marked as stale because it has been marked as requiring author action but has not had any activity for **14 days**.
+              
+              It will be closed if no further activity occurs **within 7 days of this comment**.

--- a/.github/policies/scheduledSearch.markNoRecentActivity.yml
+++ b/.github/policies/scheduledSearch.markNoRecentActivity.yml
@@ -11,23 +11,20 @@ configuration:
       - description: Add no-recent-activity label to issues and PRs that have not been updated in a while
         frequencies:
           - hourly:
-            hour: 3
+              hour: 3
         filters:
-          - or:
-            - isPullRequest
-            - isIssue
           - isOpen
           - isNotLabeledWith:
-            label: no-recent-activity
+              label: no-recent-activity
           - hasLabel:
-            label: needs-author-action
+              label: needs-author-action
           - noActivitySince:
-            days: 14
+              days: 14
         actions:
           - addLabel:
-            label: no-recent-activity
+              label: no-recent-activity
           - addReply:
-            reply: >-
-              This submission has been automatically marked as stale because it has been marked as requiring author action but has not had any activity for **14 days**.
+              reply: >-
+                This submission has been automatically marked as stale because it has been marked as requiring author action but has not had any activity for **14 days**.
               
-              It will be closed if no further activity occurs **within 7 days of this comment**.
+                It will be closed if no further activity occurs **within 7 days of this comment**.


### PR DESCRIPTION
Fixes #169 

This is the initial onboard into the new fabricbot service. It adds basic triage for issues and PRs. Here are the automations that are added with this:

1. Add untriaged label to new issues
2. Add Codeflow links to new PRs
3. Add `needs-author-action` to PRs when a review is submitted and changes are requested
4. Monitors for issues and PRs with `needs-author-action` label that haven't been updated in 2 weeks, and will add `no-recent-activity` label as well as add a comment mentioning that it will be closed in one more week of inactivity.
5. Monitors for issues and PRs that have `no-recent-activity` label and haven't had activity for an additional week, and closes them.


cc: @jeffhandley @wtgodbe @mkArtakMSFT 

FYI: @DamianEdwards @davidfowl @danmoseley 