### PR TITLE
Small perf improvements in log filtering

### DIFF
--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -114,7 +114,8 @@ public class LogFilter
                 }
             default:
                 {
-                    return input.Where(x => ConditionToFuncString(Condition)(GetFieldValue(x)!, Value));
+                    var func = ConditionToFuncString(Condition);
+                    return input.Where(x => func(GetFieldValue(x)!, Value));
                 }
         }
     }

--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -105,9 +105,9 @@ public class LogFilter
                 }
             case nameof(OtlpLogEntry.Severity):
                 {
-                    var func = ConditionToFuncNumber(Condition);
-                    if (Enum.TryParse<LogLevel>(Value, true, out var value))
+                    if (Enum.TryParse<LogLevel>(Value, ignoreCase: true, out var value))
                     {
+                        var func = ConditionToFuncNumber(Condition);
                         return input.Where(x => func((int)x.Severity, (double)value));
                     }
                     return input;

--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -37,7 +37,7 @@ public class LogFilter
             _ => throw new ArgumentOutOfRangeException(nameof(c), c, null)
         };
 
-    private static Func<string, string, bool> ConditionToFuncString(FilterCondition c) =>
+    private static Func<string?, string, bool> ConditionToFuncString(FilterCondition c) =>
         c switch
         {
             FilterCondition.Equals => (a, b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase),
@@ -115,7 +115,7 @@ public class LogFilter
             default:
                 {
                     var func = ConditionToFuncString(Condition);
-                    return input.Where(x => func(GetFieldValue(x)!, Value));
+                    return input.Where(x => func(GetFieldValue(x), Value));
                 }
         }
     }


### PR DESCRIPTION
- Hoist call to `ConditionToFuncString` outside loop, so it's called once rather than per log entry.
- Only call `ConditionToFuncNumber` if parse succeeds
- Avoid null suppression
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1325)