### PR TITLE
Configured DefaultAzureCredentialOptions when provisioning azure resources

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -66,13 +66,16 @@ internal sealed class AzureProvisioner(
 
     private async Task ProvisionAzureResources(IConfiguration configuration, IHostEnvironment environment, ILogger<AzureProvisioner> logger, IEnumerable<IAzureResource> azureResources, CancellationToken cancellationToken)
     {
-        var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions()
+        var defaultAzureCredentialOptions = new DefaultAzureCredentialOptions()
         {
             ExcludeManagedIdentityCredential = true,
             ExcludeWorkloadIdentityCredential = true,
             ExcludeAzurePowerShellCredential = true,
             CredentialProcessTimeout = TimeSpan.FromSeconds(15)
-        });
+        };
+
+        configuration.GetSection("Azure").GetSection(nameof(DefaultAzureCredential)).Bind(defaultAzureCredentialOptions);
+        var credential = new DefaultAzureCredential(defaultAzureCredentialOptions);
 
         var subscriptionId = _options.SubscriptionId ?? throw new MissingConfigurationException("An azure subscription id is required. Set the Azure:SubscriptionId configuration value.");
         var location = _options.Location switch


### PR DESCRIPTION
This PR is addressing #1329

The section Azure was already defined in order to bind the `AzureProvisionerOptions`, so I just added a sub-section for `DefaultAzureCredential`.

It seems that there are not tests yet for the azure provisioner at all, so I didn't add any.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1330)