### PR TITLE
Label community PRs

### DIFF
--- a/.github/policies/labelManagement.prOpened.yml
+++ b/.github/policies/labelManagement.prOpened.yml
@@ -1,0 +1,43 @@
+id: labelManagement.prOpened
+name: New PRs
+description: Adds community-contribution label to new PRs that are coming from the community
+owner: 
+resource: repository
+disabled: false
+where: 
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+    - description: Label community PRs
+      if:
+      - payloadType: Pull_Request
+      - isAction:
+          action: Opened
+      - and:
+        - not:
+            activitySenderHasPermission:
+              permission: Admin
+        - not:
+            activitySenderHasPermission:
+              permission: Write
+        - not:
+            isActivitySender:
+              user: github-actions[bot]
+        - not:
+            isActivitySender:
+              user: dotnet-maestro[bot]
+        - not:
+            isActivitySender:
+              user: dotnet-maestro-bot[bot]
+        - not:
+            isActivitySender:
+              user: dotnet-maestro-bot
+        - not:
+            isActivitySender:
+              user: dotnet-maestro
+        - not:
+            isActivitySender:
+              user: github-actions
+      then:
+      - addLabel:
+          label: community-contribution


### PR DESCRIPTION
When new PRs are opened, if they are not from bots or from users with admin or write permissions, then they get labeled as community contributions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1334)