### PR TITLE
Simplify ResourcePublisher

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -208,7 +208,7 @@ public partial class ConsoleLogs : ComponentBase, IAsyncDisposable
                 }
             }
         }
-        else if (changeType == ResourceChangeType.Deleted)
+        else if (changeType == ResourceChangeType.Delete)
         {
             _resourceNameMapping.Remove(resourceViewModel.Name);
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -155,7 +155,7 @@ public partial class Resources : ComponentBase, IDisposable
                 _resourcesMap[resource.Name] = resource;
                 break;
 
-            case ResourceChangeType.Deleted:
+            case ResourceChangeType.Delete:
                 _resourcesMap.Remove(resource.Name);
                 break;
         }

--- a/src/Aspire.Dashboard/Model/ResourceChangeType.cs
+++ b/src/Aspire.Dashboard/Model/ResourceChangeType.cs
@@ -15,5 +15,5 @@ public enum ResourceChangeType
     /// <summary>
     /// The object was deleted.
     /// </summary>
-    Deleted
+    Delete
 }

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -39,7 +39,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
         {
             _resourceNameMapping[resourceViewModel.Name] = resourceViewModel;
         }
-        else if (changeType == ResourceChangeType.Deleted)
+        else if (changeType == ResourceChangeType.Delete)
         {
             _resourceNameMapping.TryRemove(resourceViewModel.Name, out _);
         }

--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -405,7 +405,7 @@ internal sealed class DcpDataSource
         return watchEventType switch
         {
             WatchEventType.Added or WatchEventType.Modified => ResourceChangeType.Upsert,
-            WatchEventType.Deleted => ResourceChangeType.Deleted,
+            WatchEventType.Deleted => ResourceChangeType.Delete,
             _ => ResourceChangeType.Other
         };
     }

--- a/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
@@ -63,7 +63,7 @@ internal sealed class ResourcePublisher(CancellationToken cancellationToken)
                     _snapshot[resource.Name] = resource;
                     break;
 
-                case ResourceChangeType.Deleted:
+                case ResourceChangeType.Delete:
                     _snapshot.Remove(resource.Name);
                     break;
             }

--- a/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
@@ -53,7 +53,7 @@ internal sealed class ResourcePublisher(CancellationToken cancellationToken)
     /// <param name="resource">The resource that was modified.</param>
     /// <param name="changeType">The change type (Added, Modified, Deleted).</param>
     /// <returns>A task that completes when the cache has been updated and all subscribers notified.</returns>
-    public async ValueTask Integrate(ResourceViewModel resource, ResourceChangeType changeType)
+    public async ValueTask IntegrateAsync(ResourceViewModel resource, ResourceChangeType changeType)
     {
         lock (_syncLock)
         {

--- a/src/Aspire.Hosting/Dashboard/ResourceService.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceService.cs
@@ -21,7 +21,7 @@ internal sealed partial class ResourceService : IResourceService, IAsyncDisposab
 
         _resourcePublisher = new ResourcePublisher(_cancellationTokenSource.Token);
 
-        _ = new DcpDataSource(kubernetesService, applicationModel, loggerFactory, _resourcePublisher.Integrate, _cancellationTokenSource.Token);
+        _ = new DcpDataSource(kubernetesService, applicationModel, loggerFactory, _resourcePublisher.IntegrateAsync, _cancellationTokenSource.Token);
 
         static string ComputeApplicationName(string applicationName)
         {

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.Dashboard;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Dashboard;
+
+public class ResourcePublisherTests
+{
+    [Fact]
+    public async Task ProducesExpectedSnapshotAndUpdates()
+    {
+        CancellationTokenSource cts = new();
+        ResourcePublisher publisher = new(cts.Token);
+
+        var a = CreateResource("A");
+        var b = CreateResource("B");
+        var c = CreateResource("C");
+
+        await publisher.IntegrateAsync(a, ResourceChangeType.Upsert).ConfigureAwait(false);
+        await publisher.IntegrateAsync(b, ResourceChangeType.Upsert).ConfigureAwait(false);
+
+        var (snapshot, subscription) = publisher.Subscribe();
+
+        Assert.Equal(2, snapshot.Count);
+        Assert.Contains(a, snapshot);
+        Assert.Contains(b, snapshot);
+
+        using AutoResetEvent sync = new(initialState: false);
+        List<ResourceChange> changes = [];
+
+        var task = Task.Run(async () =>
+        {
+            await foreach (var change in subscription)
+            {
+                changes.Add(change);
+                sync.Set();
+            }
+        });
+
+        await publisher.IntegrateAsync(c, ResourceChangeType.Upsert).ConfigureAwait(false);
+
+        sync.WaitOne(TimeSpan.FromSeconds(1));
+
+        var change = Assert.Single(changes);
+        Assert.Equal(ResourceChangeType.Upsert, change.ChangeType);
+        Assert.Same(c, change.Resource);
+
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => task);
+    }
+
+    [Fact]
+    public async Task SupportsMultipleSubscribers()
+    {
+        CancellationTokenSource cts = new();
+        ResourcePublisher publisher = new(cts.Token);
+
+        var a = CreateResource("A");
+        var b = CreateResource("B");
+        var c = CreateResource("C");
+
+        await publisher.IntegrateAsync(a, ResourceChangeType.Upsert).ConfigureAwait(false);
+        await publisher.IntegrateAsync(b, ResourceChangeType.Upsert).ConfigureAwait(false);
+
+        var (snapshot1, subscription1) = publisher.Subscribe();
+        var (snapshot2, subscription2) = publisher.Subscribe();
+
+        Assert.Equal(2, snapshot1.Count);
+        Assert.Equal(2, snapshot2.Count);
+
+        await publisher.IntegrateAsync(c, ResourceChangeType.Upsert).ConfigureAwait(false);
+
+        var enumerator1 = subscription1.GetAsyncEnumerator(cts.Token);
+        var enumerator2 = subscription2.GetAsyncEnumerator(cts.Token);
+
+        await enumerator1.MoveNextAsync();
+        await enumerator2.MoveNextAsync();
+
+        Assert.Equal(ResourceChangeType.Upsert, enumerator1.Current.ChangeType);
+        Assert.Equal(ResourceChangeType.Upsert, enumerator2.Current.ChangeType);
+        Assert.Same(c, enumerator1.Current.Resource);
+        Assert.Same(c, enumerator2.Current.Resource);
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task MergesResourcesInSnapshot()
+    {
+        CancellationTokenSource cts = new();
+        ResourcePublisher publisher = new(cts.Token);
+
+        var a1 = CreateResource("A");
+        var a2 = CreateResource("A");
+        var a3 = CreateResource("A");
+
+        await publisher.IntegrateAsync(a1, ResourceChangeType.Upsert).ConfigureAwait(false);
+        await publisher.IntegrateAsync(a2, ResourceChangeType.Upsert).ConfigureAwait(false);
+        await publisher.IntegrateAsync(a3, ResourceChangeType.Upsert).ConfigureAwait(false);
+
+        var (snapshot, _) = publisher.Subscribe();
+
+        Assert.Same(a3, Assert.Single(snapshot));
+
+        await cts.CancelAsync();
+    }
+
+    [Fact]
+    public async Task DeletesRemoveFromSnapshot()
+    {
+        CancellationTokenSource cts = new();
+        ResourcePublisher publisher = new(cts.Token);
+
+        var a = CreateResource("A");
+        var b = CreateResource("B");
+
+        await publisher.IntegrateAsync(a, ResourceChangeType.Upsert).ConfigureAwait(false);
+        await publisher.IntegrateAsync(b, ResourceChangeType.Upsert).ConfigureAwait(false);
+        await publisher.IntegrateAsync(a, ResourceChangeType.Delete).ConfigureAwait(false);
+
+        var (snapshot, _) = publisher.Subscribe();
+
+        Assert.Same(b, Assert.Single(snapshot));
+
+        await cts.CancelAsync();
+    }
+
+    private static ContainerViewModel CreateResource(string name)
+    {
+        return new ContainerViewModel()
+        {
+            Name = name,
+            Uid = "",
+            State = "",
+            CreationTimeStamp = null,
+            DisplayName = "",
+            Endpoints = [],
+            Environment = [],
+            ExpectedEndpointsCount = null,
+            LogSource = null!,
+            Services = [],
+            Args = [],
+            Command = "",
+            ContainerId = "",
+            Image = "",
+            Ports = []
+        };
+    }
+}


### PR DESCRIPTION
We publish updates to resources via `IAsyncEnumerable<ResourceChange>`. The previous code defined a custom enumerable/enumerator for this, but it's possible to use a [generator function](https://learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/async-return-types#async-streams-with-iasyncenumerablet) instead and reduce the amount of code a bit.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1346)