### PR TITLE
Don't send no-op updates to the dashboard

### DIFF
--- a/src/Aspire.Dashboard/Model/EnvironmentVariableViewModel.cs
+++ b/src/Aspire.Dashboard/Model/EnvironmentVariableViewModel.cs
@@ -1,4 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace Aspire.Dashboard.Model;

--- a/src/Aspire.Hosting/Dashboard/ContainerSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ContainerSnapshot.cs
@@ -12,6 +12,8 @@ namespace Aspire.Hosting.Dashboard;
 /// </summary>
 internal sealed class ContainerSnapshot : ResourceSnapshot
 {
+    // IMPORTANT! Be sure to reflect any property changes here in the Equals and GetProperties methods below
+
     public override string ResourceType => KnownResourceTypes.Container;
 
     public required string? ContainerId { get; init; }
@@ -27,5 +29,17 @@ internal sealed class ContainerSnapshot : ResourceSnapshot
         yield return (KnownProperties.Container.Ports, Value.ForList(Ports.Select(port => Value.ForNumber(port)).ToArray()));
         yield return (KnownProperties.Container.Command, Command is null ? Value.ForNull() : Value.ForString(Command));
         yield return (KnownProperties.Container.Args, Args is null ? Value.ForNull() : Value.ForList(Args.Value.Select(port => Value.ForString(port)).ToArray()));
+    }
+
+    public override bool Equals(ResourceSnapshot? other)
+    {
+        return other is ContainerSnapshot container
+            && StringComparer.Ordinal.Equals(ContainerId, container.ContainerId)
+            && StringComparer.Ordinal.Equals(Image, container.Image)
+            && StringComparer.Ordinal.Equals(Command, container.Command)
+            && Ports.SequenceEqual(container.Ports)
+            && Args is null == container.Args is null
+            && (Args is null || Args.Value.SequenceEqual(container.Args!.Value))
+            && base.Equals(other);
     }
 }

--- a/src/Aspire.Hosting/Dashboard/ProjectSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ProjectSnapshot.cs
@@ -11,6 +11,8 @@ namespace Aspire.Hosting.Dashboard;
 /// </summary>
 internal class ProjectSnapshot : ExecutableSnapshot
 {
+    // IMPORTANT! Be sure to reflect any property changes here in the Equals and GetProperties methods below
+
     public override string ResourceType => KnownResourceTypes.Project;
 
     public required string ProjectPath { get; init; }
@@ -23,5 +25,12 @@ internal class ProjectSnapshot : ExecutableSnapshot
         {
             yield return pair;
         }
+    }
+
+    public override bool Equals(ResourceSnapshot? other)
+    {
+        return other is ProjectSnapshot project
+            && StringComparer.Ordinal.Equals(ProjectPath, project.ProjectPath)
+            && base.Equals(other);
     }
 }

--- a/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
@@ -70,6 +70,12 @@ internal sealed class ResourcePublisher(CancellationToken cancellationToken)
             switch (changeType)
             {
                 case ResourceSnapshotChangeType.Upsert:
+                    if (_snapshot.TryGetValue(resource.Name, out var existing) && existing.Equals(resource))
+                    {
+                        // The new value is identical to the prior one, so don't send it.
+                        return;
+                    }
+
                     _snapshot[resource.Name] = resource;
                     break;
 

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -4,12 +4,15 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Hosting.Dashboard;
 
-internal abstract class ResourceSnapshot
+internal abstract class ResourceSnapshot : IEquatable<ResourceSnapshot>
 {
+    // IMPORTANT! Be sure to reflect any property changes here in the Equals method and Properties property below
+
     public abstract string ResourceType { get; }
 
     public required string Name { get; init; }
@@ -43,24 +46,69 @@ internal abstract class ResourceSnapshot
             }
         }
     }
+
+    public virtual bool Equals(ResourceSnapshot? other)
+    {
+        return other is not null
+            && StringComparers.ResourceType.Equals(ResourceType, other.ResourceType)
+            && StringComparers.ResourceName.Equals(Name, other.Name)
+            && StringComparer.Ordinal.Equals(Uid, other.Uid)
+            && StringComparer.Ordinal.Equals(DisplayName, other.DisplayName)
+            && StringComparer.Ordinal.Equals(State, other.State)
+            && ExitCode == other.ExitCode
+            && CreationTimeStamp == other.CreationTimeStamp
+            && ExpectedEndpointsCount == other.ExpectedEndpointsCount
+            && Environment.SequenceEqual(other.Environment)
+            && Endpoints.SequenceEqual(other.Endpoints)
+            && Services.SequenceEqual(other.Services);
+    }
 }
 
-internal sealed class EnvironmentVariableSnapshot(string name, string? value, bool isFromSpec)
+internal sealed class EnvironmentVariableSnapshot(string name, string? value, bool isFromSpec) : IEquatable<EnvironmentVariableSnapshot>
 {
+    // IMPORTANT! Be sure to reflect any property changes here in the Equals method below
+
     public string Name { get; } = name;
     public string? Value { get; } = value;
     public bool IsFromSpec { get; } = isFromSpec;
+
+    public bool Equals(EnvironmentVariableSnapshot? other)
+    {
+        return other is not null
+            && StringComparer.Ordinal.Equals(Name, other.Name)
+            && StringComparer.Ordinal.Equals(Value, other.Value)
+            && IsFromSpec == other.IsFromSpec;
+    }
 }
 
-internal sealed record EndpointSnapshot(string endpointUrl, string proxyUrl)
+internal sealed class EndpointSnapshot(string endpointUrl, string proxyUrl) : IEquatable<EndpointSnapshot>
 {
+    // IMPORTANT! Be sure to reflect any property changes here in the Equals method below
+
     public string EndpointUrl { get; } = endpointUrl;
     public string ProxyUrl { get; } = proxyUrl;
+
+    public bool Equals(EndpointSnapshot? other)
+    {
+        return other is not null
+            && StringComparer.Ordinal.Equals(EndpointUrl, other.EndpointUrl)
+            && StringComparer.Ordinal.Equals(ProxyUrl, other.ProxyUrl);
+    }
 }
 
-internal sealed class ResourceServiceSnapshot(string name, string? allocatedAddress, int? allocatedPort)
+internal sealed class ResourceServiceSnapshot(string name, string? allocatedAddress, int? allocatedPort) : IEquatable<ResourceServiceSnapshot>
 {
+    // IMPORTANT! Be sure to reflect any property changes here in the Equals method below
+
     public string Name { get; } = name;
     public string? AllocatedAddress { get; } = allocatedAddress;
     public int? AllocatedPort { get; } = allocatedPort;
+
+    public bool Equals(ResourceServiceSnapshot? other)
+    {
+        return other is not null
+            && StringComparer.Ordinal.Equals(Name, other.Name)
+            && StringComparer.Ordinal.Equals(AllocatedAddress, other.AllocatedAddress)
+            && AllocatedPort == other.AllocatedPort;
+    }
 }


### PR DESCRIPTION
Avoids sending a resource update that has no actual changes compared to the last value sent.

This can happen because of how we process services/endpoints. When they are updated, we attempt to apply that updated data to existing DCP containers/executables. Sometimes this results in no actual difference, so we can drop these updates and avoid sending them over the wite and triggering UI refreshes.

As an example, when loading dashboard for the eShopLite sample solution, I see up to eight redundant updates that are now avoided.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1348)