### PR TITLE
Added support for adding connection strings to non-resources

### DIFF
--- a/src/Aspire.Hosting/Extensions/ConnectionString.cs
+++ b/src/Aspire.Hosting/Extensions/ConnectionString.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Represents a connection string.
+/// </summary>
+public readonly struct ConnectionString
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ConnectionString"/> with a name and value.
+    /// </summary>
+    /// <param name="name">The name of the connection string.</param>
+    /// <param name="value">The value of the connection string</param>
+    public ConnectionString(string name, string value)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(value);
+
+        Name = name;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ConnectionString"/> with a name.
+    /// </summary>
+    /// <param name="name"></param>
+    public ConnectionString(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        Name = name;
+        Value = null;
+    }
+
+    /// <summary>
+    /// The name of the connection string.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// The value of the connection string.
+    /// </summary>
+    public string? Value { get; }
+}

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -229,6 +229,38 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Injects a connection string as an environment variable. The format of the environment variable will be "ConnectionStrings__{name}={value}." If the
+    /// connection string is not specified, the configuration system will be queried for a connection string using the connection string name.
+    /// </summary>
+    /// <typeparam name="TDestination"></typeparam>
+    /// <param name="builder">The resource where connection string will be injected.</param>
+    /// <param name="connectionString">A connection string</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{TDestination}"/>.</returns>
+    public static IResourceBuilder<TDestination> WithReference<TDestination>(this IResourceBuilder<TDestination> builder, ConnectionString connectionString)
+        where TDestination : IResourceWithEnvironment
+    {
+        var connectionStringName = $"{ConnectionStringEnvironmentName}{connectionString.Name}";
+
+        return builder.WithEnvironment(context =>
+        {
+            var connectionStringValue = connectionString.Value ??
+                builder.ApplicationBuilder.Configuration.GetConnectionString(connectionString.Name);
+
+            if (string.IsNullOrEmpty(connectionStringValue))
+            {
+                throw new DistributedApplicationException($"A connection string for '{connectionString.Name}' could not be retrieved.");
+            }
+
+            if (builder.Resource is ContainerResource)
+            {
+                connectionStringValue = HostNameResolver.ReplaceLocalhostWithContainerHost(connectionStringValue, builder.ApplicationBuilder.Configuration);
+            }
+
+            context.EnvironmentVariables[connectionStringName] = connectionStringValue;
+        });
+    }
+
+    /// <summary>
     /// Injects service discovery information from the specified endpoint into the project resource using the source resource's name as the service name.
     /// Each service binding will be injected using the format "services__{sourceResourceName}__{bindingIndex}={bindingNameQualifiedUriString}."
     /// </summary>


### PR DESCRIPTION
- Adds a new ConnectionString type that lets users specify the connection string name and an optional value. If there's no value then lookup happens based on the connection string name via configuration.

Fixes https://github.com/dotnet/aspire/issues/1328
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1350)