### PR TITLE
Reduce CPU while polling for console log changes

### DIFF
--- a/src/Aspire.Hosting/Dashboard/FileLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/FileLogSource.cs
@@ -69,6 +69,16 @@ internal sealed class FileLogSource(string? stdOutPath, string? stdErrPath) : IL
 
                 if (result.IsCompleted)
                 {
+                    // There's no more data in the file. Because we are polling, we will loop
+                    // around again and land back here almost immediately. We introduce a small
+                    // sleep here in order to not burn CPU while polling. This sleep won't limit
+                    // the rate at which we can consume file changes when many exist, as the sleep
+                    // only occurs when we have caught up.
+                    //
+                    // Longer term we hope to have a log streaming API from DCP for this.
+                    // https://github.com/dotnet/aspire/issues/760
+                    await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+
                     break;
                 }
 


### PR DESCRIPTION
Fixes #760

The current implementation polls the file system for changes to stdout/stderr files on disk. This polling causes high CPU while logs are visible in the UI.

To reduce the problem, we introduce a small sleep that happens only when we are caught up with the contents of the file. The delay of 100ms is forever in computer time (i.e. it's a low duty cycle activity) while also being very fast for a human's perception.

Note that if logs start streaming in fast, we will not hit this sleep. It only occurs when we've read everything. If in the subsequent 100ms new logs arrive, they'll all be processed in the next iteration of the loop.

Longer term we hope to have a console log streaming API from DCP for this.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1354)