### PR TITLE
Ensure WithArgs can be used with executable resources

### DIFF
--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -87,7 +87,7 @@ public static class ContainerResourceBuilderExtensions
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
     /// <param name="args">The arguments to be passed to the container when it is started.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>    
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<T> WithArgs<T>(this IResourceBuilder<T> builder, params string[] args) where T : ContainerResource
     {
         var annotation = new ExecutableArgsCallbackAnnotation(updatedArgs =>

--- a/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
@@ -40,6 +40,22 @@ public static class ExecutableResourceBuilderExtensions
         return builder.WithManifestPublishingCallback(context => WriteExecutableAsDockerfileResource(context, builder.Resource));
     }
 
+    /// <summary>
+    /// Adds the arguments to be passed to a executable resource when the executable is started.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="args">The arguments to be passed to the executable when it is started.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithArgs<T>(this IResourceBuilder<T> builder, params string[] args) where T : ExecutableResource
+    {
+        var annotation = new ExecutableArgsCallbackAnnotation(updatedArgs =>
+        {
+            updatedArgs.AddRange(args);
+        });
+        return builder.WithAnnotation(annotation);
+    }
+
     private static void WriteExecutableAsDockerfileResource(ManifestPublishingContext context, ExecutableResource executable)
     {
         context.Writer.WriteString("type", "dockerfile.v0");

--- a/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
@@ -41,7 +41,7 @@ public static class ExecutableResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds the arguments to be passed to a executable resource when the executable is started.
+    /// Adds the arguments to be passed to an executable resource when the executable is started.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -132,6 +132,10 @@ public class ManifestPublisher(ILogger<ManifestPublisher> logger,
         context.Writer.WriteString("workingDirectory", relativePathToProjectFile);
 
         context.Writer.WriteString("command", executable.Command);
+
+        // TODO: This should be calling into any added ExecutableArgsCallbackAnnotation instances on the resource to allow them to
+        //       add additional arguments to the executable, as is done for containers in ManifestPublishingContext.WriteContainer.
+        //       See https://github.com/dotnet/aspire/issues/1362
         context.Writer.WriteStartArray("args");
 
         foreach (var arg in executable.Args ?? [])

--- a/tests/Aspire.Hosting.Tests/WithArgsTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithArgsTests.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class WithArgsTests
+{
+    [Fact]
+    public void WithArgsAddsAnnotationToExecutableResource()
+    {
+        var appBuilder = CreateBuilder();
+
+        appBuilder.AddExecutable("dotnet", "dotnet", Environment.CurrentDirectory)
+            .WithArgs("--version");
+
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var executableResources = appModel.GetExecutableResources();
+
+        var resource = Assert.Single(executableResources);
+
+        var annotations = resource.Annotations.OfType<ExecutableArgsCallbackAnnotation>();
+
+        Assert.NotNull(resource.Args);
+        Assert.Empty(resource.Args);
+
+        var argsList = resource.Args.ToList();
+
+        foreach (var annotation in annotations)
+        {
+            annotation.Callback(argsList);
+        }
+
+        Assert.Collection(argsList, arg => Assert.Equal("--version", arg));
+    }
+
+    [Fact]
+    public void WithArgsAddsAnnotationToContainerResource()
+    {
+        var appBuilder = CreateBuilder();
+
+        appBuilder.AddContainer("acontainer", "acontainer")
+            .WithArgs("anArg", "another", "oneMore");
+
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var containerResources = appModel.GetContainerResources();
+
+        var resource = Assert.Single(containerResources);
+
+        var annotations = resource.Annotations.OfType<ExecutableArgsCallbackAnnotation>();
+
+        var argsList = new List<string>();
+
+        foreach (var annotation in annotations)
+        {
+            annotation.Callback(argsList);
+        }
+
+        Assert.Collection(argsList,
+            arg => Assert.Equal("anArg", arg),
+            arg => Assert.Equal("another", arg),
+            arg => Assert.Equal("oneMore", arg));
+    }
+
+    private static IDistributedApplicationBuilder CreateBuilder()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder(["--publisher", "manifest"]);
+        // Block DCP from actually starting anything up as we don't need it for this test.
+        appBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>("manifest");
+
+        return appBuilder;
+    }
+}


### PR DESCRIPTION
This is follow up to https://github.com/dotnet/aspire/pull/1308 which incorrectly constrained `WithArgs` to `ContainerResource` resources only.

This needs to be backported to preview.2 also.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1363)