### PR TITLE
Replace note with comment in resx files

### DIFF
--- a/src/Aspire.Dashboard/Resources/Columns.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Columns.Designer.cs
@@ -79,7 +79,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Container ID: {0}.
         /// </summary>
         public static string ResourceNameDisplayContainerIdText {
             get {
@@ -97,7 +97,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Process ID: {0}.
         /// </summary>
         public static string ResourceNameDisplayProcessIdText {
             get {

--- a/src/Aspire.Dashboard/Resources/Columns.resx
+++ b/src/Aspire.Dashboard/Resources/Columns.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
 	<!--
 		Microsoft ResX Schema
@@ -106,14 +106,14 @@
   </data>
   <data name="ResourceNameDisplayProcessIdText" xml:space="preserve">
     <value>Process ID: {0}</value>
-    <note>{0} is a numeric id</note>
+    <comment>{0} is a numeric id</comment>
   </data>
   <data name="ResourceNameDisplayCopyContainerIdText" xml:space="preserve">
     <value>Copy Container ID to clipboard</value>
   </data>
   <data name="ResourceNameDisplayContainerIdText" xml:space="preserve">
     <value>Container ID: {0}</value>
-    <note>{0} is an alphanumeric id</note>
+    <comment>{0} is an alphanumeric id</comment>
   </data>
   <data name="SourceColumnDisplayWorkingDirectory" xml:space="preserve">
     <value>Working Dir: {0}</value>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -106,7 +106,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Show Spec Only.
         /// </summary>
         public static string EnvironmentVariablesFilterToggleShowSpecOnly {
             get {
@@ -178,7 +178,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Count.
         /// </summary>
         public static string PlotlyChartCount {
             get {
@@ -187,7 +187,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Length.
         /// </summary>
         public static string PlotlyChartLength {
             get {
@@ -196,7 +196,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Value.
         /// </summary>
         public static string PlotlyChartValue {
             get {
@@ -223,7 +223,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Duration &lt;strong&gt;{0}&lt;/strong&gt;.
         /// </summary>
         public static string SpanDetailsDuration {
             get {
@@ -232,7 +232,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Service &lt;strong&gt;{0}&lt;/strong&gt;.
         /// </summary>
         public static string SpanDetailsService {
             get {
@@ -241,7 +241,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Start Time &lt;strong&gt;{0}&lt;/strong&gt;.
         /// </summary>
         public static string SpanDetailsStartTime {
             get {
@@ -277,7 +277,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Total: &lt;strong&gt;{0} results found&lt;/strong&gt;.
         /// </summary>
         public static string TotalItemsFooterText {
             get {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -128,7 +128,7 @@
   </data>
   <data name="EnvironmentVariablesFilterToggleShowSpecOnly" xml:space="preserve">
     <value>Show Spec Only</value>
-    <note>Spec means from the resource specification</note>
+    <comment>Spec means from the resource specification</comment>
   </data>
   <data name="EnvironmentVariablesFilterToggleShowAll" xml:space="preserve">
     <value>Show All</value>
@@ -153,15 +153,15 @@
   </data>
   <data name="PlotlyChartCount" xml:space="preserve">
     <value>Count</value>
-    <note>Count is the name of a plot y-axis label</note>
+    <comment>Count is the name of a plot y-axis label</comment>
   </data>
   <data name="PlotlyChartLength" xml:space="preserve">
     <value>Length</value>
-    <note>Length is the name of a plot y-axis label</note>
+    <comment>Length is the name of a plot y-axis label</comment>
   </data>
   <data name="PlotlyChartValue" xml:space="preserve">
     <value>Value</value>
-    <note>Value is the name of a plot y-axis label</note>
+    <comment>Value is the name of a plot y-axis label</comment>
   </data>
   <data name="NameColumnHeader" xml:space="preserve">
     <value>Name</value>
@@ -171,15 +171,15 @@
   </data>
   <data name="SpanDetailsService" xml:space="preserve">
     <value>Service &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+    <comment>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
   </data>
   <data name="SpanDetailsDuration" xml:space="preserve">
     <value>Duration &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+    <comment>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
   </data>
   <data name="SpanDetailsStartTime" xml:space="preserve">
     <value>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+    <comment>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
   </data>
   <data name="ViewLogsLink" xml:space="preserve">
     <value>View Logs</value>
@@ -195,7 +195,7 @@
   </data>
   <data name="TotalItemsFooterText" xml:space="preserve">
     <value>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</value>
-    <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+    <comment>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
   </data>
   <data name="SelectAnApplication" xml:space="preserve">
     <value>Select an Application</value>

--- a/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Dialogs.Designer.cs
@@ -142,7 +142,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Version: {0}.
         /// </summary>
         public static string SettingsDialogVersion {
             get {

--- a/src/Aspire.Dashboard/Resources/Dialogs.resx
+++ b/src/Aspire.Dashboard/Resources/Dialogs.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -146,6 +146,6 @@
   </data>
   <data name="SettingsDialogVersion" xml:space="preserve">
     <value>Version: {0}</value>
-    <note>{0} is the dashboard version string</note>
+    <comment>{0} is the dashboard version string</comment>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
@@ -15,7 +15,7 @@
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="new">Container ID: {0}</target>
-        <note />
+        <note>{0} is an alphanumeric id</note>
       </trans-unit>
       <trans-unit id="ResourceNameDisplayCopyContainerIdText">
         <source>Copy Container ID to clipboard</source>
@@ -25,7 +25,7 @@
       <trans-unit id="ResourceNameDisplayProcessIdText">
         <source>Process ID: {0}</source>
         <target state="new">Process ID: {0}</target>
-        <note />
+        <note>{0} is a numeric id</note>
       </trans-unit>
       <trans-unit id="SourceColumnDisplayContainerArgsTitle">
         <source>Container args</source>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -35,7 +35,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show Spec Only</source>
         <target state="new">Show Spec Only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide Values</source>
@@ -70,17 +70,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -95,17 +95,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start Time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start Time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -135,7 +135,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.cs.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.de.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.es.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.fr.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.it.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ja.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ko.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pl.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.pt-BR.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.ru.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.tr.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hans.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Dialogs.zh-Hant.xlf
@@ -50,7 +50,7 @@
       <trans-unit id="SettingsDialogVersion">
         <source>Version: {0}</source>
         <target state="new">Version: {0}</target>
-        <note />
+        <note>{0} is the dashboard version string</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
`<note>` tags caused VS 2022 preview and VS 2022 int preview to remove values when editing resx files.

Some files already used `<comment>` so this makes resx consistent.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1374)