### PR TITLE
Revert "Include Executable WithArgs in manifest (#1366)"

### DIFF
--- a/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
@@ -40,22 +40,6 @@ public static class ExecutableResourceBuilderExtensions
         return builder.WithManifestPublishingCallback(context => WriteExecutableAsDockerfileResource(context, builder.Resource));
     }
 
-    /// <summary>
-    /// Adds the arguments to be passed to an executable resource when the executable is started.
-    /// </summary>
-    /// <typeparam name="T">The resource type.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="args">The arguments to be passed to the executable when it is started.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> WithArgs<T>(this IResourceBuilder<T> builder, params string[] args) where T : ExecutableResource
-    {
-        var annotation = new ExecutableArgsCallbackAnnotation(updatedArgs =>
-        {
-            updatedArgs.AddRange(args);
-        });
-        return builder.WithAnnotation(annotation);
-    }
-
     private static void WriteExecutableAsDockerfileResource(ManifestPublishingContext context, ExecutableResource executable)
     {
         context.Writer.WriteString("type", "dockerfile.v0");

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -132,26 +132,13 @@ public class ManifestPublisher(ILogger<ManifestPublisher> logger,
         context.Writer.WriteString("workingDirectory", relativePathToProjectFile);
 
         context.Writer.WriteString("command", executable.Command);
+        context.Writer.WriteStartArray("args");
 
-        var args = new List<string>(executable.Args ?? []);
-        if (executable.TryGetAnnotationsOfType<ExecutableArgsCallbackAnnotation>(out var argsCallback))
+        foreach (var arg in executable.Args ?? [])
         {
-            foreach (var callback in argsCallback)
-            {
-                callback.Callback(args);
-            }
+            context.Writer.WriteStringValue(arg);
         }
-
-        if (args.Count > 0)
-        {
-            context.Writer.WriteStartArray("args");
-
-            foreach (var arg in args)
-            {
-                context.Writer.WriteStringValue(arg);
-            }
-            context.Writer.WriteEndArray();
-        }
+        context.Writer.WriteEndArray();
 
         context.WriteEnvironmentVariables(executable);
         context.WriteBindings(executable);

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -103,65 +103,6 @@ public class ManifestGenerationTests
             arg => Assert.Equal("more", arg.GetString()));
     }
 
-    [Theory]
-    [InlineData(new string[] { "args1", "args2" }, new string[] { "withArgs1", "withArgs2" })]
-    [InlineData(new string[] { }, new string[] { "withArgs1", "withArgs2" })]
-    [InlineData(new string[] { "args1", "args2" }, new string[] { })]
-    public void EnsureExecutableWithArgsEmitsExecutableArgs(string[] addExecutableArgs, string[] withArgsArgs)
-    {
-        var program = CreateTestProgramJsonDocumentManifestPublisher();
-
-        var resourceBuilder = program.AppBuilder.AddExecutable("program", "run program", "c:/", addExecutableArgs);
-        if (withArgsArgs.Length > 0)
-        {
-            resourceBuilder.WithArgs(withArgsArgs);
-        }
-
-        // Build AppHost so that publisher can be resolved.
-        program.Build();
-        var publisher = program.GetManifestPublisher();
-
-        program.Run();
-
-        var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
-
-        var resource = resources.GetProperty("program");
-        var args = resource.GetProperty("args");
-        Assert.Equal(addExecutableArgs.Length + withArgsArgs.Length, args.GetArrayLength());
-
-        var verify = new List<Action<JsonElement>>();
-        foreach (var addExecutableArg in addExecutableArgs)
-        {
-            verify.Add(arg => Assert.Equal(addExecutableArg, arg.GetString()));
-        }
-        foreach (var withArgsArg in withArgsArgs)
-        {
-            verify.Add(arg => Assert.Equal(withArgsArg, arg.GetString()));
-        }
-
-        Assert.Collection(args.EnumerateArray(), [.. verify]);
-    }
-
-    [Fact]
-    public void ExecutableManifestNotIncludeArgsWhenEmpty()
-    {
-        var program = CreateTestProgramJsonDocumentManifestPublisher();
-
-        program.AppBuilder.AddExecutable("program", "run program", "c:/");
-
-        // Build AppHost so that publisher can be resolved.
-        program.Build();
-        var publisher = program.GetManifestPublisher();
-
-        program.Run();
-
-        var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
-
-        var resource = resources.GetProperty("program");
-        var exists = resource.TryGetProperty("args", out _);
-        Assert.False(exists);
-    }
-
     [Fact]
     public void EnsureAllRedisManifestTypesHaveVersion0Suffix()
     {


### PR DESCRIPTION
This reverts commit 0c3d01451c7e3a0f69bb166dce0e813615041f1c.

I think I rushed a little bit on solving this bug. (https://github.com/dotnet/aspire/issues/1362). The `WithArgs()` method mentioned in the issue was in another PR (https://github.com/dotnet/aspire/pull/1363) and I assumed it will be merged so I include the method in my own PR in order to be able to produce the bug and fix it. 

But now that that PR is closed, and my PR got merged, but it shouldn't since I've added `WithArgs()` the API which I shouldn't. 

> Closing this out after talking to @davidfowl. We don't need to expose this publicly for executables for now.

https://github.com/dotnet/aspire/pull/1363#issuecomment-1852847321



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1376)