### PR TITLE
Remember select resource in console logs

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/IMemoryPage.cs
+++ b/src/Aspire.Dashboard/Components/Pages/IMemoryPage.cs
@@ -8,6 +8,7 @@ namespace Aspire.Dashboard.Components.Pages;
 
 public interface IMemoryPage<in T>
 {
+    string MemoryKey { get; }
     ProtectedSessionStorage ProtectedSessionStore { get; set; }
     NavigationManager NavigationManager { get; set; }
 
@@ -16,5 +17,14 @@ public interface IMemoryPage<in T>
     public void NavigateTo(T state)
     {
         NavigationManager.NavigateTo(GetNavigationUrl(state));
+    }
+
+    public async Task NavigateToCurrentStateIfSetAsync()
+    {
+        var result = await ProtectedSessionStore.GetAsync<T>(MemoryKey);
+        if (result is { Success: true, Value: not null })
+        {
+            NavigateTo(result.Value);
+        }
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/IMemoryPage.cs
+++ b/src/Aspire.Dashboard/Components/Pages/IMemoryPage.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace Aspire.Dashboard.Components.Pages;
+
+public interface IMemoryPage<in T>
+{
+    ProtectedSessionStorage ProtectedSessionStore { get; set; }
+    NavigationManager NavigationManager { get; set; }
+
+    string GetNavigationUrl(T state);
+
+    public void NavigateTo(T state)
+    {
+        NavigationManager.NavigateTo(GetNavigationUrl(state));
+    }
+}

--- a/src/Aspire.Dashboard/Components/Pages/IMemoryPage.cs
+++ b/src/Aspire.Dashboard/Components/Pages/IMemoryPage.cs
@@ -9,8 +9,8 @@ namespace Aspire.Dashboard.Components.Pages;
 public interface IMemoryPage<in T>
 {
     string MemoryKey { get; }
-    ProtectedSessionStorage ProtectedSessionStore { get; set; }
-    NavigationManager NavigationManager { get; set; }
+    ProtectedSessionStorage ProtectedSessionStore { get; }
+    NavigationManager NavigationManager { get; }
 
     string GetNavigationUrl(T state);
 

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -27,6 +27,8 @@ public partial class Metrics : IDisposable, IMemoryPage<Metrics.MetricsSelectedS
     private OtlpMeter? _selectedMeter;
     private OtlpInstrument? _selectedInstrument;
 
+    public string MemoryKey => "Metrics_SelectState";
+
     [Parameter]
     public string? ApplicationInstanceId { get; set; }
 
@@ -119,7 +121,7 @@ public partial class Metrics : IDisposable, IMemoryPage<Metrics.MetricsSelectedS
         var state = new MetricsSelectedState { ApplicationId = _selectedApplication.Id, DurationMinutes = (int)_selectedDuration.Id.TotalMinutes };
 
         ((IMemoryPage<MetricsSelectedState>)this).NavigateTo(state);
-        await ProtectedSessionStore.SetAsync(MetricsSelectedState.Key, state);
+        await ProtectedSessionStore.SetAsync(MemoryKey, state);
     }
 
     private async Task HandleSelectedDurationChangedAsync()
@@ -127,12 +129,11 @@ public partial class Metrics : IDisposable, IMemoryPage<Metrics.MetricsSelectedS
         var state = new MetricsSelectedState { ApplicationId = _selectedApplication.Id, DurationMinutes = (int)_selectedDuration.Id.TotalMinutes, InstrumentName = InstrumentName, MeterName = MeterName };
 
         ((IMemoryPage<MetricsSelectedState>)this).NavigateTo(state);
-        await ProtectedSessionStore.SetAsync(MetricsSelectedState.Key, state);
+        await ProtectedSessionStore.SetAsync(MemoryKey, state);
     }
 
     public sealed class MetricsSelectedState
     {
-        public const string Key = "Metrics_SelectState";
         public string? ApplicationId { get; set; }
         public string? MeterName { get; set; }
         public string? InstrumentName { get; set; }
@@ -157,7 +158,7 @@ public partial class Metrics : IDisposable, IMemoryPage<Metrics.MetricsSelectedS
         }
 
         ((IMemoryPage<MetricsSelectedState>)this).NavigateTo(state);
-        await ProtectedSessionStore.SetAsync(MetricsSelectedState.Key, state);
+        await ProtectedSessionStore.SetAsync(MemoryKey, state);
     }
 
     public string GetNavigationUrl(MetricsSelectedState state)
@@ -214,11 +215,7 @@ public partial class Metrics : IDisposable, IMemoryPage<Metrics.MetricsSelectedS
     {
         if (firstRender)
         {
-            var result = await ProtectedSessionStore.GetAsync<MetricsSelectedState>(MetricsSelectedState.Key);
-            if (result is { Success: true, Value: not null })
-            {
-                ((IMemoryPage<MetricsSelectedState>)this).NavigateTo(result.Value);
-            }
+            await ((IMemoryPage<MetricsSelectedState>)this).NavigateToCurrentStateIfSetAsync();
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -7,7 +7,6 @@ using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.Extensions.Logging;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -41,9 +40,6 @@ public partial class StructuredLogs
 
     [Inject]
     public required IDialogService DialogService { get; set; }
-
-    [Inject]
-    public required ProtectedSessionStorage ProtectedSessionStore { get; set; }
 
     [Parameter]
     [SupplyParameterFromQuery]
@@ -300,14 +296,5 @@ public partial class StructuredLogs
         _applicationsSubscription?.Dispose();
         _logsSubscription?.Dispose();
         _filterCts?.Dispose();
-    }
-
-    private sealed class StructuredLogsSelectedState
-    {
-        public const string Key = "StructuredLogs_SelectState";
-        public required string ApplicationId { get; set; }
-        public required LogLevel? LogLevel { get; set; }
-        public required List<LogFilter> Filters { get; set; }
-        public required string FilterText { get; set; }
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -7,6 +7,7 @@ using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.Extensions.Logging;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -40,6 +41,9 @@ public partial class StructuredLogs
 
     [Inject]
     public required IDialogService DialogService { get; set; }
+
+    [Inject]
+    public required ProtectedSessionStorage ProtectedSessionStore { get; set; }
 
     [Parameter]
     [SupplyParameterFromQuery]
@@ -296,5 +300,14 @@ public partial class StructuredLogs
         _applicationsSubscription?.Dispose();
         _logsSubscription?.Dispose();
         _filterCts?.Dispose();
+    }
+
+    private sealed class StructuredLogsSelectedState
+    {
+        public const string Key = "StructuredLogs_SelectState";
+        public required string ApplicationId { get; set; }
+        public required LogLevel? LogLevel { get; set; }
+        public required List<LogFilter> Filters { get; set; }
+        public required string FilterText { get; set; }
     }
 }


### PR DESCRIPTION
Adds some memory to the console logs page to go back to the previous selected resource when navigating back. This also creates a common shape to pages with memory (`IMemoryPage`) in case we want to do this with additional ones.

![Animation](https://github.com/dotnet/aspire/assets/20359921/0cfee3d1-50da-4cd7-afd9-ff745aba8b5d)

Note: we could do this in Structured Logs and Traces, however this would be slightly more work as we do not currently persist filters in the URL. I would love thoughts on whether it's worth it.

Fixes #1261


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1379)