### PR TITLE
Change traces page duration progress bar to a ring icon

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -66,7 +66,11 @@
                 </TemplateColumn>
                 <TemplateColumn Title="@TraceDetailLoc[Dashboard.Resources.TraceDetail.TraceDetailDurationHeader]">
                     <div class="duration-container">
-                        <FluentProgressRing Class="duration-ring" Min="0" Max="@Convert.ToInt32(ViewModel.MaxDuration.TotalMilliseconds)" Value="@Convert.ToInt32(context.Duration.TotalMilliseconds)" />
+                        <FluentProgressRing Class="duration-ring"
+                                            Min="0"
+                                            Max="@Convert.ToInt32(ViewModel.MaxDuration.TotalMilliseconds)"
+                                            Value="@Convert.ToInt32(context.Duration.TotalMilliseconds)"
+                                            aria-label="@TraceDetailLoc[Dashboard.Resources.TraceDetail.TraceDetailDurationHeader]" />
                         <span class="trace-duration">
                             @DurationFormatter.FormatDuration(context.Duration)
                         </span>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -34,7 +34,7 @@
                       slot="end" />
     </FluentToolbar>
     <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
-        <FluentDataGrid Virtualize="true" RowStyle="@GetRowStyle" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.5fr 0.5fr">
+        <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr">
             <ChildContent>
                 <PropertyColumn Title="@StructuredLogsLoc[Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader]" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
                 <TemplateColumn Title="@ControlsStringsLoc[ControlsStrings.NameColumnHeader]" Tooltip="true" TooltipText="@((t) => $"{t.FullName}: {OtlpHelpers.ToShortenedId(t.TraceId)}")">
@@ -64,7 +64,27 @@
                         </MoreButtonTemplate>
                     </FluentOverflow>
                 </TemplateColumn>
-                <PropertyColumn Title="@TraceDetailLoc[Dashboard.Resources.TraceDetail.TraceDetailDurationHeader]" Property="@(context => DurationFormatter.FormatDuration(context.Duration))" />
+                <TemplateColumn Title="@TraceDetailLoc[Dashboard.Resources.TraceDetail.TraceDetailDurationHeader]">
+                    @{
+                        var percentage = 0.0;
+                        if (ViewModel.MaxDuration != TimeSpan.Zero)
+                        {
+                            percentage = context.Duration / ViewModel.MaxDuration * 100.0;
+                        }
+                    }
+
+                    <div style="display:flex;align-items:center;max-width:110px;">
+                        <svg class="trace-progress-ring" width="20" height="20" viewBox="0 0 20 20">
+                            <circle cx="10" cy="10" r="8" fill="none" stroke="var(--neutral-fill-input-alt-active)" stroke-width="4" />
+                            <circle class="progress-percent" style="--val: @percentage.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)" cx="10" cy="10" r="8" fill="none" stroke="var(--accent-fill-rest)" stroke-width="4" pathLength="100" />
+                        </svg>
+                        <span style="padding-left:10px;">
+                            @DurationFormatter.FormatDuration(context.Duration)
+                        </span>
+
+                    </div>
+                </TemplateColumn>
+
                 <TemplateColumn>
                     <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/Trace/{context.TraceId}")">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
                 </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -73,15 +73,15 @@
                         }
                     }
 
-                    <div style="display:flex;align-items:center;max-width:110px;">
+                    <div style="display:flex;align-items:center;">
                         <svg class="trace-progress-ring" width="20" height="20" viewBox="0 0 20 20">
                             <circle cx="10" cy="10" r="8" fill="none" stroke="var(--neutral-fill-input-alt-active)" stroke-width="4" />
                             <circle class="progress-percent" style="--val: @percentage.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)" cx="10" cy="10" r="8" fill="none" stroke="var(--accent-fill-rest)" stroke-width="4" pathLength="100" />
                         </svg>
+                        @* <FluentProgressRing Min="0" Max="@Convert.ToInt32(ViewModel.MaxDuration.TotalMilliseconds)" Value="@Convert.ToInt32(context.Duration.TotalMilliseconds)" style="width:20px;height:20px;" /> *@
                         <span style="padding-left:10px;">
                             @DurationFormatter.FormatDuration(context.Duration)
                         </span>
-
                     </div>
                 </TemplateColumn>
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -65,21 +65,9 @@
                     </FluentOverflow>
                 </TemplateColumn>
                 <TemplateColumn Title="@TraceDetailLoc[Dashboard.Resources.TraceDetail.TraceDetailDurationHeader]">
-                    @{
-                        var percentage = 0.0;
-                        if (ViewModel.MaxDuration != TimeSpan.Zero)
-                        {
-                            percentage = context.Duration / ViewModel.MaxDuration * 100.0;
-                        }
-                    }
-
-                    <div style="display:flex;align-items:center;">
-                        <svg class="trace-progress-ring" width="20" height="20" viewBox="0 0 20 20">
-                            <circle cx="10" cy="10" r="8" fill="none" stroke="var(--neutral-fill-input-alt-active)" stroke-width="4" />
-                            <circle class="progress-percent" style="--val: @percentage.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture)" cx="10" cy="10" r="8" fill="none" stroke="var(--accent-fill-rest)" stroke-width="4" pathLength="100" />
-                        </svg>
-                        @* <FluentProgressRing Min="0" Max="@Convert.ToInt32(ViewModel.MaxDuration.TotalMilliseconds)" Value="@Convert.ToInt32(context.Duration.TotalMilliseconds)" style="width:20px;height:20px;" /> *@
-                        <span style="padding-left:10px;">
+                    <div class="duration-container">
+                        <FluentProgressRing Class="duration-ring" Min="0" Max="@Convert.ToInt32(ViewModel.MaxDuration.TotalMilliseconds)" Value="@Convert.ToInt32(context.Duration.TotalMilliseconds)" />
+                        <span class="trace-duration">
                             @DurationFormatter.FormatDuration(context.Duration)
                         </span>
                     </div>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -39,17 +39,6 @@ public partial class Traces
     [Inject]
     public required IDialogService DialogService { get; set; }
 
-    private string GetRowStyle(OtlpTrace trace)
-    {
-        var percentage = 0.0;
-        if (ViewModel.MaxDuration != TimeSpan.Zero)
-        {
-            percentage = trace.Duration / ViewModel.MaxDuration * 100.0;
-        }
-
-        return string.Create(CultureInfo.InvariantCulture, $"background: linear-gradient(to right, var(--neutral-fill-input-alt-active) {percentage:0.##}%, transparent {percentage:0.##}%);");
-    }
-
     private string GetTooltip(IGrouping<OtlpApplication, OtlpSpan> applicationSpans)
     {
         var count = applicationSpans.Count();

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -49,11 +49,29 @@
     padding-bottom: calc(var(--design-unit) * 2px);
 }
 
-::deep .trace-progress-ring {
-    transform: rotate(-90deg);
+::deep fluent-progress-ring::part(background) {
+    stroke: var(--neutral-fill-input-alt-active);
+    stroke-width: 3px;
+    r: 6.5px;
 }
 
-::deep .progress-percent {
-    stroke-dasharray: 100;
-    stroke-dashoffset: calc(100 - var(--val));
+::deep fluent-progress-ring::part(determinate) {
+    transition: unset;
+    stroke-linecap: unset;
+    stroke-width: 3px;
+    r: 6.5px;
+}
+
+::deep .duration-container {
+    display: flex;
+    align-items: center;
+}
+
+::deep .duration-ring {
+    width: 20px;
+    height: 20px;
+}
+
+::deep .trace-duration {
+    padding-left: 10px;
 }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -51,15 +51,11 @@
 
 ::deep fluent-progress-ring::part(background) {
     stroke: var(--neutral-fill-input-alt-active);
-    stroke-width: 3px;
-    r: 6.5px;
 }
 
 ::deep fluent-progress-ring::part(determinate) {
     transition: unset;
     stroke-linecap: unset;
-    stroke-width: 3px;
-    r: 6.5px;
 }
 
 ::deep .duration-container {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -48,3 +48,12 @@
     grid-area: foot;
     padding-bottom: calc(var(--design-unit) * 2px);
 }
+
+::deep .trace-progress-ring {
+    transform: rotate(-90deg);
+}
+
+::deep .progress-percent {
+    stroke-dasharray: 100;
+    stroke-dashoffset: calc(100 - var(--val));
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/689

a11y requirements make the trace progress bar problematic. A potential replacement is to replace the progress bar with an icon.

Looks pretty good to me. Hopefully no a11y issues? 🙏 Has a benefit of being in the duration column so it's obvious what it's for. Some people either didn't notice the progress bar or didn't know what it meant.

Screenshot:
![image](https://github.com/dotnet/aspire/assets/303201/ed5b69d0-c3c3-405c-ac92-3392a55057af)

Thoughts?

The PR code is hacky. If we like this then I'll clean it up.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1387)