### PR TITLE
Reduce CI timeout

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -97,7 +97,7 @@ stages:
       jobs:
 
       - job: windows
-        timeoutInMinutes: 60
+        timeoutInMinutes: 30
 
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -130,7 +130,7 @@ stages:
 
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: linux
-          timeoutInMinutes: 60
+          timeoutInMinutes: 30
 
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
Successful CI runs take under 20 minutes. The timeout was increased from 30 to 60 because of test hangs, but this makes the hangs even worse because now it takes a full hour before the leg fails.

See https://github.com/dotnet/aspire/pull/842#issuecomment-1814911384
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1395)