### PR TITLE
Improve structured log exception experience

### DIFF
--- a/samples/eShopLite/BasketService/Repositories/RedisBasketRepository.cs
+++ b/samples/eShopLite/BasketService/Repositories/RedisBasketRepository.cs
@@ -41,6 +41,15 @@ public class RedisBasketRepository(ILogger<RedisBasketRepository> logger, IConne
 
     public async Task<CustomerBasket?> UpdateBasketAsync(CustomerBasket basket)
     {
+        try
+        {
+            throw new InvalidCastException("oh no");
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Oh no there was an exception");
+        }
+
         if (basket.BuyerId == null)
         {
             return null;

--- a/samples/eShopLite/BasketService/Repositories/RedisBasketRepository.cs
+++ b/samples/eShopLite/BasketService/Repositories/RedisBasketRepository.cs
@@ -41,15 +41,6 @@ public class RedisBasketRepository(ILogger<RedisBasketRepository> logger, IConne
 
     public async Task<CustomerBasket?> UpdateBasketAsync(CustomerBasket basket)
     {
-        try
-        {
-            throw new InvalidCastException("oh no");
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Oh no there was an exception");
-        }
-
         if (basket.BuyerId == null)
         {
             return null;

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -18,9 +18,16 @@
     }
     else
     {
-        <span class="cellText" title="@(ToolTip ?? Value)">
-            @(MaxDisplayLength.HasValue ? TrimLength(Value) : Value)
-        </span>
+        @if (IsMultilineValue is true && Value is not null)
+        {
+            <FluentTextArea Rows="@GetNumberOfLines(Value)" Resize="TextAreaResize.Both" Value="@Value" ReadOnly="true" />
+        }
+        else
+        {
+            <span class="cellText" title="@(ToolTip ?? Value)">
+                @(MaxDisplayLength.HasValue ? TrimLength(Value) : Value)
+            </span>
+        }
     }
     @if (EnableMasking)
     {
@@ -38,3 +45,8 @@
                   aria-label="@Loc[ControlsStrings.GridValueCopyToClipboard]" />
     <FluentTooltip Anchor="@_anchorId" Position="TooltipPosition.Top">@PreCopyToolTip</FluentTooltip>
 </div>
+
+@code {
+    [Parameter]
+    public bool? IsMultilineValue { get; set; }
+}

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
@@ -70,4 +70,9 @@ public partial class GridValue
 
         return text ?? "";
     }
+
+    private static int GetNumberOfLines(string value)
+    {
+        return value.Length - value.Replace("\n", "").Length + 1;
+    }
 }

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -13,7 +13,12 @@
     <TemplateColumn Title="@(ValueColumnTitle ?? Loc[ControlsStrings.PropertyGridValueColumnHeader])" Class="valueColumn" SortBy="@ValueSort" Sortable="@IsValueSortable">
         <GridValue Value="@ValueColumnValue(context)" HighlightText="@HighlightText"
                    EnableMasking="@EnableValueMasking" IsMasked="@GetIsItemMasked(context)"
-                   IsMaskedChanged="(newValue) => OnIsMaskedChanged(context, newValue)" />
+                   IsMaskedChanged="(newValue) => OnIsMaskedChanged(context, newValue)"
+                   IsMultilineValue="@(NameColumnValue(context) is { } name && MultilineProperties?.Contains(name) is true)"/>
     </TemplateColumn>
 </FluentDataGrid>
 
+@code {
+    [Parameter]
+    public List<string>? MultilineProperties { get; set; }
+}

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
@@ -20,6 +20,7 @@
                       ValueColumnValue="(vm) => vm.Value"
                       NameSort="_nameSort"
                       ValueSort="_valueSort"
-                      HighlightText="@_filter" />
+                      HighlightText="@_filter"
+                      MultilineProperties="@(new List<string> { "exception.stacktrace" })"/>
     </div>
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -72,16 +72,23 @@
                             <TemplateColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader]">
                                 @if (context.Severity is LogLevel.Error or LogLevel.Critical)
                                 {
-                                    <FluentIcon Id="@GetDomIconId(context)" Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="logs-severity-icon" />
-                                    <FluentTooltip Anchor="@GetDomIconId(context)">
-                                        @GetFirstLineOfExceptionMessage(context.Message)
-                                    </FluentTooltip>
+
+                                    <FluentButton IconEnd="@(new Icons.Filled.Size16.ErrorCircle().WithColor(Color.Error))"
+                                                  Title="@GetFirstLineOfExceptionMessage(context.Message)"
+                                                  Appearance="Appearance.Stealth"
+                                                  Class="logs-severity-icon"
+                                                  OnClick="@(() => OnShowProperties(context))"
+                                                  Id="@GetDomIconId(context)">@context.Severity</FluentButton>
                                 }
                                 else if (context.Severity is LogLevel.Warning)
                                 {
                                     <FluentIcon Icon="Icons.Filled.Size16.Warning" Color="Color.Warning" Class="logs-severity-icon" />
+                                    @context.Severity
                                 }
-                                @context.Severity
+                                else
+                                {
+                                    @context.Severity
+                                }
                             </TemplateColumn>
                             <PropertyColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader]" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" Tooltip="true" />
                             <TemplateColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader]" Tooltip="true" TooltipText="(e) => e.Message">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -72,7 +72,10 @@
                             <TemplateColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader]">
                                 @if (context.Severity is LogLevel.Error or LogLevel.Critical)
                                 {
-                                    <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="logs-severity-icon" />
+                                    <FluentIcon Id="@GetDomIconId(context)" Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="logs-severity-icon" />
+                                    <FluentTooltip Anchor="@GetDomIconId(context)">
+                                        @GetFirstLineOfExceptionMessage(context.Message)
+                                    </FluentTooltip>
                                 }
                                 else if (context.Severity is LogLevel.Warning)
                                 {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -278,6 +278,22 @@ public partial class StructuredLogs
         }
     }
 
+    private static string GetDomIconId(OtlpLogEntry logEntry)
+    {
+        return $"log-{logEntry.GetHashCode()}";
+    }
+
+    private static string GetFirstLineOfExceptionMessage(string fullMessage)
+    {
+        var firstIndexOfNewline = fullMessage.IndexOf("\r\n", StringComparison.Ordinal);
+        if (firstIndexOfNewline == -1)
+        {
+            firstIndexOfNewline = fullMessage.IndexOf("\n", StringComparison.Ordinal);
+        }
+
+        return firstIndexOfNewline == -1 ? fullMessage : fullMessage[..firstIndexOfNewline];
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (_applicationChanged)

--- a/src/Aspire.Dashboard/Extensions/StringExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/StringExtensions.cs
@@ -2,11 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using System.Web;
 
 namespace Aspire.Dashboard.Extensions;
 
 internal static class StringExtensions
 {
+    public static string WithUriQueryParameter(this string uri, string key, string value)
+    {
+        var uriBuilder = new UriBuilder(uri);
+        var query = HttpUtility.ParseQueryString(uriBuilder.Query);
+        query[key] = value;
+        uriBuilder.Query = query.ToString();
+        return uriBuilder.ToString();
+    }
+
     /// <summary>
     /// Shortens a string by replacing the middle with an ellipsis.
     /// </summary>


### PR DESCRIPTION
This fixes #1177

- First, display preview of primary error when hovering over the error button as a tooltip
- Second, change the error icon to a fluent button, as users would not know otherwise that this is an actionable element (see below for inline view with other log types)
![image](https://github.com/dotnet/aspire/assets/20359921/d2a58498-64e1-4655-9463-f0e762283821)
- Third, allows grid values to be specified as multiline. I'm assuming exception.stacktrace is a fairly safe bet to signify as multiline. We might also want to have a button to allow users to toggle between multiline and single-line view for properties. 
- Fourth, adds the log entry to the URI so that users can navigate directly to a structured log preview. I'm assuming `TraceId + SpanId` is a unique identifier for a log and `SpanId` is only unique within a trace, but would love for that to be confirmed.
- 
![Animation](https://github.com/dotnet/aspire/assets/20359921/41ddff09-0765-4994-82cc-ead78e39739e)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1396)