### PR TITLE
Fix endpoint sorting issue

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -9,7 +9,7 @@
     else
     {
         @* If we have any, regardless of the state, go ahead and display them *@
-        foreach (var endpoint in Resource.Endpoints.OrderBy(e => e))
+        foreach (var endpoint in Resource.Endpoints.OrderBy(e => e.ProxyUrl))
         {
             if (HasMultipleReplicas)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1400

`ResourceViewModel.Endpoints` was changed in #1344 from a `List<string>` to a `List<EndpointViewModel>` and in doing so, it changed what `.Endpoints.OrderBy(e => e)` meant in this line of code. Since `EndpointViewModel`s aren't IComparable (or anything similar), it can't sort them. 

Quick fix to just change the `OrderBy` to use the `EndpointViewModel.ProxyUrl` instead
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1398)