### PR TITLE
Successfully copying changes the icon to a tick

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -34,9 +34,11 @@
     }
     <FluentButton Appearance="Appearance.Lightweight"
                   Id="@_anchorId"
-                  IconEnd="@(new Icons.Regular.Size16.Copy())"
                   Class="defaultHidden"
-                  @onclick="@(() => CopyTextToClipboardAsync(ValueToCopy ?? Value, @_anchorId))"
-                  aria-label="@Loc[ControlsStrings.GridValueCopyToClipboard]" />
+                  @onclick="@(() => CopyTextToClipboardAsync(ValueToCopy ?? Value, _anchorId))"
+                  aria-label="@Loc[ControlsStrings.GridValueCopyToClipboard]">
+        <FluentIcon Class="copy-icon" Style="display:inline;" Icon="Icons.Regular.Size16.Copy" />
+        <FluentIcon Class="checkmark-icon" Style="display:none;" Icon="Icons.Regular.Size16.Checkmark" />
+    </FluentButton>
     <FluentTooltip Anchor="@_anchorId" Position="TooltipPosition.Top">@PreCopyToolTip</FluentTooltip>
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -21,7 +21,3 @@
 ::deep:hover .defaultHidden {
     visibility: visible;
 }
-
-::deep .copy-checkmark {
-    display: none;
-}

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -21,3 +21,7 @@
 ::deep:hover .defaultHidden {
     visibility: visible;
 }
+
+::deep .copy-checkmark {
+    display: none;
+}

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -53,15 +53,24 @@ function isScrolledToBottom(container) {
 }
 
 window.copyTextToClipboard = function (id, text, precopy, postcopy) {
+    let button = document.querySelector(`#${id}`);
+    let copyIcon = button.querySelector('.copy-icon');
+    let checkmarkIcon = button.querySelector('.checkmark-icon');
     let tooltipDiv = document.querySelector('fluent-tooltip[anchor="' + id + '"]').children[0];
     navigator.clipboard.writeText(text)
         .then(() => {
             tooltipDiv.innerText = postcopy;
+            copyIcon.style.display = 'none';
+            checkmarkIcon.style.display = 'inline';
         })
         .catch(() => {
             tooltipDiv.innerText = 'Could not access clipboard';
         });
-    setTimeout(function () { tooltipDiv.innerText = precopy }, 1500);
+    setTimeout(function () {
+        tooltipDiv.innerText = precopy;
+        copyIcon.style.display = 'inline';
+        checkmarkIcon.style.display = 'none';
+    }, 1500);
 };
 
 window.updateFluentSelectDisplayValue = function (fluentSelect) {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -53,7 +53,7 @@ function isScrolledToBottom(container) {
 }
 
 window.copyTextToClipboard = function (id, text, precopy, postcopy) {
-    let button = document.querySelector(`#${id}`);
+    const button = document.querySelector(`#${id}`);
 
     // If there is a pending timeout then clear it. Otherwise the pending timeout will prematurely reset values.
     if (button.dataset.copyTimeout) {
@@ -61,9 +61,9 @@ window.copyTextToClipboard = function (id, text, precopy, postcopy) {
         delete button.dataset.copyTimeout;
     }
 
-    let copyIcon = button.querySelector('.copy-icon');
-    let checkmarkIcon = button.querySelector('.checkmark-icon');
-    let tooltipDiv = document.querySelector(`fluent-tooltip[anchor="${id}"]`).children[0];
+    const copyIcon = button.querySelector('.copy-icon');
+    const checkmarkIcon = button.querySelector('.checkmark-icon');
+    const tooltipDiv = document.querySelector(`fluent-tooltip[anchor="${id}"]`).children[0];
     navigator.clipboard.writeText(text)
         .then(() => {
             tooltipDiv.innerText = postcopy;

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -53,7 +53,7 @@ function isScrolledToBottom(container) {
 }
 
 window.copyTextToClipboard = function (id, text, precopy, postcopy) {
-    const button = document.querySelector(`#${id}`);
+    const button = document.getElementById(id);
 
     // If there is a pending timeout then clear it. Otherwise the pending timeout will prematurely reset values.
     if (button.dataset.copyTimeout) {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -54,9 +54,16 @@ function isScrolledToBottom(container) {
 
 window.copyTextToClipboard = function (id, text, precopy, postcopy) {
     let button = document.querySelector(`#${id}`);
+
+    // If there is a pending timeout then clear it. Otherwise the pending timeout will prematurely reset values.
+    if (button.dataset.copyTimeout) {
+        clearTimeout(button.dataset.copyTimeout);
+        delete button.dataset.copyTimeout;
+    }
+
     let copyIcon = button.querySelector('.copy-icon');
     let checkmarkIcon = button.querySelector('.checkmark-icon');
-    let tooltipDiv = document.querySelector('fluent-tooltip[anchor="' + id + '"]').children[0];
+    let tooltipDiv = document.querySelector(`fluent-tooltip[anchor="${id}"]`).children[0];
     navigator.clipboard.writeText(text)
         .then(() => {
             tooltipDiv.innerText = postcopy;
@@ -66,11 +73,13 @@ window.copyTextToClipboard = function (id, text, precopy, postcopy) {
         .catch(() => {
             tooltipDiv.innerText = 'Could not access clipboard';
         });
-    setTimeout(function () {
+
+    button.dataset.copyTimeout = setTimeout(function () {
         tooltipDiv.innerText = precopy;
         copyIcon.style.display = 'inline';
         checkmarkIcon.style.display = 'none';
-    }, 1500);
+        delete button.dataset.copyTimeout;
+   }, 1500);
 };
 
 window.updateFluentSelectDisplayValue = function (fluentSelect) {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1386

* Clicking on a copy icon temporarily changes it to a tick.
* Clear pending timeout if one exits on click. This fixes an issue where copy icon could be clicked multiple times in quick succession and the reset function runs prematurely. e.g.
  1. Click copy button
  2. Wait 1.4 seconds
  3. Click again
  4. Tooltip and icon reset almost immediately.

![copy-button-tick-fix](https://github.com/dotnet/aspire/assets/303201/6ff1952e-ad37-42e0-ad0c-a3944d11d157)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1404)