### PR TITLE
Order span apps in trace view by first start time

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -44,7 +44,7 @@
                 <TemplateColumn Title="@Loc[Dashboard.Resources.Traces.TracesSpansColumnHeader]">
                     <FluentOverflow>
                         <ChildContent>
-                            @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Key.ApplicationName))
+                            @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Min(s => s.StartTime)))
                             {
                                 <FluentOverflowItem @key=item>
                                     <span class="trace-tag trace-service-tag" title="@(GetTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(item.Key)));">


### PR DESCRIPTION
Order in traces view:
![image](https://github.com/dotnet/aspire/assets/303201/d341cc49-97b7-4977-b65d-01b22dbe7a88)

The selected trace above in details view. Note the order of spans matches the order in traces view:
![image](https://github.com/dotnet/aspire/assets/303201/976bd0b1-e3d3-4249-a979-710cce43fbd4)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1407)