### PR TITLE
Fix replica id trimming

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -422,11 +422,11 @@ internal sealed class DcpDataSource
         );
         if (replicaSetOwner is not null && displayName.Length > 3)
         {
-            var nameParts = displayName.Split('-');
-            if (nameParts.Length == 2 && nameParts[0].Length > 0 && nameParts[1].Length > 0)
+            var lastHyphenIndex = displayName.LastIndexOf('-');
+            if (lastHyphenIndex > 0 && lastHyphenIndex < displayName.Length - 1)
             {
                 // Strip the replica ID from the name.
-                displayName = nameParts[0];
+                displayName = displayName[..lastHyphenIndex];
             }
         }
         return displayName;


### PR DESCRIPTION
Fixes #1408 for main

Old code assumed that there'd only be a hyphen if there was a replica id at the end, but names can have hyphens (and in fact eShop has them). Change it to just strip off the last hyphen and everything after it instead.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1409)