### PR TITLE
Split dashboard resource snapshots from view models

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -153,7 +153,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable
             {
                 var task = _logViewer.SetLogSourceAsync(
                     subscription,
-                    convertTimestampsFromUtc: _selectedResource is ContainerViewModel);
+                    convertTimestampsFromUtc: _selectedResource.ResourceType is "Container");
 
                 _initialisedSuccessfully = true;
                 _status = Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsWatchingLogs];
@@ -168,7 +168,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable
             else
             {
                 _initialisedSuccessfully = false;
-                _status = Loc[_selectedResource is ContainerViewModel
+                _status = Loc[_selectedResource.ResourceType is "Container"
                     ? Dashboard.Resources.ConsoleLogs.ConsoleLogsFailedToInitialize
                     : Dashboard.Resources.ConsoleLogs.ConsoleLogsLogsNotYetAvailable];
             }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -29,7 +29,7 @@ public partial class Resources : ComponentBase, IDisposable
     private readonly CancellationTokenSource _watchTaskCancellationTokenSource = new();
     private readonly Dictionary<string, ResourceViewModel> _resourcesMap = [];
     // TODO populate resource types from server data
-    private readonly ImmutableArray<string> _allResourceTypes = ["Project", "Executable", "Container"];
+    private readonly ImmutableArray<string> _allResourceTypes = [KnownResourceTypes.Project, KnownResourceTypes.Executable, KnownResourceTypes.Container];
     private readonly HashSet<string> _visibleResourceTypes;
     private string _filter = "";
     private bool _isTypeFilterVisible;

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -4,21 +4,21 @@
 
 <FluentStack Orientation="Orientation.Horizontal" VerticalAlignment="VerticalAlignment.Center">
     <span><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)" /></span>
-    @if (Resource is ContainerViewModel containerViewModel)
+    @if (Resource.TryGetContainerId(out var containerId))
     {
         <div class="subtext">
-            <GridValue Value="@containerViewModel.ContainerId"
+            <GridValue Value="@containerId"
                        MaxDisplayLength="8"
                        EnableHighlighting="false"
                        PreCopyToolTip="@Loc[Columns.ResourceNameDisplayCopyContainerIdText]"
-                       ToolTip="@string.Format(Loc[Columns.ResourceNameDisplayContainerIdText], containerViewModel.ContainerId)"/>
+                       ToolTip="@string.Format(Loc[Columns.ResourceNameDisplayContainerIdText], containerId)"/>
         </div>
     }
-    else if (Resource is ExecutableViewModel executableViewModel)
+    else if (Resource.TryGetProcessId(out int processId))
     {
         // NOTE projects are also executables, so this will handle both
-        var title = string.Format(Loc[Columns.ResourceNameDisplayProcessIdText], executableViewModel.ProcessId);
-        <span class="subtext" title="@title" aria-label="@title">@executableViewModel.ProcessId</span>
+        var title = string.Format(Loc[Columns.ResourceNameDisplayProcessIdText], processId);
+        <span class="subtext" title="@title" aria-label="@title">@processId</span>
     }
 </FluentStack>
 

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -3,65 +3,70 @@
 @using Aspire.Dashboard.Resources
 @inject IStringLocalizer<Columns> Loc
 
-@if (Resource is ProjectViewModel projectViewModel)
+@if (Resource.IsProject() && Resource.TryGetProjectPath(out var projectPath))
 {
     // NOTE projects are also executables, so we have to check for projects first
-    <GridValue Value="@Path.GetFileName(projectViewModel.ProjectPath)"
-               ValueToCopy="@projectViewModel.ProjectPath"
+    <GridValue Value="@Path.GetFileName(projectPath)"
+               ValueToCopy="@projectPath"
                EnableHighlighting="true"
                HighlightText="@FilterText"
                PreCopyToolTip="@Loc[Columns.SourceColumnSourceCopyFullPathToClipboard]"
-               ToolTip="@projectViewModel.ProjectPath" />
+               ToolTip="@projectPath" />
 }
-else if (Resource is ExecutableViewModel executableViewModel)
+else if (Resource.TryGetExecutablePath(out var executablePath) && Resource.TryGetWorkingDirectory(out var workingDirectory))
 {
-    var arguments = string.Join(" ", executableViewModel.Arguments ?? []);
-    var fullCommandLine = $"{executableViewModel.ExecutablePath} {arguments}";
+    Resource.TryGetExecutableArguments(out var arguments);
+    var argumentsString = arguments.IsDefaultOrEmpty ? "" : string.Join(" ", arguments);
+    var fullCommandLine = $"{executablePath} {argumentsString}";
 
-    <GridValue Value="@Path.GetFileName(executableViewModel.ExecutablePath)"
+    <GridValue Value="@Path.GetFileName(executablePath)"
                ValueToCopy="@fullCommandLine"
                EnableHighlighting="true"
                HighlightText="@FilterText"
                PreCopyToolTip="@Loc[Columns.SourceColumnSourceCopyFullPathToClipboard]"
-               ToolTip="@executableViewModel.ExecutablePath">
+               ToolTip="@executablePath">
         <ContentAfterValue>
-            <span class="subtext">@arguments</span>
+            <span class="subtext">@argumentsString</span>
         </ContentAfterValue>
     </GridValue>
 
-    <div class="ellipsis-overflow" title="@executableViewModel.WorkingDirectory" aria-label="@executableViewModel.WorkingDirectory">@string.Format(Loc[Columns.SourceColumnDisplayWorkingDirectory], executableViewModel.WorkingDirectory?.TrimMiddle(35))</div>
+    <div class="ellipsis-overflow" title="@workingDirectory" aria-label="@workingDirectory">@string.Format(Loc[Columns.SourceColumnDisplayWorkingDirectory], workingDirectory?.TrimMiddle(35))</div>
 }
-else if (Resource is ContainerViewModel containerViewModel)
+else if (Resource.TryGetContainerImage(out var containerImage) && Resource.TryGetContainerPorts(out var ports))
 {
-    var ports = string.Join("; ", containerViewModel.Ports);
-    <GridValue Value="@containerViewModel.Image"
+    var portsString = string.Join("; ", ports);
+    <GridValue Value="@containerImage"
                EnableHighlighting="true"
                HighlightText="@FilterText"
                PreCopyToolTip="@Loc[Columns.SourceColumnSourceCopyContainerToClipboard]"
-               ToolTip="@containerViewModel.Image">
+               ToolTip="@containerImage">
         <ContentAfterValue>
-           @if (containerViewModel.Ports.Length > 0)
+           @if (ports.Length > 0)
            {
                var title = string.Format(
-                   Loc[containerViewModel.Ports.Length == 1
+                   Loc[ports.Length == 1
                        ? Columns.SourceColumnDisplayPort
                        : Columns.SourceColumnDisplayPorts],
                    ports);
                    <span class="subtext" aria-label="@title">@title</span>
            }
         </ContentAfterValue>
-   </GridValue>
+    </GridValue>
     <FluentStack Orientation="Orientation.Horizontal">
-        @if (containerViewModel.Command is not null)
+        @if (Resource.TryGetContainerCommand(out var command))
         {
-            <div class="ellipsis-overflow" title="@Loc[Columns.SourceColumnDisplayContainerCommandTitle]" aria-label="@Loc[Columns.SourceColumnDisplayContainerCommandTitle]">@Loc[Columns.SourceColumnDisplayContainerCommand, containerViewModel.Command]</div>
+            <div class="ellipsis-overflow" title="@Loc[Columns.SourceColumnDisplayContainerCommandTitle]" aria-label="@Loc[Columns.SourceColumnDisplayContainerCommandTitle]">@Loc[Columns.SourceColumnDisplayContainerCommand, command]</div>
         }
-        @if (containerViewModel.Args is not null)
+        @if (Resource.TryGetContainerArgs(out var args))
         {
-            var args = string.Join(" ", containerViewModel.Args);
-            <div class="ellipsis-overflow" title="@Loc[Columns.SourceColumnDisplayContainerArgsTitle]" aria-label="@Loc[Columns.SourceColumnDisplayContainerArgsTitle]">@args</div>
+            var argsString = string.Join(" ", args);
+            <div class="ellipsis-overflow" title="@Loc[Columns.SourceColumnDisplayContainerArgsTitle]" aria-label="@Loc[Columns.SourceColumnDisplayContainerArgsTitle]">@argsString</div>
         }
     </FluentStack>
+}
+else
+{
+    // TODO we need to add support for arbitrary resource types. Until then, they'll just show an empty source column.
 }
 
 @code {

--- a/src/Aspire.Dashboard/Model/ContainerViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ContainerViewModel.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Aspire.Dashboard.Utils;
+using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Dashboard.Model;
 
@@ -22,5 +23,12 @@ public class ContainerViewModel : ResourceViewModel
     internal override bool MatchesFilter(string filter)
     {
         return base.MatchesFilter(filter) || Image.Contains(filter, StringComparisons.UserTextSearch);
+    }
+
+    protected override IEnumerable<(string Key, Value Value)> GetCustomData()
+    {
+        yield return (ResourceDataKeys.Container.Id, Value.ForString(ContainerId));
+        yield return (ResourceDataKeys.Container.Image, Value.ForString(Image));
+        yield return (ResourceDataKeys.Container.Ports, Value.ForList(Ports.Select(port => Value.ForNumber(port)).ToArray()));
     }
 }

--- a/src/Aspire.Dashboard/Model/ExecutableViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ExecutableViewModel.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Globalization;
+using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Dashboard.Model;
 
@@ -18,5 +20,14 @@ public class ExecutableViewModel : ResourceViewModel
     public required ImmutableArray<string>? Arguments { get; init; }
     public required string? StdOutFile { get; init; }
     public required string? StdErrFile { get; init; }
+
+    protected override IEnumerable<(string Key, Value Value)> GetCustomData()
+    {
+        yield return (ResourceDataKeys.Executable.Path, Value.ForString(ExecutablePath));
+        yield return (ResourceDataKeys.Executable.WorkDir, Value.ForString(WorkingDirectory));
+        yield return (ResourceDataKeys.Executable.Args, Arguments is null ? Value.ForNull() : Value.ForList(Arguments.Value.Select(arg => Value.ForString(arg)).ToArray()));
+        yield return (ResourceDataKeys.Executable.Pid, ProcessId is null ? Value.ForNull() : Value.ForString(ProcessId.Value.ToString("N", CultureInfo.InvariantCulture)));
+        // TODO decide whether to send StdOut/StdErr file paths or not, and what we could use them for in the client.
+    }
 }
 

--- a/src/Aspire.Dashboard/Model/IResourceService.cs
+++ b/src/Aspire.Dashboard/Model/IResourceService.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
+
 namespace Aspire.Dashboard.Model;
 
 /// <summary>
@@ -34,5 +36,5 @@ public interface IResourceService
 }
 
 public sealed record ResourceSubscription(
-    List<ResourceViewModel> Snapshot,
+    ImmutableArray<ResourceViewModel> InitialState,
     IAsyncEnumerable<ResourceChange> Subscription);

--- a/src/Aspire.Dashboard/Model/KnownResourceTypes.cs
+++ b/src/Aspire.Dashboard/Model/KnownResourceTypes.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+// TODO use these constants throughout
+public static class KnownResourceTypes
+{
+    public const string Executable = "Executable";
+    public const string Project = "Project";
+    public const string Container = "Container";
+}

--- a/src/Aspire.Dashboard/Model/ProjectViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ProjectViewModel.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Google.Protobuf.WellKnownTypes;
+
 namespace Aspire.Dashboard.Model;
 
 /// <summary>
@@ -11,4 +13,14 @@ public class ProjectViewModel : ExecutableViewModel
     public override string ResourceType => "Project";
 
     public required string ProjectPath { get; init; }
+
+    protected override IEnumerable<(string Key, Value Value)> GetCustomData()
+    {
+        yield return (ResourceDataKeys.Project.Path, Value.ForString(ProjectPath));
+
+        foreach (var pair in base.GetCustomData())
+        {
+            yield return pair;
+        }
+    }
 }

--- a/src/Aspire.Dashboard/Model/ResourceDataKeys.cs
+++ b/src/Aspire.Dashboard/Model/ResourceDataKeys.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public static class ResourceDataKeys
+{
+    public static class Resource
+    {
+        public const string Uid = "resource.uid";
+        public const string Name = "resource.name";
+        public const string Type = "resource.type";
+        public const string DisplayName = "resource.displayName";
+        public const string State = "resource.state";
+        public const string CreateTime = "resource.createTime";
+    }
+
+    public static class Container
+    {
+        public const string Id = "container.id";
+        public const string Image = "container.image";
+        public const string Ports = "container.ports";
+    }
+
+    public static class Executable
+    {
+        public const string Path = "executable.path";
+        public const string Pid = "executable.pid";
+        public const string WorkDir = "executable.workDir";
+        public const string Args = "executable.args";
+    }
+
+    public static class Project
+    {
+        public const string Path = "project.path";
+    }
+}

--- a/src/Aspire.Dashboard/Model/ResourceDataKeys.cs
+++ b/src/Aspire.Dashboard/Model/ResourceDataKeys.cs
@@ -20,6 +20,8 @@ public static class ResourceDataKeys
         public const string Id = "container.id";
         public const string Image = "container.image";
         public const string Ports = "container.ports";
+        public const string Command = "container.command";
+        public const string Args = "container.args";
     }
 
     public static class Executable

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using Aspire.Dashboard.Utils;
+using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Dashboard.Model;
 
@@ -44,6 +45,26 @@ public abstract class ResourceViewModel
     internal virtual bool MatchesFilter(string filter)
     {
         return Name.Contains(filter, StringComparisons.UserTextSearch);
+    }
+
+    protected abstract IEnumerable<(string Key, Value Value)> GetCustomData();
+
+    public IEnumerable<(string Key, Value Value)> Data
+    {
+        get
+        {
+            yield return (ResourceDataKeys.Resource.Uid, Value.ForString(Uid));
+            yield return (ResourceDataKeys.Resource.Name, Value.ForString(Name));
+            yield return (ResourceDataKeys.Resource.Type, Value.ForString(ResourceType));
+            yield return (ResourceDataKeys.Resource.DisplayName, Value.ForString(DisplayName));
+            yield return (ResourceDataKeys.Resource.State, Value.ForString(State));
+            yield return (ResourceDataKeys.Resource.CreateTime, CreationTimeStamp is null ? Value.ForNull() : Value.ForString(CreationTimeStamp.Value.ToString("O")));
+
+            foreach (var pair in GetCustomData())
+            {
+                yield return pair;
+            }
+        }
     }
 }
 

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -57,8 +57,6 @@ public sealed class ResourceServiceViewModel(string name, string? allocatedAddre
     public string AddressAndPort { get; } = $"{allocatedAddress}:{allocatedPort}";
 }
 
-// TODO move this to back end?
-// TODO model this in the proto
 public sealed record EndpointSnapshot(string EndpointUrl, string ProxyUrl);
 
 internal static class ResourceViewModelExtensions

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -1,28 +1,34 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Frozen;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Aspire.Dashboard.Utils;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Dashboard.Model;
 
-/// <summary>
-/// Base class for immutable snapshots of resource state at a point in time.
-/// </summary>
-public abstract class ResourceViewModel
+public sealed class ResourceViewModel
 {
     public required string Name { get; init; }
+    public required string ResourceType { get; init; }
     public required string DisplayName { get; init; }
     public required string Uid { get; init; }
     public required string? State { get; init; }
     public required DateTime? CreationTimeStamp { get; init; }
     public required ImmutableArray<EnvironmentVariableViewModel> Environment { get; init; }
-    public required ImmutableArray<EndpointViewModel> Endpoints { get; init; }
-    public required ImmutableArray<ResourceServiceSnapshot> Services { get; init; }
+    public required ImmutableArray<EndpointSnapshot> Endpoints { get; init; }
+    public required ImmutableArray<ResourceServiceViewModel> Services { get; init; }
     public required int? ExpectedEndpointsCount { get; init; }
+    public required FrozenDictionary<string, Value> CustomData { get; init; }
 
-    public abstract string ResourceType { get; }
+    internal bool MatchesFilter(string filter)
+    {
+        // TODO let ResourceType define the additional data values we include in searches
+        return Name.Contains(filter, StringComparisons.UserTextSearch);
+    }
 
     public static string GetResourceName(ResourceViewModel resource, IEnumerable<ResourceViewModel> allResources)
     {
@@ -41,34 +47,9 @@ public abstract class ResourceViewModel
 
         return resource.DisplayName;
     }
-
-    internal virtual bool MatchesFilter(string filter)
-    {
-        return Name.Contains(filter, StringComparisons.UserTextSearch);
-    }
-
-    protected abstract IEnumerable<(string Key, Value Value)> GetCustomData();
-
-    public IEnumerable<(string Key, Value Value)> Data
-    {
-        get
-        {
-            yield return (ResourceDataKeys.Resource.Uid, Value.ForString(Uid));
-            yield return (ResourceDataKeys.Resource.Name, Value.ForString(Name));
-            yield return (ResourceDataKeys.Resource.Type, Value.ForString(ResourceType));
-            yield return (ResourceDataKeys.Resource.DisplayName, Value.ForString(DisplayName));
-            yield return (ResourceDataKeys.Resource.State, Value.ForString(State));
-            yield return (ResourceDataKeys.Resource.CreateTime, CreationTimeStamp is null ? Value.ForNull() : Value.ForString(CreationTimeStamp.Value.ToString("O")));
-
-            foreach (var pair in GetCustomData())
-            {
-                yield return pair;
-            }
-        }
-    }
 }
 
-public sealed class ResourceServiceSnapshot(string name, string? allocatedAddress, int? allocatedPort)
+public sealed class ResourceServiceViewModel(string name, string? allocatedAddress, int? allocatedPort)
 {
     public string Name { get; } = name;
     public string? AllocatedAddress { get; } = allocatedAddress;
@@ -76,4 +57,187 @@ public sealed class ResourceServiceSnapshot(string name, string? allocatedAddres
     public string AddressAndPort { get; } = $"{allocatedAddress}:{allocatedPort}";
 }
 
-public sealed record EndpointViewModel(string EndpointUrl, string ProxyUrl);
+// TODO move this to back end?
+// TODO model this in the proto
+public sealed record EndpointSnapshot(string EndpointUrl, string ProxyUrl);
+
+internal static class ResourceViewModelExtensions
+{
+    public static bool IsContainer(this ResourceViewModel resource)
+    {
+        return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Container);
+    }
+
+    public static bool IsProject(this ResourceViewModel resource)
+    {
+        return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Container);
+    }
+
+    public static bool IsExecutable(this ResourceViewModel resource, bool allowSubtypes)
+    {
+        if (StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Container))
+        {
+            return true;
+        }
+
+        if (allowSubtypes)
+        {
+            return StringComparers.ResourceType.Equals(resource.ResourceType, KnownResourceTypes.Project);
+        }
+
+        return false;
+    }
+
+    public static bool TryGetContainerId(this ResourceViewModel resource, [NotNullWhen(returnValue: true)] out string? containerId)
+    {
+        return resource.TryGetCustomDataString(ResourceDataKeys.Container.Id, out containerId);
+    }
+
+    public static bool TryGetContainerImage(this ResourceViewModel resource, [NotNullWhen(returnValue: true)] out string? containerImage)
+    {
+        return resource.TryGetCustomDataString(ResourceDataKeys.Container.Image, out containerImage);
+    }
+
+    public static bool TryGetContainerPorts(this ResourceViewModel resource, out ImmutableArray<int> containerImage)
+    {
+        return resource.TryGetCustomDataIntArray(ResourceDataKeys.Container.Ports, out containerImage);
+    }
+
+    public static bool TryGetContainerCommand(this ResourceViewModel resource, [NotNullWhen(returnValue: true)] out string? command)
+    {
+        return resource.TryGetCustomDataString(ResourceDataKeys.Container.Command, out command);
+    }
+
+    public static bool TryGetContainerArgs(this ResourceViewModel resource, out ImmutableArray<string> args)
+    {
+        return resource.TryGetCustomDataStringArray(ResourceDataKeys.Container.Args, out args);
+    }
+
+    public static bool TryGetProcessId(this ResourceViewModel resource, out int processId)
+    {
+        return resource.TryGetCustomDataInt(ResourceDataKeys.Executable.Pid, out processId);
+    }
+
+    public static bool TryGetProjectPath(this ResourceViewModel resource, [NotNullWhen(returnValue: true)] out string? projectPath)
+    {
+        return resource.TryGetCustomDataString(ResourceDataKeys.Project.Path, out projectPath);
+    }
+
+    public static bool TryGetExecutablePath(this ResourceViewModel resource, [NotNullWhen(returnValue: true)] out string? executablePath)
+    {
+        return resource.TryGetCustomDataString(ResourceDataKeys.Executable.Path, out executablePath);
+    }
+
+    public static bool TryGetExecutableArguments(this ResourceViewModel resource, out ImmutableArray<string> arguments)
+    {
+        return resource.TryGetCustomDataStringArray(ResourceDataKeys.Executable.Args, out arguments);
+    }
+
+    public static bool TryGetWorkingDirectory(this ResourceViewModel resource, [NotNullWhen(returnValue: true)] out string? workingDirectory)
+    {
+        return resource.TryGetCustomDataString(ResourceDataKeys.Executable.WorkDir, out workingDirectory);
+    }
+
+    private static bool TryGetCustomDataString(this ResourceViewModel resource, string key, [NotNullWhen(returnValue: true)] out string? s)
+    {
+        if (resource.CustomData.TryGetValue(key, out var value) && value.TryConvertToString(out var valueString))
+        {
+            s = valueString;
+            return true;
+        }
+
+        s = null;
+        return false;
+    }
+
+    private static bool TryGetCustomDataStringArray(this ResourceViewModel resource, string key, out ImmutableArray<string> strings)
+    {
+        if (resource.CustomData.TryGetValue(key, out var value) && value.ListValue is not null)
+        {
+            var builder = ImmutableArray.CreateBuilder<string>(value.ListValue.Values.Count);
+
+            foreach (var element in value.ListValue.Values)
+            {
+                if (!element.TryConvertToString(out var elementString))
+                {
+                    strings = default;
+                    return false;
+                }
+
+                builder.Add(elementString);
+            }
+
+            strings = builder.MoveToImmutable();
+            return true;
+        }
+
+        strings = default;
+        return false;
+    }
+
+    private static bool TryGetCustomDataInt(this ResourceViewModel resource, string key, out int i)
+    {
+        if (resource.CustomData.TryGetValue(key, out var value) && value.TryConvertToInt(out i))
+        {
+            return true;
+        }
+
+        i = 0;
+        return false;
+    }
+
+    private static bool TryGetCustomDataIntArray(this ResourceViewModel resource, string key, out ImmutableArray<int> ints)
+    {
+        if (resource.CustomData.TryGetValue(key, out var value) && value.ListValue is not null)
+        {
+            var builder = ImmutableArray.CreateBuilder<int>(value.ListValue.Values.Count);
+
+            foreach (var element in value.ListValue.Values)
+            {
+                if (!element.TryConvertToInt(out var i))
+                {
+                    ints = default;
+                    return false;
+                }
+                builder.Add(i);
+            }
+
+            ints = builder.MoveToImmutable();
+            return true;
+        }
+
+        ints = default;
+        return false;
+    }
+}
+
+internal static class ValueExtensions
+{
+    public static bool TryConvertToInt(this Value value, out int i)
+    {
+        if (value.HasStringValue && int.TryParse(value.StringValue, CultureInfo.InvariantCulture, out i))
+        {
+            return true;
+        }
+        else if (value.HasNumberValue)
+        {
+            i = (int)Math.Round(value.NumberValue);
+            return true;
+        }
+
+        i = 0;
+        return false;
+    }
+
+    public static bool TryConvertToString(this Value value, [NotNullWhen(returnValue: true)] out string? s)
+    {
+        if (value.HasStringValue)
+        {
+            s = value.StringValue;
+            return true;
+        }
+
+        s = null;
+        return false;
+    }
+}

--- a/src/Aspire.Dashboard/Utils/StringComparers.cs
+++ b/src/Aspire.Dashboard/Utils/StringComparers.cs
@@ -6,11 +6,13 @@ namespace Aspire.Dashboard.Utils;
 internal static class StringComparers
 {
     public static StringComparer ResourceType => StringComparer.Ordinal;
+    public static StringComparer ResourceDataKey => StringComparer.Ordinal;
     public static StringComparer UserTextSearch => StringComparer.CurrentCultureIgnoreCase;
 }
 
 internal static class StringComparisons
 {
     public static StringComparison ResourceType => StringComparison.Ordinal;
+    public static StringComparison ResourceDataKey => StringComparison.Ordinal;
     public static StringComparison UserTextSearch => StringComparison.CurrentCultureIgnoreCase;
 }

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -14,6 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Aspire.Dashboard\Utils\StringComparers.cs" Link="Utils\StringComparers.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="KubernetesClient" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>

--- a/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Model;
-
 namespace Aspire.Hosting.Dashboard;
 
 internal sealed class ConsoleLogPublisher(ResourcePublisher resourcePublisher)
@@ -19,12 +17,12 @@ internal sealed class ConsoleLogPublisher(ResourcePublisher resourcePublisher)
         // Note, we would like to obtain these logs via DCP directly, rather than sourcing them in the dashboard.
         return resource switch
         {
-            ExecutableViewModel executable => SubscribeExecutable(executable),
-            ContainerViewModel container => SubscribeContainer(container),
+            ExecutableSnapshot executable => SubscribeExecutable(executable),
+            ContainerSnapshot container => SubscribeContainer(container),
             _ => throw new NotSupportedException($"Unsupported resource type {resource.GetType()}.")
         };
 
-        static FileLogSource? SubscribeExecutable(ExecutableViewModel executable)
+        static FileLogSource? SubscribeExecutable(ExecutableSnapshot executable)
         {
             if (executable.StdOutFile is null || executable.StdErrFile is null)
             {
@@ -34,7 +32,7 @@ internal sealed class ConsoleLogPublisher(ResourcePublisher resourcePublisher)
             return new FileLogSource(executable.StdOutFile, executable.StdErrFile);
         }
 
-        static DockerContainerLogSource? SubscribeContainer(ContainerViewModel container)
+        static DockerContainerLogSource? SubscribeContainer(ContainerSnapshot container)
         {
             if (container.ContainerId is null)
             {

--- a/src/Aspire.Hosting/Dashboard/ContainerSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ContainerSnapshot.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
-using Aspire.Dashboard.Utils;
+using Aspire.Dashboard.Model;
 using Google.Protobuf.WellKnownTypes;
 
-namespace Aspire.Dashboard.Model;
+namespace Aspire.Hosting.Dashboard;
 
 /// <summary>
-/// Immutable snapshot of container state at a point in time.
+/// Immutable snapshot of a container's state at a point in time.
 /// </summary>
-public class ContainerViewModel : ResourceViewModel
+public sealed class ContainerSnapshot : ResourceSnapshot
 {
-    public override string ResourceType => "Container";
+    public override string ResourceType => KnownResourceTypes.Container;
 
     public required string? ContainerId { get; init; }
     public required string Image { get; init; }
@@ -20,15 +20,12 @@ public class ContainerViewModel : ResourceViewModel
     public required string? Command { get; init; }
     public required ImmutableArray<string>? Args { get; init; }
 
-    internal override bool MatchesFilter(string filter)
-    {
-        return base.MatchesFilter(filter) || Image.Contains(filter, StringComparisons.UserTextSearch);
-    }
-
     protected override IEnumerable<(string Key, Value Value)> GetCustomData()
     {
         yield return (ResourceDataKeys.Container.Id, Value.ForString(ContainerId));
         yield return (ResourceDataKeys.Container.Image, Value.ForString(Image));
         yield return (ResourceDataKeys.Container.Ports, Value.ForList(Ports.Select(port => Value.ForNumber(port)).ToArray()));
+        yield return (ResourceDataKeys.Container.Command, Command is null ? Value.ForNull() : Value.ForString(Command));
+        yield return (ResourceDataKeys.Container.Args, Args is null ? Value.ForNull() : Value.ForList(Args.Value.Select(port => Value.ForString(port)).ToArray()));
     }
 }

--- a/src/Aspire.Hosting/Dashboard/EnvironmentVariableSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/EnvironmentVariableSnapshot.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Dashboard;
+
+public sealed class EnvironmentVariableSnapshot
+{
+    public required string Name { get; init; }
+    public required string? Value { get; init; }
+    public required bool FromSpec { get; init; }
+}

--- a/src/Aspire.Hosting/Dashboard/ExecutableSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ExecutableSnapshot.cs
@@ -3,16 +3,17 @@
 
 using System.Collections.Immutable;
 using System.Globalization;
+using Aspire.Dashboard.Model;
 using Google.Protobuf.WellKnownTypes;
 
-namespace Aspire.Dashboard.Model;
+namespace Aspire.Hosting.Dashboard;
 
 /// <summary>
-/// Immutable snapshot of executable state at a point in time.
+/// Immutable snapshot of an executable's state at a point in time.
 /// </summary>
-public class ExecutableViewModel : ResourceViewModel
+public class ExecutableSnapshot : ResourceSnapshot
 {
-    public override string ResourceType => "Executable";
+    public override string ResourceType => KnownResourceTypes.Executable;
 
     public required int? ProcessId { get; init; }
     public required string? ExecutablePath { get; init; }

--- a/src/Aspire.Hosting/Dashboard/ProjectSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ProjectSnapshot.cs
@@ -1,16 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Model;
 using Google.Protobuf.WellKnownTypes;
 
-namespace Aspire.Dashboard.Model;
+namespace Aspire.Hosting.Dashboard;
 
 /// <summary>
-/// Immutable snapshot of project state at a point in time.
+/// Immutable snapshot of a project's state at a point in time.
 /// </summary>
-public class ProjectViewModel : ExecutableViewModel
+public class ProjectSnapshot : ExecutableSnapshot
 {
-    public override string ResourceType => "Project";
+    public override string ResourceType => KnownResourceTypes.Project;
 
     public required string ProjectPath { get; init; }
 

--- a/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
@@ -1,10 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Channels;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
 
 namespace Aspire.Hosting.Dashboard;
 
@@ -16,10 +18,10 @@ namespace Aspire.Hosting.Dashboard;
 internal sealed class ResourcePublisher(CancellationToken cancellationToken)
 {
     private readonly object _syncLock = new();
-    private readonly Dictionary<string, ResourceViewModel> _snapshot = [];
+    private readonly Dictionary<string, ResourceSnapshot> _snapshot = [];
     private ImmutableHashSet<Channel<ResourceChange>> _outgoingChannels = [];
 
-    internal bool TryGetResource(string resourceName, [NotNullWhen(returnValue: true)] out ResourceViewModel? resource)
+    internal bool TryGetResource(string resourceName, [NotNullWhen(returnValue: true)] out ResourceSnapshot? resource)
     {
         lock (_syncLock)
         {
@@ -36,8 +38,15 @@ internal sealed class ResourcePublisher(CancellationToken cancellationToken)
 
             ImmutableInterlocked.Update(ref _outgoingChannels, static (set, channel) => set.Add(channel), channel);
 
+            var builder = ImmutableArray.CreateBuilder<ResourceViewModel>(_snapshot.Values.Count);
+
+            foreach (var (_, value) in _snapshot)
+            {
+                builder.Add(ToViewModel(value));
+            }
+
             return new ResourceSubscription(
-                Snapshot: _snapshot.Values.ToList(),
+                InitialState: builder.MoveToImmutable(),
                 Subscription: StreamUpdates());
 
             async IAsyncEnumerable<ResourceChange> StreamUpdates()
@@ -63,7 +72,7 @@ internal sealed class ResourcePublisher(CancellationToken cancellationToken)
     /// <param name="resource">The resource that was modified.</param>
     /// <param name="changeType">The change type (Added, Modified, Deleted).</param>
     /// <returns>A task that completes when the cache has been updated and all subscribers notified.</returns>
-    public async ValueTask IntegrateAsync(ResourceViewModel resource, ResourceChangeType changeType)
+    public async ValueTask IntegrateAsync(ResourceSnapshot resource, ResourceChangeType changeType)
     {
         lock (_syncLock)
         {
@@ -81,7 +90,29 @@ internal sealed class ResourcePublisher(CancellationToken cancellationToken)
 
         foreach (var channel in _outgoingChannels)
         {
-            await channel.Writer.WriteAsync(new(changeType, resource), cancellationToken).ConfigureAwait(false);
+            await channel.Writer.WriteAsync(new(changeType, ToViewModel(resource)), cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    private static ResourceViewModel ToViewModel(ResourceSnapshot snapshot)
+    {
+        // NOTE this is a temporary method -- ultimately, snapshots will be converted to gRPC messages,
+        // then on the other side those gRPC messages will be turned into ResourceViewModel objects, or
+        // maybe just used to update existing ones.
+
+        return new()
+        {
+            Name = snapshot.Name,
+            ResourceType = snapshot.ResourceType,
+            DisplayName = snapshot.DisplayName,
+            Uid = snapshot.Uid,
+            State = snapshot.State,
+            CreationTimeStamp = snapshot.CreationTimeStamp,
+            Environment = snapshot.Environment.Select(e => new EnvironmentVariableViewModel { Name = e.Name, Value = e.Value, FromSpec = e.FromSpec }).ToImmutableArray(),
+            Endpoints = snapshot.Endpoints,
+            Services = snapshot.Services.Select(s => new ResourceServiceViewModel(s.Name, s.AllocatedAddress, s.AllocatedPort)).ToImmutableArray(),
+            ExpectedEndpointsCount = snapshot.ExpectedEndpointsCount,
+            CustomData = snapshot.Data.ToFrozenDictionary(pair => pair.Key, pair => pair.Value, StringComparers.ResourceDataKey)
+        };
     }
 }

--- a/src/Aspire.Hosting/Dashboard/ResourceServiceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceServiceSnapshot.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Dashboard;
+
+public sealed class ResourceServiceSnapshot(string name, string? allocatedAddress, int? allocatedPort)
+{
+    public string Name { get; } = name;
+    public string? AllocatedAddress { get; } = allocatedAddress;
+    public int? AllocatedPort { get; } = allocatedPort;
+}

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Aspire.Dashboard.Model;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aspire.Hosting.Dashboard;
+
+public abstract class ResourceSnapshot
+{
+    public abstract string ResourceType { get; }
+
+    public required string Name { get; init; }
+    public required string DisplayName { get; init; }
+    public required string Uid { get; init; }
+    public required string? State { get; init; }
+    public required DateTime? CreationTimeStamp { get; init; }
+    public required ImmutableArray<EnvironmentVariableSnapshot> Environment { get; init; }
+    public required ImmutableArray<EndpointSnapshot> Endpoints { get; init; }
+    public required ImmutableArray<ResourceServiceSnapshot> Services { get; init; }
+    public required int? ExpectedEndpointsCount { get; init; }
+
+    protected abstract IEnumerable<(string Key, Value Value)> GetCustomData();
+
+    public IEnumerable<(string Key, Value Value)> Data
+    {
+        get
+        {
+            yield return (ResourceDataKeys.Resource.Uid, Value.ForString(Uid));
+            yield return (ResourceDataKeys.Resource.Name, Value.ForString(Name));
+            yield return (ResourceDataKeys.Resource.Type, Value.ForString(ResourceType));
+            yield return (ResourceDataKeys.Resource.DisplayName, Value.ForString(DisplayName));
+            yield return (ResourceDataKeys.Resource.State, Value.ForString(State));
+            yield return (ResourceDataKeys.Resource.CreateTime, CreationTimeStamp is null ? Value.ForNull() : Value.ForString(CreationTimeStamp.Value.ToString("O")));
+
+            foreach (var pair in GetCustomData())
+            {
+                yield return pair;
+            }
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -15,18 +15,18 @@ public class ResourcePublisherTests
         CancellationTokenSource cts = new();
         ResourcePublisher publisher = new(cts.Token);
 
-        var a = CreateResource("A");
-        var b = CreateResource("B");
-        var c = CreateResource("C");
+        var a = CreateResourceSnapshot("A");
+        var b = CreateResourceSnapshot("B");
+        var c = CreateResourceSnapshot("C");
 
         await publisher.IntegrateAsync(a, ResourceChangeType.Upsert).ConfigureAwait(false);
         await publisher.IntegrateAsync(b, ResourceChangeType.Upsert).ConfigureAwait(false);
 
         var (snapshot, subscription) = publisher.Subscribe();
 
-        Assert.Equal(2, snapshot.Count);
-        Assert.Contains(a, snapshot);
-        Assert.Contains(b, snapshot);
+        Assert.Equal(2, snapshot.Length);
+        Assert.Single(snapshot.Where(s => s.Name == "A"));
+        Assert.Single(snapshot.Where(s => s.Name == "B"));
 
         using AutoResetEvent sync = new(initialState: false);
         List<ResourceChange> changes = [];
@@ -59,9 +59,9 @@ public class ResourcePublisherTests
         CancellationTokenSource cts = new();
         ResourcePublisher publisher = new(cts.Token);
 
-        var a = CreateResource("A");
-        var b = CreateResource("B");
-        var c = CreateResource("C");
+        var a = CreateResourceSnapshot("A");
+        var b = CreateResourceSnapshot("B");
+        var c = CreateResourceSnapshot("C");
 
         await publisher.IntegrateAsync(a, ResourceChangeType.Upsert).ConfigureAwait(false);
         await publisher.IntegrateAsync(b, ResourceChangeType.Upsert).ConfigureAwait(false);
@@ -69,8 +69,8 @@ public class ResourcePublisherTests
         var (snapshot1, subscription1) = publisher.Subscribe();
         var (snapshot2, subscription2) = publisher.Subscribe();
 
-        Assert.Equal(2, snapshot1.Count);
-        Assert.Equal(2, snapshot2.Count);
+        Assert.Equal(2, snapshot1.Length);
+        Assert.Equal(2, snapshot2.Length);
 
         await publisher.IntegrateAsync(c, ResourceChangeType.Upsert).ConfigureAwait(false);
 
@@ -94,9 +94,9 @@ public class ResourcePublisherTests
         CancellationTokenSource cts = new();
         ResourcePublisher publisher = new(cts.Token);
 
-        var a1 = CreateResource("A");
-        var a2 = CreateResource("A");
-        var a3 = CreateResource("A");
+        var a1 = CreateResourceSnapshot("A");
+        var a2 = CreateResourceSnapshot("A");
+        var a3 = CreateResourceSnapshot("A");
 
         await publisher.IntegrateAsync(a1, ResourceChangeType.Upsert).ConfigureAwait(false);
         await publisher.IntegrateAsync(a2, ResourceChangeType.Upsert).ConfigureAwait(false);
@@ -104,7 +104,7 @@ public class ResourcePublisherTests
 
         var (snapshot, _) = publisher.Subscribe();
 
-        Assert.Same(a3, Assert.Single(snapshot));
+        Assert.Equal("A", Assert.Single(snapshot).Name);
 
         await cts.CancelAsync();
     }
@@ -115,8 +115,8 @@ public class ResourcePublisherTests
         CancellationTokenSource cts = new();
         ResourcePublisher publisher = new(cts.Token);
 
-        var a = CreateResource("A");
-        var b = CreateResource("B");
+        var a = CreateResourceSnapshot("A");
+        var b = CreateResourceSnapshot("B");
 
         await publisher.IntegrateAsync(a, ResourceChangeType.Upsert).ConfigureAwait(false);
         await publisher.IntegrateAsync(b, ResourceChangeType.Upsert).ConfigureAwait(false);
@@ -129,9 +129,9 @@ public class ResourcePublisherTests
         await cts.CancelAsync();
     }
 
-    private static ContainerViewModel CreateResource(string name)
+    private static ContainerSnapshot CreateResourceSnapshot(string name)
     {
-        return new ContainerViewModel()
+        return new ContainerSnapshot()
         {
             Name = name,
             Uid = "",

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -46,7 +46,7 @@ public class ResourcePublisherTests
 
         var change = Assert.Single(changes);
         Assert.Equal(ResourceChangeType.Upsert, change.ChangeType);
-        Assert.Same(c, change.Resource);
+        Assert.Equal("C", change.Resource.Name);
 
         await cts.CancelAsync();
 
@@ -82,8 +82,8 @@ public class ResourcePublisherTests
 
         Assert.Equal(ResourceChangeType.Upsert, enumerator1.Current.ChangeType);
         Assert.Equal(ResourceChangeType.Upsert, enumerator2.Current.ChangeType);
-        Assert.Same(c, enumerator1.Current.Resource);
-        Assert.Same(c, enumerator2.Current.Resource);
+        Assert.Equal("C", enumerator1.Current.Resource.Name);
+        Assert.Equal("C", enumerator2.Current.Resource.Name);
 
         await cts.CancelAsync();
     }
@@ -124,7 +124,7 @@ public class ResourcePublisherTests
 
         var (snapshot, _) = publisher.Subscribe();
 
-        Assert.Same(b, Assert.Single(snapshot));
+        Assert.Equal("B", Assert.Single(snapshot).Name);
 
         await cts.CancelAsync();
     }


### PR DESCRIPTION
We are moving towards removing `Aspire.Hosting`'s reference to `Aspire.Dashboard`. In this new model we will have different types on the back end and front end.

- DCP has its own types (e.g. `CustomResource`), which remain untouched, and exist only on the back end.
- `ResourceSnapshot` is a new abstract base class for `ContainerSnapshot`, `ExecutableSnapshot` and `ProjectSnapshot`. These are immutable, have no view-specific data, and will only be used on the back end. In the near future, these objects will be used to populate gRPC messages.
- `ResourceViewModel` remains, though only on the front end. It no longer has subclasses. We are designing the dashboard to support arbitrary resource types. In the near future, these objects will be constructed and updated in response to gRPC messages.

As the front end no longer has subclasses of `ResourceViewModel`, some of the hard-coded resource-specific logic has been changed to work on the additional data within a resource.

We also introduce a `KnownResourceTypes` static class with consts for known resource type names (e.g. "Container").







 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1415)