### PR TITLE
Support passing the endpoint env into containers

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -518,21 +518,17 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model,
                 var dcpContainerResource = (Container)cr.DcpResource;
                 var modelContainerResource = cr.ModelResource;
 
+                var config = new Dictionary<string, string>();
+
                 dcpContainerResource.Spec.Env = new();
 
                 if (modelContainerResource.TryGetEnvironmentVariables(out var containerEnvironmentVariables))
                 {
-                    var config = new Dictionary<string, string>();
                     var context = new EnvironmentCallbackContext("dcp", config);
 
                     foreach (var v in containerEnvironmentVariables)
                     {
                         v.Callback(context);
-                    }
-
-                    foreach (var kvp in config)
-                    {
-                        dcpContainerResource.Spec.Env.Add(new EnvVar { Name = kvp.Key, Value = kvp.Value });
                     }
                 }
 
@@ -566,7 +562,20 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model,
                         }
 
                         dcpContainerResource.Spec.Ports.Add(portSpec);
+
+                        var name = sp.Service.Metadata.Name;
+                        var envVar = sp.ServiceBindingAnnotation.EnvironmentVariable;
+
+                        if (envVar is not null)
+                        {
+                            config.Add(envVar, $"{{{{- portForServing \"{name}\" }}}}");
+                        }
                     }
+                }
+
+                foreach (var kvp in config)
+                {
+                    dcpContainerResource.Spec.Env.Add(new EnvVar { Name = kvp.Key, Value = kvp.Value });
                 }
 
                 if (modelContainerResource.TryGetAnnotationsOfType<ExecutableArgsCallbackAnnotation>(out var argsCallback))

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -399,17 +399,7 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model,
                             config["ASPNETCORE_URLS"] = string.Join(";", urls);
                         }
 
-                        // Inject environment variables for services produced by this executable.
-                        foreach (var serviceProduced in er.ServicesProduced)
-                        {
-                            var name = serviceProduced.Service.Metadata.Name;
-                            var envVar = serviceProduced.ServiceBindingAnnotation.EnvironmentVariable;
-
-                            if (envVar is not null)
-                            {
-                                config.Add(envVar, $"{{{{- portForServing \"{name}\" }}}}");
-                            }
-                        }
+                        InjectPortEnvVars(er, config);
                     }
                 }
 
@@ -452,18 +442,36 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model,
                     var url = sar.ServiceBindingAnnotation.UriScheme + "://localhost:{{- portForServing \"" + sar.Service.Metadata.Name + "\" -}}";
                     return url;
                 });
+
                 config.Add("ASPNETCORE_URLS", string.Join(";", urls));
             }
             else
             {
                 config.Add("ASPNETCORE_URLS", launchProfile.ApplicationUrl);
             }
+
+            InjectPortEnvVars(executableResource, config);
         }
 
         foreach (var envVar in launchProfile.EnvironmentVariables)
         {
             string value = Environment.ExpandEnvironmentVariables(envVar.Value);
             config[envVar.Key] = value;
+        }
+    }
+
+    private static void InjectPortEnvVars(AppResource executableResource, Dictionary<string, string> config)
+    {
+        // Inject environment variables for services produced by this executable.
+        foreach (var serviceProduced in executableResource.ServicesProduced)
+        {
+            var name = serviceProduced.Service.Metadata.Name;
+            var envVar = serviceProduced.ServiceBindingAnnotation.EnvironmentVariable;
+
+            if (envVar is not null)
+            {
+                config.Add(envVar, $"{{{{- portForServing \"{name}\" }}}}");
+            }
         }
     }
 

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -522,16 +522,6 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model,
 
                 dcpContainerResource.Spec.Env = new();
 
-                if (modelContainerResource.TryGetEnvironmentVariables(out var containerEnvironmentVariables))
-                {
-                    var context = new EnvironmentCallbackContext("dcp", config);
-
-                    foreach (var v in containerEnvironmentVariables)
-                    {
-                        v.Callback(context);
-                    }
-                }
-
                 if (cr.ServicesProduced.Count > 0)
                 {
                     dcpContainerResource.Spec.Ports = new();
@@ -570,6 +560,16 @@ internal sealed class ApplicationExecutor(DistributedApplicationModel model,
                         {
                             config.Add(envVar, $"{{{{- portForServing \"{name}\" }}}}");
                         }
+                    }
+                }
+
+                if (modelContainerResource.TryGetEnvironmentVariables(out var containerEnvironmentVariables))
+                {
+                    var context = new EnvironmentCallbackContext("dcp", config);
+
+                    foreach (var v in containerEnvironmentVariables)
+                    {
+                        v.Callback(context);
                     }
                 }
 

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -47,8 +47,9 @@ public static class ContainerResourceBuilderExtensions
     /// <param name="hostPort">The host machine port.</param>
     /// <param name="scheme">The scheme e.g http/https/amqp</param>
     /// <param name="name">The name of the binding.</param>
+    /// <param name="env">The name of the environment variable to inject.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> WithServiceBinding<T>(this IResourceBuilder<T> builder, int containerPort, int? hostPort = null, string? scheme = null, string? name = null) where T : IResource
+    public static IResourceBuilder<T> WithServiceBinding<T>(this IResourceBuilder<T> builder, int containerPort, int? hostPort = null, string? scheme = null, string? name = null, string? env = null) where T : IResource
     {
         if (builder.Resource.Annotations.OfType<ServiceBindingAnnotation>().Any(sb => sb.Name == name))
         {
@@ -60,7 +61,8 @@ public static class ContainerResourceBuilderExtensions
             uriScheme: scheme,
             name: name,
             port: hostPort,
-            containerPort: containerPort);
+            containerPort: containerPort,
+            env: env);
 
         return builder.WithAnnotation(annotation);
     }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Globalization;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Tests.Helpers;
+using k8s.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -259,6 +261,75 @@ public class DistributedApplicationTests
                 Assert.Equal("redis:latest", item.Spec.Image);
                 Assert.Equal(["redis-cli", "-h", "host.docker.internal", "-p", "9999", "MONITOR"], item.Spec.Args);
             });
+
+        await app.StopAsync();
+    }
+
+    [LocalOnlyFact("docker")]
+    public async Task SpecifyingEnvPortInServiceBindingFlowsToEnv()
+    {
+        var testProgram = CreateTestProgram(includeNodeApp: true);
+
+        testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
+
+        testProgram.ServiceABuilder
+            .WithServiceBinding(scheme: "http", name: "http0", env: "PORT0");
+
+        testProgram.AppBuilder.AddContainer("redis0", "redis")
+            .WithServiceBinding(containerPort: 6379, name: "tcp", env: "REDIS_PORT");
+
+        await using var app = testProgram.Build();
+
+        var kubernetes = app.Services.GetRequiredService<KubernetesService>();
+
+        await app.StartAsync();
+
+        async Task<T> GetResourceByNameAsync<T>(string resourceName, Func<T, bool> ready, CancellationToken cancellationToken) where T : CustomResource
+        {
+            await foreach (var (_, r) in kubernetes!.WatchAsync<T>(cancellationToken: cancellationToken))
+            {
+                var name = r.Name();
+
+                if ((name == resourceName || name.StartsWith(resourceName + "-", StringComparison.Ordinal)) && ready(r))
+                {
+                    return r;
+                }
+            }
+
+            throw new InvalidOperationException($"Resource {resourceName}, not ready");
+        }
+
+        using var cts = new CancellationTokenSource(Debugger.IsAttached ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(10));
+        var token = cts.Token;
+
+        var redisContainer = await GetResourceByNameAsync<Container>("redis0", r => r.Status?.EffectiveEnv is not null, token);
+        Assert.NotNull(redisContainer);
+
+        var serviceA = await GetResourceByNameAsync<Executable>("servicea", r => r.Status?.EffectiveEnv is not null, token);
+        Assert.NotNull(serviceA);
+
+        var nodeApp = await GetResourceByNameAsync<Executable>("nodeapp", r => r.Status?.EffectiveEnv is not null, token);
+        Assert.NotNull(nodeApp);
+
+        string? GetEnv(IEnumerable<EnvVar>? envVars, string name)
+        {
+            Assert.NotNull(envVars);
+            return Assert.Single(envVars.Where(e => e.Name == name)).Value;
+        };
+
+        Assert.Equal("redis:latest", redisContainer.Spec.Image);
+        Assert.Equal("{{- portForServing \"redis0\" }}", GetEnv(redisContainer.Spec.Env, "REDIS_PORT"));
+        Assert.Equal("6379", GetEnv(redisContainer.Status!.EffectiveEnv, "REDIS_PORT"));
+
+        Assert.Equal("{{- portForServing \"servicea_http0\" }}", GetEnv(serviceA.Spec.Env, "PORT0"));
+        var serviceAPortValue = GetEnv(serviceA.Status!.EffectiveEnv, "PORT0");
+        Assert.False(string.IsNullOrEmpty(serviceAPortValue));
+        Assert.NotEqual(0, int.Parse(serviceAPortValue, CultureInfo.InvariantCulture));
+
+        Assert.Equal("{{- portForServing \"nodeapp\" }}", GetEnv(nodeApp.Spec.Env, "PORT"));
+        var nodeAppPortValue = GetEnv(nodeApp.Status!.EffectiveEnv, "PORT");
+        Assert.False(string.IsNullOrEmpty(nodeAppPortValue));
+        Assert.NotEqual(0, int.Parse(nodeAppPortValue, CultureInfo.InvariantCulture));
 
         await app.StopAsync();
     }

--- a/tests/Aspire.Hosting.Tests/WithServiceBindingTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithServiceBindingTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -31,6 +32,28 @@ public class WithServiceBindingTests
         });
 
         Assert.Equal("Service binding with name 'mybinding' already exists", ex.Message);
+    }
+
+    [Fact]
+    public void CanAddServiceBindingWithContainerPortAndEnv()
+    {
+        var testProgram = CreateTestProgram();
+        testProgram.AppBuilder.AddExecutable("foo", "foo", ".")
+                              .WithServiceBinding(containerPort: 3001, scheme: "http", name: "mybinding", env: "PORT");
+
+        var app = testProgram.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var exeResources = appModel.GetExecutableResources();
+
+        var resource = Assert.Single(exeResources);
+        Assert.Equal("foo", resource.Name);
+        var serviceBindings = resource.Annotations.OfType<ServiceBindingAnnotation>().ToArray();
+        Assert.Single(serviceBindings);
+        Assert.Equal("mybinding", serviceBindings[0].Name);
+        Assert.Equal(3001, serviceBindings[0].ContainerPort);
+        Assert.Equal("http", serviceBindings[0].UriScheme);
+        Assert.Equal("PORT", serviceBindings[0].EnvironmentVariable);
     }
 
     private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithServiceBindingTests>(args);


### PR DESCRIPTION
This pull request includes various changes to improve the testing and functionality of the codebase. The most important changes include adding new test methods to verify the correct setup of service bindings with container ports and environment variables, and modifying the `ApplicationExecutor.cs` file to correctly inject environment variables for services produced by an executable resource.

Testing improvements:

* <a href="diffhunk://#diff-35a9d5fac987460007cf4938bb05c98d227d1d3f2e95d59087a8b60fe2568f1fR37-R58">`tests/Aspire.Hosting.Tests/WithServiceBindingTests.cs`</a>: Added a new test method to verify the correct addition of a service binding with a container port and environment variable.
* <a href="diffhunk://#diff-4af17e3376a4a26b4c6e09721a127087cae9306d3e4dd806ef76359e91a6c3e9R268-R336">`tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs`</a>: Added a new test method to verify that a specified environment variable is correctly set in a service binding.

Code functionality improvements:

* <a href="diffhunk://#diff-cdadf87bce531cd3d8c0bf20daab0e73f2befaabcac6da90f9ab5d9cfab9cda9R463-R477">`src/Aspire.Hosting/Dcp/ApplicationExecutor.cs`</a>: Added a new private method `InjectPortEnvVars` to inject environment variables for services produced by an executable resource. Modified `ApplyLaunchProfile` and `CreateExecutablesAsync` to call `InjectPortEnvVars` to ensure the environment variables are injected into the configuration dictionary. <a href="diffhunk://#diff-cdadf87bce531cd3d8c0bf20daab0e73f2befaabcac6da90f9ab5d9cfab9cda9R463-R477">[1]</a> <a href="diffhunk://#diff-cdadf87bce531cd3d8c0bf20daab0e73f2befaabcac6da90f9ab5d9cfab9cda9R445-R453">[2]</a> <a href="diffhunk://#diff-cdadf87bce531cd3d8c0bf20daab0e73f2befaabcac6da90f9ab5d9cfab9cda9L402-R402">[3]</a>

Configuration improvements:

* <a href="diffhunk://#diff-3ab0bf8f6bfe27862cac4d1067b22ba2d2b620c6bfb15d679aeade0130101670L63-R65">`src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs`</a>: Modified the `AddContainer` and `WithServiceBinding` extension methods to include an additional parameter for specifying the name of the environment variable to inject.


Fixes https://github.com/dotnet/aspire/issues/1430

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1432)