### PR TITLE
Add missing resources to ControlStrings.resx, use nameof for resource lookups

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
@@ -8,7 +8,7 @@
 
 @if (_instrument is null)
 {
-    <div>@Loc[nameof(ControlsStrings.ChartContainerUnableToDisplay)]</div>
+    <div>@Loc[ControlsStrings.ChartContainerUnableToDisplay]</div>
 }
 else
 {

--- a/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
@@ -8,7 +8,7 @@
 
 @if (_instrument is null)
 {
-    <div>@Loc[ControlsStrings.ChartContainerUnableToDisplay]</div>
+    <div>@Loc[nameof(ControlsStrings.ChartContainerUnableToDisplay)]</div>
 }
 else
 {
@@ -23,7 +23,7 @@ else
                 @if (_viewModel.DimensionFilters.Count > 0)
                 {
                     <div class="metrics-filters-section">
-                        <h5>@Loc[ControlsStrings.ChartContainerFiltersHeader]</h5>
+                        <h5>@Loc[nameof(ControlsStrings.ChartContainerFiltersHeader)]</h5>
                         <FluentDataGrid Items="@Queryable.AsQueryable(_viewModel.DimensionFilters)" GridTemplateColumns="200px 1fr auto" GenerateHeader="GenerateHeaderOption.None">
                             <ChildContent>
                                 <PropertyColumn Tooltip="true" TooltipText="@(c => c.Name)" Property="@(c => c.Name)" />
@@ -56,7 +56,7 @@ else
                                                   IconEnd="@(new Icons.Regular.Size20.Filter())"
                                                   Appearance="@(context.AreAllValuesSelected is true ? Appearance.Stealth : Appearance.Accent)"
                                                   @onclick="() => context.PopupVisible = !context.PopupVisible"
-                                                  aria-label="@(context.AreAllValuesSelected is true ? Loc[ControlsStrings.ChartContainerAllTags] : Loc[ControlsStrings.ChartContainerFilteredTags])" />
+                                                  aria-label="@(context.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.ChartContainerAllTags)] : Loc[nameof(ControlsStrings.ChartContainerFilteredTags)])" />
                                     <FluentPopover AnchorId="@($"typeFilterButton-{context.SanitizedHtmlId}")" @bind-Open="context.PopupVisible">
                                         <Header>@context.Name</Header>
                                         <Body>
@@ -84,9 +84,9 @@ else
                 @if (_instrument.Type == OtlpInstrumentType.Histogram)
                 {
                     <div class="metrics-filters-section">
-                        <h5>@Loc[ControlsStrings.ChartContainerOptionsHeader]</h5>
+                        <h5>@Loc[nameof(ControlsStrings.ChartContainerOptionsHeader)]</h5>
                         <div>
-                            <FluentSwitch Label="@Loc[ControlsStrings.ChartContainerShowCountLabel]" @bind-Value="_showCount" @bind-Value:after="ShowCountChanged" />
+                            <FluentSwitch Label="@Loc[nameof(ControlsStrings.ChartContainerShowCountLabel)]" @bind-Value="_showCount" @bind-Value:after="ShowCountChanged" />
                         </div>
                     </div>
                 }

--- a/src/Aspire.Dashboard/Components/Controls/EnvironmentVariables.razor
+++ b/src/Aspire.Dashboard/Components/Controls/EnvironmentVariables.razor
@@ -9,18 +9,18 @@
         {
             <FluentButton Appearance="Appearance.Lightweight"
                           IconEnd="@(_showAll ? _showSpecOnlyIcon : _showAllIcon)"
-                          Title="@(_showAll ? Loc[ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly] : ControlsStrings.EnvironmentVariablesFilterToggleShowAll)"
-                          aria-label="@(_showAll ? Loc[ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly] : ControlsStrings.EnvironmentVariablesFilterToggleShowAll)"
+                          Title="@(_showAll ? Loc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly)] : ControlsStrings.EnvironmentVariablesFilterToggleShowAll)"
+                          aria-label="@(_showAll ? Loc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly)] : ControlsStrings.EnvironmentVariablesFilterToggleShowAll)"
                           OnClick="() => _showAll = !_showAll"
                           slot="end" />
         }
         <FluentButton Appearance="Appearance.Lightweight"
                       IconEnd="@(_defaultMasked ? _unmaskIcon : _maskIcon)"
-                      Title="@(_defaultMasked ? Loc[ControlsStrings.EnvironmentVariablesShowVariableValues] : Loc[ControlsStrings.EnvironmentVariablesHideVariableValues])"
-                      aria-label="@(_defaultMasked ? Loc[ControlsStrings.EnvironmentVariablesShowVariableValues] : Loc[ControlsStrings.EnvironmentVariablesHideVariableValues])"
+                      Title="@(_defaultMasked ? Loc[nameof(ControlsStrings.EnvironmentVariablesShowVariableValues)] : Loc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)])"
+                      aria-label="@(_defaultMasked ? Loc[nameof(ControlsStrings.EnvironmentVariablesShowVariableValues)] : Loc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)])"
                       OnClick="ToggleMaskState"
                       slot="end" />
-        <FluentSearch Placeholder="@Loc[ControlsStrings.FilterPlaceholder]"
+        <FluentSearch Placeholder="@Loc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"
                       Autofocus="true"
                       @bind-Value="_filter"

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -28,15 +28,15 @@
     {
         <FluentButton Appearance="Appearance.Lightweight"
                       IconEnd="@(IsMasked ? _unmaskIcon : _maskIcon)"
-                      Title="@(IsMasked ? Loc[ControlsStrings.GridValueMaskShowValue] : Loc[ControlsStrings.GridValueMaskHideValue])"
+                      Title="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])"
                       OnClick="ToggleMaskStateAsync"
-                      aria-label="@(IsMasked ? Loc[ControlsStrings.GridValueMaskShowValue] : Loc[ControlsStrings.GridValueMaskHideValue])" />
+                      aria-label="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])" />
     }
     <FluentButton Appearance="Appearance.Lightweight"
                   Id="@_anchorId"
                   IconEnd="@(new Icons.Regular.Size16.Copy())"
                   Class="defaultHidden"
                   @onclick="@(() => CopyTextToClipboardAsync(ValueToCopy ?? Value, @_anchorId))"
-                  aria-label="@Loc[ControlsStrings.GridValueCopyToClipboard]" />
+                  aria-label="@Loc[nameof(ControlsStrings.GridValueCopyToClipboard)]" />
     <FluentTooltip Anchor="@_anchorId" Position="TooltipPosition.Top">@PreCopyToolTip</FluentTooltip>
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
@@ -459,15 +459,15 @@ public partial class PlotlyChart : ComponentBase
         // but have a descriptive name that lets us infer the unit.
         if (instrument.Name.EndsWith(".count"))
         {
-            return Loc[ControlsStrings.PlotlyChartCount];
+            return Loc[nameof(ControlsStrings.PlotlyChartCount)];
         }
         else if (instrument.Name.EndsWith(".length"))
         {
-            return Loc[ControlsStrings.PlotlyChartLength];
+            return Loc[nameof(ControlsStrings.PlotlyChartLength)];
         }
         else
         {
-            return Loc[ControlsStrings.PlotlyChartValue];
+            return Loc[nameof(ControlsStrings.PlotlyChartValue)];
         }
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -7,10 +7,10 @@
                 Style="width:100%"
                 GenerateHeader="GenerateHeaderOption.Sticky"
                 GridTemplateColumns="@GridTemplateColumns">
-    <TemplateColumn Title="@(NameColumnTitle ?? Loc[ControlsStrings.NameColumnHeader])" Class="nameColumn" SortBy="@NameSort" Sortable="@IsNameSortable">
+    <TemplateColumn Title="@(NameColumnTitle ?? Loc[nameof(ControlsStrings.NameColumnHeader)])" Class="nameColumn" SortBy="@NameSort" Sortable="@IsNameSortable">
         <GridValue Value="@NameColumnValue(context)" HighlightText="@HighlightText" />
     </TemplateColumn>
-    <TemplateColumn Title="@(ValueColumnTitle ?? Loc[ControlsStrings.PropertyGridValueColumnHeader])" Class="valueColumn" SortBy="@ValueSort" Sortable="@IsValueSortable">
+    <TemplateColumn Title="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])" Class="valueColumn" SortBy="@ValueSort" Sortable="@IsValueSortable">
         <GridValue Value="@ValueColumnValue(context)" HighlightText="@HighlightText"
                    EnableMasking="@EnableValueMasking" IsMasked="@GetIsItemMasked(context)"
                    IsMaskedChanged="(newValue) => OnIsMaskedChanged(context, newValue)" />

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -16,9 +16,9 @@
         <div>
             @((MarkupString)string.Format(ControlsStrings.SpanDetailsStartTime, DurationFormatter.FormatDuration(ViewModel.Span.StartTime - ViewModel.Span.Trace.FirstSpan.StartTime)))
         </div>
-        <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?spanId={ViewModel.Span.SpanId}")">@Loc[ControlsStrings.ViewLogsLink]</FluentAnchor>
+        <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?spanId={ViewModel.Span.SpanId}")">@Loc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-        <FluentSearch Placeholder="@Loc[ControlsStrings.FilterPlaceholder]"
+        <FluentSearch Placeholder="@Loc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"
                       Autofocus="true"
                       @bind-Value="_filter"

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
@@ -4,7 +4,7 @@
 
 <div class="structured-log-details-layout">
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <FluentSearch Placeholder="@Loc[ControlsStrings.FilterPlaceholder]"
+        <FluentSearch Placeholder="@Loc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"
                       Autofocus="true"
                       @bind-Value="_filter"

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -26,10 +26,10 @@
                         <FluentButton Appearance="Appearance.Stealth"
                                       IconEnd="@(Orientation == Orientation.Horizontal ? _splitHorizontalIcon : _splitVerticalIcon)"
                                       OnClick="HandleToggleOrientation"
-                                      Title="@(Orientation == Orientation.Horizontal ? Loc[ControlsStrings.SummaryDetailsViewSplitHorizontal] : Loc[ControlsStrings.SummaryDetailsViewSplitVertical])"
-                                      aria-label="@(Orientation == Orientation.Horizontal ? Loc[ControlsStrings.SummaryDetailsViewSplitHorizontal] : Loc[ControlsStrings.SummaryDetailsViewSplitVertical])" />
+                                      Title="@(Orientation == Orientation.Horizontal ? Loc[nameof(ControlsStrings.SummaryDetailsViewSplitHorizontal)] : Loc[nameof(ControlsStrings.SummaryDetailsViewSplitVertical)])"
+                                      aria-label="@(Orientation == Orientation.Horizontal ? Loc[nameof(ControlsStrings.SummaryDetailsViewSplitHorizontal)] : Loc[nameof(ControlsStrings.SummaryDetailsViewSplitVertical)])" />
                         <FluentButton Appearance="Appearance.Stealth" IconEnd="@(new Icons.Regular.Size16.Dismiss())"
-                                      OnClick="HandleDismissAsync" Title="@Loc[ControlsStrings.SummaryDetailsViewCloseView]" aria-label="@Loc[ControlsStrings.SummaryDetailsViewCloseView]" />
+                                      OnClick="HandleDismissAsync" Title="@Loc[nameof(ControlsStrings.SummaryDetailsViewCloseView)]" aria-label="@Loc[nameof(ControlsStrings.SummaryDetailsViewCloseView)]" />
                     </div>
                 </header>
                 @Details

--- a/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TotalItemsFooter.razor
@@ -2,7 +2,7 @@
 @namespace Aspire.Dashboard.Components
 @inject IStringLocalizer<ControlsStrings> Loc
 
-<div class="total-items-footer">@((MarkupString)string.Format(Loc[ControlsStrings.TotalItemsFooterText], _totalItemCount))</div>
+<div class="total-items-footer">@((MarkupString)string.Format(Loc[nameof(ControlsStrings.TotalItemsFooterText)], _totalItemCount))</div>
 
 @code {
     private int _totalItemCount;

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -10,19 +10,19 @@
     <DataAnnotationsValidator />
 
     <FluentStack Orientation="Orientation.Vertical" VerticalGap="8">
-        <FluentCombobox Placeholder="@Loc[Dialogs.FilterDialogFieldPlaceholder]" Items=@Parameters @bind-Value="@_formModel.Parameter" Width="100%" Height="500px" />
+        <FluentCombobox Placeholder="@Loc[nameof(Dialogs.FilterDialogFieldPlaceholder)]" Items=@Parameters @bind-Value="@_formModel.Parameter" Width="100%" Height="500px" />
 
         <FluentSelect TOption="SelectViewModel<FilterCondition>" Items="@s_filterConditions" @bind-SelectedOption="@_formModel.Condition" OptionText="@(i => i.Name)" Width="100%" />
 
-        <FluentTextField @bind-Value="_formModel.Value" Placeholder="@Loc[Dialogs.FilterDialogTextValuePlaceholder]" />
+        <FluentTextField @bind-Value="_formModel.Value" Placeholder="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]" />
         <ValidationMessage For="() => _formModel.Value" />
 
         <FluentStack Orientation="Orientation.Horizontal" HorizontalAlignment="HorizontalAlignment.Right">
-            <FluentButton OnClick="Cancel">@Loc[Dialogs.FilterDialogCancelButtonText]</FluentButton>
-            <FluentButton Color="Color.Primary" Type="ButtonType.Submit">@Loc[Dialogs.FilterDialogApplyFilterButtonText]</FluentButton>
+            <FluentButton OnClick="Cancel">@Loc[nameof(Dialogs.FilterDialogCancelButtonText)]</FluentButton>
+            <FluentButton Color="Color.Primary" Type="ButtonType.Submit">@Loc[nameof(Dialogs.FilterDialogApplyFilterButtonText)]</FluentButton>
             @if (Content.Filter is not null)
             {
-                <FluentButton Appearance="Appearance.Stealth" aria-label="@Loc[Dialogs.FilterDialogRemoveFilterButtonText]" OnClick="Delete"><FluentIcon Value="@(new Icons.Regular.Size16.Delete())" /></FluentButton>
+                <FluentButton Appearance="Appearance.Stealth" aria-label="@Loc[nameof(Dialogs.FilterDialogRemoveFilterButtonText)]" OnClick="Delete"><FluentIcon Value="@(new Icons.Regular.Size16.Delete())" /></FluentButton>
             }
         </FluentStack>
     </FluentStack>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -4,11 +4,11 @@
 @inject IStringLocalizer<Dialogs> Loc
 
 <FluentStack Orientation="Orientation.Vertical" Style="display: contents">
-    <FluentRadioGroup TValue="string" Label="@Loc[Dialogs.SettingsDialogTheme]" Value="@_currentSetting" ValueChanged="SettingChangedAsync" Orientation="Orientation.Vertical">
-        <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingSystem">@Loc[Dialogs.SettingsDialogSystemTheme]</FluentRadio>
-        <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingLight">@Loc[Dialogs.SettingsDialogLightTheme]</FluentRadio>
-        <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingDark">@Loc[Dialogs.SettingsDialogDarkTheme]</FluentRadio>
+    <FluentRadioGroup TValue="string" Label="@Loc[nameof(Dialogs.SettingsDialogTheme)]" Value="@_currentSetting" ValueChanged="SettingChangedAsync" Orientation="Orientation.Vertical">
+        <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingSystem">@Loc[nameof(Dialogs.SettingsDialogSystemTheme)]</FluentRadio>
+        <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingLight">@Loc[nameof(Dialogs.SettingsDialogLightTheme)]</FluentRadio>
+        <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingDark">@Loc[nameof(Dialogs.SettingsDialogDarkTheme)]</FluentRadio>
     </FluentRadioGroup>
     <div style="height: 100%;"></div>
-    <div class="version">@string.Format(Loc[Dialogs.SettingsDialogVersion], s_version)</div>
+    <div class="version">@string.Format(Loc[nameof(Dialogs.SettingsDialogVersion)], s_version)</div>
 </FluentStack>

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -9,18 +9,18 @@
     <FluentHeader>
         <div class="header-title">
             <FluentAnchor IconStart="@(new AspireIcons.Size32.Logo())" Appearance="Appearance.Stealth" Href="/" Class="logo">
-                @string.Format(Loc[Layout.MainLayoutDashboardName], ResourceService.ApplicationName)
+                @string.Format(Loc[nameof(Layout.MainLayoutDashboardName)], ResourceService.ApplicationName)
             </FluentAnchor>
         </div>
         <div class="header-right">
             <FluentAnchor Appearance="Appearance.Stealth" IconEnd="@(new AspireIcons.Size24.GitHub())"
                           Href="https://aka.ms/dotnet/aspire/repo" Target="_blank" Rel="noreferrer noopener"
-                          Title="@Loc[Layout.MainLayoutAspireRepoLink]" aria-label="@Loc[Layout.MainLayoutAspireRepoLink]" />
+                          Title="@Loc[nameof(Layout.MainLayoutAspireRepoLink)]" aria-label="@Loc[nameof(Layout.MainLayoutAspireRepoLink)]" />
             <FluentAnchor Appearance="Appearance.Stealth" IconEnd="@(new Icons.Regular.Size24.QuestionCircle())"
                           Href="https://aka.ms/dotnet/aspire/dashboard" Target="_blank" Rel="noreferrer noopener"
-                          Title="@Loc[Layout.MainLayoutAspireDashboardHelpLink]" aria-label="@Loc[Layout.MainLayoutAspireDashboardHelpLink]" />
+                          Title="@Loc[nameof(Layout.MainLayoutAspireDashboardHelpLink)]" aria-label="@Loc[nameof(Layout.MainLayoutAspireDashboardHelpLink)]" />
             <FluentButton Appearance="Appearance.Stealth" OnClick="LaunchSettings" IconEnd="@(new Icons.Regular.Size24.Settings())"
-                          Title="@Loc[Layout.MainLayoutLaunchSettings]" aria-label="@Loc[Layout.MainLayoutLaunchSettings]" />
+                          Title="@Loc[nameof(Layout.MainLayoutLaunchSettings)]" aria-label="@Loc[nameof(Layout.MainLayoutLaunchSettings)]" />
         </div>
     </FluentHeader>
     <NavMenu />
@@ -31,8 +31,8 @@
     <FluentDialogProvider />
     <FluentTooltipProvider />
     <div id="blazor-error-ui">
-        @Loc[Layout.MainLayoutUnhandledErrorMessage]
-        <a href="" class="reload">@Loc[Layout.MainLayoutUnhandledErrorReload]</a>
+        @Loc[nameof(Layout.MainLayoutUnhandledErrorMessage)]
+        <a href="" class="reload">@Loc[nameof(Layout.MainLayoutUnhandledErrorReload)]</a>
         <a class="dismiss">🗙</a>
     </div>
 </div>

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -91,7 +91,7 @@ public partial class MainLayout : IDisposable
     {
         DialogParameters parameters = new()
         {
-            Title = Loc[Resources.Layout.MainLayoutSettingsDialogTitle],
+            Title = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogTitle)],
             PrimaryAction = Resources.Layout.MainLayoutSettingsDialogClose,
             PrimaryActionEnabled = true,
             SecondaryAction = null,

--- a/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
@@ -3,12 +3,12 @@
 
 <div class="nav-menu-container">
     <FluentNavMenu @bind-Expanded="@Expanded" Width="250" Collapsible="true">
-        <FluentNavLink Icon="@(new Icons.Regular.Size24.AppFolder())" Href="/" Match="NavLinkMatch.All" Tooltip="@Loc[Layout.NavMenuResourcesTab]">@Loc[Layout.NavMenuResourcesTab]</FluentNavLink>
-        <FluentNavGroup Title="@Loc[Layout.NavMenuMonitoringTab]" Icon="@(new Icons.Regular.Size24.SlideText())" Expanded="true" Gap="10px 0;" Tooltip="@Loc[Layout.NavMenuMonitoringTab]">
-            <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ConsoleLogs" Tooltip="@Loc[Layout.NavMenuConsoleLogsTab]">@Loc[Layout.NavMenuConsoleLogsTab]</FluentNavLink>
-            <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Href="/StructuredLogs" Tooltip="@Loc[Layout.NavMenuStructuredLogsTab]">@Loc[Layout.NavMenuStructuredLogsTab]</FluentNavLink>
-            <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces" Tooltip="@Loc[Layout.NavMenuTracesTab]">@Loc[Layout.NavMenuTracesTab]</FluentNavLink>
-            <FluentNavLink Icon="@(new Icons.Regular.Size24.ChartMultiple())" Href="/Metrics" Tooltip="@Loc[Layout.NavMenuMetricsTab]">@Loc[Layout.NavMenuMetricsTab]</FluentNavLink>
+        <FluentNavLink Icon="@(new Icons.Regular.Size24.AppFolder())" Href="/" Match="NavLinkMatch.All" Tooltip="@Loc[nameof(Layout.NavMenuResourcesTab)]">@Loc[nameof(Layout.NavMenuResourcesTab)]</FluentNavLink>
+        <FluentNavGroup Title="@Loc[nameof(Layout.NavMenuMonitoringTab)]" Icon="@(new Icons.Regular.Size24.SlideText())" Expanded="true" Gap="10px 0;" Tooltip="@Loc[nameof(Layout.NavMenuMonitoringTab)]">
+            <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideText())" Href="/ConsoleLogs" Tooltip="@Loc[nameof(Layout.NavMenuConsoleLogsTab)]">@Loc[nameof(Layout.NavMenuConsoleLogsTab)]</FluentNavLink>
+            <FluentNavLink Icon="@(new Icons.Regular.Size24.SlideTextSparkle())" Href="/StructuredLogs" Tooltip="@Loc[nameof(Layout.NavMenuStructuredLogsTab)]">@Loc[nameof(Layout.NavMenuStructuredLogsTab)]</FluentNavLink>
+            <FluentNavLink Icon="@(new Icons.Regular.Size24.GanttChart())" Href="/Traces" Tooltip="@Loc[nameof(Layout.NavMenuTracesTab)]">@Loc[nameof(Layout.NavMenuTracesTab)]</FluentNavLink>
+            <FluentNavLink Icon="@(new Icons.Regular.Size24.ChartMultiple())" Href="/Metrics" Tooltip="@Loc[nameof(Layout.NavMenuMetricsTab)]">@Loc[nameof(Layout.NavMenuMetricsTab)]</FluentNavLink>
         </FluentNavGroup>
     </FluentNavMenu>
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -2,10 +2,10 @@
 @namespace Aspire.Dashboard.Components.Pages
 @inject IStringLocalizer<Dashboard.Resources.ConsoleLogs> Loc
 
-<PageTitle>@string.Format(Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsPageTitle], ResourceService.ApplicationName)</PageTitle>
+<PageTitle>@string.Format(Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsPageTitle)], ResourceService.ApplicationName)</PageTitle>
 
 <div class="resource-logs-layout">
-    <h1 class="page-header">@Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsHeader]</h1>
+    <h1 class="page-header">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect @ref="_resourceSelectComponent" TOption="Option<string>"
                       Items="@_resources"
@@ -13,7 +13,7 @@
                       OptionValue="(o) => o.Value"
                       @bind-SelectedOption="_selectedOption"
                       @bind-SelectedOption:after="HandleSelectedOptionChangedAsync"
-                      AriaLabel="@Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsSelectAResource]"/>
+                      AriaLabel="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsSelectAResource)]"/>
         <FluentLabel Typo="Typography.Body">@_status</FluentLabel>
     </FluentToolbar>
     <LogViewer @ref="_logViewer" />

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -41,8 +41,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable
 
     protected override void OnInitialized()
     {
-        _noSelection = new() { Value = null, Text = Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsSelectAResource] };
-        _status = Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsLoadingResources];
+        _noSelection = new() { Value = null, Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsSelectAResource)] };
+        _status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLoadingResources)];
 
         TrackResources();
 
@@ -90,7 +90,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable
             await ClearLogsAsync();
             _selectedOption = _noSelection;
             _selectedResource = null;
-            _status = Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsNoResourceSelected];
+            _status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsNoResourceSelected)];
         }
     }
 
@@ -117,7 +117,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable
 
                 return resource.State switch
                 {
-                    null or { Length: 0 } => $"{resourceName} ({Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsUnknownState]})",
+                    null or { Length: 0 } => $"{resourceName} ({Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsUnknownState)]})",
                     "Running" => resourceName,
                     _ => $"{resourceName} ({resource.State})"
                 };
@@ -137,11 +137,11 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable
 
         if (_selectedResource is null)
         {
-            _status = Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsNoResourceSelected];
+            _status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsNoResourceSelected)];
         }
         else if (_logViewer is null)
         {
-            _status = Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsInitializingLogViewer];
+            _status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsInitializingLogViewer)];
         }
         else
         {
@@ -156,11 +156,11 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable
                     convertTimestampsFromUtc: _selectedResource is ContainerViewModel);
 
                 _initialisedSuccessfully = true;
-                _status = Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsWatchingLogs];
+                _status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsWatchingLogs)];
 
                 // Indicate when logs finish (other than by cancellation).
                 _ = task.ContinueWith(
-                    _ => _status = Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs],
+                    _ => _status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs)],
                     CancellationToken.None,
                     TaskContinuationOptions.NotOnCanceled,
                     TaskScheduler.Current);
@@ -169,8 +169,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable
             {
                 _initialisedSuccessfully = false;
                 _status = Loc[_selectedResource is ContainerViewModel
-                    ? Dashboard.Resources.ConsoleLogs.ConsoleLogsFailedToInitialize
-                    : Dashboard.Resources.ConsoleLogs.ConsoleLogsLogsNotYetAvailable];
+                    ? nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsFailedToInitialize)
+                    : nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLogsNotYetAvailable)];
             }
         }
     }
@@ -199,7 +199,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable
                 }
                 else if (!string.Equals(_selectedResource.State, "Running", StringComparison.Ordinal))
                 {
-                    _status = Loc[Dashboard.Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs];
+                    _status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs)];
                 }
             }
         }

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -8,24 +8,24 @@
 @inject IStringLocalizer<Dashboard.Resources.Metrics> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
-<PageTitle>@string.Format(Loc[Dashboard.Resources.Metrics.MetricsPageTitle], ResourceService.ApplicationName)</PageTitle>
+<PageTitle>@string.Format(Loc[nameof(Dashboard.Resources.Metrics.MetricsPageTitle)], ResourceService.ApplicationName)</PageTitle>
 
 <div class="metrics-layout">
-    <h1 class="page-header">@Loc[Dashboard.Resources.Metrics.MetricsHeader]</h1>
+    <h1 class="page-header">@Loc[nameof(Dashboard.Resources.Metrics.MetricsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect TOption="SelectViewModel<string>"
                       Items="@_applications"
                       OptionText="@(c => c.Name)"
                       @bind-SelectedOption="_selectedApplication"
                       @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync"
-                      AriaLabel="@ControlsStringsLoc[ControlsStrings.SelectAnApplication]"/>
+                      AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"/>
         <FluentIcon slot="end" Icon="Icons.Regular.Size20.Clock" Style="margin-right:5px;" />
         <FluentSelect slot="end" TOption="SelectViewModel<TimeSpan>"
                       Items="@_durations"
                       OptionText="@(c => c.Name)"
                       @bind-SelectedOption="_selectedDuration"
                       @bind-SelectedOption:after="HandleSelectedDurationChangedAsync"
-                      AriaLabel="@Loc[Dashboard.Resources.Metrics.MetricsSelectADuration]"/>
+                      AriaLabel="@Loc[nameof(Dashboard.Resources.Metrics.MetricsSelectADuration)]"/>
     </FluentToolbar>
     <div class="page-content-area">
         @if (_instruments?.Count > 0)
@@ -70,7 +70,7 @@
                         }
                         else
                         {
-                            <p>@Loc[Dashboard.Resources.Metrics.MetricsSelectInstrument]</p>
+                            <p>@Loc[nameof(Dashboard.Resources.Metrics.MetricsSelectInstrument)]</p>
                         }
                     </div>
                 </Panel2>
@@ -79,13 +79,13 @@
         else if (_instruments == null)
         {
             <div class="empty-content">
-                <FluentIcon Icon="Icons.Regular.Size24.ChartMultiple" />&nbsp;@Loc[Dashboard.Resources.Metrics.MetricsSelectAResource]
+                <FluentIcon Icon="Icons.Regular.Size24.ChartMultiple" />&nbsp;@Loc[nameof(Dashboard.Resources.Metrics.MetricsSelectAResource)]
             </div>
         }
         else
         {
             <div class="empty-content">
-                <FluentIcon Icon="Icons.Regular.Size24.ChartMultiple" />&nbsp;@Loc[Dashboard.Resources.Metrics.MetricsNoMetricsForResource]
+                <FluentIcon Icon="Icons.Regular.Size24.ChartMultiple" />&nbsp;@Loc[nameof(Dashboard.Resources.Metrics.MetricsNoMetricsForResource)]
             </div>
         }
     </div>

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -59,15 +59,15 @@ public partial class Metrics : IDisposable
     {
         _durations = new List<SelectViewModel<TimeSpan>>
         {
-            new() { Name = Loc[Dashboard.Resources.Metrics.MetricsLastOneMinute], Id = TimeSpan.FromMinutes(1) },
-            new() { Name = Loc[Dashboard.Resources.Metrics.MetricsLastFiveMinutes], Id = TimeSpan.FromMinutes(5) },
-            new() { Name = Loc[Dashboard.Resources.Metrics.MetricsLastFifteenMinutes], Id = TimeSpan.FromMinutes(15) },
-            new() { Name = Loc[Dashboard.Resources.Metrics.MetricsLastThirtyMinutes], Id = TimeSpan.FromMinutes(30) },
-            new() { Name = Loc[Dashboard.Resources.Metrics.MetricsLastHour], Id = TimeSpan.FromHours(1) },
-            new() { Name = Loc[Dashboard.Resources.Metrics.MetricsLastThreeHours], Id = TimeSpan.FromHours(3) },
-            new() { Name = Loc[Dashboard.Resources.Metrics.MetricsLastSixHours], Id = TimeSpan.FromHours(6) },
-            new() { Name = Loc[Dashboard.Resources.Metrics.MetricsLastTwelveHours], Id = TimeSpan.FromHours(12) },
-            new() { Name = Loc[Dashboard.Resources.Metrics.MetricsLastTwentyFourHours], Id = TimeSpan.FromHours(24) },
+            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastOneMinute)], Id = TimeSpan.FromMinutes(1) },
+            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastFiveMinutes)], Id = TimeSpan.FromMinutes(5) },
+            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastFifteenMinutes)], Id = TimeSpan.FromMinutes(15) },
+            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastThirtyMinutes)], Id = TimeSpan.FromMinutes(30) },
+            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastHour)], Id = TimeSpan.FromHours(1) },
+            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastThreeHours)], Id = TimeSpan.FromHours(3) },
+            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastSixHours)], Id = TimeSpan.FromHours(6) },
+            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastTwelveHours)], Id = TimeSpan.FromHours(12) },
+            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastTwentyFourHours)], Id = TimeSpan.FromHours(24) },
         };
 
         _selectedDuration = _durations.Single(d => d.Id == s_defaultDuration);

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -4,23 +4,23 @@
 @inject IStringLocalizer<Dashboard.Resources.Resources> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
-<PageTitle>@string.Format(Loc[Dashboard.Resources.Resources.ResourcesPageTitle], ResourceService.ApplicationName)</PageTitle>
+<PageTitle>@string.Format(Loc[nameof(Dashboard.Resources.Resources.ResourcesPageTitle)], ResourceService.ApplicationName)</PageTitle>
 
 <div class="content-layout-with-toolbar">
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <h1 slot="label">@Loc[Dashboard.Resources.Resources.ResourcesHeader]</h1>
+        <h1 slot="label">@Loc[nameof(Dashboard.Resources.Resources.ResourcesHeader)]</h1>
         <FluentButton id="typeFilterButton" slot="end"
                       Appearance="@(AreAllTypesVisible is true ? Appearance.Stealth : Appearance.Accent)"
                       IconEnd="@(new Icons.Regular.Size24.Filter())"
                       @onclick="() => _isTypeFilterVisible = !_isTypeFilterVisible"
-                      Title="@(AreAllTypesVisible is true ? Loc[Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible] : Loc[Dashboard.Resources.Resources.ResourcesTypeFiltered])"
-                      aria-label="@(AreAllTypesVisible is true ? Loc[Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible] : Loc[Dashboard.Resources.Resources.ResourcesTypeFiltered])" />
+                      Title="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])"
+                      aria-label="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])" />
         <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible">
-            <Header>@Loc[Dashboard.Resources.Resources.ResourcesResourceTypesHeader]</Header>
+            <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
             <Body>
                 <FluentStack Orientation="Orientation.Vertical">
                     <FluentCheckbox
-                        Label="@ControlsStringsLoc[ControlsStrings.All]"
+                        Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
                         ThreeState="true"
                         ShowIndeterminate="false"
                         @bind-CheckState="AreAllTypesVisible" />
@@ -36,14 +36,14 @@
                 </FluentStack>
             </Body>
         </FluentPopover>
-        <FluentSearch Placeholder="@ControlsStringsLoc[ControlsStrings.FilterPlaceholder]"
+        <FluentSearch Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
                         Immediate="true"
                         @bind-Value="_filter"
                         @oninput="HandleFilter"
                         @bind-Value:after="HandleClear"
                         slot="end" />
     </FluentToolbar>
-    <SummaryDetailsView DetailsTitle="@string.Format(Loc[Dashboard.Resources.Resources.ResourcesEnvironmentVariablesHeader], SelectedResource != null ? GetResourceName(SelectedResource) : null)"
+    <SummaryDetailsView DetailsTitle="@string.Format(Loc[nameof(Dashboard.Resources.Resources.ResourcesEnvironmentVariablesHeader)], SelectedResource != null ? GetResourceName(SelectedResource) : null)"
                         ShowDetails="@(SelectedEnvironmentVariables is not null)"
                         OnDismiss="() => ClearSelectedResource()"
                         ViewKey="ResourcesList">
@@ -51,34 +51,34 @@
             <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1fr 2fr 2.5fr 2fr 1fr 1fr" RowClass="GetRowClass">
                 <ChildContent>
                     <PropertyColumn Property="@(c => c.ResourceType)" Title="Type" Sortable="true" />
-                    <TemplateColumn Title="@Loc[Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridNameColumnHeader]" Sortable="true" SortBy="@_nameSort">
+                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridNameColumnHeader)]" Sortable="true" SortBy="@_nameSort">
                         <ResourceNameDisplay Resource="context" FilterText="@_filter" FormatName="GetResourceName" />
                     </TemplateColumn>
-                    <TemplateColumn Title="@Loc[Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridStateColumnHeader]" Sortable="true" SortBy="@_stateSort">
+                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridStateColumnHeader)]" Sortable="true" SortBy="@_stateSort">
                         <div class="resource-state-container">
                             @context.State
                             <UnreadLogErrorsBadge UnviewedCount="@GetUnviewedErrorCount(context)" OnClick="@(() => ViewErrorStructuredLogs(context))" />
                         </div>
                     </TemplateColumn>
-                    <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="@Loc[Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridStartTimeColumnHeader]" Sortable="true" Tooltip="true" />
-                    <TemplateColumn Title="@Loc[Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridSourceColumnHeader]">
+                    <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridStartTimeColumnHeader)]" Sortable="true" Tooltip="true" />
+                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridSourceColumnHeader)]">
                         <SourceColumnDisplay Resource="context" FilterText="@_filter" />
                     </TemplateColumn>
-                    <TemplateColumn Title="@Loc[Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridEndpointsColumnHeader]">
+                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridEndpointsColumnHeader)]">
                         <EndpointsColumnDisplay Resource="context" HasMultipleReplicas="HasMultipleReplicas(context)" />
                     </TemplateColumn>
-                    <TemplateColumn Title="@Loc[Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridEnvironmentColumnHeader]" Sortable="false">
+                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridEnvironmentColumnHeader)]" Sortable="false">
                         <FluentButton Appearance="Appearance.Lightweight"
                                       Disabled="@(!context.Environment.Any())"
-                                      Title="@(context.Environment.Any() ? ControlsStringsLoc[ControlsStrings.ViewAction] : @Loc[Dashboard.Resources.Resources.ResourcesNoEnvironmentVariables])"
-                                      OnClick="() => ShowEnvironmentVariables(context)">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentButton>
+                                      Title="@(context.Environment.Any() ? ControlsStringsLoc[nameof(ControlsStrings.ViewAction)] : @Loc[nameof(Dashboard.Resources.Resources.ResourcesNoEnvironmentVariables)])"
+                                      OnClick="() => ShowEnvironmentVariables(context)">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
                     </TemplateColumn>
                     <TemplateColumn Title="Logs">
-                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ConsoleLogs/{context.Name}")">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
+                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ConsoleLogs/{context.Name}")">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
                     </TemplateColumn>
                 </ChildContent>
                 <EmptyContent>
-                    <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;@Loc[Dashboard.Resources.Resources.ResourcesNoResources]
+                    <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;@Loc[nameof(Dashboard.Resources.Resources.ResourcesNoResources)]
                 </EmptyContent>
             </FluentDataGrid>
         </Summary>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -12,25 +12,25 @@
 @inject IStringLocalizer<Dialogs> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
-<PageTitle>@string.Format(Loc[Dashboard.Resources.StructuredLogs.StructuredLogsPageTitle], resourceService.ApplicationName)</PageTitle>
+<PageTitle>@string.Format(Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsPageTitle)], resourceService.ApplicationName)</PageTitle>
 
 <div class="logs-layout">
-    <h1 class="page-header">@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsHeader]</h1>
+    <h1 class="page-header">@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect TOption="SelectViewModel<string>"
                       Items="@_applicationViewModels"
                       OptionText="@(c => c.Name)"
                       @bind-SelectedOption="_selectedApplication"
                       @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync"
-                      AriaLabel="@ControlsStringsLoc[ControlsStrings.SelectAnApplication]"/>
+                      AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"/>
         <FluentSearch @bind-Value="_filter"
                       @oninput="HandleFilter"
                       @bind-Value:after="HandleClear"
-                      Placeholder="@ControlsStringsLoc[ControlsStrings.FilterPlaceholder]"
-                      title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsMessageFilter]"
+                      Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
+                      title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageFilter)]"
                       slot="end" />
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-        <div title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsMinimumLogFilter]" slot="end" style="display: flex;align-items: center;">
+        <div title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMinimumLogFilter)]" slot="end" style="display: flex;align-items: center;">
             <span>Level:</span>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <FluentSelect TOption="SelectViewModel<LogLevel?>"
@@ -40,13 +40,13 @@
                           @bind-SelectedOption:after="HandleSelectedLogLevelChangedAsync"
                           Width="120px"
                           Style="min-width: auto;"
-                          AriaLabel="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsSelectMinimumLogLevel]" />
+                          AriaLabel="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsSelectMinimumLogLevel)]" />
         </div>
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-        <FluentLabel slot="end">@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsFilters]</FluentLabel>
+        <FluentLabel slot="end">@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsFilters)]</FluentLabel>
         @if (ViewModel.Filters.Count == 0)
         {
-            <span slot="end">@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsNoFilters]</span>
+            <span slot="end">@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsNoFilters)]</span>
         }
         else
         {
@@ -58,18 +58,18 @@
         }
         <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="Add Filter" OnClick="() => OpenFilterAsync(null)"><FluentIcon Value="@(new Icons.Regular.Size16.Filter())" /></FluentButton>
     </FluentToolbar>
-    <SummaryDetailsView DetailsTitle="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails]" ShowDetails="SelectedLogEntryProperties is not null" OnDismiss="() => ClearSelectedLogEntry()">
+    <SummaryDetailsView DetailsTitle="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails)]" ShowDetails="SelectedLogEntryProperties is not null" OnDismiss="() => ClearSelectedLogEntry()">
         <Summary>
             <div class="logs-summary-layout">
                 <div class="logs-grid-container continuous-scroll-overflow">
                     <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
                         <ChildContent>
-                            <TemplateColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader]" Tooltip="true" TooltipText="@(e => GetResourceName(e.Application))">
+                            <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.Application))">
                                 <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Application)));">
                                     @GetResourceName(context.Application)
                                 </span>
                             </TemplateColumn>
-                            <TemplateColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader]">
+                            <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
                                 @if (context.Severity is LogLevel.Error or LogLevel.Critical)
                                 {
                                     <FluentIcon Icon="Icons.Filled.Size16.ErrorCircle" Color="Color.Error" Class="logs-severity-icon" />
@@ -80,11 +80,11 @@
                                 }
                                 @context.Severity
                             </TemplateColumn>
-                            <PropertyColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader]" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" Tooltip="true" />
-                            <TemplateColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader]" Tooltip="true" TooltipText="(e) => e.Message">
+                            <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" Tooltip="true" />
+                            <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">
                                 <FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@context.Message" />
                             </TemplateColumn>
-                            <TemplateColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader]">
+                            <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
                                 @if (!string.IsNullOrEmpty(context.TraceId))
                                 {
                                     <a href="@($"/Trace/{HttpUtility.UrlEncode(context.TraceId)}")" class="long-inner-content">
@@ -92,12 +92,12 @@
                                     </a>
                                 }
                             </TemplateColumn>
-                            <TemplateColumn Title="@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsDetailsColumnHeader]">
-                                <FluentButton Appearance="Appearance.Lightweight" OnClick="() => OnShowProperties(context)">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentButton>
+                            <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsDetailsColumnHeader)]">
+                                <FluentButton Appearance="Appearance.Lightweight" OnClick="() => OnShowProperties(context)">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
                             </TemplateColumn>
                         </ChildContent>
                         <EmptyContent>
-                            <FluentIcon Icon="Icons.Regular.Size24.SlideTextSparkle" />&nbsp;@Loc[Dashboard.Resources.StructuredLogs.StructuredLogsNoLogsFound]
+                            <FluentIcon Icon="Icons.Regular.Size24.SlideTextSparkle" />&nbsp;@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsNoLogsFound)]
                         </EmptyContent>
                     </FluentDataGrid>
                 </div>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -85,7 +85,7 @@ public partial class StructuredLogs
 
         _logLevels = new List<SelectViewModel<LogLevel?>>
         {
-            new SelectViewModel<LogLevel?> { Id = null, Name = $"({Loc[Dashboard.Resources.StructuredLogs.StructuredLogsAllTypes]})" },
+            new SelectViewModel<LogLevel?> { Id = null, Name = $"({Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsAllTypes)]})" },
             new SelectViewModel<LogLevel?> { Id = LogLevel.Trace, Name = "Trace" },
             new SelectViewModel<LogLevel?> { Id = LogLevel.Debug, Name = "Debug" },
             new SelectViewModel<LogLevel?> { Id = LogLevel.Information, Name = "Information" },
@@ -185,7 +185,7 @@ public partial class StructuredLogs
     {
         var logPropertyKeys = TelemetryRepository.GetLogPropertyKeys(_selectedApplication.Id);
 
-        var title = entry is not null ? Loc[Dashboard.Resources.StructuredLogs.StructuredLogsEditFilter] : Loc[Dashboard.Resources.StructuredLogs.StructuredLogsAddFilter];
+        var title = entry is not null ? Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEditFilter)] : Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsAddFilter)];
         var parameters = new DialogParameters
         {
             OnDialogResult = DialogService.CreateDialogCallback(this, HandleFilterDialog),

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -10,7 +10,7 @@
 @inject IStringLocalizer<ControlsStrings> ControlStringsLoc
 @inject IResourceService DashboardService
 
-<PageTitle>@string.Format(Loc[Dashboard.Resources.TraceDetail.TraceDetailPageTitle], DashboardService.ApplicationName)</PageTitle>
+<PageTitle>@string.Format(Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailPageTitle)], DashboardService.ApplicationName)</PageTitle>
 
 @if (_trace != null)
 {
@@ -21,27 +21,27 @@
         </div>
         <FluentToolbar Orientation="Orientation.Horizontal">
             <div>
-                @Loc[Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader] <strong>@_trace.FirstSpan.StartTime.ToString("MMMM d yyyy"), @OtlpHelpers.FormatTimeStamp(_trace.FirstSpan.StartTime)</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)] <strong>@_trace.FirstSpan.StartTime.ToString("MMMM d yyyy"), @OtlpHelpers.FormatTimeStamp(_trace.FirstSpan.StartTime)</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
-                @Loc[Dashboard.Resources.TraceDetail.TraceDetailDurationHeader] <strong>@DurationFormatter.FormatDuration(_trace.Duration)</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailDurationHeader)] <strong>@DurationFormatter.FormatDuration(_trace.Duration)</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
-                @Loc[Dashboard.Resources.TraceDetail.TraceDetailResourcesHeader] <strong>@_trace.Spans.GroupBy(s => s.Source).Count()</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailResourcesHeader)] <strong>@_trace.Spans.GroupBy(s => s.Source).Count()</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
-                @Loc[Dashboard.Resources.TraceDetail.TraceDetailDepthHeader] <strong>@_maxDepth</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailDepthHeader)] <strong>@_maxDepth</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
-                @Loc[Dashboard.Resources.TraceDetail.TraceDetailTotalSpansHeader] <strong>@_trace.Spans.Count</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTotalSpansHeader)] <strong>@_trace.Spans.Count</strong>
             </div>
-            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?traceId={_trace.TraceId}")">@ControlStringsLoc[ControlsStrings.ViewLogsLink]</FluentAnchor>
+            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?traceId={_trace.TraceId}")">@ControlStringsLoc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
             <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/Traces")">@Loc[Dashboard.Resources.TraceDetail.TraceDetailBackButtonText]</FluentAnchor>
+            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/Traces")">@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailBackButtonText)]</FluentAnchor>
         </FluentToolbar>
 
         <SummaryDetailsView ShowDetails="SelectedSpan is not null" OnDismiss="() => ClearSelectedSpan()" ViewKey="TraceDetail">
@@ -120,6 +120,6 @@
 else
 {
     <div class="empty-content">
-        <FluentIcon Icon="Icons.Regular.Size24.GanttChart" /> &nbsp; @Loc[Dashboard.Resources.TraceDetail.TraceDetailTraceNotFound]
+        <FluentIcon Icon="Icons.Regular.Size24.GanttChart" /> &nbsp; @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceNotFound)]
     </div>
 }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -13,11 +13,11 @@
 @inject IStringLocalizer<StructuredLogs> StructuredLogsLoc
 @implements IDisposable
 
-<PageTitle>@string.Format(Loc[Dashboard.Resources.Traces.TracesPageTitle], ResourceService.ApplicationName)</PageTitle>
+<PageTitle>@string.Format(Loc[nameof(Dashboard.Resources.Traces.TracesPageTitle)], ResourceService.ApplicationName)</PageTitle>
 
 
 <div class="traces-layout">
-    <h1 class="page-header">@Loc[Dashboard.Resources.Traces.TracesHeader]</h1>
+    <h1 class="page-header">@Loc[nameof(Dashboard.Resources.Traces.TracesHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect TOption="SelectViewModel<string>"
                       Items="@_applicationViewModels"
@@ -25,23 +25,23 @@
                       OptionText="@(c => c.Name)"
                       @bind-SelectedOption="_selectedApplication"
                       @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync"
-                      AriaLabel="@ControlsStringsLoc[ControlsStrings.SelectAnApplication]"/>
+                      AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"/>
         <FluentSearch @bind-Value="_filter"
                       @oninput="HandleFilter"
                       @bind-Value:after="HandleClear"
-                      Placeholder="@ControlsStringsLoc[ControlsStrings.FilterPlaceholder]"
-                      title="@Loc[Dashboard.Resources.Traces.TracesNameFilter]"
+                      Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
+                      title="@Loc[nameof(Dashboard.Resources.Traces.TracesNameFilter)]"
                       slot="end" />
     </FluentToolbar>
     <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
         <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr">
             <ChildContent>
-                <PropertyColumn Title="@StructuredLogsLoc[Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader]" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
-                <TemplateColumn Title="@ControlsStringsLoc[ControlsStrings.NameColumnHeader]" Tooltip="true" TooltipText="@((t) => $"{t.FullName}: {OtlpHelpers.ToShortenedId(t.TraceId)}")">
+                <PropertyColumn Title="@StructuredLogsLoc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
+                <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@((t) => $"{t.FullName}: {OtlpHelpers.ToShortenedId(t.TraceId)}")">
                     <span><FluentHighlighter HighlightedText="@(ViewModel.FilterText)" Text="@(context.FullName)" /></span>
                     <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
                 </TemplateColumn>
-                <TemplateColumn Title="@Loc[Dashboard.Resources.Traces.TracesSpansColumnHeader]">
+                <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Traces.TracesSpansColumnHeader)]">
                     <FluentOverflow>
                         <ChildContent>
                             @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Min(s => s.StartTime)))
@@ -64,13 +64,13 @@
                         </MoreButtonTemplate>
                     </FluentOverflow>
                 </TemplateColumn>
-                <TemplateColumn Title="@TraceDetailLoc[Dashboard.Resources.TraceDetail.TraceDetailDurationHeader]">
+                <TemplateColumn Title="@TraceDetailLoc[nameof(Dashboard.Resources.TraceDetail.TraceDetailDurationHeader)]">
                     <div class="duration-container">
                         <FluentProgressRing Class="duration-ring"
                                             Min="0"
                                             Max="@Convert.ToInt32(ViewModel.MaxDuration.TotalMilliseconds)"
                                             Value="@Convert.ToInt32(context.Duration.TotalMilliseconds)"
-                                            aria-label="@TraceDetailLoc[Dashboard.Resources.TraceDetail.TraceDetailDurationHeader]" />
+                                            aria-label="@TraceDetailLoc[nameof(Dashboard.Resources.TraceDetail.TraceDetailDurationHeader)]" />
                         <span class="trace-duration">
                             @DurationFormatter.FormatDuration(context.Duration)
                         </span>
@@ -78,11 +78,11 @@
                 </TemplateColumn>
 
                 <TemplateColumn>
-                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/Trace/{context.TraceId}")">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
+                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/Trace/{context.TraceId}")">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
                 </TemplateColumn>
             </ChildContent>
             <EmptyContent>
-                <FluentIcon Icon="Icons.Regular.Size24.GanttChart" />&nbsp;@Loc[Dashboard.Resources.Traces.TracesNoTraces]
+                <FluentIcon Icon="Icons.Regular.Size24.GanttChart" />&nbsp;@Loc[nameof(Dashboard.Resources.Traces.TracesNoTraces)]
             </EmptyContent>
         </FluentDataGrid>
     </div>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -44,11 +44,11 @@ public partial class Traces
         var count = applicationSpans.Count();
         var errorCount = applicationSpans.Count(s => s.Status == OtlpSpanStatusCode.Error);
 
-        var tooltip = string.Format(CultureInfo.InvariantCulture, Loc[Dashboard.Resources.Traces.TracesResourceSpans], GetResourceName(applicationSpans.Key));
-        tooltip += Environment.NewLine + string.Format(CultureInfo.InvariantCulture, Loc[Dashboard.Resources.Traces.TracesTotalTraces], count);
+        var tooltip = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.TracesResourceSpans)], GetResourceName(applicationSpans.Key));
+        tooltip += Environment.NewLine + string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.TracesTotalTraces)], count);
         if (errorCount > 0)
         {
-            tooltip += Environment.NewLine + string.Format(CultureInfo.InvariantCulture, Loc[Dashboard.Resources.Traces.TracesTotalErroredTraces], errorCount);
+            tooltip += Environment.NewLine + string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.TracesTotalErroredTraces)], errorCount);
         }
 
         return tooltip;
@@ -70,7 +70,7 @@ public partial class Traces
 
     protected override Task OnInitializedAsync()
     {
-        _allApplication  = new SelectViewModel<string> { Id = null, Name = $"({ControlsStringsLoc[ControlsStrings.All]})" };
+        _allApplication  = new SelectViewModel<string> { Id = null, Name = $"({ControlsStringsLoc[nameof(ControlsStrings.All)]})" };
         _selectedApplication = _allApplication;
 
         UpdateApplications();

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -6,7 +6,7 @@
     @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
     @if (Resource.Endpoints.Length == 0 && (Resource.State == FinishedState || Resource.ExpectedEndpointsCount == 0))
     {
-        <span class="long-inner-content">@Loc[Columns.EndpointsColumnDisplayNone]</span>
+        <span class="long-inner-content">@Loc[nameof(Columns.EndpointsColumnDisplayNone)]</span>
     }
     else
     {
@@ -27,7 +27,7 @@
         if (Resource.State != FinishedState
         && (Resource.ExpectedEndpointsCount is null || Resource.ExpectedEndpointsCount > Resource.Endpoints.Length))
         {
-            <span class="long-inner-content">@Loc[Columns.EndpointsColumnDisplayPlaceholder]</span>
+            <span class="long-inner-content">@Loc[nameof(Columns.EndpointsColumnDisplayPlaceholder)]</span>
         }
     }
 </FluentStack>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -10,14 +10,14 @@
             <GridValue Value="@containerViewModel.ContainerId"
                        MaxDisplayLength="8"
                        EnableHighlighting="false"
-                       PreCopyToolTip="@Loc[Columns.ResourceNameDisplayCopyContainerIdText]"
-                       ToolTip="@string.Format(Loc[Columns.ResourceNameDisplayContainerIdText], containerViewModel.ContainerId)"/>
+                       PreCopyToolTip="@Loc[nameof(Columns.ResourceNameDisplayCopyContainerIdText)]"
+                       ToolTip="@string.Format(Loc[nameof(Columns.ResourceNameDisplayContainerIdText)], containerViewModel.ContainerId)"/>
         </div>
     }
     else if (Resource is ExecutableViewModel executableViewModel)
     {
         // NOTE projects are also executables, so this will handle both
-        var title = string.Format(Loc[Columns.ResourceNameDisplayProcessIdText], executableViewModel.ProcessId);
+        var title = string.Format(Loc[nameof(Columns.ResourceNameDisplayProcessIdText)], executableViewModel.ProcessId);
         <span class="subtext" title="@title" aria-label="@title">@executableViewModel.ProcessId</span>
     }
 </FluentStack>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -10,7 +10,7 @@
                ValueToCopy="@projectViewModel.ProjectPath"
                EnableHighlighting="true"
                HighlightText="@FilterText"
-               PreCopyToolTip="@Loc[Columns.SourceColumnSourceCopyFullPathToClipboard]"
+               PreCopyToolTip="@Loc[nameof(Columns.SourceColumnSourceCopyFullPathToClipboard)]"
                ToolTip="@projectViewModel.ProjectPath" />
 }
 else if (Resource is ExecutableViewModel executableViewModel)
@@ -22,14 +22,14 @@ else if (Resource is ExecutableViewModel executableViewModel)
                ValueToCopy="@fullCommandLine"
                EnableHighlighting="true"
                HighlightText="@FilterText"
-               PreCopyToolTip="@Loc[Columns.SourceColumnSourceCopyFullPathToClipboard]"
+               PreCopyToolTip="@Loc[nameof(Columns.SourceColumnSourceCopyFullPathToClipboard)]"
                ToolTip="@executableViewModel.ExecutablePath">
         <ContentAfterValue>
             <span class="subtext">@arguments</span>
         </ContentAfterValue>
     </GridValue>
 
-    <div class="ellipsis-overflow" title="@executableViewModel.WorkingDirectory" aria-label="@executableViewModel.WorkingDirectory">@string.Format(Loc[Columns.SourceColumnDisplayWorkingDirectory], executableViewModel.WorkingDirectory?.TrimMiddle(35))</div>
+    <div class="ellipsis-overflow" title="@executableViewModel.WorkingDirectory" aria-label="@executableViewModel.WorkingDirectory">@string.Format(Loc[nameof(Columns.SourceColumnDisplayWorkingDirectory)], executableViewModel.WorkingDirectory?.TrimMiddle(35))</div>
 }
 else if (Resource is ContainerViewModel containerViewModel)
 {
@@ -37,15 +37,15 @@ else if (Resource is ContainerViewModel containerViewModel)
     <GridValue Value="@containerViewModel.Image"
                EnableHighlighting="true"
                HighlightText="@FilterText"
-               PreCopyToolTip="@Loc[Columns.SourceColumnSourceCopyContainerToClipboard]"
+               PreCopyToolTip="@Loc[nameof(Columns.SourceColumnSourceCopyContainerToClipboard)]"
                ToolTip="@containerViewModel.Image">
         <ContentAfterValue>
            @if (containerViewModel.Ports.Length > 0)
            {
                var title = string.Format(
                    Loc[containerViewModel.Ports.Length == 1
-                       ? Columns.SourceColumnDisplayPort
-                       : Columns.SourceColumnDisplayPorts],
+                       ? nameof(Columns.SourceColumnDisplayPort)
+                       : nameof(Columns.SourceColumnDisplayPorts)],
                    ports);
                    <span class="subtext" aria-label="@title">@title</span>
            }
@@ -54,12 +54,12 @@ else if (Resource is ContainerViewModel containerViewModel)
     <FluentStack Orientation="Orientation.Horizontal">
         @if (containerViewModel.Command is not null)
         {
-            <div class="ellipsis-overflow" title="@Loc[Columns.SourceColumnDisplayContainerCommandTitle]" aria-label="@Loc[Columns.SourceColumnDisplayContainerCommandTitle]">@Loc[Columns.SourceColumnDisplayContainerCommand, containerViewModel.Command]</div>
+            <div class="ellipsis-overflow" title="@Loc[nameof(Columns.SourceColumnDisplayContainerCommandTitle)]" aria-label="@Loc[nameof(Columns.SourceColumnDisplayContainerCommandTitle)]">@Loc[nameof(Columns.SourceColumnDisplayContainerCommand), containerViewModel.Command]</div>
         }
         @if (containerViewModel.Args is not null)
         {
             var args = string.Join(" ", containerViewModel.Args);
-            <div class="ellipsis-overflow" title="@Loc[Columns.SourceColumnDisplayContainerArgsTitle]" aria-label="@Loc[Columns.SourceColumnDisplayContainerArgsTitle]">@args</div>
+            <div class="ellipsis-overflow" title="@Loc[nameof(Columns.SourceColumnDisplayContainerArgsTitle)]" aria-label="@Loc[nameof(Columns.SourceColumnDisplayContainerArgsTitle)]">@args</div>
         }
     </FluentStack>
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor
@@ -5,7 +5,7 @@
 @if (UnviewedCount > 0)
 {
     <div @onclick="OnClick" class="resource-error-badge">
-        <FluentBadge title="@string.Format(Loc[UnviewedCount == 1 ? Columns.UnreadLogErrorsBadgeErrorLog : Columns.UnreadLogErrorsBadgeErrorLogs], UnviewedCount)"
+        <FluentBadge title="@string.Format(Loc[UnviewedCount == 1 ? nameof(Columns.UnreadLogErrorsBadgeErrorLog) : nameof(Columns.UnreadLogErrorsBadgeErrorLogs)], UnviewedCount)"
                      Appearance="Appearance.Accent"
                      Circular="true"
                      Fill="error"

--- a/src/Aspire.Dashboard/Components/Routes.razor
+++ b/src/Aspire.Dashboard/Components/Routes.razor
@@ -5,9 +5,9 @@
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)" />
     </Found>
     <NotFound>
-        <PageTitle>@Loc[Resources.Routes.RoutesPageTitle]</PageTitle>
+        <PageTitle>@Loc[nameof(Resources.Routes.RoutesPageTitle)]</PageTitle>
         <LayoutView Layout="@typeof(Layout.MainLayout)">
-            <p role="alert">@Loc[Resources.Routes.RoutesNotFoundDescription]</p>
+            <p role="alert">@Loc[nameof(Resources.Routes.RoutesNotFoundDescription)]</p>
         </LayoutView>
     </NotFound>
 </Router>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -141,7 +141,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show Spec Only.
+        ///   Looks up a localized string similar to .
         /// </summary>
         public static string EnvironmentVariablesFilterToggleShowSpecOnly {
             get {
@@ -213,7 +213,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Count.
+        ///   Looks up a localized string similar to .
         /// </summary>
         public static string PlotlyChartCount {
             get {
@@ -222,7 +222,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Length.
+        ///   Looks up a localized string similar to .
         /// </summary>
         public static string PlotlyChartLength {
             get {
@@ -231,7 +231,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value.
+        ///   Looks up a localized string similar to .
         /// </summary>
         public static string PlotlyChartValue {
             get {
@@ -258,7 +258,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Duration &lt;strong&gt;{0}&lt;/strong&gt;.
+        ///   Looks up a localized string similar to .
         /// </summary>
         public static string SpanDetailsDuration {
             get {
@@ -267,7 +267,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Service &lt;strong&gt;{0}&lt;/strong&gt;.
+        ///   Looks up a localized string similar to .
         /// </summary>
         public static string SpanDetailsService {
             get {
@@ -276,7 +276,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start Time &lt;strong&gt;{0}&lt;/strong&gt;.
+        ///   Looks up a localized string similar to .
         /// </summary>
         public static string SpanDetailsStartTime {
             get {
@@ -312,7 +312,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Total: &lt;strong&gt;{0} results found&lt;/strong&gt;.
+        ///   Looks up a localized string similar to .
         /// </summary>
         public static string TotalItemsFooterText {
             get {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -141,7 +141,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Show spec only.
         /// </summary>
         public static string EnvironmentVariablesFilterToggleShowSpecOnly {
             get {
@@ -213,7 +213,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Count.
         /// </summary>
         public static string PlotlyChartCount {
             get {
@@ -222,7 +222,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Length.
         /// </summary>
         public static string PlotlyChartLength {
             get {
@@ -231,7 +231,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Value.
         /// </summary>
         public static string PlotlyChartValue {
             get {
@@ -258,7 +258,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Duration &lt;strong&gt;{0}&lt;/strong&gt;.
         /// </summary>
         public static string SpanDetailsDuration {
             get {
@@ -267,7 +267,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Service &lt;strong&gt;{0}&lt;/strong&gt;.
         /// </summary>
         public static string SpanDetailsService {
             get {
@@ -276,7 +276,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Start time &lt;strong&gt;{0}&lt;/strong&gt;.
         /// </summary>
         public static string SpanDetailsStartTime {
             get {
@@ -312,7 +312,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to Total: &lt;strong&gt;{0} results found&lt;/strong&gt;.
         /// </summary>
         public static string TotalItemsFooterText {
             get {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -128,7 +128,7 @@
   </data>
   <data name="EnvironmentVariablesFilterToggleShowSpecOnly" xml:space="preserve">
     <value>Show spec only</value>
-    <note>Spec means from the resource specification</note>
+    <comment>Spec means from the resource specification</comment>
   </data>
   <data name="EnvironmentVariablesFilterToggleShowAll" xml:space="preserve">
     <value>Show all</value>
@@ -153,15 +153,15 @@
   </data>
   <data name="PlotlyChartCount" xml:space="preserve">
     <value>Count</value>
-    <note>Count is the name of a plot y-axis label</note>
+    <comment>Count is the name of a plot y-axis label</comment>
   </data>
   <data name="PlotlyChartLength" xml:space="preserve">
     <value>Length</value>
-    <note>Length is the name of a plot y-axis label</note>
+    <comment>Length is the name of a plot y-axis label</comment>
   </data>
   <data name="PlotlyChartValue" xml:space="preserve">
     <value>Value</value>
-    <note>Value is the name of a plot y-axis label</note>
+    <comment>Value is the name of a plot y-axis label</comment>
   </data>
   <data name="NameColumnHeader" xml:space="preserve">
     <value>Name</value>
@@ -171,15 +171,15 @@
   </data>
   <data name="SpanDetailsService" xml:space="preserve">
     <value>Service &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+    <comment>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
   </data>
   <data name="SpanDetailsDuration" xml:space="preserve">
     <value>Duration &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+    <comment>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
   </data>
   <data name="SpanDetailsStartTime" xml:space="preserve">
     <value>Start time &lt;strong&gt;{0}&lt;/strong&gt;</value>
-    <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+    <comment>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
   </data>
   <data name="ViewLogsLink" xml:space="preserve">
     <value>View logs</value>
@@ -195,7 +195,7 @@
   </data>
   <data name="TotalItemsFooterText" xml:space="preserve">
     <value>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</value>
-    <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
+    <comment>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</comment>
   </data>
   <data name="SelectAnApplication" xml:space="preserve">
     <value>Select an application</value>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -206,4 +206,16 @@
   <data name="All" xml:space="preserve">
     <value>All</value>
   </data>
+  <data name="ChartContainerAllTags" xml:space="preserve">
+    <value>All tags</value>
+  </data>
+  <data name="ChartContainerFilteredTags" xml:space="preserve">
+    <value>Filtered tags</value>
+  </data>
+  <data name="ChartContainerOptionsHeader" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="ChartContainerShowCountLabel" xml:space="preserve">
+    <value>Show count</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -7,14 +7,34 @@
         <target state="new">All</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerAllTags">
+        <source>All tags</source>
+        <target state="new">All tags</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerFilteredTags">
+        <source>Filtered tags</source>
+        <target state="new">Filtered tags</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerFiltersHeader">
         <source>Filters</source>
         <target state="new">Filters</target>
         <note />
       </trans-unit>
+      <trans-unit id="ChartContainerOptionsHeader">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ChartContainerSelectFilters">
         <source>Select filters</source>
         <target state="new">Select filters</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ChartContainerShowCountLabel">
+        <source>Show count</source>
+        <target state="new">Show count</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerUnableToDisplay">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -55,7 +55,7 @@
       <trans-unit id="EnvironmentVariablesFilterToggleShowSpecOnly">
         <source>Show spec only</source>
         <target state="new">Show spec only</target>
-        <note />
+        <note>Spec means from the resource specification</note>
       </trans-unit>
       <trans-unit id="EnvironmentVariablesHideVariableValues">
         <source>Hide values</source>
@@ -90,17 +90,17 @@
       <trans-unit id="PlotlyChartCount">
         <source>Count</source>
         <target state="new">Count</target>
-        <note />
+        <note>Count is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartLength">
         <source>Length</source>
         <target state="new">Length</target>
-        <note />
+        <note>Length is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PlotlyChartValue">
         <source>Value</source>
         <target state="new">Value</target>
-        <note />
+        <note>Value is the name of a plot y-axis label</note>
       </trans-unit>
       <trans-unit id="PropertyGridValueColumnHeader">
         <source>Value</source>
@@ -115,17 +115,17 @@
       <trans-unit id="SpanDetailsDuration">
         <source>Duration &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Duration &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsService">
         <source>Service &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Service &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is the application name. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">
         <source>Start time &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="new">Start time &lt;strong&gt;{0}&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a duration. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
       <trans-unit id="ViewAction">
         <source>View</source>
@@ -155,7 +155,7 @@
       <trans-unit id="TotalItemsFooterText">
         <source>Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</source>
         <target state="new">Total: &lt;strong&gt;{0} results found&lt;/strong&gt;</target>
-        <note />
+        <note>{0} is a number. This is raw markup, so &lt;strong&gt; and &lt;/strong&gt; should not be modified</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Fixes #1440

Three strings were erroneously removed from `ControlsStrings.resx`, and were added back; the generated c# files should have then removed the respective fields, which would have caught this, but they did not.

Additionally, we should be using nameof instead of directly referencing the field values in localization lookups, so I made those changes project-wide.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1445)