### PR TITLE
Support for more package managers (pnpm & yarn)

### DIFF
--- a/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
+++ b/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
@@ -57,6 +57,58 @@ public static class NodeAppHostingExtension
                       .WithArgs(allArgs);
     }
 
+    /// <summary>
+    /// Adds a node application to the application model. Executes the command with the specified script name.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/> to add the resource to.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="workingDirectory">The working directory to use for the command. If null, the working directory of the current process is used.</param>
+    /// <param name="nodeExecutor">The executor to use. Can be a package manager like npm, pnpm, yarn or directly node.</param>
+    /// <param name="scriptName">The script to execute.</param>
+    /// <param name="args">The arguments to pass to the command.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<NodeAppResource> AddGenericNodeApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, string nodeExecutor, string scriptName, string[]? args = null)
+    {
+        string[] allArgs = args is { Length: > 0 }
+            ? ["run", scriptName, "--", .. args]
+            : ["run", scriptName];
+
+        workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, workingDirectory));
+        var resource = new NodeAppResource(name, nodeExecutor, workingDirectory);
+
+        return builder.AddResource(resource)
+                      .WithNodeDefaults()
+                      .WithArgs(allArgs);
+    }
+
+    /// <summary>
+    /// Adds a node application to the application model. Executes the yarn command with the specified script name.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/> to add the resource to.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="workingDirectory">The working directory to use for the command. If null, the working directory of the current process is used.</param>
+    /// <param name="scriptName">The script to execute.</param>
+    /// <param name="args">The arguments to pass to the command.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<NodeAppResource> AddYarnApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, string scriptName, string[]? args = null)
+    {
+        return builder.AddGenericNodeApp(name, workingDirectory, "yarn", scriptName, args);
+    }
+
+    /// <summary>
+    /// Adds a node application to the application model. Executes the pnpm command with the specified script name.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/> to add the resource to.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="workingDirectory">The working directory to use for the command. If null, the working directory of the current process is used.</param>
+    /// <param name="scriptName">The script to execute.</param>
+    /// <param name="args">The arguments to pass to the command.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<NodeAppResource> AddPnpmApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, string scriptName, string[]? args = null)
+    {
+        return builder.AddGenericNodeApp(name, workingDirectory, "pnpm", scriptName, args);
+    }
+
     private static IResourceBuilder<NodeAppResource> WithNodeDefaults(this IResourceBuilder<NodeAppResource> builder) =>
         builder.WithOtlpExporter()
             .WithEnvironment("NODE_ENV", builder.ApplicationBuilder.Environment.IsDevelopment() ? "development" : "production");

--- a/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
+++ b/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
@@ -67,7 +67,7 @@ public static class NodeAppHostingExtension
     /// <param name="scriptName">The script to execute.</param>
     /// <param name="args">The arguments to pass to the command.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<NodeAppResource> AddGenericNodeApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, string nodeExecutor, string scriptName, string[]? args = null)
+    private static IResourceBuilder<NodeAppResource> AddGenericNodeApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, string nodeExecutor, string scriptName, string[]? args = null)
     {
         string[] allArgs = args is { Length: > 0 }
             ? ["run", scriptName, "--", .. args]

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -309,6 +309,10 @@ public class ManifestGenerationTests
             .WithHttpEndpoint(port: 5031, env: "PORT");
         program.AppBuilder.AddNpmApp("npmapp", "..\\foo")
             .WithHttpEndpoint(port: 5032, env: "PORT");
+        program.AppBuilder.AddYarnApp("yarnapp", "..\\foo", "start")
+            .WithHttpEndpoint(port: 5032, env: "PORT");
+        program.AppBuilder.AddPnpmApp("pnpmapp", "..\\foo", "start")
+            .WithHttpEndpoint(port: 5032, env: "PORT");
 
         // Build AppHost so that publisher can be resolved.
         program.Build();
@@ -320,6 +324,8 @@ public class ManifestGenerationTests
 
         var nodeApp = resources.GetProperty("nodeapp");
         var npmApp = resources.GetProperty("npmapp");
+        var yarnApp = resources.GetProperty("yarnapp");
+        var pnpmApp = resources.GetProperty("pnpmapp");
 
         static void AssertNodeResource(TestProgram program, string resourceName, JsonElement jsonElement, string expectedCommand, string[] expectedArgs)
         {
@@ -342,6 +348,8 @@ public class ManifestGenerationTests
 
         AssertNodeResource(program, "nodeapp", nodeApp, "node", ["..\\foo\\app.js"]);
         AssertNodeResource(program, "npmapp", npmApp, "npm", ["run", "start"]);
+        AssertNodeResource(program, "yarnapp", yarnApp, "yarn", ["run", "start"]);
+        AssertNodeResource(program, "pnpmapp", pnpmApp, "pnpm", ["run", "start"]);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Node/NodeFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Tests/Node/NodeFunctionalTests.cs
@@ -26,8 +26,12 @@ public class NodeFunctionalTests
 
         var response0 = await testProgram.NodeAppBuilder!.HttpGetStringWithRetryAsync(client, "http", "/", cts.Token);
         var response1 = await testProgram.NpmAppBuilder!.HttpGetStringWithRetryAsync(client, "http", "/", cts.Token);
+        var response2 = await testProgram.YarnAppBuilder!.HttpGetStringWithRetryAsync(client, "http", "/", cts.Token);
+        var response3 = await testProgram.PnpmAppBuilder!.HttpGetStringWithRetryAsync(client, "http", "/", cts.Token);
 
         Assert.Equal("Hello from node!", response0);
         Assert.Equal("Hello from node!", response1);
+        Assert.Equal("Hello from node!", response2);
+        Assert.Equal("Hello from node!", response3);
     }
 }

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -53,6 +53,12 @@ public class TestProgram : IDisposable
 
             NpmAppBuilder = AppBuilder.AddNpmApp("npmapp", path)
                 .WithHttpEndpoint(port: 5032, env: "PORT");
+
+            YarnAppBuilder = AppBuilder.AddYarnApp("yarnapp", path, "start")
+                .WithHttpEndpoint(port: 5032, env: "PORT");
+
+            PnpmAppBuilder = AppBuilder.AddPnpmApp("pnpmapp", path, "start")
+                .WithHttpEndpoint(port: 5032, env: "PORT");
         }
 
         if (includeIntegrationServices)
@@ -133,6 +139,8 @@ public class TestProgram : IDisposable
     public IResourceBuilder<ProjectResource>? IntegrationServiceABuilder { get; private set; }
     public IResourceBuilder<NodeAppResource>? NodeAppBuilder { get; private set; }
     public IResourceBuilder<NodeAppResource>? NpmAppBuilder { get; private set; }
+    public IResourceBuilder<NodeAppResource>? YarnAppBuilder { get; private set; }
+    public IResourceBuilder<NodeAppResource>? PnpmAppBuilder { get; private set; }
     public DistributedApplication? App { get; private set; }
 
     public List<IResourceBuilder<ProjectResource>> ServiceProjectBuilders => [ServiceABuilder, ServiceBBuilder, ServiceCBuilder];


### PR DESCRIPTION
Added `AddPnpmApp(...)` and `AddYarnApp(...)`

They all run the same underling code so adding a generic method (like bellow) could also be an option
`AddGenericNodeApp(string name, string workingDirectory, string packageManager = "npm", string scriptName = "start", string[]? args = null)`

```
public static IResourceBuilder<NodeAppResource> AddGenericNodeApp(this IDistributedApplicationBuilder builder, string name, string workingDirectory, string packageManager = "npm", string scriptName = "start", string[]? args = null)
    {
        string[] allArgs = args is { Length: > 0 }
            ? ["run", scriptName, "--", .. args]
            : ["run", scriptName];

        workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, workingDirectory));
        var resource = new NodeAppResource(name, packageManager, workingDirectory, allArgs);

        return builder.AddResource(resource)
                      .WithNodeDefaults();
    }
```

If this generic method is the approach that the team prefers, I can also submit a PR with this instead
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1448)