### PR TITLE
Mark method as used

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -65,7 +65,7 @@
                         <SourceColumnDisplay Resource="context" FilterText="@_filter" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridEndpointsColumnHeader]">
-                        <EndpointsColumnDisplay Resource="context" HasMultipleReplicas="HasMultipleReplicas(context)" />
+                        <EndpointsColumnDisplay Resource="context" HasMultipleReplicas="@HasMultipleReplicas(context)" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridEnvironmentColumnHeader]" Sortable="false">
                         <FluentButton Appearance="Appearance.Lightweight"


### PR DESCRIPTION
This change lets VS see the `HasMultipleReplicas` as actually used. Otherwise, the backing file gets an _IDE0051 Member unused_ diagnostic.

![image](https://github.com/dotnet/aspire/assets/350947/65e8b907-9752-4400-b1b7-dec91e8d0fc9)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1449)