### PR TITLE
Avoid concurrency issues with dictionaries

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -2,14 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Utils;
 
 namespace Aspire.Dashboard.Model;
 
 public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsyncDisposable
 {
-    private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceNameMapping = new();
+    private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private readonly CancellationTokenSource _watchContainersTokenSource = new();
     private readonly Task _watchTask;
     private readonly List<ModelSubscription> _subscriptions = [];
@@ -21,7 +23,8 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
 
         foreach (var resource in snapshot)
         {
-            _resourceNameMapping[resource.Name] = resource;
+            var added = _resourceByName.TryAdd(resource.Name, resource);
+            Debug.Assert(added, "Should not receive duplicate resources in initial snapshot data.");
         }
 
         _watchTask = Task.Run(async () =>
@@ -37,11 +40,12 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
     {
         if (changeType == ResourceChangeType.Upsert)
         {
-            _resourceNameMapping[resourceViewModel.Name] = resourceViewModel;
+            _resourceByName[resourceViewModel.Name] = resourceViewModel;
         }
         else if (changeType == ResourceChangeType.Delete)
         {
-            _resourceNameMapping.TryRemove(resourceViewModel.Name, out _);
+            var removed = _resourceByName.TryRemove(resourceViewModel.Name, out _);
+            Debug.Assert(removed, "Cannot remove unknown resource.");
         }
 
         await RaisePeerChangesAsync().ConfigureAwait(false);
@@ -52,7 +56,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
         var address = OtlpHelpers.GetValue(attributes, OtlpSpan.PeerServiceAttributeKey);
         if (address != null)
         {
-            foreach (var (resourceName, resource) in _resourceNameMapping)
+            foreach (var (resourceName, resource) in _resourceByName)
             {
                 foreach (var service in resource.Services)
                 {

--- a/src/Aspire.Dashboard/Utils/StringComparers.cs
+++ b/src/Aspire.Dashboard/Utils/StringComparers.cs
@@ -5,12 +5,14 @@ namespace Aspire.Dashboard.Utils;
 
 internal static class StringComparers
 {
+    public static StringComparer ResourceName => StringComparer.Ordinal;
     public static StringComparer ResourceType => StringComparer.Ordinal;
     public static StringComparer UserTextSearch => StringComparer.CurrentCultureIgnoreCase;
 }
 
 internal static class StringComparisons
 {
+    public static StringComparison ResourceName => StringComparison.Ordinal;
     public static StringComparison ResourceType => StringComparison.Ordinal;
     public static StringComparison UserTextSearch => StringComparison.CurrentCultureIgnoreCase;
 }


### PR DESCRIPTION
Fixes #1239

Background processes can trigger concurrent modifications of collections being queried or enumerated, which can lead to corruptions and exceptions or runaway CPU.

Use `ConcurrentDictionary<,>` instead to prevent these issues.

Also:

- Add explicit string comparer for comparing resource names.
- Use consistent name for these collections.
- Add some debug assertions as validation of incoming data.

Future work might pull this pattern out into a new class, potentially also using a lighter collection than `ConcurrentDictionary<,>`. I'll wait until the current client/server refactoring is complete before doing that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1450)