### PR TITLE
Add tags to hosting packages for easier searching

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/Aspire.Hosting.Azure.Provisioning.csproj
+++ b/src/Aspire.Hosting.Azure.Provisioning/Aspire.Hosting.Azure.Provisioning.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <PackageTags>aspire hosting azure provisioning</PackageTags>
     <Description>Provisions Azure resources for development in .NET Aspire projects.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <PackageTags>aspire hosting azure</PackageTags>
     <Description>Azure resource types for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
+++ b/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
+    <PackageTags>aspire hosting dapr</PackageTags>
     <Description>Dapr support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
+++ b/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
@@ -3,6 +3,7 @@
   <Import Project="$(SharedDir)Workload.targets" />
 
   <PropertyGroup>
+    <PackageTags>aspire hosting sdk</PackageTags>
     <Description>.NET Aspire Hosting SDK. Enabled via &lt;IsAspireHost&gt;true&lt;/IsAspireHost&gt;.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -6,6 +6,7 @@
     <IsPackable>true</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
+    <PackageTags>aspire hosting</PackageTags>
     <Description>Core API and abstractions for the .NET Aspire application model.</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
Related to #1314

This PR moves all `Aspire.Hosting.*` project to `/src/Hosting/` and adds a directory-specific `Directory.Build.props` to said directory to manage common and specific hosting-related tags.

It also adds relative `<PackageTags>...<PackageTags/>` to all `Aspire.Hosting.*` projects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1462)