### PR TITLE
Add `PasswordUtil.GeneratePassword`

### DIFF
--- a/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -24,7 +25,7 @@ public static class MySqlBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{MySqlContainerResource}"/>.</returns>
     public static IResourceBuilder<MySqlContainerResource> AddMySqlContainer(this IDistributedApplicationBuilder builder, string name, int? port = null, string? password = null)
     {
-        password ??= Guid.NewGuid().ToString("N");
+        password ??= PasswordUtil.GeneratePassword();
         var mySqlContainer = new MySqlContainerResource(name, password);
         return builder.AddResource(mySqlContainer)
                       .WithManifestPublishingCallback(context => WriteMySqlContainerResourceToManifest(context, mySqlContainer))
@@ -51,7 +52,7 @@ public static class MySqlBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{MySqlContainerResource}"/>.</returns>
     public static IResourceBuilder<MySqlServerResource> AddMySql(this IDistributedApplicationBuilder builder, string name)
     {
-        var password = Guid.NewGuid().ToString("N");
+        var password = PasswordUtil.GeneratePassword();
         var mySqlContainer = new MySqlServerResource(name, password);
         return builder.AddResource(mySqlContainer)
                       .WithManifestPublishingCallback(WriteMySqlContainerToManifest)

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -24,7 +25,7 @@ public static class PostgresBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{PostgresContainerResource}"/>.</returns>
     public static IResourceBuilder<PostgresContainerResource> AddPostgresContainer(this IDistributedApplicationBuilder builder, string name, int? port = null, string? password = null)
     {
-        password = password ?? Guid.NewGuid().ToString("N");
+        password = password ?? PasswordUtil.GeneratePassword();
         var postgresContainer = new PostgresContainerResource(name, password);
         return builder.AddResource(postgresContainer)
                       .WithManifestPublishingCallback(context => WritePostgresContainerResourceToManifest(context, postgresContainer))
@@ -53,7 +54,7 @@ public static class PostgresBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{PostgresContainerResource}"/>.</returns>
     public static IResourceBuilder<PostgresServerResource> AddPostgres(this IDistributedApplicationBuilder builder, string name)
     {
-        var password = Guid.NewGuid().ToString("N");
+        var password = PasswordUtil.GeneratePassword();
         var postgresServer = new PostgresServerResource(name, password);
         return builder.AddResource(postgresServer)
                       .WithManifestPublishingCallback(WritePostgresContainerToManifest)

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -22,7 +23,7 @@ public static class RabbitMQBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{RabbitMQContainerResource}"/>.</returns>
     public static IResourceBuilder<RabbitMQContainerResource> AddRabbitMQContainer(this IDistributedApplicationBuilder builder, string name, int? port = null, string? password = null)
     {
-        password ??= Guid.NewGuid().ToString("N");
+        password ??= PasswordUtil.GeneratePassword();
         var rabbitMq = new RabbitMQContainerResource(name, password);
         return builder.AddResource(rabbitMq)
                        .WithAnnotation(new ServiceBindingAnnotation(ProtocolType.Tcp, port: port, containerPort: 5672))
@@ -52,7 +53,7 @@ public static class RabbitMQBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{RabbitMQContainerResource}"/>.</returns>
     public static IResourceBuilder<RabbitMQServerResource> AddRabbitMQ(this IDistributedApplicationBuilder builder, string name)
     {
-        var password = Guid.NewGuid().ToString("N");
+        var password = PasswordUtil.GeneratePassword();
         var rabbitMq = new RabbitMQServerResource(name, password);
         return builder.AddResource(rabbitMq)
                        .WithAnnotation(new ServiceBindingAnnotation(ProtocolType.Tcp, containerPort: 5672))

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -22,7 +23,7 @@ public static class SqlServerBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{SqlServerContainerResource}"/>.</returns>
     public static IResourceBuilder<SqlServerContainerResource> AddSqlServerContainer(this IDistributedApplicationBuilder builder, string name, string? password = null, int? port = null)
     {
-        password = password ?? Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N").ToUpper();
+        password = password ?? PasswordUtil.GeneratePassword();
         var sqlServer = new SqlServerContainerResource(name, password);
 
         return builder.AddResource(sqlServer)
@@ -52,7 +53,7 @@ public static class SqlServerBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{SqlServerContainerResource}"/>.</returns>
     public static IResourceBuilder<SqlServerServerResource> AddSqlServer(this IDistributedApplicationBuilder builder, string name)
     {
-        var password = Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N").ToUpper();
+        var password = PasswordUtil.GeneratePassword();
         var sqlServer = new SqlServerServerResource(name, password);
 
         return builder.AddResource(sqlServer)

--- a/src/Aspire.Hosting/Utils/PasswordUtil.cs
+++ b/src/Aspire.Hosting/Utils/PasswordUtil.cs
@@ -6,4 +6,47 @@ namespace Aspire.Hosting.Utils;
 internal static class PasswordUtil
 {
     internal static string EscapePassword(string password) => password.Replace("\"", "\"\"");
+
+    /// <summary>
+    /// Returns a random password of length <paramref name="length"/> that does not contain any characters that would be escaped by <see cref="EscapePassword(string)"/>.
+    /// </summary>
+    /// <remarks>If <paramref name="length"/> is greater than or equal to four, the password is guaranteed to contain an uppercase ASCII letter, a lowercase ASCII letter, a digit, and a symbol.</remarks>
+    internal static string GeneratePassword(int length = 20)
+    {
+        return string.Create(length, 0, (buffer, _) =>
+        {
+            if (length >= 1)
+            {
+                // add an uppercase ASCII letter
+                Random.Shared.GetItems(PasswordChars.Slice(0, 26), buffer[..1]);
+
+                if (length >= 2)
+                {
+                    // add a lowercase ASCII letter
+                    Random.Shared.GetItems(PasswordChars.Slice(26, 26), buffer[1..2]);
+
+                    if (length >= 3)
+                    {
+                        // add a digit
+                        Random.Shared.GetItems(PasswordChars.Slice(52, 10), buffer[2..3]);
+
+                        if (length >= 4)
+                        {
+                            // add a symbol
+                            Random.Shared.GetItems(PasswordChars.Slice(62), buffer[3..4]);
+
+                            if (length >= 5)
+                            {
+                                // use random password characters for the rest of the password
+                                Random.Shared.GetItems(PasswordChars, buffer[4..]);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // Characters to use in a password that do not need to be escaped. They should be in the order: UPPER, lower, digits, symbols
+    private static ReadOnlySpan<char> PasswordChars => "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmonpqrstuvwxyz0123456789!@$^&*()[]{}':,._-";
 }


### PR DESCRIPTION
This method generates a random password that is guaranteed to contain a mix of character types, and does not need to be escaped if used in a connection string.

Based on a comment here: https://github.com/dotnet/aspire/pull/1295/files#r1428294263

The algorithm is designed to generate a password that meets SQL Server complexity requirements (e.g., to avoid the following error message):

> The password does not meet SQL Server password policy requirements because it is not complex enough. The password must be at least 8 characters long and contain characters from three of the following four sets: Uppercase letters, Lowercase letters, Base 10 digits, and Symbols.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1469)