### PR TITLE
Reduce splitter bar size to 5 in summary view

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -5,7 +5,8 @@
     <FluentSplitter Orientation="@Orientation" Collapsed="@(!ShowDetails)"
                     OnResized="HandleSplitterResize"
                     Panel1Size="@_panel1Size" Panel2Size="@_panel2Size"
-                    Panel1MinSize="150px" Panel2MinSize="150px">
+                    Panel1MinSize="150px" Panel2MinSize="150px"
+                    BarSize="5">
         <Panel1>
             <div class="summary-container">
                 @Summary


### PR DESCRIPTION
I reduced the bar size from 8 to 5 in summary view. It's still easy to land on. Let me know if it seems too thin

screenshot:
![image](https://github.com/dotnet/aspire/assets/20359921/bc7069c9-1beb-4a6d-b991-ccae35f67943)

resolves #864

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1474)