### PR TITLE
Fix meter node remaining selected when instrument is selected

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -37,7 +37,11 @@
                         <ChildContent>
                             @foreach (var meterGroup in _instruments.GroupBy(i => i.Parent).OrderBy(g => g.Key.MeterName))
                             {
-                                <FluentTreeItem @key="meterGroup.Key" Text="@meterGroup.Key.MeterName" Data="@meterGroup.Key" title="@meterGroup.Key.MeterName" InitiallyExpanded="true" InitiallySelected="@(_selectedInstrument == null && meterGroup.Key.MeterName == _selectedMeter?.MeterName)">
+                                // Track whether a child instrument is selected for a meter.
+                                // This value is used in the meter item key to force the item to refresh when a child is selected.
+                                var childSelected = meterGroup.Key.MeterName == _selectedInstrument?.Parent.MeterName;
+
+                                <FluentTreeItem @key="(meterGroup.Key, childSelected)" Text="@meterGroup.Key.MeterName" Data="@meterGroup.Key" title="@meterGroup.Key.MeterName" InitiallyExpanded="true" InitiallySelected="@(_selectedInstrument == null && meterGroup.Key.MeterName == _selectedMeter?.MeterName)">
                                     @foreach (var instrument in meterGroup.OrderBy(i => i.Name))
                                     {
                                         <FluentTreeItem @key="instrument" Class="nested" Text="@instrument.Name" Data="@instrument" title="@instrument.Name" InitiallySelected="@(instrument.Name == _selectedInstrument?.Name && instrument.Parent.MeterName == _selectedMeter?.MeterName)" />


### PR DESCRIPTION
**Before:**
Meter incorrectly stays selected when an instrument is selected
![select-instrument](https://github.com/dotnet/aspire/assets/303201/30b468f6-6c20-402f-9d66-952c3c6f4f25)

**After:**
Instrument is selected and meter item is deselected.
![select-instrument-fix](https://github.com/dotnet/aspire/assets/303201/f742873f-4fa3-4f76-8322-4ca27f22019a)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1500)