### PR TITLE
Hide splitter handle and apply new width to metrics splitter

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -31,7 +31,7 @@
     <div class="page-content-area">
         @if (_instruments?.Count > 0)
         {
-            <FluentSplitter Style="height:100%" Panel1Size="2fr" Panel2Size="8fr">
+            <FluentSplitter Style="height:100%" Panel1Size="2fr" Panel2Size="8fr" BarSize="5">
                 <Panel1>
                     <FluentTreeView Class="metrics-tree" @bind-CurrentSelected="_selectedTreeItem" @bind-CurrentSelected:after="HandleSelectedTreeItemChanged">
                         <ChildContent>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -176,3 +176,7 @@ fluent-data-grid-cell .long-inner-content {
     vertical-align: text-bottom;
     margin-right: 3px;
 }
+
+split-panels::part(handle) {
+    display: none;
+}


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspire/pull/1474

After:
![image](https://github.com/dotnet/aspire/assets/303201/a705ab29-df71-43d6-94a1-cd6a109b551c)

![image](https://github.com/dotnet/aspire/assets/303201/656b25c8-5022-4575-9cc8-6ed00aa3b8a8)


Splitter handles aren't commonly used in modern designs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1506)