### PR TITLE
Adds live region to console log status + rows

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.js
@@ -36,7 +36,7 @@ export function addLogEntries(logEntries) {
             // logEntry.content should already be HTMLEncoded other than the <span>s produced
             // by the ANSI Control Sequence Parsing, so it should be safe to set innerHTML here
             content.innerHTML = logEntry.content;
-            
+
             if (logEntry.type === "Error") {
                 const stdErrorBadge = getStdErrorBadge();
                 // If there's a timestamp, we want to put the badge after it to keep timestamps
@@ -62,7 +62,7 @@ export function addLogEntries(logEntries) {
 }
 
 /**
- * 
+ *
  * @param {HTMLElement} container
  * @param {HTMLElement} row
  * @param {string} timestamp
@@ -124,11 +124,11 @@ function getStdErrorBadge() {
  * @returns {HTMLElement}
  */
 function createRowTemplate() {
-    
+
     const templateString = `
         <div class="line-row-container">
             <div class="line-row">
-                <span class="line-area">
+                <span class="line-area" role="log">
                     <span class="line-number"></span>
                     <span class="content"></span>
                 </span>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -14,7 +14,7 @@
                       @bind-SelectedOption="_selectedOption"
                       @bind-SelectedOption:after="HandleSelectedOptionChangedAsync"
                       AriaLabel="@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsSelectAResource)]"/>
-        <FluentLabel Typo="Typography.Body">@_status</FluentLabel>
+        <FluentLabel Typo="Typography.Body" aria-live="polite" aria-label="@Loc[nameof(Dashboard.Resources.ConsoleLogs.LogStatusLabel)]">@_status</FluentLabel>
     </FluentToolbar>
     <LogViewer @ref="_logViewer" />
 </div>

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.Designer.cs
@@ -157,5 +157,14 @@ namespace Aspire.Dashboard.Resources {
                 return ResourceManager.GetString("ConsoleLogsWatchingLogs", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Service log status.
+        /// </summary>
+        public static string LogStatusLabel {
+            get {
+                return ResourceManager.GetString("LogStatusLabel", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
+++ b/src/Aspire.Dashboard/Resources/ConsoleLogs.resx
@@ -132,4 +132,7 @@
   <data name="ConsoleLogsUnknownState" xml:space="preserve">
     <value>Unknown state</value>
   </data>
+  <data name="LogStatusLabel" xml:space="preserve">
+    <value>Service log status</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.cs.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.de.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.es.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.fr.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.it.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ja.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ko.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pl.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.ru.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.tr.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ConsoleLogs.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="new">Watching logs...</target>
         <note />
       </trans-unit>
+      <trans-unit id="LogStatusLabel">
+        <source>Service log status</source>
+        <target state="new">Service log status</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Based on guidance from [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live), it appears like the only place where it is necessary to announce changes is the console log status text (see below), as well as announcing new console log rows.
![image](https://github.com/dotnet/aspire/assets/20359921/d915efcd-3a7b-4cfb-9bca-a5bf03750c67)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1514)