### PR TITLE
Adds a failure icon to FailedToStart resources

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -4,7 +4,7 @@
 
 <FluentStack Orientation="Orientation.Vertical">
     @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
-    @if (Resource.Endpoints.Length == 0 && (Resource.State == ResourceStates.FinishedState || Resource.ExpectedEndpointsCount == 0))
+    @if (Resource.Endpoints.Length == 0 && (Resource.State == ResourceStates.Finished || Resource.ExpectedEndpointsCount == 0))
     {
         <span class="long-inner-content">@Loc[nameof(Columns.EndpointsColumnDisplayNone)]</span>
     }
@@ -24,7 +24,7 @@
             }
         }
         @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
-        if (Resource.State != ResourceStates.FinishedState
+        if (Resource.State != ResourceStates.Finished
         && (Resource.ExpectedEndpointsCount is null || Resource.ExpectedEndpointsCount > Resource.Endpoints.Length))
         {
             <span class="long-inner-content">@Loc[nameof(Columns.EndpointsColumnDisplayPlaceholder)]</span>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -4,7 +4,7 @@
 @inject IStringLocalizer<Columns> Loc
 
 <div class="resource-state-container">
-    @if (Resource is { State: ResourceStates.ExitedState /* containers */ or ResourceStates.FinishedState /* executables */, ExitCode: not null and not 0 })
+    @if (Resource is { State: ResourceStates.Exited /* containers */ or ResourceStates.Finished /* executables */, ExitCode: not null and not 0 })
     {
         <!-- process completed unexpectedly, hence the non-zero code. this is almost certainly an error, so warn users -->
         <FluentIcon
@@ -13,7 +13,7 @@
             Color="Color.Error"
             Class="severity-icon"/>
     }
-    else if (Resource is { State: ResourceStates.ExitedState /* containers */ or ResourceStates.FinishedState /* containers */ })
+    else if (Resource is { State: ResourceStates.Exited /* containers */ or ResourceStates.Finished /* containers */ })
     {
         <!-- process completed, which may not have been unexpected -->
         <FluentIcon
@@ -22,6 +22,13 @@
             Color="Color.Warning"
             Class="severity-icon"/>
     }
+    else if (Resource is { State: ResourceStates.FailedToStart })
+     {
+         <FluentIcon
+             Icon="Icons.Filled.Size16.ErrorCircle"
+             Color="Color.Error"
+             Class="severity-icon"/>
+     }
 
     @Resource.State
     <UnreadLogErrorsBadge UnviewedCount="@GetUnviewedErrorCount(Resource)" Resource="@Resource"/>

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -60,6 +60,7 @@ public sealed record EndpointViewModel(string EndpointUrl, string ProxyUrl);
 
 public static class ResourceStates
 {
-    public const string FinishedState = "Finished";
-    public const string ExitedState = "Exited";
+    public const string Finished = "Finished";
+    public const string Exited = "Exited";
+    public const string FailedToStart = "FailedToStart";
 }


### PR DESCRIPTION
This adds the same icon to failedtostart resources as exist in finished/exited resources that exited unexpectedly. 

![image](https://github.com/dotnet/aspire/assets/20359921/de0f856d-f4a6-4008-8d0d-7e24a1ddcb3d)


Additionally, I renamed ResourceStates.XState to ResourceStates.X, as the State suffix was redundant

resolves #1503
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1517)