### PR TITLE
Support all XML doc ID strings

### DIFF
--- a/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
@@ -78,7 +78,7 @@
                             "None",
                             "Base64"
                           ],
-                          "description": "Gets or sets a message encoding that determines how 'Azure.Storage.Queues.Models.QueueMessage.Body' is represented in HTTP requests and responses.\nThe default is F:Azure.Storage.Queues.QueueMessageEncoding.None."
+                          "description": "Gets or sets a message encoding that determines how 'Azure.Storage.Queues.Models.QueueMessage.Body' is represented in HTTP requests and responses.\nThe default is 'Azure.Storage.Queues.QueueMessageEncoding.None'."
                         },
                         "Retry": {
                           "type": "object",

--- a/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
@@ -87,7 +87,7 @@
                         "Packet",
                         "ControllerAreaNetwork"
                       ],
-                      "description": "Address family used by default.\nUse F:System.Net.Sockets.AddressFamily.InterNetwork to force to IPv4.\nUse F:System.Net.Sockets.AddressFamily.InterNetworkV6 to force to IPv6.\nOr use F:System.Net.Sockets.AddressFamily.Unknown to attempt both IPv6 and IPv4."
+                      "description": "Address family used by default.\nUse 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4.\nUse 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6.\nOr use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
                     },
                     "DefaultAmqpUriSslProtocols": {
                       "enum": [
@@ -145,7 +145,7 @@
                             "Packet",
                             "ControllerAreaNetwork"
                           ],
-                          "description": "Used to force the address family of the endpoint.\nUse F:System.Net.Sockets.AddressFamily.InterNetwork to force to IPv4.\nUse F:System.Net.Sockets.AddressFamily.InterNetworkV6 to force to IPv6.\nOr use F:System.Net.Sockets.AddressFamily.Unknown to attempt both IPv6 and IPv4."
+                          "description": "Used to force the address family of the endpoint.\nUse 'System.Net.Sockets.AddressFamily.InterNetwork' to force to IPv4.\nUse 'System.Net.Sockets.AddressFamily.InterNetworkV6' to force to IPv6.\nOr use 'System.Net.Sockets.AddressFamily.Unknown' to attempt both IPv6 and IPv4."
                         },
                         "HostName": {
                           "type": "string",
@@ -198,7 +198,7 @@
                                 "Tls12",
                                 "Tls13"
                               ],
-                              "description": "Retrieve or set the TLS protocol version.\nThe client will let the OS pick a suitable version by using F:System.Security.Authentication.SslProtocols.None .\nIf this option is disabled, e.g.see via app context, the client will attempt to fall back\nto TLSv1.2."
+                              "description": "Retrieve or set the TLS protocol version.\nThe client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None' .\nIf this option is disabled, e.g.see via app context, the client will attempt to fall back\nto TLSv1.2."
                             }
                           },
                           "description": "Retrieve the TLS options for this AmqpTcpEndpoint. If not set, null is returned."
@@ -230,7 +230,7 @@
                     },
                     "Port": {
                       "type": "integer",
-                      "description": "The port to connect on. F:RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort indicates the default for the protocol should be used."
+                      "description": "The port to connect on. 'RabbitMQ.Client.AmqpTcpEndpoint.UseDefaultPort' indicates the default for the protocol should be used."
                     },
                     "RequestedChannelMax": {
                       "type": "integer",
@@ -303,7 +303,7 @@
                             "Tls12",
                             "Tls13"
                           ],
-                          "description": "Retrieve or set the TLS protocol version.\nThe client will let the OS pick a suitable version by using F:System.Security.Authentication.SslProtocols.None .\nIf this option is disabled, e.g.see via app context, the client will attempt to fall back\nto TLSv1.2."
+                          "description": "Retrieve or set the TLS protocol version.\nThe client will let the OS pick a suitable version by using 'System.Security.Authentication.SslProtocols.None' .\nIf this option is disabled, e.g.see via app context, the client will attempt to fall back\nto TLSv1.2."
                         }
                       },
                       "description": "TLS options setting."

--- a/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
+++ b/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
@@ -38,7 +38,7 @@
                       "properties": {
                         "UseImplicitAutoPattern": {
                           "type": "boolean",
-                          "description": "Indicates whether channels should use F:StackExchange.Redis.RedisChannel.PatternMode.Auto when no 'StackExchange.Redis.RedisChannel.PatternMode' is specified; this is enabled by default, but can be disabled to avoid unexpected wildcard scenarios."
+                          "description": "Indicates whether channels should use 'StackExchange.Redis.RedisChannel.PatternMode.Auto' when no 'StackExchange.Redis.RedisChannel.PatternMode' is specified; this is enabled by default, but can be disabled to avoid unexpected wildcard scenarios."
                         }
                       },
                       "description": "Automatically encodes and decodes channels."
@@ -113,7 +113,7 @@
                         "Twemproxy",
                         "Envoyproxy"
                       ],
-                      "description": "Type of proxy to use (if any); for example F:StackExchange.Redis.Proxy.Twemproxy."
+                      "description": "Type of proxy to use (if any); for example 'StackExchange.Redis.Proxy.Twemproxy'."
                     },
                     "ResolveDns": {
                       "type": "boolean",

--- a/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
+++ b/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
@@ -41,10 +41,13 @@ public class GeneratorTests
     }
 
     [Theory]
+    [InlineData("<see cref=\"N:System.Diagnostics\"/>", "'System.Diagnostics'")]
     [InlineData("<see cref=\"T:System.Uri\"/>", "'System.Uri'")]
     [InlineData("<see cref=\"T:Azure.Core.Extensions.IAzureClientBuilder`2\"/>", "'Azure.Core.Extensions.IAzureClientBuilder`2'")]
+    [InlineData("<see cref=\"F:Azure.Storage.Queues.QueueMessageEncoding.None\"/>", "'Azure.Storage.Queues.QueueMessageEncoding.None'")]
     [InlineData("<see cref=\"P:Aspire.Azure.Storage.Blobs.AzureStorageBlobsSettings.ConnectionString\"/>", "'Aspire.Azure.Storage.Blobs.AzureStorageBlobsSettings.ConnectionString'")]
     [InlineData("<see cref=\"M:System.Diagnostics.Debug.Assert(bool)\"/>", "'System.Diagnostics.Debug.Assert(bool)'")]
+    [InlineData("<see cref=\"E:System.Windows.Input.ICommand.CanExecuteChanged\"/>", "'System.Windows.Input.ICommand.CanExecuteChanged'")]
     [InlineData("<exception cref=\"T:System.InvalidOperationException\" />", "'System.InvalidOperationException'")]
     public void StripXmlElementsShouldFormatCrefAttributes(string input, string expected)
     {


### PR DESCRIPTION
Add support for namespace, field, and event ID strings in the ConfigurationSchemaGenerator.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1524)