### PR TITLE
Restyle error ui and reconnection ui

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -14,7 +14,22 @@
     <!-- Make the body background dark if dark mode will be enabled to prevent a flash of white
          before fully rendered. This value is from --neutral-fill-layer-rest, but that custom
          property isn't available at this point. -->
-    <style>@@media (prefers-color-scheme: dark) { body { background-color: #272727; } }</style>
+    <style>
+        @@media (prefers-color-scheme: dark) {
+            body {
+                background-color: #272727;
+            }
+        }
+
+        #components-reconnect-modal :is(h5, p) {
+            color: var(--error-ui-foreground-color);
+        }
+
+        #components-reconnect-modal :is(a) {
+            color: var(--error-ui-accent-foreground-color);
+        }
+    </style>
+
 </head>
 
 <body class="before-upgrade">

--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -28,6 +28,10 @@
         #components-reconnect-modal a {
             color: var(--error-ui-accent-foreground-color);
         }
+
+        #components-reconnect-modal {
+            background-color: var(--reconnection-ui-bg) !important;
+        }
     </style>
 
 </head>

--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -25,7 +25,7 @@
             color: var(--error-ui-foreground-color);
         }
 
-        #components-reconnect-modal :is(a) {
+        #components-reconnect-modal a {
             color: var(--error-ui-accent-foreground-color);
         }
     </style>

--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -20,18 +20,6 @@
                 background-color: #272727;
             }
         }
-
-        #components-reconnect-modal :is(h5, p) {
-            color: var(--error-ui-foreground-color);
-        }
-
-        #components-reconnect-modal a {
-            color: var(--error-ui-accent-foreground-color);
-        }
-
-        #components-reconnect-modal {
-            background-color: var(--reconnection-ui-bg) !important;
-        }
     </style>
 
 </head>

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -31,7 +31,7 @@
     <FluentDialogProvider />
     <FluentTooltipProvider />
     <div id="blazor-error-ui">
-        @Loc[nameof(Layout.MainLayoutUnhandledErrorMessage)]
+        <span id="error-message">@Loc[nameof(Layout.MainLayoutUnhandledErrorMessage)]</span>
         <a href="" class="reload">@Loc[nameof(Layout.MainLayoutUnhandledErrorReload)]</a>
         <a class="dismiss">🗙</a>
     </div>

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -31,7 +31,7 @@
     <FluentDialogProvider />
     <FluentTooltipProvider />
     <div id="blazor-error-ui">
-        <span id="error-message">@Loc[nameof(Layout.MainLayoutUnhandledErrorMessage)]</span>
+        @Loc[nameof(Layout.MainLayoutUnhandledErrorMessage)]
         <a href="" class="reload">@Loc[nameof(Layout.MainLayoutUnhandledErrorReload)]</a>
         <a class="dismiss">🗙</a>
     </div>

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -1,5 +1,5 @@
 #blazor-error-ui {
-    background: lightyellow;
+    background: var(--highlight-bg);
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
     display: none;
@@ -8,6 +8,11 @@
     position: fixed;
     width: 100%;
     z-index: 1000;
+    color: var(--error-ui-foreground-color);
+}
+
+#blazor-error-ui a {
+    color: var(--error-ui-accent-foreground-color);
 }
 
 #blazor-error-ui .dismiss {
@@ -15,6 +20,10 @@
     position: absolute;
     right: 0.75rem;
     top: 0.5rem;
+}
+
+#blazor-error-ui .reload {
+    color: var(--error-ui-accent-foreground-color);
 }
 
 ::deep.layout {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -49,7 +49,7 @@ fluent-toolbar[orientation=horizontal] {
 
     --error-ui-foreground-color: #000000;
     --error-ui-accent-foreground-color: #512bd4;
-    --reconnection-ui-bg: #D1D1D1;
+    --reconnection-ui-bg: #D6D6D6;
 }
 
  #components-reconnect-modal :is(h5, p) {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -52,6 +52,18 @@ fluent-toolbar[orientation=horizontal] {
     --reconnection-ui-bg: #D1D1D1;
 }
 
+ #components-reconnect-modal :is(h5, p) {
+     color: var(--error-ui-foreground-color);
+ }
+
+ #components-reconnect-modal a {
+     color: var(--error-ui-accent-foreground-color);
+ }
+
+ #components-reconnect-modal {
+     background-color: var(--reconnection-ui-bg) !important;
+ }
+
 .datagrid-overflow-area,
 .parent-details-container {
     /*

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -33,8 +33,10 @@ fluent-toolbar[orientation=horizontal] {
     --badge-color-error: var(--foreground-on-accent-rest);
     --foreground-subtext-rest: #5D5D5D;
     --foreground-subtext-hover: #6C6C6C;
-    --error-ui-foreground-color: var(--neutral-foreground-rest);
-    --error-ui-accent-foreground-color: var(--accent-foreground-rest);
+
+    --error-ui-foreground-color: #131313;
+    --error-ui-accent-foreground-color: #1d00d0;
+    --reconnection-ui-bg: rgb(255, 255, 255);
 }
 
 [data-theme="dark"] {
@@ -44,8 +46,10 @@ fluent-toolbar[orientation=horizontal] {
     --error: #F8040A !important;
     --foreground-subtext-rest: #8D8D8D;
     --foreground-subtext-hover: #A1A1A1;
-    --error-ui-foreground-color: var(--foreground-on-accent-rest);
-    --error-ui-accent-foreground-color: var(--accent-base-color);
+
+    --error-ui-foreground-color: #000000;
+    --error-ui-accent-foreground-color: #512bd4;
+    --reconnection-ui-bg: #D1D1D1;
 }
 
 .datagrid-overflow-area,

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -33,6 +33,8 @@ fluent-toolbar[orientation=horizontal] {
     --badge-color-error: var(--foreground-on-accent-rest);
     --foreground-subtext-rest: #5D5D5D;
     --foreground-subtext-hover: #6C6C6C;
+    --error-ui-foreground-color: var(--neutral-foreground-rest);
+    --error-ui-accent-foreground-color: var(--accent-foreground-rest);
 }
 
 [data-theme="dark"] {
@@ -42,6 +44,8 @@ fluent-toolbar[orientation=horizontal] {
     --error: #F8040A !important;
     --foreground-subtext-rest: #8D8D8D;
     --foreground-subtext-hover: #A1A1A1;
+    --error-ui-foreground-color: var(--foreground-on-accent-rest);
+    --error-ui-accent-foreground-color: var(--accent-base-color);
 }
 
 .datagrid-overflow-area,


### PR DESCRIPTION
We had problems with contrast issues with dark theme for the error ui, as well as the reconnection ui, which is provided by default by the blazor framework (resolves #1464)

You can see below and after pictures below. The first image in each category is the error ui, the second the reconnecting in progress ui, and the third is the reconnection failed ui.

Before
Light theme:
![image](https://github.com/dotnet/aspire/assets/20359921/a975c339-041e-4917-b107-c0430eb4e7cb)
![image](https://github.com/dotnet/aspire/assets/20359921/426684a2-f842-414e-92ab-4580549e7e76)
![image](https://github.com/dotnet/aspire/assets/20359921/6077961f-a562-4589-855f-b99c3cf5e097)


Dark theme:
![image](https://github.com/dotnet/aspire/assets/20359921/2f0ebbc7-728d-41cf-bcb3-7e1b0379c62e)
![image](https://github.com/dotnet/aspire/assets/20359921/ae0f7621-7eac-41ef-b6be-9a991639dc29)
![image](https://github.com/dotnet/aspire/assets/20359921/3a4e76f0-7076-4e3d-9a58-468cd03fd997)

After
Light theme:
![image](https://github.com/dotnet/aspire/assets/20359921/cb822862-afde-4abf-94a1-39ea2269cc9a)
![image](https://github.com/dotnet/aspire/assets/20359921/62559053-db49-40d7-900e-9ebed46f92e0)
![image](https://github.com/dotnet/aspire/assets/20359921/0f45d8b4-d689-416f-bef0-757ec940ae81)
 
Dark theme:
![image](https://github.com/dotnet/aspire/assets/20359921/bb2f8680-057f-4dc7-a18c-f069b6dd80a8)
![image](https://github.com/dotnet/aspire/assets/20359921/aa0b6d1a-010b-4685-b67f-5c1715c2e410)
![image](https://github.com/dotnet/aspire/assets/20359921/c05fb31e-6ea5-436d-9e77-4472bee99484)

 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1527)