### PR TITLE
Remove Container from AppHost extensions in README

### DIFF
--- a/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
@@ -88,10 +88,10 @@ Also you can pass the `Action<MicrosoftDataSqlClientSettings> configureSettings`
 
 ## AppHost extensions
 
-In your AppHost project, register a SqlServer container and consume the connection using the following methods:
+In your AppHost project, register a SqlServer database and consume the connection using the following methods:
 
 ```csharp
-var sql = builder.AddSqlServerContainer("sql").AddDatabase("sqldata");
+var sql = builder.AddSqlServer("sql").AddDatabase("sqldata");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(sql);

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
@@ -90,10 +90,10 @@ Also you can pass the `Action<MicrosoftEntityFrameworkCoreSqlServerSettings> con
 
 ## AppHost extensions
 
-In your AppHost project, register a SqlServer container and consume the connection using the following methods:
+In your AppHost project, register a SqlServer database and consume the connection using the following methods:
 
 ```csharp
-var sql = builder.AddSqlServerContainer("sql").AddDatabase("sqldata");
+var sql = builder.AddSqlServer("sql").AddDatabase("sqldata");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(sql);

--- a/src/Components/Aspire.MongoDB.Driver/README.md
+++ b/src/Components/Aspire.MongoDB.Driver/README.md
@@ -88,10 +88,10 @@ Also you can pass the `Action<MongoDBSettings> configureSettings` delegate to se
 
 ## AppHost extensions
 
-In your AppHost project, register a MongoDB container and consume the connection using the following methods:
+In your AppHost project, register a MongoDB database and consume the connection using the following methods:
 
 ```csharp
-var mongodb = builder.AddMongoDBContainer("mongodb").AddDatabase("mydatabase");
+var mongodb = builder.AddMongoDB("mongodb").AddDatabase("mydatabase");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(mongodb);

--- a/src/Components/Aspire.MySqlConnector/README.md
+++ b/src/Components/Aspire.MySqlConnector/README.md
@@ -84,10 +84,10 @@ Also you can pass the `Action<MySqlConnectorSettings> configureSettings` delegat
 
 ## AppHost extensions
 
-In your AppHost project, register a MySQL container and consume the connection using the following methods:
+In your AppHost project, register a MySQL database and consume the connection using the following methods:
 
 ```csharp
-var mysqldb = builder.AddMySqlContainer("mysql").AddDatabase("mysqldb");
+var mysqldb = builder.AddMySql("mysql").AddDatabase("mysqldb");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(mysqldb);

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
@@ -89,10 +89,10 @@ Also you can pass the `Action<NpgsqlEntityFrameworkCorePostgreSQLSettings> confi
 
 ## AppHost extensions
 
-In your AppHost project, register a Postgres container and consume the connection using the following methods:
+In your AppHost project, register a Postgres database and consume the connection using the following methods:
 
 ```csharp
-var postgresdb = builder.AddPostgresContainer("pg").AddDatabase("postgresdb");
+var postgresdb = builder.AddPostgres("pg").AddDatabase("postgresdb");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(postgresdb);

--- a/src/Components/Aspire.Npgsql/README.md
+++ b/src/Components/Aspire.Npgsql/README.md
@@ -84,10 +84,10 @@ Also you can pass the `Action<NpgsqlSettings> configureSettings` delegate to set
 
 ## AppHost extensions
 
-In your AppHost project, register a Postgres container and consume the connection using the following methods:
+In your AppHost project, register a Postgres database and consume the connection using the following methods:
 
 ```csharp
-var postgresdb = builder.AddPostgresContainer("pg").AddDatabase("postgresdb");
+var postgresdb = builder.AddPostgres("pg").AddDatabase("postgresdb");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(postgresdb);

--- a/src/Components/Aspire.RabbitMQ.Client/README.md
+++ b/src/Components/Aspire.RabbitMQ.Client/README.md
@@ -91,10 +91,10 @@ builder.AddRabbitMQ("messaging", configureConnectionFactory: factory => factory.
 
 ## AppHost extensions
 
-In your AppHost project, register a RabbitMQ container and consume the connection using the following methods:
+In your AppHost project, register a RabbitMQ server and consume the connection using the following methods:
 
 ```csharp
-var messaging = builder.AddRabbitMQContainer("messaging");
+var messaging = builder.AddRabbitMQ("messaging");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(messaging);

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
@@ -96,10 +96,10 @@ builder.AddRedisDistributedCache("cache", configureOptions: options => options.C
 
 ## AppHost extensions
 
-In your AppHost project, register a Redis container and consume the connection using the following methods:
+In your AppHost project, register a Redis server and consume the connection using the following methods:
 
 ```csharp
-var redis = builder.AddRedisContainer("cache");
+var redis = builder.AddRedis("cache");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(redis);

--- a/src/Components/Aspire.StackExchange.Redis.OutputCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.OutputCaching/README.md
@@ -101,10 +101,10 @@ builder.AddRedisOutputCache("cache", configureOptions: options => options.Connec
 
 ## AppHost extensions
 
-In your AppHost project, register a Redis container and consume the connection using the following methods:
+In your AppHost project, register a Redis server and consume the connection using the following methods:
 
 ```csharp
-var redis = builder.AddRedisContainer("cache");
+var redis = builder.AddRedis("cache");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(redis);

--- a/src/Components/Aspire.StackExchange.Redis/README.md
+++ b/src/Components/Aspire.StackExchange.Redis/README.md
@@ -98,10 +98,10 @@ builder.AddRedis("cache", configureOptions: options => options.ConnectTimeout = 
 
 ## AppHost extensions
 
-In your AppHost project, register a Redis container and consume the connection using the following methods:
+In your AppHost project, register a Redis server and consume the connection using the following methods:
 
 ```csharp
-var redis = builder.AddRedisContainer("cache");
+var redis = builder.AddRedis("cache");
 
 var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(redis);


### PR DESCRIPTION
It isn't recommended to use the "AddXYZContainer" methods, but instead just "AddXYZ". Using the Container methods means that you want a container even after publishing to a cloud service, which has hosted versions of these resources.

Contributes to #1528
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1529)