### PR TITLE
Update Integration Tests

### DIFF
--- a/tests/Aspire.Hosting.Tests/Cosmos/CosmosFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cosmos/CosmosFunctionalTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Tests.Helpers;
-using Polly;
-using Polly.Retry;
 using Xunit;
 
 namespace Aspire.Hosting.Tests.Cosmos;
@@ -26,15 +24,9 @@ public class CosmosFunctionalTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(6));
 
-        await RetryPolicy.Handle<HttpRequestException>()
-                         .WaitAndRetryAsync(20, (count) => TimeSpan.FromSeconds(15))
-                         .ExecuteAsync(async () =>
-                         {
-                             var response = await testProgram.IntegrationServiceABuilder!.HttpGetAsync(client, "http", "/cosmos/verify", cts.Token);
-                             response.EnsureSuccessStatusCode();
+        var response = await testProgram.IntegrationServiceABuilder!.HttpGetAsync(client, "http", "/cosmos/verify", cts.Token);
+        var responseContent = await response.Content.ReadAsStringAsync();
 
-                             var responseContent = await response.Content.ReadAsStringAsync();
-                             Assert.True(response.IsSuccessStatusCode, responseContent);
-                         });
+        Assert.True(response.IsSuccessStatusCode, responseContent);
     }
 }

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/RabbitMQFunctionalTests.cs
@@ -24,7 +24,7 @@ public class RabbitMQFunctionalTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
 
-        var response = await testProgram.IntegrationServiceABuilder!.HttpGetAsync(client, "http", "/rabbit/verify", cts.Token);
+        var response = await testProgram.IntegrationServiceABuilder!.HttpGetAsync(client, "http", "/rabbitmq/verify", cts.Token);
         var responseContent = await response.Content.ReadAsStringAsync();
 
         Assert.True(response.IsSuccessStatusCode, responseContent);

--- a/tests/Aspire.Hosting.Tests/SqlServer/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/SqlServerFunctionalTests.cs
@@ -25,7 +25,8 @@ public class SqlServerFunctionalTests
         using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
 
         var response = await testProgram.IntegrationServiceABuilder!.HttpGetAsync(client, "http", "/sqlserver/verify", cts.Token);
+        var responseContent = await response.Content.ReadAsStringAsync();
 
-        Assert.True(response.IsSuccessStatusCode);
+        Assert.True(response.IsSuccessStatusCode, responseContent);
     }
 }

--- a/tests/Aspire.Hosting.Tests/TestProgramFixture.cs
+++ b/tests/Aspire.Hosting.Tests/TestProgramFixture.cs
@@ -111,8 +111,13 @@ public class IntegrationServicesFixture : TestProgramFixture
                     handler.ConnectTimeout = TimeSpan.FromSeconds(5);
                 });
 
-                // Ensure transient errors are retried.
-                b.AddStandardResilienceHandler();
+                // Ensure transient errors are retried for up to 1 minute
+                b.AddStandardResilienceHandler(options =>
+                {
+                    options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(1);
+                    options.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(2); // needs to be at least double the AttemptTimeout to pass options validation
+                    options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(1);
+                });
             });
 
         return testProgram;

--- a/tests/Aspire.Hosting.Tests/TestProgramFixture.cs
+++ b/tests/Aspire.Hosting.Tests/TestProgramFixture.cs
@@ -111,12 +111,12 @@ public class IntegrationServicesFixture : TestProgramFixture
                     handler.ConnectTimeout = TimeSpan.FromSeconds(5);
                 });
 
-                // Ensure transient errors are retried for up to 1 minute
+                // Ensure transient errors are retried for up to 5 minutes
                 b.AddStandardResilienceHandler(options =>
                 {
                     options.AttemptTimeout.Timeout = TimeSpan.FromMinutes(1);
                     options.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(2); // needs to be at least double the AttemptTimeout to pass options validation
-                    options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(1);
+                    options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(5);
                 });
             });
 

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -47,12 +47,12 @@ public class TestProgram
             var postgres = AppBuilder.AddPostgres("postgres")
                 .WithEnvironment("POSTGRES_DB", postgresDbName)
                 .AddDatabase(postgresDbName);
-            var rabbitmq = AppBuilder.AddRabbitMQContainer("rabbitmq");
-            var mongodb = AppBuilder.AddMongoDBContainer("mongodb")
+            var rabbitmq = AppBuilder.AddRabbitMQ("rabbitmq");
+            var mongodb = AppBuilder.AddMongoDB("mongodb")
                 .AddDatabase(mongoDbName);
             var oracleDatabase = AppBuilder.AddOracleDatabase("oracledatabase")
                 .AddDatabase(oracleDbName);
-            var kafkaContainer = AppBuilder.AddKafkaContainer("kafkacontainer");
+            var kafka = AppBuilder.AddKafka("kafka");
             var cosmos = AppBuilder.AddAzureCosmosDB("cosmos").UseEmulator();
 
             IntegrationServiceABuilder = AppBuilder.AddProject<Projects.IntegrationServiceA>("integrationservicea")
@@ -63,7 +63,7 @@ public class TestProgram
                 .WithReference(rabbitmq)
                 .WithReference(mongodb)
                 .WithReference(oracleDatabase)
-                .WithReference(kafkaContainer)
+                .WithReference(kafka)
                 .WithReference(cosmos);
         }
     }

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -38,32 +38,21 @@ public class TestProgram
             var mongoDbName = "mymongodb";
             var oracleDbName = "freepdb1";
 
-            var sqlserverContainer = AppBuilder.AddSqlServerContainer("sqlservercontainer")
+            var sqlserver = AppBuilder.AddSqlServer("sqlserver")
                 .AddDatabase(sqlserverDbName);
-            var mysqlContainer = AppBuilder.AddMySqlContainer("mysqlcontainer")
+            var mysql = AppBuilder.AddMySql("mysql")
                 .WithEnvironment("MYSQL_DATABASE", mysqlDbName)
                 .AddDatabase(mysqlDbName);
-            var redisContainer = AppBuilder.AddRedisContainer("rediscontainer");
-            var postgresContainer = AppBuilder.AddPostgresContainer("postgrescontainer")
+            var redis = AppBuilder.AddRedis("redis");
+            var postgres = AppBuilder.AddPostgres("postgres")
                 .WithEnvironment("POSTGRES_DB", postgresDbName)
                 .AddDatabase(postgresDbName);
-            var rabbitmqContainer = AppBuilder.AddRabbitMQContainer("rabbitmqcontainer");
-            var mongodbContainer = AppBuilder.AddMongoDBContainer("mongodbcontainer")
+            var rabbitmq = AppBuilder.AddRabbitMQContainer("rabbitmq");
+            var mongodb = AppBuilder.AddMongoDBContainer("mongodb")
                 .AddDatabase(mongoDbName);
-            var oracleDatabaseContainer = AppBuilder.AddOracleDatabaseContainer("oracledatabasecontainer")
+            var oracleDatabase = AppBuilder.AddOracleDatabase("oracledatabase")
                 .AddDatabase(oracleDbName);
             var kafkaContainer = AppBuilder.AddKafkaContainer("kafkacontainer");
-
-            var sqlserverAbstract = AppBuilder.AddSqlServer("sqlserverabstract");
-            var mysqlAbstract = AppBuilder.AddMySql("mysqlabstract");
-            var redisAbstract = AppBuilder.AddRedis("redisabstract");
-            var postgresAbstract = AppBuilder.AddPostgres("postgresabstract");
-            var rabbitmqAbstract = AppBuilder.AddRabbitMQ("rabbitmqabstract");
-            var mongodbAbstract = AppBuilder.AddMongoDB("mongodbabstract");
-            var oracleDatabaseAbstract = AppBuilder.AddOracleDatabaseContainer("oracledatabaseabstract");
-            var kafkaAbstract = AppBuilder.AddKafka("kafkaabstract");
-
-            var cosmos = AppBuilder.AddAzureCosmosDB("cosmos").UseEmulator();
 
             IntegrationServiceABuilder = AppBuilder.AddProject<Projects.IntegrationServiceA>("integrationservicea")
                 .WithReference(sqlserverContainer)
@@ -73,7 +62,6 @@ public class TestProgram
                 .WithReference(rabbitmqContainer)
                 .WithReference(mongodbContainer)
                 .WithReference(oracleDatabaseContainer)
-                .WithReference(kafkaContainer)
                 .WithReference(sqlserverAbstract)
                 .WithReference(mysqlAbstract)
                 .WithReference(redisAbstract)
@@ -81,8 +69,7 @@ public class TestProgram
                 .WithReference(rabbitmqAbstract)
                 .WithReference(mongodbAbstract)
                 .WithReference(oracleDatabaseAbstract)
-                .WithReference(kafkaAbstract)
-                .WithReference(cosmos);
+                .WithReference(kafkaContainer);
         }
     }
 

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -53,23 +53,18 @@ public class TestProgram
             var oracleDatabase = AppBuilder.AddOracleDatabase("oracledatabase")
                 .AddDatabase(oracleDbName);
             var kafkaContainer = AppBuilder.AddKafkaContainer("kafkacontainer");
+            var cosmos = AppBuilder.AddAzureCosmosDB("cosmos").UseEmulator();
 
             IntegrationServiceABuilder = AppBuilder.AddProject<Projects.IntegrationServiceA>("integrationservicea")
-                .WithReference(sqlserverContainer)
-                .WithReference(mysqlContainer)
-                .WithReference(redisContainer)
-                .WithReference(postgresContainer)
-                .WithReference(rabbitmqContainer)
-                .WithReference(mongodbContainer)
-                .WithReference(oracleDatabaseContainer)
-                .WithReference(sqlserverAbstract)
-                .WithReference(mysqlAbstract)
-                .WithReference(redisAbstract)
-                .WithReference(postgresAbstract)
-                .WithReference(rabbitmqAbstract)
-                .WithReference(mongodbAbstract)
-                .WithReference(oracleDatabaseAbstract)
-                .WithReference(kafkaContainer);
+                .WithReference(sqlserver)
+                .WithReference(mysql)
+                .WithReference(redis)
+                .WithReference(postgres)
+                .WithReference(rabbitmq)
+                .WithReference(mongodb)
+                .WithReference(oracleDatabase)
+                .WithReference(kafkaContainer)
+                .WithReference(cosmos);
         }
     }
 

--- a/tests/testproject/TestProject.IntegrationServiceA/Cosmos/CosmosExtensions.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Cosmos/CosmosExtensions.cs
@@ -22,8 +22,8 @@ public static class CosmosExtensions
 
             var item = await container.CreateItemAsync(new
             {
-                id = id,
-                title = title
+                id,
+                title
             });
 
             return item.Resource.id == id ? Results.Ok() : Results.Problem();

--- a/tests/testproject/TestProject.IntegrationServiceA/MySql/MySqlExtensions.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/MySql/MySqlExtensions.cs
@@ -20,16 +20,13 @@ public static class MySqlExtensions
                 // retry every second for 60 seconds
                 .WaitAndRetryAsync(60, retryAttempt => TimeSpan.FromSeconds(1));
 
-            return await policy.ExecuteAsync(async () =>
-            {
-                await connection.OpenAsync();
+            await policy.ExecuteAsync(connection.OpenAsync);
 
-                var command = connection.CreateCommand();
-                command.CommandText = $"SELECT 1";
-                var results = await command.ExecuteReaderAsync();
+            var command = connection.CreateCommand();
+            command.CommandText = $"SELECT 1";
+            var results = await command.ExecuteReaderAsync();
 
-                return results.HasRows ? Results.Ok("Success!") : Results.Problem("Failed");
-            });
+            return results.HasRows ? Results.Ok("Success!") : Results.Problem("Failed");
         }
         catch (Exception e)
         {

--- a/tests/testproject/TestProject.IntegrationServiceA/MySql/MySqlExtensions.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/MySql/MySqlExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using MySqlConnector;
+using Polly;
 
 public static class MySqlExtensions
 {
@@ -14,13 +15,21 @@ public static class MySqlExtensions
     {
         try
         {
-            await connection.OpenAsync();
+            var policy = Policy
+                .Handle<MySqlException>()
+                // retry every second for 60 seconds
+                .WaitAndRetryAsync(60, retryAttempt => TimeSpan.FromSeconds(1));
 
-            var command = connection.CreateCommand();
-            command.CommandText = $"SELECT 1";
-            var results = await command.ExecuteReaderAsync();
+            return await policy.ExecuteAsync(async () =>
+            {
+                await connection.OpenAsync();
 
-            return results.HasRows ? Results.Ok("Success!") : Results.Problem("Failed");
+                var command = connection.CreateCommand();
+                command.CommandText = $"SELECT 1";
+                var results = await command.ExecuteReaderAsync();
+
+                return results.HasRows ? Results.Ok("Success!") : Results.Problem("Failed");
+            });
         }
         catch (Exception e)
         {

--- a/tests/testproject/TestProject.IntegrationServiceA/Oracle/OracleDatabaseExtensions.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Oracle/OracleDatabaseExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.EntityFrameworkCore;
+using Oracle.ManagedDataAccess.Client;
+using Polly;
 
 public static class OracleDatabaseExtensions
 {
@@ -14,8 +16,16 @@ public static class OracleDatabaseExtensions
     {
         try
         {
-            var results = context.Database.SqlQueryRaw<int>("SELECT 1 FROM DUAL");
-            return results.Any() ? Results.Ok("Success!") : Results.Problem("Failed");
+            var policy = Policy
+                .Handle<OracleException>()
+                // retry every second for 60 seconds
+                .WaitAndRetry(60, retryAttempt => TimeSpan.FromSeconds(1));
+
+            return policy.Execute(() =>
+            {
+                var results = context.Database.SqlQueryRaw<int>("SELECT 1 FROM DUAL");
+                return results.Any() ? Results.Ok("Success!") : Results.Problem("Failed");
+            });
         }
         catch (Exception e)
         {

--- a/tests/testproject/TestProject.IntegrationServiceA/Program.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Program.cs
@@ -5,28 +5,15 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddSqlServerClient("tempdb");
 builder.AddMySqlDataSource("mysqldb");
 builder.AddMySqlDbContext<PomeloDbContext>("mysqldb", settings => settings.ServerVersion = "8.2.0-mysql");
-builder.AddRedis("rediscontainer");
+builder.AddRedis("redis");
 builder.AddNpgsqlDataSource("postgresdb");
-builder.AddRabbitMQ("rabbitmqcontainer");
+builder.AddRabbitMQ("rabbitmq");
 builder.AddMongoDBClient("mymongodb");
 builder.AddOracleDatabaseDbContext<MyDbContext>("freepdb1");
 builder.AddKafkaProducer<string, string>("kafkacontainer");
 builder.AddKafkaConsumer<string, string>("kafkacontainer", consumerBuilder =>
 {
     consumerBuilder.Config.GroupId = "aspire-consumer-group";
-    consumerBuilder.Config.AutoOffsetReset = AutoOffsetReset.Earliest;
-});
-
-builder.AddKeyedSqlServerClient("sqlserverabstract");
-builder.AddKeyedMySqlDataSource("mysqlabstract");
-builder.AddKeyedRedis("redisabstract");
-builder.AddKeyedNpgsqlDataSource("postgresabstract");
-builder.AddKeyedRabbitMQ("rabbitmqabstract");
-builder.AddKeyedMongoDBClient("mongodbabstract");
-builder.AddKeyedKafkaProducer<string, string>("kafkaabstract");
-builder.AddKeyedKafkaConsumer<string, string>("kafkaabstract", consumerBuilder =>
-{
-    consumerBuilder.Config.GroupId = "aspire-abstract-consumer-group";
     consumerBuilder.Config.AutoOffsetReset = AutoOffsetReset.Earliest;
 });
 

--- a/tests/testproject/TestProject.IntegrationServiceA/RabbitMQ/RabbitMQExtensions.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/RabbitMQ/RabbitMQExtensions.cs
@@ -8,7 +8,7 @@ public static class RabbitMQExtensions
 {
     public static void MapRabbitMQApi(this WebApplication app)
     {
-        app.MapGet("/rabbit/verify", VerifyRabbitMQ);
+        app.MapGet("/rabbitmq/verify", VerifyRabbitMQ);
     }
 
     private static IResult VerifyRabbitMQ(IConnection connection)

--- a/tests/testproject/TestProject.IntegrationServiceA/Redis/RedisExtensions.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Redis/RedisExtensions.cs
@@ -13,13 +13,13 @@ public static class RedisExtensions
     private static async Task<IResult> VerifyRedisAsync(IConnectionMultiplexer cm)
     {
         try
-        { 
-        var key = "somekey";
-        var content = "somecontent";
+        {
+            var key = "somekey";
+            var content = "somecontent";
 
-        var database = cm.GetDatabase();
-        await database.StringSetAsync(key, content);
-        var data = await database.StringGetAsync(key);
+            var database = cm.GetDatabase();
+            await database.StringSetAsync(key, content);
+            var data = await database.StringGetAsync(key);
 
             return data == content ? Results.Ok("Success!") : Results.Problem("Failed");
         }

--- a/tests/testproject/TestProject.IntegrationServiceA/SqlServer/SqlServerExtensions.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/SqlServer/SqlServerExtensions.cs
@@ -20,16 +20,13 @@ public static class SqlServerExtensions
                 // retry every second for 60 seconds
                 .WaitAndRetryAsync(60, retryAttempt => TimeSpan.FromSeconds(1));
 
-            return await policy.ExecuteAsync(async () =>
-            {
-                await connection.OpenAsync();
+            await policy.ExecuteAsync(connection.OpenAsync);
 
-                var command = connection.CreateCommand();
-                command.CommandText = $"SELECT 1";
-                var results = await command.ExecuteReaderAsync();
+            var command = connection.CreateCommand();
+            command.CommandText = $"SELECT 1";
+            var results = await command.ExecuteReaderAsync();
 
-                return results.HasRows ? Results.Ok("Success!") : Results.Problem("Failed");
-            });
+            return results.HasRows ? Results.Ok("Success!") : Results.Problem("Failed");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
1. Add retry / resilience logic to the services that have slow starting containers (MySQL, Oracle, and SqlServer). Each of these containers can take more than 30 seconds to start on my machine.
2. Remove unnecessary containers from the IntegrationServiceA project. Adding double the containers make the startup take even longer. So just use AddXYX resources and remove AddXYZContainer services.
3. A couple other cosmetic changes - Use "rabbitmq" vs. "rabbit" - Log the responseContent in the SqlServer test


This won't be the last refactoring to these tests, but I think it is a step in the right direction.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1540)