### PR TITLE
Update global.json rollforward

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "8.0.100",
-    "rollForward": "latestPatch",
+    "rollForward": "major",
     "allowPrerelease": true
   },
   "tools": {


### PR DESCRIPTION
Allow a newer SDK to be used if 8.0.1xx isn't found. VS preview updates will uninstall 8.0.1xx and install 8.0.2xx-preview. We should still work with that.

This uses the same global.json policy as dotnet/runtime.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1541)