### PR TITLE
Enable DAPR to work with services listening on addresses different from localhost

### DIFF
--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -98,6 +98,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
             var daprHttpPortArg = (string? port) => ModelNamedArg("--dapr-http-port", port);
             var daprMetricsPortArg = (string? port) => ModelNamedArg("--metrics-port", port);
             var daprProfilePortArg = (string? port) => ModelNamedArg("--profile-port", port);
+            var daprAppChannelAddressArg = (string? address) => ModelNamedArg("--app-channel-address", address);
 
             var appId = sidecarOptions?.AppId ?? resource.Name;
 
@@ -143,6 +144,8 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                             return;
                         }
 
+                        string? grpcEndpoint, httpEndpoint;
+
                         if (resource is ContainerResource)
                         {
                             // By default, the Dapr sidecar will listen on localhost, which is not accessible from the container.
@@ -153,9 +156,13 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                             context.EnvironmentVariables.TryAdd("DAPR_GRPC_ENDPOINT", HostNameResolver.ReplaceLocalhostWithContainerHost(grpcEndpoint, _configuration));
                             context.EnvironmentVariables.TryAdd("DAPR_HTTP_ENDPOINT", HostNameResolver.ReplaceLocalhostWithContainerHost(httpEndpoint, _configuration));
                         }
-
-                        context.EnvironmentVariables.TryAdd("DAPR_GRPC_PORT", $"{{{{- portFor \"{daprCliResourceName}_grpc\" -}}}}");
-                        context.EnvironmentVariables.TryAdd("DAPR_HTTP_PORT", $"{{{{- portFor \"{daprCliResourceName}_http\" -}}}}");
+                        else
+                        {
+                            grpcEndpoint = $"http://{{{{- addressFor \"{daprCliResourceName}_grpc\" -}}}}:{{{{- portFor \"{daprCliResourceName}_grpc\" -}}}}";
+                            httpEndpoint = $"http://{{{{- addressFor \"{daprCliResourceName}_http\" -}}}}:{{{{- portFor \"{daprCliResourceName}_http\" -}}}}";
+                            context.EnvironmentVariables.TryAdd("DAPR_GRPC_ENDPOINT", grpcEndpoint);
+                            context.EnvironmentVariables.TryAdd("DAPR_HTTP_ENDPOINT", httpEndpoint);
+                        }
                     }));
 
             daprCli.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: "grpc", port: sidecarOptions?.DaprGrpcPort));
@@ -192,6 +199,10 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         if (sidecarOptions?.EnableProfiling == true)
                         {
                             updatedArgs.AddRange(daprProfilePortArg($"{{{{- portForServing \"{daprCliResourceName}_profile\" -}}}}")());
+                        }
+                        if (sidecarOptions?.AppChannelAddress is null)
+                        {
+                            updatedArgs.AddRange(daprAppChannelAddressArg($"{{{{- addressForServing \"{daprCliResourceName}_grpc\" -}}}}")());
                         }
                     }));
 


### PR DESCRIPTION
DO NOT MERGRE YET

This requires new DCP version with support for `addressFor` and `addressForServing` template functions (ETA ~ second week of January). Just want to get feedback about this change at this point.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1548)

UPDATE: the relevant DCP change has been merged, so this is good to go