### PR TITLE
Fix up the WithPgAdmin extension.

### DIFF
--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -1,6 +1,6 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var catalogDb = builder.AddPostgresContainer("postgres")
+var catalogDb = builder.AddPostgres("postgres")
                     .WithPgAdmin(hostPort: 8081)
                     .AddDatabase("catalogdb");
 

--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -1,7 +1,7 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var catalogDb = builder.AddPostgres("postgres")
-                    .WithPgAdmin(hostPort: 8081)
+                    .WithPgAdmin()
                     .AddDatabase("catalogdb");
 
 var basketCache = builder.AddRedis("basketcache");

--- a/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
+
+namespace Aspire.Hosting.Postgres;
+
+internal class PgAdminConfigWriterHook : IDistributedApplicationLifecycleHook
+{
+    public Task AfterEndpointsAllocatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
+    {
+        var adminResource = appModel.Resources.OfType<PgAdminContainerResource>().Single();
+        var serverFileMount = adminResource.Annotations.OfType<VolumeMountAnnotation>().Single(v => v.Target == "/pgadmin4/servers.json");
+        var postgresInstances = appModel.Resources.OfType<IPostgresParentResource>();
+
+        var serverFileBuilder = new StringBuilder();
+
+        using var stream = new FileStream(serverFileMount.Source, FileMode.Create);
+        using var writer = new Utf8JsonWriter(stream);
+
+        var serverIndex = 1;
+
+        writer.WriteStartObject();
+        writer.WriteStartObject("Servers");
+
+        foreach (var postgresInstance in postgresInstances)
+        {
+            if (postgresInstance.TryGetAllocatedEndPoints(out var allocatedEndpoints))
+            {
+                var endpoint = allocatedEndpoints.Where(ae => ae.Name == "tcp").Single();
+
+                var password = postgresInstance switch
+                {
+                    PostgresServerResource psr => psr.Password,
+                    PostgresContainerResource pcr => pcr.Password,
+                    _ => throw new InvalidOperationException("Postgres resource is neither PostgresServerResource or PostgresContainerResource.")
+                };
+
+                writer.WriteStartObject($"{serverIndex}");
+                writer.WriteString("Name", postgresInstance.Name);
+                writer.WriteString("Group", "Aspire instances");
+                writer.WriteString("Host", "host.docker.internal");
+                writer.WriteNumber("Port", endpoint.Port);
+                writer.WriteString("Username", "postgres");
+                writer.WriteString("SSLMode", "prefer");
+                writer.WriteString("MaintenanceDB", "postgres");
+                writer.WriteString("PasswordExecCommand", $"echo '{password}'"); // HACK: Generating a pass file and playing around with chmod is too painful.
+                writer.WriteEndObject();
+            }
+
+            serverIndex++;
+        }
+
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -6,7 +6,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Publishing;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting;
 
@@ -87,16 +86,14 @@ public static class PostgresBuilderExtensions
     /// <param name="hostPort">The host port for the application ui.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{PostgresContainerResource}"/>.</returns>
-    public static IResourceBuilder<T> WithPgAdmin<T>(this IResourceBuilder<T> builder, int? hostPort, string? containerName = null) where T: IPostgresParentResource
+    public static IResourceBuilder<T> WithPgAdmin<T>(this IResourceBuilder<T> builder, int? hostPort = null, string? containerName = null) where T: IPostgresParentResource
     {
         if (builder.ApplicationBuilder.Resources.OfType<PgAdminContainerResource>().Any())
         {
             return builder;
         }
 
-        builder.ApplicationBuilder.Services.AddSingleton<IDistributedApplicationLifecycleHook, PgAdminConfigWriterHook>();
-
-        ArgumentNullException.ThrowIfNull(hostPort);
+        builder.ApplicationBuilder.Services.TryAddLifecycleHook<PgAdminConfigWriterHook>();
 
         containerName ??= $"{builder.Resource.Name}-pgadmin";
 

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -3,8 +3,10 @@
 
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting;
 
@@ -85,12 +87,14 @@ public static class PostgresBuilderExtensions
     /// <param name="hostPort">The host port for the application ui.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{PostgresContainerResource}"/>.</returns>
-    public static IResourceBuilder<PostgresContainerResource> WithPgAdmin(this IResourceBuilder<PostgresContainerResource> builder, int? hostPort, string? containerName = null)
+    public static IResourceBuilder<T> WithPgAdmin<T>(this IResourceBuilder<T> builder, int? hostPort, string? containerName = null) where T: IPostgresParentResource
     {
         if (builder.ApplicationBuilder.Resources.OfType<PgAdminContainerResource>().Any())
         {
             return builder;
         }
+
+        builder.ApplicationBuilder.Services.AddSingleton<IDistributedApplicationLifecycleHook, PgAdminConfigWriterHook>();
 
         ArgumentNullException.ThrowIfNull(hostPort);
 
@@ -101,7 +105,7 @@ public static class PostgresBuilderExtensions
                                   .WithAnnotation(new ContainerImageAnnotation { Image = "dpage/pgadmin4", Tag = "latest" })
                                   .WithEndpoint(containerPort: 80, hostPort: hostPort, scheme: "http", name: containerName)
                                   .WithEnvironment(SetPgAdminEnviromentVariables)
-                                  .WithVolumeMount(WritePgAdminTempServersJson(builder), "/pgadmin4/servers.json")
+                                  .WithVolumeMount(Path.GetTempFileName(), "/pgadmin4/servers.json")
                                   .ExcludeFromManifest();
 
         return builder;
@@ -118,39 +122,6 @@ public static class PostgresBuilderExtensions
         context.EnvironmentVariables.Add("PGADMIN_DEFAULT_PASSWORD", "admin");
     }
 
-    private static string WritePgAdminTempServersJson(IResourceBuilder<PostgresContainerResource> builder)
-    {
-        var serversFile = Path.GetTempFileName();
-
-        // At this point the container is not running yet, so we need to get the port from the service bindings.
-        // If the port is not user defined we will ignore it.
-        if (builder.Resource.TryGetEndpoints(out var serviceBindings))
-        {
-            if (serviceBindings.First().Port is not null)
-            {
-                var json = $@"
-                {{
-                    ""Servers"": {{
-                        ""1"": {{
-                            ""Name"": ""{builder.Resource.Name}"",
-                            ""Group"": ""Aspire servers"",
-                            ""Host"": ""host.docker.internal"",
-                            ""Port"": {serviceBindings.First().Port},
-                            ""Username"": ""postgres"",
-                            ""SSLMode"": ""prefer"",
-                            ""MaintenanceDB"": ""postgres""
-                        }}
-                    }}
-                }}
-                ";
-
-                File.WriteAllText(serversFile, json);
-            }
-        }
-
-        return serversFile;
-    }
-  
     private static void WritePostgresContainerToManifest(ManifestPublishingContext context)
     {
         context.Writer.WriteString("type", "postgres.server.v0");


### PR DESCRIPTION
This PR #1135 had a few issues that I didn't pick up in review. This PR should address most of the issues:

1. Generation of the `servers.json` file is deferred until after endpoints are allocated.
2. `WithPgAdmin` now works with `PostgresServerResource` in addition to `PostgresContainerResource`.
3. Generates a server entry for each server in the app model.
4. Configures a password exec command to automatically provide the password so folks don't have to cut-paste.
5. Added some test cases.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1552)