### PR TITLE
Remove no longer used InterceptorsPreview feature. 

### DIFF
--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -9,7 +9,6 @@
   <PropertyGroup>
     <ConfigurationSchemaPath>$(MSBuildProjectDirectory)\ConfigurationSchema.json</ConfigurationSchemaPath>
     <ConfigurationSchemaExists Condition="Exists('$(ConfigurationSchemaPath)')">true</ConfigurationSchemaExists>
-    <Features Condition="'$(EnableConfigurationBindingGenerator)' == 'true'">$(Features);InterceptorsPreview</Features>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ConfigurationSchemaExists)' == 'true'">


### PR DESCRIPTION
This was needed during preview .NET 8 versions but is no longer necessary
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1567)