### PR TITLE
Fix dashboard client subscription leak

### DIFF
--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -35,7 +35,8 @@ internal sealed class DashboardClient : IDashboardClient
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<DashboardClient> _logger;
 
-    private ImmutableHashSet<Channel<ResourceViewModelChange>> _outgoingChannels = [];
+    // Internal for testing.
+    internal ImmutableHashSet<Channel<ResourceViewModelChange>> _outgoingChannels = [];
     private string? _applicationName;
 
     private const int StateNone = 0;
@@ -300,11 +301,11 @@ internal sealed class DashboardClient : IDashboardClient
                 InitialState: _resourceByName.Values.ToImmutableArray(),
                 Subscription: StreamUpdates());
 
-            async IAsyncEnumerable<ResourceViewModelChange> StreamUpdates()
+            async IAsyncEnumerable<ResourceViewModelChange> StreamUpdates([EnumeratorCancellation] CancellationToken cancellationToken = default)
             {
                 try
                 {
-                    await foreach (var batch in channel.Reader.ReadAllAsync(_cts.Token).ConfigureAwait(false))
+                    await foreach (var batch in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
                     {
                         yield return batch;
                     }

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -343,6 +343,17 @@ internal sealed class DashboardClient : IDashboardClient
     {
         if (Interlocked.Exchange(ref _state, StateDisposed) is not StateDisposed)
         {
+            // Complete outstanding subscriptions.
+            lock (_lock)
+            {
+                foreach (var item in _outgoingChannels)
+                {
+                    item.Writer.Complete();
+                }
+
+                _outgoingChannels = _outgoingChannels.Clear();
+            }
+
             await _cts.CancelAsync().ConfigureAwait(false);
 
             _cts.Dispose();

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -285,8 +285,6 @@ internal sealed class DashboardClient : IDashboardClient
 
     ResourceViewModelSubscription IDashboardClient.SubscribeResources()
     {
-        ObjectDisposedException.ThrowIf(_state == StateDisposed, this);
-
         EnsureInitialized();
 
         // There are two types of channel in this class. This is not a gRPC channel.

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -344,14 +344,11 @@ internal sealed class DashboardClient : IDashboardClient
         if (Interlocked.Exchange(ref _state, StateDisposed) is not StateDisposed)
         {
             // Complete outstanding subscriptions.
-            lock (_lock)
-            {
-                foreach (var item in _outgoingChannels)
-                {
-                    item.Writer.Complete();
-                }
+            var channelsToComplete = Interlocked.Exchange(ref _outgoingChannels, ImmutableHashSet<Channel<ResourceViewModelChange>>.Empty);
 
-                _outgoingChannels = _outgoingChannels.Clear();
+            foreach (var channel in channelsToComplete)
+            {
+                channel.Writer.Complete();
             }
 
             await _cts.CancelAsync().ConfigureAwait(false);

--- a/tests/Aspire.Dashboard.Tests/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardClientTests.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class DashboardClientTests
+{
+    [Fact]
+    public async void SubscribeResources_Cancellation_ChannelRemoved()
+    {
+        var instance = new DashboardClient(NullLoggerFactory.Instance);
+        IDashboardClient client = instance;
+
+        var cts = new CancellationTokenSource();
+        var (snapshot, subscription) = client.SubscribeResources();
+
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var item in subscription.WithCancellation(cts.Token))
+            {
+            }
+        });
+
+        Assert.Collection(instance._outgoingChannels, item =>
+        {
+            Assert.False(item.Reader.Completion.IsCompleted);
+        });
+
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => readTask).ConfigureAwait(false);
+
+        Assert.Empty(instance._outgoingChannels);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardClientTests.cs
@@ -10,8 +10,9 @@ namespace Aspire.Dashboard.Tests;
 public class DashboardClientTests
 {
     [Fact]
-    public async void SubscribeResources_Cancellation_ChannelRemoved()
+    public async Task SubscribeResources_Cancellation_ChannelRemoved()
     {
+        // Arrange
         var instance = new DashboardClient(NullLoggerFactory.Instance);
         IDashboardClient client = instance;
 
@@ -25,15 +26,42 @@ public class DashboardClientTests
             }
         });
 
-        Assert.Collection(instance._outgoingChannels, item =>
-        {
-            Assert.False(item.Reader.Completion.IsCompleted);
-        });
+        Assert.Collection(instance._outgoingChannels,
+            item => Assert.False(item.Reader.Completion.IsCompleted));
 
+        // Act
         cts.Cancel();
 
+        // Assert
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => readTask).ConfigureAwait(false);
+        Assert.Empty(instance._outgoingChannels);
+    }
 
+    [Fact]
+    public async Task SubscribeResources_Dispose_ChannelRemoved()
+    {
+        // Arrange
+        var instance = new DashboardClient(NullLoggerFactory.Instance);
+        IDashboardClient client = instance;
+
+        var cts = new CancellationTokenSource();
+        var (snapshot, subscription) = client.SubscribeResources();
+
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var item in subscription.WithCancellation(cts.Token))
+            {
+            }
+        });
+
+        Assert.Collection(instance._outgoingChannels,
+            item => Assert.False(item.Reader.Completion.IsCompleted));
+
+        // Act
+        await instance.DisposeAsync();
+
+        // Assert
+        await readTask.ConfigureAwait(false);
         Assert.Empty(instance._outgoingChannels);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardClientTests.cs
@@ -64,4 +64,17 @@ public class DashboardClientTests
         await readTask.ConfigureAwait(false);
         Assert.Empty(instance._outgoingChannels);
     }
+
+    [Fact]
+    public async Task SubscribeResources_AfterDispose_DisposedException()
+    {
+        // Arrange
+        var instance = new DashboardClient(NullLoggerFactory.Instance);
+        IDashboardClient client = instance;
+
+        await instance.DisposeAsync();
+
+        // Act & Assert
+        Assert.Throws<ObjectDisposedException>(client.SubscribeResources);
+    }
 }


### PR DESCRIPTION
Subscriptions will build up as a user navigates around the app and never be removed. Need to use `[EnumeratorCancellation]` to receive notification the subscription async enumerable is no longer being read.

* Fix enumerable cancellation not removing subscription.
* Fix dispose not completing subscriptions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1576)