### PR TITLE
Fix many subscription leaks and hanging console log server calls

### DIFF
--- a/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
@@ -3,12 +3,21 @@
 
 namespace Aspire.Hosting.Dashboard;
 
-internal sealed class ConsoleLogPublisher(ResourcePublisher resourcePublisher)
+internal sealed class ConsoleLogPublisher : IDisposable
 {
+    private readonly ResourcePublisher _resourcePublisher;
+    private readonly CancellationTokenSource _cts;
+
+    public ConsoleLogPublisher(ResourcePublisher resourcePublisher)
+    {
+        _resourcePublisher = resourcePublisher;
+        _cts = new();
+    }
+
     internal IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>>? Subscribe(string resourceName)
     {
         // Look up the requested resource, so we know how to obtain logs.
-        if (!resourcePublisher.TryGetResource(resourceName, out var resource))
+        if (!_resourcePublisher.TryGetResource(resourceName, out var resource))
         {
             throw new ArgumentException($"Unknown resource {resourceName}.", nameof(resourceName));
         }
@@ -17,29 +26,35 @@ internal sealed class ConsoleLogPublisher(ResourcePublisher resourcePublisher)
         // Note, we would like to obtain these logs via DCP directly, rather than sourcing them in the dashboard.
         return resource switch
         {
-            ExecutableSnapshot executable => SubscribeExecutable(executable),
-            ContainerSnapshot container => SubscribeContainer(container),
+            ExecutableSnapshot executable => SubscribeExecutable(executable, _cts.Token),
+            ContainerSnapshot container => SubscribeContainer(container, _cts.Token),
             _ => throw new NotSupportedException($"Unsupported resource type {resource.GetType()}.")
         };
 
-        static FileLogSource? SubscribeExecutable(ExecutableSnapshot executable)
+        static FileLogSource? SubscribeExecutable(ExecutableSnapshot executable, CancellationToken cancellationToken)
         {
             if (executable.StdOutFile is null || executable.StdErrFile is null)
             {
                 return null;
             }
 
-            return new FileLogSource(executable.StdOutFile, executable.StdErrFile);
+            return new FileLogSource(executable.StdOutFile, executable.StdErrFile, cancellationToken);
         }
 
-        static DockerContainerLogSource? SubscribeContainer(ContainerSnapshot container)
+        static DockerContainerLogSource? SubscribeContainer(ContainerSnapshot container, CancellationToken cancellationToken)
         {
             if (container.ContainerId is null)
             {
                 return null;
             }
 
-            return new DockerContainerLogSource(container.ContainerId);
+            return new DockerContainerLogSource(container.ContainerId, cancellationToken);
         }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
     }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
 using Microsoft.Extensions.Logging;
@@ -11,28 +12,26 @@ namespace Aspire.Hosting.Dashboard;
 /// Models the state for <see cref="DashboardService"/>, as that service is constructed
 /// for each gRPC request. This long-lived object holds state across requests.
 /// </summary>
-internal sealed class DashboardServiceData : IAsyncDisposable
+internal sealed class DashboardServiceData : IDisposable
 {
-    private readonly CancellationTokenSource _cts = new();
     private readonly ResourcePublisher _resourcePublisher;
     private readonly ConsoleLogPublisher _consoleLogPublisher;
+    private readonly DcpDataSource _dcpDataSource;
 
     public DashboardServiceData(
         DistributedApplicationModel applicationModel,
         KubernetesService kubernetesService,
         ILoggerFactory loggerFactory)
     {
-        _resourcePublisher = new ResourcePublisher(_cts.Token);
+        _resourcePublisher = new ResourcePublisher();
         _consoleLogPublisher = new ConsoleLogPublisher(_resourcePublisher);
-
-        _ = new DcpDataSource(kubernetesService, applicationModel, loggerFactory, _resourcePublisher.IntegrateAsync, _cts.Token);
+        _dcpDataSource = new DcpDataSource(kubernetesService, applicationModel, loggerFactory, _resourcePublisher.IntegrateAsync);
     }
 
-    public async ValueTask DisposeAsync()
+    public void Dispose()
     {
-        await _cts.CancelAsync().ConfigureAwait(false);
-
-        _cts.Dispose();
+        _resourcePublisher.Dispose();
+        _dcpDataSource.Dispose();
     }
 
     internal ResourceSnapshotSubscription SubscribeResources()
@@ -46,9 +45,9 @@ internal sealed class DashboardServiceData : IAsyncDisposable
 
         return sequence is null ? null : Enumerate();
 
-        async IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>> Enumerate()
+        async IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>> Enumerate([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            await foreach (var item in sequence.WithCancellation(_cts.Token))
+            await foreach (var item in sequence.WithCancellation(cancellationToken))
             {
                 yield return item;
             }

--- a/src/Aspire.Hosting/Dashboard/DockerContainerLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DockerContainerLogSource.cs
@@ -41,7 +41,7 @@ internal sealed class DockerContainerLogSource(string containerId) : IAsyncEnume
             // Don't forward cancellationToken here, because it's handled internally in WaitForExit
             _ = Task.Run(() => WaitForExit(tcs, ctr), CancellationToken.None);
 
-            await foreach (var batch in channel.GetBatches(cancellationToken))
+            await foreach (var batch in channel.GetBatchesAsync(cancellationToken))
             {
                 yield return batch;
             }

--- a/src/Aspire.Hosting/Dashboard/FileLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/FileLogSource.cs
@@ -23,7 +23,7 @@ internal sealed partial class FileLogSource(string stdOutPath, string stdErrPath
         var stdOut = Task.Run(() => WatchFileAsync(stdOutPath, isError: false), cancellationToken);
         var stdErr = Task.Run(() => WatchFileAsync(stdErrPath, isError: true), cancellationToken);
 
-        await foreach (var batch in channel.GetBatches(cancellationToken))
+        await foreach (var batch in channel.GetBatchesAsync(cancellationToken))
         {
             yield return batch;
         }

--- a/src/Aspire.Hosting/Extensions/ChannelExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ChannelExtensions.cs
@@ -21,7 +21,7 @@ internal static class ChannelExtensions
     /// <param name="channel">The channel to read values from.</param>
     /// <param name="cancellationToken">A token that signals a loss of interest in the operation.</param>
     /// <returns></returns>
-    public static async IAsyncEnumerable<IReadOnlyList<T>> GetBatches<T>(
+    public static async IAsyncEnumerable<IReadOnlyList<T>> GetBatchesAsync<T>(
         this Channel<T> channel,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/tests/Aspire.Hosting.Tests/Dashboard/FileLogSourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/FileLogSourceTests.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Aspire.Hosting.Dashboard;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Dashboard;
+
+public class FileLogSourceTests
+{
+    [Fact]
+    public async Task Read_LifetimeCancellation_Complete()
+    {
+        // Arrange
+        var outPath = Path.GetTempFileName();
+        var errorPath = Path.GetTempFileName();
+        var cts = new CancellationTokenSource();
+        var s = new FileLogSource(outPath, errorPath, cts.Token);
+        var channel = Channel.CreateUnbounded<IReadOnlyList<(string Content, bool IsErrorMessage)>>();
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var item in s)
+            {
+                await channel.Writer.WriteAsync(item);
+            }
+            channel.Writer.Complete();
+        });
+
+        // Act
+        cts.Cancel();
+        await readTask;
+        var all = await ReadResultsAsync(channel.Reader.ReadAllAsync());
+
+        // Assert
+        Assert.Empty(all);
+    }
+
+    [Fact]
+    public async Task Read_EnumerableCancellation_Complete()
+    {
+        // Arrange
+        var outPath = Path.GetTempFileName();
+        var errorPath = Path.GetTempFileName();
+        var cts = new CancellationTokenSource();
+        var s = new FileLogSource(outPath, errorPath, CancellationToken.None);
+        var channel = Channel.CreateUnbounded<IReadOnlyList<(string Content, bool IsErrorMessage)>>();
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var item in s.WithCancellation(cts.Token))
+            {
+                await channel.Writer.WriteAsync(item);
+            }
+            channel.Writer.Complete();
+        });
+
+        // Act
+        cts.Cancel();
+        await readTask;
+        var all = await ReadResultsAsync(channel.Reader.ReadAllAsync());
+
+        // Assert
+        Assert.Empty(all);
+    }
+
+    [Fact]
+    public async Task Read_NewFile_ReturnResult()
+    {
+        // Arrange
+        var outPath = Path.GetTempFileName();
+        var errorPath = Path.GetTempFileName();
+        var cts = new CancellationTokenSource();
+        var s = new FileLogSource(outPath, errorPath, CancellationToken.None);
+        var channel = Channel.CreateUnbounded<IReadOnlyList<(string Content, bool IsErrorMessage)>>();
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var item in s.WithCancellation(cts.Token))
+            {
+                await channel.Writer.WriteAsync(item);
+            }
+            channel.Writer.Complete();
+        });
+
+        try
+        {
+            // Act
+            using var outStream = File.CreateText(outPath);
+            using var errorStream = File.CreateText(errorPath);
+
+            await outStream.WriteLineAsync("Out 1");
+            await outStream.WriteLineAsync("Out 2");
+            await outStream.FlushAsync();
+
+            var outResults = await ReadResultsAsync(channel.Reader.ReadAllAsync(), readAtLeast: 2);
+
+            await errorStream.WriteLineAsync("Error 1");
+            await errorStream.WriteLineAsync("Error 2");
+            await errorStream.FlushAsync();
+
+            var errorResults = await ReadResultsAsync(channel.Reader.ReadAllAsync(), readAtLeast: 2);
+
+            cts.Cancel();
+            try { await readTask; } catch (OperationCanceledException) { }
+
+            // Assert
+            Assert.Collection(outResults,
+                r =>
+                {
+                    Assert.Equal("Out 1", r.Content);
+                    Assert.False(r.IsErrorMessage);
+                },
+                r =>
+                {
+                    Assert.Equal("Out 2", r.Content);
+                    Assert.False(r.IsErrorMessage);
+                });
+            Assert.Collection(errorResults,
+                r =>
+                {
+                    Assert.Equal("Error 1", r.Content);
+                    Assert.True(r.IsErrorMessage);
+                },
+                r =>
+                {
+                    Assert.Equal("Error 2", r.Content);
+                    Assert.True(r.IsErrorMessage);
+                });
+        }
+        finally
+        {
+            File.Delete(outPath);
+            File.Delete(errorPath);
+        }
+    }
+
+    public static async Task<List<(string Content, bool IsErrorMessage)>> ReadResultsAsync(IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>> asyncEnumerable, int? readAtLeast = null)
+    {
+        ArgumentNullException.ThrowIfNull(asyncEnumerable);
+
+        var list = new List<(string Content, bool IsErrorMessage)>();
+        await foreach (var t in asyncEnumerable)
+        {
+            foreach (var item in t)
+            {
+                list.Add(item);
+
+                if (readAtLeast != null && list.Count >= readAtLeast)
+                {
+                    return list;
+                }
+            }
+        }
+
+        return list;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -129,7 +129,7 @@ public class ResourcePublisherTests
         });
 
         await cts.CancelAsync();
-        await Assert.ThrowsAsync<OperationCanceledException>(() => task);
+        await task;
 
         Assert.Empty(publisher._outgoingChannels);
     }

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -129,7 +129,7 @@ public class ResourcePublisherTests
         });
 
         await cts.CancelAsync();
-        await task;
+        try { await task; } catch (OperationCanceledException) { }
 
         Assert.Empty(publisher._outgoingChannels);
     }


### PR DESCRIPTION
* Changed `DashboardServiceData` child types to implement IDisposable and use dispose instead of cancellation token for cleanup. Confusion between type lifetime cancellation tokens and subscription lifetime cancellation tokens was the source of problems in this area. Only having subscription cancellation token helps prevent this from happening.
* Fix resource publisher subscription leak caused by using the lifetime CT instead of the subscription CT.
* The `WatchResourceConsoleLogs` method was hanging in the server when canceled. The console log subscription wasn't completing when the method was canceled. This might be the cause of https://github.com/dotnet/aspire/issues/1557 (Kestrel is trying to drain outstanding request delegates and the console logs methods are hanging). **Update: It's fixed.**
* Update console log subscriptions to be canceled when the async enumerable cancellation token was canceled or the `ConsoleLogPublisher` is disposed.
* Catch cancellation related errors in gRPC watch methods. Reduces noise in logs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1578)