### PR TITLE
Add Redis Commander extension to app model.

### DIFF
--- a/samples/eShopLite/AppHost/Program.cs
+++ b/samples/eShopLite/AppHost/Program.cs
@@ -1,20 +1,21 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var catalogDb = builder.AddPostgres("postgres")
-                    .WithPgAdmin()
-                    .AddDatabase("catalogdb");
+                       .WithPgAdmin()
+                       .AddDatabase("catalogdb");
 
-var basketCache = builder.AddRedis("basketcache");
+var basketCache = builder.AddRedis("basketcache")
+                         .WithRedisCommander();
 
 var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice")
-                     .WithReference(catalogDb)
-                     .WithReplicas(2);
+                            .WithReference(catalogDb)
+                            .WithReplicas(2);
 
 var messaging = builder.AddRabbitMQ("messaging");
 
 var basketService = builder.AddProject("basketservice", @"..\BasketService\BasketService.csproj")
-                    .WithReference(basketCache)
-                    .WithReference(messaging);
+                           .WithReference(basketCache)
+                           .WithReference(messaging);
 
 builder.AddProject<Projects.MyFrontend>("frontend")
        .WithReference(basketService)

--- a/src/Aspire.Hosting/Redis/IRedisResource.cs
+++ b/src/Aspire.Hosting/Redis/IRedisResource.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Redis;
+public interface IRedisResource : IResourceWithConnectionString
+{
+}

--- a/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
@@ -3,7 +3,9 @@
 
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Redis;
 
 namespace Aspire.Hosting;
 
@@ -41,6 +43,26 @@ public static class RedisBuilderExtensions
                       .WithManifestPublishingCallback(WriteRedisResourceToManifest)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, containerPort: 6379))
                       .WithAnnotation(new ContainerImageAnnotation { Image = "redis", Tag = "latest" });
+    }
+
+    public static IResourceBuilder<T> WithRedisCommander<T>(this IResourceBuilder<T> builder, string? containerName = null, int? hostPort = null) where T: IRedisResource
+    {
+        if (builder.ApplicationBuilder.Resources.OfType<RedisCommanderResource>().Any())
+        {
+            return builder;
+        }
+
+        builder.ApplicationBuilder.Services.TryAddLifecycleHook<RedisCommanderConfigWriterHook>();
+
+        containerName ??= $"{builder.Resource.Name}-commander";
+
+        var resource = new RedisCommanderResource(containerName);
+        builder.ApplicationBuilder.AddResource(resource)
+                                  .WithAnnotation(new ContainerImageAnnotation { Image = "rediscommander/redis-commander", Tag = "latest" })
+                                  .WithEndpoint(containerPort: 8081, hostPort: hostPort, scheme: "http", name: containerName)
+                                  .ExcludeFromManifest();
+
+        return builder;
     }
 
     private static void WriteRedisResourceToManifest(ManifestPublishingContext context)

--- a/src/Aspire.Hosting/Redis/RedisCommanderConfigWriterHook.cs
+++ b/src/Aspire.Hosting/Redis/RedisCommanderConfigWriterHook.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using System.Text;
+using Aspire.Hosting.Lifecycle;
+
+namespace Aspire.Hosting.Redis;
+
+public class RedisCommanderConfigWriterHook : IDistributedApplicationLifecycleHook
+{
+    public Task AfterEndpointsAllocatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
+    {
+        var commanderResource = appModel.Resources.OfType<RedisCommanderResource>().Single();
+        var redisInstances = appModel.Resources.OfType<IRedisResource>();
+
+        var hostsVariableBuilder = new StringBuilder();
+
+        foreach (var redisInstance in redisInstances)
+        {
+            if (redisInstance.TryGetAllocatedEndPoints(out var allocatedEndpoints))
+            {
+                var endpoint = allocatedEndpoints.Where(ae => ae.Name == "tcp").Single();
+
+                var hostString = $"{(hostsVariableBuilder.Length > 0 ? "," : string.Empty)}{redisInstance.Name}:host.docker.internal:{endpoint.Port}:0";
+                hostsVariableBuilder.Append(hostString);
+            }
+        }
+
+        commanderResource.Annotations.Add(new EnvironmentCallbackAnnotation((EnvironmentCallbackContext context) =>
+        {
+            context.EnvironmentVariables.Add("REDIS_HOSTS", hostsVariableBuilder.ToString());
+        }));
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Aspire.Hosting/Redis/RedisCommanderConfigWriterHook.cs
+++ b/src/Aspire.Hosting/Redis/RedisCommanderConfigWriterHook.cs
@@ -11,8 +11,19 @@ public class RedisCommanderConfigWriterHook : IDistributedApplicationLifecycleHo
 {
     public Task AfterEndpointsAllocatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
     {
-        var commanderResource = appModel.Resources.OfType<RedisCommanderResource>().Single();
+        if (appModel.Resources.OfType<RedisCommanderResource>().SingleOrDefault() is not { } commanderResource)
+        {
+            // No-op if there is no commander resource (removed after hook added).
+            return Task.CompletedTask;
+        }
+
         var redisInstances = appModel.Resources.OfType<IRedisResource>();
+
+        if (!redisInstances.Any())
+        {
+            // No-op if there are no Redis resources present.
+            return Task.CompletedTask;
+        }
 
         var hostsVariableBuilder = new StringBuilder();
 

--- a/src/Aspire.Hosting/Redis/RedisCommanderResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisCommanderResource.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Redis;
+
+public class RedisCommanderResource(string name) : ContainerResource(name)
+{
+}

--- a/src/Aspire.Hosting/Redis/RedisContainerResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisContainerResource.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Redis;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
 /// A resource that represents a Redis container.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
-public class RedisContainerResource(string name) : ContainerResource(name), IResourceWithConnectionString
+public class RedisContainerResource(string name) : ContainerResource(name), IResourceWithConnectionString, IRedisResource
 {
     /// <summary>
     /// Gets the connection string for the Redis server.

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Redis;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
 /// Represents a Redis resource independent of hosting model.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
-public class RedisResource(string name) : Resource(name), IResourceWithConnectionString
+public class RedisResource(string name) : Resource(name), IResourceWithConnectionString, IRedisResource
 {
     /// <summary>
     /// Gets the connection string for the Redis server.


### PR DESCRIPTION
This PR adds a `WithRedisCommander` extension to both `IResourceBuilder<RedisResource>` and `IResourceBuilder<RedisContainerResource>` which results in a container resource being added to the model (once) and a lifecycle hook which configures it for Redis Commander.

The idea is that once you do this and hit F5 you will be able to go into a pre-configured Redis Commander instance to interactively browse what is in the Redis Cache.

Usage:

```csharp
var builder = DistributedApplication.CreateBuilder(args);
builder.AddRedis("myredis1").WithRedisCommander();
builder.AddRedis("myredis2").WithRedisCommander(); // This second WithRedisCommander is necessary.
```

The Redis Commander instance will then be bound to a random endpoint and when it is opened from the dashboard each Redis instance will be preconfigured.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1580)