### PR TITLE
Fix cancellation of async enumerations

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
 using Microsoft.Extensions.Logging;
@@ -46,9 +47,11 @@ internal sealed class DashboardServiceData : IAsyncDisposable
 
         return sequence is null ? null : Enumerate();
 
-        async IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>> Enumerate()
+        async IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>> Enumerate([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            await foreach (var item in sequence.WithCancellation(_cts.Token))
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
+
+            await foreach (var item in sequence.WithCancellation(linked.Token))
             {
                 yield return item;
             }

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class DashboardClientTests
+{
+    [Fact]
+    public async Task SubscribeResources_OnCancel_ChannelRemoved()
+    {
+        var instance = new DashboardClient(NullLoggerFactory.Instance);
+        IDashboardClient client = instance;
+
+        var cts = new CancellationTokenSource();
+
+        Assert.Equal(0, instance.OutgoingResourceSubscriberCount);
+
+        var (_, subscription) = client.SubscribeResources();
+
+        Assert.Equal(1, instance.OutgoingResourceSubscriberCount);
+
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var item in subscription.WithCancellation(cts.Token))
+            {
+            }
+        });
+
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => readTask).ConfigureAwait(false);
+
+        Assert.Equal(0, instance.OutgoingResourceSubscriberCount);
+    }
+
+    [Fact]
+    public async Task SubscribeResources_OnDispose_ChannelRemoved()
+    {
+        var instance = new DashboardClient(NullLoggerFactory.Instance);
+        IDashboardClient client = instance;
+
+        Assert.Equal(0, instance.OutgoingResourceSubscriberCount);
+
+        var (_, subscription) = client.SubscribeResources();
+
+        Assert.Equal(1, instance.OutgoingResourceSubscriberCount);
+
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var item in subscription)
+            {
+            }
+        });
+
+        await instance.DisposeAsync();
+
+        Assert.Equal(0, instance.OutgoingResourceSubscriberCount);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => readTask).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task SubscribeResources_ThrowsIfDisposed()
+    {
+        IDashboardClient client = new DashboardClient(NullLoggerFactory.Instance);
+
+        await client.DisposeAsync();
+
+        Assert.Throws<ObjectDisposedException>(client.SubscribeResources);
+    }
+
+    [Fact]
+    public async Task SubscribeResources_IncreasesSubscriberCount()
+    {
+        var instance = new DashboardClient(NullLoggerFactory.Instance);
+        IDashboardClient client = instance;
+
+        Assert.Equal(0, instance.OutgoingResourceSubscriberCount);
+
+        _ = client.SubscribeResources();
+
+        Assert.Equal(1, instance.OutgoingResourceSubscriberCount);
+
+        await instance.DisposeAsync();
+
+        Assert.Equal(0, instance.OutgoingResourceSubscriberCount);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -21,7 +21,11 @@ public class ResourcePublisherTests
         await publisher.IntegrateAsync(a, ResourceSnapshotChangeType.Upsert).ConfigureAwait(false);
         await publisher.IntegrateAsync(b, ResourceSnapshotChangeType.Upsert).ConfigureAwait(false);
 
+        Assert.Equal(0, publisher.OutgoingSubscriberCount);
+
         var (snapshot, subscription) = publisher.Subscribe();
+
+        Assert.Equal(1, publisher.OutgoingSubscriberCount);
 
         Assert.Equal(2, snapshot.Length);
         Assert.Single(snapshot.Where(s => s.Name == "A"));
@@ -50,6 +54,8 @@ public class ResourcePublisherTests
         await cts.CancelAsync();
 
         await Assert.ThrowsAsync<OperationCanceledException>(() => task);
+
+        Assert.Equal(0, publisher.OutgoingSubscriberCount);
     }
 
     [Fact]
@@ -65,8 +71,12 @@ public class ResourcePublisherTests
         await publisher.IntegrateAsync(a, ResourceSnapshotChangeType.Upsert).ConfigureAwait(false);
         await publisher.IntegrateAsync(b, ResourceSnapshotChangeType.Upsert).ConfigureAwait(false);
 
+        Assert.Equal(0, publisher.OutgoingSubscriberCount);
+
         var (snapshot1, subscription1) = publisher.Subscribe();
         var (snapshot2, subscription2) = publisher.Subscribe();
+
+        Assert.Equal(2, publisher.OutgoingSubscriberCount);
 
         Assert.Equal(2, snapshot1.Length);
         Assert.Equal(2, snapshot2.Length);
@@ -88,6 +98,11 @@ public class ResourcePublisherTests
         Assert.Equal("C", v2.Resource.Name);
 
         await cts.CancelAsync();
+
+        Assert.False(await enumerator1.MoveNextAsync());
+        Assert.False(await enumerator2.MoveNextAsync());
+
+        Assert.Equal(0, publisher.OutgoingSubscriberCount);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #1451
Fixes #1557

Even though we call the `IAsyncEnumerable<T>`-returning methods directly, the generator function emitted by the compiler can still provide a `.WithCancellation(...)`-provided cancellation token to the method.

This commit fixes a few places where this annotation was missed, and links some tokens where composition was needed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1589)