### PR TITLE
Avoid cancellation messages in logs

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -51,9 +51,9 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
         {
             await WatchResourcesInternal().ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (Exception ex) when (ex is OperationCanceledException or IOException && context.CancellationToken.IsCancellationRequested)
         {
-            // Ignore cancellation and just return.
+            // Ignore cancellation and just return. Note that cancelled writes throw IOException.
         }
 
         async Task WatchResourcesInternal()
@@ -107,9 +107,9 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
         {
             await WatchResourceConsoleLogsInternal().ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (Exception ex) when (ex is OperationCanceledException or IOException && context.CancellationToken.IsCancellationRequested)
         {
-            // Ignore cancellation and just return.
+            // Ignore cancellation and just return. Note that cancelled writes throw IOException.
         }
 
         async Task WatchResourceConsoleLogsInternal()


### PR DESCRIPTION
Relates to #1557

When clients unsubscribe from resources or console logs, suppress any logging due to cancellation exceptions.

This helps avoid log messages like this:

```
fail: Grpc.AspNetCore.Server.ServerCallHandler[6]
      Error when executing service method 'WatchResourceConsoleLogs'.
      System.OperationCanceledException: The operation was canceled.
         at System.Threading.Channels.AsyncOperation`1.GetResult(Int16 token)
         at Aspire.Hosting.Extensions.ChannelExtensions.GetBatches[T](Channel`1 channel, CancellationToken cancellationToken)+MoveNext() in D:\repos\aspire\src\Aspire.Hosting\Extensions\ChannelExtensions.cs:line 33
         at Aspire.Hosting.Extensions.ChannelExtensions.GetBatches[T](Channel`1 channel, CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
         at Aspire.Hosting.Dashboard.FileLogSource.GetAsyncEnumerator(CancellationToken cancellationToken)+MoveNext() in D:\repos\aspire\src\Aspire.Hosting\Dashboard\FileLogSource.cs:line 26
         at Aspire.Hosting.Dashboard.FileLogSource.GetAsyncEnumerator(CancellationToken cancellationToken)+MoveNext() in D:\repos\aspire\src\Aspire.Hosting\Dashboard\FileLogSource.cs:line 26
         at Aspire.Hosting.Dashboard.FileLogSource.GetAsyncEnumerator(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
         at Aspire.Hosting.Dashboard.DashboardServiceData.<>c__DisplayClass6_0.<<SubscribeConsoleLogs>g__Enumerate|0>d.MoveNext() in D:\repos\aspire\src\Aspire.Hosting\Dashboard\DashboardServiceData.cs:line 54
      --- End of stack trace from previous location ---
         at Aspire.Hosting.Dashboard.DashboardServiceData.<>c__DisplayClass6_0.<<SubscribeConsoleLogs>g__Enumerate|0>d.MoveNext() in D:\repos\aspire\src\Aspire.Hosting\Dashboard\DashboardServiceData.cs:line 54
      --- End of stack trace from previous location ---
         at Aspire.Hosting.Dashboard.DashboardServiceData.<>c__DisplayClass6_0.<<SubscribeConsoleLogs>g__Enumerate|0>d.System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult(Int16 token)
         at Aspire.Hosting.Dashboard.DashboardService.WatchResourceConsoleLogs(WatchResourceConsoleLogsRequest request, IServerStreamWriter`1 responseStream, ServerCallContext context) in D:\repos\aspire\src\Aspire.Hosting\Dashboard\DashboardService.cs:line 101
         at Aspire.Hosting.Dashboard.DashboardService.WatchResourceConsoleLogs(WatchResourceConsoleLogsRequest request, IServerStreamWriter`1 responseStream, ServerCallContext context) in D:\repos\aspire\src\Aspire.Hosting\Dashboard\DashboardService.cs:line 101
         at Grpc.Shared.Server.ServerStreamingServerMethodInvoker`3.Invoke(HttpContext httpContext, ServerCallContext serverCallContext, TRequest request, IServerStreamWriter`1 streamWriter)
         at Grpc.Shared.Server.ServerStreamingServerMethodInvoker`3.Invoke(HttpContext httpContext, ServerCallContext serverCallContext, TRequest request, IServerStreamWriter`1 streamWriter)
         at Grpc.AspNetCore.Server.Internal.CallHandlers.ServerStreamingServerCallHandler`3.HandleCallAsyncCore(HttpContext httpContext, HttpContextServerCallContext serverCallContext)
         at Grpc.AspNetCore.Server.Internal.CallHandlers.ServerCallHandlerBase`3.<HandleCallAsync>g__AwaitHandleCall|8_0(HttpContextServerCallContext serverCallContext, Method`2 method, Task handleCall)
```

Easiest to [review with whitespace changes hidden](https://github.com/dotnet/aspire/pull/1590/files?w=1).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1590)