### PR TITLE
Fix bug in FileUtil.FindFullPathFromPath

### DIFF
--- a/src/Aspire.Hosting/Utils/FileUtil.cs
+++ b/src/Aspire.Hosting/Utils/FileUtil.cs
@@ -18,7 +18,7 @@ internal static class FileUtil
 
         foreach (var directory in (Environment.GetEnvironmentVariable("PATH") ?? string.Empty).Split(Path.PathSeparator))
         {
-            var fullPath = Path.Combine(directory, command + FileNameSuffixes.CurrentPlatform.Exe);
+            var fullPath = Path.Combine(directory, command);
             if (File.Exists(fullPath))
             {
                 return fullPath;


### PR DESCRIPTION
`FileUtil.FindFullPathFromPath` attempts to find a given executable on the user's path. It does this by appending a platform-specific executable suffix (e.g. `.exe` on Windows), however it does this twice -- once before the loop and once within. This means it ends up checking for files such as `c:\folder\in\my\path\docker.exe.exe` (with double extension) which is unlikely to be found.

REVIEWERS: The fact that this bug has not caused any problem before now (on Windows at least) suggests that perhaps this behaviour is not needed. It does a bunch of random disk access, and avoiding that would be good. Should we just remove it?

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1591)