### PR TITLE
Fix configuration section in XML docs

### DIFF
--- a/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
+++ b/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
@@ -29,7 +29,7 @@ public static class AspireTablesExtensions
     /// <param name="connectionName">A name used to retrieve the connection string from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureDataTablesSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TableServiceClient, TableClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Data.Tables" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Data:Tables" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureDataTablesSettings.ConnectionString"/> nor <see cref="AzureDataTablesSettings.ServiceUri"/> is provided.</exception>
     public static void AddAzureTableService(
         this IHostApplicationBuilder builder,
@@ -48,7 +48,7 @@ public static class AspireTablesExtensions
     /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection string from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureDataTablesSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TableServiceClient, TableClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Data.Tables:{name}" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Data:Tables:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureDataTablesSettings.ConnectionString"/> nor <see cref="AzureDataTablesSettings.ServiceUri"/> is provided.</exception>
     public static void AddKeyedAzureTableService(
         this IHostApplicationBuilder builder,

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -29,7 +29,7 @@ public static class AspireServiceBusExtensions
     /// <param name="connectionName">A name used to retrieve the connection string from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingServiceBusSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{ServiceBusClient, ServiceBusClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Messaging.ServiceBus" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:ServiceBus" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingServiceBusSettings.ConnectionString"/> nor <see cref="AzureMessagingServiceBusSettings.Namespace"/> is provided.</exception>
     public static void AddAzureServiceBus(
         this IHostApplicationBuilder builder,
@@ -47,7 +47,7 @@ public static class AspireServiceBusExtensions
     /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection string from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingServiceBusSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{ServiceBusClient, ServiceBusClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Messaging.ServiceBus:{name}" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:ServiceBus:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingServiceBusSettings.ConnectionString"/> nor <see cref="AzureMessagingServiceBusSettings.Namespace"/> is provided.</exception>
     public static void AddKeyedAzureServiceBus(
         this IHostApplicationBuilder builder,

--- a/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
@@ -31,7 +31,7 @@ public static class AspireKeyVaultExtensions
     /// <param name="connectionName">A name used to retrieve the connection string from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureSecurityKeyVaultSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{SecretClient, SecretClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Security.KeyVault" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Security:KeyVault" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when mandatory <see cref="AzureSecurityKeyVaultSettings.VaultUri"/> is not provided.</exception>
     public static void AddAzureKeyVaultSecrets(
         this IHostApplicationBuilder builder,
@@ -50,7 +50,7 @@ public static class AspireKeyVaultExtensions
     /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection information from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureSecurityKeyVaultSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{SecretClient, SecretClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Security.KeyVault:{name}" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Security:KeyVault:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when mandatory <see cref="AzureSecurityKeyVaultSettings.VaultUri"/> is not provided.</exception>
     public static void AddKeyedAzureKeyVaultSecrets(
         this IHostApplicationBuilder builder,

--- a/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
@@ -29,7 +29,7 @@ public static class AspireBlobStorageExtensions
     /// <param name="connectionName">A name used to retrieve the connection string from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureStorageBlobsSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{BlobServiceClient, BlobClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Storage.Blobs" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Storage:Blobs" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureStorageBlobsSettings.ConnectionString"/> nor <see cref="AzureStorageBlobsSettings.ServiceUri"/> is provided.</exception>
     public static void AddAzureBlobService(
         this IHostApplicationBuilder builder,
@@ -48,7 +48,7 @@ public static class AspireBlobStorageExtensions
     /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection string from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureStorageBlobsSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{BlobServiceClient, BlobClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Storage.Blobs:{name}" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Storage:Blobs:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureStorageBlobsSettings.ConnectionString"/> nor <see cref="AzureStorageBlobsSettings.ServiceUri"/> is provided.</exception>
     public static void AddKeyedAzureBlobService(
         this IHostApplicationBuilder builder,

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
@@ -30,7 +30,7 @@ public static class AspireQueueStorageExtensions
     /// <param name="connectionName">A name used to retrieve the connection string from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureStorageQueuesSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{QueueServiceClient, QueueClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Storage.Queues" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Storage:Queues" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureStorageQueuesSettings.ConnectionString"/> nor <see cref="AzureStorageQueuesSettings.ServiceUri"/> is provided.</exception>
     public static void AddAzureQueueService(
         this IHostApplicationBuilder builder,
@@ -49,7 +49,7 @@ public static class AspireQueueStorageExtensions
     /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection string from the ConnectionStrings configuration section.</param>
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureStorageQueuesSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{QueueServiceClient, QueueClientOptions}"/>.</param>
-    /// <remarks>Reads the configuration from "Aspire.Azure.Storage.Queues:{name}" section.</remarks>
+    /// <remarks>Reads the configuration from "Aspire:Azure:Storage:Queues:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureStorageQueuesSettings.ConnectionString"/> nor <see cref="AzureStorageQueuesSettings.ServiceUri"/> is provided.</exception>
     public static void AddKeyedAzureQueueService(
         this IHostApplicationBuilder builder,


### PR DESCRIPTION
These should use the config separator, which is a colon.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1596)