### PR TITLE
Model Dapr sidecar as an Aspire resource

### DIFF
--- a/samples/dapr/AppHost/aspire-manifest.json
+++ b/samples/dapr/AppHost/aspire-manifest.json
@@ -32,6 +32,17 @@
         }
       }
     },
+    "servicea-dapr": {
+      "type": "dapr.v0",
+      "dapr": {
+        "application": "servicea",
+        "appId": "servicea",
+        "components": [
+          "statestore",
+          "pubsub"
+        ]
+      }
+    },
     "serviceb": {
       "type": "project.v0",
       "path": "../ServiceB/DaprServiceB.csproj",
@@ -50,17 +61,6 @@
           "protocol": "tcp",
           "transport": "http"
         }
-      }
-    },
-    "servicea-dapr": {
-      "type": "dapr.v0",
-      "dapr": {
-        "application": "servicea",
-        "appId": "servicea",
-        "components": [
-          "statestore",
-          "pubsub"
-        ]
       }
     },
     "serviceb-dapr": {

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -99,6 +99,8 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
             var daprMetricsPortArg = (string? port) => ModelNamedArg("--metrics-port", port);
             var daprProfilePortArg = (string? port) => ModelNamedArg("--profile-port", port);
 
+            var appId = sidecarOptions?.AppId ?? resource.Name;
+
             var daprCommandLine =
                 CommandLineBuilder
                     .Create(
@@ -110,7 +112,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         ModelNamedArg("--app-health-probe-interval", sidecarOptions?.AppHealthProbeInterval),
                         ModelNamedArg("--app-health-probe-timeout", sidecarOptions?.AppHealthProbeTimeout),
                         ModelNamedArg("--app-health-threshold", sidecarOptions?.AppHealthThreshold),
-                        ModelNamedArg("--app-id", sidecarOptions?.AppId),
+                        ModelNamedArg("--app-id", appId),
                         ModelNamedArg("--app-max-concurrency", sidecarOptions?.AppMaxConcurrency),
                         ModelNamedArg("--app-protocol", sidecarOptions?.AppProtocol),
                         ModelNamedArg("--config", NormalizePath(sidecarOptions?.Config)),
@@ -128,11 +130,6 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         ModelNamedArg("--runtime-path", NormalizePath(sidecarOptions?.RuntimePath)),
                         ModelNamedArg("--unix-domain-socket", sidecarOptions?.UnixDomainSocket),
                         PostOptionsArgs(Args(sidecarOptions?.Command)));
-
-            if (!(sidecarOptions?.AppId is { } appId))
-            {
-                throw new DistributedApplicationException("AppId is required for Dapr sidecar executable.");
-            }
 
             var daprSideCarResourceName = $"{sidecar.Name}-cli";
             var daprSideCar = new ExecutableResource(daprSideCarResourceName, fileName, appHostDirectory, daprCommandLine.Arguments.ToArray());
@@ -211,7 +208,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         context.Writer.TryWriteNumber("appHealthProbeInterval", sidecarOptions?.AppHealthProbeInterval);
                         context.Writer.TryWriteNumber("appHealthProbeTimeout", sidecarOptions?.AppHealthProbeTimeout);
                         context.Writer.TryWriteNumber("appHealthThreshold", sidecarOptions?.AppHealthThreshold);
-                        context.Writer.TryWriteString("appId", sidecarOptions?.AppId);
+                        context.Writer.TryWriteString("appId", appId);
                         context.Writer.TryWriteNumber("appMaxConcurrency", sidecarOptions?.AppMaxConcurrency);
                         context.Writer.TryWriteNumber("appPort", sidecarOptions?.AppPort);
                         context.Writer.TryWriteString("appProtocol", sidecarOptions?.AppProtocol);

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -195,6 +195,10 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         }
                     }));
 
+            // Apply environment variables to the CLI...
+            daprSideCar.Annotations.AddRange(sidecar.Annotations.OfType<EnvironmentCallbackAnnotation>());
+
+            // The CLI is an artifact of a local run, so it should not be published...
             daprSideCar.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
 
             sidecar.Annotations.Add(

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -195,7 +195,9 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         }
                     }));
 
-            daprSideCar.Annotations.Add(
+            daprSideCar.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
+
+            sidecar.Annotations.Add(
                 new ManifestPublishingCallbackAnnotation(
                     context =>
                     {

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -50,7 +50,11 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                 continue;
             }
 
-            var sidecarOptions = daprAnnotation.Options;
+            var sidecar = daprAnnotation.Sidecar;
+
+            var sidecarOptionsAnnotation = sidecar.Annotations.OfType<DaprSidecarOptionsAnnotation>().LastOrDefault();
+
+            var sidecarOptions = sidecarOptionsAnnotation?.Options;
 
             [return: NotNullIfNotNull(nameof(path))]
             string? NormalizePath(string? path)
@@ -130,7 +134,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                 throw new DistributedApplicationException("AppId is required for Dapr sidecar executable.");
             }
 
-            var daprSideCarResourceName = $"{resource.Name}-dapr";
+            var daprSideCarResourceName = $"{sidecar.Name}-cli";
             var daprSideCar = new ExecutableResource(daprSideCarResourceName, fileName, appHostDirectory, daprCommandLine.Arguments.ToArray());
 
             resource.Annotations.Add(

--- a/src/Aspire.Hosting.Dapr/DaprSidecarOptionsAnnotation.cs
+++ b/src/Aspire.Hosting.Dapr/DaprSidecarOptionsAnnotation.cs
@@ -6,8 +6,8 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Dapr;
 
 /// <summary>
-/// Indicates that a Dapr sidecar should be started for the associated resource.
+/// Indicates the options used to configure a Dapr sidecar.
 /// </summary>
-public sealed record DaprSidecarOptionsAnnotation(DaprSidecarOptions? Options) : IResourceAnnotation
+public sealed record DaprSidecarOptionsAnnotation(DaprSidecarOptions Options) : IResourceAnnotation
 {
 }

--- a/src/Aspire.Hosting.Dapr/DaprSidecarOptionsAnnotation.cs
+++ b/src/Aspire.Hosting.Dapr/DaprSidecarOptionsAnnotation.cs
@@ -8,6 +8,6 @@ namespace Aspire.Hosting.Dapr;
 /// <summary>
 /// Indicates that a Dapr sidecar should be started for the associated resource.
 /// </summary>
-public sealed record DaprSidecarAnnotation(IDaprSidecarResource Sidecar) : IResourceAnnotation
+public sealed record DaprSidecarOptionsAnnotation(DaprSidecarOptions? Options) : IResourceAnnotation
 {
 }

--- a/src/Aspire.Hosting.Dapr/DaprSidecarResource.cs
+++ b/src/Aspire.Hosting.Dapr/DaprSidecarResource.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Dapr;
+
+/// <summary>
+/// Represents a Dapr component resource.
+/// </summary>
+public sealed class DaprSidecarResource : Resource, IDaprSidecarResource
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="DaprComponentResource"/>.
+    /// </summary>
+    /// <param name="name">The resource name.</param>
+    public DaprSidecarResource(string name) : base(name)
+    {
+    }
+
+    /// <inheritdoc/>
+    public DaprSidecarOptions? Options { get; init; }
+}

--- a/src/Aspire.Hosting.Dapr/DaprSidecarResource.cs
+++ b/src/Aspire.Hosting.Dapr/DaprSidecarResource.cs
@@ -8,13 +8,4 @@ namespace Aspire.Hosting.Dapr;
 /// <summary>
 /// Represents a Dapr sidecar resource.
 /// </summary>
-internal sealed class DaprSidecarResource : Resource, IDaprSidecarResource
-{
-    /// <summary>
-    /// Initializes a new instance of <see cref="DaprSidecarResource"/>.
-    /// </summary>
-    /// <param name="name">The resource name.</param>
-    public DaprSidecarResource(string name) : base(name)
-    {
-    }
-}
+internal sealed class DaprSidecarResource(string name) : Resource(name), IDaprSidecarResource { }

--- a/src/Aspire.Hosting.Dapr/DaprSidecarResource.cs
+++ b/src/Aspire.Hosting.Dapr/DaprSidecarResource.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Dapr;
 /// <summary>
 /// Represents a Dapr component resource.
 /// </summary>
-public sealed class DaprSidecarResource : Resource, IDaprSidecarResource
+internal sealed class DaprSidecarResource : Resource, IDaprSidecarResource
 {
     /// <summary>
     /// Initializes a new instance of <see cref="DaprComponentResource"/>.
@@ -17,7 +17,4 @@ public sealed class DaprSidecarResource : Resource, IDaprSidecarResource
     public DaprSidecarResource(string name) : base(name)
     {
     }
-
-    /// <inheritdoc/>
-    public DaprSidecarOptions? Options { get; init; }
 }

--- a/src/Aspire.Hosting.Dapr/DaprSidecarResource.cs
+++ b/src/Aspire.Hosting.Dapr/DaprSidecarResource.cs
@@ -6,12 +6,12 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Dapr;
 
 /// <summary>
-/// Represents a Dapr component resource.
+/// Represents a Dapr sidecar resource.
 /// </summary>
 internal sealed class DaprSidecarResource : Resource, IDaprSidecarResource
 {
     /// <summary>
-    /// Initializes a new instance of <see cref="DaprComponentResource"/>.
+    /// Initializes a new instance of <see cref="DaprSidecarResource"/>.
     /// </summary>
     /// <param name="name">The resource name.</param>
     public DaprSidecarResource(string name) : base(name)

--- a/src/Aspire.Hosting.Dapr/IDaprSidecarResource.cs
+++ b/src/Aspire.Hosting.Dapr/IDaprSidecarResource.cs
@@ -10,8 +10,4 @@ namespace Aspire.Hosting.Dapr;
 /// </summary>
 public interface IDaprSidecarResource : IResource
 {
-    /// <summary>
-    /// Gets options used to configure the sidecar, if any.
-    /// </summary>
-    DaprSidecarOptions? Options { get; }
 }

--- a/src/Aspire.Hosting.Dapr/IDaprSidecarResource.cs
+++ b/src/Aspire.Hosting.Dapr/IDaprSidecarResource.cs
@@ -6,7 +6,7 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Dapr;
 
 /// <summary>
-/// Represents a Dapr component resource.
+/// Represents a Dapr sidecar resource.
 /// </summary>
 public interface IDaprSidecarResource : IResource
 {

--- a/src/Aspire.Hosting.Dapr/IDaprSidecarResource.cs
+++ b/src/Aspire.Hosting.Dapr/IDaprSidecarResource.cs
@@ -6,8 +6,12 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Dapr;
 
 /// <summary>
-/// Indicates that a Dapr sidecar should be started for the associated resource.
+/// Represents a Dapr component resource.
 /// </summary>
-public sealed record DaprSidecarAnnotation(IDaprSidecarResource Sidecar) : IResourceAnnotation
+public interface IDaprSidecarResource : IResource
 {
+    /// <summary>
+    /// Gets options used to configure the sidecar, if any.
+    /// </summary>
+    DaprSidecarOptions? Options { get; }
 }

--- a/src/Aspire.Hosting.Dapr/IDistributedApplicationComponentBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Dapr/IDistributedApplicationComponentBuilderExtensions.cs
@@ -35,10 +35,20 @@ public static class IDistributedApplicationResourceBuilderExtensions
         return builder.WithDaprSidecar(
             sidecarBuilder =>
             {
-                sidecarBuilder.WithOptions(options);
+                if (options is not null)
+                {
+                    sidecarBuilder.WithOptions(options);
+                }
             });
     }
 
+    /// <summary>
+    /// Ensures that a Dapr sidecar is started for the resource.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder instance.</param>
+    /// <param name="configureSidecar">A callback that can be use to configure the Dapr sidecar.</param>
+    /// <returns>The resource builder instance.</returns>
     public static IResourceBuilder<T> WithDaprSidecar<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<IDaprSidecarResource>> configureSidecar) where T : IResource
     {
         // Add Dapr is idempoent, so we can call it multiple times.
@@ -51,7 +61,13 @@ public static class IDistributedApplicationResourceBuilderExtensions
         return builder.WithAnnotation(new DaprSidecarAnnotation(sidecarBuilder.Resource));
     }
 
-    public static IResourceBuilder<IDaprSidecarResource> WithOptions(this IResourceBuilder<IDaprSidecarResource> builder, DaprSidecarOptions? options)
+    /// <summary>
+    /// Configures a Dapr sidecar with the specified options.
+    /// </summary>
+    /// <param name="builder">The Dapr sidecar resource builder instance.</param>
+    /// <param name="options">Options for configuring the Dapr sidecar.</param>
+    /// <returns>The Dapr sidecar resource builder instance.</returns>
+    public static IResourceBuilder<IDaprSidecarResource> WithOptions(this IResourceBuilder<IDaprSidecarResource> builder, DaprSidecarOptions options)
     {
         return builder.WithAnnotation(new DaprSidecarOptionsAnnotation(options));
     }

--- a/src/Aspire.Hosting.Dapr/IDistributedApplicationComponentBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Dapr/IDistributedApplicationComponentBuilderExtensions.cs
@@ -12,17 +12,6 @@ namespace Aspire.Hosting;
 public static class IDistributedApplicationResourceBuilderExtensions
 {
     /// <summary>
-    /// Ensures that a Dapr sidecar is started for the resource. The default app is the resource name.
-    /// </summary>
-    /// <typeparam name="T">The type of the resource.</typeparam>
-    /// <param name="builder">The resource builder instance.</param>
-    /// <returns>The resource builder instance.</returns>
-    public static IResourceBuilder<T> WithDaprSidecar<T>(this IResourceBuilder<T> builder) where T : IResource
-    {
-        return builder.WithDaprSidecar(builder.Resource.Name);
-    }
-
-    /// <summary>
     /// Ensures that a Dapr sidecar is started for the resource.
     /// </summary>
     /// <typeparam name="T">The type of the resource.</typeparam>


### PR DESCRIPTION
Currently, Dapr sidecars are modeled as annotations on a parent resource, which indicates the need for a Dapr sidecar started for that resource. The Dapr lifecycle hook will then generate appropriate Dapr CLI executable resources to start the sidecars.  When publishing, that hook will write Dapr sidecar resources to the manifest.

This model has a disadvantage in that, because the sidecars are not true resources, users cannot modify them like other resources (e.g. set environment variables). This was done originally due to the tight 1:1 mapping between Dapr sidecar and parent resource.  For example, it would be semantically invalid to create a Dapr sidecar resource and then reference it from several resources.

This PR updates the model such that the Dapr sidecar is a true resource, but one exposed only through the existing `AddDaprSidecar()` API to avoid semantic errors; users cannot create an arbitrary Dapr sidecar resource, only configure the one associated with a given resource.  The API allows the existing sidecar options (if any) to be specified, as well as use the existing resource annotation helpers, such as `WithEnvironment()`. 

The API looks like:

```csharp

builder.AddProject<Projects.DaprServiceA>("servicea")
       .WithDaprSidecar(
                 sidecarBuilder =>
                 {
                     sidecarBuilder
                         .WithOptions(new DaprSidecarOptions { ... })
                         .WithEnvironment("DAPR_TEST_VAR", "Dapr Test Value");
                 }
       )

```

> NOTE: Currently only the environment variables annotations are applied to the implicit Dapr CLI executable resource.

Resolves #1553
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1604)