### PR TITLE
Stop console and Docker logging on shutdown

### DIFF
--- a/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
@@ -3,12 +3,21 @@
 
 namespace Aspire.Hosting.Dashboard;
 
-internal sealed class ConsoleLogPublisher(ResourcePublisher resourcePublisher)
+internal sealed class ConsoleLogPublisher : IDisposable
 {
+    private readonly ResourcePublisher _resourcePublisher;
+    private readonly CancellationTokenSource _cts;
+
+    public ConsoleLogPublisher(ResourcePublisher resourcePublisher)
+    {
+        _resourcePublisher = resourcePublisher;
+        _cts = new();
+    }
+
     internal IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>>? Subscribe(string resourceName)
     {
         // Look up the requested resource, so we know how to obtain logs.
-        if (!resourcePublisher.TryGetResource(resourceName, out var resource))
+        if (!_resourcePublisher.TryGetResource(resourceName, out var resource))
         {
             throw new ArgumentException($"Unknown resource {resourceName}.", nameof(resourceName));
         }
@@ -17,29 +26,35 @@ internal sealed class ConsoleLogPublisher(ResourcePublisher resourcePublisher)
         // Note, we would like to obtain these logs via DCP directly, rather than sourcing them in the dashboard.
         return resource switch
         {
-            ExecutableSnapshot executable => SubscribeExecutable(executable),
-            ContainerSnapshot container => SubscribeContainer(container),
+            ExecutableSnapshot executable => SubscribeExecutable(executable, _cts.Token),
+            ContainerSnapshot container => SubscribeContainer(container, _cts.Token),
             _ => throw new NotSupportedException($"Unsupported resource type {resource.GetType()}.")
         };
 
-        static FileLogSource? SubscribeExecutable(ExecutableSnapshot executable)
+        static FileLogSource? SubscribeExecutable(ExecutableSnapshot executable, CancellationToken cancellationToken)
         {
             if (executable.StdOutFile is null || executable.StdErrFile is null)
             {
                 return null;
             }
 
-            return new FileLogSource(executable.StdOutFile, executable.StdErrFile);
+            return new FileLogSource(executable.StdOutFile, executable.StdErrFile, cancellationToken);
         }
 
-        static DockerContainerLogSource? SubscribeContainer(ContainerSnapshot container)
+        static DockerContainerLogSource? SubscribeContainer(ContainerSnapshot container, CancellationToken cancellationToken)
         {
             if (container.ContainerId is null)
             {
                 return null;
             }
 
-            return new DockerContainerLogSource(container.ContainerId);
+            return new DockerContainerLogSource(container.ContainerId, cancellationToken);
         }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
     }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -32,8 +32,9 @@ internal sealed class DashboardServiceData : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         await _cts.CancelAsync().ConfigureAwait(false);
-
         _cts.Dispose();
+
+        _consoleLogPublisher.Dispose();
     }
 
     internal ResourceSnapshotSubscription SubscribeResources()

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -24,7 +24,7 @@ internal sealed class DashboardServiceData : IAsyncDisposable
         ILoggerFactory loggerFactory)
     {
         _resourcePublisher = new ResourcePublisher(_cts.Token);
-        _consoleLogPublisher = new ConsoleLogPublisher(_resourcePublisher);
+        _consoleLogPublisher = new ConsoleLogPublisher(_resourcePublisher, _cts.Token);
 
         _ = new DcpDataSource(kubernetesService, applicationModel, loggerFactory, _resourcePublisher.IntegrateAsync, _cts.Token);
     }
@@ -33,8 +33,6 @@ internal sealed class DashboardServiceData : IAsyncDisposable
     {
         await _cts.CancelAsync().ConfigureAwait(false);
         _cts.Dispose();
-
-        _consoleLogPublisher.Dispose();
     }
 
     internal ResourceSnapshotSubscription SubscribeResources()

--- a/tests/Aspire.Hosting.Tests/Dashboard/FileLogSourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/FileLogSourceTests.cs
@@ -1,0 +1,162 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Aspire.Hosting.Dashboard;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Dashboard;
+
+public class FileLogSourceTests
+{
+    [Fact]
+    public async Task Read_LifetimeCancellation_Complete()
+    {
+        // Arrange
+        var outPath = Path.GetTempFileName();
+        var errorPath = Path.GetTempFileName();
+        var cts = new CancellationTokenSource();
+        var s = new FileLogSource(outPath, errorPath, cts.Token);
+        var channel = Channel.CreateUnbounded<IReadOnlyList<(string Content, bool IsErrorMessage)>>();
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var item in s)
+            {
+                await channel.Writer.WriteAsync(item);
+            }
+            channel.Writer.Complete();
+        });
+
+        // Act
+        cts.Cancel();
+        await readTask;
+        var all = await ReadResultsAsync(channel.Reader.ReadAllAsync());
+
+        // Assert
+        Assert.Empty(all);
+    }
+
+    [Fact]
+    public async Task Read_EnumerableCancellation_Complete()
+    {
+        // Arrange
+        var outPath = Path.GetTempFileName();
+        var errorPath = Path.GetTempFileName();
+        var cts = new CancellationTokenSource();
+        var s = new FileLogSource(outPath, errorPath, CancellationToken.None);
+        var channel = Channel.CreateUnbounded<IReadOnlyList<(string Content, bool IsErrorMessage)>>();
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var item in s.WithCancellation(cts.Token))
+            {
+                await channel.Writer.WriteAsync(item);
+            }
+            channel.Writer.Complete();
+        });
+
+        // Act
+        cts.Cancel();
+        await readTask;
+        var all = await ReadResultsAsync(channel.Reader.ReadAllAsync());
+
+        // Assert
+        Assert.Empty(all);
+    }
+
+    [Fact]
+    public async Task Read_NewFileWithLines_ReturnResults()
+    {
+        // Arrange
+        var outPath = Path.GetTempFileName();
+        var errorPath = Path.GetTempFileName();
+        var cts = new CancellationTokenSource();
+        var s = new FileLogSource(outPath, errorPath, CancellationToken.None);
+        var channel = Channel.CreateUnbounded<IReadOnlyList<(string Content, bool IsErrorMessage)>>();
+        var readTask = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var item in s.WithCancellation(cts.Token))
+                {
+                    await channel.Writer.WriteAsync(item);
+                }
+            }
+            finally
+            {
+                channel.Writer.Complete();
+            }
+        });
+
+        try
+        {
+            // Act
+            using var outStream = File.CreateText(outPath);
+            using var errorStream = File.CreateText(errorPath);
+
+            await outStream.WriteLineAsync("Out 1");
+            await outStream.WriteLineAsync("Out 2");
+            await outStream.FlushAsync();
+            var outResults = await ReadResultsAsync(channel.Reader.ReadAllAsync(), readAtLeast: 2);
+
+            await errorStream.WriteLineAsync("Error 1");
+            await errorStream.WriteLineAsync("Error 2");
+            await errorStream.FlushAsync();
+            var errorResults = await ReadResultsAsync(channel.Reader.ReadAllAsync(), readAtLeast: 2);
+
+            cts.Cancel();
+            try { await readTask; } catch (OperationCanceledException) { }
+            var completeResults = await ReadResultsAsync(channel.Reader.ReadAllAsync());
+
+            // Assert
+            Assert.Collection(outResults,
+                r =>
+                {
+                    Assert.Equal("Out 1", r.Content);
+                    Assert.False(r.IsErrorMessage);
+                },
+                r =>
+                {
+                    Assert.Equal("Out 2", r.Content);
+                    Assert.False(r.IsErrorMessage);
+                });
+            Assert.Collection(errorResults,
+                r =>
+                {
+                    Assert.Equal("Error 1", r.Content);
+                    Assert.True(r.IsErrorMessage);
+                },
+                r =>
+                {
+                    Assert.Equal("Error 2", r.Content);
+                    Assert.True(r.IsErrorMessage);
+                });
+            Assert.Empty(completeResults);
+        }
+        finally
+        {
+            File.Delete(outPath);
+            File.Delete(errorPath);
+        }
+    }
+
+    public static async Task<List<(string Content, bool IsErrorMessage)>> ReadResultsAsync(IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>> asyncEnumerable, int? readAtLeast = null)
+    {
+        ArgumentNullException.ThrowIfNull(asyncEnumerable);
+
+        var list = new List<(string Content, bool IsErrorMessage)>();
+        await foreach (var t in asyncEnumerable)
+        {
+            foreach (var item in t)
+            {
+                list.Add(item);
+
+                if (readAtLeast != null && list.Count >= readAtLeast)
+                {
+                    return list;
+                }
+            }
+        }
+
+        return list;
+    }
+}


### PR DESCRIPTION
Left over changes from https://github.com/dotnet/aspire/pull/1578

* DashboardServiceData dispose now stops any outstanding console and Docker container logging.
* Unit test console logging
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1620)