### PR TITLE
Fix excludefrommanifest

### DIFF
--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -360,7 +360,7 @@ public static class ResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<T> ExcludeFromManifest<T>(this IResourceBuilder<T> builder) where T : IResource
     {
-        foreach (var annotation in builder.Resource.Annotations.OfType<ManifestPublishingCallbackAnnotation>())
+        foreach (var annotation in builder.Resource.Annotations.OfType<ManifestPublishingCallbackAnnotation>().ToList())
         {
             builder.Resource.Annotations.Remove(annotation);
         }

--- a/tests/Aspire.Hosting.Tests/ExcludeFromManifestTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExcludeFromManifestTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class ExcludeFromManifestTests
+{
+    [Fact]
+    public void CanExcludeFromManifestWithCallbackAnnotation()
+    {
+        var testProgram = CreateTestProgram();
+
+        testProgram.ServiceABuilder.WithAnnotation(ManifestPublishingCallbackAnnotation.Ignore)
+            .ExcludeFromManifest();
+    }
+
+    private static TestProgram CreateTestProgram() => TestProgram.Create<ExcludeFromManifestTests>();
+}


### PR DESCRIPTION
Fixes #1595 by not modifying the same collection. Even though a resource may already have the `ManifestPublishingCallbackAnnotation.Ignore` now when added, there's no guarantee that the behaviour will remain constant. Allowing `ExcludeFromManifest` to operate despite this keeps the API consistent.

Also adds test for the method.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1625)