### PR TITLE
Enable Redis Logging

### DIFF
--- a/src/Components/Aspire.StackExchange.Redis/AssemblyInfo.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AssemblyInfo.cs
@@ -8,4 +8,4 @@ using StackExchange.Redis;
 [assembly: ConfigurationSchema("Aspire:StackExchange:Redis", typeof(StackExchangeRedisSettings))]
 [assembly: ConfigurationSchema("Aspire:StackExchange:Redis:ConfigurationOptions", typeof(ConfigurationOptions))]
 
-[assembly: LoggingCategories("Aspire.StackExchange.Redis")]
+[assembly: LoggingCategories("StackExchange.Redis")]

--- a/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
+++ b/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
@@ -2,7 +2,7 @@
   "definitions": {
     "logLevel": {
       "properties": {
-        "Aspire.StackExchange.Redis": {
+        "StackExchange.Redis": {
           "$ref": "#/definitions/logLevelThreshold"
         }
       }

--- a/src/Components/Telemetry.md
+++ b/src/Components/Telemetry.md
@@ -260,7 +260,7 @@ Aspire.RabbitMQ.Client:
 
 Aspire.StackExchange.Redis:
 - Log categories:
-  - "Aspire.StackExchange.Redis" (this name is defined by our component, we can change it)
+  - "StackExchange.Redis"
 - Activity source names:
   - "OpenTelemetry.Instrumentation.StackExchangeRedis"
 - Metric names:

--- a/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
@@ -20,7 +20,7 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
 
     protected override bool SupportsKeyedRegistrations => true;
 
-    protected override string[] RequiredLogCategories => new string[] { "Aspire.StackExchange.Redis" };
+    protected override string[] RequiredLogCategories => ["StackExchange.Redis"];
 
     // https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/e4cb523a4a3592e1a1adf30f3596025bfd8978e3/src/OpenTelemetry.Instrumentation.StackExchangeRedis/StackExchangeRedisConnectionInstrumentation.cs#L34
     protected override string ActivitySourceName => "OpenTelemetry.Instrumentation.StackExchangeRedis";


### PR DESCRIPTION
SE.Redis has ILogger support now, update to use it

With the latest DCP (#1599), the proxy issues we had in the past are now resolved. Redis doesn't log errors on startup anymore.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1628)