### PR TITLE
Remove unnecessary ServiceBus Activity name

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,11 +8,11 @@
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.2" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
     <PackageVersion Include="Azure.Identity" Version="1.10.4" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0-beta.2" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.17.1" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.37.0" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.1" />
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.ResourceManager.CosmosDB" Version="1.4.0-beta.5" />

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -64,9 +64,6 @@ public static class AspireServiceBusExtensions
 
     private sealed class MessageBusComponent : AzureComponent<AzureMessagingServiceBusSettings, ServiceBusClient, ServiceBusClientOptions>
     {
-        // TODO: Remove "Azure.Messaging.ServiceBus" source when https://github.com/Azure/azure-sdk-for-net/issues/39166 is fixed
-        protected override string[] ActivitySourceNames => ["Azure.Messaging.ServiceBus.*", "Azure.Messaging.ServiceBus"];
-
         protected override IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureMessagingServiceBusSettings settings, string connectionName, string configurationSectionName)
         {
             return azureFactoryBuilder.RegisterClientFactory<ServiceBusClient, ServiceBusClientOptions>((options, cred) =>

--- a/src/Components/Telemetry.md
+++ b/src/Components/Telemetry.md
@@ -25,7 +25,6 @@ Aspire.Azure.Messaging.ServiceBus:
   - "Azure.Messaging.ServiceBus"
 - Activity source names:
   - "Azure.Messaging.ServiceBus.*"
-  - "Azure.Messaging.ServiceBus"
 - Metric names:
   - none (currently not supported by the Azure SDK)
 


### PR DESCRIPTION
Now that we have a build with https://github.com/Azure/azure-sdk-for-net/issues/39166 fixed, we can remove this workaround.

Also updating Azure packages to the latest released versions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1648)