### PR TITLE
Validate tokens can be cancelled

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DockerContainerLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DockerContainerLogSource.cs
@@ -10,8 +10,13 @@ namespace Aspire.Hosting.Dashboard;
 
 internal sealed class DockerContainerLogSource(string containerId) : IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>>
 {
-    public async IAsyncEnumerator<IReadOnlyList<(string Content, bool IsErrorMessage)>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    public async IAsyncEnumerator<IReadOnlyList<(string Content, bool IsErrorMessage)>> GetAsyncEnumerator(CancellationToken cancellationToken)
     {
+        if (!cancellationToken.CanBeCanceled)
+        {
+            throw new ArgumentException("Cancellation token must be cancellable in order to prevent leaking resources.", nameof(cancellationToken));
+        }
+
         Task<ProcessResult>? processResultTask = null;
         IAsyncDisposable? processDisposable = null;
 

--- a/src/Aspire.Hosting/Dashboard/FileLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/FileLogSource.cs
@@ -17,6 +17,11 @@ internal sealed partial class FileLogSource(string stdOutPath, string stdErrPath
 
     public async IAsyncEnumerator<IReadOnlyList<(string Content, bool IsErrorMessage)>> GetAsyncEnumerator(CancellationToken cancellationToken)
     {
+        if (!cancellationToken.CanBeCanceled)
+        {
+            throw new ArgumentException("Cancellation token must be cancellable in order to prevent leaking resources.", nameof(cancellationToken));
+        }
+
         var channel = Channel.CreateUnbounded<(string Content, bool IsErrorMessage)>(
             new UnboundedChannelOptions { AllowSynchronousContinuations = false, SingleReader = true, SingleWriter = false });
 


### PR DESCRIPTION
These components use the cancellation token to clean up the resources they provide. We expect all callers to provide a token that will be cancelled at some point.

This change adds validation that the tokens are actually cancelable, protecting against the case that a caller indavertently passes `CancellationToken.None` or `default(CancellationToken)`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1658)