### PR TITLE
fix incorrect type of shared RoundRobinServiceEndPointSelectorProvider instance 

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery/LoadBalancing/RoundRobinServiceEndPointSelectorProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/LoadBalancing/RoundRobinServiceEndPointSelectorProvider.cs
@@ -11,7 +11,7 @@ public class RoundRobinServiceEndPointSelectorProvider : IServiceEndPointSelecto
     /// <summary>
     /// Gets a shared instance of this class.
     /// </summary>
-    public static RandomServiceEndPointSelectorProvider Instance { get; } = new();
+    public static RoundRobinServiceEndPointSelectorProvider Instance { get; } = new();
 
     /// <inheritdoc/>
     public IServiceEndPointSelector CreateSelector() => new RoundRobinServiceEndPointSelector();


### PR DESCRIPTION
I've just noticed that RoundRobinServiceEndPointSelectorProvider has an incorrect type for shared instance.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1661)