### PR TITLE
Improve environment variable parsing

### DIFF
--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -174,6 +174,7 @@
       <Link>Protos\resource_service.proto</Link>
     </Protobuf>
     <Compile Include="..\Aspire.Hosting\Extensions\ChannelExtensions.cs" Link="Extensions\ChannelExtensions.cs" />
+    <Compile Include="..\Aspire.Hosting\Utils\EnvironmentUtil.cs" Link="Utils\EnvironmentUtil.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -144,10 +144,19 @@ public class DashboardWebApplication : IHostedService
 
     private static Uri[] GetAddressUris(string variableName, string defaultValue)
     {
-        var urls = Environment.GetEnvironmentVariable(variableName) ?? defaultValue;
+        var urls = Environment.GetEnvironmentVariable(variableName);
+
+        if (string.IsNullOrWhiteSpace(urls))
+        {
+            urls = defaultValue;
+        }
+
         try
         {
-            return urls.Split(';').Select(url => new Uri(url)).ToArray();
+            return urls
+                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(url => new Uri(url))
+                .ToArray();
         }
         catch (Exception ex)
         {

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -6,6 +6,7 @@ using Aspire.Dashboard.Components;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Grpc;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
@@ -37,7 +38,7 @@ public class DashboardWebApplication : IHostedService
         builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.None);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error);
 
-        var dashboardUris = GetAddressUris(DashboardUrlVariableName, DashboardUrlDefaultValue);
+        var dashboardUris = EnvironmentUtil.GetAddressUris(DashboardUrlVariableName, DashboardUrlDefaultValue);
 
         if (dashboardUris.FirstOrDefault() is { } reportedDashboardUri)
         {
@@ -46,7 +47,7 @@ public class DashboardWebApplication : IHostedService
         }
 
         var dashboardHttpsPort = dashboardUris.FirstOrDefault(IsHttps)?.Port;
-        var otlpUris = GetAddressUris(DashboardOtlpUrlVariableName, DashboardOtlpUrlDefaultValue);
+        var otlpUris = EnvironmentUtil.GetAddressUris(DashboardOtlpUrlVariableName, DashboardOtlpUrlDefaultValue);
 
         if (otlpUris.Length > 1)
         {
@@ -140,28 +141,6 @@ public class DashboardWebApplication : IHostedService
         _app.MapGrpcService<OtlpMetricsService>();
         _app.MapGrpcService<OtlpTraceService>();
         _app.MapGrpcService<OtlpLogsService>();
-    }
-
-    private static Uri[] GetAddressUris(string variableName, string defaultValue)
-    {
-        var urls = Environment.GetEnvironmentVariable(variableName);
-
-        if (string.IsNullOrWhiteSpace(urls))
-        {
-            urls = defaultValue;
-        }
-
-        try
-        {
-            return urls
-                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(url => new Uri(url))
-                .ToArray();
-        }
-        catch (Exception ex)
-        {
-            throw new InvalidOperationException($"Error parsing URIs from environment variable '{variableName}'.", ex);
-        }
     }
 
     private static void ConfigureListenAddresses(KestrelServerOptions kestrelOptions, Uri[] uris, HttpProtocols? httpProtocols = null)

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Dashboard;
 
@@ -69,7 +70,7 @@ internal sealed class DashboardServiceHost : IHostedService
 
         static void ConfigureKestrel(KestrelServerOptions kestrelOptions)
         {
-            var uris = GetAddressUris(DashboardServiceUrlVariableName, DashboardServiceUrlDefaultValue);
+            var uris = EnvironmentUtil.GetAddressUris(DashboardServiceUrlVariableName, DashboardServiceUrlDefaultValue);
 
             foreach (var uri in uris)
             {
@@ -92,28 +93,6 @@ internal sealed class DashboardServiceHost : IHostedService
                     {
                         options.UseHttps();
                     }
-                }
-            }
-
-            static Uri[] GetAddressUris(string variableName, string defaultValue)
-            {
-                try
-                {
-                    var urls = Environment.GetEnvironmentVariable(variableName);
-
-                    if (string.IsNullOrWhiteSpace(urls))
-                    {
-                        urls = defaultValue;
-                    }
-
-                    return urls
-                        .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                        .Select(url => new Uri(url))
-                        .ToArray();
-                }
-                catch (Exception ex)
-                {
-                    throw new InvalidOperationException($"Error parsing URIs from environment variable '{variableName}'.", ex);
                 }
             }
         }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -99,9 +99,17 @@ internal sealed class DashboardServiceHost : IHostedService
             {
                 try
                 {
-                    var urls = Environment.GetEnvironmentVariable(variableName) ?? defaultValue;
+                    var urls = Environment.GetEnvironmentVariable(variableName);
 
-                    return urls.Split(';').Select(url => new Uri(url)).ToArray();
+                    if (string.IsNullOrWhiteSpace(urls))
+                    {
+                        urls = defaultValue;
+                    }
+
+                    return urls
+                        .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .Select(url => new Uri(url))
+                        .ToArray();
                 }
                 catch (Exception ex)
                 {

--- a/src/Aspire.Hosting/Utils/EnvironmentUtil.cs
+++ b/src/Aspire.Hosting/Utils/EnvironmentUtil.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Utils;
+
+internal static class EnvironmentUtil
+{
+    public static Uri[] GetAddressUris(string variableName, string defaultValue)
+    {
+        try
+        {
+            var urls = Environment.GetEnvironmentVariable(variableName);
+
+            if (string.IsNullOrWhiteSpace(urls))
+            {
+                urls = defaultValue;
+            }
+
+            return urls
+                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(url => new Uri(url))
+                .ToArray();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Error parsing URIs from environment variable '{variableName}'.", ex);
+        }
+    }
+}


### PR DESCRIPTION
During debugging I noticed a scenario where the returned environment variable was empty, which led to an exception that `""` was an invalid URI. This change ensures that empty or whitespace strings are treated the same as nulls, such that the default is used.

Additionally, support for ignoring of empty URLs is included too. This fixes cases like `http://foo;` (trailing semicolon).

This code was duplicated in two places, so we pull it out into a util method for re-use.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1665)