### PR TITLE
Add option to ignore Cosmos emulator certificate.

### DIFF
--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared\Cosmos\CosmosConstants.cs">
+      <Link>Shared\CosmosConstants.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -8,9 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Shared\Cosmos\CosmosConstants.cs">
-      <Link>Shared\CosmosConstants.cs</Link>
-    </Compile>
+    <Compile Include="..\Shared\Cosmos\CosmosConstants.cs" Link="Shared\CosmosConstants.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure/AzureCosmosDBCloudApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBCloudApplicationBuilderExtensions.cs
@@ -50,15 +50,16 @@ public static class AzureCosmosDBCloudApplicationBuilderExtensions
 
     private static void WriteCosmosDBToManifest(ManifestPublishingContext context, AzureCosmosDBResource cosmosDb)
     {
-        var connectionString = cosmosDb.GetConnectionString();
-        if (connectionString is null)
+        // If we are using an emulator then we assume that a connection string was not
+        // provided for the purpose of manifest generation.
+        if (cosmosDb.IsEmulator || cosmosDb.GetConnectionString() is not { } connectionString)
         {
             context.Writer.WriteString("type", "azure.cosmosdb.account.v0");
         }
         else
         {
             context.Writer.WriteString("type", "azure.cosmosdb.connection.v0");
-            context.Writer.WriteString("connectionString", cosmosDb.GetConnectionString());
+            context.Writer.WriteString("connectionString", connectionString);
         }
 
     }

--- a/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.ObjectModel;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.Cosmos;
 
 namespace Aspire.Hosting.Azure.Data.Cosmos;
 
@@ -58,13 +59,5 @@ public class AzureCosmosDBResource(string name, string? connectionString)
 
 file static class AzureCosmosDBEmulatorConnectionString
 {
-    /// <summary>
-    /// Gets the well-known and documented Azure Cosmos DB emulator account key.
-    /// See <a href="https://learn.microsoft.com/azure/cosmos-db/emulator#authentication"></a>
-    /// </summary>
-    private const string ConnectionStringHeader = """
-        AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;
-        """;
-
-    public static string Create(int port) => $"{ConnectionStringHeader}AccountEndpoint=https://127.0.0.1:{port};";
+    public static string Create(int port) => $"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint=https://127.0.0.1:{port};";
 }

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
@@ -11,9 +11,8 @@
 
   <ItemGroup>
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
-    <Compile Include="..\..\Shared\Cosmos\CosmosConstants.cs">
-      <Link>Shared\CosmosConstants.cs</Link>
-    </Compile>
+    <Compile Include="..\..\Shared\Cosmos\CosmosConstants.cs" Link="Shared\CosmosConstants.cs" />
+    <Compile Include="..\..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
@@ -11,8 +11,11 @@
 
   <ItemGroup>
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
+    <Compile Include="..\..\Shared\Cosmos\CosmosConstants.cs">
+      <Link>Shared\CosmosConstants.cs</Link>
+    </Compile>
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Azure.Cosmos" />

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireAzureCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireAzureCosmosDBExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Data.Common;
 using Aspire.Hosting.Azure.Cosmos;
 using Aspire.Microsoft.Azure.Cosmos;
 using Azure.Identity;
@@ -56,19 +55,6 @@ public static class AspireAzureCosmosDBExtensions
         AddAzureCosmosDB(builder, $"{DefaultConfigSectionName}:{name}", configureSettings, configureClientOptions, connectionName: name, serviceKey: name);
     }
 
-    private static bool IsEmulatorConnectionString(string? connectionString)
-    {
-        if (connectionString == null)
-        {
-            return false;
-        }
-
-        var builder = new DbConnectionStringBuilder();
-        builder.ConnectionString = connectionString;
-        var accountKeyFromConnectionString = builder["AccountKey"].ToString();
-        return accountKeyFromConnectionString == CosmosConstants.EmulatorAccountKey;
-    }
-
     private static void AddAzureCosmosDB(
         this IHostApplicationBuilder builder,
         string configurationSectionName,
@@ -107,10 +93,7 @@ public static class AspireAzureCosmosDBExtensions
             });
         }
 
-        // If the user opts into ignoring the emualtor certificate and the emulator is detected
-        // via the use of the hard coded account key, then disable certificate checking for the
-        // Cosmos DB client.
-        if (settings.IgnoreEmulatorCertificate && IsEmulatorConnectionString(settings.ConnectionString))
+        if (settings.IgnoreEmulatorCertificate && CosmosUtils.IsEmulatorConnectionString(settings.ConnectionString))
         {
             clientOptions.HttpClientFactory = () => new HttpClient(new HttpClientHandler()
             {

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AzureCosmosDBSettings.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AzureCosmosDBSettings.cs
@@ -42,6 +42,5 @@ public sealed class AzureCosmosDBSettings
     /// Controls whether the Cosmos DB emulator certificate is ignored when its use is detected.
     /// </summary>
     public bool IgnoreEmulatorCertificate { get; set; }
-
 }
 

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AzureCosmosDBSettings.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AzureCosmosDBSettings.cs
@@ -37,5 +37,11 @@ public sealed class AzureCosmosDBSettings
     /// Gets or sets the credential used to authenticate to the Azure Cosmos DB endpoint.
     /// </summary>
     public TokenCredential? Credential { get; set; }
+
+    /// <summary>
+    /// Controls whether the Cosmos DB emulator certificate is ignored when its use is detected.
+    /// </summary>
+    public bool IgnoreEmulatorCertificate { get; set; }
+
 }
 

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
@@ -30,6 +30,10 @@
                       "type": "string",
                       "description": "Gets or sets the connection string of the Azure Cosmos database to connect to."
                     },
+                    "IgnoreEmulatorCertificate": {
+                      "type": "boolean",
+                      "description": "Controls whether the Cosmos DB emulator certificate is ignored when its use is detected."
+                    },
                     "Tracing": {
                       "type": "boolean",
                       "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -140,7 +140,7 @@ Aspire supports the usage of the Azure Cosmos DB emulator to use the emulator, a
 var cosmosdb = builder.AddAzureCosmosDB("cosmos").UseEmulator();
 ```
 
-When the AppHost starts up a local container running the Azure CosmosDB will also be started. Inside the project that uses CosmosDB you also need to specify that you want to ignore the server certificate (so you don't need to manually download and install it):
+When the AppHost starts up a local container running the Azure CosmosDB will also be started. Inside the project that uses CosmosDB you can specify that you want to ignore the server certificate, so you don't need to manually download and install it:
 
 ```csharp
 // Service code

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -131,6 +131,25 @@ The `AddAzureCosmosDB` method will read connection information from the AppHost'
 builder.AddAzureCosmosDB("cosmosdb");
 ```
 
+### Emulator usage
+
+Aspire supports the usage of the Azure Cosmos DB emulator to use the emulator, add the following to your AppHost project:
+
+```csharp
+// AppHost
+var cosmosdb = builder.AddAzureCosmosDB("cosmos").UseEmulator();
+```
+
+When the AppHost starts up a local container running the Azure CosmosDB will also be started. Inside the project that uses CosmosDB you also need to specify that you want to ignore the server certificate (so you don't need to manually download and install it):
+
+```csharp
+// Service code
+builder.AddCosmosDB("cosmos", (settings) =>
+{
+    settings.IgnoreEmulatorCertificate = true;
+});
+```
+
 ## Additional documentation
 
 * https://learn.microsoft.com/azure/cosmos-db/nosql/sdk-dotnet-v3

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
+    <Compile Include="..\..\Shared\Cosmos\CosmosConstants.cs" Link="Shared\CosmosConstants.cs" />
+    <Compile Include="..\..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosDBExtensions.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.Azure.Cosmos;
 using Aspire.Microsoft.EntityFrameworkCore.Cosmos;
 using Azure.Identity;
+using Microsoft.Azure.Cosmos;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
@@ -126,6 +128,16 @@ public static class AspireAzureEFCoreCosmosDBExtensions
             if (settings.Region is not null)
             {
                 builder.Region(settings.Region);
+            }
+
+            if (settings.IgnoreEmulatorCertificate && CosmosUtils.IsEmulatorConnectionString(settings.ConnectionString))
+            {
+                builder.HttpClientFactory(() => new HttpClient(new HttpClientHandler()
+                {
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                }));
+                builder.ConnectionMode(ConnectionMode.Gateway);
+                builder.LimitToEndpoint(true);
             }
         }
     }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
@@ -52,6 +52,10 @@
                       "type": "boolean",
                       "description": "Gets or sets a boolean value that indicates whether the DbContext will be pooled or explicitly created every time it's requested."
                     },
+                    "IgnoreEmulatorCertificate": {
+                      "type": "boolean",
+                      "description": "Controls whether the Cosmos DB emulator certificate is ignored when its use is detected."
+                    },
                     "Metrics": {
                       "type": "boolean",
                       "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosDBSettings.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosDBSettings.cs
@@ -55,4 +55,9 @@ public sealed class EntityFrameworkCoreCosmosDBSettings
     /// Gets or sets a string value that indicates what Azure region this client will run in.
     /// </summary>
     public string? Region { get; set; }
+
+    /// <summary>
+    /// Controls whether the Cosmos DB emulator certificate is ignored when its use is detected.
+    /// </summary>
+    public bool IgnoreEmulatorCertificate { get; set; }
 }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
@@ -109,6 +109,26 @@ The `AddAzureCosmosDB` method will read connection information from the AppHost'
 builder.AddCosmosDbContext<MyDbContext>("cosmosdb");
 ```
 
+### Emulator usage
+
+Aspire supports the usage of the Azure Cosmos DB emulator to use the emulator, add the following to your AppHost project:
+
+```csharp
+// AppHost
+var cosmosdb = builder.AddAzureCosmosDB("cosmos").UseEmulator();
+```
+
+When the AppHost starts up a local container running the Azure CosmosDB will also be started. Inside the project that uses CosmosDB you also need to specify that you want to ignore the server certificate (so you don't need to manually download and install it):
+
+```csharp
+// Service code
+builder.AddCosmosDbContext<MyDbContext>("cosmos", "mydb", (settings) =>
+{
+    settings.IgnoreEmulatorCertificate = true;
+});
+
+```
+
 ## Additional documentation
 
 * https://learn.microsoft.com/ef/core/

--- a/src/Shared/Cosmos/CosmosConstants.cs
+++ b/src/Shared/Cosmos/CosmosConstants.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Cosmos;
+
+internal static class CosmosConstants
+{
+    /// <summary>
+    /// Gets the well-known and documented Azure Cosmos DB emulator account key.
+    /// See <a href="https://learn.microsoft.com/azure/cosmos-db/emulator#authentication"></a>
+    /// </summary>
+    internal const string EmulatorAccountKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+}

--- a/src/Shared/Cosmos/CosmosUtils.cs
+++ b/src/Shared/Cosmos/CosmosUtils.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data.Common;
+
+namespace Aspire.Hosting.Azure.Cosmos;
+
+internal static class CosmosUtils
+{
+    internal static bool IsEmulatorConnectionString(string? connectionString)
+    {
+        if (connectionString == null)
+        {
+            return false;
+        }
+
+        var builder = new DbConnectionStringBuilder();
+        builder.ConnectionString = connectionString;
+        var accountKeyFromConnectionString = builder["AccountKey"].ToString();
+        return accountKeyFromConnectionString == CosmosConstants.EmulatorAccountKey;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Cosmos/CosmosFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Tests/Cosmos/CosmosFunctionalTests.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Tests.Helpers;
+using Polly;
+using Polly.Retry;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Cosmos;
+
+[Collection("IntegrationServices")]
+public class CosmosFunctionalTests
+{
+    private readonly IntegrationServicesFixture _integrationServicesFixture;
+
+    public CosmosFunctionalTests(IntegrationServicesFixture integrationServicesFixture)
+    {
+        _integrationServicesFixture = integrationServicesFixture;
+    }
+
+    [LocalOnlyFact()]
+    public async Task VerifyCosmosWorks()
+    {
+        var testProgram = _integrationServicesFixture.TestProgram;
+        var client = _integrationServicesFixture.HttpClient;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(6));
+
+        await RetryPolicy.Handle<HttpRequestException>()
+                         .WaitAndRetryAsync(20, (count) => TimeSpan.FromSeconds(15))
+                         .ExecuteAsync(async () =>
+                         {
+                             var response = await testProgram.IntegrationServiceABuilder!.HttpGetAsync(client, "http", "/cosmos/verify", cts.Token);
+                             response.EnsureSuccessStatusCode();
+
+                             var responseContent = await response.Content.ReadAsStringAsync();
+                             Assert.True(response.IsSuccessStatusCode, responseContent);
+                         });
+    }
+}

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -63,6 +63,8 @@ public class TestProgram
             var oracleDatabaseAbstract = AppBuilder.AddOracleDatabaseContainer("oracledatabaseabstract");
             var kafkaAbstract = AppBuilder.AddKafka("kafkaabstract");
 
+            var cosmos = AppBuilder.AddAzureCosmosDB("cosmos").UseEmulator();
+
             IntegrationServiceABuilder = AppBuilder.AddProject<Projects.IntegrationServiceA>("integrationservicea")
                 .WithReference(sqlserverContainer)
                 .WithReference(mysqlContainer)
@@ -79,7 +81,8 @@ public class TestProgram
                 .WithReference(rabbitmqAbstract)
                 .WithReference(mongodbAbstract)
                 .WithReference(oracleDatabaseAbstract)
-                .WithReference(kafkaAbstract);
+                .WithReference(kafkaAbstract)
+                .WithReference(cosmos);
         }
     }
 

--- a/tests/testproject/TestProject.AppHost/TestProject.AppHost.csproj
+++ b/tests/testproject/TestProject.AppHost/TestProject.AppHost.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
     <ProjectReference Include="..\TestProject.IntegrationServiceA\TestProject.IntegrationServiceA.csproj" ServiceNameOverride="IntegrationServiceA" />
     <ProjectReference Include="..\TestProject.ServiceA\TestProject.ServiceA.csproj" ServiceNameOverride="ServiceA" />

--- a/tests/testproject/TestProject.IntegrationServiceA/Cosmos/CosmosExtensions.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Cosmos/CosmosExtensions.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Azure.Cosmos;
+
+public static class CosmosExtensions
+{
+    public static void MapCosmosApi(this WebApplication app)
+    {
+        app.MapGet("/cosmos/verify", VerifyCosmosAsync);
+    }
+
+    private static async Task<IResult> VerifyCosmosAsync(CosmosClient cosmosClient)
+    {
+        try
+        {
+            var db = (await cosmosClient.CreateDatabaseIfNotExistsAsync("db")).Database;
+            var container = (await db.CreateContainerIfNotExistsAsync("todos", "/id")).Container;
+
+            var id = Guid.NewGuid().ToString();
+            var title = "Do some work.";
+
+            var item = await container.CreateItemAsync(new
+            {
+                id = id,
+                title = title
+            });
+
+            return item.Resource.id == id ? Results.Ok() : Results.Problem();
+        }
+        catch (Exception e)
+        {
+            return Results.Problem(e.ToString());
+        }
+    }
+}

--- a/tests/testproject/TestProject.IntegrationServiceA/Program.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Program.cs
@@ -29,6 +29,11 @@ builder.AddKeyedKafkaConsumer<string, string>("kafkaabstract", consumerBuilder =
     consumerBuilder.Config.AutoOffsetReset = AutoOffsetReset.Earliest;
 });
 
+builder.AddAzureCosmosDB("cosmos", settings =>
+{
+    settings.IgnoreEmulatorCertificate = true;
+});
+
 var app = builder.Build();
 
 app.MapHealthChecks("/health");
@@ -52,5 +57,7 @@ app.MapRabbitMQApi();
 app.MapOracleDatabaseApi();
 
 app.MapKafkaApi();
+
+app.MapCosmosApi();
 
 app.Run();

--- a/tests/testproject/TestProject.IntegrationServiceA/TestProject.IntegrationServiceA.csproj
+++ b/tests/testproject/TestProject.IntegrationServiceA/TestProject.IntegrationServiceA.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Components\Aspire.Confluent.Kafka\Aspire.Confluent.Kafka.csproj" />
+    <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.Azure.Cosmos\Aspire.Microsoft.Azure.Cosmos.csproj" />
     <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.Data.SqlClient\Aspire.Microsoft.Data.SqlClient.csproj" />
     <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.EntityFrameworkCore.SqlServer\Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj" />
     <ProjectReference Include="..\..\..\src\Components\Aspire.MongoDB.Driver\Aspire.MongoDB.Driver.csproj" />


### PR DESCRIPTION
This PR adds an option to allow developers to ignore the Cosmos emulator ceritficate if it is detected. Usage:

```csharp
builder.AddAzureCosmosDB("ratingsdb", (settings) =>
{
    settings.IgnoreEmulatorCertificate = true;
});
```

Also fixes:
https://github.com/dotnet/aspire/issues/1664

Related:
https://github.com/dotnet/aspire/issues/1002

Outstanding items:
- [ ] Update README.md
- [ ] Add some test coverage.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1668)