### PR TITLE
Fix Orleans sample to use AzureProvisioning when not running locally

### DIFF
--- a/playground/orleans/OrleansAppHost/Program.cs
+++ b/playground/orleans/OrleansAppHost/Program.cs
@@ -4,7 +4,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage");
 
-if (builder.Environment.IsDevelopment())
+if (!args.Contains("--publisher")) // AZD UP passes in --publisher manifest
 {
     storage.UseEmulator();
 }


### PR DESCRIPTION
Since `AppHost` only exists in development, differentiating on `Environment` does not work.

The intention is to differentiate between running the application locally versus generating an Aspire deployment manifest; the latter is done by running the Apphost with command-line parameter `--publisher manifest`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1669)