### PR TITLE
Fix ObjectDisposedException in CancellationSeries

### DIFF
--- a/src/Aspire.Dashboard/Utils/CancellationSeries.cs
+++ b/src/Aspire.Dashboard/Utils/CancellationSeries.cs
@@ -32,9 +32,14 @@ internal sealed class CancellationSeries
     {
         var nextCts = new CancellationTokenSource();
 
+        // Obtain the token before exchange, as otherwise the CTS may be cancelled before
+        // we request the Token, which will result in an ObjectDisposedException.
+        // This way we would return a cancelled token, which is reasonable.
+        var nextToken = nextCts.Token;
+
         await Next(nextCts).ConfigureAwait(false);
 
-        return nextCts.Token;
+        return nextToken;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #1636

When a token is requested, the prior one will be cancelled and its CTS disposed. If two concurrent requests are made quickly enough, it's important that the disposal doesn't trigger an `ObjectDisposedException`.

To address that, we request theCTS's `Token` property _before_ there's any chance for the CTS to be disposed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1677)