### PR TITLE
Change outgoing request to arrow in trace span

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -82,7 +82,7 @@
                                 @if (context.HasUninstrumentedPeer)
                                 {
                                     <span class="uninstrumented-peer">
-                                        <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")" Icon="Icons.Filled.Size16.ArrowBounce" Class="uninstrumented-peer-icon"/>
+                                        <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")" Icon="Icons.Filled.Size16.ArrowExportLtr" Class="uninstrumented-peer-icon"/>
                                         @context.UninstrumentedPeer
                                     </span>
                                 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -71,7 +71,7 @@
                                         Class="server-request-icon"
                                         Color="Color.Custom"
                                         CustomColor="@ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))"
-                                        Icon="Icons.Filled.Size16.ArrowCircleRight"/>
+                                        Icon="Icons.Filled.Size16.Server"/>
                                 }
 
                                 @if (context.IsError)
@@ -82,7 +82,7 @@
                                 @if (context.HasUninstrumentedPeer)
                                 {
                                     <span class="uninstrumented-peer">
-                                        <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")" Icon="Icons.Filled.Size16.ArrowExportLtr" Class="uninstrumented-peer-icon"/>
+                                        <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")" Icon="Icons.Filled.Size16.ArrowCircleRight" Class="uninstrumented-peer-icon"/>
                                         @context.UninstrumentedPeer
                                     </span>
                                 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -56,16 +56,33 @@
                 <FluentDataGrid Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="2fr 6fr">
                     <TemplateColumn Title="Name">
                         <div class="col-long-content" title="@context.GetTooltip()" @onclick="() => OnShowProperties(context)">
-                            <span class="span-name-container" style="@($"margin-left: {(context.Depth - 1) * 15}px; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))};")">
+                            @{
+                                var isServerKind = context.Span.Kind == OtlpSpanKind.Server;
+                                var spanNameContainerStyle = $"margin-left: {(context.Depth - 1) * 15}px;";
+                                if (!isServerKind)
+                                {
+                                    spanNameContainerStyle += $"border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 5px;";
+                                }
+                            }
+                            <span class="span-name-container" style="@spanNameContainerStyle">
+                                @if (isServerKind)
+                                {
+                                    <FluentIcon
+                                        Class="server-request-icon"
+                                        Color="Color.Custom"
+                                        CustomColor="@ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))"
+                                        Icon="Icons.Filled.Size16.ArrowCircleRight"/>
+                                }
+
                                 @if (context.IsError)
                                 {
-                                    <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
+                                    <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon"/>
                                 }
                                 @GetResourceName(context.Span.Source)
                                 @if (context.HasUninstrumentedPeer)
                                 {
                                     <span class="uninstrumented-peer">
-                                        <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")" Icon="Icons.Filled.Size16.ArrowCircleRight" Class="uninstrumented-peer-icon" />
+                                        <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")" Icon="Icons.Filled.Size16.ArrowBounce" Class="uninstrumented-peer-icon"/>
                                         @context.UninstrumentedPeer
                                     </span>
                                 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -139,7 +139,6 @@
 
 ::deep .uninstrumented-peer-icon {
     vertical-align: text-bottom;
-    transform: scaleX(-1);
 }
 
 ::deep .span-row-name {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -87,9 +87,6 @@
 }
 
 ::deep .span-name-container {
-    border-left-width: 5px;
-    border-left-style: solid;
-    padding-left: 5px;
     line-height: 28px;
 }
 
@@ -132,11 +129,17 @@
 }
 
 ::deep .uninstrumented-peer {
-    padding-left: 0.5rem;
+    padding-left: 0.25rem;
+}
+
+::deep .server-request-icon {
+    margin-right: 3px;
+    vertical-align: text-bottom;
 }
 
 ::deep .uninstrumented-peer-icon {
     vertical-align: text-bottom;
+    transform: scaleX(-1);
 }
 
 ::deep .span-row-name {


### PR DESCRIPTION
Changes the trace bar into `ArrowCircleRight` icon for outgoing requests, as well as changes the uninstrumented peer icon from `ArrowCircleRight` to `ArrowBounce` (the fact that it's an outgoing request is also captured by its parent's icon)

<img width="389" alt="image" src="https://github.com/dotnet/aspire/assets/20359921/3c2a5f96-53ac-44a7-a622-cfa02545ba4f">

resolves #1675

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1684)