### PR TITLE
Clear logs on console logs parameters change

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -92,6 +92,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     {
         await this.InitializeViewModelAsync();
 
+        await ClearLogsAsync();
+
         if (ViewModel.SelectedResource is not null)
         {
             await LoadLogsAsync();
@@ -99,7 +101,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         else
         {
             await StopWatchingLogsAsync();
-            await ClearLogsAsync();
         }
     }
 


### PR DESCRIPTION
Fixes #1678

We should clear existing logs when there was a previously-selected resource, as we will be loading them again and do not want duplicates.