### PR TITLE
Adds FluentIconSwitch component, ensures correct environment variable masking behavior when the resource panel is open

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/FluentIconSwitch.razor
+++ b/src/Aspire.Dashboard/Components/Controls/FluentIconSwitch.razor
@@ -1,0 +1,36 @@
+﻿<FluentButton Appearance="@Appearance"
+              Disabled="Disabled"
+              Title="@(Value is true ? CheckedTitle : UncheckedTitle)"
+              aria-label="@(Value is true ? CheckedTitle : UncheckedTitle)"
+              OnClick="@(() => OnToggleInternalAsync())"
+              IconEnd="@(Value is true ? CheckedIcon : UncheckedIcon)"
+              slot="end" />
+
+@code {
+    [Parameter, EditorRequired]
+    public required Appearance Appearance { get; set; }
+
+    [Parameter]
+    public bool Disabled { get; set; }
+
+    [Parameter, EditorRequired]
+    public required Icon CheckedIcon { get; set; }
+
+    [Parameter, EditorRequired]
+    public required Icon UncheckedIcon { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string CheckedTitle { get; set; }
+
+    [Parameter, EditorRequired]
+    public required string UncheckedTitle { get; set; }
+
+    [Parameter]
+    public bool? Value { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ValueChanged { get; set; }
+
+    [Parameter]
+    public EventCallback OnToggle { get; set; }
+}

--- a/src/Aspire.Dashboard/Components/Controls/FluentIconSwitch.razor
+++ b/src/Aspire.Dashboard/Components/Controls/FluentIconSwitch.razor
@@ -4,7 +4,7 @@
               aria-label="@(Value is true ? CheckedTitle : UncheckedTitle)"
               OnClick="@(() => OnToggleInternalAsync())"
               IconEnd="@(Value is true ? CheckedIcon : UncheckedIcon)"
-              slot="end" />
+              @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter, EditorRequired]
@@ -33,4 +33,7 @@
 
     [Parameter]
     public EventCallback OnToggle { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public IReadOnlyDictionary<string, object>? AdditionalAttributes { get; set; }
 }

--- a/src/Aspire.Dashboard/Components/Controls/FluentIconSwitch.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/FluentIconSwitch.razor.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Components.Controls;
+
+public partial class FluentIconSwitch
+{
+    private async Task OnToggleInternalAsync()
+    {
+        Value = Value is not true;
+        await ValueChanged.InvokeAsync(Value.Value);
+        await OnToggle.InvokeAsync();
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -15,7 +15,8 @@
                               UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowAll)]"
                               OnToggle="@(() => _showAll = !_showAll)"
                               CheckedIcon="@(new Icons.Regular.Size16.DocumentHeader())"
-                              UncheckedIcon="@(new Icons.Regular.Size16.DocumentOnePage())" />
+                              UncheckedIcon="@(new Icons.Regular.Size16.DocumentOnePage())"
+                              slot="end"/>
         }
 
         <FluentIconSwitch @bind-Value="@_areEnvironmentVariablesMasked"
@@ -24,7 +25,8 @@
                           UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)]"
                           OnToggle="@ToggleMaskState"
                           CheckedIcon="@(new Icons.Regular.Size16.Eye())"
-                          UncheckedIcon="@(new Icons.Regular.Size16.EyeOff())" />
+                          UncheckedIcon="@(new Icons.Regular.Size16.EyeOff())"
+                          slot="end" />
 
         <FluentSearch Placeholder="@ControlStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -9,20 +9,23 @@
 
         @if (ShowSpecOnlyToggle)
         {
-            <FluentButton Appearance="Appearance.Lightweight"
-                          Disabled="IsSpecOnlyToggleDisabled"
-                          IconEnd="@(_showAll ? _showSpecOnlyIcon : _showAllIcon)"
-                          Title="@(_showAll ? ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly)] : ControlsStrings.EnvironmentVariablesFilterToggleShowAll)"
-                          aria-label="@(_showAll ? ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly)] : ControlsStrings.EnvironmentVariablesFilterToggleShowAll)"
-                          OnClick="() => _showAll = !_showAll"
-                          slot="end" />
+            <FluentIconSwitch Appearance="Appearance.Lightweight"
+                              Disabled="IsSpecOnlyToggleDisabled"
+                              CheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly)]"
+                              UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesFilterToggleShowAll)]"
+                              OnToggle="@(() => _showAll = !_showAll)"
+                              CheckedIcon="@(new Icons.Regular.Size16.DocumentHeader())"
+                              UncheckedIcon="@(new Icons.Regular.Size16.DocumentOnePage())" />
         }
-        <FluentButton Appearance="Appearance.Lightweight"
-                      IconEnd="@(_defaultMasked ? _unmaskIcon : _maskIcon)"
-                      Title="@(_defaultMasked ? ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesShowVariableValues)] : ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)])"
-                      aria-label="@(_defaultMasked ? ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesShowVariableValues)] : ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)])"
-                      OnClick="ToggleMaskState"
-                      slot="end" />
+
+        <FluentIconSwitch @bind-Value="@_areEnvironmentVariablesMasked"
+                          Appearance="Appearance.Lightweight"
+                          CheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesShowVariableValues)]"
+                          UncheckedTitle="@ControlStringsLoc[nameof(ControlsStrings.EnvironmentVariablesHideVariableValues)]"
+                          OnToggle="@ToggleMaskState"
+                          CheckedIcon="@(new Icons.Regular.Size16.Eye())"
+                          UncheckedIcon="@(new Icons.Regular.Size16.EyeOff())" />
+
         <FluentSearch Placeholder="@ControlStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"
                       Autofocus="true"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -88,12 +88,9 @@ public partial class ResourceDetails
 
     protected override void OnParametersSet()
     {
-        if (Resource.Environment is var environment)
+        foreach (var vm in Resource.Environment.Where(vm => vm.IsValueMasked != _areEnvironmentVariablesMasked))
         {
-            foreach (var vm in environment.Where(vm => vm.IsValueMasked != _areEnvironmentVariablesMasked))
-            {
-                vm.IsValueMasked = _areEnvironmentVariablesMasked;
-            }
+            vm.IsValueMasked = _areEnvironmentVariablesMasked;
         }
     }
 
@@ -191,25 +188,21 @@ public partial class ResourceDetails
 
     private void CheckAllMaskStates()
     {
-        if (Resource.Environment is { } environment)
-        {
-            var foundMasked = false;
-            var foundUnmasked = false;
-            foreach (var vm in environment)
-            {
-                foundMasked |= vm.IsValueMasked;
-                foundUnmasked |= !vm.IsValueMasked;
-            }
+        var foundMasked = false;
+        var foundUnmasked = false;
 
-            if (!foundMasked && foundUnmasked)
-            {
-                _areEnvironmentVariablesMasked = false;
-            }
-            else if (foundMasked && !foundUnmasked)
-            {
-                _areEnvironmentVariablesMasked = true;
-            }
+        foreach (var vm in Resource.Environment)
+        {
+            foundMasked |= vm.IsValueMasked;
+            foundUnmasked |= !vm.IsValueMasked;
         }
+
+        _areEnvironmentVariablesMasked = foundMasked switch
+        {
+            false when foundUnmasked => false,
+            true when !foundUnmasked => true,
+            _ => _areEnvironmentVariablesMasked
+        };
     }
 
     private sealed class Endpoint

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -42,12 +42,7 @@ public partial class ResourceDetails
         .AsQueryable();
 
     private string _filter = "";
-    private bool _defaultMasked = true;
-
-    private readonly Icon _maskIcon = new Icons.Regular.Size16.EyeOff();
-    private readonly Icon _unmaskIcon = new Icons.Regular.Size16.Eye();
-    private readonly Icon _showSpecOnlyIcon = new Icons.Regular.Size16.DocumentHeader();
-    private readonly Icon _showAllIcon = new Icons.Regular.Size16.DocumentOnePage();
+    private bool _areEnvironmentVariablesMasked = true;
 
     private readonly GridSort<EnvironmentVariableViewModel> _nameSort = GridSort<EnvironmentVariableViewModel>.ByAscending(vm => vm.Name);
     private readonly GridSort<EnvironmentVariableViewModel> _valueSort = GridSort<EnvironmentVariableViewModel>.ByAscending(vm => vm.Value);
@@ -89,6 +84,24 @@ public partial class ResourceDetails
             new KnownProperty(KnownProperties.Container.Args, Loc[Resources.Resources.ResourcesDetailsContainerArgumentsProperty]),
             new KnownProperty(KnownProperties.Container.Ports, Loc[Resources.Resources.ResourcesDetailsContainerPortsProperty]),
         ];
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (Resource.Environment is var environment)
+        {
+            var anyChanged = false;
+            foreach (var vm in environment.Where(vm => vm.IsValueMasked != _areEnvironmentVariablesMasked))
+            {
+                anyChanged = true;
+                vm.IsValueMasked = _areEnvironmentVariablesMasked;
+            }
+
+            if (anyChanged)
+            {
+                await InvokeAsync(StateHasChanged);
+            }
+        }
     }
 
     private IEnumerable<Endpoint> GetEndpoints()
@@ -174,12 +187,11 @@ public partial class ResourceDetails
 
     private void ToggleMaskState()
     {
-        _defaultMasked = !_defaultMasked;
-        if (Resource.Environment is { } environment)
+        if (Resource.Environment is var environment)
         {
             foreach (var vm in environment)
             {
-                vm.IsValueMasked = _defaultMasked;
+                vm.IsValueMasked = _areEnvironmentVariablesMasked;
             }
         }
     }
@@ -198,11 +210,11 @@ public partial class ResourceDetails
 
             if (!foundMasked && foundUnmasked)
             {
-                _defaultMasked = false;
+                _areEnvironmentVariablesMasked = false;
             }
             else if (foundMasked && !foundUnmasked)
             {
-                _defaultMasked = true;
+                _areEnvironmentVariablesMasked = true;
             }
         }
     }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -86,20 +86,13 @@ public partial class ResourceDetails
         ];
     }
 
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
         if (Resource.Environment is var environment)
         {
-            var anyChanged = false;
             foreach (var vm in environment.Where(vm => vm.IsValueMasked != _areEnvironmentVariablesMasked))
             {
-                anyChanged = true;
                 vm.IsValueMasked = _areEnvironmentVariablesMasked;
-            }
-
-            if (anyChanged)
-            {
-                await InvokeAsync(StateHasChanged);
             }
         }
     }


### PR DESCRIPTION
We have two buttons being used as switches - fluentui-blazor's switch component does not allow for custom icons, so I created `FluentIconSwitch` so that this behavior is encompassed in a component for reuse.

Fixes #1519 by updating individual environment variable `IsValueMasked` on component render
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1700)