### PR TITLE
Quick fix for UseEmulator() breaking with AddDatabase().

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureCosmosDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBDatabaseResource.cs
@@ -26,5 +26,5 @@ public class AzureCosmosDBDatabaseResource : Resource, IResourceWithConnectionSt
     /// Gets the connection string to use for this database.
     /// </summary>
     /// <returns>The connection string to use for this database.</returns>
-    public string? GetConnectionString() => ConnectionString;
+    public string? GetConnectionString() => ConnectionString ?? Parent.GetConnectionString();
 }


### PR DESCRIPTION
The following code throws:

```csharp
var db = builder.AddAzureCosmosDB("cosmos").UseEmulator().AddDatabase("db");
builder.AddProject<Projects.MyApp>("myapp").WithReference(db);
```

This PR fixes that issue. Its a side effect of the way that the AzureCosmosDBDatabaseResource interacts with the Azure Provisioner. This is a quick fix that will work until we remove the Azure Provisioner.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1702)