### PR TITLE
Use consistent comparer for resource names

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
-using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
-using Aspire.Dashboard.Utils;
 using Aspire.V1;
 using Grpc.Core;
 using Grpc.Net.Client;

--- a/src/Aspire.Dashboard/Model/KnownProperties.cs
+++ b/src/Aspire.Dashboard/Model/KnownProperties.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Utils;
-
 namespace Aspire.Dashboard.Model;
 
 /// <summary>

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Dashboard.Otlp.Model;
-using Aspire.Dashboard.Utils;
 
 namespace Aspire.Dashboard.Model;
 

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Frozen;
 using System.Collections.Immutable;
-using Aspire.Dashboard.Utils;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Dashboard.Model;

--- a/src/Aspire.Dashboard/Protos/Partials.cs
+++ b/src/Aspire.Dashboard/Protos/Partials.cs
@@ -4,7 +4,6 @@
 using System.Collections.Frozen;
 using System.Collections.Immutable;
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Utils;
 
 namespace Aspire.V1;
 

--- a/src/Aspire.Dashboard/Utils/StringComparers.cs
+++ b/src/Aspire.Dashboard/Utils/StringComparers.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Dashboard.Utils;
+namespace Aspire;
 
 internal static class StringComparers
 {
-    public static StringComparer ResourceName => StringComparer.Ordinal;
+    public static StringComparer ResourceName => StringComparer.OrdinalIgnoreCase;
     public static StringComparer ResourceType => StringComparer.Ordinal;
     public static StringComparer ResourcePropertyName => StringComparer.Ordinal;
     public static StringComparer UserTextSearch => StringComparer.CurrentCultureIgnoreCase;
@@ -13,7 +13,7 @@ internal static class StringComparers
 
 internal static class StringComparisons
 {
-    public static StringComparison ResourceName => StringComparison.Ordinal;
+    public static StringComparison ResourceName => StringComparison.OrdinalIgnoreCase;
     public static StringComparison ResourceType => StringComparison.Ordinal;
     public static StringComparison ResourcePropertyName => StringComparison.Ordinal;
     public static StringComparison UserTextSearch => StringComparison.CurrentCultureIgnoreCase;

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -105,7 +105,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         {
             // AddResource(resource) validates that a name is unique but it's possible to add resources directly to the resource collection.
             // Validate names for duplicates while building the application.
-            foreach (var duplicateResourceName in Resources.GroupBy(r => r.Name, StringComparer.OrdinalIgnoreCase)
+            foreach (var duplicateResourceName in Resources.GroupBy(r => r.Name, StringComparers.ResourceName)
                 .Where(g => g.Count() > 1)
                 .Select(g => g.Key))
             {
@@ -124,7 +124,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     /// <inheritdoc />
     public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource
     {
-        if (Resources.FirstOrDefault(r => string.Equals(r.Name, resource.Name, StringComparison.OrdinalIgnoreCase)) is { } existingResource)
+        if (Resources.FirstOrDefault(r => string.Equals(r.Name, resource.Name, StringComparisons.ResourceName)) is { } existingResource)
         {
             throw new DistributedApplicationException($"Cannot add resource of type '{resource.GetType()}' with name '{resource.Name}' because resource of type '{existingResource.GetType()}' with that name already exists. Resource names are case-insensitive.");
         }


### PR DESCRIPTION
In #1691 the semantics around comparisons of resource names changed to make them case-insensitive. This change needs to be applied in some other places, for consistency.

We have a `StringComparers` class which denotes the comparison style for different types of values. This change extends the use of that type, and changes the value for `ResourceName` from `Ordinal` to `OrdinalIgnoreCase`.

It also moves that internal type into the `Aspire` namespace so that it's picked up by both projects that link it (`Aspire.Hosting` and `Aspire.Dashboard`) without needing to choose a namespace from either one, which then wouldn't make sense in the other.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1710)