### PR TITLE
Validate endpoint names

### DIFF
--- a/src/Aspire.Dashboard/Utils/StringComparers.cs
+++ b/src/Aspire.Dashboard/Utils/StringComparers.cs
@@ -6,6 +6,7 @@ namespace Aspire;
 internal static class StringComparers
 {
     public static StringComparer ResourceName => StringComparer.OrdinalIgnoreCase;
+    public static StringComparer EndpointAnnotationName => StringComparer.OrdinalIgnoreCase;
     public static StringComparer ResourceType => StringComparer.Ordinal;
     public static StringComparer ResourcePropertyName => StringComparer.Ordinal;
     public static StringComparer UserTextSearch => StringComparer.CurrentCultureIgnoreCase;
@@ -14,6 +15,7 @@ internal static class StringComparers
 internal static class StringComparisons
 {
     public static StringComparison ResourceName => StringComparison.OrdinalIgnoreCase;
+    public static StringComparison EndpointAnnotationName => StringComparison.OrdinalIgnoreCase;
     public static StringComparison ResourceType => StringComparison.Ordinal;
     public static StringComparison ResourcePropertyName => StringComparison.Ordinal;
     public static StringComparison UserTextSearch => StringComparison.CurrentCultureIgnoreCase;

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -22,10 +22,15 @@ public sealed class EndpointAnnotation : IResourceAnnotation
         // is because we eventually always need these values to be populated so lets do
         // it up front.
 
+        uriScheme ??= protocol.ToString().ToLowerInvariant();
+        name ??= uriScheme;
+
+        ModelName.ValidateName(nameof(EndpointAnnotation), name);
+
         Protocol = protocol;
-        UriScheme = uriScheme ?? protocol.ToString().ToLowerInvariant();
+        UriScheme = uriScheme;
         Transport = transport ?? (UriScheme == "http" || UriScheme == "https" ? "http" : Protocol.ToString().ToLowerInvariant());
-        Name = name ?? UriScheme;
+        Name = name;
         Port = port;
         ContainerPort = containerPort ?? port;
         IsExternal = isExternal ?? false;

--- a/src/Aspire.Hosting/ApplicationModel/ModelName.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ModelName.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+internal static class ModelName
+{
+    /// <summary>
+    /// Validate that a model name is valid.
+    /// - Must start with an ASCII letter.
+    /// - Must contain only ASCII letters, digits, and hyphens.
+    /// - Must not end with a hyphen.
+    /// - Must not contain consecutive hyphens.
+    /// - Must be between 1 and 64 characters long.
+    /// </summary>
+    internal static void ValidateName(string target, string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
+
+        if (name.Length > 64)
+        {
+            throw new ArgumentException($"{target} name '{name}' is invalid. Name must be between 1 and 64 characters long.", nameof(name));
+        }
+
+        var lastCharacterHyphen = false;
+        for (var i = 0; i < name.Length; i++)
+        {
+            if (name[i] == '-')
+            {
+                if (lastCharacterHyphen)
+                {
+                    throw new ArgumentException($"{target} name '{name}' is invalid. Name cannot contain consecutive hyphens.", nameof(name));
+                }
+                lastCharacterHyphen = true;
+            }
+            else if (!char.IsAsciiLetterOrDigit(name[i]))
+            {
+                throw new ArgumentException($"{target} name '{name}' is invalid. Name must contain only ASCII letters, digits, and hyphens.", nameof(name));
+            }
+            else
+            {
+                lastCharacterHyphen = false;
+            }
+        }
+
+        if (!char.IsAsciiLetter(name[0]))
+        {
+            throw new ArgumentException($"{target} name '{name}' is invalid. Name must start with an ASCII letter.", nameof(name));
+        }
+
+        if (name[^1] == '-')
+        {
+            throw new ArgumentException($"{target} name '{name}' is invalid. Name cannot end with a hyphen.", nameof(name));
+        }
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ModelName.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ModelName.cs
@@ -15,9 +15,10 @@ internal static class ModelName
     /// </summary>
     internal static void ValidateName(string target, string name)
     {
-        ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(name);
 
-        if (name.Length > 64)
+        if (name.Length < 1 || name.Length > 64)
         {
             throw new ArgumentException($"{target} name '{name}' is invalid. Name must be between 1 and 64 characters long.", nameof(name));
         }

--- a/src/Aspire.Hosting/ApplicationModel/Resource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/Resource.cs
@@ -21,61 +21,15 @@ public abstract class Resource : IResource
     /// </summary>
     public ResourceMetadataCollection Annotations { get; } = new();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Resource"/> class.
+    /// </summary>
     /// <param name="name">The name of the resource.</param>
-    public Resource(string name)
+    protected Resource(string name)
     {
-        ValidateName(name);
+        ModelName.ValidateName(nameof(Resource), name);
 
         Name = name;
-    }
-
-    /// <summary>
-    /// Validate that a resource name is valid.
-    /// - Must start with an ASCII letter.
-    /// - Must contain only ASCII letters, digits, and hyphens.
-    /// - Must not end with a hyphen.
-    /// - Must not contain consecutive hyphens.
-    /// - Must be between 1 and 64 characters long.
-    /// </summary>
-    internal static void ValidateName(string name)
-    {
-        ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
-
-        if (name.Length > 64)
-        {
-            throw new ArgumentException($"Resource name '{name}' is invalid. Name must be between 1 and 64 characters long.", nameof(name));
-        }
-
-        var lastCharacterHyphen = false;
-        for (var i = 0; i < name.Length; i++)
-        {
-            if (name[i] == '-')
-            {
-                if (lastCharacterHyphen)
-                {
-                    throw new ArgumentException($"Resource name '{name}' is invalid. Name cannot contain consecutive hyphens.", nameof(name));
-                }
-                lastCharacterHyphen = true;
-            }
-            else if (!char.IsAsciiLetterOrDigit(name[i]))
-            {
-                throw new ArgumentException($"Resource name '{name}' is invalid. Name must contain only ASCII letters, digits, and hyphens.", nameof(name));
-            }
-            else
-            {
-                lastCharacterHyphen = false;
-            }
-        }
-
-        if (!char.IsAsciiLetter(name[0]))
-        {
-            throw new ArgumentException($"Resource name '{name}' is invalid. Name must start with an ASCII letter.", nameof(name));
-        }
-
-        if (name[^1] == '-')
-        {
-            throw new ArgumentException($"Resource name '{name}' is invalid. Name cannot end with a hyphen.", nameof(name));
-        }
     }
 
     private string DebuggerToString()

--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Publishing;

--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Publishing;
@@ -41,7 +42,7 @@ internal sealed class DcpDistributedApplicationLifecycleHook(IOptions<Publishing
             {
                 var uri = new Uri(url);
 
-                if (projectResource.Annotations.OfType<EndpointAnnotation>().Any(sb => sb.Name == uri.Scheme))
+                if (projectResource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, uri.Scheme, StringComparisons.EndpointAnnotationName)))
                 {
                     // If someone uses WithEndpoint in the dev host to register a endpoint with the name
                     // http or https this exception will be thrown.

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
-using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting;

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
+using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting;
@@ -51,7 +52,7 @@ public static class ContainerResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<T> WithEndpoint<T>(this IResourceBuilder<T> builder, int containerPort, int? hostPort = null, string? scheme = null, string? name = null, string? env = null) where T : IResource
     {
-        if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => sb.Name == name))
+        if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, name, StringComparisons.EndpointAnnotationName)))
         {
             throw new DistributedApplicationException($"Endpoint with name '{name}' already exists");
         }

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
-using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
+using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
@@ -319,9 +320,9 @@ public static class ResourceBuilderExtensions
     /// <exception cref="DistributedApplicationException">Throws an exception if the a binding with the same name already exists on the specified resource.</exception>
     public static IResourceBuilder<T> WithEndpoint<T>(this IResourceBuilder<T> builder, int? hostPort = null, string? scheme = null, string? name = null, string? env = null) where T : IResource
     {
-        if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => sb.Name == name))
+        if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, name, StringComparisons.EndpointAnnotationName)))
         {
-            throw new DistributedApplicationException($"Endpoint '{name}' already exists");
+            throw new DistributedApplicationException($"Endpoint '{name}' already exists. Endpoint names are case-insensitive.");
         }
 
         var annotation = new EndpointAnnotation(ProtocolType.Tcp, uriScheme: scheme, name: name, port: hostPort, env: env);

--- a/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
+++ b/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Publishing;
+
 internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<PublishingOptions> publishingOptions) : IDistributedApplicationLifecycleHook
 {
     private readonly IOptions<PublishingOptions> _publishingOptions = publishingOptions;
@@ -53,7 +55,7 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
                 continue;
             }
 
-            if (!projectResource.Annotations.OfType<EndpointAnnotation>().Any(sb => sb.UriScheme == "http" || sb.Name == "http"))
+            if (!projectResource.Annotations.OfType<EndpointAnnotation>().Any(sb => sb.UriScheme == "http" || string.Equals(sb.Name, "http", StringComparisons.EndpointAnnotationName)))
             {
                 var httpBinding = new EndpointAnnotation(
                     System.Net.Sockets.ProtocolType.Tcp,
@@ -63,7 +65,7 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
                 httpBinding.Transport = isHttp2ConfiguredInAppSettings ? "http2" : httpBinding.Transport;
             }
 
-            if (!projectResource.Annotations.OfType<EndpointAnnotation>().Any(sb => sb.UriScheme == "https" || sb.Name == "https"))
+            if (!projectResource.Annotations.OfType<EndpointAnnotation>().Any(sb => sb.UriScheme == "https" || string.Equals(sb.Name, "https", StringComparisons.EndpointAnnotationName)))
             {
                 var httpsBinding = new EndpointAnnotation(
                     System.Net.Sockets.ProtocolType.Tcp,

--- a/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
+++ b/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.Configuration;

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
-using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Publishing;

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using Aspire.Dashboard.Utils;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Publishing;
@@ -136,7 +137,7 @@ public sealed class ManifestPublishingContext(string manifestPath, Utf8JsonWrite
 
                 var endpointAnnotationsGroupedByScheme = endpointReferenceAnnotation.Resource.Annotations
                     .OfType<EndpointAnnotation>()
-                    .Where(sba => endpointNames.Contains(sba.Name))
+                    .Where(sba => endpointNames.Contains(sba.Name, StringComparers.EndpointAnnotationName))
                     .GroupBy(sba => sba.UriScheme);
 
                 var i = 0;

--- a/tests/Aspire.Hosting.Tests/ModelNameTests.cs
+++ b/tests/Aspire.Hosting.Tests/ModelNameTests.cs
@@ -24,7 +24,7 @@ public class ModelNameTests
         var exception = Assert.Throws<ArgumentException>(() => ModelName.ValidateName(nameof(Resource), ""));
 
         // Assert
-        Assert.Equal("The value cannot be an empty string. (Parameter 'name')", exception.Message);
+        Assert.Equal($"Resource name '' is invalid. Name must be between 1 and 64 characters long. (Parameter 'name')", exception.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ModelNameTests.cs
+++ b/tests/Aspire.Hosting.Tests/ModelNameTests.cs
@@ -5,13 +5,13 @@ using Xunit;
 
 namespace Aspire.Hosting.Tests;
 
-public class ResourceTests
+public class ModelNameTests
 {
     [Fact]
     public void ValidateName_Null_Error()
     {
         // Arrange & Act
-        var exception = Assert.Throws<ArgumentNullException>(() => Resource.ValidateName(null!));
+        var exception = Assert.Throws<ArgumentNullException>(() => ModelName.ValidateName(nameof(Resource), null!));
 
         // Assert
         Assert.Equal("Value cannot be null. (Parameter 'name')", exception.Message);
@@ -21,7 +21,7 @@ public class ResourceTests
     public void ValidateName_Empty_Error()
     {
         // Arrange & Act
-        var exception = Assert.Throws<ArgumentException>(() => Resource.ValidateName(""));
+        var exception = Assert.Throws<ArgumentException>(() => ModelName.ValidateName(nameof(Resource), ""));
 
         // Assert
         Assert.Equal("The value cannot be an empty string. (Parameter 'name')", exception.Message);
@@ -32,7 +32,7 @@ public class ResourceTests
     {
         // Arrange & Act
         var name = new string('a', 65);
-        var exception = Assert.Throws<ArgumentException>(() => Resource.ValidateName(name));
+        var exception = Assert.Throws<ArgumentException>(() => ModelName.ValidateName(nameof(Resource), name));
 
         // Assert
         Assert.Equal($"Resource name '{name}' is invalid. Name must be between 1 and 64 characters long. (Parameter 'name')", exception.Message);
@@ -42,7 +42,7 @@ public class ResourceTests
     public void ValidateName_Whitespace_Error()
     {
         // Arrange & Act
-        var exception = Assert.Throws<ArgumentException>(() => Resource.ValidateName(" "));
+        var exception = Assert.Throws<ArgumentException>(() => ModelName.ValidateName(nameof(Resource), " "));
 
         // Assert
         Assert.Equal("Resource name ' ' is invalid. Name must contain only ASCII letters, digits, and hyphens. (Parameter 'name')", exception.Message);
@@ -52,7 +52,7 @@ public class ResourceTests
     public void ValidateName_Underscore_Error()
     {
         // Arrange & Act
-        var exception = Assert.Throws<ArgumentException>(() => Resource.ValidateName("test_name"));
+        var exception = Assert.Throws<ArgumentException>(() => ModelName.ValidateName(nameof(Resource), "test_name"));
 
         // Assert
         Assert.Equal("Resource name 'test_name' is invalid. Name must contain only ASCII letters, digits, and hyphens. (Parameter 'name')", exception.Message);
@@ -62,7 +62,7 @@ public class ResourceTests
     public void ValidateName_StartHyphen_Error()
     {
         // Arrange & Act
-        var exception = Assert.Throws<ArgumentException>(() => Resource.ValidateName("-abc"));
+        var exception = Assert.Throws<ArgumentException>(() => ModelName.ValidateName(nameof(Resource), "-abc"));
 
         // Assert
         Assert.Equal("Resource name '-abc' is invalid. Name must start with an ASCII letter. (Parameter 'name')", exception.Message);
@@ -72,7 +72,7 @@ public class ResourceTests
     public void ValidateName_ConsecutiveHyphens_Error()
     {
         // Arrange & Act
-        var exception = Assert.Throws<ArgumentException>(() => Resource.ValidateName("test--name"));
+        var exception = Assert.Throws<ArgumentException>(() => ModelName.ValidateName(nameof(Resource), "test--name"));
 
         // Assert
         Assert.Equal("Resource name 'test--name' is invalid. Name cannot contain consecutive hyphens. (Parameter 'name')", exception.Message);
@@ -82,7 +82,7 @@ public class ResourceTests
     public void ValidateName_StartNumber_Error()
     {
         // Arrange & Act
-        var exception = Assert.Throws<ArgumentException>(() => Resource.ValidateName("1abc"));
+        var exception = Assert.Throws<ArgumentException>(() => ModelName.ValidateName(nameof(Resource), "1abc"));
 
         // Assert
         Assert.Equal("Resource name '1abc' is invalid. Name must start with an ASCII letter. (Parameter 'name')", exception.Message);
@@ -92,7 +92,7 @@ public class ResourceTests
     public void ValidateName_EndHyphen_Error()
     {
         // Arrange & Act
-        var exception = Assert.Throws<ArgumentException>(() => Resource.ValidateName("abc-"));
+        var exception = Assert.Throws<ArgumentException>(() => ModelName.ValidateName(nameof(Resource), "abc-"));
 
         // Assert
         Assert.Equal("Resource name 'abc-' is invalid. Name cannot end with a hyphen. (Parameter 'name')", exception.Message);
@@ -108,6 +108,6 @@ public class ResourceTests
     [InlineData("ABC")]
     public void ValidateName_ValidNames_Success(string name)
     {
-        Resource.ValidateName(name);
+        ModelName.ValidateName(nameof(Resource), name);
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/dotnet/aspire/pull/1691

Is anything else that has a name that should be validated? env vars are connection strings can both map to real world configuration so I left them out.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1712)