### PR TITLE
Add support for general Azure Storage connection string.

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureStorageResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// Represents an Azure Storage resource.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
-public class AzureStorageResource(string name) : Resource(name), IAzureResource
+public class AzureStorageResource(string name) : Resource(name), IAzureResource, IResourceWithConnectionString
 {
     /// <summary>
     /// Gets or sets the URI of the Azure Table Storage resource.
@@ -31,6 +31,14 @@ public class AzureStorageResource(string name) : Resource(name), IAzureResource
     /// Gets a value indicating whether the Azure Storage resource is running in the local emulator.
     /// </summary>
     public bool IsEmulator => this.IsContainer();
+
+    public string? GetConnectionString() => IsEmulator
+        ? AzureStorageEmulatorConnectionString.Create(
+            tablePort: GetEmulatorPort("table"),
+            queuePort: GetEmulatorPort("queue"),
+            blobPort: GetEmulatorPort("blob"))
+        // TODO: I'm not entirely sure what the behavior should be for when *not* emulated; the existing behavior component-specific URIs wouldn't be valid connection strings either.
+        : throw new DistributedApplicationException($"Azure storage resource does not generate non-emulated connection strings.");
 
     internal string? GetTableConnectionString() => IsEmulator
         ? AzureStorageEmulatorConnectionString.Create(tablePort: GetEmulatorPort("table"))

--- a/tests/Aspire.Hosting.Tests/Azure/AzureStorageResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureStorageResourceTests.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Azure;
+
+public class AzureStorageResourceTests
+{
+    [Fact]
+    public void AzureStorageReferenceGetsExpectedConnectionString()
+    {
+        var testProgram = CreateTestProgram();
+
+        var storage = testProgram.AppBuilder.AddAzureStorage("storage").UseEmulator();
+
+        storage.WithAnnotation(
+            new AllocatedEndpointAnnotation("blob",
+            ProtocolType.Tcp,
+            "localhost",
+            3000,
+            "http"
+            ));
+
+        storage.WithAnnotation(
+            new AllocatedEndpointAnnotation("queue",
+            ProtocolType.Tcp,
+            "localhost",
+            3001,
+            "http"
+            ));
+
+        storage.WithAnnotation(
+            new AllocatedEndpointAnnotation("table",
+            ProtocolType.Tcp,
+            "localhost",
+            3002,
+            "http"
+            ));
+
+        testProgram.ServiceABuilder.WithReference(storage);
+
+        testProgram.Build();
+
+        // Call environment variable callbacks.
+        var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
+
+        var config = new Dictionary<string, string>();
+        var context = new EnvironmentCallbackContext("dcp", config);
+
+        foreach (var annotation in annotations)
+        {
+            annotation.Callback(context);
+        }
+
+        // Simple test to ensure that the connection string exists and appears to contain all three endpoints.
+        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
+        Assert.Equal(1, servicesKeysCount);
+        Assert.Contains(
+            config, 
+            kvp => kvp.Key == "ConnectionStrings__storage" 
+                && Regex.IsMatch(kvp.Value, "BlobEndpoint=[^;]+;")
+                && Regex.IsMatch(kvp.Value, "QueueEndpoint=[^;]+;")
+                && Regex.IsMatch(kvp.Value, "TableEndpoint=[^;]+;"));
+    }
+
+    [Fact]
+    public void AzureStorageConnectionStringFailsWhenNotEmulated()
+    {
+        var testProgram = CreateTestProgram();
+
+        var storage = testProgram.AppBuilder.AddAzureStorage("storage");
+
+        storage.WithAnnotation(
+            new AllocatedEndpointAnnotation("blob",
+            ProtocolType.Tcp,
+            "localhost",
+            3000,
+            "http"
+            ));
+
+        storage.WithAnnotation(
+            new AllocatedEndpointAnnotation("queue",
+            ProtocolType.Tcp,
+            "localhost",
+            3001,
+            "http"
+            ));
+
+        storage.WithAnnotation(
+            new AllocatedEndpointAnnotation("table",
+            ProtocolType.Tcp,
+            "localhost",
+            3002,
+            "http"
+            ));
+
+        testProgram.ServiceABuilder.WithReference(storage);
+
+        testProgram.Build();
+
+        // Call environment variable callbacks.
+        var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
+
+        var config = new Dictionary<string, string>();
+        var context = new EnvironmentCallbackContext("dcp", config);
+
+        Assert.Throws<DistributedApplicationException>(() =>
+        {
+            foreach (var annotation in annotations)
+            {
+                annotation.Callback(context);
+            }
+        });
+    }
+
+    private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithReferenceTests>(args);
+}


### PR DESCRIPTION
Makes `AzureStorageResource` implement `IResourceWithConnectionString` that generates a "general" connection string for Azure Storage that are required by some APIs.

Resolves #1727 

> NOTE: There's an outstanding question related to how the resource should behave when storage is *not* emulated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1728)