### PR TITLE
Add safe helper method for accessing protected storage

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -61,7 +62,7 @@ public partial class SummaryDetailsView
     {
         if (RememberOrientation)
         {
-            var orientationResult = await ProtectedLocalStore.GetAsync<Orientation>(GetOrientationStorageKey());
+            var orientationResult = await ProtectedLocalStore.SafeGetAsync<Orientation>(GetOrientationStorageKey());
             if (orientationResult.Success)
             {
                 Orientation = orientationResult.Value;
@@ -70,7 +71,7 @@ public partial class SummaryDetailsView
 
         if (RememberSize)
         {
-            var panel1FractionResult = await ProtectedLocalStore.GetAsync<float>(GetSizeStorageKey());
+            var panel1FractionResult = await ProtectedLocalStore.SafeGetAsync<float>(GetSizeStorageKey());
             if (panel1FractionResult.Success)
             {
                 SetPanelSizes(panel1FractionResult.Value);

--- a/src/Aspire.Dashboard/Utils/ProtectedLocalStorageExtensions.cs
+++ b/src/Aspire.Dashboard/Utils/ProtectedLocalStorageExtensions.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace Aspire.Dashboard.Utils;
+
+internal static class ProtectedLocalStorageExtensions
+{
+    /// <summary>
+    /// Retrieves the value associated with the specified key.
+    /// If there is a CryptographicException, return default instead of throwing. A CryptographicException can occur
+    /// because the local data protection key for the dashboard has changed, and previously stored data can no longer be
+    /// successfully decrypted.
+    /// </summary>
+    public static async Task<ProtectedBrowserStorageResult<T>> SafeGetAsync<T>(this ProtectedLocalStorage value, string key)
+    {
+        try
+        {
+            return await value.GetAsync<T>(key).ConfigureAwait(false);
+        }
+        catch (CryptographicException ex)
+        {
+            Debug.WriteLine($"Failed to decrypt data for key '{key}': {ex.Message}");
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
Data protection keys used by Aspire dashboard could change. This is a problem because values protected by data protection are set in browser local storage and persisted.

If keys change, then we don't want to throw errors trying to access previously set values in browser local storage.

If a crypto error occurs then return default (non-success).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1729)