### PR TITLE
[dashboard-oop] Dynamic dashboard port

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -30,16 +30,16 @@ public class DashboardWebApplication
         builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.None);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error);
 
-        var dashboardUris = EnvironmentUtil.GetAddressUris(DashboardUrlVariableName, DashboardUrlDefaultValue);
+        var dashboardUris = EnvironmentUtil.GetAddressUris(DashboardUrlVariableName, new(DashboardUrlDefaultValue));
 
-        var dashboardHttpsPort = dashboardUris.FirstOrDefault(IsHttps)?.Port;
-        var otlpUris = EnvironmentUtil.GetAddressUris(DashboardOtlpUrlVariableName, DashboardOtlpUrlDefaultValue);
+        var otlpUris = EnvironmentUtil.GetAddressUris(DashboardOtlpUrlVariableName, new(DashboardOtlpUrlDefaultValue));
 
         if (otlpUris.Length > 1)
         {
             throw new InvalidOperationException("Only one URL for Aspire dashboard OTLP endpoint is supported.");
         }
 
+        var dashboardHttpsPort = dashboardUris.FirstOrDefault(IsHttps)?.Port;
         var isAllHttps = dashboardHttpsPort is not null && IsHttps(otlpUris[0]);
 
         builder.WebHost.ConfigureKestrel(kestrelOptions =>

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -1,29 +1,41 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.Net;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Aspire.Hosting.Publishing;
-using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Dashboard;
 
 /// <summary>
-/// Hosts a gRPC service (via <see cref="DashboardService"/>) that a dashboard can connect to.
+/// Hosts a gRPC service via <see cref="DashboardService"/> (aka the "Resource Service") that a dashboard can connect to.
 /// Configures DI and networking options for the service.
 /// </summary>
 internal sealed class DashboardServiceHost : IHostedService
 {
+    /// <summary>
+    /// Name of the environment variable that optionally specifies the resource service URL,
+    /// which the dashboard will connect to over gRPC.
+    /// </summary>
+    /// <remarks>
+    /// This is primarily intended for cases outside of the local developer environment.
+    /// If no value exists for this variable, a port is assigned dynamically.
+    /// </remarks>
     private const string DashboardServiceUrlVariableName = "DOTNET_DASHBOARD_GRPC_ENDPOINT_URL";
-    private const string DashboardServiceUrlDefaultValue = "http://localhost:18999";
+
+    private readonly TaskCompletionSource<ImmutableArray<string>> _uris = new();
 
     /// <summary>
     /// <see langword="null"/> if <see cref="DistributedApplicationOptions.DashboardEnabled"/> is <see langword="false"/>.
@@ -38,13 +50,10 @@ internal sealed class DashboardServiceHost : IHostedService
         ILoggerFactory loggerFactory,
         IConfigureOptions<LoggerFilterOptions> loggerOptions)
     {
-        if (!options.DashboardEnabled)
+        if (!options.DashboardEnabled ||
+            publishingOptions.Value.Publisher == "manifest") // HACK: Manifest publisher check is temporary until DcpHostService is integrated with DcpPublisher.
         {
-            return;
-        }
-        else if (publishingOptions.Value.Publisher == "manifest")
-        {
-            // HACK: Manifest publisher check is temporary until DcpHostService is integrated with DcpPublisher.
+            _uris.SetCanceled();
             return;
         }
 
@@ -70,32 +79,61 @@ internal sealed class DashboardServiceHost : IHostedService
 
         static void ConfigureKestrel(KestrelServerOptions kestrelOptions)
         {
-            var uris = EnvironmentUtil.GetAddressUris(DashboardServiceUrlVariableName, DashboardServiceUrlDefaultValue);
+            // Check env var for URLs to listen on.
+            var uris = EnvironmentUtil.GetAddressUris(DashboardServiceUrlVariableName, defaultValue: null);
 
-            foreach (var uri in uris)
+            string? scheme;
+
+            if (uris is null or { Length: 0 })
             {
-                if (uri.IsLoopback)
-                {
-                    kestrelOptions.ListenLocalhost(uri.Port, ConfigureListen);
-                }
-                else
-                {
-                    kestrelOptions.Listen(IPAddress.Parse(uri.Host), uri.Port, ConfigureListen);
-                }
+                // No URI available from the environment.
+                scheme = null;
 
-                void ConfigureListen(ListenOptions options)
+                // Listen on a random port.
+                kestrelOptions.Listen(IPAddress.Loopback, port: 0, ConfigureListen);
+            }
+            else
+            {
+                // We have one or more configured URLs to listen on.
+                foreach (var uri in uris)
                 {
-                    // Force HTTP/2 for gRPC, so that it works over non-TLS connections
-                    // which cannot negotiate between HTTP/1.1 and HTTP/2.
-                    options.Protocols = HttpProtocols.Http2;
+                    scheme = uri.Scheme;
 
-                    if (string.Equals(uri.Scheme, "https", StringComparison.Ordinal))
+                    if (uri.IsLoopback)
                     {
-                        options.UseHttps();
+                        kestrelOptions.ListenLocalhost(uri.Port, ConfigureListen);
+                    }
+                    else
+                    {
+                        kestrelOptions.Listen(IPAddress.Parse(uri.Host), uri.Port, ConfigureListen);
                     }
                 }
             }
+
+            void ConfigureListen(ListenOptions options)
+            {
+                // Force HTTP/2 for gRPC, so that it works over non-TLS connections
+                // which cannot negotiate between HTTP/1.1 and HTTP/2.
+                options.Protocols = HttpProtocols.Http2;
+
+                if (string.Equals(scheme, "https", StringComparison.Ordinal))
+                {
+                    options.UseHttps();
+                }
+            }
         }
+    }
+
+    /// <summary>
+    /// Gets the URIs upon which the resource service is listening.
+    /// </summary>
+    /// <remarks>
+    /// Intended to be used by the app model when launching the dashboard process, populating the
+    /// <c>DOTNET_DASHBOARD_GRPC_ENDPOINT_URL</c> environment variable (semicolon delimited).
+    /// </remarks>
+    public Task<ImmutableArray<string>> GetUrisAsync(CancellationToken cancellationToken = default)
+    {
+        return _uris.Task.WaitAsync(cancellationToken);
     }
 
     async Task IHostedService.StartAsync(CancellationToken cancellationToken)
@@ -103,11 +141,23 @@ internal sealed class DashboardServiceHost : IHostedService
         if (_app is not null)
         {
             await _app.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            var addressFeature = _app.Services.GetService<IServer>()?.Features.Get<IServerAddressesFeature>();
+
+            if (addressFeature is null)
+            {
+                _uris.SetException(new InvalidOperationException("Could not obtain IServerAddressesFeature. Dashboard URIs are not available."));
+                return;
+            }
+
+            _uris.SetResult(addressFeature.Addresses.ToImmutableArray());
         }
     }
 
     async Task IHostedService.StopAsync(CancellationToken cancellationToken)
     {
+        _uris.TrySetCanceled(cancellationToken);
+
         if (_app is not null)
         {
             await _app.StopAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Utils/EnvironmentUtil.cs
+++ b/src/Aspire.Hosting/Utils/EnvironmentUtil.cs
@@ -7,6 +7,13 @@ namespace Aspire.Hosting.Utils;
 
 internal static class EnvironmentUtil
 {
+    /// <summary>
+    /// Parses a environment variable's semicolon-delimited value into an array of <see cref="Uri"/> objects.
+    /// </summary>
+    /// <param name="variableName">The name of the environment variable.</param>
+    /// <param name="defaultValue">A default value, for when the environment variable is unspecified or white space. May be <see langword="null"/>.</param>
+    /// <returns>The parsed values, or the default value if specified and parsing failed. Returns <see langword="null"/> if <paramref name="defaultValue"/> is <see langword="null"/> and parsing failed.</returns>
+    /// <exception cref="InvalidOperationException">The environment variable could not be accessed, or contained an unparseable value.</exception>
     [return: NotNullIfNotNull(nameof(defaultValue))]
     public static Uri[]? GetAddressUris(string variableName, Uri? defaultValue)
     {
@@ -26,7 +33,7 @@ internal static class EnvironmentUtil
             {
                 return urls
                     .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(url => new Uri(url))
+                    .Select(url => new Uri(url, UriKind.Absolute))
                     .ToArray();
             }
         }

--- a/src/Aspire.Hosting/Utils/EnvironmentUtil.cs
+++ b/src/Aspire.Hosting/Utils/EnvironmentUtil.cs
@@ -1,11 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Aspire.Hosting.Utils;
 
 internal static class EnvironmentUtil
 {
-    public static Uri[] GetAddressUris(string variableName, string defaultValue)
+    [return: NotNullIfNotNull(nameof(defaultValue))]
+    public static Uri[]? GetAddressUris(string variableName, Uri? defaultValue)
     {
         try
         {
@@ -13,13 +16,19 @@ internal static class EnvironmentUtil
 
             if (string.IsNullOrWhiteSpace(urls))
             {
-                urls = defaultValue;
+                return defaultValue switch
+                {
+                    not null => [defaultValue],
+                    null => null
+                };
             }
-
-            return urls
-                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .Select(url => new Uri(url))
-                .ToArray();
+            else
+            {
+                return urls
+                    .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(url => new Uri(url))
+                    .ToArray();
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
The resource server will no longer bind to a default, hardcoded port in the app host. This encourages port collisions. Instead, when no URL is set in the environment, a port is chosen dynamically.

When the app model launches the dashboard, it must pass the URIs exposed via `DashboardServiceHost.GetUrisAsync` via the `DOTNET_DASHBOARD_GRPC_ENDPOINT_URL` environment variable to the spawned instance. That work is happening concurrently, and will use this API is a subsequent change.

---

This diagram shows our goal state for the `feature/dashboard-oop` branch:

![image](https://github.com/dotnet/aspire/assets/350947/d3901349-1bcd-42ef-825c-8d9bf4ee1338)

This PR adds the behaviour seen in the top left box (dynamic port, and a way to obtain the URL).

The app model will be able to pick this value up and pass it to `DOTNET_DASHBOARD_GRPC_ENDPOINT_URL` env var of the dashboard.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1750)