### PR TITLE
Remove `IServiceEndPointResolver.DisplayName` property and use `ToString()` instead

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/IServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/IServiceEndPointResolver.cs
@@ -9,11 +9,6 @@ namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 public interface IServiceEndPointResolver : IAsyncDisposable
 {
     /// <summary>
-    /// Gets the diagnostic display name for this resolver.
-    /// </summary>
-    string DisplayName { get; }
-
-    /// <summary>
     /// Attempts to resolve the endpoints for the service which this instance is configured to resolve endpoints for.
     /// </summary>
     /// <param name="endPoints">The endpoint collection, which resolved endpoints will be added to.</param>

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
@@ -23,7 +23,7 @@ internal sealed partial class DnsServiceEndPointResolver(
     string IHostNameFeature.HostName => hostName;
 
     /// <inheritdoc/>
-    public override string DisplayName => "DNS";
+    public override string ToString() => "DNS";
 
     protected override async Task ResolveAsyncCore()
     {

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
@@ -44,16 +44,18 @@ internal abstract partial class DnsServiceEndPointResolverBase : IServiceEndPoin
         _lastChangeToken = new CancellationChangeToken(cancellation.Token);
     }
 
-    public abstract string DisplayName { get; }
-
     private TimeSpan ElapsedSinceRefresh => _timeProvider.GetElapsedTime(_lastRefreshTimeStamp);
 
     protected string ServiceName { get; }
 
     protected abstract double RetryBackOffFactor { get; }
+
     protected abstract TimeSpan MinRetryPeriod { get; }
+
     protected abstract TimeSpan MaxRetryPeriod { get; }
+
     protected abstract TimeSpan DefaultRefreshPeriod { get; }
+
     protected CancellationToken ShutdownToken => _disposeCancellation.Token;
 
     /// <inheritdoc/>
@@ -116,7 +118,9 @@ internal abstract partial class DnsServiceEndPointResolverBase : IServiceEndPoin
     }
 
     protected void SetException(Exception exception) => SetResult(endPoints: null, exception, validityPeriod: TimeSpan.Zero);
+
     protected void SetResult(List<ServiceEndPoint> endPoints, TimeSpan validityPeriod) => SetResult(endPoints, exception: null, validityPeriod);
+
     private void SetResult(List<ServiceEndPoint>? endPoints, Exception? exception, TimeSpan validityPeriod)
     {
         lock (_lock)

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
@@ -20,11 +20,14 @@ internal sealed partial class DnsSrvServiceEndPointResolver(
     TimeProvider timeProvider) : DnsServiceEndPointResolverBase(serviceName, logger, timeProvider), IHostNameFeature
 {
     protected override double RetryBackOffFactor => options.CurrentValue.RetryBackOffFactor;
+
     protected override TimeSpan MinRetryPeriod => options.CurrentValue.MinRetryPeriod;
+
     protected override TimeSpan MaxRetryPeriod => options.CurrentValue.MaxRetryPeriod;
+
     protected override TimeSpan DefaultRefreshPeriod => options.CurrentValue.DefaultRefreshPeriod;
 
-    public override string DisplayName => "DNS SRV";
+    public override string ToString() => "DNS SRV";
 
     string IHostNameFeature.HostName => hostName;
 

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.cs
@@ -50,9 +50,6 @@ internal sealed partial class ConfigurationServiceEndPointResolver : IServiceEnd
     }
 
     /// <inheritdoc/>
-    public string DisplayName => "Configuration";
-
-    /// <inheritdoc/>
     public ValueTask DisposeAsync() => default;
 
     /// <inheritdoc/>

--- a/src/Microsoft.Extensions.ServiceDiscovery/PassThrough/PassThroughServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/PassThrough/PassThroughServiceEndPointResolver.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Extensions.ServiceDiscovery.PassThrough;
 /// </summary>
 internal sealed partial class PassThroughServiceEndPointResolver(ILogger logger, string serviceName, EndPoint endPoint) : IServiceEndPointResolver
 {
-    public string DisplayName => "Pass-through";
-
     public ValueTask<ResolutionStatus> ResolveAsync(ServiceEndPointCollectionSource endPoints, CancellationToken cancellationToken)
     {
         if (endPoints.EndPoints.Count != 0)
@@ -29,4 +27,6 @@ internal sealed partial class PassThroughServiceEndPointResolver(ILogger logger,
     }
 
     public ValueTask DisposeAsync() => default;
+
+    public override string ToString() => "Pass-through";
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolver.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolver.Log.cs
@@ -30,7 +30,7 @@ public sealed partial class ServiceEndPointResolver
             {
                 if (ep.Features.Get<IServiceEndPointResolver>() is { } resolver)
                 {
-                    return $"{ep.GetEndPointString()} ({resolver.DisplayName})";
+                    return $"{ep.GetEndPointString()} ({resolver})";
                 }
 
                 return ep.GetEndPointString();

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.Log.cs
@@ -16,7 +16,7 @@ public partial class ServiceEndPointResolverFactory
         {
             if (logger.IsEnabled(LogLevel.Debug))
             {
-                ServiceEndPointResolverListCore(logger, serviceName, resolvers.Count, string.Join(", ", resolvers.Select(static r => r.DisplayName)));
+                ServiceEndPointResolverListCore(logger, serviceName, resolvers.Count, string.Join(", ", resolvers.Select(static r => r.ToString())));
             }
         }
     }

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndPointResolverTests.cs
@@ -77,8 +77,6 @@ public class ServiceEndPointResolverTests
 
     private sealed class FakeEndPointResolver(Func<ServiceEndPointCollectionSource, CancellationToken, ValueTask<ResolutionStatus>> resolveAsync, Func<ValueTask> disposeAsync) : IServiceEndPointResolver
     {
-        public string DisplayName => "Fake";
-
         public ValueTask<ResolutionStatus> ResolveAsync(ServiceEndPointCollectionSource endPoints, CancellationToken cancellationToken) => resolveAsync(endPoints, cancellationToken);
         public ValueTask DisposeAsync() => disposeAsync();
     }


### PR DESCRIPTION
This string is purely for diagnostic purposes, and I'm not convinced it's worth having an interface member just for this.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1761)