### PR TITLE
[feature/dashboard-oop] Publish dashboard for specific RIDs before packing

### DIFF
--- a/eng/dashboardpack/Sdk.targets
+++ b/eng/dashboardpack/Sdk.targets
@@ -5,7 +5,8 @@
   <PropertyGroup>
     <AspireDashboardDir Condition=" '$(AspireDashboardDir)' == '' ">$([MSBuild]::NormalizeDirectory($(MSBuildThisFileDirectory), '..', 'tools'))</AspireDashboardDir>
     <AspireDashboardDir>$([MSBuild]::EnsureTrailingSlash('$(AspireDashboardDir)'))</AspireDashboardDir>
-    <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard.dll'))</AspireDashboardPath>
+    <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard'))</AspireDashboardPath>
+    <AspireDashboardPath Condition=" '$(OS)' == 'Windows_NT' and !$(AspireDashboardPath.EndsWith('.exe')) ">$(AspireDashboardPath).exe</AspireDashboardPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/dashboardpack/UnixFilePermissions.xml
+++ b/eng/dashboardpack/UnixFilePermissions.xml
@@ -1,0 +1,3 @@
+<FileList>
+  <File Path="tools/Aspire.Dashboard" Permission="755"/>
+</FileList>

--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -13,22 +13,28 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>Aspire.Dashboard.Sdk</PackageId>
+    <PackageId>Aspire.Dashboard.Sdk.$(DashboardRuntime)</PackageId>
     <Description>Dashboard browser interface for .NET Aspire.</Description>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DashboardPlatformType Condition=" '$(DashboardPlatformType)' == '' and $(DcpPlatform.StartsWith('win-')) ">Windows</DashboardPlatformType>
+    <DashboardPlatformType Condition=" '$(DashboardPlatformType)' == '' ">Unix</DashboardPlatformType>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 
-<Target Name="Build" />
+  <Target Name="Build" />
 
   <Target Name="BeforeBuild" BeforeTargets="Build">
-    <MSBuild Projects="../../src/Aspire.Dashboard/Aspire.Dashboard.csproj" Targets="publish" Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework)" />
+    <MSBuild Projects="../../src/Aspire.Dashboard/Aspire.Dashboard.csproj" Targets="publish" Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework);RuntimeIdentifier=$(DashboardRuntime)" />
   </Target>
 
   <ItemGroup>
     <None Include="Sdk.props" Pack="true" PackagePath="Sdk/" />
     <None Include="Sdk.targets" Pack="true" PackagePath="Sdk/" />
-    <None Include="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/**/*" Pack="true" PackagePath="tools/" />
+    <None Include="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/**/*" Pack="true" PackagePath="tools/" />
+    <None Include="UnixFilePermissions.xml" Pack="true" PackagePath="data/" Condition=" '$(DashboardPlatformType)' == 'Unix' " />
   </ItemGroup>
 
 </Project>

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -38,6 +38,7 @@
 
   <!-- The list of supported runtimes -->
   <ItemGroup>
+    <!-- Update Aspire.Dashboard.csproj RuntimeIdentifiers if this list changes -->
     <_PackRuntimes Include="win-x86" />
     <_PackRuntimes Include="win-x64" />
     <_PackRuntimes Include="win-arm64" />
@@ -48,13 +49,6 @@
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
-
-  <!--<Target Name="PublishDashboard" BeforeTargets="Build">
-    <PropertyGroup>
-      <_PublishRuntimes>@(_PackRuntimes)</_PublishRuntimes>
-    </PropertyGroup>
-    <MSBuild Projects="../../src/Aspire.Dashboard/Aspire.Dashboard.csproj" Targets="restore;publish" Properties="RuntimeIdentifiers=$(_PublishRuntimes)" />
-  </Target>-->
 
   <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
     <ItemGroup>

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -75,7 +75,7 @@
       </ShortNames>
     </ItemGroup>
 
-    <MSBuild Projects="../dashboardpack/dashboardpack.csproj" Targets="restore;build" Properties="DashboardRuntime=%(_PackRuntimes.Identity);PackageOutputPath=$(PackageSource)" BuildInParallel="false" />
+    <MSBuild Projects="../dashboardpack/dashboardpack.csproj" Targets="restore;build" Properties="DashboardRuntime=%(_PackRuntimes.Identity);PackageOutputPath=$(PackageSource)" />
     <MSBuild Projects="../dcppack/dcppack.csproj" Targets="restore;build" Properties="DcpRuntime=%(_PackRuntimes.Identity);PackageOutputPath=$(PackageSource)" />
 
     <ItemGroup>

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <!-- The list of supported runtimes -->
+  <!-- The list of supported runtimes, which matches those of DCP -->
   <ItemGroup>
     <!-- Update Aspire.Dashboard.csproj RuntimeIdentifiers if this list changes -->
     <_PackRuntimes Include="win-x86" />

--- a/eng/workloads/workloads.csproj
+++ b/eng/workloads/workloads.csproj
@@ -36,18 +36,25 @@
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <!-- The list of runtimes DCP provides binaries for -->
+  <!-- The list of supported runtimes -->
   <ItemGroup>
-    <_DcpRuntimes Include="win-x86" />
-    <_DcpRuntimes Include="win-x64" />
-    <_DcpRuntimes Include="win-arm64" />
-    <_DcpRuntimes Include="linux-x64" />
-    <_DcpRuntimes Include="linux-arm64" />
-    <_DcpRuntimes Include="osx-x64" />
-    <_DcpRuntimes Include="osx-arm64" />
+    <_PackRuntimes Include="win-x86" />
+    <_PackRuntimes Include="win-x64" />
+    <_PackRuntimes Include="win-arm64" />
+    <_PackRuntimes Include="linux-x64" />
+    <_PackRuntimes Include="linux-arm64" />
+    <_PackRuntimes Include="osx-x64" />
+    <_PackRuntimes Include="osx-arm64" />
   </ItemGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+
+  <!--<Target Name="PublishDashboard" BeforeTargets="Build">
+    <PropertyGroup>
+      <_PublishRuntimes>@(_PackRuntimes)</_PublishRuntimes>
+    </PropertyGroup>
+    <MSBuild Projects="../../src/Aspire.Dashboard/Aspire.Dashboard.csproj" Targets="restore;publish" Properties="RuntimeIdentifiers=$(_PublishRuntimes)" />
+  </Target>-->
 
   <Target Name="Build" DependsOnTargets="GetAssemblyVersion;_GetVersionProps;_GenerateMsiVersionString">
     <ItemGroup>
@@ -74,8 +81,8 @@
       </ShortNames>
     </ItemGroup>
 
-    <MSBuild Projects="../dashboardpack/dashboardpack.csproj" Targets="restore;build" Properties="PackageOutputPath=$(PackageSource)" />
-    <MSBuild Projects="../dcppack/dcppack.csproj" Targets="restore;build" Properties="DcpRuntime=%(_DcpRuntimes.Identity);PackageOutputPath=$(PackageSource)" />
+    <MSBuild Projects="../dashboardpack/dashboardpack.csproj" Targets="restore;build" Properties="DashboardRuntime=%(_PackRuntimes.Identity);PackageOutputPath=$(PackageSource)" BuildInParallel="false" />
+    <MSBuild Projects="../dcppack/dcppack.csproj" Targets="restore;build" Properties="DcpRuntime=%(_PackRuntimes.Identity);PackageOutputPath=$(PackageSource)" />
 
     <ItemGroup>
       <ManifestPackages Include="$(PackageSource)Microsoft.NET.Sdk.Aspire.Manifest*.nupkg"

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -1,22 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <IsPackable>true</IsPackable>
+    <RuntimeIdentifiers>win-x86;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <Description>Dashboard browser interface for .NET Aspire.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Title>.NET Aspire Dashboard</Title>
-    <PackageProjectUrl>https://github.com/dotnet/aspire</PackageProjectUrl>
-    <PackageIcon>Aspire_icon_256.png</PackageIcon>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/dotnet/aspire</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
+    <!-- This list of runtimes needs to match the set of runtimes specified in eng/workloads/workloads.csproj -->
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCurrent)</TargetFramework>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -11,10 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\Shared\Aspire_icon_256.png" Pack="True" PackagePath="\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Protobuf Include="**/*.proto" GrpcServices="Server">
       <ProtoRoot>Otlp</ProtoRoot>
     </Protobuf>

--- a/src/Microsoft.NET.Sdk.Aspire/WorkloadManifest.in.json
+++ b/src/Microsoft.NET.Sdk.Aspire/WorkloadManifest.in.json
@@ -49,7 +49,16 @@
     },
     "Aspire.Dashboard.Sdk": {
       "kind": "sdk",
-      "version": "@VERSION@"
+      "version": "@VERSION@",
+      "alias-to": {
+        "win-x86": "Aspire.Dashboard.Sdk.win-x86",
+        "win-x64": "Aspire.Dashboard.Sdk.win-x64",
+        "win-arm64": "Aspire.Dashboard.Sdk.win-arm64",
+        "linux-x64": "Aspire.Dashboard.Sdk.linux-x64",
+        "linux-arm64": "Aspire.Dashboard.Sdk.linux-arm64",
+        "osx-x64": "Aspire.Dashboard.Sdk.osx-x64",
+        "osx-arm64": "Aspire.Dashboard.Sdk.osx-arm64"
+      }
     }
   }
 }


### PR DESCRIPTION
This PR publishes the Dashboard for every RID we support in the Aspire workload before building the workload pack.
 
###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1771)