### PR TITLE
Consistent resource type XML docs

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
@@ -4,7 +4,7 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents an Azure App Configuration resource.
+/// A resource that represents Azure App Configuration.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 public class AzureAppConfigurationResource(string name) : Resource(name), IAzureResource, IResourceWithConnectionString

--- a/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
@@ -1,10 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents a resource that is stored in Azure Blob Storage.
+/// A resource that represents an Azure Blob Storage account.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="storage">The <see cref="AzureStorageResource"/> that the resource is stored in.</param>

--- a/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
@@ -8,7 +8,7 @@ using Aspire.Hosting.Azure.Cosmos;
 namespace Aspire.Hosting.Azure.Data.Cosmos;
 
 /// <summary>
-/// Represents a connection to an Azure Cosmos DB account.
+/// A resource that represents an Azure Cosmos DB.
 /// </summary>
 /// <param name="name">The resource name.</param>
 /// <param name="connectionString">The connection string to use to connect.</param>

--- a/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
@@ -4,7 +4,7 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents an Azure Key Vault resource that can be deployed to an Azure resource group.
+/// A resource that represents an Azure Key Vault.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 public class AzureKeyVaultResource(string name) : Resource(name), IAzureResource, IResourceWithConnectionString

--- a/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
@@ -4,9 +4,10 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents a container resource that implements <see cref="IResourceWithEnvironment"/> 
-/// and <see cref="IResourceWithEndpoints"/>.
+/// A resource that represents a specified container.
 /// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="entrypoint">An optional container entrypoint.</param>
 public class ContainerResource(string name, string? entrypoint = null) : Resource(name), IResourceWithEnvironment, IResourceWithEndpoints
 {
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -4,7 +4,7 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents a resource that can be executed as a standalone process.
+/// A resource that represents a specified executable process.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="command">The command to execute.</param>

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -4,9 +4,9 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents a project resource that implements <see cref="IResourceWithEnvironment"/> and 
-/// <see cref="IResourceWithEndpoints"/>.
+/// A resource that represents a specified .NET project.
 /// </summary>
+/// <param name="name">The name of the resource.</param>
 public class ProjectResource(string name) : Resource(name), IResourceWithEnvironment, IResourceWithServiceDiscovery
 {
 }

--- a/src/Aspire.Hosting/Kafka/KafkaContainerResource.cs
+++ b/src/Aspire.Hosting/Kafka/KafkaContainerResource.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting;
 /// <summary>
 /// A resource that represents a Kafka broker container.
 /// </summary>
-/// <param name="name"></param>
+/// <param name="name">The name of the resource.</param>
 public class KafkaContainerResource(string name) : ContainerResource(name), IResourceWithConnectionString, IResourceWithEnvironment
 {
     /// <summary>

--- a/src/Aspire.Hosting/Node/NodeAppResource.cs
+++ b/src/Aspire.Hosting/Node/NodeAppResource.cs
@@ -7,7 +7,7 @@ namespace Aspire.Hosting;
 /// <summary>
 /// A resource that represents a node application.
 /// </summary>
-/// <param name="name">The name of the resource</param>
+/// <param name="name">The name of the resource.</param>
 /// <param name="command">The command to execute.</param>
 /// <param name="workingDirectory">The working directory to use for the command. If null, the working directory of the current process is used.</param>
 /// <param name="args">The arguments to pass to the command.</param>

--- a/src/Aspire.Hosting/OpenAI/OpenAIResource.cs
+++ b/src/Aspire.Hosting/OpenAI/OpenAIResource.cs
@@ -4,7 +4,7 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents an OpenAI resource independent of hosting model.
+/// A resource that represents an OpenAI resource independent of the hosting model.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 public class OpenAIResource(string name) : Resource(name), IResourceWithConnectionString

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
@@ -4,7 +4,7 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// A resource that represents a Oracle Database database. This is a child resource of a <see cref="OracleDatabaseContainerResource"/>.
+/// A resource that represents an Oracle Database database. This is a child resource of a <see cref="OracleDatabaseContainerResource"/>.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="oracleParentResource">The Oracle Database parent resource associated with this database.</param>

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
@@ -6,7 +6,7 @@ using Aspire.Hosting.Utils;
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// A resource that represents a Oracle Database container.
+/// A resource that represents an Oracle Database container.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="password">The Oracle Database server password.</param>

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -6,7 +6,7 @@ using Aspire.Hosting.Redis;
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents a Redis resource independent of hosting model.
+/// A resource that represents a Redis resource independent of the hosting model.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 public class RedisResource(string name) : Resource(name), IResourceWithConnectionString, IRedisResource

--- a/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
@@ -4,7 +4,7 @@
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents a SQL Server database resource that is a child of a SQL Server container resource.
+/// A resource that represents a SQL Server database that is a child of a SQL Server container resource.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="sqlServerContainer">The parent SQL Server container resource.</param>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1613

This isn't all resources. Before I do all of them I want to double check whether this format is preferred. There appear to be two:

1. Represents an Azure App Configuration resource.
2. A resource that represents Azure App Configuration.

Which do we want?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1772)