### PR TITLE
Start dashboard first for playground scenario

### DIFF
--- a/playground/dapr/AppHost/DaprAppHost.csproj
+++ b/playground/dapr/AppHost/DaprAppHost.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\src\Aspire.Hosting\Utils\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
     <ProjectReference Include="..\..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
     <ProjectReference Include="..\..\..\src\Aspire.Hosting.Dapr\Aspire.Hosting.Dapr.csproj" />

--- a/playground/eShopLite/AppHost/AppHost.csproj
+++ b/playground/eShopLite/AppHost/AppHost.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\..\src\Aspire.Hosting\Utils\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
     <ProjectReference Include="..\..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
     <ProjectReference Include="..\..\..\src\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />

--- a/playground/eShopLite/AppHost/Program.cs
+++ b/playground/eShopLite/AppHost/Program.cs
@@ -37,7 +37,7 @@ builder.AddProject<Projects.CatalogDb>("catalogdbapp")
 // to test end developer dashboard launch experience. Refer to WorkloadAttributes.cs
 // for the path to the dashboard binary (defaults to a relative path to the artifacts
 // directory).
-builder.AddProject<Projects.Aspire_Dashboard>("aspire-dashboard")
+builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard)
     .WithEnvironment("DOTNET_DASHBOARD_GRPC_ENDPOINT_URL", "http://localhost:5555")
     .ExcludeFromManifest();
 

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -184,6 +184,7 @@
     </Protobuf>
     <Compile Include="..\Aspire.Hosting\Extensions\ChannelExtensions.cs" Link="Extensions\ChannelExtensions.cs" />
     <Compile Include="..\Aspire.Hosting\Utils\EnvironmentUtil.cs" Link="Utils\EnvironmentUtil.cs" />
+    <Compile Include="..\Aspire.Hosting\Utils\KnownResourceNames.cs" Link="Utils\KnownResourceNames.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -94,7 +94,7 @@ internal sealed class DcpDataSource
     private static bool IsFilteredResource<T>(T resource) where T: CustomResource
     {
         // We filter out any resources that start with aspire-dashboard (there are services as well as executables).
-        if (resource.Metadata.Name.StartsWith("aspire-dashboard", StringComparisons.ResourceName))
+        if (resource.Metadata.Name.StartsWith(KnownResourceNames.AspireDashboard, StringComparisons.ResourceName))
         {
             if (Environment.GetEnvironmentVariable("DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES") is { } showDashboardResourcesValue)
             {

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -81,9 +81,19 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         AspireEventSource.Instance.DcpModelCreationStart();
         try
         {
-            if (!_model.Resources.Any(static r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)))
+            var (dashboardIndex, dashboardResource) = _model.Resources.IndexOf(static r => !StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard));
+
+            if (dashboardIndex is -1)
             {
+                // No dashboard is specified, so start one.
+                // TODO validate that the dashboard has not been suppressed
                 await StartDashboardAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else if (dashboardIndex is not 0)
+            {
+                // A dashboard exists in the set. Move it to the front so it starts first.
+                _model.Resources.RemoveAt(dashboardIndex);
+                _model.Resources.Insert(0, dashboardResource);
             }
 
             PrepareServices();

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -81,7 +81,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         AspireEventSource.Instance.DcpModelCreationStart();
         try
         {
-            if (!_model.Resources.Any(r => r.Name == DashboardReservedResourceName))
+            if (!_model.Resources.Any(static r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)))
             {
                 await StartDashboardAsync(cancellationToken).ConfigureAwait(false);
             }
@@ -99,8 +99,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             AspireEventSource.Instance.DcpModelCreationStop();
         }
     }
-
-    private const string DashboardReservedResourceName = "aspire-dashboard";
 
     private async Task StartDashboardAsync(CancellationToken cancellationToken = default)
     {
@@ -154,8 +152,10 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
         dashboardExecutableSpec.Env = environment;
 
-        var dashboardExecutable = new Executable(dashboardExecutableSpec);
-        dashboardExecutable.Metadata.Name = DashboardReservedResourceName;
+        var dashboardExecutable = new Executable(dashboardExecutableSpec)
+        {
+            Metadata = { Name = KnownResourceNames.AspireDashboard }
+        };
 
         await kubernetesService.CreateAsync(dashboardExecutable, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting/Utils/KnownResourceNames.cs
+++ b/src/Aspire.Hosting/Utils/KnownResourceNames.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+internal static class KnownResourceNames
+{
+    public static string AspireDashboard => "aspire-dashboard";
+}

--- a/src/Aspire.Hosting/Utils/LinqExtensions.cs
+++ b/src/Aspire.Hosting/Utils/LinqExtensions.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+internal static class LinqExtensions
+{
+    public static (int index, T value) IndexOf<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+    {
+        var index = 0;
+
+        foreach (var item in source)
+        {
+            if (predicate(item))
+            {
+                return (index, item);
+            }
+
+            index++;
+        }
+
+        return (-1, default!);
+    }
+}


### PR DESCRIPTION
When F5'ing one of the playground solutions in the dotnet/aspire repo, the dashboard is added as the last resource. This means it starts after all other resources, which is not what we want. This change ensures it is always started first.

Also adds a `KnownResourceNames` type to avoid hard-coding the string `"aspire-dashboard"`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1775)