### PR TITLE
Rename and format

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -44,6 +44,7 @@ internal sealed class DashboardServiceHost : IHostedService
     /// <see langword="null"/> if <see cref="DistributedApplicationOptions.DashboardEnabled"/> is <see langword="false"/>.
     /// </summary>
     private readonly WebApplication? _app;
+    private readonly ILogger<DashboardServiceHost> _logger;
 
     public DashboardServiceHost(
         DistributedApplicationOptions options,
@@ -51,8 +52,11 @@ internal sealed class DashboardServiceHost : IHostedService
         KubernetesService kubernetesService,
         IOptions<PublishingOptions> publishingOptions,
         ILoggerFactory loggerFactory,
+        ILogger<DashboardServiceHost> logger,
         IConfigureOptions<LoggerFilterOptions> loggerOptions)
     {
+        _logger = logger;
+
         if (!options.DashboardEnabled ||
             publishingOptions.Value.Publisher == "manifest") // HACK: Manifest publisher check is temporary until DcpHostService is integrated with DcpPublisher.
         {
@@ -151,7 +155,7 @@ internal sealed class DashboardServiceHost : IHostedService
 
         if (stopwatch.Elapsed > TimeSpan.FromSeconds(2))
         {
-            Trace.WriteLine($"Unexpectedly long wait for resource service URI ({stopwatch.Elapsed}).");
+            _logger.LogWarning("Unexpectedly long wait for resource service URI ({elapsed}).", stopwatch.Elapsed);
         }
 
         return uri;

--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -91,7 +91,7 @@ internal sealed class DcpDataSource
         }
     }
 
-    private static bool IsFilteredResource<T>(T resource) where T: CustomResource
+    private static bool IsFilteredResource<T>(T resource) where T : CustomResource
     {
         // We filter out any resources that start with aspire-dashboard (there are services as well as executables).
         if (resource.Metadata.Name.StartsWith("aspire-dashboard", StringComparisons.ResourceName))

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -22,20 +22,9 @@ internal sealed class KubernetesService(Locations locations) : IDisposable
     private static readonly TimeSpan s_initialRetryDelay = TimeSpan.FromMilliseconds(100);
     private static GroupVersion GroupVersion => Model.Dcp.GroupVersion;
 
-    private IKubernetes? _kubernetes;
-    private TimeSpan _maxRetryDuration = TimeSpan.FromSeconds(5);
+    private Kubernetes? _kubernetes;
 
-    public TimeSpan MaxRetryDuration
-    {
-        get
-        {
-            return _maxRetryDuration;
-        }
-        set
-        {
-            _maxRetryDuration = value;
-        }
-    }
+    public TimeSpan MaxRetryDuration { get; set; } = TimeSpan.FromSeconds(5);
 
     public Task<T> CreateAsync<T>(T obj, CancellationToken cancellationToken = default)
         where T : CustomResource


### PR DESCRIPTION
- Renames `DashboardServiceHost.GetUrisAsync` to `DashboardServiceHost.GetResourceServiceUriAsync`
- Use object and collection literals
- Address some formatting diagnostics in the IDE to keep the gutter clean
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1776)