### PR TITLE
fix Orleans invalid environment var names for ACA

### DIFF
--- a/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
@@ -350,12 +350,12 @@ public static class OrleansServiceExtensions
 
         if (!string.IsNullOrWhiteSpace(res.ClusterId))
         {
-            builder.WithEnvironment("Orleans:ClusterId", res.ClusterId);
+            builder.WithEnvironment("Orleans__ClusterId", res.ClusterId);
         }
 
         if (!string.IsNullOrWhiteSpace(res.ServiceId))
         {
-            builder.WithEnvironment("Orleans:ServiceId", res.ServiceId);
+            builder.WithEnvironment("Orleans__ServiceId", res.ServiceId);
         }
 
         return builder;


### PR DESCRIPTION
Fix for Aspire deployment of Orleans to ACA fails with below error

```json
RESPONSE 400: 400 Bad Request
ERROR CODE: ContainerAppInvalidEnvVarName
--------------------------------------------------------------------------------
{
  "error": {
    "code": "ContainerAppInvalidEnvVarName",
    "message": "Env variable name 'Orleans:ClusterId' contains invalid character, regex used for validation is '^[-._a-zA-Z][-._a-zA-Z0-9]*$'"
  }
}
--------------------------------------------------------------------------------
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1779)