### PR TITLE
fix for renamed methods in commented-out code in Orleans example

### DIFF
--- a/playground/orleans/OrleansAppHost/Program.cs
+++ b/playground/orleans/OrleansAppHost/Program.cs
@@ -24,8 +24,8 @@ var orleans = builder.AddOrleans("my-app")
 // one can use the in memory provider from Orleans:
 //
 //var orleans = builder.AddOrleans("my-app")
-//                     .WithLocalhostClustering()
-//                     .WithInMemoryGrainStorage("Default");
+//                     .WithDevelopmentClustering()
+//                     .WithMemoryGrainStorage("Default");
 
 builder.AddProject<Projects.OrleansServer>("silo")
        .WithReference(orleans);


### PR DESCRIPTION
fix for commented-out code in Orleans example contains non-existing methods due to rename
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1780)