### PR TITLE
Orleans: consistently use env-var syntax for config paths

### DIFF
--- a/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
@@ -330,22 +330,22 @@ public static class OrleansServiceExtensions
 
         foreach (var (name, provider) in res.GrainStorage)
         {
-            provider.ConfigureResource(builder, $"GrainStorage:{name}");
+            provider.ConfigureResource(builder, $"GrainStorage__{name}");
         }
 
         foreach (var (name, provider) in res.GrainDirectory)
         {
-            provider.ConfigureResource(builder, $"GrainDirectory:{name}");
+            provider.ConfigureResource(builder, $"GrainDirectory__{name}");
         }
 
         foreach (var (name, provider) in res.Streaming)
         {
-            provider.ConfigureResource(builder, $"Streaming:{name}");
+            provider.ConfigureResource(builder, $"Streaming__{name}");
         }
 
         foreach (var (name, provider) in res.BroadcastChannel)
         {
-            provider.ConfigureResource(builder, $"BroadcastChannel:{name}");
+            provider.ConfigureResource(builder, $"BroadcastChannel__{name}");
         }
 
         if (!string.IsNullOrWhiteSpace(res.ClusterId))


### PR DESCRIPTION
Follow-up to #1779.

This is not strictly required, since we perform a string.Replace anyhow, but consistency makes the convention clearer.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1786)