### PR TITLE
[dashboard-oop] Fix dashboard publish pack by adding published assets to tools folder

### DIFF
--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -28,12 +28,16 @@
 
   <Target Name="BeforeBuild" BeforeTargets="Build">
     <MSBuild Projects="../../src/Aspire.Dashboard/Aspire.Dashboard.csproj" Targets="publish" Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework);RuntimeIdentifier=$(DashboardRuntime)" />
+
+    <!-- After publishing the project, we ensure that the published assets get packed in the nuspec. -->
+    <ItemGroup>
+      <None Include="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/**/*" Pack="true" PackagePath="tools/" />
+    </ItemGroup>
   </Target>
 
   <ItemGroup>
     <None Include="Sdk.props" Pack="true" PackagePath="Sdk/" />
     <None Include="Sdk.targets" Pack="true" PackagePath="Sdk/" />
-    <None Include="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/**/*" Pack="true" PackagePath="tools/" />
     <None Include="UnixFilePermissions.xml" Pack="true" PackagePath="data/" Condition=" '$(DashboardPlatformType)' == 'Unix' " />
   </ItemGroup>
 


### PR DESCRIPTION
Currently published assets are not being added to the package due to a timing issue. This is fixing that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1796)