### PR TITLE
[dashboard-oop] Support starting dashboard as DLL or executable

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -131,7 +131,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             WorkingDirectory = dashboardWorkingDirectory
         };
 
-        if (StringComparer.OrdinalIgnoreCase.Equals(".dll", Path.GetExtension(fullyQualifiedDashboardPath))
+        if (StringComparer.OrdinalIgnoreCase.Equals(".dll", Path.GetExtension(fullyQualifiedDashboardPath)))
         {
             // The dashboard path is a DLL, so run it with `dotnet <dll>`
             dashboardExecutableSpec.ExecutablePath = "dotnet";

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -128,10 +128,20 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         var dashboardExecutableSpec = new ExecutableSpec
         {
             ExecutionType = ExecutionType.Process,
-            ExecutablePath = "dotnet",
-            Args = [fullyQualifiedDashboardPath],
             WorkingDirectory = dashboardWorkingDirectory
         };
+
+        if (StringComparer.OrdinalIgnoreCase.Equals(".dll", Path.GetExtension(fullyQualifiedDashboardPath))
+        {
+            // The dashboard path is a DLL, so run it with `dotnet <dll>`
+            dashboardExecutableSpec.ExecutablePath = "dotnet";
+            dashboardExecutableSpec.Args = [fullyQualifiedDashboardPath];
+        }
+        else
+        {
+            // Assume the dashboard path is directly executable
+            dashboardExecutableSpec.ExecutablePath = fullyQualifiedDashboardPath;
+        }
 
         var grpcEndpointUrl = await _dashboardServiceHost.GetResourceServiceUriAsync(cancellationToken).ConfigureAwait(false);
         var otlpEndpointUrl = Environment.GetEnvironmentVariable("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL");


### PR DESCRIPTION
The workload ships an executable, but `ApplicationExecutor` was written to run a DLL via `dotnet <dll>`.

This change checks whether the dashboard is a DLL or not, and configures the executable spec accordingly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1798)