### PR TITLE
[dashboard-oop] Update dashboard attribute config for playground projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,6 +36,7 @@
     <BuildArch Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64' ">arm64</BuildArch>
     <BuildArch Condition=" '$(BuildArch)' == '' ">amd64</BuildArch>
     <DcpDir>$(NuGetPackageRoot)microsoft.developercontrolplane.$(BuildOs)-$(BuildArch)/$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)/tools/</DcpDir>
+    <AspireDashboardDir>$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/</AspireDashboardDir>
   </PropertyGroup>
 
 </Project>

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <Compile Include="..\..\..\src\Aspire.Hosting\Utils\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
-    <Compile Include="..\..\Shared\WorkloadAttributes.cs" Link="WorkloadAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -13,8 +13,8 @@ builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
 // to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to a relative path to the artifacts
-// directory).
+// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
+// in the artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard)
     .WithEnvironment("DOTNET_DASHBOARD_GRPC_ENDPOINT_URL", "http://localhost:5555")
     .ExcludeFromManifest();

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -12,7 +12,7 @@ builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to WorkloadAttributes.cs
+// to test end developer dashboard launch experience. Refer to Directory.Build.props
 // for the path to the dashboard binary (defaults to a relative path to the artifacts
 // directory).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard)

--- a/playground/Shared/WorkloadAttributes.cs
+++ b/playground/Shared/WorkloadAttributes.cs
@@ -1,9 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using System.Reflection;
-
-// In our released product this attribute is added automatically by the SDK, here we reference
-// the path relative to the AppHost working directory and code inside the ApplicationExecutor
-// resolves it to the full path.
-[assembly:AssemblyMetadata("aspiredashboardpath", "..\\..\\..\\artifacts\\bin\\Aspire.Dashboard\\Debug\\net8.0\\Aspire.Dashboard.dll")]

--- a/playground/dapr/AppHost/DaprAppHost.csproj
+++ b/playground/dapr/AppHost/DaprAppHost.csproj
@@ -10,7 +10,6 @@
 
   <ItemGroup>
     <Compile Include="..\..\..\src\Aspire.Hosting\Utils\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
-    <Compile Include="..\..\Shared\WorkloadAttributes.cs" Link="WorkloadAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/playground/dapr/AppHost/Program.cs
+++ b/playground/dapr/AppHost/Program.cs
@@ -14,7 +14,7 @@ builder.AddProject<Projects.DaprServiceB>("serviceb")
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to WorkloadAttributes.cs
+// to test end developer dashboard launch experience. Refer to Directory.Build.props
 // for the path to the dashboard binary (defaults to a relative path to the artifacts
 // directory).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard)

--- a/playground/dapr/AppHost/Program.cs
+++ b/playground/dapr/AppHost/Program.cs
@@ -15,8 +15,8 @@ builder.AddProject<Projects.DaprServiceB>("serviceb")
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
 // to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to a relative path to the artifacts
-// directory).
+// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
+// in the artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard)
     .WithEnvironment("DOTNET_DASHBOARD_GRPC_ENDPOINT_URL", "http://localhost:5555")
     .ExcludeFromManifest();

--- a/playground/eShopLite/AppHost/AppHost.csproj
+++ b/playground/eShopLite/AppHost/AppHost.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <Compile Include="..\..\..\src\Aspire.Hosting\Utils\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
-    <Compile Include="..\..\Shared\WorkloadAttributes.cs" Link="WorkloadAttributes.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/playground/eShopLite/AppHost/Program.cs
+++ b/playground/eShopLite/AppHost/Program.cs
@@ -34,7 +34,7 @@ builder.AddProject<Projects.CatalogDb>("catalogdbapp")
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to WorkloadAttributes.cs
+// to test end developer dashboard launch experience. Refer to Directory.Build.props
 // for the path to the dashboard binary (defaults to a relative path to the artifacts
 // directory).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard)

--- a/playground/eShopLite/AppHost/Program.cs
+++ b/playground/eShopLite/AppHost/Program.cs
@@ -35,8 +35,8 @@ builder.AddProject<Projects.CatalogDb>("catalogdbapp")
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
 // to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to a relative path to the artifacts
-// directory).
+// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
+// in the artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard)
     .WithEnvironment("DOTNET_DASHBOARD_GRPC_ENDPOINT_URL", "http://localhost:5555")
     .ExcludeFromManifest();

--- a/playground/orleans/OrleansAppHost/OrleansAppHost.csproj
+++ b/playground/orleans/OrleansAppHost/OrleansAppHost.csproj
@@ -11,9 +11,8 @@
 
   <ItemGroup>
     <Compile Include="..\..\..\src\Aspire.Hosting\Utils\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
-    <Compile Include="..\..\Shared\WorkloadAttributes.cs" Link="WorkloadAttributes.cs" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
     <ProjectReference Include="..\..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" />
@@ -21,5 +20,5 @@
     <ProjectReference Include="..\..\..\src\Aspire.Hosting.Orleans\Aspire.Hosting.Orleans.csproj" />
     <ProjectReference Include="..\OrleansServer\OrleansServer.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/playground/orleans/OrleansAppHost/Program.cs
+++ b/playground/orleans/OrleansAppHost/Program.cs
@@ -33,8 +33,8 @@ builder.AddProject<Projects.OrleansServer>("silo")
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
 // to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to a relative path to the artifacts
-// directory).
+// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
+// in the artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard)
     .WithEnvironment("DOTNET_DASHBOARD_GRPC_ENDPOINT_URL", "http://localhost:5555")
     .ExcludeFromManifest();

--- a/playground/orleans/OrleansAppHost/Program.cs
+++ b/playground/orleans/OrleansAppHost/Program.cs
@@ -32,7 +32,7 @@ builder.AddProject<Projects.OrleansServer>("silo")
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to WorkloadAttributes.cs
+// to test end developer dashboard launch experience. Refer to Directory.Build.props
 // for the path to the dashboard binary (defaults to a relative path to the artifacts
 // directory).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard)

--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -143,7 +143,13 @@ internal static class ]]>%(ClassName)<![CDATA[
     </ItemGroup>
   </Target>
 
-  <Target Name="SetDashboardDiscoveryAttributes" BeforeTargets="GetAssemblyAttributes" Condition=" '$(AspireDashboardPath)' != '' ">
+  <Target Name="SetDashboardDiscoveryAttributes" BeforeTargets="GetAssemblyAttributes" Condition=" '$(AspireDashboardDir)' != '' ">
+    <PropertyGroup>
+      <AspireDashboardDir>$([MSBuild]::EnsureTrailingSlash('$(AspireDashboardDir)'))</AspireDashboardDir>
+      <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard'))</AspireDashboardPath>
+      <AspireDashboardPath Condition=" '$(OS)' == 'Windows_NT' and !$(AspireDashboardPath.EndsWith('.exe')) ">$(AspireDashboardPath).exe</AspireDashboardPath>
+    </PropertyGroup>
+
     <ItemGroup>
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
         <_Parameter1>aspiredashboardpath</_Parameter1>


### PR DESCRIPTION
Update some dashboard attribute discovery logic to use Directory.Build.props to define the path to the dashboard binary to match how we reference other workload binaries for local development.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1799)