### PR TITLE
Fix dashboard startup ordering.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,10 @@
     <BuildArch Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64' ">arm64</BuildArch>
     <BuildArch Condition=" '$(BuildArch)' == '' ">amd64</BuildArch>
     <DcpDir>$(NuGetPackageRoot)microsoft.developercontrolplane.$(BuildOs)-$(BuildArch)/$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)/tools/</DcpDir>
-    <AspireDashboardDir>$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/</AspireDashboardDir>
+
+    <!-- TODO: Need to figure out we can automatically detect target framework here. This property
+               is specified to support dashboard path metadata generation on the inner loop. -->
+    <AspireDashboardDir>$(MSBuildThisFileDirectory)/artifacts/bin/Aspire.Dashboard/$(Configuration)/net8.0/</AspireDashboardDir>
   </PropertyGroup>
 
 </Project>

--- a/playground/eShopLite/AppHost/AppHost.csproj
+++ b/playground/eShopLite/AppHost/AppHost.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsAspireHost>true</IsAspireHost>
     <AssemblyName>eShopLite.AppHost</AssemblyName>
+    <AspireDashboardDir>..\..\..\artifacts\bin\Aspire.Dashboard\Debug\net8.0\</AspireDashboardDir>
   </PropertyGroup>
 
   <ItemGroup>

--- a/playground/eShopLite/AppHost/AppHost.csproj
+++ b/playground/eShopLite/AppHost/AppHost.csproj
@@ -7,7 +7,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsAspireHost>true</IsAspireHost>
     <AssemblyName>eShopLite.AppHost</AssemblyName>
-    <AspireDashboardDir>..\..\..\artifacts\bin\Aspire.Dashboard\Debug\net8.0\</AspireDashboardDir>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -80,19 +80,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         AspireEventSource.Instance.DcpModelCreationStart();
         try
         {
-            var (dashboardIndex, dashboardResource) = _model.Resources.IndexOf(static r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard));
-
-            if (dashboardIndex is -1)
+            if (!_model.Resources.Any(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)))
             {
                 // No dashboard is specified, so start one.
                 // TODO validate that the dashboard has not been suppressed
                 await StartDashboardAsync(cancellationToken).ConfigureAwait(false);
-            }
-            else if (dashboardIndex is not 0)
-            {
-                // A dashboard exists in the set. Move it to the front so it starts first.
-                _model.Resources.RemoveAt(dashboardIndex);
-                _model.Resources.Insert(0, dashboardResource);
             }
 
             PrepareServices();
@@ -456,7 +448,18 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         {
             AspireEventSource.Instance.DcpExecutablesCreateStart();
 
-            foreach (var er in executableResources)
+            // Hoisting the aspire-dashboard resource if it exists to the top of
+            // the list so we start it first.
+            var sortedExecutableResources = executableResources.ToList();
+            var (dashboardIndex, dashboardAppResource) = sortedExecutableResources.IndexOf(static r => StringComparers.ResourceName.Equals(r.ModelResource.Name, KnownResourceNames.AspireDashboard));
+
+            if (dashboardIndex > 0)
+            {
+                sortedExecutableResources.RemoveAt(dashboardIndex);
+                sortedExecutableResources.Insert(0, dashboardAppResource);
+            }
+
+            foreach (var er in sortedExecutableResources)
             {
                 ExecutableSpec spec;
                 Func<Task<CustomResource>> createResource;


### PR DESCRIPTION
We now do the reordering of the dashboard resource in `CreateExecutablesAsync(...)`. Reordering in the resources app model didn't do anything because the `_appResources` property ends up with a different ordering.

Note: this PR has a tempoary workaround for the AspireDashboardDir path not being correct. Need to figure out why that isn't working before merging. From what I can tell it could never work the way it is?