### PR TITLE
Enable distributed tracing in Orleans example

### DIFF
--- a/playground/orleans/OrleansServer/Program.cs
+++ b/playground/orleans/OrleansServer/Program.cs
@@ -5,7 +5,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 builder.AddKeyedAzureTableService("clustering");
 builder.AddKeyedAzureBlobService("grainstate");
-builder.UseOrleans();
+builder.UseOrleans(siloBuilder => siloBuilder.AddActivityPropagation());
 
 var app = builder.Build();
 


### PR DESCRIPTION
Call `siloBuilder.AddActivityPropagation` in Orleans example to enable Orleans built-in distributed tracing

To illustrate the effect, here is a before / after of a distributed trace in the Aspire dashboard:

Before:
![image](https://github.com/dotnet/aspire/assets/1872271/65669f51-8ca5-489b-849f-9a16dd7f0ece)

After:
![image](https://github.com/dotnet/aspire/assets/1872271/751139b6-941f-4a58-ba42-c7cdb91966a8)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1811)