### PR TITLE
Fix Aspire title not displayed on telemetry pages

### DIFF
--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -279,7 +279,17 @@ internal sealed class DashboardClient : IDashboardClient
         }
     }
 
-    Task IDashboardClient.WhenConnected => _whenConnected.Task;
+    Task IDashboardClient.WhenConnected
+    {
+        get
+        {
+            // All pages wait for this task (it is used to display the title) but some don't subscribe to resources.
+            // If someone is waiting for the connection, we need to ensure connection is starting.
+            EnsureInitialized();
+
+            return _whenConnected.Task;
+        }
+    }
 
     string IDashboardClient.ApplicationName => _applicationName ?? "";
 


### PR DESCRIPTION
Refreshing the browser on a page that doesn't use resources causes the page title to disappear. The problem is waiting for the `WhenConnected` property doesn't start a connection. The title stays blank until the user browses to a page that uses resources.

![aspire-page-title](https://github.com/dotnet/aspire/assets/303201/2e201511-bfbc-4d5c-826a-d60ce553ddf5)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1814)