### PR TITLE
Update orchestration discovery properties

### DIFF
--- a/eng/dcppack/Aspire.Hosting.Orchestration.targets
+++ b/eng/dcppack/Aspire.Hosting.Orchestration.targets
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <DcpDir Condition=" '$(DcpDir)' == '' ">$([MSBuild]::NormalizeDirectory($(MSBuildThisFileDirectory), '..', 'tools'))</DcpDir>
     <DcpDir>$([MSBuild]::EnsureTrailingSlash('$(DcpDir)'))</DcpDir>
-    <DcpExtensionsPath Condition=" '$(DcpExtensionsPath)' == '' ">$([MSBuild]::NormalizeDirectory($(DcpDir), 'ext'))</DcpExtensionsPath>
-    <DcpExtensionsPath>$([MSBuild]::EnsureTrailingSlash('$(DcpExtensionsPath)'))</DcpExtensionsPath>
-    <DcpBinPath Condition=" '$(DcpBinPath)' == '' ">$([MSBuild]::NormalizeDirectory($(DcpExtensionsPath), 'bin'))</DcpBinPath>
-    <DcpBinPath>$([MSBuild]::EnsureTrailingSlash('$(DcpBinPath)'))</DcpBinPath>
+    <DcpExtensionsDir Condition=" '$(DcpExtensionsDir)' == '' ">$([MSBuild]::NormalizeDirectory($(DcpDir), 'ext'))</DcpExtensionsDir>
+    <DcpExtensionsDir>$([MSBuild]::EnsureTrailingSlash('$(DcpExtensionsDir)'))</DcpExtensionsDir>
+    <DcpBinDir Condition=" '$(DcpBinDir)' == '' ">$([MSBuild]::NormalizeDirectory($(DcpExtensionsDir), 'bin'))</DcpBinDir>
+    <DcpBinDir>$([MSBuild]::EnsureTrailingSlash('$(DcpBinDir)'))</DcpBinDir>
     <DcpCliPath Condition=" '$(DcpCliPath)'  == '' ">$([MSBuild]::NormalizePath($(DcpDir), 'dcp'))</DcpCliPath>
     <DcpCliPath Condition=" '$(OS)' == 'Windows_NT' and !$(DcpCliPath.EndsWith('.exe')) ">$(DcpCliPath).exe</DcpCliPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -114,11 +114,13 @@ internal static class ]]>%(ClassName)<![CDATA[
   <Target Name="WriteServiceMetadataSources" DependsOnTargets="$(_WriteServiceMetadataSourcesDependsOn)" BeforeTargets="CoreCompile" />
 
   <!-- This target registers the location of the Aspire orchestration dependencies -->
-  <Target Name="SetOrchestrationDiscoveryAttributes" BeforeTargets="GetAssemblyAttributes">
+  <Target Name="SetOrchestrationDiscoveryAttributes" BeforeTargets="GetAssemblyAttributes" Condition=" '$(DcpDir)' != '' ">
     <PropertyGroup>
-      <DcpDir Condition=" '$(DcpDir)' == '' ">$([MSBuild]::NormalizePath($([System.Environment]::GetFolderPath(SpecialFolder.UserProfile)), '.dcp'))</DcpDir>
-      <DcpExtensionsPath Condition=" '$(DcpExtensionsPath)' == '' ">$([MSBuild]::NormalizePath($(DcpDir), 'ext'))</DcpExtensionsPath>
-      <DcpBinPath Condition=" '$(DcpBinPath)' == '' ">$([MSBuild]::NormalizePath($(DcpExtensionsPath), 'bin'))</DcpBinPath>
+      <DcpDir>$([MSBuild]::EnsureTrailingSlash('$(DcpDir)'))</DcpDir>
+      <DcpExtensionsDir Condition=" '$(DcpExtensionsDir)' == '' ">$([MSBuild]::NormalizePath($(DcpDir), 'ext'))</DcpExtensionsDir>
+      <DcpExtensionsDir>$([MSBuild]::EnsureTrailingSlash('$(DcpExtensionsDir)'))</DcpExtensionsDir>
+      <DcpBinDir Condition=" '$(DcpBinDir)' == '' ">$([MSBuild]::NormalizePath($(DcpExtensionsDir), 'bin'))</DcpBinDir>
+      <DcpBinDir>$([MSBuild]::EnsureTrailingSlash('$(DcpBinDir)'))</DcpBinDir>
       <DcpCliPath Condition=" '$(DcpCliPath)'  == '' ">$([MSBuild]::NormalizePath($(DcpDir), 'dcp'))</DcpCliPath>
       <DcpCliPath Condition=" '$(OS)' == 'Windows_NT' and !$(DcpCliPath.EndsWith('.exe')) ">$(DcpCliPath).exe</DcpCliPath>
     </PropertyGroup>
@@ -130,11 +132,11 @@ internal static class ]]>%(ClassName)<![CDATA[
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
         <_Parameter1>dcpextensionpaths</_Parameter1>
-        <_Parameter2>$(DcpExtensionsPath)</_Parameter2>
+        <_Parameter2>$(DcpExtensionsDir)</_Parameter2>
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
         <_Parameter1>dcpbinpath</_Parameter1>
-        <_Parameter2>$(DcpBinPath)</_Parameter2>
+        <_Parameter2>$(DcpBinDir)</_Parameter2>
       </AssemblyAttribute>
       <AssemblyAttribute Include="System.Reflection.AssemblyMetadata">
         <_Parameter1>apphostprojectpath</_Parameter1>


### PR DESCRIPTION
Standardize the MSBuild properties for orchestration discovery to use Dir suffix for directories and Path suffix for file names (to match the new dashboard discovery properties). Removes default path behavior for attributes if DcpDir isn't defined (workload is missing).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1826)