### PR TITLE
Add public API tracking

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -350,6 +350,9 @@ dotnet_diagnostic.IDE0200.severity = warning
 dotnet_style_allow_multiple_blank_lines_experimental = false
 dotnet_diagnostic.IDE2000.severity = warning
 
+# RS0026: Backcompat: Do not add multiple overloads with optional parameters
+dotnet_diagnostic.RS0026.severity = none
+
 [{eng/tools/**.cs,**/{test,testassets,samples,Samples,perf,benchmarkapps,scripts,stress}/**.cs,src/Hosting/Server.IntegrationTesting/**.cs,src/Servers/IIS/IntegrationTesting.IIS/**.cs,src/Shared/Http2cat/**.cs,src/Testing/**.cs}]
 # CA1018: Mark attributes with AttributeUsageAttribute
 dotnet_diagnostic.CA1018.severity = suggestion

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -116,5 +116,7 @@
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Installers" Version="8.0.0-beta.23564.4" />
     <!-- unit test dependencies -->
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.0.0" />
+    <!-- analyzers -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.11.0-beta1.23525.2" />
   </ItemGroup>
 </Project>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -21,6 +21,11 @@
     <PackageReference Include="Humanizer.Core" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" />
     <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components.Icons" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/PublicAPI.Shipped.txt
+++ b/src/Aspire.Dashboard/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Aspire.Dashboard/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Dashboard/PublicAPI.Unshipped.txt
@@ -1,0 +1,2390 @@
+#nullable enable
+abstract Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase.Clone() -> Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase!
+Aspire.Dashboard.Components.ApplicationName
+Aspire.Dashboard.Components.ApplicationName.ApplicationName() -> void
+Aspire.Dashboard.Components.ApplicationName.DashboardClient.get -> Aspire.Dashboard.Model.IDashboardClient!
+Aspire.Dashboard.Components.ApplicationName.DashboardClient.init -> void
+Aspire.Dashboard.Components.ApplicationName.Dispose() -> void
+Aspire.Dashboard.Components.ApplicationName.Loc.get -> Microsoft.Extensions.Localization.IStringLocalizer!
+Aspire.Dashboard.Components.ApplicationName.Loc.init -> void
+Aspire.Dashboard.Components.ApplicationName.ResourceName.get -> string!
+Aspire.Dashboard.Components.ApplicationName.ResourceName.init -> void
+Aspire.Dashboard.Components.ChartContainer
+Aspire.Dashboard.Components.ChartContainer.ApplicationId.get -> string!
+Aspire.Dashboard.Components.ChartContainer.ApplicationId.set -> void
+Aspire.Dashboard.Components.ChartContainer.ChartContainer() -> void
+Aspire.Dashboard.Components.ChartContainer.DimensionValuesChangedAsync(Aspire.Dashboard.Model.DimensionFilterViewModel! dimensionViewModel) -> System.Threading.Tasks.Task!
+Aspire.Dashboard.Components.ChartContainer.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Aspire.Dashboard.Components.ChartContainer.Duration.get -> System.TimeSpan
+Aspire.Dashboard.Components.ChartContainer.Duration.set -> void
+Aspire.Dashboard.Components.ChartContainer.InstrumentName.get -> string!
+Aspire.Dashboard.Components.ChartContainer.InstrumentName.set -> void
+Aspire.Dashboard.Components.ChartContainer.Logger.get -> Microsoft.Extensions.Logging.ILogger<Aspire.Dashboard.Components.ChartContainer!>!
+Aspire.Dashboard.Components.ChartContainer.Logger.set -> void
+Aspire.Dashboard.Components.ChartContainer.MeterName.get -> string!
+Aspire.Dashboard.Components.ChartContainer.MeterName.set -> void
+Aspire.Dashboard.Components.ChartContainer.TelemetryRepository.get -> Aspire.Dashboard.Otlp.Storage.TelemetryRepository!
+Aspire.Dashboard.Components.ChartContainer.TelemetryRepository.set -> void
+Aspire.Dashboard.Components.ChartContainer.ThemeManager.get -> Aspire.Dashboard.Model.ThemeManager!
+Aspire.Dashboard.Components.ChartContainer.ThemeManager.set -> void
+Aspire.Dashboard.Components.Controls.FluentIconSwitch
+Aspire.Dashboard.Components.Controls.FluentIconSwitch.FluentIconSwitch() -> void
+Aspire.Dashboard.Components.Controls.GridValue
+Aspire.Dashboard.Components.Controls.GridValue.ContentAfterValue.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Aspire.Dashboard.Components.Controls.GridValue.ContentAfterValue.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.EnableHighlighting.get -> bool
+Aspire.Dashboard.Components.Controls.GridValue.EnableHighlighting.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.EnableMasking.get -> bool
+Aspire.Dashboard.Components.Controls.GridValue.EnableMasking.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.GridValue() -> void
+Aspire.Dashboard.Components.Controls.GridValue.HighlightText.get -> string?
+Aspire.Dashboard.Components.Controls.GridValue.HighlightText.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.IsMasked.get -> bool
+Aspire.Dashboard.Components.Controls.GridValue.IsMasked.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.IsMaskedChanged.get -> Microsoft.AspNetCore.Components.EventCallback<bool>
+Aspire.Dashboard.Components.Controls.GridValue.IsMaskedChanged.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.MaxDisplayLength.get -> int?
+Aspire.Dashboard.Components.Controls.GridValue.MaxDisplayLength.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.PostCopyToolTip.get -> string!
+Aspire.Dashboard.Components.Controls.GridValue.PostCopyToolTip.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.PreCopyToolTip.get -> string!
+Aspire.Dashboard.Components.Controls.GridValue.PreCopyToolTip.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.ToolTip.get -> string?
+Aspire.Dashboard.Components.Controls.GridValue.ToolTip.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.Value.get -> string?
+Aspire.Dashboard.Components.Controls.GridValue.Value.set -> void
+Aspire.Dashboard.Components.Controls.GridValue.ValueToCopy.get -> string?
+Aspire.Dashboard.Components.Controls.GridValue.ValueToCopy.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.EnableValueMasking.get -> bool
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.EnableValueMasking.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.ExtraValueContent.get -> Microsoft.AspNetCore.Components.RenderFragment<TItem>!
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.ExtraValueContent.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.GetIsItemMasked.get -> System.Func<TItem, bool>!
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.GetIsItemMasked.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.GridTemplateColumns.get -> string!
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.GridTemplateColumns.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.HighlightText.get -> string?
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.HighlightText.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.IsMaskedChanged.get -> Microsoft.AspNetCore.Components.EventCallback<TItem>
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.IsMaskedChanged.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.IsNameSortable.get -> bool
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.IsNameSortable.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.IsValueSortable.get -> bool
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.IsValueSortable.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.Items.get -> System.Linq.IQueryable<TItem>?
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.Items.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.NameColumnTitle.get -> string?
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.NameColumnTitle.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.NameColumnValue.get -> System.Func<TItem, string?>!
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.NameColumnValue.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.NameSort.get -> Microsoft.FluentUI.AspNetCore.Components.GridSort<TItem>?
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.NameSort.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGrid() -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.Deconstruct(out TItem Item, out bool NewValue) -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.Equals(Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs other) -> bool
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.Item.get -> TItem
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.Item.init -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.NewValue.get -> bool
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.NewValue.init -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.PropertyGridIsMaskedChangedArgs() -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.PropertyGridIsMaskedChangedArgs(TItem Item, bool NewValue) -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.SetIsItemMasked.get -> System.Action<TItem, bool>!
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.SetIsItemMasked.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.ValueColumnTitle.get -> string?
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.ValueColumnTitle.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.ValueColumnValue.get -> System.Func<TItem, string?>!
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.ValueColumnValue.set -> void
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.ValueSort.get -> Microsoft.FluentUI.AspNetCore.Components.GridSort<TItem>?
+Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.ValueSort.set -> void
+Aspire.Dashboard.Components.Controls.ResourceDetails
+Aspire.Dashboard.Components.Controls.ResourceDetails.Loc.get -> Microsoft.Extensions.Localization.IStringLocalizer<Aspire.Dashboard.Resources.Resources!>!
+Aspire.Dashboard.Components.Controls.ResourceDetails.Loc.init -> void
+Aspire.Dashboard.Components.Controls.ResourceDetails.Resource.get -> Aspire.Dashboard.Model.ResourceViewModel!
+Aspire.Dashboard.Components.Controls.ResourceDetails.Resource.set -> void
+Aspire.Dashboard.Components.Controls.ResourceDetails.ResourceDetails() -> void
+Aspire.Dashboard.Components.Controls.ResourceDetails.ShowSpecOnlyToggle.get -> bool
+Aspire.Dashboard.Components.Controls.ResourceDetails.ShowSpecOnlyToggle.set -> void
+Aspire.Dashboard.Components.Controls.SpanDetails
+Aspire.Dashboard.Components.Controls.SpanDetails.SpanDetails() -> void
+Aspire.Dashboard.Components.Controls.SpanDetails.ViewModel.get -> Aspire.Dashboard.Model.SpanDetailsViewModel!
+Aspire.Dashboard.Components.Controls.SpanDetails.ViewModel.set -> void
+Aspire.Dashboard.Components.Controls.StructuredLogDetails
+Aspire.Dashboard.Components.Controls.StructuredLogDetails.Items.get -> System.Collections.Generic.IEnumerable<Aspire.Dashboard.Model.LogEntryPropertyViewModel!>!
+Aspire.Dashboard.Components.Controls.StructuredLogDetails.Items.set -> void
+Aspire.Dashboard.Components.Controls.StructuredLogDetails.StructuredLogDetails() -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.Details.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.Details.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.DetailsTitle.get -> string?
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.DetailsTitle.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.DetailsTitleTemplate.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.DetailsTitleTemplate.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.NavigationManager.get -> Microsoft.AspNetCore.Components.NavigationManager!
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.NavigationManager.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.OnDismiss.get -> Microsoft.AspNetCore.Components.EventCallback
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.OnDismiss.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.Orientation.get -> Microsoft.FluentUI.AspNetCore.Components.Orientation
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.Orientation.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.ProtectedLocalStore.get -> Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage.ProtectedLocalStorage!
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.ProtectedLocalStore.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.RememberOrientation.get -> bool
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.RememberOrientation.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.RememberSize.get -> bool
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.RememberSize.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.ShowDetails.get -> bool
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.ShowDetails.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.Summary.get -> Microsoft.AspNetCore.Components.RenderFragment?
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.Summary.set -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.SummaryDetailsView() -> void
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.ViewKey.get -> string?
+Aspire.Dashboard.Components.Controls.SummaryDetailsView.ViewKey.set -> void
+Aspire.Dashboard.Components.Dialogs.FilterDialog
+Aspire.Dashboard.Components.Dialogs.FilterDialog.Content.get -> Aspire.Dashboard.Model.FilterDialogViewModel!
+Aspire.Dashboard.Components.Dialogs.FilterDialog.Content.set -> void
+Aspire.Dashboard.Components.Dialogs.FilterDialog.Dialog.get -> Microsoft.FluentUI.AspNetCore.Components.FluentDialog?
+Aspire.Dashboard.Components.Dialogs.FilterDialog.Dialog.set -> void
+Aspire.Dashboard.Components.Dialogs.FilterDialog.EditContext.get -> Microsoft.AspNetCore.Components.Forms.EditContext!
+Aspire.Dashboard.Components.Dialogs.FilterDialog.FilterDialog() -> void
+Aspire.Dashboard.Components.Dialogs.FilterDialog.Parameters.get -> System.Collections.Generic.List<string!>!
+Aspire.Dashboard.Components.Dialogs.FilterDialog.TelemetryRepository.get -> Aspire.Dashboard.Otlp.Storage.TelemetryRepository!
+Aspire.Dashboard.Components.Dialogs.FilterDialog.TelemetryRepository.set -> void
+Aspire.Dashboard.Components.Dialogs.SettingsDialog
+Aspire.Dashboard.Components.Dialogs.SettingsDialog.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Aspire.Dashboard.Components.Dialogs.SettingsDialog.JS.get -> Microsoft.JSInterop.IJSRuntime!
+Aspire.Dashboard.Components.Dialogs.SettingsDialog.JS.set -> void
+Aspire.Dashboard.Components.Dialogs.SettingsDialog.SettingsDialog() -> void
+Aspire.Dashboard.Components.Dialogs.SettingsDialog.ThemeManager.get -> Aspire.Dashboard.Model.ThemeManager!
+Aspire.Dashboard.Components.Dialogs.SettingsDialog.ThemeManager.set -> void
+Aspire.Dashboard.Components.Layout.MainLayout
+Aspire.Dashboard.Components.Layout.MainLayout.DashboardClient.get -> Aspire.Dashboard.Model.IDashboardClient!
+Aspire.Dashboard.Components.Layout.MainLayout.DashboardClient.set -> void
+Aspire.Dashboard.Components.Layout.MainLayout.DialogService.get -> Microsoft.FluentUI.AspNetCore.Components.IDialogService!
+Aspire.Dashboard.Components.Layout.MainLayout.DialogService.set -> void
+Aspire.Dashboard.Components.Layout.MainLayout.Dispose() -> void
+Aspire.Dashboard.Components.Layout.MainLayout.JS.get -> Microsoft.JSInterop.IJSRuntime!
+Aspire.Dashboard.Components.Layout.MainLayout.JS.set -> void
+Aspire.Dashboard.Components.Layout.MainLayout.LaunchSettings() -> System.Threading.Tasks.Task!
+Aspire.Dashboard.Components.Layout.MainLayout.Loc.get -> Microsoft.Extensions.Localization.IStringLocalizer<Aspire.Dashboard.Resources.Layout!>!
+Aspire.Dashboard.Components.Layout.MainLayout.Loc.set -> void
+Aspire.Dashboard.Components.Layout.MainLayout.MainLayout() -> void
+Aspire.Dashboard.Components.Layout.MainLayout.ThemeManager.get -> Aspire.Dashboard.Model.ThemeManager!
+Aspire.Dashboard.Components.Layout.MainLayout.ThemeManager.init -> void
+Aspire.Dashboard.Components.LogViewer
+Aspire.Dashboard.Components.LogViewer.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Aspire.Dashboard.Components.LogViewer.LogViewer() -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs
+Aspire.Dashboard.Components.Pages.ConsoleLogs.BasePath.get -> string!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogs() -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsPageState
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsPageState.ConsoleLogsPageState() -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsPageState.SelectedResource.get -> string?
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsPageState.SelectedResource.set -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel.ConsoleLogsViewModel() -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel.InitialisedSuccessfully.get -> bool?
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel.InitialisedSuccessfully.set -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel.SelectedOption.get -> Microsoft.FluentUI.AspNetCore.Components.Option<string!>?
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel.SelectedOption.set -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel.SelectedResource.get -> Aspire.Dashboard.Model.ResourceViewModel?
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel.SelectedResource.set -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel.Status.get -> string!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel.Status.set -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ConvertViewModelToSerializable() -> Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsPageState!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.DashboardClient.get -> Aspire.Dashboard.Model.IDashboardClient!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.DashboardClient.init -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Aspire.Dashboard.Components.Pages.ConsoleLogs.GetUrlFromSerializableViewModel(Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsPageState! serializable) -> Aspire.Dashboard.Components.Pages.UrlState!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.JS.get -> Microsoft.JSInterop.IJSRuntime!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.JS.init -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.NavigationManager.get -> Microsoft.AspNetCore.Components.NavigationManager!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.NavigationManager.set -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ResourceName.get -> string?
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ResourceName.set -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.SessionStorage.get -> Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage.ProtectedSessionStorage!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.SessionStorage.set -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.SessionStorageKey.get -> string!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.UpdateViewModelFromQuery(Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel! viewModel) -> void
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ViewModel.get -> Aspire.Dashboard.Components.Pages.ConsoleLogs.ConsoleLogsViewModel!
+Aspire.Dashboard.Components.Pages.ConsoleLogs.ViewModel.set -> void
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.BasePath.get -> string!
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.ConvertViewModelToSerializable() -> TSerializableViewModel!
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.GetUrlFromSerializableViewModel(TSerializableViewModel! serializable) -> Aspire.Dashboard.Components.Pages.UrlState!
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.NavigationManager.get -> Microsoft.AspNetCore.Components.NavigationManager!
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.NavigationManager.set -> void
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.SessionStorage.get -> Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage.ProtectedSessionStorage!
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.SessionStorageKey.get -> string!
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.UpdateViewModelFromQuery(TViewModel viewModel) -> void
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.ViewModel.get -> TViewModel
+Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>.ViewModel.set -> void
+Aspire.Dashboard.Components.Pages.Metrics
+Aspire.Dashboard.Components.Pages.Metrics.ApplicationInstanceId.get -> string?
+Aspire.Dashboard.Components.Pages.Metrics.ApplicationInstanceId.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.BasePath.get -> string!
+Aspire.Dashboard.Components.Pages.Metrics.ConvertViewModelToSerializable() -> Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState!
+Aspire.Dashboard.Components.Pages.Metrics.DashboardClient.get -> Aspire.Dashboard.Model.IDashboardClient!
+Aspire.Dashboard.Components.Pages.Metrics.DashboardClient.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.Dispose() -> void
+Aspire.Dashboard.Components.Pages.Metrics.DurationMinutes.get -> int
+Aspire.Dashboard.Components.Pages.Metrics.DurationMinutes.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.GetUrlFromSerializableViewModel(Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState! serializable) -> Aspire.Dashboard.Components.Pages.UrlState!
+Aspire.Dashboard.Components.Pages.Metrics.InstrumentName.get -> string?
+Aspire.Dashboard.Components.Pages.Metrics.InstrumentName.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MeterName.get -> string?
+Aspire.Dashboard.Components.Pages.Metrics.MeterName.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.Metrics() -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState.ApplicationId.get -> string?
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState.ApplicationId.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState.DurationMinutes.get -> int
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState.DurationMinutes.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState.InstrumentName.get -> string?
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState.InstrumentName.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState.MeterName.get -> string?
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState.MeterName.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsPageState.MetricsPageState() -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.Instruments.get -> System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.OtlpInstrument!>?
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.Instruments.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.MetricsViewModel() -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedApplication.get -> Aspire.Dashboard.Model.Otlp.SelectViewModel<string!>!
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedApplication.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedDuration.get -> Aspire.Dashboard.Model.Otlp.SelectViewModel<System.TimeSpan>!
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedDuration.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedInstrument.get -> Aspire.Dashboard.Otlp.Model.OtlpInstrument?
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedInstrument.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedMeter.get -> Aspire.Dashboard.Otlp.Model.OtlpMeter?
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedMeter.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedTreeItem.get -> Microsoft.FluentUI.AspNetCore.Components.FluentTreeItem?
+Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel.SelectedTreeItem.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.NavigationManager.get -> Microsoft.AspNetCore.Components.NavigationManager!
+Aspire.Dashboard.Components.Pages.Metrics.NavigationManager.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.SessionStorage.get -> Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage.ProtectedSessionStorage!
+Aspire.Dashboard.Components.Pages.Metrics.SessionStorage.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.SessionStorageKey.get -> string!
+Aspire.Dashboard.Components.Pages.Metrics.TelemetryRepository.get -> Aspire.Dashboard.Otlp.Storage.TelemetryRepository!
+Aspire.Dashboard.Components.Pages.Metrics.TelemetryRepository.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.TracesViewModel.get -> Aspire.Dashboard.Model.TracesViewModel!
+Aspire.Dashboard.Components.Pages.Metrics.TracesViewModel.set -> void
+Aspire.Dashboard.Components.Pages.Metrics.UpdateViewModelFromQuery(Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel! viewModel) -> void
+Aspire.Dashboard.Components.Pages.Metrics.ViewModel.get -> Aspire.Dashboard.Components.Pages.Metrics.MetricsViewModel!
+Aspire.Dashboard.Components.Pages.Metrics.ViewModel.set -> void
+Aspire.Dashboard.Components.Pages.PageExtensions
+Aspire.Dashboard.Components.Pages.Resources
+Aspire.Dashboard.Components.Pages.Resources.DashboardClient.get -> Aspire.Dashboard.Model.IDashboardClient!
+Aspire.Dashboard.Components.Pages.Resources.DashboardClient.init -> void
+Aspire.Dashboard.Components.Pages.Resources.Dispose() -> void
+Aspire.Dashboard.Components.Pages.Resources.NavigationManager.get -> Microsoft.AspNetCore.Components.NavigationManager!
+Aspire.Dashboard.Components.Pages.Resources.NavigationManager.init -> void
+Aspire.Dashboard.Components.Pages.Resources.OnResourceTypeVisibilityChanged(string! resourceType, bool isVisible) -> void
+Aspire.Dashboard.Components.Pages.Resources.Resources() -> void
+Aspire.Dashboard.Components.Pages.Resources.TelemetryRepository.get -> Aspire.Dashboard.Otlp.Storage.TelemetryRepository!
+Aspire.Dashboard.Components.Pages.Resources.TelemetryRepository.init -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs
+Aspire.Dashboard.Components.Pages.StructuredLogs.ApplicationInstanceId.get -> string?
+Aspire.Dashboard.Components.Pages.StructuredLogs.ApplicationInstanceId.set -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs.DialogService.get -> Microsoft.FluentUI.AspNetCore.Components.IDialogService!
+Aspire.Dashboard.Components.Pages.StructuredLogs.DialogService.set -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs.Dispose() -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs.LogLevelText.get -> string?
+Aspire.Dashboard.Components.Pages.StructuredLogs.LogLevelText.set -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs.SelectedLogEntryProperties.get -> System.Collections.Generic.IEnumerable<Aspire.Dashboard.Model.LogEntryPropertyViewModel!>?
+Aspire.Dashboard.Components.Pages.StructuredLogs.SelectedLogEntryProperties.set -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs.SpanId.get -> string?
+Aspire.Dashboard.Components.Pages.StructuredLogs.SpanId.set -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs.StructuredLogs() -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs.TelemetryRepository.get -> Aspire.Dashboard.Otlp.Storage.TelemetryRepository!
+Aspire.Dashboard.Components.Pages.StructuredLogs.TelemetryRepository.set -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs.TraceId.get -> string?
+Aspire.Dashboard.Components.Pages.StructuredLogs.TraceId.set -> void
+Aspire.Dashboard.Components.Pages.StructuredLogs.ViewModel.get -> Aspire.Dashboard.Model.StructuredLogsViewModel!
+Aspire.Dashboard.Components.Pages.StructuredLogs.ViewModel.set -> void
+Aspire.Dashboard.Components.Pages.TraceDetail
+Aspire.Dashboard.Components.Pages.TraceDetail.Dispose() -> void
+Aspire.Dashboard.Components.Pages.TraceDetail.OutgoingPeerResolvers.get -> System.Collections.Generic.IEnumerable<Aspire.Dashboard.Model.IOutgoingPeerResolver!>!
+Aspire.Dashboard.Components.Pages.TraceDetail.OutgoingPeerResolvers.set -> void
+Aspire.Dashboard.Components.Pages.TraceDetail.SelectedSpan.get -> Aspire.Dashboard.Model.SpanDetailsViewModel?
+Aspire.Dashboard.Components.Pages.TraceDetail.SelectedSpan.set -> void
+Aspire.Dashboard.Components.Pages.TraceDetail.SpanId.get -> string?
+Aspire.Dashboard.Components.Pages.TraceDetail.SpanId.set -> void
+Aspire.Dashboard.Components.Pages.TraceDetail.TelemetryRepository.get -> Aspire.Dashboard.Otlp.Storage.TelemetryRepository!
+Aspire.Dashboard.Components.Pages.TraceDetail.TelemetryRepository.set -> void
+Aspire.Dashboard.Components.Pages.TraceDetail.TraceDetail() -> void
+Aspire.Dashboard.Components.Pages.TraceDetail.TraceId.get -> string!
+Aspire.Dashboard.Components.Pages.TraceDetail.TraceId.set -> void
+Aspire.Dashboard.Components.Pages.Traces
+Aspire.Dashboard.Components.Pages.Traces.ApplicationInstanceId.get -> string?
+Aspire.Dashboard.Components.Pages.Traces.ApplicationInstanceId.set -> void
+Aspire.Dashboard.Components.Pages.Traces.DialogService.get -> Microsoft.FluentUI.AspNetCore.Components.IDialogService!
+Aspire.Dashboard.Components.Pages.Traces.DialogService.set -> void
+Aspire.Dashboard.Components.Pages.Traces.Dispose() -> void
+Aspire.Dashboard.Components.Pages.Traces.TelemetryRepository.get -> Aspire.Dashboard.Otlp.Storage.TelemetryRepository!
+Aspire.Dashboard.Components.Pages.Traces.TelemetryRepository.set -> void
+Aspire.Dashboard.Components.Pages.Traces.Traces() -> void
+Aspire.Dashboard.Components.Pages.Traces.TracesViewModel.get -> Aspire.Dashboard.Model.TracesViewModel!
+Aspire.Dashboard.Components.Pages.Traces.TracesViewModel.set -> void
+Aspire.Dashboard.Components.Pages.UrlState
+Aspire.Dashboard.Components.Pages.UrlState.<Clone>$() -> Aspire.Dashboard.Components.Pages.UrlState!
+Aspire.Dashboard.Components.Pages.UrlState.Deconstruct(out string! Path, out System.Collections.Generic.Dictionary<string!, string?>? QueryParameters) -> void
+Aspire.Dashboard.Components.Pages.UrlState.Equals(Aspire.Dashboard.Components.Pages.UrlState? other) -> bool
+Aspire.Dashboard.Components.Pages.UrlState.Path.get -> string!
+Aspire.Dashboard.Components.Pages.UrlState.Path.init -> void
+Aspire.Dashboard.Components.Pages.UrlState.QueryParameters.get -> System.Collections.Generic.Dictionary<string!, string?>?
+Aspire.Dashboard.Components.Pages.UrlState.QueryParameters.init -> void
+Aspire.Dashboard.Components.Pages.UrlState.UrlState(string! Path, System.Collections.Generic.Dictionary<string!, string?>? QueryParameters) -> void
+Aspire.Dashboard.Components.PlotlyChart
+Aspire.Dashboard.Components.PlotlyChart.Duration.get -> System.TimeSpan
+Aspire.Dashboard.Components.PlotlyChart.Duration.set -> void
+Aspire.Dashboard.Components.PlotlyChart.InstrumentViewModel.get -> Aspire.Dashboard.Model.InstrumentViewModel!
+Aspire.Dashboard.Components.PlotlyChart.InstrumentViewModel.set -> void
+Aspire.Dashboard.Components.PlotlyChart.JSRuntime.get -> Microsoft.JSInterop.IJSRuntime!
+Aspire.Dashboard.Components.PlotlyChart.JSRuntime.set -> void
+Aspire.Dashboard.Components.PlotlyChart.PlotlyChart() -> void
+Aspire.Dashboard.Components.ResourcesGridColumns.StateColumnDisplay
+Aspire.Dashboard.Components.ResourcesGridColumns.StateColumnDisplay.Resource.get -> Aspire.Dashboard.Model.ResourceViewModel!
+Aspire.Dashboard.Components.ResourcesGridColumns.StateColumnDisplay.Resource.set -> void
+Aspire.Dashboard.Components.ResourcesGridColumns.StateColumnDisplay.StateColumnDisplay() -> void
+Aspire.Dashboard.Components.ResourcesGridColumns.StateColumnDisplay.UnviewedErrorCounts.get -> System.Collections.Generic.Dictionary<Aspire.Dashboard.Otlp.Model.OtlpApplication!, int>?
+Aspire.Dashboard.Components.ResourcesGridColumns.StateColumnDisplay.UnviewedErrorCounts.set -> void
+Aspire.Dashboard.Components.UnreadLogErrorsBadge
+Aspire.Dashboard.Components.UnreadLogErrorsBadge.NavigationManager.get -> Microsoft.AspNetCore.Components.NavigationManager!
+Aspire.Dashboard.Components.UnreadLogErrorsBadge.NavigationManager.init -> void
+Aspire.Dashboard.Components.UnreadLogErrorsBadge.Resource.get -> Aspire.Dashboard.Model.ResourceViewModel!
+Aspire.Dashboard.Components.UnreadLogErrorsBadge.Resource.set -> void
+Aspire.Dashboard.Components.UnreadLogErrorsBadge.TelemetryRepository.get -> Aspire.Dashboard.Otlp.Storage.TelemetryRepository!
+Aspire.Dashboard.Components.UnreadLogErrorsBadge.TelemetryRepository.init -> void
+Aspire.Dashboard.Components.UnreadLogErrorsBadge.UnreadLogErrorsBadge() -> void
+Aspire.Dashboard.Components.UnreadLogErrorsBadge.UnviewedErrorCounts.get -> System.Collections.Generic.Dictionary<Aspire.Dashboard.Otlp.Model.OtlpApplication!, int>?
+Aspire.Dashboard.Components.UnreadLogErrorsBadge.UnviewedErrorCounts.set -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser
+Aspire.Dashboard.ConsoleLogs.AnsiParser.AnsiParser() -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.ConversionResult() -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.ConversionResult(string? ConvertedText, Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState ResidualState) -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.ConvertedText.get -> string?
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.ConvertedText.init -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.Deconstruct(out string? ConvertedText, out Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState ResidualState) -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.Equals(Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult other) -> bool
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.ResidualState.get -> Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.ResidualState.init -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.BackgroundColor.get -> System.ConsoleColor?
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.BackgroundColor.set -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.Bright.get -> bool
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.Bright.set -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.Equals(Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState other) -> bool
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.ForegroundColor.get -> System.ConsoleColor?
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.ForegroundColor.set -> void
+Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.ParserState() -> void
+Aspire.Dashboard.ConsoleLogs.LogLevelParser
+Aspire.Dashboard.ConsoleLogs.TimestampParser
+Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult
+Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.Deconstruct(out string! ModifiedText, out string! Timestamp) -> void
+Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.Equals(Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult other) -> bool
+Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.ModifiedText.get -> string!
+Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.ModifiedText.init -> void
+Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.Timestamp.get -> string!
+Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.Timestamp.init -> void
+Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.TimestampParserResult() -> void
+Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.TimestampParserResult(string! ModifiedText, string! Timestamp) -> void
+Aspire.Dashboard.ConsoleLogs.UrlParser
+Aspire.Dashboard.DashboardWebApplication
+Aspire.Dashboard.DashboardWebApplication.DashboardWebApplication() -> void
+Aspire.Dashboard.DashboardWebApplication.Run() -> void
+Aspire.Dashboard.Model.BrowserLinkOutgoingPeerResolver
+Aspire.Dashboard.Model.BrowserLinkOutgoingPeerResolver.BrowserLinkOutgoingPeerResolver() -> void
+Aspire.Dashboard.Model.BrowserLinkOutgoingPeerResolver.OnPeerChanges(System.Func<System.Threading.Tasks.Task!>! callback) -> System.IDisposable!
+Aspire.Dashboard.Model.BrowserLinkOutgoingPeerResolver.TryResolvePeerName(System.Collections.Generic.KeyValuePair<string!, string!>[]! attributes, out string? name) -> bool
+Aspire.Dashboard.Model.CounterChartViewModel
+Aspire.Dashboard.Model.CounterChartViewModel.CounterChartViewModel() -> void
+Aspire.Dashboard.Model.CounterChartViewModel.DimensionFilters.get -> System.Collections.Generic.List<Aspire.Dashboard.Model.DimensionFilterViewModel!>!
+Aspire.Dashboard.Model.DimensionFilterViewModel
+Aspire.Dashboard.Model.DimensionFilterViewModel.AreAllValuesSelected.get -> bool?
+Aspire.Dashboard.Model.DimensionFilterViewModel.AreAllValuesSelected.set -> void
+Aspire.Dashboard.Model.DimensionFilterViewModel.DimensionFilterViewModel() -> void
+Aspire.Dashboard.Model.DimensionFilterViewModel.Name.get -> string!
+Aspire.Dashboard.Model.DimensionFilterViewModel.Name.init -> void
+Aspire.Dashboard.Model.DimensionFilterViewModel.OnTagSelectionChanged(Aspire.Dashboard.Model.DimensionValueViewModel! dimensionValue, bool isChecked) -> void
+Aspire.Dashboard.Model.DimensionFilterViewModel.PopupVisible.get -> bool
+Aspire.Dashboard.Model.DimensionFilterViewModel.PopupVisible.set -> void
+Aspire.Dashboard.Model.DimensionFilterViewModel.SanitizedHtmlId.get -> string!
+Aspire.Dashboard.Model.DimensionFilterViewModel.SelectedValues.get -> System.Collections.Generic.HashSet<Aspire.Dashboard.Model.DimensionValueViewModel!>!
+Aspire.Dashboard.Model.DimensionFilterViewModel.Values.get -> System.Collections.Generic.List<Aspire.Dashboard.Model.DimensionValueViewModel!>!
+Aspire.Dashboard.Model.DimensionValueViewModel
+Aspire.Dashboard.Model.DimensionValueViewModel.DimensionValueViewModel() -> void
+Aspire.Dashboard.Model.DimensionValueViewModel.Empty.get -> bool
+Aspire.Dashboard.Model.DimensionValueViewModel.Empty.init -> void
+Aspire.Dashboard.Model.DimensionValueViewModel.Name.get -> string!
+Aspire.Dashboard.Model.DimensionValueViewModel.Name.init -> void
+Aspire.Dashboard.Model.EndpointViewModel
+Aspire.Dashboard.Model.EndpointViewModel.EndpointUrl.get -> string!
+Aspire.Dashboard.Model.EndpointViewModel.EndpointViewModel(string! endpointUrl, string! proxyUrl) -> void
+Aspire.Dashboard.Model.EndpointViewModel.ProxyUrl.get -> string!
+Aspire.Dashboard.Model.EnvironmentVariablesDialogViewModel
+Aspire.Dashboard.Model.EnvironmentVariablesDialogViewModel.EnvironmentVariables.get -> System.Collections.Generic.List<Aspire.Dashboard.Model.EnvironmentVariableViewModel!>!
+Aspire.Dashboard.Model.EnvironmentVariablesDialogViewModel.EnvironmentVariables.init -> void
+Aspire.Dashboard.Model.EnvironmentVariablesDialogViewModel.EnvironmentVariablesDialogViewModel() -> void
+Aspire.Dashboard.Model.EnvironmentVariablesDialogViewModel.ShowSpecOnlyToggle.get -> bool
+Aspire.Dashboard.Model.EnvironmentVariablesDialogViewModel.ShowSpecOnlyToggle.set -> void
+Aspire.Dashboard.Model.EnvironmentVariableViewModel
+Aspire.Dashboard.Model.EnvironmentVariableViewModel.EnvironmentVariableViewModel(string! name, string? value, bool fromSpec) -> void
+Aspire.Dashboard.Model.EnvironmentVariableViewModel.FromSpec.get -> bool
+Aspire.Dashboard.Model.EnvironmentVariableViewModel.IsValueMasked.get -> bool
+Aspire.Dashboard.Model.EnvironmentVariableViewModel.IsValueMasked.set -> void
+Aspire.Dashboard.Model.EnvironmentVariableViewModel.Name.get -> string!
+Aspire.Dashboard.Model.EnvironmentVariableViewModel.Value.get -> string?
+Aspire.Dashboard.Model.FilterDialogViewModel
+Aspire.Dashboard.Model.FilterDialogViewModel.Filter.get -> Aspire.Dashboard.Model.Otlp.LogFilter?
+Aspire.Dashboard.Model.FilterDialogViewModel.Filter.init -> void
+Aspire.Dashboard.Model.FilterDialogViewModel.FilterDialogViewModel() -> void
+Aspire.Dashboard.Model.FilterDialogViewModel.LogPropertyKeys.get -> System.Collections.Generic.List<string!>!
+Aspire.Dashboard.Model.FilterDialogViewModel.LogPropertyKeys.init -> void
+Aspire.Dashboard.Model.IDashboardClient
+Aspire.Dashboard.Model.IDashboardClient.ApplicationName.get -> string!
+Aspire.Dashboard.Model.IDashboardClient.SubscribeConsoleLogs(string! resourceName, System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerable<System.Collections.Generic.IReadOnlyList<(string! Content, bool IsErrorMessage)>!>?
+Aspire.Dashboard.Model.IDashboardClient.SubscribeResources() -> Aspire.Dashboard.Model.ResourceViewModelSubscription!
+Aspire.Dashboard.Model.IDashboardClient.WhenConnected.get -> System.Threading.Tasks.Task!
+Aspire.Dashboard.Model.InstrumentViewModel
+Aspire.Dashboard.Model.InstrumentViewModel.Instrument.get -> Aspire.Dashboard.Otlp.Model.OtlpInstrument?
+Aspire.Dashboard.Model.InstrumentViewModel.InstrumentViewModel() -> void
+Aspire.Dashboard.Model.InstrumentViewModel.MatchedDimensions.get -> System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope!>?
+Aspire.Dashboard.Model.InstrumentViewModel.OnDataUpdate.get -> System.Func<System.Threading.Tasks.Task!>?
+Aspire.Dashboard.Model.InstrumentViewModel.OnDataUpdate.set -> void
+Aspire.Dashboard.Model.InstrumentViewModel.ShowCount.get -> bool
+Aspire.Dashboard.Model.InstrumentViewModel.ShowCount.set -> void
+Aspire.Dashboard.Model.InstrumentViewModel.Theme.get -> string?
+Aspire.Dashboard.Model.InstrumentViewModel.Theme.set -> void
+Aspire.Dashboard.Model.InstrumentViewModel.UpdateDataAsync(Aspire.Dashboard.Otlp.Model.OtlpInstrument! instrument, System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope!>! matchedDimensions) -> System.Threading.Tasks.Task!
+Aspire.Dashboard.Model.IOutgoingPeerResolver
+Aspire.Dashboard.Model.IOutgoingPeerResolver.OnPeerChanges(System.Func<System.Threading.Tasks.Task!>! callback) -> System.IDisposable!
+Aspire.Dashboard.Model.IOutgoingPeerResolver.TryResolvePeerName(System.Collections.Generic.KeyValuePair<string!, string!>[]! attributes, out string? name) -> bool
+Aspire.Dashboard.Model.LogEntryPropertyViewModel
+Aspire.Dashboard.Model.LogEntryPropertyViewModel.LogEntryPropertyViewModel() -> void
+Aspire.Dashboard.Model.LogEntryPropertyViewModel.Name.get -> string!
+Aspire.Dashboard.Model.LogEntryPropertyViewModel.Name.init -> void
+Aspire.Dashboard.Model.LogEntryPropertyViewModel.Value.get -> string!
+Aspire.Dashboard.Model.LogEntryPropertyViewModel.Value.init -> void
+Aspire.Dashboard.Model.ModelSubscription
+Aspire.Dashboard.Model.ModelSubscription.Dispose() -> void
+Aspire.Dashboard.Model.ModelSubscription.ExecuteAsync() -> System.Threading.Tasks.Task!
+Aspire.Dashboard.Model.ModelSubscription.ModelSubscription(System.Func<System.Threading.Tasks.Task!>! callback, System.Action<Aspire.Dashboard.Model.ModelSubscription!>! onDispose) -> void
+Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.FilterCondition.Contains = 1 -> Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.FilterCondition.Equals = 0 -> Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.FilterCondition.GreaterThan = 2 -> Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.FilterCondition.GreaterThanOrEqual = 4 -> Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.FilterCondition.LessThan = 3 -> Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.FilterCondition.LessThanOrEqual = 5 -> Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.FilterCondition.NotContains = 7 -> Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.FilterCondition.NotEqual = 6 -> Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.FilterDialogResult
+Aspire.Dashboard.Model.Otlp.FilterDialogResult.Add.get -> bool
+Aspire.Dashboard.Model.Otlp.FilterDialogResult.Add.set -> void
+Aspire.Dashboard.Model.Otlp.FilterDialogResult.Delete.get -> bool
+Aspire.Dashboard.Model.Otlp.FilterDialogResult.Delete.set -> void
+Aspire.Dashboard.Model.Otlp.FilterDialogResult.Filter.get -> Aspire.Dashboard.Model.Otlp.LogFilter?
+Aspire.Dashboard.Model.Otlp.FilterDialogResult.Filter.set -> void
+Aspire.Dashboard.Model.Otlp.FilterDialogResult.FilterDialogResult() -> void
+Aspire.Dashboard.Model.Otlp.LogDialogFormModel
+Aspire.Dashboard.Model.Otlp.LogDialogFormModel.Condition.get -> Aspire.Dashboard.Model.Otlp.SelectViewModel<Aspire.Dashboard.Model.Otlp.FilterCondition>?
+Aspire.Dashboard.Model.Otlp.LogDialogFormModel.Condition.set -> void
+Aspire.Dashboard.Model.Otlp.LogDialogFormModel.LogDialogFormModel() -> void
+Aspire.Dashboard.Model.Otlp.LogDialogFormModel.Parameter.get -> string?
+Aspire.Dashboard.Model.Otlp.LogDialogFormModel.Parameter.set -> void
+Aspire.Dashboard.Model.Otlp.LogDialogFormModel.Value.get -> string?
+Aspire.Dashboard.Model.Otlp.LogDialogFormModel.Value.set -> void
+Aspire.Dashboard.Model.Otlp.LogFilter
+Aspire.Dashboard.Model.Otlp.LogFilter.Apply(System.Collections.Generic.IEnumerable<Aspire.Dashboard.Otlp.Model.OtlpLogEntry!>! input) -> System.Collections.Generic.IEnumerable<Aspire.Dashboard.Otlp.Model.OtlpLogEntry!>!
+Aspire.Dashboard.Model.Otlp.LogFilter.Condition.get -> Aspire.Dashboard.Model.Otlp.FilterCondition
+Aspire.Dashboard.Model.Otlp.LogFilter.Condition.set -> void
+Aspire.Dashboard.Model.Otlp.LogFilter.Field.get -> string!
+Aspire.Dashboard.Model.Otlp.LogFilter.Field.set -> void
+Aspire.Dashboard.Model.Otlp.LogFilter.FilterText.get -> string!
+Aspire.Dashboard.Model.Otlp.LogFilter.LogFilter() -> void
+Aspire.Dashboard.Model.Otlp.LogFilter.Value.get -> string!
+Aspire.Dashboard.Model.Otlp.LogFilter.Value.set -> void
+Aspire.Dashboard.Model.Otlp.SelectViewModel<T>
+Aspire.Dashboard.Model.Otlp.SelectViewModel<T>.Id.get -> T?
+Aspire.Dashboard.Model.Otlp.SelectViewModel<T>.Id.init -> void
+Aspire.Dashboard.Model.Otlp.SelectViewModel<T>.Name.get -> string!
+Aspire.Dashboard.Model.Otlp.SelectViewModel<T>.Name.init -> void
+Aspire.Dashboard.Model.Otlp.SelectViewModel<T>.SelectViewModel() -> void
+Aspire.Dashboard.Model.Otlp.SelectViewModelFactory
+Aspire.Dashboard.Model.Otlp.SelectViewModelFactory.SelectViewModelFactory() -> void
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.Depth.get -> int
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.Depth.init -> void
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.GetDisplaySummary() -> string!
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.GetTooltip() -> string!
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.HasUninstrumentedPeer.get -> bool
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.IsError.get -> bool
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.LabelIsRight.get -> bool
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.LabelIsRight.init -> void
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.LeftOffset.get -> double
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.LeftOffset.init -> void
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.Span.get -> Aspire.Dashboard.Otlp.Model.OtlpSpan!
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.Span.init -> void
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.SpanWaterfallViewModel() -> void
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.UninstrumentedPeer.get -> string?
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.UninstrumentedPeer.init -> void
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.Width.get -> double
+Aspire.Dashboard.Model.Otlp.SpanWaterfallViewModel.Width.init -> void
+Aspire.Dashboard.Model.ResourceFormatter
+Aspire.Dashboard.Model.ResourceOutgoingPeerResolver
+Aspire.Dashboard.Model.ResourceOutgoingPeerResolver.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Aspire.Dashboard.Model.ResourceOutgoingPeerResolver.OnPeerChanges(System.Func<System.Threading.Tasks.Task!>! callback) -> System.IDisposable!
+Aspire.Dashboard.Model.ResourceOutgoingPeerResolver.ResourceOutgoingPeerResolver(Aspire.Dashboard.Model.IDashboardClient! resourceService) -> void
+Aspire.Dashboard.Model.ResourceOutgoingPeerResolver.TryResolvePeerName(System.Collections.Generic.KeyValuePair<string!, string!>[]! attributes, out string? name) -> bool
+Aspire.Dashboard.Model.ResourceServiceViewModel
+Aspire.Dashboard.Model.ResourceServiceViewModel.AddressAndPort.get -> string!
+Aspire.Dashboard.Model.ResourceServiceViewModel.AllocatedAddress.get -> string?
+Aspire.Dashboard.Model.ResourceServiceViewModel.AllocatedPort.get -> int?
+Aspire.Dashboard.Model.ResourceServiceViewModel.Name.get -> string!
+Aspire.Dashboard.Model.ResourceServiceViewModel.ResourceServiceViewModel(string! name, string? allocatedAddress, int? allocatedPort) -> void
+Aspire.Dashboard.Model.ResourceStates
+Aspire.Dashboard.Model.ResourceViewModel
+Aspire.Dashboard.Model.ResourceViewModel.CreationTimeStamp.get -> System.DateTime?
+Aspire.Dashboard.Model.ResourceViewModel.CreationTimeStamp.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.DisplayName.get -> string!
+Aspire.Dashboard.Model.ResourceViewModel.DisplayName.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.Endpoints.get -> System.Collections.Immutable.ImmutableArray<Aspire.Dashboard.Model.EndpointViewModel!>
+Aspire.Dashboard.Model.ResourceViewModel.Endpoints.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.Environment.get -> System.Collections.Immutable.ImmutableArray<Aspire.Dashboard.Model.EnvironmentVariableViewModel!>
+Aspire.Dashboard.Model.ResourceViewModel.Environment.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.ExpectedEndpointsCount.get -> int?
+Aspire.Dashboard.Model.ResourceViewModel.ExpectedEndpointsCount.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.Name.get -> string!
+Aspire.Dashboard.Model.ResourceViewModel.Name.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.Properties.get -> System.Collections.Frozen.FrozenDictionary<string!, Google.Protobuf.WellKnownTypes.Value!>!
+Aspire.Dashboard.Model.ResourceViewModel.Properties.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.ResourceType.get -> string!
+Aspire.Dashboard.Model.ResourceViewModel.ResourceType.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.ResourceViewModel() -> void
+Aspire.Dashboard.Model.ResourceViewModel.Services.get -> System.Collections.Immutable.ImmutableArray<Aspire.Dashboard.Model.ResourceServiceViewModel!>
+Aspire.Dashboard.Model.ResourceViewModel.Services.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.State.get -> string?
+Aspire.Dashboard.Model.ResourceViewModel.State.init -> void
+Aspire.Dashboard.Model.ResourceViewModel.Uid.get -> string!
+Aspire.Dashboard.Model.ResourceViewModel.Uid.init -> void
+Aspire.Dashboard.Model.ResourceViewModelChange
+Aspire.Dashboard.Model.ResourceViewModelChange.<Clone>$() -> Aspire.Dashboard.Model.ResourceViewModelChange!
+Aspire.Dashboard.Model.ResourceViewModelChange.ChangeType.get -> Aspire.Dashboard.Model.ResourceViewModelChangeType
+Aspire.Dashboard.Model.ResourceViewModelChange.ChangeType.init -> void
+Aspire.Dashboard.Model.ResourceViewModelChange.Deconstruct(out Aspire.Dashboard.Model.ResourceViewModelChangeType ChangeType, out Aspire.Dashboard.Model.ResourceViewModel! Resource) -> void
+Aspire.Dashboard.Model.ResourceViewModelChange.Equals(Aspire.Dashboard.Model.ResourceViewModelChange? other) -> bool
+Aspire.Dashboard.Model.ResourceViewModelChange.Resource.get -> Aspire.Dashboard.Model.ResourceViewModel!
+Aspire.Dashboard.Model.ResourceViewModelChange.Resource.init -> void
+Aspire.Dashboard.Model.ResourceViewModelChange.ResourceViewModelChange(Aspire.Dashboard.Model.ResourceViewModelChangeType ChangeType, Aspire.Dashboard.Model.ResourceViewModel! Resource) -> void
+Aspire.Dashboard.Model.ResourceViewModelChangeType
+Aspire.Dashboard.Model.ResourceViewModelChangeType.Delete = 1 -> Aspire.Dashboard.Model.ResourceViewModelChangeType
+Aspire.Dashboard.Model.ResourceViewModelChangeType.Upsert = 0 -> Aspire.Dashboard.Model.ResourceViewModelChangeType
+Aspire.Dashboard.Model.ResourceViewModelSubscription
+Aspire.Dashboard.Model.ResourceViewModelSubscription.<Clone>$() -> Aspire.Dashboard.Model.ResourceViewModelSubscription!
+Aspire.Dashboard.Model.ResourceViewModelSubscription.Deconstruct(out System.Collections.Immutable.ImmutableArray<Aspire.Dashboard.Model.ResourceViewModel!> InitialState, out System.Collections.Generic.IAsyncEnumerable<Aspire.Dashboard.Model.ResourceViewModelChange!>! Subscription) -> void
+Aspire.Dashboard.Model.ResourceViewModelSubscription.Equals(Aspire.Dashboard.Model.ResourceViewModelSubscription? other) -> bool
+Aspire.Dashboard.Model.ResourceViewModelSubscription.InitialState.get -> System.Collections.Immutable.ImmutableArray<Aspire.Dashboard.Model.ResourceViewModel!>
+Aspire.Dashboard.Model.ResourceViewModelSubscription.InitialState.init -> void
+Aspire.Dashboard.Model.ResourceViewModelSubscription.ResourceViewModelSubscription(System.Collections.Immutable.ImmutableArray<Aspire.Dashboard.Model.ResourceViewModel!> InitialState, System.Collections.Generic.IAsyncEnumerable<Aspire.Dashboard.Model.ResourceViewModelChange!>! Subscription) -> void
+Aspire.Dashboard.Model.ResourceViewModelSubscription.Subscription.get -> System.Collections.Generic.IAsyncEnumerable<Aspire.Dashboard.Model.ResourceViewModelChange!>!
+Aspire.Dashboard.Model.ResourceViewModelSubscription.Subscription.init -> void
+Aspire.Dashboard.Model.SpanDetailsViewModel
+Aspire.Dashboard.Model.SpanDetailsViewModel.Properties.get -> System.Collections.Generic.List<Aspire.Dashboard.Model.SpanPropertyViewModel!>!
+Aspire.Dashboard.Model.SpanDetailsViewModel.Properties.init -> void
+Aspire.Dashboard.Model.SpanDetailsViewModel.Span.get -> Aspire.Dashboard.Otlp.Model.OtlpSpan!
+Aspire.Dashboard.Model.SpanDetailsViewModel.Span.init -> void
+Aspire.Dashboard.Model.SpanDetailsViewModel.SpanDetailsViewModel() -> void
+Aspire.Dashboard.Model.SpanDetailsViewModel.Title.get -> string!
+Aspire.Dashboard.Model.SpanDetailsViewModel.Title.init -> void
+Aspire.Dashboard.Model.SpanPropertyViewModel
+Aspire.Dashboard.Model.SpanPropertyViewModel.Name.get -> string!
+Aspire.Dashboard.Model.SpanPropertyViewModel.Name.init -> void
+Aspire.Dashboard.Model.SpanPropertyViewModel.SpanPropertyViewModel() -> void
+Aspire.Dashboard.Model.SpanPropertyViewModel.Value.get -> string!
+Aspire.Dashboard.Model.SpanPropertyViewModel.Value.init -> void
+Aspire.Dashboard.Model.StructuredLogsViewModel
+Aspire.Dashboard.Model.StructuredLogsViewModel.AddFilter(Aspire.Dashboard.Model.Otlp.LogFilter! filter) -> void
+Aspire.Dashboard.Model.StructuredLogsViewModel.ApplicationServiceId.get -> string?
+Aspire.Dashboard.Model.StructuredLogsViewModel.ApplicationServiceId.set -> void
+Aspire.Dashboard.Model.StructuredLogsViewModel.ClearData() -> void
+Aspire.Dashboard.Model.StructuredLogsViewModel.Count.get -> int?
+Aspire.Dashboard.Model.StructuredLogsViewModel.Count.set -> void
+Aspire.Dashboard.Model.StructuredLogsViewModel.Filters.get -> System.Collections.Generic.IReadOnlyList<Aspire.Dashboard.Model.Otlp.LogFilter!>!
+Aspire.Dashboard.Model.StructuredLogsViewModel.FilterText.get -> string!
+Aspire.Dashboard.Model.StructuredLogsViewModel.FilterText.set -> void
+Aspire.Dashboard.Model.StructuredLogsViewModel.GetLogs() -> Aspire.Dashboard.Otlp.Storage.PagedResult<Aspire.Dashboard.Otlp.Model.OtlpLogEntry!>!
+Aspire.Dashboard.Model.StructuredLogsViewModel.LogLevel.get -> Microsoft.Extensions.Logging.LogLevel?
+Aspire.Dashboard.Model.StructuredLogsViewModel.LogLevel.set -> void
+Aspire.Dashboard.Model.StructuredLogsViewModel.RemoveFilter(Aspire.Dashboard.Model.Otlp.LogFilter! filter) -> bool
+Aspire.Dashboard.Model.StructuredLogsViewModel.StartIndex.get -> int
+Aspire.Dashboard.Model.StructuredLogsViewModel.StartIndex.set -> void
+Aspire.Dashboard.Model.StructuredLogsViewModel.StructuredLogsViewModel(Aspire.Dashboard.Otlp.Storage.TelemetryRepository! telemetryRepository) -> void
+Aspire.Dashboard.Model.ThemeManager
+Aspire.Dashboard.Model.ThemeManager.OnThemeChanged(System.Func<System.Threading.Tasks.Task!>! callback) -> System.IDisposable!
+Aspire.Dashboard.Model.ThemeManager.RaiseThemeChangedAsync(string! theme) -> System.Threading.Tasks.Task!
+Aspire.Dashboard.Model.ThemeManager.Theme.get -> string?
+Aspire.Dashboard.Model.ThemeManager.ThemeManager() -> void
+Aspire.Dashboard.Model.TracesViewModel
+Aspire.Dashboard.Model.TracesViewModel.ApplicationServiceId.get -> string?
+Aspire.Dashboard.Model.TracesViewModel.ApplicationServiceId.set -> void
+Aspire.Dashboard.Model.TracesViewModel.ClearData() -> void
+Aspire.Dashboard.Model.TracesViewModel.Count.get -> int?
+Aspire.Dashboard.Model.TracesViewModel.Count.set -> void
+Aspire.Dashboard.Model.TracesViewModel.FilterText.get -> string!
+Aspire.Dashboard.Model.TracesViewModel.FilterText.set -> void
+Aspire.Dashboard.Model.TracesViewModel.GetTraces() -> Aspire.Dashboard.Otlp.Storage.PagedResult<Aspire.Dashboard.Otlp.Model.OtlpTrace!>!
+Aspire.Dashboard.Model.TracesViewModel.MaxDuration.get -> System.TimeSpan
+Aspire.Dashboard.Model.TracesViewModel.StartIndex.get -> int
+Aspire.Dashboard.Model.TracesViewModel.StartIndex.set -> void
+Aspire.Dashboard.Model.TracesViewModel.TracesViewModel(Aspire.Dashboard.Otlp.Storage.TelemetryRepository! telemetryRepository) -> void
+Aspire.Dashboard.Otlp.Grpc.OtlpLogsService
+Aspire.Dashboard.Otlp.Grpc.OtlpLogsService.OtlpLogsService(Microsoft.Extensions.Logging.ILogger<Aspire.Dashboard.Otlp.Grpc.OtlpLogsService!>! logger, Aspire.Dashboard.Otlp.Storage.TelemetryRepository! telemetryRepository) -> void
+Aspire.Dashboard.Otlp.Grpc.OtlpMetricsService
+Aspire.Dashboard.Otlp.Grpc.OtlpMetricsService.OtlpMetricsService(Microsoft.Extensions.Logging.ILogger<Aspire.Dashboard.Otlp.Grpc.OtlpMetricsService!>! logger, Aspire.Dashboard.Otlp.Storage.TelemetryRepository! telemetryRepository) -> void
+Aspire.Dashboard.Otlp.Grpc.OtlpTraceService
+Aspire.Dashboard.Otlp.Grpc.OtlpTraceService.OtlpTraceService(Microsoft.Extensions.Logging.ILogger<Aspire.Dashboard.Otlp.Grpc.OtlpTraceService!>! logger, Aspire.Dashboard.Otlp.Storage.TelemetryRepository! telemetryRepository) -> void
+Aspire.Dashboard.Otlp.Model.AddContext
+Aspire.Dashboard.Otlp.Model.AddContext.AddContext() -> void
+Aspire.Dashboard.Otlp.Model.AddContext.FailureCount.get -> int
+Aspire.Dashboard.Otlp.Model.AddContext.FailureCount.set -> void
+Aspire.Dashboard.Otlp.Model.ColorGenerator
+Aspire.Dashboard.Otlp.Model.ColorGenerator.Clear() -> void
+Aspire.Dashboard.Otlp.Model.ColorGenerator.GetColorHexByKey(string! key) -> string!
+Aspire.Dashboard.Otlp.Model.DurationFormatter
+Aspire.Dashboard.Otlp.Model.GeneratedColor
+Aspire.Dashboard.Otlp.Model.GeneratedColor.Blue.get -> int
+Aspire.Dashboard.Otlp.Model.GeneratedColor.Blue.init -> void
+Aspire.Dashboard.Otlp.Model.GeneratedColor.GeneratedColor() -> void
+Aspire.Dashboard.Otlp.Model.GeneratedColor.Green.get -> int
+Aspire.Dashboard.Otlp.Model.GeneratedColor.Green.init -> void
+Aspire.Dashboard.Otlp.Model.GeneratedColor.Hex.get -> string!
+Aspire.Dashboard.Otlp.Model.GeneratedColor.Hex.init -> void
+Aspire.Dashboard.Otlp.Model.GeneratedColor.Red.get -> int
+Aspire.Dashboard.Otlp.Model.GeneratedColor.Red.init -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope
+Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope.AddHistogramValue(OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint! h) -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope.AddPointValue(OpenTelemetry.Proto.Metrics.V1.NumberDataPoint! d) -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope.Attributes.get -> System.Collections.Generic.KeyValuePair<string!, string!>[]!
+Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope.Attributes.init -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope.DimensionScope(System.Collections.Generic.KeyValuePair<string!, string!>[]! attributes) -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope.Name.get -> string!
+Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope.Name.init -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue
+Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue.ExplicitBounds.get -> double[]!
+Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue.ExplicitBounds.init -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue.HistogramValue(ulong[]! values, double sum, ulong count, System.DateTime start, System.DateTime end, double[]! explicitBounds) -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue.Sum.get -> double
+Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue.Sum.init -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue.Values.get -> ulong[]!
+Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue.Values.init -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.MetricValue<T>
+Aspire.Dashboard.Otlp.Model.MetricValues.MetricValue<T>.MetricValue(T value, System.DateTime start, System.DateTime end) -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase
+Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase.Count -> ulong
+Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase.End.get -> System.DateTime
+Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase.End.set -> void
+Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase.MetricValueBase(System.DateTime start, System.DateTime end) -> void
+Aspire.Dashboard.Otlp.Model.OtlpApplication
+Aspire.Dashboard.Otlp.Model.OtlpApplication.AddMetrics(Aspire.Dashboard.Otlp.Model.AddContext! context, Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.ScopeMetrics!>! scopeMetrics) -> void
+Aspire.Dashboard.Otlp.Model.OtlpApplication.AllProperties() -> System.Collections.Generic.Dictionary<string!, string!>!
+Aspire.Dashboard.Otlp.Model.OtlpApplication.ApplicationName.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpApplication.GetInstrument(string! meterName, string! instrumentName, System.DateTime? valuesStart, System.DateTime? valuesEnd) -> Aspire.Dashboard.Otlp.Model.OtlpInstrument?
+Aspire.Dashboard.Otlp.Model.OtlpApplication.GetInstrumentsSummary() -> System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.OtlpInstrument!>!
+Aspire.Dashboard.Otlp.Model.OtlpApplication.InstanceId.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpApplication.OtlpApplication(OpenTelemetry.Proto.Resource.V1.Resource! resource, System.Collections.Generic.IReadOnlyDictionary<string!, Aspire.Dashboard.Otlp.Model.OtlpApplication!>! applications, Microsoft.Extensions.Logging.ILogger! logger) -> void
+Aspire.Dashboard.Otlp.Model.OtlpApplication.Properties.get -> System.Collections.Generic.KeyValuePair<string!, string!>[]!
+Aspire.Dashboard.Otlp.Model.OtlpHelpers
+Aspire.Dashboard.Otlp.Model.OtlpInstrument
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.AddMetrics(OpenTelemetry.Proto.Metrics.V1.Metric! metric, ref System.Collections.Generic.KeyValuePair<string!, string!>[]? tempAttributes) -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Description.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Description.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Dimensions.get -> System.Collections.Generic.Dictionary<System.ReadOnlyMemory<System.Collections.Generic.KeyValuePair<string!, string!>>, Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope!>!
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.GetKey() -> Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.KnownAttributeValues.get -> System.Collections.Generic.Dictionary<string!, System.Collections.Generic.List<string!>!>!
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Name.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Name.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.OtlpInstrument() -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Parent.get -> Aspire.Dashboard.Otlp.Model.OtlpMeter!
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Parent.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Type.get -> Aspire.Dashboard.Otlp.Model.OtlpInstrumentType
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Type.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Unit.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpInstrument.Unit.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.Deconstruct(out string! MeterName, out string! InstrumentName) -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.Equals(Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey other) -> bool
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.InstrumentName.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.InstrumentName.set -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.MeterName.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.MeterName.set -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.OtlpInstrumentKey() -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.OtlpInstrumentKey(string! MeterName, string! InstrumentName) -> void
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentType
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentType.Gauge = 1 -> Aspire.Dashboard.Otlp.Model.OtlpInstrumentType
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentType.Histogram = 3 -> Aspire.Dashboard.Otlp.Model.OtlpInstrumentType
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentType.Sum = 2 -> Aspire.Dashboard.Otlp.Model.OtlpInstrumentType
+Aspire.Dashboard.Otlp.Model.OtlpInstrumentType.Unsupported = 0 -> Aspire.Dashboard.Otlp.Model.OtlpInstrumentType
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.AllProperties() -> System.Collections.Generic.Dictionary<string!, string!>!
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.Application.get -> Aspire.Dashboard.Otlp.Model.OtlpApplication!
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.Flags.get -> uint
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.Message.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.OriginalFormat.get -> string?
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.OtlpLogEntry(OpenTelemetry.Proto.Logs.V1.LogRecord! record, Aspire.Dashboard.Otlp.Model.OtlpApplication! logApp, Aspire.Dashboard.Otlp.Model.OtlpScope! scope) -> void
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.Properties.get -> System.Collections.Generic.KeyValuePair<string!, string!>[]!
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.Scope.get -> Aspire.Dashboard.Otlp.Model.OtlpScope!
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.Severity.get -> Microsoft.Extensions.Logging.LogLevel
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.SpanId.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.TimeStamp.get -> System.DateTime
+Aspire.Dashboard.Otlp.Model.OtlpLogEntry.TraceId.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpMeter
+Aspire.Dashboard.Otlp.Model.OtlpMeter.MeterName.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpMeter.MeterName.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpMeter.OtlpMeter(OpenTelemetry.Proto.Common.V1.InstrumentationScope! scope) -> void
+Aspire.Dashboard.Otlp.Model.OtlpMeter.Properties.get -> System.Collections.Generic.KeyValuePair<string!, string!>[]!
+Aspire.Dashboard.Otlp.Model.OtlpMeter.Version.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpMeter.Version.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpScope
+Aspire.Dashboard.Otlp.Model.OtlpScope.OtlpScope(OpenTelemetry.Proto.Common.V1.InstrumentationScope! scope) -> void
+Aspire.Dashboard.Otlp.Model.OtlpScope.Properties.get -> System.Collections.Generic.KeyValuePair<string!, string!>[]!
+Aspire.Dashboard.Otlp.Model.OtlpScope.ScopeName.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpScope.ServiceProperties.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpScope.Version.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpSpan
+Aspire.Dashboard.Otlp.Model.OtlpSpan.AllProperties() -> System.Collections.Generic.Dictionary<string!, string!>!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Attributes.get -> System.Collections.Generic.KeyValuePair<string!, string!>[]!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Attributes.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Duration.get -> System.TimeSpan
+Aspire.Dashboard.Otlp.Model.OtlpSpan.EndTime.get -> System.DateTime
+Aspire.Dashboard.Otlp.Model.OtlpSpan.EndTime.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Events.get -> System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.OtlpSpanEvent!>!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Events.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.GetChildSpans() -> System.Collections.Generic.IEnumerable<Aspire.Dashboard.Otlp.Model.OtlpSpan!>!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.GetParentSpan() -> Aspire.Dashboard.Otlp.Model.OtlpSpan?
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Kind.get -> Aspire.Dashboard.Otlp.Model.OtlpSpanKind
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Kind.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Name.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Name.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.OtlpSpan(Aspire.Dashboard.Otlp.Model.OtlpApplication! application, Aspire.Dashboard.Otlp.Model.OtlpTrace! trace) -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.ParentSpanId.get -> string?
+Aspire.Dashboard.Otlp.Model.OtlpSpan.ParentSpanId.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.ScopeName.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.ScopeSource.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Source.get -> Aspire.Dashboard.Otlp.Model.OtlpApplication!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.SpanId.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.SpanId.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.StartTime.get -> System.DateTime
+Aspire.Dashboard.Otlp.Model.OtlpSpan.StartTime.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.State.get -> string?
+Aspire.Dashboard.Otlp.Model.OtlpSpan.State.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Status.get -> Aspire.Dashboard.Otlp.Model.OtlpSpanStatusCode
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Status.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.StatusMessage.get -> string?
+Aspire.Dashboard.Otlp.Model.OtlpSpan.StatusMessage.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpan.Trace.get -> Aspire.Dashboard.Otlp.Model.OtlpTrace!
+Aspire.Dashboard.Otlp.Model.OtlpSpan.TraceId.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpSpanEvent
+Aspire.Dashboard.Otlp.Model.OtlpSpanEvent.Attributes.get -> System.Collections.Generic.KeyValuePair<string!, string!>[]!
+Aspire.Dashboard.Otlp.Model.OtlpSpanEvent.Attributes.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpanEvent.Name.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpSpanEvent.Name.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpanEvent.OtlpSpanEvent() -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpanEvent.Time.get -> System.DateTime
+Aspire.Dashboard.Otlp.Model.OtlpSpanEvent.Time.init -> void
+Aspire.Dashboard.Otlp.Model.OtlpSpanEvent.TimeOffset(Aspire.Dashboard.Otlp.Model.OtlpSpan! span) -> System.TimeSpan
+Aspire.Dashboard.Otlp.Model.OtlpSpanKind
+Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Client = 3 -> Aspire.Dashboard.Otlp.Model.OtlpSpanKind
+Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Consumer = 5 -> Aspire.Dashboard.Otlp.Model.OtlpSpanKind
+Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Internal = 1 -> Aspire.Dashboard.Otlp.Model.OtlpSpanKind
+Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Producer = 4 -> Aspire.Dashboard.Otlp.Model.OtlpSpanKind
+Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Server = 2 -> Aspire.Dashboard.Otlp.Model.OtlpSpanKind
+Aspire.Dashboard.Otlp.Model.OtlpSpanKind.Unspecified = 0 -> Aspire.Dashboard.Otlp.Model.OtlpSpanKind
+Aspire.Dashboard.Otlp.Model.OtlpSpanStatusCode
+Aspire.Dashboard.Otlp.Model.OtlpSpanStatusCode.Error = 2 -> Aspire.Dashboard.Otlp.Model.OtlpSpanStatusCode
+Aspire.Dashboard.Otlp.Model.OtlpSpanStatusCode.Ok = 1 -> Aspire.Dashboard.Otlp.Model.OtlpSpanStatusCode
+Aspire.Dashboard.Otlp.Model.OtlpSpanStatusCode.Unset = 0 -> Aspire.Dashboard.Otlp.Model.OtlpSpanStatusCode
+Aspire.Dashboard.Otlp.Model.OtlpTrace
+Aspire.Dashboard.Otlp.Model.OtlpTrace.AddSpan(Aspire.Dashboard.Otlp.Model.OtlpSpan! span) -> void
+Aspire.Dashboard.Otlp.Model.OtlpTrace.CalculateDepth(Aspire.Dashboard.Otlp.Model.OtlpSpan! span) -> int
+Aspire.Dashboard.Otlp.Model.OtlpTrace.CalculateMaxDepth() -> int
+Aspire.Dashboard.Otlp.Model.OtlpTrace.Duration.get -> System.TimeSpan
+Aspire.Dashboard.Otlp.Model.OtlpTrace.FirstSpan.get -> Aspire.Dashboard.Otlp.Model.OtlpSpan!
+Aspire.Dashboard.Otlp.Model.OtlpTrace.FullName.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpTrace.Key.get -> System.ReadOnlyMemory<byte>
+Aspire.Dashboard.Otlp.Model.OtlpTrace.OtlpTrace(System.ReadOnlyMemory<byte> traceId, Aspire.Dashboard.Otlp.Model.OtlpScope! traceScope) -> void
+Aspire.Dashboard.Otlp.Model.OtlpTrace.RootSpan.get -> Aspire.Dashboard.Otlp.Model.OtlpSpan?
+Aspire.Dashboard.Otlp.Model.OtlpTrace.Spans.get -> System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.OtlpSpan!>!
+Aspire.Dashboard.Otlp.Model.OtlpTrace.TraceId.get -> string!
+Aspire.Dashboard.Otlp.Model.OtlpTrace.TraceScope.get -> Aspire.Dashboard.Otlp.Model.OtlpScope!
+Aspire.Dashboard.Otlp.Model.OtlpTraceCollection
+Aspire.Dashboard.Otlp.Model.OtlpTraceCollection.OtlpTraceCollection() -> void
+Aspire.Dashboard.Otlp.Model.OtlpUnits
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.ApplicationServiceId.get -> string!
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.ApplicationServiceId.init -> void
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.EndTime.get -> System.DateTime?
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.EndTime.init -> void
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.GetInstrumentRequest() -> void
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.InstrumentName.get -> string!
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.InstrumentName.init -> void
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.MeterName.get -> string!
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.MeterName.init -> void
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.StartTime.get -> System.DateTime?
+Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest.StartTime.init -> void
+Aspire.Dashboard.Otlp.Storage.GetLogsContext
+Aspire.Dashboard.Otlp.Storage.GetLogsContext.ApplicationServiceId.get -> string?
+Aspire.Dashboard.Otlp.Storage.GetLogsContext.ApplicationServiceId.init -> void
+Aspire.Dashboard.Otlp.Storage.GetLogsContext.Count.get -> int?
+Aspire.Dashboard.Otlp.Storage.GetLogsContext.Count.init -> void
+Aspire.Dashboard.Otlp.Storage.GetLogsContext.Filters.get -> System.Collections.Generic.List<Aspire.Dashboard.Model.Otlp.LogFilter!>!
+Aspire.Dashboard.Otlp.Storage.GetLogsContext.Filters.init -> void
+Aspire.Dashboard.Otlp.Storage.GetLogsContext.GetLogsContext() -> void
+Aspire.Dashboard.Otlp.Storage.GetLogsContext.StartIndex.get -> int
+Aspire.Dashboard.Otlp.Storage.GetLogsContext.StartIndex.init -> void
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest.ApplicationServiceId.get -> string?
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest.ApplicationServiceId.init -> void
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest.Count.get -> int?
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest.Count.init -> void
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest.FilterText.get -> string!
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest.FilterText.init -> void
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest.GetTracesRequest() -> void
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest.StartIndex.get -> int
+Aspire.Dashboard.Otlp.Storage.GetTracesRequest.StartIndex.init -> void
+Aspire.Dashboard.Otlp.Storage.GetTracesResponse
+Aspire.Dashboard.Otlp.Storage.GetTracesResponse.GetTracesResponse() -> void
+Aspire.Dashboard.Otlp.Storage.GetTracesResponse.MaxDuration.get -> System.TimeSpan
+Aspire.Dashboard.Otlp.Storage.GetTracesResponse.MaxDuration.init -> void
+Aspire.Dashboard.Otlp.Storage.GetTracesResponse.PagedResult.get -> Aspire.Dashboard.Otlp.Storage.PagedResult<Aspire.Dashboard.Otlp.Model.OtlpTrace!>!
+Aspire.Dashboard.Otlp.Storage.GetTracesResponse.PagedResult.init -> void
+Aspire.Dashboard.Otlp.Storage.PagedResult<T>
+Aspire.Dashboard.Otlp.Storage.PagedResult<T>.Items.get -> System.Collections.Generic.List<T>!
+Aspire.Dashboard.Otlp.Storage.PagedResult<T>.Items.init -> void
+Aspire.Dashboard.Otlp.Storage.PagedResult<T>.PagedResult() -> void
+Aspire.Dashboard.Otlp.Storage.PagedResult<T>.TotalItemCount.get -> int
+Aspire.Dashboard.Otlp.Storage.PagedResult<T>.TotalItemCount.init -> void
+Aspire.Dashboard.Otlp.Storage.Subscription
+Aspire.Dashboard.Otlp.Storage.Subscription.ApplicationId.get -> string?
+Aspire.Dashboard.Otlp.Storage.Subscription.Dispose() -> void
+Aspire.Dashboard.Otlp.Storage.Subscription.ExecuteAsync() -> System.Threading.Tasks.Task!
+Aspire.Dashboard.Otlp.Storage.Subscription.Subscription(string? applicationId, Aspire.Dashboard.Otlp.Storage.SubscriptionType subscriptionType, System.Func<System.Threading.Tasks.Task!>! callback, System.Action! unsubscribe) -> void
+Aspire.Dashboard.Otlp.Storage.Subscription.SubscriptionType.get -> Aspire.Dashboard.Otlp.Storage.SubscriptionType
+Aspire.Dashboard.Otlp.Storage.SubscriptionType
+Aspire.Dashboard.Otlp.Storage.SubscriptionType.Other = 1 -> Aspire.Dashboard.Otlp.Storage.SubscriptionType
+Aspire.Dashboard.Otlp.Storage.SubscriptionType.Read = 0 -> Aspire.Dashboard.Otlp.Storage.SubscriptionType
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.AddLogs(Aspire.Dashboard.Otlp.Model.AddContext! context, Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Logs.V1.ResourceLogs!>! resourceLogs) -> void
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.AddLogsCore(Aspire.Dashboard.Otlp.Model.AddContext! context, Aspire.Dashboard.Otlp.Model.OtlpApplication! application, Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Logs.V1.ScopeLogs!>! scopeLogs) -> void
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.AddMetrics(Aspire.Dashboard.Otlp.Model.AddContext! context, Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics!>! resourceMetrics) -> void
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.AddTraces(Aspire.Dashboard.Otlp.Model.AddContext! context, Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Trace.V1.ResourceSpans!>! resourceSpans) -> void
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetApplication(string! instanceId) -> Aspire.Dashboard.Otlp.Model.OtlpApplication?
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetApplications() -> System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.OtlpApplication!>!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetApplicationUnviewedErrorLogsCount() -> System.Collections.Generic.Dictionary<Aspire.Dashboard.Otlp.Model.OtlpApplication!, int>!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetInstrument(Aspire.Dashboard.Otlp.Storage.GetInstrumentRequest! request) -> Aspire.Dashboard.Otlp.Model.OtlpInstrument?
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetInstrumentsSummary(string! applicationServiceId) -> System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.OtlpInstrument!>!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetLogPropertyKeys(string? applicationServiceId) -> System.Collections.Generic.List<string!>!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetLogs(Aspire.Dashboard.Otlp.Storage.GetLogsContext! context) -> Aspire.Dashboard.Otlp.Storage.PagedResult<Aspire.Dashboard.Otlp.Model.OtlpLogEntry!>!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetOrAddApplication(OpenTelemetry.Proto.Resource.V1.Resource! resource) -> Aspire.Dashboard.Otlp.Model.OtlpApplication!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetTrace(string! traceId) -> Aspire.Dashboard.Otlp.Model.OtlpTrace?
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetTraces(Aspire.Dashboard.Otlp.Storage.GetTracesRequest! context) -> Aspire.Dashboard.Otlp.Storage.GetTracesResponse!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.GetUnviewedErrorLogsCount(string? instanceId) -> int
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.OnNewApplications(System.Func<System.Threading.Tasks.Task!>! callback) -> Aspire.Dashboard.Otlp.Storage.Subscription!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.OnNewLogs(string? applicationId, Aspire.Dashboard.Otlp.Storage.SubscriptionType subscriptionType, System.Func<System.Threading.Tasks.Task!>! callback) -> Aspire.Dashboard.Otlp.Storage.Subscription!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.OnNewMetrics(string? applicationId, Aspire.Dashboard.Otlp.Storage.SubscriptionType subscriptionType, System.Func<System.Threading.Tasks.Task!>! callback) -> Aspire.Dashboard.Otlp.Storage.Subscription!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.OnNewTraces(string? applicationId, Aspire.Dashboard.Otlp.Storage.SubscriptionType subscriptionType, System.Func<System.Threading.Tasks.Task!>! callback) -> Aspire.Dashboard.Otlp.Storage.Subscription!
+Aspire.Dashboard.Otlp.Storage.TelemetryRepository.TelemetryRepository(Microsoft.Extensions.Configuration.IConfiguration! config, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
+Aspire.Dashboard.Resources.Columns
+Aspire.Dashboard.Resources.ConsoleLogs
+Aspire.Dashboard.Resources.ControlsStrings
+Aspire.Dashboard.Resources.Dialogs
+Aspire.Dashboard.Resources.Layout
+Aspire.Dashboard.Resources.Metrics
+Aspire.Dashboard.Resources.Resources
+Aspire.Dashboard.Resources.Routes
+Aspire.Dashboard.Resources.StructuredLogs
+Aspire.Dashboard.Resources.TraceDetail
+Aspire.Dashboard.Resources.Traces
+const Aspire.Dashboard.Model.ResourceStates.ExitedState = "Exited" -> string!
+const Aspire.Dashboard.Model.ResourceStates.FinishedState = "Finished" -> string!
+const Aspire.Dashboard.Model.ThemeManager.DarkThemeLuminance = 0.15 -> float
+const Aspire.Dashboard.Model.ThemeManager.LightThemeLuminance = 0.95 -> float
+const Aspire.Dashboard.Model.ThemeManager.ThemeSettingDark = "Dark" -> string!
+const Aspire.Dashboard.Model.ThemeManager.ThemeSettingLight = "Light" -> string!
+const Aspire.Dashboard.Model.ThemeManager.ThemeSettingSystem = "System" -> string!
+const Aspire.Dashboard.Otlp.Model.OtlpApplication.SERVICE_INSTANCE_ID = "service.instance.id" -> string!
+const Aspire.Dashboard.Otlp.Model.OtlpApplication.SERVICE_NAME = "service.name" -> string!
+const Aspire.Dashboard.Otlp.Model.OtlpSpan.PeerServiceAttributeKey = "peer.service" -> string!
+const Aspire.Dashboard.Otlp.Model.OtlpSpan.SpanKindAttributeKey = "span.kind" -> string!
+const OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.ErrorMessageFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.RejectedLogRecordsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.ResourceLogsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.PartialSuccessFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.ErrorMessageFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.RejectedDataPointsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.ResourceMetricsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.PartialSuccessFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.ErrorMessageFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.RejectedSpansFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.ResourceSpansFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.PartialSuccessFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Common.V1.AnyValue.ArrayValueFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Common.V1.AnyValue.BoolValueFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Common.V1.AnyValue.BytesValueFieldNumber = 7 -> int
+const OpenTelemetry.Proto.Common.V1.AnyValue.DoubleValueFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Common.V1.AnyValue.IntValueFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Common.V1.AnyValue.KvlistValueFieldNumber = 6 -> int
+const OpenTelemetry.Proto.Common.V1.AnyValue.StringValueFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Common.V1.ArrayValue.ValuesFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Common.V1.InstrumentationScope.AttributesFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Common.V1.InstrumentationScope.DroppedAttributesCountFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Common.V1.InstrumentationScope.NameFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Common.V1.InstrumentationScope.VersionFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Common.V1.KeyValue.KeyFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Common.V1.KeyValue.ValueFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Common.V1.KeyValueList.ValuesFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.AttributesFieldNumber = 6 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.BodyFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.DroppedAttributesCountFieldNumber = 7 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.FlagsFieldNumber = 8 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.ObservedTimeUnixNanoFieldNumber = 11 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.SeverityNumberFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.SeverityTextFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.SpanIdFieldNumber = 10 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.TimeUnixNanoFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Logs.V1.LogRecord.TraceIdFieldNumber = 9 -> int
+const OpenTelemetry.Proto.Logs.V1.LogsData.ResourceLogsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Logs.V1.ResourceLogs.ResourceFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Logs.V1.ResourceLogs.SchemaUrlFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Logs.V1.ResourceLogs.ScopeLogsFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Logs.V1.ScopeLogs.LogRecordsFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Logs.V1.ScopeLogs.SchemaUrlFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Logs.V1.ScopeLogs.ScopeFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.Exemplar.AsDoubleFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Metrics.V1.Exemplar.AsIntFieldNumber = 6 -> int
+const OpenTelemetry.Proto.Metrics.V1.Exemplar.FilteredAttributesFieldNumber = 7 -> int
+const OpenTelemetry.Proto.Metrics.V1.Exemplar.SpanIdFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Metrics.V1.Exemplar.TimeUnixNanoFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.Exemplar.TraceIdFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.AggregationTemporalityFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.DataPointsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.AttributesFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.CountFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ExemplarsFieldNumber = 11 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.FlagsFieldNumber = 10 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.MaxFieldNumber = 13 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.MinFieldNumber = 12 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.NegativeFieldNumber = 9 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.PositiveFieldNumber = 8 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ScaleFieldNumber = 6 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.StartTimeUnixNanoFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.SumFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.TimeUnixNanoFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.BucketCountsFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.OffsetFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ZeroCountFieldNumber = 7 -> int
+const OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ZeroThresholdFieldNumber = 14 -> int
+const OpenTelemetry.Proto.Metrics.V1.Gauge.DataPointsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.Histogram.AggregationTemporalityFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.Histogram.DataPointsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.AttributesFieldNumber = 9 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.BucketCountsFieldNumber = 6 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.CountFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.ExemplarsFieldNumber = 8 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.ExplicitBoundsFieldNumber = 7 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.FlagsFieldNumber = 10 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.MaxFieldNumber = 12 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.MinFieldNumber = 11 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.StartTimeUnixNanoFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.SumFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.TimeUnixNanoFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Metrics.V1.Metric.DescriptionFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.Metric.ExponentialHistogramFieldNumber = 10 -> int
+const OpenTelemetry.Proto.Metrics.V1.Metric.GaugeFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Metrics.V1.Metric.HistogramFieldNumber = 9 -> int
+const OpenTelemetry.Proto.Metrics.V1.Metric.NameFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.Metric.SumFieldNumber = 7 -> int
+const OpenTelemetry.Proto.Metrics.V1.Metric.SummaryFieldNumber = 11 -> int
+const OpenTelemetry.Proto.Metrics.V1.Metric.UnitFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Metrics.V1.MetricsData.ResourceMetricsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.AsDoubleFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.AsIntFieldNumber = 6 -> int
+const OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.AttributesFieldNumber = 7 -> int
+const OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ExemplarsFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.FlagsFieldNumber = 8 -> int
+const OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.StartTimeUnixNanoFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.TimeUnixNanoFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.ResourceFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.SchemaUrlFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.ScopeMetricsFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.MetricsFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.SchemaUrlFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.ScopeFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.Sum.AggregationTemporalityFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.Sum.DataPointsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.Sum.IsMonotonicFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Metrics.V1.Summary.DataPointsFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.AttributesFieldNumber = 7 -> int
+const OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.CountFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.FlagsFieldNumber = 8 -> int
+const OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.QuantileValuesFieldNumber = 6 -> int
+const OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.StartTimeUnixNanoFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.SumFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.TimeUnixNanoFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.QuantileFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.ValueFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Resource.V1.Resource.AttributesFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Resource.V1.Resource.DroppedAttributesCountFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Trace.V1.ResourceSpans.ResourceFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Trace.V1.ResourceSpans.SchemaUrlFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Trace.V1.ResourceSpans.ScopeSpansFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Trace.V1.ScopeSpans.SchemaUrlFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Trace.V1.ScopeSpans.ScopeFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Trace.V1.ScopeSpans.SpansFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.AttributesFieldNumber = 9 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.DroppedAttributesCountFieldNumber = 10 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.DroppedEventsCountFieldNumber = 12 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.DroppedLinksCountFieldNumber = 14 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.EndTimeUnixNanoFieldNumber = 8 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.EventsFieldNumber = 11 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.KindFieldNumber = 6 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.LinksFieldNumber = 13 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.NameFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.ParentSpanIdFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.SpanIdFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.StartTimeUnixNanoFieldNumber = 7 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.StatusFieldNumber = 15 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.TraceIdFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.TraceStateFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.Types.Event.AttributesFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.Types.Event.DroppedAttributesCountFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.Types.Event.NameFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.Types.Event.TimeUnixNanoFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.Types.Link.AttributesFieldNumber = 4 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.Types.Link.DroppedAttributesCountFieldNumber = 5 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.Types.Link.SpanIdFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.Types.Link.TraceIdFieldNumber = 1 -> int
+const OpenTelemetry.Proto.Trace.V1.Span.Types.Link.TraceStateFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Trace.V1.Status.CodeFieldNumber = 3 -> int
+const OpenTelemetry.Proto.Trace.V1.Status.MessageFieldNumber = 2 -> int
+const OpenTelemetry.Proto.Trace.V1.TracesData.ResourceSpansFieldNumber = 1 -> int
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.CalculateSize() -> int
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.ExportLogsPartialSuccess() -> void
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.RejectedLogRecords.get -> long
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.RejectedLogRecords.set -> void
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.CalculateSize() -> int
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.ExportLogsServiceRequest() -> void
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.CalculateSize() -> int
+OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.ExportLogsServiceResponse() -> void
+OpenTelemetry.Proto.Collector.Logs.V1.LogsService
+OpenTelemetry.Proto.Collector.Logs.V1.LogsService.LogsServiceBase
+OpenTelemetry.Proto.Collector.Logs.V1.LogsService.LogsServiceBase.LogsServiceBase() -> void
+OpenTelemetry.Proto.Collector.Logs.V1.LogsServiceReflection
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.CalculateSize() -> int
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.ExportMetricsPartialSuccess() -> void
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.RejectedDataPoints.get -> long
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.RejectedDataPoints.set -> void
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.CalculateSize() -> int
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.ExportMetricsServiceRequest() -> void
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.CalculateSize() -> int
+OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.ExportMetricsServiceResponse() -> void
+OpenTelemetry.Proto.Collector.Metrics.V1.MetricsService
+OpenTelemetry.Proto.Collector.Metrics.V1.MetricsService.MetricsServiceBase
+OpenTelemetry.Proto.Collector.Metrics.V1.MetricsService.MetricsServiceBase.MetricsServiceBase() -> void
+OpenTelemetry.Proto.Collector.Metrics.V1.MetricsServiceReflection
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.CalculateSize() -> int
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.ExportTracePartialSuccess() -> void
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.RejectedSpans.get -> long
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.RejectedSpans.set -> void
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.CalculateSize() -> int
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.ExportTraceServiceRequest() -> void
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.CalculateSize() -> int
+OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.ExportTraceServiceResponse() -> void
+OpenTelemetry.Proto.Collector.Trace.V1.TraceService
+OpenTelemetry.Proto.Collector.Trace.V1.TraceService.TraceServiceBase
+OpenTelemetry.Proto.Collector.Trace.V1.TraceService.TraceServiceBase.TraceServiceBase() -> void
+OpenTelemetry.Proto.Collector.Trace.V1.TraceServiceReflection
+OpenTelemetry.Proto.Common.V1.AnyValue
+OpenTelemetry.Proto.Common.V1.AnyValue.AnyValue() -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.BoolValue.get -> bool
+OpenTelemetry.Proto.Common.V1.AnyValue.BoolValue.set -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.CalculateSize() -> int
+OpenTelemetry.Proto.Common.V1.AnyValue.ClearBoolValue() -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.ClearBytesValue() -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.ClearDoubleValue() -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.ClearIntValue() -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.ClearStringValue() -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.ClearValue() -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.DoubleValue.get -> double
+OpenTelemetry.Proto.Common.V1.AnyValue.DoubleValue.set -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.HasBoolValue.get -> bool
+OpenTelemetry.Proto.Common.V1.AnyValue.HasBytesValue.get -> bool
+OpenTelemetry.Proto.Common.V1.AnyValue.HasDoubleValue.get -> bool
+OpenTelemetry.Proto.Common.V1.AnyValue.HasIntValue.get -> bool
+OpenTelemetry.Proto.Common.V1.AnyValue.HasStringValue.get -> bool
+OpenTelemetry.Proto.Common.V1.AnyValue.IntValue.get -> long
+OpenTelemetry.Proto.Common.V1.AnyValue.IntValue.set -> void
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueCase.get -> OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase.ArrayValue = 5 -> OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase.BoolValue = 2 -> OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase.BytesValue = 7 -> OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase.DoubleValue = 4 -> OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase.IntValue = 3 -> OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase.KvlistValue = 6 -> OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase.None = 0 -> OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase.StringValue = 1 -> OpenTelemetry.Proto.Common.V1.AnyValue.ValueOneofCase
+OpenTelemetry.Proto.Common.V1.ArrayValue
+OpenTelemetry.Proto.Common.V1.ArrayValue.ArrayValue() -> void
+OpenTelemetry.Proto.Common.V1.ArrayValue.CalculateSize() -> int
+OpenTelemetry.Proto.Common.V1.CommonReflection
+OpenTelemetry.Proto.Common.V1.InstrumentationScope
+OpenTelemetry.Proto.Common.V1.InstrumentationScope.CalculateSize() -> int
+OpenTelemetry.Proto.Common.V1.InstrumentationScope.DroppedAttributesCount.get -> uint
+OpenTelemetry.Proto.Common.V1.InstrumentationScope.DroppedAttributesCount.set -> void
+OpenTelemetry.Proto.Common.V1.InstrumentationScope.InstrumentationScope() -> void
+OpenTelemetry.Proto.Common.V1.KeyValue
+OpenTelemetry.Proto.Common.V1.KeyValue.CalculateSize() -> int
+OpenTelemetry.Proto.Common.V1.KeyValue.KeyValue() -> void
+OpenTelemetry.Proto.Common.V1.KeyValueList
+OpenTelemetry.Proto.Common.V1.KeyValueList.CalculateSize() -> int
+OpenTelemetry.Proto.Common.V1.KeyValueList.KeyValueList() -> void
+OpenTelemetry.Proto.Logs.V1.LogRecord
+OpenTelemetry.Proto.Logs.V1.LogRecord.CalculateSize() -> int
+OpenTelemetry.Proto.Logs.V1.LogRecord.DroppedAttributesCount.get -> uint
+OpenTelemetry.Proto.Logs.V1.LogRecord.DroppedAttributesCount.set -> void
+OpenTelemetry.Proto.Logs.V1.LogRecord.Flags.get -> uint
+OpenTelemetry.Proto.Logs.V1.LogRecord.Flags.set -> void
+OpenTelemetry.Proto.Logs.V1.LogRecord.LogRecord() -> void
+OpenTelemetry.Proto.Logs.V1.LogRecord.ObservedTimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Logs.V1.LogRecord.ObservedTimeUnixNano.set -> void
+OpenTelemetry.Proto.Logs.V1.LogRecord.SeverityNumber.get -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.LogRecord.SeverityNumber.set -> void
+OpenTelemetry.Proto.Logs.V1.LogRecord.TimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Logs.V1.LogRecord.TimeUnixNano.set -> void
+OpenTelemetry.Proto.Logs.V1.LogRecordFlags
+OpenTelemetry.Proto.Logs.V1.LogRecordFlags.DoNotUse = 0 -> OpenTelemetry.Proto.Logs.V1.LogRecordFlags
+OpenTelemetry.Proto.Logs.V1.LogRecordFlags.TraceFlagsMask = 255 -> OpenTelemetry.Proto.Logs.V1.LogRecordFlags
+OpenTelemetry.Proto.Logs.V1.LogsData
+OpenTelemetry.Proto.Logs.V1.LogsData.CalculateSize() -> int
+OpenTelemetry.Proto.Logs.V1.LogsData.LogsData() -> void
+OpenTelemetry.Proto.Logs.V1.LogsReflection
+OpenTelemetry.Proto.Logs.V1.ResourceLogs
+OpenTelemetry.Proto.Logs.V1.ResourceLogs.CalculateSize() -> int
+OpenTelemetry.Proto.Logs.V1.ResourceLogs.ResourceLogs() -> void
+OpenTelemetry.Proto.Logs.V1.ScopeLogs
+OpenTelemetry.Proto.Logs.V1.ScopeLogs.CalculateSize() -> int
+OpenTelemetry.Proto.Logs.V1.ScopeLogs.ScopeLogs() -> void
+OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug = 5 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug2 = 6 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug3 = 7 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Debug4 = 8 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error = 17 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error2 = 18 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error3 = 19 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Error4 = 20 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal = 21 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal2 = 22 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal3 = 23 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Fatal4 = 24 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info = 9 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info2 = 10 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info3 = 11 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Info4 = 12 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace = 1 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace2 = 2 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace3 = 3 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Trace4 = 4 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Unspecified = 0 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn = 13 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn2 = 14 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn3 = 15 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Logs.V1.SeverityNumber.Warn4 = 16 -> OpenTelemetry.Proto.Logs.V1.SeverityNumber
+OpenTelemetry.Proto.Metrics.V1.AggregationTemporality
+OpenTelemetry.Proto.Metrics.V1.AggregationTemporality.Cumulative = 2 -> OpenTelemetry.Proto.Metrics.V1.AggregationTemporality
+OpenTelemetry.Proto.Metrics.V1.AggregationTemporality.Delta = 1 -> OpenTelemetry.Proto.Metrics.V1.AggregationTemporality
+OpenTelemetry.Proto.Metrics.V1.AggregationTemporality.Unspecified = 0 -> OpenTelemetry.Proto.Metrics.V1.AggregationTemporality
+OpenTelemetry.Proto.Metrics.V1.DataPointFlags
+OpenTelemetry.Proto.Metrics.V1.DataPointFlags.DoNotUse = 0 -> OpenTelemetry.Proto.Metrics.V1.DataPointFlags
+OpenTelemetry.Proto.Metrics.V1.DataPointFlags.NoRecordedValueMask = 1 -> OpenTelemetry.Proto.Metrics.V1.DataPointFlags
+OpenTelemetry.Proto.Metrics.V1.Exemplar
+OpenTelemetry.Proto.Metrics.V1.Exemplar.AsDouble.get -> double
+OpenTelemetry.Proto.Metrics.V1.Exemplar.AsDouble.set -> void
+OpenTelemetry.Proto.Metrics.V1.Exemplar.AsInt.get -> long
+OpenTelemetry.Proto.Metrics.V1.Exemplar.AsInt.set -> void
+OpenTelemetry.Proto.Metrics.V1.Exemplar.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.Exemplar.ClearAsDouble() -> void
+OpenTelemetry.Proto.Metrics.V1.Exemplar.ClearAsInt() -> void
+OpenTelemetry.Proto.Metrics.V1.Exemplar.ClearValue() -> void
+OpenTelemetry.Proto.Metrics.V1.Exemplar.Exemplar() -> void
+OpenTelemetry.Proto.Metrics.V1.Exemplar.HasAsDouble.get -> bool
+OpenTelemetry.Proto.Metrics.V1.Exemplar.HasAsInt.get -> bool
+OpenTelemetry.Proto.Metrics.V1.Exemplar.TimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.Exemplar.TimeUnixNano.set -> void
+OpenTelemetry.Proto.Metrics.V1.Exemplar.ValueCase.get -> OpenTelemetry.Proto.Metrics.V1.Exemplar.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.Exemplar.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.Exemplar.ValueOneofCase.AsDouble = 3 -> OpenTelemetry.Proto.Metrics.V1.Exemplar.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.Exemplar.ValueOneofCase.AsInt = 6 -> OpenTelemetry.Proto.Metrics.V1.Exemplar.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.Exemplar.ValueOneofCase.None = 0 -> OpenTelemetry.Proto.Metrics.V1.Exemplar.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.AggregationTemporality.get -> OpenTelemetry.Proto.Metrics.V1.AggregationTemporality
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.AggregationTemporality.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.ExponentialHistogram() -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ClearMax() -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ClearMin() -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ClearSum() -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Count.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Count.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ExponentialHistogramDataPoint() -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Flags.get -> uint
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Flags.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.HasMax.get -> bool
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.HasMin.get -> bool
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.HasSum.get -> bool
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Max.get -> double
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Max.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Min.get -> double
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Min.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Scale.get -> int
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Scale.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.StartTimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.StartTimeUnixNano.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Sum.get -> double
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Sum.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.TimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.TimeUnixNano.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.Buckets() -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.Offset.get -> int
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.Offset.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ZeroCount.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ZeroCount.set -> void
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ZeroThreshold.get -> double
+OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ZeroThreshold.set -> void
+OpenTelemetry.Proto.Metrics.V1.Gauge
+OpenTelemetry.Proto.Metrics.V1.Gauge.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.Gauge.Gauge() -> void
+OpenTelemetry.Proto.Metrics.V1.Histogram
+OpenTelemetry.Proto.Metrics.V1.Histogram.AggregationTemporality.get -> OpenTelemetry.Proto.Metrics.V1.AggregationTemporality
+OpenTelemetry.Proto.Metrics.V1.Histogram.AggregationTemporality.set -> void
+OpenTelemetry.Proto.Metrics.V1.Histogram.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.Histogram.Histogram() -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.ClearMax() -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.ClearMin() -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.ClearSum() -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Count.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Count.set -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Flags.get -> uint
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Flags.set -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.HasMax.get -> bool
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.HasMin.get -> bool
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.HasSum.get -> bool
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.HistogramDataPoint() -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Max.get -> double
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Max.set -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Min.get -> double
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Min.set -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.StartTimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.StartTimeUnixNano.set -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Sum.get -> double
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Sum.set -> void
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.TimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.TimeUnixNano.set -> void
+OpenTelemetry.Proto.Metrics.V1.Metric
+OpenTelemetry.Proto.Metrics.V1.Metric.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.Metric.ClearData() -> void
+OpenTelemetry.Proto.Metrics.V1.Metric.DataCase.get -> OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase
+OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase
+OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase.ExponentialHistogram = 10 -> OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase
+OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase.Gauge = 5 -> OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase
+OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase.Histogram = 9 -> OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase
+OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase.None = 0 -> OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase
+OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase.Sum = 7 -> OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase
+OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase.Summary = 11 -> OpenTelemetry.Proto.Metrics.V1.Metric.DataOneofCase
+OpenTelemetry.Proto.Metrics.V1.Metric.Metric() -> void
+OpenTelemetry.Proto.Metrics.V1.MetricsData
+OpenTelemetry.Proto.Metrics.V1.MetricsData.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.MetricsData.MetricsData() -> void
+OpenTelemetry.Proto.Metrics.V1.MetricsReflection
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.AsDouble.get -> double
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.AsDouble.set -> void
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.AsInt.get -> long
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.AsInt.set -> void
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ClearAsDouble() -> void
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ClearAsInt() -> void
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ClearValue() -> void
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.Flags.get -> uint
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.Flags.set -> void
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.HasAsDouble.get -> bool
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.HasAsInt.get -> bool
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.NumberDataPoint() -> void
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.StartTimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.StartTimeUnixNano.set -> void
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.TimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.TimeUnixNano.set -> void
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ValueCase.get -> OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ValueOneofCase.AsDouble = 4 -> OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ValueOneofCase.AsInt = 6 -> OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ValueOneofCase.None = 0 -> OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ValueOneofCase
+OpenTelemetry.Proto.Metrics.V1.ResourceMetrics
+OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.ResourceMetrics() -> void
+OpenTelemetry.Proto.Metrics.V1.ScopeMetrics
+OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.ScopeMetrics() -> void
+OpenTelemetry.Proto.Metrics.V1.Sum
+OpenTelemetry.Proto.Metrics.V1.Sum.AggregationTemporality.get -> OpenTelemetry.Proto.Metrics.V1.AggregationTemporality
+OpenTelemetry.Proto.Metrics.V1.Sum.AggregationTemporality.set -> void
+OpenTelemetry.Proto.Metrics.V1.Sum.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.Sum.IsMonotonic.get -> bool
+OpenTelemetry.Proto.Metrics.V1.Sum.IsMonotonic.set -> void
+OpenTelemetry.Proto.Metrics.V1.Sum.Sum() -> void
+OpenTelemetry.Proto.Metrics.V1.Summary
+OpenTelemetry.Proto.Metrics.V1.Summary.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.Summary.Summary() -> void
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Count.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Count.set -> void
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Flags.get -> uint
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Flags.set -> void
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.StartTimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.StartTimeUnixNano.set -> void
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Sum.get -> double
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Sum.set -> void
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.SummaryDataPoint() -> void
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.TimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.TimeUnixNano.set -> void
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.CalculateSize() -> int
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.Quantile.get -> double
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.Quantile.set -> void
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.Value.get -> double
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.Value.set -> void
+OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.ValueAtQuantile() -> void
+OpenTelemetry.Proto.Resource.V1.Resource
+OpenTelemetry.Proto.Resource.V1.Resource.CalculateSize() -> int
+OpenTelemetry.Proto.Resource.V1.Resource.DroppedAttributesCount.get -> uint
+OpenTelemetry.Proto.Resource.V1.Resource.DroppedAttributesCount.set -> void
+OpenTelemetry.Proto.Resource.V1.Resource.Resource() -> void
+OpenTelemetry.Proto.Resource.V1.ResourceReflection
+OpenTelemetry.Proto.Trace.V1.ResourceSpans
+OpenTelemetry.Proto.Trace.V1.ResourceSpans.CalculateSize() -> int
+OpenTelemetry.Proto.Trace.V1.ResourceSpans.ResourceSpans() -> void
+OpenTelemetry.Proto.Trace.V1.ScopeSpans
+OpenTelemetry.Proto.Trace.V1.ScopeSpans.CalculateSize() -> int
+OpenTelemetry.Proto.Trace.V1.ScopeSpans.ScopeSpans() -> void
+OpenTelemetry.Proto.Trace.V1.Span
+OpenTelemetry.Proto.Trace.V1.Span.CalculateSize() -> int
+OpenTelemetry.Proto.Trace.V1.Span.DroppedAttributesCount.get -> uint
+OpenTelemetry.Proto.Trace.V1.Span.DroppedAttributesCount.set -> void
+OpenTelemetry.Proto.Trace.V1.Span.DroppedEventsCount.get -> uint
+OpenTelemetry.Proto.Trace.V1.Span.DroppedEventsCount.set -> void
+OpenTelemetry.Proto.Trace.V1.Span.DroppedLinksCount.get -> uint
+OpenTelemetry.Proto.Trace.V1.Span.DroppedLinksCount.set -> void
+OpenTelemetry.Proto.Trace.V1.Span.EndTimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Trace.V1.Span.EndTimeUnixNano.set -> void
+OpenTelemetry.Proto.Trace.V1.Span.Kind.get -> OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind
+OpenTelemetry.Proto.Trace.V1.Span.Kind.set -> void
+OpenTelemetry.Proto.Trace.V1.Span.Span() -> void
+OpenTelemetry.Proto.Trace.V1.Span.StartTimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Trace.V1.Span.StartTimeUnixNano.set -> void
+OpenTelemetry.Proto.Trace.V1.Span.Types
+OpenTelemetry.Proto.Trace.V1.Span.Types.Event
+OpenTelemetry.Proto.Trace.V1.Span.Types.Event.CalculateSize() -> int
+OpenTelemetry.Proto.Trace.V1.Span.Types.Event.DroppedAttributesCount.get -> uint
+OpenTelemetry.Proto.Trace.V1.Span.Types.Event.DroppedAttributesCount.set -> void
+OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Event() -> void
+OpenTelemetry.Proto.Trace.V1.Span.Types.Event.TimeUnixNano.get -> ulong
+OpenTelemetry.Proto.Trace.V1.Span.Types.Event.TimeUnixNano.set -> void
+OpenTelemetry.Proto.Trace.V1.Span.Types.Link
+OpenTelemetry.Proto.Trace.V1.Span.Types.Link.CalculateSize() -> int
+OpenTelemetry.Proto.Trace.V1.Span.Types.Link.DroppedAttributesCount.get -> uint
+OpenTelemetry.Proto.Trace.V1.Span.Types.Link.DroppedAttributesCount.set -> void
+OpenTelemetry.Proto.Trace.V1.Span.Types.Link.Link() -> void
+OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind
+OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind.Client = 3 -> OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind
+OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind.Consumer = 5 -> OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind
+OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind.Internal = 1 -> OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind
+OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind.Producer = 4 -> OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind
+OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind.Server = 2 -> OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind
+OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind.Unspecified = 0 -> OpenTelemetry.Proto.Trace.V1.Span.Types.SpanKind
+OpenTelemetry.Proto.Trace.V1.Status
+OpenTelemetry.Proto.Trace.V1.Status.CalculateSize() -> int
+OpenTelemetry.Proto.Trace.V1.Status.Code.get -> OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode
+OpenTelemetry.Proto.Trace.V1.Status.Code.set -> void
+OpenTelemetry.Proto.Trace.V1.Status.Status() -> void
+OpenTelemetry.Proto.Trace.V1.Status.Types
+OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode
+OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode.Error = 2 -> OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode
+OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode.Ok = 1 -> OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode
+OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode.Unset = 0 -> OpenTelemetry.Proto.Trace.V1.Status.Types.StatusCode
+OpenTelemetry.Proto.Trace.V1.TraceReflection
+OpenTelemetry.Proto.Trace.V1.TracesData
+OpenTelemetry.Proto.Trace.V1.TracesData.CalculateSize() -> int
+OpenTelemetry.Proto.Trace.V1.TracesData.TracesData() -> void
+override Aspire.Dashboard.Components.ChartContainer.OnInitialized() -> void
+override Aspire.Dashboard.Components.ChartContainer.OnParametersSetAsync() -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.GetHashCode() -> int
+override Aspire.Dashboard.Components.Controls.ResourceDetails.OnInitialized() -> void
+override Aspire.Dashboard.Components.Controls.ResourceDetails.OnParametersSet() -> void
+override Aspire.Dashboard.Components.Controls.SummaryDetailsView.OnParametersSetAsync() -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Dialogs.FilterDialog.OnInitialized() -> void
+override Aspire.Dashboard.Components.Dialogs.SettingsDialog.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Dialogs.SettingsDialog.OnInitialized() -> void
+override Aspire.Dashboard.Components.Layout.MainLayout.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Layout.MainLayout.OnInitialized() -> void
+override Aspire.Dashboard.Components.Pages.Metrics.OnInitializedAsync() -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Pages.Metrics.OnParametersSetAsync() -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Pages.Resources.OnInitialized() -> void
+override Aspire.Dashboard.Components.Pages.StructuredLogs.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Pages.StructuredLogs.OnInitializedAsync() -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Pages.StructuredLogs.OnParametersSet() -> void
+override Aspire.Dashboard.Components.Pages.TraceDetail.OnInitialized() -> void
+override Aspire.Dashboard.Components.Pages.TraceDetail.OnParametersSet() -> void
+override Aspire.Dashboard.Components.Pages.Traces.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Pages.Traces.OnInitializedAsync() -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.Pages.Traces.OnParametersSet() -> void
+override Aspire.Dashboard.Components.Pages.UrlState.Equals(object? obj) -> bool
+override Aspire.Dashboard.Components.Pages.UrlState.GetHashCode() -> int
+override Aspire.Dashboard.Components.Pages.UrlState.ToString() -> string!
+override Aspire.Dashboard.Components.PlotlyChart.OnAfterRenderAsync(bool firstRender) -> System.Threading.Tasks.Task!
+override Aspire.Dashboard.Components.PlotlyChart.OnInitialized() -> void
+override Aspire.Dashboard.Components.PlotlyChart.OnParametersSet() -> void
+override Aspire.Dashboard.Components.UnreadLogErrorsBadge.OnParametersSet() -> void
+override Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.GetHashCode() -> int
+override Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.GetHashCode() -> int
+override Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.GetHashCode() -> int
+override Aspire.Dashboard.Model.ResourceViewModelChange.Equals(object? obj) -> bool
+override Aspire.Dashboard.Model.ResourceViewModelChange.GetHashCode() -> int
+override Aspire.Dashboard.Model.ResourceViewModelChange.ToString() -> string!
+override Aspire.Dashboard.Model.ResourceViewModelSubscription.Equals(object? obj) -> bool
+override Aspire.Dashboard.Model.ResourceViewModelSubscription.GetHashCode() -> int
+override Aspire.Dashboard.Model.ResourceViewModelSubscription.ToString() -> string!
+override Aspire.Dashboard.Otlp.Grpc.OtlpLogsService.Export(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest! request, Grpc.Core.ServerCallContext! context) -> System.Threading.Tasks.Task<OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse!>!
+override Aspire.Dashboard.Otlp.Grpc.OtlpMetricsService.Export(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest! request, Grpc.Core.ServerCallContext! context) -> System.Threading.Tasks.Task<OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse!>!
+override Aspire.Dashboard.Otlp.Grpc.OtlpTraceService.Export(OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest! request, Grpc.Core.ServerCallContext! context) -> System.Threading.Tasks.Task<OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse!>!
+override Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue.Clone() -> Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase!
+override Aspire.Dashboard.Otlp.Model.MetricValues.HistogramValue.ToString() -> string!
+override Aspire.Dashboard.Otlp.Model.MetricValues.MetricValue<T>.Clone() -> Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase!
+override Aspire.Dashboard.Otlp.Model.MetricValues.MetricValue<T>.ToString() -> string?
+override Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.GetHashCode() -> int
+override OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.GetHashCode() -> int
+override OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.GetHashCode() -> int
+override OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.GetHashCode() -> int
+override OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.GetHashCode() -> int
+override OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.GetHashCode() -> int
+override OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.GetHashCode() -> int
+override OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.GetHashCode() -> int
+override OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.GetHashCode() -> int
+override OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.GetHashCode() -> int
+override OpenTelemetry.Proto.Common.V1.AnyValue.GetHashCode() -> int
+override OpenTelemetry.Proto.Common.V1.ArrayValue.GetHashCode() -> int
+override OpenTelemetry.Proto.Common.V1.InstrumentationScope.GetHashCode() -> int
+override OpenTelemetry.Proto.Common.V1.KeyValue.GetHashCode() -> int
+override OpenTelemetry.Proto.Common.V1.KeyValueList.GetHashCode() -> int
+override OpenTelemetry.Proto.Logs.V1.LogRecord.GetHashCode() -> int
+override OpenTelemetry.Proto.Logs.V1.LogsData.GetHashCode() -> int
+override OpenTelemetry.Proto.Logs.V1.ResourceLogs.GetHashCode() -> int
+override OpenTelemetry.Proto.Logs.V1.ScopeLogs.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.Exemplar.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.Gauge.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.Histogram.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.Metric.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.MetricsData.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.Sum.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.Summary.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.GetHashCode() -> int
+override OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.GetHashCode() -> int
+override OpenTelemetry.Proto.Resource.V1.Resource.GetHashCode() -> int
+override OpenTelemetry.Proto.Trace.V1.ResourceSpans.GetHashCode() -> int
+override OpenTelemetry.Proto.Trace.V1.ScopeSpans.GetHashCode() -> int
+override OpenTelemetry.Proto.Trace.V1.Span.GetHashCode() -> int
+override OpenTelemetry.Proto.Trace.V1.Span.Types.Event.GetHashCode() -> int
+override OpenTelemetry.Proto.Trace.V1.Span.Types.Link.GetHashCode() -> int
+override OpenTelemetry.Proto.Trace.V1.Status.GetHashCode() -> int
+override OpenTelemetry.Proto.Trace.V1.TracesData.GetHashCode() -> int
+readonly Aspire.Dashboard.Otlp.Model.MetricValues.DimensionScope.Values -> System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase!>!
+readonly Aspire.Dashboard.Otlp.Model.MetricValues.MetricValue<T>.Value -> T
+readonly Aspire.Dashboard.Otlp.Model.MetricValues.MetricValueBase.Start -> System.DateTime
+static Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.operator !=(Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs left, Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs right) -> bool
+static Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.operator ==(Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs left, Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs right) -> bool
+static Aspire.Dashboard.Components.Pages.PageExtensions.AfterViewModelChangedAsync<TViewModel, TSerializableViewModel>(this Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel!>! page) -> System.Threading.Tasks.Task!
+static Aspire.Dashboard.Components.Pages.PageExtensions.InitializeViewModelAsync<TViewModel, TSerializableViewModel>(this Aspire.Dashboard.Components.Pages.IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel!>! page) -> System.Threading.Tasks.Task!
+static Aspire.Dashboard.Components.Pages.UrlState.operator !=(Aspire.Dashboard.Components.Pages.UrlState? left, Aspire.Dashboard.Components.Pages.UrlState? right) -> bool
+static Aspire.Dashboard.Components.Pages.UrlState.operator ==(Aspire.Dashboard.Components.Pages.UrlState? left, Aspire.Dashboard.Components.Pages.UrlState? right) -> bool
+static Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.operator !=(Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult left, Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult right) -> bool
+static Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.operator ==(Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult left, Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult right) -> bool
+static Aspire.Dashboard.ConsoleLogs.AnsiParser.ConvertToHtml(string? text, Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState? priorResidualState = null) -> Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult
+static Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.operator !=(Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState left, Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState right) -> bool
+static Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.operator ==(Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState left, Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState right) -> bool
+static Aspire.Dashboard.ConsoleLogs.LogLevelParser.StartsWithLogLevelHeader(string! text) -> bool
+static Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.operator !=(Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult left, Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult right) -> bool
+static Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.operator ==(Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult left, Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult right) -> bool
+static Aspire.Dashboard.ConsoleLogs.TimestampParser.TryColorizeTimestamp(string! text, bool convertTimestampsFromUtc, out Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult result) -> bool
+static Aspire.Dashboard.ConsoleLogs.UrlParser.TryParse(string? text, out string? modifiedText) -> bool
+static Aspire.Dashboard.Model.Otlp.LogFilter.ConditionToString(Aspire.Dashboard.Model.Otlp.FilterCondition c) -> string!
+static Aspire.Dashboard.Model.Otlp.LogFilter.GetAllPropertyNames(System.Collections.Generic.List<string!>! propertyKeys) -> System.Collections.Generic.List<string!>!
+static Aspire.Dashboard.Model.Otlp.SelectViewModelFactory.CreateApplicationsSelectViewModel(System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.OtlpApplication!>! applications) -> System.Collections.Generic.List<Aspire.Dashboard.Model.Otlp.SelectViewModel<string!>!>!
+static Aspire.Dashboard.Model.ResourceFormatter.GetName(string! name, string! uid) -> string!
+static Aspire.Dashboard.Model.ResourceViewModel.GetResourceName(Aspire.Dashboard.Model.ResourceViewModel! resource, System.Collections.Generic.IEnumerable<Aspire.Dashboard.Model.ResourceViewModel!>! allResources) -> string!
+static Aspire.Dashboard.Model.ResourceViewModelChange.operator !=(Aspire.Dashboard.Model.ResourceViewModelChange? left, Aspire.Dashboard.Model.ResourceViewModelChange? right) -> bool
+static Aspire.Dashboard.Model.ResourceViewModelChange.operator ==(Aspire.Dashboard.Model.ResourceViewModelChange? left, Aspire.Dashboard.Model.ResourceViewModelChange? right) -> bool
+static Aspire.Dashboard.Model.ResourceViewModelSubscription.operator !=(Aspire.Dashboard.Model.ResourceViewModelSubscription? left, Aspire.Dashboard.Model.ResourceViewModelSubscription? right) -> bool
+static Aspire.Dashboard.Model.ResourceViewModelSubscription.operator ==(Aspire.Dashboard.Model.ResourceViewModelSubscription? left, Aspire.Dashboard.Model.ResourceViewModelSubscription? right) -> bool
+static Aspire.Dashboard.Otlp.Model.DurationFormatter.FormatDuration(System.TimeSpan duration) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpApplication.GetResourceName(Aspire.Dashboard.Otlp.Model.OtlpApplication! app, System.Collections.Generic.List<Aspire.Dashboard.Otlp.Model.OtlpApplication!>! allApplications) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.ConcatProperties(this System.Collections.Generic.KeyValuePair<string!, string!>[]! properties) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.CopyKeyValuePairs(Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue!>! attributes, ref System.Collections.Generic.KeyValuePair<string!, string!>[]? copiedAttributes) -> void
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.FormatTimeStamp(System.DateTime timestamp) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.GetItems<T>(System.Collections.Generic.IEnumerable<T>! results, int startIndex, int? count) -> Aspire.Dashboard.Otlp.Storage.PagedResult<T>!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.GetItems<TSource, TResult>(System.Collections.Generic.IEnumerable<TSource>! results, int startIndex, int? count, System.Func<TSource, TResult>? select) -> Aspire.Dashboard.Otlp.Storage.PagedResult<TResult>!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.GetServiceId(this OpenTelemetry.Proto.Resource.V1.Resource! resource) -> string?
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.GetString(this OpenTelemetry.Proto.Common.V1.AnyValue! value) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.GetValue(this System.Collections.Generic.KeyValuePair<string!, string!>[]! values, string! name) -> string?
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.ToHexString(System.ReadOnlyMemory<byte> bytes) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.ToHexString(this Google.Protobuf.ByteString! bytes) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.ToKeyValuePairs(this Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue!>! attributes) -> System.Collections.Generic.KeyValuePair<string!, string!>[]!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.ToShortenedId(string! id) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpHelpers.UnixNanoSecondsToDateTime(ulong unixTimeNanoSeconds) -> System.DateTime
+static Aspire.Dashboard.Otlp.Model.OtlpInstrument.Clone(Aspire.Dashboard.Otlp.Model.OtlpInstrument! instrument, bool cloneData, System.DateTime? valuesStart, System.DateTime? valuesEnd) -> Aspire.Dashboard.Otlp.Model.OtlpInstrument!
+static Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.operator !=(Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey left, Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey right) -> bool
+static Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.operator ==(Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey left, Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey right) -> bool
+static Aspire.Dashboard.Otlp.Model.OtlpSpan.Clone(Aspire.Dashboard.Otlp.Model.OtlpSpan! item, Aspire.Dashboard.Otlp.Model.OtlpTrace! trace) -> Aspire.Dashboard.Otlp.Model.OtlpSpan!
+static Aspire.Dashboard.Otlp.Model.OtlpTrace.Clone(Aspire.Dashboard.Otlp.Model.OtlpTrace! trace) -> Aspire.Dashboard.Otlp.Model.OtlpTrace!
+static Aspire.Dashboard.Otlp.Model.OtlpUnits.GetUnit(string! unit) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpUnits.MapPerUnit(System.ReadOnlySpan<char> perUnit) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpUnits.MapUnit(System.ReadOnlySpan<char> unit) -> string!
+static Aspire.Dashboard.Otlp.Model.OtlpUnits.RemoveAnnotations(string! unit) -> string!
+static readonly Aspire.Dashboard.Otlp.Model.ColorGenerator.Instance -> Aspire.Dashboard.Otlp.Model.ColorGenerator!
+static readonly Aspire.Dashboard.Otlp.Model.OtlpScope.Empty -> Aspire.Dashboard.Otlp.Model.OtlpScope!
+static readonly Aspire.Dashboard.Otlp.Storage.PagedResult<T>.Empty -> Aspire.Dashboard.Otlp.Storage.PagedResult<T>!
+virtual Aspire.Dashboard.Components.Pages.Resources.Dispose(bool disposing) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.Clone() -> OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.Equals(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess other) -> bool
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.ErrorMessage.get -> string
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.ErrorMessage.set -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.ExportLogsPartialSuccess(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess other) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.MergeFrom(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess other) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.Clone() -> OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.Equals(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest other) -> bool
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.ExportLogsServiceRequest(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest other) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.MergeFrom(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest other) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.ResourceLogs.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Logs.V1.ResourceLogs>
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.Clone() -> OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.Equals(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse other) -> bool
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.ExportLogsServiceResponse(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse other) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.MergeFrom(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse other) -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.PartialSuccess.get -> OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.PartialSuccess.set -> void
+~OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.Clone() -> OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.Equals(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess other) -> bool
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.ErrorMessage.get -> string
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.ErrorMessage.set -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.ExportMetricsPartialSuccess(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess other) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.MergeFrom(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess other) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.Clone() -> OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.Equals(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest other) -> bool
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.ExportMetricsServiceRequest(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest other) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.MergeFrom(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest other) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.ResourceMetrics.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.Clone() -> OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.Equals(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse other) -> bool
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.ExportMetricsServiceResponse(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse other) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.MergeFrom(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse other) -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.PartialSuccess.get -> OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.PartialSuccess.set -> void
+~OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.Clone() -> OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.Equals(OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess other) -> bool
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.ErrorMessage.get -> string
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.ErrorMessage.set -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.ExportTracePartialSuccess(OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess other) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.MergeFrom(OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess other) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.Clone() -> OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.Equals(OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest other) -> bool
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.ExportTraceServiceRequest(OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest other) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.MergeFrom(OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest other) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.ResourceSpans.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Trace.V1.ResourceSpans>
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.Clone() -> OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.Equals(OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse other) -> bool
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.ExportTraceServiceResponse(OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse other) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.MergeFrom(OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse other) -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.PartialSuccess.get -> OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.PartialSuccess.set -> void
+~OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Common.V1.AnyValue.AnyValue(OpenTelemetry.Proto.Common.V1.AnyValue other) -> void
+~OpenTelemetry.Proto.Common.V1.AnyValue.ArrayValue.get -> OpenTelemetry.Proto.Common.V1.ArrayValue
+~OpenTelemetry.Proto.Common.V1.AnyValue.ArrayValue.set -> void
+~OpenTelemetry.Proto.Common.V1.AnyValue.BytesValue.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Common.V1.AnyValue.BytesValue.set -> void
+~OpenTelemetry.Proto.Common.V1.AnyValue.Clone() -> OpenTelemetry.Proto.Common.V1.AnyValue
+~OpenTelemetry.Proto.Common.V1.AnyValue.Equals(OpenTelemetry.Proto.Common.V1.AnyValue other) -> bool
+~OpenTelemetry.Proto.Common.V1.AnyValue.KvlistValue.get -> OpenTelemetry.Proto.Common.V1.KeyValueList
+~OpenTelemetry.Proto.Common.V1.AnyValue.KvlistValue.set -> void
+~OpenTelemetry.Proto.Common.V1.AnyValue.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Common.V1.AnyValue.MergeFrom(OpenTelemetry.Proto.Common.V1.AnyValue other) -> void
+~OpenTelemetry.Proto.Common.V1.AnyValue.StringValue.get -> string
+~OpenTelemetry.Proto.Common.V1.AnyValue.StringValue.set -> void
+~OpenTelemetry.Proto.Common.V1.AnyValue.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Common.V1.ArrayValue.ArrayValue(OpenTelemetry.Proto.Common.V1.ArrayValue other) -> void
+~OpenTelemetry.Proto.Common.V1.ArrayValue.Clone() -> OpenTelemetry.Proto.Common.V1.ArrayValue
+~OpenTelemetry.Proto.Common.V1.ArrayValue.Equals(OpenTelemetry.Proto.Common.V1.ArrayValue other) -> bool
+~OpenTelemetry.Proto.Common.V1.ArrayValue.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Common.V1.ArrayValue.MergeFrom(OpenTelemetry.Proto.Common.V1.ArrayValue other) -> void
+~OpenTelemetry.Proto.Common.V1.ArrayValue.Values.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.AnyValue>
+~OpenTelemetry.Proto.Common.V1.ArrayValue.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.Clone() -> OpenTelemetry.Proto.Common.V1.InstrumentationScope
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.Equals(OpenTelemetry.Proto.Common.V1.InstrumentationScope other) -> bool
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.InstrumentationScope(OpenTelemetry.Proto.Common.V1.InstrumentationScope other) -> void
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.MergeFrom(OpenTelemetry.Proto.Common.V1.InstrumentationScope other) -> void
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.Name.get -> string
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.Name.set -> void
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.Version.get -> string
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.Version.set -> void
+~OpenTelemetry.Proto.Common.V1.InstrumentationScope.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Common.V1.KeyValue.Clone() -> OpenTelemetry.Proto.Common.V1.KeyValue
+~OpenTelemetry.Proto.Common.V1.KeyValue.Equals(OpenTelemetry.Proto.Common.V1.KeyValue other) -> bool
+~OpenTelemetry.Proto.Common.V1.KeyValue.Key.get -> string
+~OpenTelemetry.Proto.Common.V1.KeyValue.Key.set -> void
+~OpenTelemetry.Proto.Common.V1.KeyValue.KeyValue(OpenTelemetry.Proto.Common.V1.KeyValue other) -> void
+~OpenTelemetry.Proto.Common.V1.KeyValue.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Common.V1.KeyValue.MergeFrom(OpenTelemetry.Proto.Common.V1.KeyValue other) -> void
+~OpenTelemetry.Proto.Common.V1.KeyValue.Value.get -> OpenTelemetry.Proto.Common.V1.AnyValue
+~OpenTelemetry.Proto.Common.V1.KeyValue.Value.set -> void
+~OpenTelemetry.Proto.Common.V1.KeyValue.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Common.V1.KeyValueList.Clone() -> OpenTelemetry.Proto.Common.V1.KeyValueList
+~OpenTelemetry.Proto.Common.V1.KeyValueList.Equals(OpenTelemetry.Proto.Common.V1.KeyValueList other) -> bool
+~OpenTelemetry.Proto.Common.V1.KeyValueList.KeyValueList(OpenTelemetry.Proto.Common.V1.KeyValueList other) -> void
+~OpenTelemetry.Proto.Common.V1.KeyValueList.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Common.V1.KeyValueList.MergeFrom(OpenTelemetry.Proto.Common.V1.KeyValueList other) -> void
+~OpenTelemetry.Proto.Common.V1.KeyValueList.Values.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Common.V1.KeyValueList.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Logs.V1.LogRecord.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Logs.V1.LogRecord.Body.get -> OpenTelemetry.Proto.Common.V1.AnyValue
+~OpenTelemetry.Proto.Logs.V1.LogRecord.Body.set -> void
+~OpenTelemetry.Proto.Logs.V1.LogRecord.Clone() -> OpenTelemetry.Proto.Logs.V1.LogRecord
+~OpenTelemetry.Proto.Logs.V1.LogRecord.Equals(OpenTelemetry.Proto.Logs.V1.LogRecord other) -> bool
+~OpenTelemetry.Proto.Logs.V1.LogRecord.LogRecord(OpenTelemetry.Proto.Logs.V1.LogRecord other) -> void
+~OpenTelemetry.Proto.Logs.V1.LogRecord.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Logs.V1.LogRecord.MergeFrom(OpenTelemetry.Proto.Logs.V1.LogRecord other) -> void
+~OpenTelemetry.Proto.Logs.V1.LogRecord.SeverityText.get -> string
+~OpenTelemetry.Proto.Logs.V1.LogRecord.SeverityText.set -> void
+~OpenTelemetry.Proto.Logs.V1.LogRecord.SpanId.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Logs.V1.LogRecord.SpanId.set -> void
+~OpenTelemetry.Proto.Logs.V1.LogRecord.TraceId.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Logs.V1.LogRecord.TraceId.set -> void
+~OpenTelemetry.Proto.Logs.V1.LogRecord.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Logs.V1.LogsData.Clone() -> OpenTelemetry.Proto.Logs.V1.LogsData
+~OpenTelemetry.Proto.Logs.V1.LogsData.Equals(OpenTelemetry.Proto.Logs.V1.LogsData other) -> bool
+~OpenTelemetry.Proto.Logs.V1.LogsData.LogsData(OpenTelemetry.Proto.Logs.V1.LogsData other) -> void
+~OpenTelemetry.Proto.Logs.V1.LogsData.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Logs.V1.LogsData.MergeFrom(OpenTelemetry.Proto.Logs.V1.LogsData other) -> void
+~OpenTelemetry.Proto.Logs.V1.LogsData.ResourceLogs.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Logs.V1.ResourceLogs>
+~OpenTelemetry.Proto.Logs.V1.LogsData.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.Clone() -> OpenTelemetry.Proto.Logs.V1.ResourceLogs
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.Equals(OpenTelemetry.Proto.Logs.V1.ResourceLogs other) -> bool
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.MergeFrom(OpenTelemetry.Proto.Logs.V1.ResourceLogs other) -> void
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.Resource.get -> OpenTelemetry.Proto.Resource.V1.Resource
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.Resource.set -> void
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.ResourceLogs(OpenTelemetry.Proto.Logs.V1.ResourceLogs other) -> void
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.SchemaUrl.get -> string
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.SchemaUrl.set -> void
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.ScopeLogs.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Logs.V1.ScopeLogs>
+~OpenTelemetry.Proto.Logs.V1.ResourceLogs.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.Clone() -> OpenTelemetry.Proto.Logs.V1.ScopeLogs
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.Equals(OpenTelemetry.Proto.Logs.V1.ScopeLogs other) -> bool
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.LogRecords.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Logs.V1.LogRecord>
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.MergeFrom(OpenTelemetry.Proto.Logs.V1.ScopeLogs other) -> void
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.SchemaUrl.get -> string
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.SchemaUrl.set -> void
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.Scope.get -> OpenTelemetry.Proto.Common.V1.InstrumentationScope
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.Scope.set -> void
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.ScopeLogs(OpenTelemetry.Proto.Logs.V1.ScopeLogs other) -> void
+~OpenTelemetry.Proto.Logs.V1.ScopeLogs.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.Clone() -> OpenTelemetry.Proto.Metrics.V1.Exemplar
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.Equals(OpenTelemetry.Proto.Metrics.V1.Exemplar other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.Exemplar(OpenTelemetry.Proto.Metrics.V1.Exemplar other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.FilteredAttributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.MergeFrom(OpenTelemetry.Proto.Metrics.V1.Exemplar other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.SpanId.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.SpanId.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.TraceId.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.TraceId.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Exemplar.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.Clone() -> OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.DataPoints.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint>
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.Equals(OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.ExponentialHistogram(OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.MergeFrom(OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Clone() -> OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Equals(OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Exemplars.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.Exemplar>
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ExponentialHistogramDataPoint(OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.MergeFrom(OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Negative.get -> OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Negative.set -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Positive.get -> OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Positive.set -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.BucketCounts.get -> Google.Protobuf.Collections.RepeatedField<ulong>
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.Buckets(OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.Clone() -> OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.Equals(OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.MergeFrom(OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.Gauge.Clone() -> OpenTelemetry.Proto.Metrics.V1.Gauge
+~OpenTelemetry.Proto.Metrics.V1.Gauge.DataPoints.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.NumberDataPoint>
+~OpenTelemetry.Proto.Metrics.V1.Gauge.Equals(OpenTelemetry.Proto.Metrics.V1.Gauge other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.Gauge.Gauge(OpenTelemetry.Proto.Metrics.V1.Gauge other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Gauge.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.Gauge.MergeFrom(OpenTelemetry.Proto.Metrics.V1.Gauge other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Gauge.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.Histogram.Clone() -> OpenTelemetry.Proto.Metrics.V1.Histogram
+~OpenTelemetry.Proto.Metrics.V1.Histogram.DataPoints.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint>
+~OpenTelemetry.Proto.Metrics.V1.Histogram.Equals(OpenTelemetry.Proto.Metrics.V1.Histogram other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.Histogram.Histogram(OpenTelemetry.Proto.Metrics.V1.Histogram other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Histogram.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.Histogram.MergeFrom(OpenTelemetry.Proto.Metrics.V1.Histogram other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Histogram.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.BucketCounts.get -> Google.Protobuf.Collections.RepeatedField<ulong>
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Clone() -> OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Equals(OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Exemplars.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.Exemplar>
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.ExplicitBounds.get -> Google.Protobuf.Collections.RepeatedField<double>
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.HistogramDataPoint(OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint other) -> void
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.MergeFrom(OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint other) -> void
+~OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.Clone() -> OpenTelemetry.Proto.Metrics.V1.Metric
+~OpenTelemetry.Proto.Metrics.V1.Metric.Description.get -> string
+~OpenTelemetry.Proto.Metrics.V1.Metric.Description.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.Equals(OpenTelemetry.Proto.Metrics.V1.Metric other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.Metric.ExponentialHistogram.get -> OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram
+~OpenTelemetry.Proto.Metrics.V1.Metric.ExponentialHistogram.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.Gauge.get -> OpenTelemetry.Proto.Metrics.V1.Gauge
+~OpenTelemetry.Proto.Metrics.V1.Metric.Gauge.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.Histogram.get -> OpenTelemetry.Proto.Metrics.V1.Histogram
+~OpenTelemetry.Proto.Metrics.V1.Metric.Histogram.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.MergeFrom(OpenTelemetry.Proto.Metrics.V1.Metric other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.Metric(OpenTelemetry.Proto.Metrics.V1.Metric other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.Name.get -> string
+~OpenTelemetry.Proto.Metrics.V1.Metric.Name.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.Sum.get -> OpenTelemetry.Proto.Metrics.V1.Sum
+~OpenTelemetry.Proto.Metrics.V1.Metric.Sum.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.Summary.get -> OpenTelemetry.Proto.Metrics.V1.Summary
+~OpenTelemetry.Proto.Metrics.V1.Metric.Summary.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.Unit.get -> string
+~OpenTelemetry.Proto.Metrics.V1.Metric.Unit.set -> void
+~OpenTelemetry.Proto.Metrics.V1.Metric.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.MetricsData.Clone() -> OpenTelemetry.Proto.Metrics.V1.MetricsData
+~OpenTelemetry.Proto.Metrics.V1.MetricsData.Equals(OpenTelemetry.Proto.Metrics.V1.MetricsData other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.MetricsData.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.MetricsData.MergeFrom(OpenTelemetry.Proto.Metrics.V1.MetricsData other) -> void
+~OpenTelemetry.Proto.Metrics.V1.MetricsData.MetricsData(OpenTelemetry.Proto.Metrics.V1.MetricsData other) -> void
+~OpenTelemetry.Proto.Metrics.V1.MetricsData.ResourceMetrics.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>
+~OpenTelemetry.Proto.Metrics.V1.MetricsData.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.Clone() -> OpenTelemetry.Proto.Metrics.V1.NumberDataPoint
+~OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.Equals(OpenTelemetry.Proto.Metrics.V1.NumberDataPoint other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.Exemplars.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.Exemplar>
+~OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.MergeFrom(OpenTelemetry.Proto.Metrics.V1.NumberDataPoint other) -> void
+~OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.NumberDataPoint(OpenTelemetry.Proto.Metrics.V1.NumberDataPoint other) -> void
+~OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.Clone() -> OpenTelemetry.Proto.Metrics.V1.ResourceMetrics
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.Equals(OpenTelemetry.Proto.Metrics.V1.ResourceMetrics other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.MergeFrom(OpenTelemetry.Proto.Metrics.V1.ResourceMetrics other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.Resource.get -> OpenTelemetry.Proto.Resource.V1.Resource
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.Resource.set -> void
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.ResourceMetrics(OpenTelemetry.Proto.Metrics.V1.ResourceMetrics other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.SchemaUrl.get -> string
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.SchemaUrl.set -> void
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.ScopeMetrics.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.ScopeMetrics>
+~OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.Clone() -> OpenTelemetry.Proto.Metrics.V1.ScopeMetrics
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.Equals(OpenTelemetry.Proto.Metrics.V1.ScopeMetrics other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.MergeFrom(OpenTelemetry.Proto.Metrics.V1.ScopeMetrics other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.Metrics.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.Metric>
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.SchemaUrl.get -> string
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.SchemaUrl.set -> void
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.Scope.get -> OpenTelemetry.Proto.Common.V1.InstrumentationScope
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.Scope.set -> void
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.ScopeMetrics(OpenTelemetry.Proto.Metrics.V1.ScopeMetrics other) -> void
+~OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.Sum.Clone() -> OpenTelemetry.Proto.Metrics.V1.Sum
+~OpenTelemetry.Proto.Metrics.V1.Sum.DataPoints.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.NumberDataPoint>
+~OpenTelemetry.Proto.Metrics.V1.Sum.Equals(OpenTelemetry.Proto.Metrics.V1.Sum other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.Sum.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.Sum.MergeFrom(OpenTelemetry.Proto.Metrics.V1.Sum other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Sum.Sum(OpenTelemetry.Proto.Metrics.V1.Sum other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Sum.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.Summary.Clone() -> OpenTelemetry.Proto.Metrics.V1.Summary
+~OpenTelemetry.Proto.Metrics.V1.Summary.DataPoints.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint>
+~OpenTelemetry.Proto.Metrics.V1.Summary.Equals(OpenTelemetry.Proto.Metrics.V1.Summary other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.Summary.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.Summary.MergeFrom(OpenTelemetry.Proto.Metrics.V1.Summary other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Summary.Summary(OpenTelemetry.Proto.Metrics.V1.Summary other) -> void
+~OpenTelemetry.Proto.Metrics.V1.Summary.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Clone() -> OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Equals(OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.MergeFrom(OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint other) -> void
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.QuantileValues.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile>
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.SummaryDataPoint(OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint other) -> void
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.Clone() -> OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.Equals(OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile other) -> bool
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.MergeFrom(OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile other) -> void
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.ValueAtQuantile(OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile other) -> void
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Resource.V1.Resource.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Resource.V1.Resource.Clone() -> OpenTelemetry.Proto.Resource.V1.Resource
+~OpenTelemetry.Proto.Resource.V1.Resource.Equals(OpenTelemetry.Proto.Resource.V1.Resource other) -> bool
+~OpenTelemetry.Proto.Resource.V1.Resource.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Resource.V1.Resource.MergeFrom(OpenTelemetry.Proto.Resource.V1.Resource other) -> void
+~OpenTelemetry.Proto.Resource.V1.Resource.Resource(OpenTelemetry.Proto.Resource.V1.Resource other) -> void
+~OpenTelemetry.Proto.Resource.V1.Resource.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.Clone() -> OpenTelemetry.Proto.Trace.V1.ResourceSpans
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.Equals(OpenTelemetry.Proto.Trace.V1.ResourceSpans other) -> bool
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.MergeFrom(OpenTelemetry.Proto.Trace.V1.ResourceSpans other) -> void
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.Resource.get -> OpenTelemetry.Proto.Resource.V1.Resource
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.Resource.set -> void
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.ResourceSpans(OpenTelemetry.Proto.Trace.V1.ResourceSpans other) -> void
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.SchemaUrl.get -> string
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.SchemaUrl.set -> void
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.ScopeSpans.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Trace.V1.ScopeSpans>
+~OpenTelemetry.Proto.Trace.V1.ResourceSpans.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.Clone() -> OpenTelemetry.Proto.Trace.V1.ScopeSpans
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.Equals(OpenTelemetry.Proto.Trace.V1.ScopeSpans other) -> bool
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.MergeFrom(OpenTelemetry.Proto.Trace.V1.ScopeSpans other) -> void
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.SchemaUrl.get -> string
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.SchemaUrl.set -> void
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.Scope.get -> OpenTelemetry.Proto.Common.V1.InstrumentationScope
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.Scope.set -> void
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.ScopeSpans(OpenTelemetry.Proto.Trace.V1.ScopeSpans other) -> void
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.Spans.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Trace.V1.Span>
+~OpenTelemetry.Proto.Trace.V1.ScopeSpans.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Trace.V1.Span.Clone() -> OpenTelemetry.Proto.Trace.V1.Span
+~OpenTelemetry.Proto.Trace.V1.Span.Equals(OpenTelemetry.Proto.Trace.V1.Span other) -> bool
+~OpenTelemetry.Proto.Trace.V1.Span.Events.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Trace.V1.Span.Types.Event>
+~OpenTelemetry.Proto.Trace.V1.Span.Links.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Trace.V1.Span.Types.Link>
+~OpenTelemetry.Proto.Trace.V1.Span.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.MergeFrom(OpenTelemetry.Proto.Trace.V1.Span other) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Name.get -> string
+~OpenTelemetry.Proto.Trace.V1.Span.Name.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.ParentSpanId.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Trace.V1.Span.ParentSpanId.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Span(OpenTelemetry.Proto.Trace.V1.Span other) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.SpanId.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Trace.V1.Span.SpanId.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Status.get -> OpenTelemetry.Proto.Trace.V1.Status
+~OpenTelemetry.Proto.Trace.V1.Span.Status.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.TraceId.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Trace.V1.Span.TraceId.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.TraceState.get -> string
+~OpenTelemetry.Proto.Trace.V1.Span.TraceState.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Clone() -> OpenTelemetry.Proto.Trace.V1.Span.Types.Event
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Equals(OpenTelemetry.Proto.Trace.V1.Span.Types.Event other) -> bool
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Event(OpenTelemetry.Proto.Trace.V1.Span.Types.Event other) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Event.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Event.MergeFrom(OpenTelemetry.Proto.Trace.V1.Span.Types.Event other) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Name.get -> string
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Name.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Event.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.Attributes.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Common.V1.KeyValue>
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.Clone() -> OpenTelemetry.Proto.Trace.V1.Span.Types.Link
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.Equals(OpenTelemetry.Proto.Trace.V1.Span.Types.Link other) -> bool
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.Link(OpenTelemetry.Proto.Trace.V1.Span.Types.Link other) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.MergeFrom(OpenTelemetry.Proto.Trace.V1.Span.Types.Link other) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.SpanId.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.SpanId.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.TraceId.get -> Google.Protobuf.ByteString
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.TraceId.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.TraceState.get -> string
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.TraceState.set -> void
+~OpenTelemetry.Proto.Trace.V1.Span.Types.Link.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Trace.V1.Span.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Trace.V1.Status.Clone() -> OpenTelemetry.Proto.Trace.V1.Status
+~OpenTelemetry.Proto.Trace.V1.Status.Equals(OpenTelemetry.Proto.Trace.V1.Status other) -> bool
+~OpenTelemetry.Proto.Trace.V1.Status.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Trace.V1.Status.MergeFrom(OpenTelemetry.Proto.Trace.V1.Status other) -> void
+~OpenTelemetry.Proto.Trace.V1.Status.Message.get -> string
+~OpenTelemetry.Proto.Trace.V1.Status.Message.set -> void
+~OpenTelemetry.Proto.Trace.V1.Status.Status(OpenTelemetry.Proto.Trace.V1.Status other) -> void
+~OpenTelemetry.Proto.Trace.V1.Status.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~OpenTelemetry.Proto.Trace.V1.TracesData.Clone() -> OpenTelemetry.Proto.Trace.V1.TracesData
+~OpenTelemetry.Proto.Trace.V1.TracesData.Equals(OpenTelemetry.Proto.Trace.V1.TracesData other) -> bool
+~OpenTelemetry.Proto.Trace.V1.TracesData.MergeFrom(Google.Protobuf.CodedInputStream input) -> void
+~OpenTelemetry.Proto.Trace.V1.TracesData.MergeFrom(OpenTelemetry.Proto.Trace.V1.TracesData other) -> void
+~OpenTelemetry.Proto.Trace.V1.TracesData.ResourceSpans.get -> Google.Protobuf.Collections.RepeatedField<OpenTelemetry.Proto.Trace.V1.ResourceSpans>
+~OpenTelemetry.Proto.Trace.V1.TracesData.TracesData(OpenTelemetry.Proto.Trace.V1.TracesData other) -> void
+~OpenTelemetry.Proto.Trace.V1.TracesData.WriteTo(Google.Protobuf.CodedOutputStream output) -> void
+~override Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.Equals(object obj) -> bool
+~override Aspire.Dashboard.Components.Controls.PropertyGrid<TItem>.PropertyGridIsMaskedChangedArgs.ToString() -> string
+~override Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.Equals(object obj) -> bool
+~override Aspire.Dashboard.ConsoleLogs.AnsiParser.ConversionResult.ToString() -> string
+~override Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.Equals(object obj) -> bool
+~override Aspire.Dashboard.ConsoleLogs.AnsiParser.ParserState.ToString() -> string
+~override Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.Equals(object obj) -> bool
+~override Aspire.Dashboard.ConsoleLogs.TimestampParser.TimestampParserResult.ToString() -> string
+~override Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.Equals(object obj) -> bool
+~override Aspire.Dashboard.Otlp.Model.OtlpInstrumentKey.ToString() -> string
+~override OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.ToString() -> string
+~override OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.ToString() -> string
+~override OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.ToString() -> string
+~override OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.ToString() -> string
+~override OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.ToString() -> string
+~override OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.ToString() -> string
+~override OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.ToString() -> string
+~override OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.ToString() -> string
+~override OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.ToString() -> string
+~override OpenTelemetry.Proto.Common.V1.AnyValue.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Common.V1.AnyValue.ToString() -> string
+~override OpenTelemetry.Proto.Common.V1.ArrayValue.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Common.V1.ArrayValue.ToString() -> string
+~override OpenTelemetry.Proto.Common.V1.InstrumentationScope.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Common.V1.InstrumentationScope.ToString() -> string
+~override OpenTelemetry.Proto.Common.V1.KeyValue.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Common.V1.KeyValue.ToString() -> string
+~override OpenTelemetry.Proto.Common.V1.KeyValueList.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Common.V1.KeyValueList.ToString() -> string
+~override OpenTelemetry.Proto.Logs.V1.LogRecord.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Logs.V1.LogRecord.ToString() -> string
+~override OpenTelemetry.Proto.Logs.V1.LogsData.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Logs.V1.LogsData.ToString() -> string
+~override OpenTelemetry.Proto.Logs.V1.ResourceLogs.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Logs.V1.ResourceLogs.ToString() -> string
+~override OpenTelemetry.Proto.Logs.V1.ScopeLogs.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Logs.V1.ScopeLogs.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.Exemplar.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.Exemplar.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.Gauge.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.Gauge.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.Histogram.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.Histogram.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.Metric.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.Metric.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.MetricsData.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.MetricsData.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.Sum.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.Sum.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.Summary.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.Summary.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.ToString() -> string
+~override OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.ToString() -> string
+~override OpenTelemetry.Proto.Resource.V1.Resource.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Resource.V1.Resource.ToString() -> string
+~override OpenTelemetry.Proto.Trace.V1.ResourceSpans.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Trace.V1.ResourceSpans.ToString() -> string
+~override OpenTelemetry.Proto.Trace.V1.ScopeSpans.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Trace.V1.ScopeSpans.ToString() -> string
+~override OpenTelemetry.Proto.Trace.V1.Span.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Trace.V1.Span.ToString() -> string
+~override OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Trace.V1.Span.Types.Event.ToString() -> string
+~override OpenTelemetry.Proto.Trace.V1.Span.Types.Link.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Trace.V1.Span.Types.Link.ToString() -> string
+~override OpenTelemetry.Proto.Trace.V1.Status.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Trace.V1.Status.ToString() -> string
+~override OpenTelemetry.Proto.Trace.V1.TracesData.Equals(object other) -> bool
+~override OpenTelemetry.Proto.Trace.V1.TracesData.ToString() -> string
+~static Aspire.Dashboard.Resources.Columns.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.Columns.Culture.set -> void
+~static Aspire.Dashboard.Resources.Columns.EndpointsColumnDisplayNone.get -> string
+~static Aspire.Dashboard.Resources.Columns.EndpointsColumnDisplayPlaceholder.get -> string
+~static Aspire.Dashboard.Resources.Columns.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.Columns.ResourceNameDisplayContainerIdText.get -> string
+~static Aspire.Dashboard.Resources.Columns.ResourceNameDisplayCopyContainerIdText.get -> string
+~static Aspire.Dashboard.Resources.Columns.ResourceNameDisplayProcessIdText.get -> string
+~static Aspire.Dashboard.Resources.Columns.SourceColumnDisplayContainerArgsTitle.get -> string
+~static Aspire.Dashboard.Resources.Columns.SourceColumnDisplayContainerCommand.get -> string
+~static Aspire.Dashboard.Resources.Columns.SourceColumnDisplayContainerCommandTitle.get -> string
+~static Aspire.Dashboard.Resources.Columns.SourceColumnDisplayPort.get -> string
+~static Aspire.Dashboard.Resources.Columns.SourceColumnDisplayPorts.get -> string
+~static Aspire.Dashboard.Resources.Columns.SourceColumnDisplayWorkingDirectory.get -> string
+~static Aspire.Dashboard.Resources.Columns.SourceColumnSourceCopyContainerToClipboard.get -> string
+~static Aspire.Dashboard.Resources.Columns.SourceColumnSourceCopyFullPathToClipboard.get -> string
+~static Aspire.Dashboard.Resources.Columns.StateColumnResourceExited.get -> string
+~static Aspire.Dashboard.Resources.Columns.StateColumnResourceExitedUnexpectedly.get -> string
+~static Aspire.Dashboard.Resources.Columns.UnreadLogErrorsBadgeErrorLog.get -> string
+~static Aspire.Dashboard.Resources.Columns.UnreadLogErrorsBadgeErrorLogs.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsFailedToInitialize.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsHeader.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsInitializingLogViewer.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsLoadingResources.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsLogsNotYetAvailable.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsNoResourceSelected.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsPageTitle.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsUnknownState.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ConsoleLogsWatchingLogs.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.ConsoleLogs.Culture.set -> void
+~static Aspire.Dashboard.Resources.ConsoleLogs.LogStatusLabel.get -> string
+~static Aspire.Dashboard.Resources.ConsoleLogs.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.ControlsStrings.All.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ChartContainerAllTags.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ChartContainerFilteredTags.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ChartContainerFiltersHeader.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ChartContainerOptionsHeader.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ChartContainerSelectFilters.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ChartContainerShowCountLabel.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ChartContainerUnableToDisplay.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.ControlsStrings.Culture.set -> void
+~static Aspire.Dashboard.Resources.ControlsStrings.DurationColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.EnvironmentVariablesFilterToggleShowAll.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.EnvironmentVariablesFilterToggleShowSpecOnly.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.EnvironmentVariablesHideVariableValues.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.EnvironmentVariablesShowVariableValues.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.EventColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.FilterPlaceholder.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.GridValueCopyToClipboard.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.GridValueMaskHideValue.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.GridValueMaskShowValue.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.NameColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.PlotlyChartCount.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.PlotlyChartLength.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.PlotlyChartValue.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.PropertyGridValueColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.ControlsStrings.SelectAnApplication.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.SelectAResource.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.SpanDetailsDuration.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.SpanDetailsService.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.SpanDetailsStartTime.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.SummaryDetailsViewCloseView.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.SummaryDetailsViewSplitHorizontal.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.SummaryDetailsViewSplitVertical.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.TimeOffsetColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.TimestampColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.TotalItemsFooterText.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ViewAction.get -> string
+~static Aspire.Dashboard.Resources.ControlsStrings.ViewLogsLink.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.Dialogs.Culture.set -> void
+~static Aspire.Dashboard.Resources.Dialogs.FilterDialogApplyFilterButtonText.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.FilterDialogCancelButtonText.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.FilterDialogConditionSelectLabel.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.FilterDialogFieldPlaceholder.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.FilterDialogRemoveFilterButtonText.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.FilterDialogTextValuePlaceholder.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.Dialogs.SettingsDialogDarkTheme.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.SettingsDialogLightTheme.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.SettingsDialogSystemTheme.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.SettingsDialogTheme.get -> string
+~static Aspire.Dashboard.Resources.Dialogs.SettingsDialogVersion.get -> string
+~static Aspire.Dashboard.Resources.Layout.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.Layout.Culture.set -> void
+~static Aspire.Dashboard.Resources.Layout.MainLayoutAspireDashboardHelpLink.get -> string
+~static Aspire.Dashboard.Resources.Layout.MainLayoutAspireRepoLink.get -> string
+~static Aspire.Dashboard.Resources.Layout.MainLayoutDashboardName.get -> string
+~static Aspire.Dashboard.Resources.Layout.MainLayoutLaunchSettings.get -> string
+~static Aspire.Dashboard.Resources.Layout.MainLayoutSettingsDialogClose.get -> string
+~static Aspire.Dashboard.Resources.Layout.MainLayoutSettingsDialogTitle.get -> string
+~static Aspire.Dashboard.Resources.Layout.MainLayoutUnhandledErrorMessage.get -> string
+~static Aspire.Dashboard.Resources.Layout.MainLayoutUnhandledErrorReload.get -> string
+~static Aspire.Dashboard.Resources.Layout.NavMenuConsoleLogsTab.get -> string
+~static Aspire.Dashboard.Resources.Layout.NavMenuMetricsTab.get -> string
+~static Aspire.Dashboard.Resources.Layout.NavMenuMonitoringTab.get -> string
+~static Aspire.Dashboard.Resources.Layout.NavMenuResourcesTab.get -> string
+~static Aspire.Dashboard.Resources.Layout.NavMenuStructuredLogsTab.get -> string
+~static Aspire.Dashboard.Resources.Layout.NavMenuTracesTab.get -> string
+~static Aspire.Dashboard.Resources.Layout.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.Metrics.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.Metrics.Culture.set -> void
+~static Aspire.Dashboard.Resources.Metrics.MetricsHeader.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsInsturementDescriptionGridNameColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsInsturementNameGridNameColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsLastFifteenMinutes.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsLastFiveMinutes.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsLastHour.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsLastOneMinute.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsLastSixHours.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsLastThirtyMinutes.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsLastThreeHours.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsLastTwelveHours.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsLastTwentyFourHours.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsNoMetricsForResource.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsPageTitle.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsSelectADuration.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsSelectAResource.get -> string
+~static Aspire.Dashboard.Resources.Metrics.MetricsSelectInstrument.get -> string
+~static Aspire.Dashboard.Resources.Metrics.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.Resources.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.Resources.Culture.set -> void
+~static Aspire.Dashboard.Resources.Resources.ResourceDetailsEndpointUrl.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourceDetailsProxyUrl.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsContainerArgumentsProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsContainerCommandProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsContainerIdProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsContainerImageProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsContainerPortsProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsDisplayNameProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsExecutableArgumentsProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsExecutablePathProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsExecutableProcessIdProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsExecutableWorkingDirectoryProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsProjectPathProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsStartTimeProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesDetailsStateProperty.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridEndpointsColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridEnvironmentColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridNameColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridSourceColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridStartTimeColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesEnvironmentVariablesGridStateColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesEnvironmentVariablesHeader.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesHeader.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesNoEnvironmentVariables.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesNoResources.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesPageTitle.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesResourceTypesHeader.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible.get -> string
+~static Aspire.Dashboard.Resources.Resources.ResourcesTypeFiltered.get -> string
+~static Aspire.Dashboard.Resources.Routes.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.Routes.Culture.set -> void
+~static Aspire.Dashboard.Resources.Routes.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.Routes.RoutesNotFoundDescription.get -> string
+~static Aspire.Dashboard.Resources.Routes.RoutesPageTitle.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.StructuredLogs.Culture.set -> void
+~static Aspire.Dashboard.Resources.StructuredLogs.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsAddFilter.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsAllTypes.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsDetailsColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsEditFilter.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsFilters.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsHeader.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsMessageFilter.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsMinimumLogFilter.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsNoFilters.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsNoLogsFound.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsPageTitle.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsSelectMinimumLogLevel.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.TraceDetail.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.TraceDetail.Culture.set -> void
+~static Aspire.Dashboard.Resources.TraceDetail.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.TraceDetail.TraceDetailBackButtonText.get -> string
+~static Aspire.Dashboard.Resources.TraceDetail.TraceDetailDepthHeader.get -> string
+~static Aspire.Dashboard.Resources.TraceDetail.TraceDetailDurationHeader.get -> string
+~static Aspire.Dashboard.Resources.TraceDetail.TraceDetailPageTitle.get -> string
+~static Aspire.Dashboard.Resources.TraceDetail.TraceDetailResourcesHeader.get -> string
+~static Aspire.Dashboard.Resources.TraceDetail.TraceDetailTotalSpansHeader.get -> string
+~static Aspire.Dashboard.Resources.TraceDetail.TraceDetailTraceNotFound.get -> string
+~static Aspire.Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader.get -> string
+~static Aspire.Dashboard.Resources.Traces.Culture.get -> System.Globalization.CultureInfo
+~static Aspire.Dashboard.Resources.Traces.Culture.set -> void
+~static Aspire.Dashboard.Resources.Traces.ResourceManager.get -> System.Resources.ResourceManager
+~static Aspire.Dashboard.Resources.Traces.TracesDetailsColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Traces.TracesHeader.get -> string
+~static Aspire.Dashboard.Resources.Traces.TracesNameFilter.get -> string
+~static Aspire.Dashboard.Resources.Traces.TracesNoTraces.get -> string
+~static Aspire.Dashboard.Resources.Traces.TracesPageTitle.get -> string
+~static Aspire.Dashboard.Resources.Traces.TracesResourceSpans.get -> string
+~static Aspire.Dashboard.Resources.Traces.TracesSpansColumnHeader.get -> string
+~static Aspire.Dashboard.Resources.Traces.TracesTotalErroredTraces.get -> string
+~static Aspire.Dashboard.Resources.Traces.TracesTotalTraces.get -> string
+~static OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsPartialSuccess>
+~static OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest>
+~static OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse>
+~static OpenTelemetry.Proto.Collector.Logs.V1.LogsService.BindService(Grpc.Core.ServiceBinderBase serviceBinder, OpenTelemetry.Proto.Collector.Logs.V1.LogsService.LogsServiceBase serviceImpl) -> void
+~static OpenTelemetry.Proto.Collector.Logs.V1.LogsService.BindService(OpenTelemetry.Proto.Collector.Logs.V1.LogsService.LogsServiceBase serviceImpl) -> Grpc.Core.ServerServiceDefinition
+~static OpenTelemetry.Proto.Collector.Logs.V1.LogsService.Descriptor.get -> Google.Protobuf.Reflection.ServiceDescriptor
+~static OpenTelemetry.Proto.Collector.Logs.V1.LogsServiceReflection.Descriptor.get -> Google.Protobuf.Reflection.FileDescriptor
+~static OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsPartialSuccess>
+~static OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest>
+~static OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse>
+~static OpenTelemetry.Proto.Collector.Metrics.V1.MetricsService.BindService(Grpc.Core.ServiceBinderBase serviceBinder, OpenTelemetry.Proto.Collector.Metrics.V1.MetricsService.MetricsServiceBase serviceImpl) -> void
+~static OpenTelemetry.Proto.Collector.Metrics.V1.MetricsService.BindService(OpenTelemetry.Proto.Collector.Metrics.V1.MetricsService.MetricsServiceBase serviceImpl) -> Grpc.Core.ServerServiceDefinition
+~static OpenTelemetry.Proto.Collector.Metrics.V1.MetricsService.Descriptor.get -> Google.Protobuf.Reflection.ServiceDescriptor
+~static OpenTelemetry.Proto.Collector.Metrics.V1.MetricsServiceReflection.Descriptor.get -> Google.Protobuf.Reflection.FileDescriptor
+~static OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Collector.Trace.V1.ExportTracePartialSuccess>
+~static OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest>
+~static OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse>
+~static OpenTelemetry.Proto.Collector.Trace.V1.TraceService.BindService(Grpc.Core.ServiceBinderBase serviceBinder, OpenTelemetry.Proto.Collector.Trace.V1.TraceService.TraceServiceBase serviceImpl) -> void
+~static OpenTelemetry.Proto.Collector.Trace.V1.TraceService.BindService(OpenTelemetry.Proto.Collector.Trace.V1.TraceService.TraceServiceBase serviceImpl) -> Grpc.Core.ServerServiceDefinition
+~static OpenTelemetry.Proto.Collector.Trace.V1.TraceService.Descriptor.get -> Google.Protobuf.Reflection.ServiceDescriptor
+~static OpenTelemetry.Proto.Collector.Trace.V1.TraceServiceReflection.Descriptor.get -> Google.Protobuf.Reflection.FileDescriptor
+~static OpenTelemetry.Proto.Common.V1.AnyValue.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Common.V1.AnyValue.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Common.V1.AnyValue>
+~static OpenTelemetry.Proto.Common.V1.ArrayValue.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Common.V1.ArrayValue.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Common.V1.ArrayValue>
+~static OpenTelemetry.Proto.Common.V1.CommonReflection.Descriptor.get -> Google.Protobuf.Reflection.FileDescriptor
+~static OpenTelemetry.Proto.Common.V1.InstrumentationScope.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Common.V1.InstrumentationScope.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Common.V1.InstrumentationScope>
+~static OpenTelemetry.Proto.Common.V1.KeyValue.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Common.V1.KeyValue.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Common.V1.KeyValue>
+~static OpenTelemetry.Proto.Common.V1.KeyValueList.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Common.V1.KeyValueList.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Common.V1.KeyValueList>
+~static OpenTelemetry.Proto.Logs.V1.LogRecord.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Logs.V1.LogRecord.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Logs.V1.LogRecord>
+~static OpenTelemetry.Proto.Logs.V1.LogsData.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Logs.V1.LogsData.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Logs.V1.LogsData>
+~static OpenTelemetry.Proto.Logs.V1.LogsReflection.Descriptor.get -> Google.Protobuf.Reflection.FileDescriptor
+~static OpenTelemetry.Proto.Logs.V1.ResourceLogs.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Logs.V1.ResourceLogs.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Logs.V1.ResourceLogs>
+~static OpenTelemetry.Proto.Logs.V1.ScopeLogs.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Logs.V1.ScopeLogs.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Logs.V1.ScopeLogs>
+~static OpenTelemetry.Proto.Metrics.V1.Exemplar.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.Exemplar.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.Exemplar>
+~static OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.ExponentialHistogram>
+~static OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint>
+~static OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.ExponentialHistogramDataPoint.Types.Buckets>
+~static OpenTelemetry.Proto.Metrics.V1.Gauge.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.Gauge.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.Gauge>
+~static OpenTelemetry.Proto.Metrics.V1.Histogram.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.Histogram.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.Histogram>
+~static OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.HistogramDataPoint>
+~static OpenTelemetry.Proto.Metrics.V1.Metric.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.Metric.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.Metric>
+~static OpenTelemetry.Proto.Metrics.V1.MetricsData.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.MetricsData.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.MetricsData>
+~static OpenTelemetry.Proto.Metrics.V1.MetricsReflection.Descriptor.get -> Google.Protobuf.Reflection.FileDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.NumberDataPoint.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.NumberDataPoint>
+~static OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.ResourceMetrics.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.ResourceMetrics>
+~static OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.ScopeMetrics.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.ScopeMetrics>
+~static OpenTelemetry.Proto.Metrics.V1.Sum.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.Sum.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.Sum>
+~static OpenTelemetry.Proto.Metrics.V1.Summary.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.Summary.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.Summary>
+~static OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint>
+~static OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Metrics.V1.SummaryDataPoint.Types.ValueAtQuantile>
+~static OpenTelemetry.Proto.Resource.V1.Resource.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Resource.V1.Resource.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Resource.V1.Resource>
+~static OpenTelemetry.Proto.Resource.V1.ResourceReflection.Descriptor.get -> Google.Protobuf.Reflection.FileDescriptor
+~static OpenTelemetry.Proto.Trace.V1.ResourceSpans.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Trace.V1.ResourceSpans.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Trace.V1.ResourceSpans>
+~static OpenTelemetry.Proto.Trace.V1.ScopeSpans.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Trace.V1.ScopeSpans.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Trace.V1.ScopeSpans>
+~static OpenTelemetry.Proto.Trace.V1.Span.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Trace.V1.Span.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Trace.V1.Span>
+~static OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Trace.V1.Span.Types.Event.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Trace.V1.Span.Types.Event>
+~static OpenTelemetry.Proto.Trace.V1.Span.Types.Link.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Trace.V1.Span.Types.Link.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Trace.V1.Span.Types.Link>
+~static OpenTelemetry.Proto.Trace.V1.Status.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Trace.V1.Status.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Trace.V1.Status>
+~static OpenTelemetry.Proto.Trace.V1.TraceReflection.Descriptor.get -> Google.Protobuf.Reflection.FileDescriptor
+~static OpenTelemetry.Proto.Trace.V1.TracesData.Descriptor.get -> Google.Protobuf.Reflection.MessageDescriptor
+~static OpenTelemetry.Proto.Trace.V1.TracesData.Parser.get -> Google.Protobuf.MessageParser<OpenTelemetry.Proto.Trace.V1.TracesData>
+~virtual OpenTelemetry.Proto.Collector.Logs.V1.LogsService.LogsServiceBase.Export(OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceRequest request, Grpc.Core.ServerCallContext context) -> System.Threading.Tasks.Task<OpenTelemetry.Proto.Collector.Logs.V1.ExportLogsServiceResponse>
+~virtual OpenTelemetry.Proto.Collector.Metrics.V1.MetricsService.MetricsServiceBase.Export(OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceRequest request, Grpc.Core.ServerCallContext context) -> System.Threading.Tasks.Task<OpenTelemetry.Proto.Collector.Metrics.V1.ExportMetricsServiceResponse>
+~virtual OpenTelemetry.Proto.Collector.Trace.V1.TraceService.TraceServiceBase.Export(OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceRequest request, Grpc.Core.ServerCallContext context) -> System.Threading.Tasks.Task<OpenTelemetry.Proto.Collector.Trace.V1.ExportTraceServiceResponse>

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -26,6 +26,10 @@
     <PackageReference Include="Grpc.AspNetCore" />
     <PackageReference Include="KubernetesClient" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <!-- Download DCP orchestrator components for local development -->

--- a/src/Aspire.Hosting/PublicAPI.Shipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -1,0 +1,412 @@
+#nullable enable
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.Address.get -> string!
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.AllocatedEndpointAnnotation(string! name, System.Net.Sockets.ProtocolType protocol, string! address, int port, string! scheme) -> void
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.EndpointNameQualifiedUriString.get -> string!
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.EndPointString.get -> string!
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.Name.get -> string!
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.Port.get -> int
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.Protocol.get -> System.Net.Sockets.ProtocolType
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.UriScheme.get -> string!
+Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.UriString.get -> string!
+Aspire.Hosting.ApplicationModel.ContainerImageAnnotation
+Aspire.Hosting.ApplicationModel.ContainerImageAnnotation.ContainerImageAnnotation() -> void
+Aspire.Hosting.ApplicationModel.ContainerImageAnnotation.Image.get -> string!
+Aspire.Hosting.ApplicationModel.ContainerImageAnnotation.Image.set -> void
+Aspire.Hosting.ApplicationModel.ContainerImageAnnotation.Registry.get -> string?
+Aspire.Hosting.ApplicationModel.ContainerImageAnnotation.Registry.set -> void
+Aspire.Hosting.ApplicationModel.ContainerImageAnnotation.Tag.get -> string!
+Aspire.Hosting.ApplicationModel.ContainerImageAnnotation.Tag.set -> void
+Aspire.Hosting.ApplicationModel.ContainerResource
+Aspire.Hosting.ApplicationModel.ContainerResource.ContainerResource(string! name, string? entrypoint = null) -> void
+Aspire.Hosting.ApplicationModel.ContainerResource.Entrypoint.get -> string?
+Aspire.Hosting.ApplicationModel.ContainerResource.Entrypoint.set -> void
+Aspire.Hosting.ApplicationModel.DistributedApplicationModel
+Aspire.Hosting.ApplicationModel.DistributedApplicationModel.DistributedApplicationModel(Aspire.Hosting.ApplicationModel.IResourceCollection! resources) -> void
+Aspire.Hosting.ApplicationModel.DistributedApplicationModel.Resources.get -> Aspire.Hosting.ApplicationModel.IResourceCollection!
+Aspire.Hosting.ApplicationModel.EndpointAnnotation
+Aspire.Hosting.ApplicationModel.EndpointAnnotation.ContainerPort.get -> int?
+Aspire.Hosting.ApplicationModel.EndpointAnnotation.EndpointAnnotation(System.Net.Sockets.ProtocolType protocol, string? uriScheme = null, string? transport = null, string? name = null, int? port = null, int? containerPort = null, bool? isExternal = null, string? env = null) -> void
+Aspire.Hosting.ApplicationModel.EndpointAnnotation.EnvironmentVariable.get -> string?
+Aspire.Hosting.ApplicationModel.EndpointAnnotation.IsExternal.get -> bool
+Aspire.Hosting.ApplicationModel.EndpointAnnotation.Name.get -> string!
+Aspire.Hosting.ApplicationModel.EndpointAnnotation.Port.get -> int?
+Aspire.Hosting.ApplicationModel.EndpointAnnotation.Protocol.get -> System.Net.Sockets.ProtocolType
+Aspire.Hosting.ApplicationModel.EndpointAnnotation.Transport.get -> string!
+Aspire.Hosting.ApplicationModel.EndpointAnnotation.UriScheme.get -> string!
+Aspire.Hosting.ApplicationModel.EndpointAnnotationExtensions
+Aspire.Hosting.ApplicationModel.EndpointReference
+Aspire.Hosting.ApplicationModel.EndpointReference.EndpointName.get -> string!
+Aspire.Hosting.ApplicationModel.EndpointReference.EndpointReference(Aspire.Hosting.ApplicationModel.IResourceWithEndpoints! owner, string! endpointName) -> void
+Aspire.Hosting.ApplicationModel.EndpointReference.Owner.get -> Aspire.Hosting.ApplicationModel.IResourceWithEndpoints!
+Aspire.Hosting.ApplicationModel.EndpointReference.UriString.get -> string!
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.Callback.get -> System.Action<Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext!>!
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.EnvironmentCallbackAnnotation(string! name, System.Func<string!>! callback) -> void
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.EnvironmentCallbackAnnotation(System.Action<Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext!>! callback) -> void
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.EnvironmentCallbackAnnotation(System.Action<System.Collections.Generic.Dictionary<string!, string!>!>! callback) -> void
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.EnvironmentCallbackContext(string! publisherName, System.Collections.Generic.Dictionary<string!, string!>? environmentVariables = null) -> void
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.EnvironmentVariables.get -> System.Collections.Generic.Dictionary<string!, string!>!
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.PublisherName.get -> string!
+Aspire.Hosting.ApplicationModel.ExecutableArgsCallbackAnnotation
+Aspire.Hosting.ApplicationModel.ExecutableArgsCallbackAnnotation.Callback.get -> System.Action<System.Collections.Generic.IList<string!>!>!
+Aspire.Hosting.ApplicationModel.ExecutableArgsCallbackAnnotation.ExecutableArgsCallbackAnnotation(System.Action<System.Collections.Generic.IList<string!>!>! callback) -> void
+Aspire.Hosting.ApplicationModel.ExecutableResource
+Aspire.Hosting.ApplicationModel.ExecutableResource.Args.get -> string![]?
+Aspire.Hosting.ApplicationModel.ExecutableResource.Command.get -> string!
+Aspire.Hosting.ApplicationModel.ExecutableResource.ExecutableResource(string! name, string! command, string! workingDirectory, string![]? args) -> void
+Aspire.Hosting.ApplicationModel.ExecutableResource.WorkingDirectory.get -> string!
+Aspire.Hosting.ApplicationModel.IMongoDBParentResource
+Aspire.Hosting.ApplicationModel.IMySqlParentResource
+Aspire.Hosting.ApplicationModel.IOracleDatabaseParentResource
+Aspire.Hosting.ApplicationModel.IPostgresParentResource
+Aspire.Hosting.ApplicationModel.IResource
+Aspire.Hosting.ApplicationModel.IResource.Annotations.get -> Aspire.Hosting.ApplicationModel.ResourceMetadataCollection!
+Aspire.Hosting.ApplicationModel.IResource.Name.get -> string!
+Aspire.Hosting.ApplicationModel.IResourceAnnotation
+Aspire.Hosting.ApplicationModel.IResourceBuilder<T>
+Aspire.Hosting.ApplicationModel.IResourceBuilder<T>.ApplicationBuilder.get -> Aspire.Hosting.IDistributedApplicationBuilder!
+Aspire.Hosting.ApplicationModel.IResourceBuilder<T>.Resource.get -> T
+Aspire.Hosting.ApplicationModel.IResourceBuilder<T>.WithAnnotation<TAnnotation>() -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+Aspire.Hosting.ApplicationModel.IResourceBuilder<T>.WithAnnotation<TAnnotation>(TAnnotation annotation) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+Aspire.Hosting.ApplicationModel.IResourceCollection
+Aspire.Hosting.ApplicationModel.IResourceWithConnectionString
+Aspire.Hosting.ApplicationModel.IResourceWithConnectionString.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.IResourceWithEndpoints
+Aspire.Hosting.ApplicationModel.IResourceWithEndpoints.GetEndpoint(string! endpointName) -> Aspire.Hosting.ApplicationModel.EndpointReference!
+Aspire.Hosting.ApplicationModel.IResourceWithEnvironment
+Aspire.Hosting.ApplicationModel.IResourceWithParent<T>
+Aspire.Hosting.ApplicationModel.IResourceWithParent<T>.Parent.get -> T
+Aspire.Hosting.ApplicationModel.ISqlServerParentResource
+Aspire.Hosting.ApplicationModel.KafkaServerResource
+Aspire.Hosting.ApplicationModel.KafkaServerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.KafkaServerResource.KafkaServerResource(string! name) -> void
+Aspire.Hosting.ApplicationModel.ManifestPublishingCallbackAnnotation
+Aspire.Hosting.ApplicationModel.ManifestPublishingCallbackAnnotation.Callback.get -> System.Action<Aspire.Hosting.Publishing.ManifestPublishingContext!>?
+Aspire.Hosting.ApplicationModel.ManifestPublishingCallbackAnnotation.ManifestPublishingCallbackAnnotation(System.Action<Aspire.Hosting.Publishing.ManifestPublishingContext!>? callback) -> void
+Aspire.Hosting.ApplicationModel.MongoDBContainerResource
+Aspire.Hosting.ApplicationModel.MongoDBContainerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.MongoDBContainerResource.MongoDBContainerResource(string! name) -> void
+Aspire.Hosting.ApplicationModel.MongoDBDatabaseResource
+Aspire.Hosting.ApplicationModel.MongoDBDatabaseResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.MongoDBDatabaseResource.MongoDBDatabaseResource(string! name, Aspire.Hosting.ApplicationModel.IMongoDBParentResource! mongoDBContainer) -> void
+Aspire.Hosting.ApplicationModel.MongoDBDatabaseResource.Parent.get -> Aspire.Hosting.ApplicationModel.IMongoDBParentResource!
+Aspire.Hosting.ApplicationModel.MongoDBServerResource
+Aspire.Hosting.ApplicationModel.MongoDBServerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.MongoDBServerResource.MongoDBServerResource(string! name) -> void
+Aspire.Hosting.ApplicationModel.MySqlContainerResource
+Aspire.Hosting.ApplicationModel.MySqlContainerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.MySqlContainerResource.MySqlContainerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.MySqlContainerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.MySqlDatabaseResource
+Aspire.Hosting.ApplicationModel.MySqlDatabaseResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.MySqlDatabaseResource.MySqlDatabaseResource(string! name, Aspire.Hosting.ApplicationModel.IMySqlParentResource! mySqlParentResource) -> void
+Aspire.Hosting.ApplicationModel.MySqlDatabaseResource.Parent.get -> Aspire.Hosting.ApplicationModel.IMySqlParentResource!
+Aspire.Hosting.ApplicationModel.MySqlServerResource
+Aspire.Hosting.ApplicationModel.MySqlServerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.MySqlServerResource.MySqlServerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.MySqlServerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.OpenAIResource
+Aspire.Hosting.ApplicationModel.OpenAIResource.ConnectionString.get -> string?
+Aspire.Hosting.ApplicationModel.OpenAIResource.ConnectionString.set -> void
+Aspire.Hosting.ApplicationModel.OpenAIResource.OpenAIResource(string! name) -> void
+Aspire.Hosting.ApplicationModel.OracleDatabaseContainerResource
+Aspire.Hosting.ApplicationModel.OracleDatabaseContainerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.OracleDatabaseContainerResource.OracleDatabaseContainerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.OracleDatabaseContainerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.OracleDatabaseResource
+Aspire.Hosting.ApplicationModel.OracleDatabaseResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.OracleDatabaseResource.OracleDatabaseResource(string! name, Aspire.Hosting.ApplicationModel.IOracleDatabaseParentResource! oracleParentResource) -> void
+Aspire.Hosting.ApplicationModel.OracleDatabaseResource.Parent.get -> Aspire.Hosting.ApplicationModel.IOracleDatabaseParentResource!
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource.OracleDatabaseServerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.PostgresContainerResource
+Aspire.Hosting.ApplicationModel.PostgresContainerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.PostgresContainerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.PostgresContainerResource.PostgresContainerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.PostgresDatabaseResource
+Aspire.Hosting.ApplicationModel.PostgresDatabaseResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.PostgresDatabaseResource.Parent.get -> Aspire.Hosting.ApplicationModel.IPostgresParentResource!
+Aspire.Hosting.ApplicationModel.PostgresDatabaseResource.PostgresDatabaseResource(string! name, Aspire.Hosting.ApplicationModel.IPostgresParentResource! postgresParentResource) -> void
+Aspire.Hosting.ApplicationModel.PostgresServerResource
+Aspire.Hosting.ApplicationModel.PostgresServerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.PostgresServerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.PostgresServerResource.PostgresServerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.ProjectResource
+Aspire.Hosting.ApplicationModel.ProjectResource.ProjectResource(string! name) -> void
+Aspire.Hosting.ApplicationModel.ProjectResourceExtensions
+Aspire.Hosting.ApplicationModel.RabbitMQContainerResource
+Aspire.Hosting.ApplicationModel.RabbitMQContainerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.RabbitMQContainerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.RabbitMQContainerResource.RabbitMQContainerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.RabbitMQServerResource
+Aspire.Hosting.ApplicationModel.RabbitMQServerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.RabbitMQServerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.RabbitMQServerResource.RabbitMQServerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.RedisContainerResource
+Aspire.Hosting.ApplicationModel.RedisContainerResource.GetConnectionString() -> string!
+Aspire.Hosting.ApplicationModel.RedisContainerResource.RedisContainerResource(string! name) -> void
+Aspire.Hosting.ApplicationModel.RedisResource
+Aspire.Hosting.ApplicationModel.RedisResource.GetConnectionString() -> string!
+Aspire.Hosting.ApplicationModel.RedisResource.RedisResource(string! name) -> void
+Aspire.Hosting.ApplicationModel.ReplicaAnnotation
+Aspire.Hosting.ApplicationModel.ReplicaAnnotation.ReplicaAnnotation(int replicas = 1) -> void
+Aspire.Hosting.ApplicationModel.ReplicaAnnotation.Replicas.get -> int
+Aspire.Hosting.ApplicationModel.Resource
+Aspire.Hosting.ApplicationModel.Resource.Annotations.get -> Aspire.Hosting.ApplicationModel.ResourceMetadataCollection!
+Aspire.Hosting.ApplicationModel.Resource.Name.get -> string!
+Aspire.Hosting.ApplicationModel.Resource.Resource(string! name) -> void
+Aspire.Hosting.ApplicationModel.ResourceExtensions
+Aspire.Hosting.ApplicationModel.ResourceMetadataCollection
+Aspire.Hosting.ApplicationModel.ResourceMetadataCollection.ResourceMetadataCollection() -> void
+Aspire.Hosting.ApplicationModel.SecretResource
+Aspire.Hosting.ApplicationModel.SecretResource.Parent.get -> Aspire.Hosting.ApplicationModel.SecretStoreResource!
+Aspire.Hosting.ApplicationModel.SecretResource.SecretResource(string! name, Aspire.Hosting.ApplicationModel.SecretStoreResource! parent) -> void
+Aspire.Hosting.ApplicationModel.SecretStoreResource
+Aspire.Hosting.ApplicationModel.SecretStoreResource.SecretStoreResource(string! name) -> void
+Aspire.Hosting.ApplicationModel.SqlServerContainerResource
+Aspire.Hosting.ApplicationModel.SqlServerContainerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.SqlServerContainerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.SqlServerContainerResource.SqlServerContainerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.SqlServerDatabaseResource
+Aspire.Hosting.ApplicationModel.SqlServerDatabaseResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.SqlServerDatabaseResource.Parent.get -> Aspire.Hosting.ApplicationModel.ISqlServerParentResource!
+Aspire.Hosting.ApplicationModel.SqlServerDatabaseResource.SqlServerDatabaseResource(string! name, Aspire.Hosting.ApplicationModel.ISqlServerParentResource! sqlServerContainer) -> void
+Aspire.Hosting.ApplicationModel.SqlServerServerResource
+Aspire.Hosting.ApplicationModel.SqlServerServerResource.GetConnectionString() -> string?
+Aspire.Hosting.ApplicationModel.SqlServerServerResource.Password.get -> string!
+Aspire.Hosting.ApplicationModel.SqlServerServerResource.SqlServerServerResource(string! name, string! password) -> void
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation.IsReadOnly.get -> bool
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation.IsReadOnly.set -> void
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation.Source.get -> string!
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation.Source.set -> void
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation.Target.get -> string!
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation.Target.set -> void
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation.Type.get -> Aspire.Hosting.ApplicationModel.VolumeMountType
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation.Type.set -> void
+Aspire.Hosting.ApplicationModel.VolumeMountAnnotation.VolumeMountAnnotation(string! source, string! target, Aspire.Hosting.ApplicationModel.VolumeMountType type = Aspire.Hosting.ApplicationModel.VolumeMountType.Bind, bool isReadOnly = false) -> void
+Aspire.Hosting.ApplicationModel.VolumeMountType
+Aspire.Hosting.ApplicationModel.VolumeMountType.Bind = 0 -> Aspire.Hosting.ApplicationModel.VolumeMountType
+Aspire.Hosting.ApplicationModel.VolumeMountType.Named = 1 -> Aspire.Hosting.ApplicationModel.VolumeMountType
+Aspire.Hosting.ConnectionString
+Aspire.Hosting.ConnectionString.ConnectionString() -> void
+Aspire.Hosting.ConnectionString.ConnectionString(string! name) -> void
+Aspire.Hosting.ConnectionString.ConnectionString(string! name, string! value) -> void
+Aspire.Hosting.ConnectionString.Name.get -> string!
+Aspire.Hosting.ConnectionString.Value.get -> string?
+Aspire.Hosting.ContainerResourceBuilderExtensions
+Aspire.Hosting.ContainerResourceExtensions
+Aspire.Hosting.DistributedApplication
+Aspire.Hosting.DistributedApplication.Dispose() -> void
+Aspire.Hosting.DistributedApplication.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Aspire.Hosting.DistributedApplication.DistributedApplication(Microsoft.Extensions.Hosting.IHost! host, string![]! args) -> void
+Aspire.Hosting.DistributedApplication.Run() -> void
+Aspire.Hosting.DistributedApplication.RunAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Aspire.Hosting.DistributedApplication.Services.get -> System.IServiceProvider!
+Aspire.Hosting.DistributedApplication.StartAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Aspire.Hosting.DistributedApplication.StopAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Aspire.Hosting.DistributedApplicationBuilder
+Aspire.Hosting.DistributedApplicationBuilder.AddResource<T>(T resource) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+Aspire.Hosting.DistributedApplicationBuilder.AppHostDirectory.get -> string!
+Aspire.Hosting.DistributedApplicationBuilder.Build() -> Aspire.Hosting.DistributedApplication!
+Aspire.Hosting.DistributedApplicationBuilder.Configuration.get -> Microsoft.Extensions.Configuration.ConfigurationManager!
+Aspire.Hosting.DistributedApplicationBuilder.DistributedApplicationBuilder(Aspire.Hosting.DistributedApplicationOptions! options) -> void
+Aspire.Hosting.DistributedApplicationBuilder.Environment.get -> Microsoft.Extensions.Hosting.IHostEnvironment!
+Aspire.Hosting.DistributedApplicationBuilder.Resources.get -> Aspire.Hosting.ApplicationModel.IResourceCollection!
+Aspire.Hosting.DistributedApplicationBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+Aspire.Hosting.DistributedApplicationException
+Aspire.Hosting.DistributedApplicationException.DistributedApplicationException() -> void
+Aspire.Hosting.DistributedApplicationException.DistributedApplicationException(string! message) -> void
+Aspire.Hosting.DistributedApplicationException.DistributedApplicationException(string! message, System.Exception! inner) -> void
+Aspire.Hosting.DistributedApplicationOptions
+Aspire.Hosting.DistributedApplicationOptions.Args.get -> string![]?
+Aspire.Hosting.DistributedApplicationOptions.Args.set -> void
+Aspire.Hosting.DistributedApplicationOptions.AssemblyName.get -> string?
+Aspire.Hosting.DistributedApplicationOptions.AssemblyName.set -> void
+Aspire.Hosting.DistributedApplicationOptions.DisableDashboard.get -> bool
+Aspire.Hosting.DistributedApplicationOptions.DisableDashboard.set -> void
+Aspire.Hosting.DistributedApplicationOptions.DistributedApplicationOptions() -> void
+Aspire.Hosting.ExecutableResourceBuilderExtensions
+Aspire.Hosting.ExecutableResourceExtensions
+Aspire.Hosting.IDistributedApplicationBuilder
+Aspire.Hosting.IDistributedApplicationBuilder.AddResource<T>(T resource) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+Aspire.Hosting.IDistributedApplicationBuilder.AppHostDirectory.get -> string!
+Aspire.Hosting.IDistributedApplicationBuilder.Build() -> Aspire.Hosting.DistributedApplication!
+Aspire.Hosting.IDistributedApplicationBuilder.Configuration.get -> Microsoft.Extensions.Configuration.ConfigurationManager!
+Aspire.Hosting.IDistributedApplicationBuilder.Environment.get -> Microsoft.Extensions.Hosting.IHostEnvironment!
+Aspire.Hosting.IDistributedApplicationBuilder.Resources.get -> Aspire.Hosting.ApplicationModel.IResourceCollection!
+Aspire.Hosting.IDistributedApplicationBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+Aspire.Hosting.IProjectMetadata
+Aspire.Hosting.IProjectMetadata.ProjectPath.get -> string!
+Aspire.Hosting.IResourceWithServiceDiscovery
+Aspire.Hosting.KafkaBuilderExtensions
+Aspire.Hosting.KafkaContainerResource
+Aspire.Hosting.KafkaContainerResource.GetConnectionString() -> string?
+Aspire.Hosting.KafkaContainerResource.KafkaContainerResource(string! name) -> void
+Aspire.Hosting.Lifecycle.IDistributedApplicationLifecycleHook
+Aspire.Hosting.Lifecycle.IDistributedApplicationLifecycleHook.AfterEndpointsAllocatedAsync(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! appModel, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Aspire.Hosting.Lifecycle.IDistributedApplicationLifecycleHook.BeforeStartAsync(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! appModel, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Aspire.Hosting.Lifecycle.LifecycleHookServiceCollectionExtensions
+Aspire.Hosting.MongoDBBuilderExtensions
+Aspire.Hosting.MySqlBuilderExtensions
+Aspire.Hosting.NodeAppHostingExtension
+Aspire.Hosting.NodeAppResource
+Aspire.Hosting.NodeAppResource.NodeAppResource(string! name, string! command, string! workingDirectory, string![]? args) -> void
+Aspire.Hosting.OpenAIBuilderExtensions
+Aspire.Hosting.OracleDatabaseBuilderExtensions
+Aspire.Hosting.OtlpConfigurationExtensions
+Aspire.Hosting.PostgresBuilderExtensions
+Aspire.Hosting.ProjectResourceBuilderExtensions
+Aspire.Hosting.Publishing.IDistributedApplicationPublisher
+Aspire.Hosting.Publishing.IDistributedApplicationPublisher.PublishAsync(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Aspire.Hosting.Publishing.ManifestPublisher
+Aspire.Hosting.Publishing.ManifestPublisher.JsonWriter.get -> System.Text.Json.Utf8JsonWriter?
+Aspire.Hosting.Publishing.ManifestPublisher.JsonWriter.set -> void
+Aspire.Hosting.Publishing.ManifestPublisher.ManifestPublisher(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.Publishing.ManifestPublisher!>! logger, Microsoft.Extensions.Options.IOptions<Aspire.Hosting.Publishing.PublishingOptions!>! options, Microsoft.Extensions.Hosting.IHostApplicationLifetime! lifetime) -> void
+Aspire.Hosting.Publishing.ManifestPublisher.WriteManifestAsync(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model, System.Text.Json.Utf8JsonWriter! jsonWriter, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Aspire.Hosting.Publishing.ManifestPublishingContext
+Aspire.Hosting.Publishing.ManifestPublishingContext.GetManifestRelativePath(string? path) -> string?
+Aspire.Hosting.Publishing.ManifestPublishingContext.ManifestPath.get -> string!
+Aspire.Hosting.Publishing.ManifestPublishingContext.ManifestPublishingContext(string! manifestPath, System.Text.Json.Utf8JsonWriter! writer) -> void
+Aspire.Hosting.Publishing.ManifestPublishingContext.WriteBindings(Aspire.Hosting.ApplicationModel.IResource! resource, bool emitContainerPort = false) -> void
+Aspire.Hosting.Publishing.ManifestPublishingContext.WriteContainer(Aspire.Hosting.ApplicationModel.ContainerResource! container) -> void
+Aspire.Hosting.Publishing.ManifestPublishingContext.WriteEnvironmentVariables(Aspire.Hosting.ApplicationModel.IResource! resource) -> void
+Aspire.Hosting.Publishing.ManifestPublishingContext.WritePortBindingEnvironmentVariables(Aspire.Hosting.ApplicationModel.IResource! resource) -> void
+Aspire.Hosting.Publishing.ManifestPublishingContext.Writer.get -> System.Text.Json.Utf8JsonWriter!
+Aspire.Hosting.Publishing.ManifestPublishingContext.WriteServiceDiscoveryEnvironmentVariables(Aspire.Hosting.ApplicationModel.IResource! resource) -> void
+Aspire.Hosting.Publishing.PublishingOptions
+Aspire.Hosting.Publishing.PublishingOptions.OutputPath.get -> string?
+Aspire.Hosting.Publishing.PublishingOptions.OutputPath.set -> void
+Aspire.Hosting.Publishing.PublishingOptions.Publisher.get -> string?
+Aspire.Hosting.Publishing.PublishingOptions.Publisher.set -> void
+Aspire.Hosting.Publishing.PublishingOptions.PublishingOptions() -> void
+Aspire.Hosting.RabbitMQBuilderExtensions
+Aspire.Hosting.Redis.IRedisResource
+Aspire.Hosting.Redis.RedisCommanderConfigWriterHook
+Aspire.Hosting.Redis.RedisCommanderConfigWriterHook.AfterEndpointsAllocatedAsync(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! appModel, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Aspire.Hosting.Redis.RedisCommanderConfigWriterHook.RedisCommanderConfigWriterHook() -> void
+Aspire.Hosting.Redis.RedisCommanderResource
+Aspire.Hosting.Redis.RedisCommanderResource.RedisCommanderResource(string! name) -> void
+Aspire.Hosting.RedisBuilderExtensions
+Aspire.Hosting.ResourceBuilderExtensions
+Aspire.Hosting.SecretResourceBuilderExtensions
+Aspire.Hosting.SqlServerBuilderExtensions
+Aspire.Hosting.Utils.FileNameSuffixes
+Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes
+Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes.DynamicLib.get -> string!
+Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes.Exe.get -> string!
+Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes.PlatformFileNameSuffixes() -> void
+Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes.ProgramDatabase.get -> string!
+Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes.StaticLib.get -> string!
+Aspire.Hosting.Utils.HostNameResolver
+Aspire.Hosting.Utils.HostNameResolver.HostNameResolver() -> void
+Aspire.Hosting.Utils.Utf8JsonWriterExtensions
+const Aspire.Hosting.Publishing.PublishingOptions.Publishing = "Publishing" -> string!
+const Aspire.Hosting.Utils.FileNameSuffixes.DepsJson = ".deps.json" -> string!
+const Aspire.Hosting.Utils.FileNameSuffixes.RuntimeConfigDevJson = ".runtimeconfig.dev.json" -> string!
+const Aspire.Hosting.Utils.FileNameSuffixes.RuntimeConfigJson = ".runtimeconfig.json" -> string!
+override Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation.ToString() -> string!
+static Aspire.Hosting.ApplicationModel.EndpointAnnotationExtensions.AsExternal(this Aspire.Hosting.ApplicationModel.EndpointAnnotation! endpoint) -> Aspire.Hosting.ApplicationModel.EndpointAnnotation!
+static Aspire.Hosting.ApplicationModel.EndpointAnnotationExtensions.AsHttp2(this Aspire.Hosting.ApplicationModel.EndpointAnnotation! endpoint) -> Aspire.Hosting.ApplicationModel.EndpointAnnotation!
+static Aspire.Hosting.ApplicationModel.ManifestPublishingCallbackAnnotation.Ignore.get -> Aspire.Hosting.ApplicationModel.ManifestPublishingCallbackAnnotation!
+static Aspire.Hosting.ApplicationModel.ProjectResourceExtensions.GetProjectMetadata(this Aspire.Hosting.ApplicationModel.ProjectResource! projectResource) -> Aspire.Hosting.IProjectMetadata!
+static Aspire.Hosting.ApplicationModel.ProjectResourceExtensions.GetProjectResources(this Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model) -> System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.ProjectResource!>!
+static Aspire.Hosting.ApplicationModel.ResourceExtensions.GetReplicaCount(this Aspire.Hosting.ApplicationModel.IResource! resource) -> int
+static Aspire.Hosting.ApplicationModel.ResourceExtensions.TryGetAllocatedEndPoints(this Aspire.Hosting.ApplicationModel.IResource! resource, out System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.AllocatedEndpointAnnotation!>? allocatedEndPoints) -> bool
+static Aspire.Hosting.ApplicationModel.ResourceExtensions.TryGetAnnotationsOfType<T>(this Aspire.Hosting.ApplicationModel.IResource! resource, out System.Collections.Generic.IEnumerable<T>? result) -> bool
+static Aspire.Hosting.ApplicationModel.ResourceExtensions.TryGetContainerImageName(this Aspire.Hosting.ApplicationModel.IResource! resource, out string? imageName) -> bool
+static Aspire.Hosting.ApplicationModel.ResourceExtensions.TryGetEndpoints(this Aspire.Hosting.ApplicationModel.IResource! resource, out System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.EndpointAnnotation!>? endpoints) -> bool
+static Aspire.Hosting.ApplicationModel.ResourceExtensions.TryGetEnvironmentVariables(this Aspire.Hosting.ApplicationModel.IResource! resource, out System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation!>? environmentVariables) -> bool
+static Aspire.Hosting.ApplicationModel.ResourceExtensions.TryGetLastAnnotation<T>(this Aspire.Hosting.ApplicationModel.IResource! resource, out T? annotation) -> bool
+static Aspire.Hosting.ApplicationModel.ResourceExtensions.TryGetVolumeMounts(this Aspire.Hosting.ApplicationModel.IResource! resource, out System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.VolumeMountAnnotation!>? volumeMounts) -> bool
+static Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string! image) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!
+static Aspire.Hosting.ContainerResourceBuilderExtensions.AddContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string! image, string! tag) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ContainerResource!>!
+static Aspire.Hosting.ContainerResourceBuilderExtensions.WithArgs<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, params string![]! args) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
+static Aspire.Hosting.ContainerResourceBuilderExtensions.WithEntrypoint<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, string! entrypoint) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
+static Aspire.Hosting.ContainerResourceBuilderExtensions.WithVolumeMount<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, string! source, string! target, Aspire.Hosting.ApplicationModel.VolumeMountType type = Aspire.Hosting.ApplicationModel.VolumeMountType.Bind, bool isReadOnly = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
+static Aspire.Hosting.ContainerResourceExtensions.GetContainerResources(this Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model) -> System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.IResource!>!
+static Aspire.Hosting.ContainerResourceExtensions.IsContainer(this Aspire.Hosting.ApplicationModel.IResource! resource) -> bool
+static Aspire.Hosting.DistributedApplication.CreateBuilder() -> Aspire.Hosting.IDistributedApplicationBuilder!
+static Aspire.Hosting.DistributedApplication.CreateBuilder(Aspire.Hosting.DistributedApplicationOptions! options) -> Aspire.Hosting.IDistributedApplicationBuilder!
+static Aspire.Hosting.DistributedApplication.CreateBuilder(string![]! args) -> Aspire.Hosting.IDistributedApplicationBuilder!
+static Aspire.Hosting.ExecutableResourceBuilderExtensions.AddExecutable(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string! command, string! workingDirectory, params string![]? args) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ExecutableResource!>!
+static Aspire.Hosting.ExecutableResourceBuilderExtensions.AsDockerfileInManifest<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
+static Aspire.Hosting.ExecutableResourceBuilderExtensions.WithArgs<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, params string![]! args) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
+static Aspire.Hosting.ExecutableResourceExtensions.GetExecutableResources(this Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model) -> System.Collections.Generic.IEnumerable<Aspire.Hosting.ApplicationModel.ExecutableResource!>!
+static Aspire.Hosting.KafkaBuilderExtensions.AddKafka(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.KafkaServerResource!>!
+static Aspire.Hosting.KafkaBuilderExtensions.AddKafkaContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, int? port = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.KafkaContainerResource!>!
+static Aspire.Hosting.Lifecycle.LifecycleHookServiceCollectionExtensions.AddLifecycleHook<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void
+static Aspire.Hosting.Lifecycle.LifecycleHookServiceCollectionExtensions.AddLifecycleHook<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Func<System.IServiceProvider!, T!>! implementationFactory) -> void
+static Aspire.Hosting.Lifecycle.LifecycleHookServiceCollectionExtensions.TryAddLifecycleHook<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> void
+static Aspire.Hosting.Lifecycle.LifecycleHookServiceCollectionExtensions.TryAddLifecycleHook<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Func<System.IServiceProvider!, T!>! implementationFactory) -> void
+static Aspire.Hosting.MongoDBBuilderExtensions.AddDatabase(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.MongoDBContainerResource!>! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.MongoDBDatabaseResource!>!
+static Aspire.Hosting.MongoDBBuilderExtensions.AddMongoDB(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.MongoDBServerResource!>!
+static Aspire.Hosting.MongoDBBuilderExtensions.AddMongoDBContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, int? port = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.MongoDBContainerResource!>!
+static Aspire.Hosting.MySqlBuilderExtensions.AddDatabase(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IMySqlParentResource!>! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.MySqlDatabaseResource!>!
+static Aspire.Hosting.MySqlBuilderExtensions.AddMySql(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.MySqlServerResource!>!
+static Aspire.Hosting.MySqlBuilderExtensions.AddMySqlContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, int? port = null, string? password = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.MySqlContainerResource!>!
+static Aspire.Hosting.NodeAppHostingExtension.AddNodeApp(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string! scriptPath, string? workingDirectory = null, string![]? args = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.NodeAppResource!>!
+static Aspire.Hosting.NodeAppHostingExtension.AddNpmApp(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string! workingDirectory, string! scriptName = "start", string![]? args = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.NodeAppResource!>!
+static Aspire.Hosting.OpenAIBuilderExtensions.AddOpenAI(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OpenAIResource!>!
+static Aspire.Hosting.OracleDatabaseBuilderExtensions.AddDatabase(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IOracleDatabaseParentResource!>! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseResource!>!
+static Aspire.Hosting.OracleDatabaseBuilderExtensions.AddOracleDatabase(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>!
+static Aspire.Hosting.OracleDatabaseBuilderExtensions.AddOracleDatabaseContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, int? port = null, string? password = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseContainerResource!>!
+static Aspire.Hosting.OtlpConfigurationExtensions.AddOtlpEnvironment(Aspire.Hosting.ApplicationModel.IResource! resource, Microsoft.Extensions.Configuration.IConfiguration! configuration, Microsoft.Extensions.Hosting.IHostEnvironment! environment) -> void
+static Aspire.Hosting.OtlpConfigurationExtensions.WithOtlpExporter<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.PostgresBuilderExtensions.AddDatabase(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IPostgresParentResource!>! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.PostgresDatabaseResource!>!
+static Aspire.Hosting.PostgresBuilderExtensions.AddPostgres(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.PostgresServerResource!>!
+static Aspire.Hosting.PostgresBuilderExtensions.AddPostgresContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, int? port = null, string? password = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.PostgresContainerResource!>!
+static Aspire.Hosting.PostgresBuilderExtensions.WithPgAdmin<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, int? hostPort = null, string? containerName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string! projectPath) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
+static Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject<TProject>(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
+static Aspire.Hosting.ProjectResourceBuilderExtensions.WithLaunchProfile(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, string! launchProfileName) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
+static Aspire.Hosting.ProjectResourceBuilderExtensions.WithReplicas(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ExecutableResource!>! builder, int replicas) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ExecutableResource!>!
+static Aspire.Hosting.ProjectResourceBuilderExtensions.WithReplicas(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, int replicas) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
+static Aspire.Hosting.RabbitMQBuilderExtensions.AddRabbitMQ(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.RabbitMQServerResource!>!
+static Aspire.Hosting.RabbitMQBuilderExtensions.AddRabbitMQContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, int? port = null, string? password = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.RabbitMQContainerResource!>!
+static Aspire.Hosting.RedisBuilderExtensions.AddRedis(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.RedisResource!>!
+static Aspire.Hosting.RedisBuilderExtensions.AddRedisContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, int? port = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.RedisContainerResource!>!
+static Aspire.Hosting.RedisBuilderExtensions.WithRedisCommander<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string? containerName = null, int? hostPort = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.AsHttp2Service<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.ExcludeFromManifest<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.GetEndpoint<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! name) -> Aspire.Hosting.ApplicationModel.EndpointReference!
+static Aspire.Hosting.ResourceBuilderExtensions.WithEndpoint<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, int containerPort, int? hostPort = null, string? scheme = null, string? name = null, string? env = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithEndpoint<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, int? hostPort = null, string? scheme = null, string? name = null, string? env = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! name, Aspire.Hosting.ApplicationModel.EndpointReference! endpointReference) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! name, string? value) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! name, System.Func<string!>! callback) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithEnvironment<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, System.Action<Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext!>! callback) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithHttpEndpoint<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, int containerPort, int? hostPort = null, string? name = null, string? env = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithHttpEndpoint<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, int? hostPort = null, string? name = null, string? env = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithHttpsEndpoint<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, int containerPort, int? hostPort = null, string? name = null, string? env = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithHttpsEndpoint<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, int? hostPort = null, string? name = null, string? env = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithManifestPublishingCallback<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, System.Action<Aspire.Hosting.Publishing.ManifestPublishingContext!>! callback) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithReference<TDestination>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>! builder, Aspire.Hosting.ApplicationModel.EndpointReference! endpointReference) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithReference<TDestination>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResourceWithConnectionString!>! source, string? connectionName = null, bool optional = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithReference<TDestination>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.IResourceWithServiceDiscovery!>! source) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithReference<TDestination>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>! builder, Aspire.Hosting.ConnectionString connectionString) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithReference<TDestination>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>! builder, string! name, System.Uri! uri) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<TDestination>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithServiceBinding<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, int containerPort, int? hostPort = null, string? scheme = null, string? name = null, string? env = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithServiceBinding<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, int? hostPort = null, string? scheme = null, string? name = null, string? env = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.SecretResourceBuilderExtensions.AddSecret(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SecretStoreResource!>! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SecretResource!>!
+static Aspire.Hosting.SecretResourceBuilderExtensions.AddSecretStore(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SecretStoreResource!>!
+static Aspire.Hosting.SecretResourceBuilderExtensions.WithEnvironment<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! name, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SecretResource!>! secret) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.SqlServerBuilderExtensions.AddDatabase(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ISqlServerParentResource!>! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqlServerDatabaseResource!>!
+static Aspire.Hosting.SqlServerBuilderExtensions.AddSqlServer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqlServerServerResource!>!
+static Aspire.Hosting.SqlServerBuilderExtensions.AddSqlServerContainer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string? password = null, int? port = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqlServerContainerResource!>!
+static Aspire.Hosting.Utils.FileNameSuffixes.CurrentPlatform.get -> Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes
+static Aspire.Hosting.Utils.FileNameSuffixes.DotNet.get -> Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes
+static Aspire.Hosting.Utils.FileNameSuffixes.OSX.get -> Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes
+static Aspire.Hosting.Utils.FileNameSuffixes.Unix.get -> Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes
+static Aspire.Hosting.Utils.FileNameSuffixes.Windows.get -> Aspire.Hosting.Utils.FileNameSuffixes.PlatformFileNameSuffixes
+static Aspire.Hosting.Utils.HostNameResolver.ReplaceLocalhostWithContainerHost(string! value, Microsoft.Extensions.Configuration.IConfiguration! configuration) -> string!
+static Aspire.Hosting.Utils.Utf8JsonWriterExtensions.TryWriteBoolean(this System.Text.Json.Utf8JsonWriter! writer, string! name, bool? value) -> bool
+static Aspire.Hosting.Utils.Utf8JsonWriterExtensions.TryWriteNumber(this System.Text.Json.Utf8JsonWriter! writer, string! name, int? value) -> bool
+static Aspire.Hosting.Utils.Utf8JsonWriterExtensions.TryWriteString(this System.Text.Json.Utf8JsonWriter! writer, string! name, string? value) -> bool
+static Aspire.Hosting.Utils.Utf8JsonWriterExtensions.TryWriteStringArray(this System.Text.Json.Utf8JsonWriter! writer, string! name, System.Collections.Generic.IEnumerable<string!>? values) -> bool
+virtual Aspire.Hosting.Publishing.ManifestPublisher.PublishAsync(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+virtual Aspire.Hosting.Publishing.ManifestPublisher.PublishInternalAsync(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!


### PR DESCRIPTION
This adds the `Microsoft.CodeAnalysis.PublicApiAnalyzers` package to the dashboard and hosting projects, though it could be added more broadly if deemed helpful.

As we approach v1, we should be very intentional about what APIs are expected to be public. I have the feeling that several public APIs we have today don't need to be public and that we may regret making them public in future when we want to change them but cannot easily do so due to backwards compatibility goals.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1828)