### PR TITLE
Ensure the targets end up in the data path instead of content

### DIFF
--- a/src/Microsoft.NET.Sdk.Aspire/Microsoft.NET.Sdk.Aspire.csproj
+++ b/src/Microsoft.NET.Sdk.Aspire/Microsoft.NET.Sdk.Aspire.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <None Include="WorkloadManifest.in.json" Pack="true" PerformTextReplacement="True" />
-    <None Include="WorkloadManifest.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="WorkloadManifest.Aspire.targets" Pack="true" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="WorkloadManifest.targets" Pack="true" PackagePath="data" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="WorkloadManifest.Aspire.targets" Pack="true" PackagePath="data" CopyToOutputDirectory="PreserveNewest" />
     <None Include="Rollback.in.json" PerformTextReplacement="True" />
     <None Include="SdkInstaller.in.json" PerformTextReplacement="True" />
     <None Update="@(None->HasMetadata('PerformTextReplacement'))" CopyToOutputDirectory="PreserveNewest" PackagePath="data" />


### PR DESCRIPTION
Targets are getting packaged but to the wrong folder; workload build expects them in the data folder.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1832)