### PR TITLE
Increase wait timeout for the dashboard

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -182,7 +182,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         await WaitForHttpSuccessOrThrow(dashboardUrl, TimeSpan.FromSeconds(DashboardWaitTimeInSeconds), cancellationToken).ConfigureAwait(false);
     }
 
+#if !DEBUG
     private const int DashboardWaitTimeInSeconds = 10;
+#else
+    private const int DashboardWaitTimeInSeconds = 30;
+#endif
 
     private async Task WaitForHttpSuccessOrThrow(string url, TimeSpan timeout, CancellationToken cancellationToken = default)
     {

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -182,12 +182,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         await WaitForHttpSuccessOrThrow(dashboardUrl, TimeSpan.FromSeconds(DashboardWaitTimeInSeconds), cancellationToken).ConfigureAwait(false);
     }
 
-#if !DEBUG
-    private const int DashboardWaitTimeInSeconds = 10;
-#else
-    // Allow extra time when building locally. Dashboard can take longer to start up because of dev binaries, debugger, etc.
+    // Allow extra time when building locally. Dashboard can take longer to start up because of dev binaries, debugger, etc
     private const int DashboardWaitTimeInSeconds = 30;
-#endif
 
     private async Task WaitForHttpSuccessOrThrow(string url, TimeSpan timeout, CancellationToken cancellationToken = default)
     {

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -182,7 +182,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         await WaitForHttpSuccessOrThrow(dashboardUrl, TimeSpan.FromSeconds(DashboardWaitTimeInSeconds), cancellationToken).ConfigureAwait(false);
     }
 
-    // Allow extra time when building locally. Dashboard can take longer to start up because of dev binaries, debugger, etc
+    // Dashboard should always launch successfully within this time.
+    // Also, gives necessary time when developing the dashboard. Dashboard can take longer to start up because of dev binaries, debugger, break points, etc
     private const int DashboardWaitTimeInSeconds = 30;
 
     private async Task WaitForHttpSuccessOrThrow(string url, TimeSpan timeout, CancellationToken cancellationToken = default)

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -185,6 +185,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 #if !DEBUG
     private const int DashboardWaitTimeInSeconds = 10;
 #else
+    // Allow extra time when building locally. Dashboard can take longer to start up because of dev binaries, debugger, etc.
     private const int DashboardWaitTimeInSeconds = 30;
 #endif
 


### PR DESCRIPTION
~Reduce chance of seeing dashboard timeout from slow startup because of _dev stuff_.~

~Testing for DEBUG build seems the simplest way of doing this.~

General increase to 30 seconds timeout.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1833)