### PR TITLE
Add containerName property to DCP spec and status

### DIFF
--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -225,7 +225,7 @@ internal sealed class Container : CustomResource<ContainerSpec, ContainerStatus>
 
     public static Container Create(string name, string image)
     {
-        var c = new Container(new ContainerSpec { Image = image, ContainerName = name });
+        var c = new Container(new ContainerSpec { Image = image });
 
         c.Kind = Dcp.ContainerKind;
         c.ApiVersion = Dcp.GroupVersion.ToString();

--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -9,6 +9,10 @@ namespace Aspire.Hosting.Dcp.Model;
 
 internal sealed class ContainerSpec
 {
+    // Container name displayed in Docker
+    [JsonPropertyName("containerName")]
+    public string? ContainerName { get; set; }
+
     // Image to be used to create the container
     [JsonPropertyName("image")]
     public string? Image { get; set; }
@@ -153,6 +157,10 @@ internal sealed class ContainerPortSpec
 
 internal sealed class ContainerStatus : V1Status
 {
+    // Container name displayed in Docker
+    [JsonPropertyName("containerName")]
+    public string? ContainerName { get; set; }
+
     // Current state of the Container.
     [JsonPropertyName("state")]
     public string? State { get; set; }
@@ -217,7 +225,7 @@ internal sealed class Container : CustomResource<ContainerSpec, ContainerStatus>
 
     public static Container Create(string name, string image)
     {
-        var c = new Container(new ContainerSpec { Image = image });
+        var c = new Container(new ContainerSpec { Image = image, ContainerName = name });
 
         c.Kind = Dcp.ContainerKind;
         c.ApiVersion = Dcp.GroupVersion.ToString();

--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.Dcp.Model;
 
 internal sealed class ContainerSpec
 {
-    // Container name displayed in Docker
+    // Container name displayed in Docker. If not specified, the metadata name + random suffix is used.
     [JsonPropertyName("containerName")]
     public string? ContainerName { get; set; }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/949

Just adds properties to DTOs. DCP changes alone handled setting a good name in Docker:

![image](https://github.com/dotnet/aspire/assets/303201/24c76703-560a-438b-986f-827d039bddb7)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1835)