### PR TITLE
Fix horizontal overflow in metrics filter popup

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
@@ -70,6 +70,7 @@ else
                                                 {
                                                     var isChecked = context.SelectedValues.Contains(tag);
                                                     <FluentCheckbox Label="@tag.Name"
+                                                                    title="@tag.Name"
                                                                     @key=tag
                                                                     @bind-Value:get="isChecked"
                                                                     @bind-Value:set="c => context.OnTagSelectionChanged(tag, c)" />

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -51,6 +51,7 @@
 ::deep .dimension-popup {
     max-width: 500px;
     min-width: 100px;
+    overflow-x: hidden;
 }
 
 ::deep .fluent-popover-content {


### PR DESCRIPTION
Metrics filter popup with long content displayed a horizontal scrollbar.

Hide overflow content and add tooltip to see long data.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1838)