### PR TITLE
Change default port for dashboard applicationUrl

### DIFF
--- a/src/Aspire.Dashboard/Properties/launchSettings.json
+++ b/src/Aspire.Dashboard/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:63824;http://localhost:15888"
+      "applicationUrl": "https://localhost:15889;http://localhost:15888"
     }
   }
 }


### PR DESCRIPTION
Windows allows systems to exclude specific port ranges, after which attempts to bind them will fail. The ranges will vary from machine to machine, and can be viewed with the command `netsh interface ipv4 show excludedportrange protocol=tcp`.

We're seeing users hitting issues with port 63824. While the excluded ranges will vary from machine to machine, it seems like these higher numbers are more likely to be excluded.

This change moves the ports lower, which should help alleviate this issue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1853)