### PR TITLE
Orleans: enable distributed tracing by default

### DIFF
--- a/src/Aspire.Hosting.Orleans/OrleansService.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansService.cs
@@ -59,4 +59,12 @@ public class OrleansService(IDistributedApplicationBuilder builder, string name)
     /// Gets the stream providers.
     /// </summary>
     public Dictionary<string, IProviderConfiguration> Streaming { get; } = [];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to enable tracing of grain calls.
+    /// </summary>
+    /// <remarks>
+    /// Distributed tracing is enabled by default.
+    /// </remarks>
+    public bool? EnableDistributedTracing { get; set; }
 }

--- a/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
@@ -358,6 +358,12 @@ public static class OrleansServiceExtensions
             builder.WithEnvironment("Orleans__ServiceId", res.ServiceId);
         }
 
+        // Enable distributed tracing by default
+        if (res.EnableDistributedTracing != false)
+        {
+            builder.WithEnvironment("Orleans__EnableDistributedTracing", "true");
+        }
+
         return builder;
     }
 }


### PR DESCRIPTION
This PR pairs with a [PR on the Orleans side](https://github.com/dotnet/orleans/pull/8829) to enable distributed tracing by default in Orleans apps in Aspire.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1858)