### PR TITLE
Publishing dashboard assets to blob storage in preparation of docker image generation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
     <!-- We don't want to use the workload for AppHost projects in this repo -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
 
-    <DashboardPublishedArtifactsOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'DashboardArtifacts', '$(Configuration)'))</DashboardPublishedArtifactsOutputPath>
+    <DashboardPublishedArtifactsOutputDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'DashboardArtifacts', '$(Configuration)'))</DashboardPublishedArtifactsOutputDir>
   </PropertyGroup>
 
   <!-- OS/Architecture properties for local development resources -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,8 @@
     <RunSettingsFilePath>$(RepositoryEngineeringDir).runsettings</RunSettingsFilePath>
     <!-- We don't want to use the workload for AppHost projects in this repo -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
+
+    <DashboardPublishedArtifactsOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'DashboardArtifacts', '$(Configuration)'))</DashboardPublishedArtifactsOutputPath>
   </PropertyGroup>
 
   <!-- OS/Architecture properties for local development resources -->

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,4 +1,5 @@
 <Project>
+
    <PropertyGroup>
       <PublishingVersion>3</PublishingVersion>
       <!-- we don't need symbol packages for aspire -->
@@ -11,6 +12,11 @@
 
   <PropertyGroup>
     <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallers;_PublishDashboardAssets</PublishDependsOnTargets>
+
+    <!-- NOTE: This property is also defined on the root-level Directory.Build.props, but that file is not imported by the Publishing project.
+    Pulling it in here will cause different issues as that file will conflict with Arcade's publishing logic, so as a workaround we define it here.
+    If you are editing this property, make sure to also edit the one in Directory.Build.props. -->
+    <DashboardPublishedArtifactsOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'DashboardArtifacts', '$(Configuration)'))</DashboardPublishedArtifactsOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -16,16 +16,18 @@
     <!-- NOTE: This property is also defined on the root-level Directory.Build.props, but that file is not imported by the Publishing project.
     Pulling it in here will cause different issues as that file will conflict with Arcade's publishing logic, so as a workaround we define it here.
     If you are editing this property, make sure to also edit the one in Directory.Build.props. -->
-    <DashboardPublishedArtifactsOutputPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'DashboardArtifacts', '$(Configuration)'))</DashboardPublishedArtifactsOutputPath>
+    <DashboardPublishedArtifactsOutputDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsDir)', 'DashboardArtifacts', '$(Configuration)'))</DashboardPublishedArtifactsOutputDir>
   </PropertyGroup>
 
   <ItemGroup>
     <_InstallersToPublish Include="$(ArtifactsDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' == 'true'" />
     <_InstallerManifestFilesToPublish Include="$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\**\*.zip" />
-    <_DashboardFilesToPublish Include="$(DashboardPublishedArtifactsOutputPath)\**\*.zip" />
+    <_DashboardFilesToPublish Include="$(DashboardPublishedArtifactsOutputDir)\**\*.zip" />
   </ItemGroup>
 
   <Target Name="_PublishDashboardAssets">
+    <Error Condition="'@(_DashboardFilesToPublish)' == ''" Text="Couldn't find any published dashboard assets to push to blob feed." />
+
     <ItemGroup>
       <ItemsToPushToBlobFeed Include="@(_DashboardFilesToPublish)">
         <IsShipping>true</IsShipping>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -26,8 +26,6 @@
   </ItemGroup>
 
   <Target Name="_PublishDashboardAssets">
-    <Error Condition="'@(_DashboardFilesToPublish)' == ''" Text="Couldn't find any published dashboard assets to push to blob feed." />
-
     <ItemGroup>
       <ItemsToPushToBlobFeed Include="@(_DashboardFilesToPublish)">
         <IsShipping>true</IsShipping>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -10,13 +10,24 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallers</PublishDependsOnTargets>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallers;_PublishDashboardAssets</PublishDependsOnTargets>
   </PropertyGroup>
 
   <ItemGroup>
     <_InstallersToPublish Include="$(ArtifactsDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' == 'true'" />
     <_InstallerManifestFilesToPublish Include="$(ArtifactsDir)VSSetup\$(Configuration)\Insertion\**\*.zip" />
+    <_DashboardFilesToPublish Include="$(DashboardPublishedArtifactsOutputPath)\**\*.zip" />
   </ItemGroup>
+
+  <Target Name="_PublishDashboardAssets">
+    <ItemGroup>
+      <ItemsToPushToBlobFeed Include="@(_DashboardFilesToPublish)">
+        <IsShipping>true</IsShipping>
+        <PublishFlatContainer>true</PublishFlatContainer>
+        <RelativeBlobPath>$(_UploadPathRoot)/dashboard-assets/%(Filename)%(Extension)</RelativeBlobPath>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+  </Target>
 
   <Target Name="_PublishInstallers">
     <MSBuild Projects="$(RepoRoot)src\Microsoft.NET.Sdk.Aspire\Microsoft.NET.Sdk.Aspire.csproj"

--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -35,6 +35,9 @@
       <None Include="@(_PublishItems)" Pack="true" PackagePath="tools/" />
     </ItemGroup>
 
+    <MakeDir Directories="$(DashboardPublishedArtifactsOutputPath)/$(DashboardRuntime)" />
+    <ZipDirectory SourceDirectory="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish" DestinationFile="$(DashboardPublishedArtifactsOutputPath)/$(DashboardRuntime)/aspire-dashboard-$(DashboardRuntime).zip" />
+
     <!-- Throw an error if _PublishItems is empty. -->
     <Error Condition="'@(_PublishItems)' == ''" Text="No files were found to pack. Ensure that the project being packed has a publish target defined." />
   </Target>

--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -35,8 +35,8 @@
       <None Include="@(_PublishItems)" Pack="true" PackagePath="tools/" />
     </ItemGroup>
 
-    <MakeDir Directories="$(DashboardPublishedArtifactsOutputPath)/$(DashboardRuntime)" />
-    <ZipDirectory SourceDirectory="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish" DestinationFile="$(DashboardPublishedArtifactsOutputPath)/$(DashboardRuntime)/aspire-dashboard-$(DashboardRuntime).zip" />
+    <MakeDir Directories="$(DashboardPublishedArtifactsOutputDir)/$(DashboardRuntime)" />
+    <ZipDirectory SourceDirectory="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish" DestinationFile="$(DashboardPublishedArtifactsOutputDir)/$(DashboardRuntime)/aspire-dashboard-$(DashboardRuntime).zip" />
 
     <!-- Throw an error if _PublishItems is empty. -->
     <Error Condition="'@(_PublishItems)' == ''" Text="No files were found to pack. Ensure that the project being packed has a publish target defined." />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspire/issues/1621

After chatting with @MichaelSimons, we agreed that in order for dotnet-docker repo to consume our build output, they require us to push our dashboard assets into blob storage. This PR is first ensuring that we create zips for each of the published platforms of the dashboard app, and then it adds them into the items to push to blob feed so that arcade can ensure that they get pushed.

FYI @lbussell 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1860)