### PR TITLE
Fix trace detail page's gap between trace ticks

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -69,7 +69,7 @@
 
 ::deep .ticks .tick {
     width: 1px;
-    height: 30px;
+    height: 32px;
     background: #d8d8d8;
     grid-row: 1;
 }


### PR DESCRIPTION
Adding a button introduced small gaps between ticks.

Before:

![image](https://github.com/dotnet/aspire/assets/303201/95c45bf7-4b50-4693-a30c-9ec532cc3656)

After:

![image](https://github.com/dotnet/aspire/assets/303201/c02b7f02-236d-424c-bf53-0ff546132d35)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1861)