### PR TITLE
Fix TryAddWillNotAddTheSameLifecycleHook test.

### DIFF
--- a/tests/Aspire.Hosting.Tests/Helpers/DummyLifecycleHook.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/DummyLifecycleHook.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Lifecycle;
+
+namespace Aspire.Hosting.Tests.Helpers;
+
+internal sealed class DummyLifecycleHook : IDistributedApplicationLifecycleHook
+{
+}


### PR DESCRIPTION
Simplifies the following test TryAddWillNotAddTheSameLifecycleHook. Old implemention resulted in DCP being launched when in fact all we are doing is just verifying that a lifecycle hook is never added twice to the service collection.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1862)