### PR TITLE
Fix inconsistent trace detail spacing

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -56,10 +56,26 @@
                         <div class="col-long-content" title="@context.GetTooltip()" @onclick="() => OnShowProperties(context)">
                             @{
                                 var isServerKind = context.Span.Kind == OtlpSpanKind.Server;
-                                var spanNameContainerStyle = $"margin-left: {(context.Depth - 1) * 15}px;";
+                                // Indent the span name based on the depth of the span.
+                                var marginLeft = (context.Depth - 1) * 15;
+
+                                // We want to have consistent margin for both client and server spans.
+                                string spanNameContainerStyle;
                                 if (!isServerKind)
                                 {
-                                    spanNameContainerStyle += $"border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 5px;";
+                                    // Client span has 19px extra content:
+                                    // - 5px border.
+                                    // - 9px padding-left;
+                                    // - 5px extra margin-left.
+                                    marginLeft += 5;
+                                    spanNameContainerStyle = $"margin-left: {marginLeft}px; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
+                                }
+                                else
+                                {
+                                    // Server span has 19px extra content:
+                                    // - 16px icon.
+                                    // - 3px padding-left;
+                                    spanNameContainerStyle = $"margin-left: {marginLeft}px;";
                                 }
                             }
                             <span class="span-name-container" style="@spanNameContainerStyle">

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -64,17 +64,17 @@
                                 if (!isServerKind)
                                 {
                                     // Client span has 19px extra content:
-                                    // - 5px border.
-                                    // - 9px padding-left;
-                                    // - 5px extra margin-left.
+                                    // - 5px border
+                                    // - 9px padding-left
+                                    // - 5px extra margin-left
                                     marginLeft += 5;
                                     spanNameContainerStyle = $"margin-left: {marginLeft}px; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
                                 }
                                 else
                                 {
                                     // Server span has 19px extra content:
-                                    // - 16px icon.
-                                    // - 3px padding-left;
+                                    // - 16px icon
+                                    // - 3px padding-left
                                     spanNameContainerStyle = $"margin-left: {marginLeft}px;";
                                 }
                             }


### PR DESCRIPTION
Adding an icon creating inconsistent spacing. There isn't a way to perfectly balance everything (the current color bar for client spans is thinner than icons) but this is the best layout I could find.

**Before:**

![image](https://github.com/dotnet/aspire/assets/303201/cec1cd88-df38-4f74-82ec-eb38e1d3c9ff)

**After:**

![image](https://github.com/dotnet/aspire/assets/303201/dba89909-dc0c-4937-9c49-28990fed425a)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1863)