### PR TITLE
Trace detail page - customize peer icons based on span attributes

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -80,7 +80,22 @@
                                 @if (context.HasUninstrumentedPeer)
                                 {
                                     <span class="uninstrumented-peer">
-                                        <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")" Icon="Icons.Filled.Size16.ArrowCircleRight" Class="uninstrumented-peer-icon"/>
+                                        @{
+                                            Icon icon;
+                                            if (context.Span.Attributes.HasKey("db.system"))
+                                            {
+                                                icon = new Icons.Filled.Size16.Database();
+                                            }
+                                            else
+                                            {
+                                                // Everything else.
+                                                icon = new Icons.Filled.Size16.ArrowCircleRight();
+                                            }
+                                        }
+                                        <FluentIcon
+                                            Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")"
+                                            Value="icon"
+                                            Class="uninstrumented-peer-icon"/>
                                         @context.UninstrumentedPeer
                                     </span>
                                 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -159,6 +159,18 @@ public static class OtlpHelpers
         return null;
     }
 
+    public static bool HasKey(this KeyValuePair<string, string>[] values, string name)
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (values[i].Key == name)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static string ConcatProperties(this KeyValuePair<string, string>[] properties)
     {
         StringBuilder sb = new();


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1725

Based on what I talked about in a [previous PR](https://github.com/dotnet/aspire/pull/1684#issuecomment-1899357018).

Customize peer icons based on the span. For example, database calls have a database icon instead of arrow icon. I think this looks great.

![image](https://github.com/dotnet/aspire/assets/303201/4ad32087-098d-4e7c-9f3b-c6e84a1b62fa)

This is just the beginning. There are [a lot of icons](https://github.com/microsoft/fluentui-system-icons/blob/main/icons_filled.md) and we can get a lot of information from spans based on attribute metadata

For example:
* RabbitMQ = message queue icon
* Azure blob storage = cloud icon
* Open AI = AI icon (if using 3rd party icons is ok we could use Open AI's icon)

etc
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1865)