### PR TITLE
Use the right health check properties in ServiceBus README.

### DIFF
--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
@@ -86,7 +86,7 @@ The .NET Aspire Azure Service Bus library supports [Microsoft.Extensions.Configu
     "Azure": {
       "Messaging": {
         "ServiceBus": {
-          "HealthChecks": false,
+          "HealthCheckQueueName": "myQueue",
           "Tracing": true,
           "ClientOptions": {
             "Identifier": "CLIENT_ID"
@@ -100,10 +100,10 @@ The .NET Aspire Azure Service Bus library supports [Microsoft.Extensions.Configu
 
 ### Use inline delegates
 
-You can also pass the `Action<AzureMessagingServiceBusSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
+You can also pass the `Action<AzureMessagingServiceBusSettings> configureSettings` delegate to set up some or all the options inline, for example to configure the health check queue name from code:
 
 ```csharp
-    builder.AddAzureServiceBus("sb", settings => settings.HealthChecks = false);
+    builder.AddAzureServiceBus("sb", settings => settings.HealthCheckQueueName = "myQueue");
 ```
 
 You can also setup the [ServiceBusClientOptions](https://learn.microsoft.com/dotnet/api/azure.messaging.servicebus.servicebusclientoptions) using the optional `Action<IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions>> configureClientBuilder` parameter of the `AddAzureServiceBus` method. For example, to set the client ID for this client:


### PR DESCRIPTION
Fix #1715

ServiceBus health checks are configured differently than our other components. The README was copy/pasted from the others.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1876)