### PR TITLE
Rename key Service Discovery types

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/IServiceEndPointProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/IServiceEndPointProvider.cs
@@ -4,12 +4,12 @@
 namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 /// <summary>
-/// Functionality for resolving endpoints for a service.
+/// Provides details about a service's endpoints.
 /// </summary>
-public interface IServiceEndPointResolver : IAsyncDisposable
+public interface IServiceEndPointProvider : IAsyncDisposable
 {
     /// <summary>
-    /// Attempts to resolve the endpoints for the service which this instance is configured to resolve endpoints for.
+    /// Resolves the endpoints for the service.
     /// </summary>
     /// <param name="endPoints">The endpoint collection, which resolved endpoints will be added to.</param>
     /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>

--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/IServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/IServiceEndPointResolverProvider.cs
@@ -6,15 +6,15 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 /// <summary>
-/// Creates <see cref="IServiceEndPointResolver"/> instances.
+/// Creates <see cref="IServiceEndPointProvider"/> instances.
 /// </summary>
 public interface IServiceEndPointResolverProvider
 {
     /// <summary>
-    /// Tries to create an <see cref="IServiceEndPointResolver"/> instance for the specified <paramref name="serviceName"/>.
+    /// Tries to create an <see cref="IServiceEndPointProvider"/> instance for the specified <paramref name="serviceName"/>.
     /// </summary>
     /// <param name="serviceName">The service to create the resolver for.</param>
     /// <param name="resolver">The resolver.</param>
     /// <returns><see langword="true"/> if the resolver was created, <see langword="false"/> otherwise.</returns>
-    bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointResolver? resolver);
+    bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointProvider? resolver);
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolver.cs
@@ -34,7 +34,7 @@ internal sealed partial class DnsServiceEndPointResolver(
         foreach (var address in addresses)
         {
             var serviceEndPoint = ServiceEndPoint.Create(new IPEndPoint(address, 0));
-            serviceEndPoint.Features.Set<IServiceEndPointResolver>(this);
+            serviceEndPoint.Features.Set<IServiceEndPointProvider>(this);
             if (options.CurrentValue.ApplyHostNameMetadata(serviceEndPoint))
             {
                 serviceEndPoint.Features.Set<IHostNameFeature>(this);

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.Log.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
-internal partial class DnsServiceEndPointResolverBase
+partial class DnsServiceEndPointResolverBase
 {
     internal static partial class Log
     {

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 /// <summary>
 /// A service end point resolver that uses DNS to resolve the service end points.
 /// </summary>
-internal abstract partial class DnsServiceEndPointResolverBase : IServiceEndPointResolver
+internal abstract partial class DnsServiceEndPointResolverBase : IServiceEndPointProvider
 {
     private readonly object _lock = new();
     private readonly ILogger _logger;

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverProvider.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.ServiceDiscovery.Internal;
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
 /// <summary>
-/// Provides <see cref="IServiceEndPointResolver"/> instances which resolve endpoints from DNS.
+/// Provides <see cref="IServiceEndPointProvider"/> instances which resolve endpoints from DNS.
 /// </summary>
 /// <remarks>
 /// Initializes a new <see cref="DnsServiceEndPointResolverProvider"/> instance.
@@ -24,7 +24,7 @@ internal sealed partial class DnsServiceEndPointResolverProvider(
     TimeProvider timeProvider) : IServiceEndPointResolverProvider
 {
     /// <inheritdoc/>
-    public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointResolver? resolver)
+    public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointProvider? resolver)
     {
         if (!ServiceNameParts.TryParse(serviceName, out var parts))
         {

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
@@ -90,7 +90,7 @@ internal sealed partial class DnsSrvServiceEndPointResolver(
         ServiceEndPoint CreateEndPoint(EndPoint endPoint)
         {
             var serviceEndPoint = ServiceEndPoint.Create(endPoint);
-            serviceEndPoint.Features.Set<IServiceEndPointResolver>(this);
+            serviceEndPoint.Features.Set<IServiceEndPointProvider>(this);
             if (options.CurrentValue.ApplyHostNameMetadata(serviceEndPoint))
             {
                 serviceEndPoint.Features.Set<IHostNameFeature>(this);

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.ServiceDiscovery.Internal;
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
 /// <summary>
-/// Provides <see cref="IServiceEndPointResolver"/> instances which resolve endpoints from DNS using SRV queries.
+/// Provides <see cref="IServiceEndPointProvider"/> instances which resolve endpoints from DNS using SRV queries.
 /// </summary>
 /// <remarks>
 /// Initializes a new <see cref="DnsSrvServiceEndPointResolverProvider"/> instance.
@@ -32,7 +32,7 @@ internal sealed partial class DnsSrvServiceEndPointResolverProvider(
     private readonly string? _querySuffix = options.CurrentValue.QuerySuffix ?? GetKubernetesHostDomain();
 
     /// <inheritdoc/>
-    public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointResolver? resolver)
+    public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointProvider? resolver)
     {
         // If a default namespace is not specified, then this provider will attempt to infer the namespace from the service name, but only when running inside Kubernetes.
         // Kubernetes DNS spec: https://github.com/kubernetes/dns/blob/master/docs/specification.md

--- a/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryDestinationResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryDestinationResolver.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Extensions.ServiceDiscovery.Yarp;
 /// <remarks>
 /// Initializes a new <see cref="ServiceDiscoveryDestinationResolver"/> instance.
 /// </remarks>
-/// <param name="registry">The endpoint resolver registry.</param>
-internal sealed class ServiceDiscoveryDestinationResolver(ServiceEndPointResolverRegistry registry) : IDestinationResolver
+/// <param name="resolver">The endpoint resolver registry.</param>
+internal sealed class ServiceDiscoveryDestinationResolver(ServiceEndPointResolverRegistry resolver) : IDestinationResolver
 {
     /// <inheritdoc/>
     public async ValueTask<ResolvedDestinationCollection> ResolveDestinationsAsync(IReadOnlyDictionary<string, DestinationConfig> destinations, CancellationToken cancellationToken)
@@ -54,7 +54,7 @@ internal sealed class ServiceDiscoveryDestinationResolver(ServiceEndPointResolve
         var originalHost = originalConfig.Host is { Length: > 0 } h ? h : originalUri.Authority;
         var serviceName = originalUri.GetLeftPart(UriPartial.Authority);
 
-        var endPoints = await registry.GetEndPointsAsync(serviceName, cancellationToken).ConfigureAwait(false);
+        var endPoints = await resolver.GetEndPointsAsync(serviceName, cancellationToken).ConfigureAwait(false);
         var results = new List<(string Name, DestinationConfig Config)>(endPoints.Count);
         var uriBuilder = new UriBuilder(originalUri);
         var healthUri = originalConfig.Health is { Length: > 0 } health ? new Uri(health) : null;

--- a/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryDestinationResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryDestinationResolver.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.Yarp;
 /// Initializes a new <see cref="ServiceDiscoveryDestinationResolver"/> instance.
 /// </remarks>
 /// <param name="resolver">The endpoint resolver registry.</param>
-internal sealed class ServiceDiscoveryDestinationResolver(ServiceEndPointResolverRegistry resolver) : IDestinationResolver
+internal sealed class ServiceDiscoveryDestinationResolver(ServiceEndPointResolver resolver) : IDestinationResolver
 {
     /// <inheritdoc/>
     public async ValueTask<ResolvedDestinationCollection> ResolveDestinationsAsync(IReadOnlyDictionary<string, DestinationConfig> destinations, CancellationToken cancellationToken)

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 /// <summary>
 /// A service endpoint resolver that uses configuration to resolve endpoints.
 /// </summary>
-internal sealed partial class ConfigurationServiceEndPointResolver : IServiceEndPointResolver, IHostNameFeature
+internal sealed partial class ConfigurationServiceEndPointResolver : IServiceEndPointProvider, IHostNameFeature
 {
     private readonly string _serviceName;
     private readonly string? _endpointName;
@@ -147,7 +147,7 @@ internal sealed partial class ConfigurationServiceEndPointResolver : IServiceEnd
     private ServiceEndPoint CreateEndPoint(EndPoint endPoint)
     {
         var serviceEndPoint = ServiceEndPoint.Create(endPoint);
-        serviceEndPoint.Features.Set<IServiceEndPointResolver>(this);
+        serviceEndPoint.Features.Set<IServiceEndPointProvider>(this);
         if (_options.Value.ApplyHostNameMetadata(serviceEndPoint))
         {
             serviceEndPoint.Features.Set<IHostNameFeature>(this);

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverProvider.cs
@@ -24,7 +24,7 @@ public class ConfigurationServiceEndPointResolverProvider(
     private readonly ILogger<ConfigurationServiceEndPointResolver> _logger = loggerFactory.CreateLogger<ConfigurationServiceEndPointResolver>();
 
     /// <inheritdoc/>
-    public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointResolver? resolver)
+    public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointProvider? resolver)
     {
         resolver = new ConfigurationServiceEndPointResolver(serviceName, _configuration, _logger, _options);
         return true;

--- a/src/Microsoft.Extensions.ServiceDiscovery/HostingExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/HostingExtensions.cs
@@ -39,7 +39,7 @@ public static class HostingExtensions
         services.TryAddSingleton<TimeProvider>(static sp => TimeProvider.System);
         services.TryAddSingleton<IServiceEndPointSelectorProvider, RoundRobinServiceEndPointSelectorProvider>();
         services.TryAddSingleton<ServiceEndPointResolverFactory>();
-        services.TryAddSingleton<ServiceEndPointResolverRegistry>();
+        services.TryAddSingleton<ServiceEndPointResolverRegistry>(sp => new ServiceEndPointResolverRegistry(sp.GetRequiredService<ServiceEndPointResolverFactory>(), sp.GetRequiredService<TimeProvider>()));
         return services;
     }
 

--- a/src/Microsoft.Extensions.ServiceDiscovery/HostingExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/HostingExtensions.cs
@@ -39,7 +39,7 @@ public static class HostingExtensions
         services.TryAddSingleton<TimeProvider>(static sp => TimeProvider.System);
         services.TryAddSingleton<IServiceEndPointSelectorProvider, RoundRobinServiceEndPointSelectorProvider>();
         services.TryAddSingleton<ServiceEndPointResolverFactory>();
-        services.TryAddSingleton<ServiceEndPointResolverRegistry>(sp => new ServiceEndPointResolverRegistry(sp.GetRequiredService<ServiceEndPointResolverFactory>(), sp.GetRequiredService<TimeProvider>()));
+        services.TryAddSingleton<ServiceEndPointResolver>(sp => new ServiceEndPointResolver(sp.GetRequiredService<ServiceEndPointResolverFactory>(), sp.GetRequiredService<TimeProvider>()));
         return services;
     }
 

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpClientBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpClientBuilderExtensions.cs
@@ -53,7 +53,6 @@ public static class HttpClientBuilderExtensions
         httpClientBuilder.AddHttpMessageHandler(services =>
         {
             var timeProvider = services.GetService<TimeProvider>() ?? TimeProvider.System;
-
             var selectorProvider = services.GetRequiredService<IServiceEndPointSelectorProvider>();
             var resolverProvider = services.GetRequiredService<ServiceEndPointResolverFactory>();
             var registry = new HttpServiceEndPointResolver(resolverProvider, selectorProvider, timeProvider);

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Extensions.ServiceDiscovery.Http;
 /// <summary>
 /// Resolves endpoints for HTTP requests.
 /// </summary>
-public class HttpServiceEndPointResolver(ServiceEndPointResolverFactory resolverProvider, IServiceEndPointSelectorProvider selectorProvider, TimeProvider timeProvider) : IAsyncDisposable
+public class HttpServiceEndPointResolver(ServiceEndPointResolverFactory resolverFactory, IServiceEndPointSelectorProvider selectorProvider, TimeProvider timeProvider) : IAsyncDisposable
 {
     private static readonly TimerCallback s_cleanupCallback = s => ((HttpServiceEndPointResolver)s!).CleanupResolvers();
     private static readonly TimeSpan s_cleanupPeriod = TimeSpan.FromSeconds(10);
 
     private readonly object _lock = new();
-    private readonly ServiceEndPointResolverFactory _resolverProvider = resolverProvider;
+    private readonly ServiceEndPointResolverFactory _resolverFactory = resolverFactory;
     private readonly IServiceEndPointSelectorProvider _selectorProvider = selectorProvider;
     private readonly ConcurrentDictionary<string, ResolverEntry> _resolvers = new();
     private ITimer? _cleanupTimer;
@@ -148,7 +148,7 @@ public class HttpServiceEndPointResolver(ServiceEndPointResolverFactory resolver
 
     private ResolverEntry CreateResolver(string serviceName)
     {
-        var resolver = _resolverProvider.CreateResolver(serviceName);
+        var resolver = _resolverFactory.CreateResolver(serviceName);
         var selector = _selectorProvider.CreateSelector();
         var result = new ResolverEntry(resolver, selector);
         resolver.Start();

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndPointResolver.cs
@@ -157,7 +157,7 @@ public class HttpServiceEndPointResolver(ServiceEndPointResolverFactory resolver
 
     private sealed class ResolverEntry : IAsyncDisposable
     {
-        private readonly ServiceEndPointResolver _resolver;
+        private readonly ServiceEndPointWatcher _resolver;
         private readonly IServiceEndPointSelector _selector;
         private const ulong CountMask = ~(RecentUseFlag | DisposingFlag);
         private const ulong RecentUseFlag = 1UL << 62;
@@ -165,7 +165,7 @@ public class HttpServiceEndPointResolver(ServiceEndPointResolverFactory resolver
         private ulong _status;
         private TaskCompletionSource? _onDisposed;
 
-        public ResolverEntry(ServiceEndPointResolver resolver, IServiceEndPointSelector selector)
+        public ResolverEntry(ServiceEndPointWatcher resolver, IServiceEndPointSelector selector)
         {
             _resolver = resolver;
             _selector = selector;

--- a/src/Microsoft.Extensions.ServiceDiscovery/PassThrough/PassThroughServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/PassThrough/PassThroughServiceEndPointResolver.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.PassThrough;
 /// <summary>
 /// Service endpoint resolver which passes through the provided value.
 /// </summary>
-internal sealed partial class PassThroughServiceEndPointResolver(ILogger logger, string serviceName, EndPoint endPoint) : IServiceEndPointResolver
+internal sealed partial class PassThroughServiceEndPointResolver(ILogger logger, string serviceName, EndPoint endPoint) : IServiceEndPointProvider
 {
     public ValueTask<ResolutionStatus> ResolveAsync(ServiceEndPointCollectionSource endPoints, CancellationToken cancellationToken)
     {
@@ -21,7 +21,7 @@ internal sealed partial class PassThroughServiceEndPointResolver(ILogger logger,
 
         Log.UsingPassThrough(logger, serviceName);
         var ep = ServiceEndPoint.Create(endPoint);
-        ep.Features.Set<IServiceEndPointResolver>(this);
+        ep.Features.Set<IServiceEndPointProvider>(this);
         endPoints.EndPoints.Add(ep);
         return new(ResolutionStatus.Success);
     }

--- a/src/Microsoft.Extensions.ServiceDiscovery/PassThrough/PassThroughServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/PassThrough/PassThroughServiceEndPointResolverProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.PassThrough;
 internal sealed class PassThroughServiceEndPointResolverProvider(ILogger<PassThroughServiceEndPointResolver> logger) : IServiceEndPointResolverProvider
 {
     /// <inheritdoc/>
-    public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointResolver? resolver)
+    public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointProvider? resolver)
     {
         if (!ServiceNameParts.TryCreateEndPoint(serviceName, out var endPoint))
         {

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolver.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolver.Log.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 namespace Microsoft.Extensions.ServiceDiscovery;
 
-public sealed partial class ServiceEndPointResolver
+partial class ServiceEndPointResolver
 {
     private sealed partial class Log
     {

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolver.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 namespace Microsoft.Extensions.ServiceDiscovery;
 
 /// <summary>
-/// Resolves endpoints for a specified service.
+/// Resolves endpoints for a specified service, delegating to one or more endpoint resolver implementations.
 /// </summary>
 public sealed partial class ServiceEndPointResolver(
     IServiceEndPointResolver[] resolvers,

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolver.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Extensions.ServiceDiscovery;
 /// <summary>
 /// Resolves service names to collections of endpoints.
 /// </summary>
-public sealed class ServiceEndPointResolverRegistry : IAsyncDisposable
+public sealed class ServiceEndPointResolver : IAsyncDisposable
 {
-    private static readonly TimerCallback s_cleanupCallback = s => ((ServiceEndPointResolverRegistry)s!).CleanupResolvers();
+    private static readonly TimerCallback s_cleanupCallback = s => ((ServiceEndPointResolver)s!).CleanupResolvers();
     private static readonly TimeSpan s_cleanupPeriod = TimeSpan.FromSeconds(10);
 
     private readonly object _lock = new();
@@ -24,11 +24,11 @@ public sealed class ServiceEndPointResolverRegistry : IAsyncDisposable
     private bool _disposed;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ServiceEndPointResolverRegistry"/> class.
+    /// Initializes a new instance of the <see cref="ServiceEndPointResolver"/> class.
     /// </summary>
     /// <param name="resolverProvider">The resolver factory.</param>
     /// <param name="timeProvider">The time provider.</param>
-    internal ServiceEndPointResolverRegistry(ServiceEndPointResolverFactory resolverProvider, TimeProvider timeProvider)
+    internal ServiceEndPointResolver(ServiceEndPointResolverFactory resolverProvider, TimeProvider timeProvider)
     {
         _resolverProvider = resolverProvider;
         _timeProvider = timeProvider;

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.Log.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 namespace Microsoft.Extensions.ServiceDiscovery;
 
-public partial class ServiceEndPointResolverFactory
+partial class ServiceEndPointResolverFactory
 {
     private sealed partial class Log
     {

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.Log.cs
@@ -12,7 +12,7 @@ partial class ServiceEndPointResolverFactory
     {
         [LoggerMessage(1, LogLevel.Debug, "Creating endpoint resolver for service '{ServiceName}' with {Count} resolvers: {Resolvers}.", EventName = "CreatingResolver")]
         public static partial void ServiceEndPointResolverListCore(ILogger logger, string serviceName, int count, string resolvers);
-        public static void CreatingResolver(ILogger logger, string serviceName, List<IServiceEndPointResolver> resolvers)
+        public static void CreatingResolver(ILogger logger, string serviceName, List<IServiceEndPointProvider> resolvers)
         {
             if (logger.IsEnabled(LogLevel.Debug))
             {

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.ServiceDiscovery.PassThrough;
 namespace Microsoft.Extensions.ServiceDiscovery;
 
 /// <summary>
-/// Creates <see cref="ServiceEndPointResolver"/> instances.
+/// Creates service endpoint resolvers.
 /// </summary>
 public partial class ServiceEndPointResolverFactory(
     IEnumerable<IServiceEndPointResolverProvider> resolvers,
@@ -25,7 +25,7 @@ public partial class ServiceEndPointResolverFactory(
     private readonly IOptions<ServiceEndPointResolverOptions> _options = options;
 
     /// <summary>
-    /// Creates a <see cref="ServiceEndPointResolver"/> instance for the provided service name.
+    /// Creates a service endpoint resolver for the provided service name.
     /// </summary>
     public ServiceEndPointResolver CreateResolver(string serviceName)
     {

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.cs
@@ -13,21 +13,21 @@ namespace Microsoft.Extensions.ServiceDiscovery;
 /// </summary>
 public partial class ServiceEndPointResolverFactory(
     IEnumerable<IServiceEndPointResolverProvider> resolvers,
-    ILogger<ServiceEndPointResolver> resolverLogger,
+    ILogger<ServiceEndPointWatcher> resolverLogger,
     IOptions<ServiceEndPointResolverOptions> options,
     TimeProvider timeProvider)
 {
     private readonly IServiceEndPointResolverProvider[] _resolverProviders = resolvers
         .Where(r => r is not PassThroughServiceEndPointResolverProvider)
         .Concat(resolvers.Where(static r => r is PassThroughServiceEndPointResolverProvider)).ToArray();
-    private readonly ILogger<ServiceEndPointResolver> _logger = resolverLogger;
+    private readonly ILogger<ServiceEndPointWatcher> _logger = resolverLogger;
     private readonly TimeProvider _timeProvider = timeProvider;
     private readonly IOptions<ServiceEndPointResolverOptions> _options = options;
 
     /// <summary>
     /// Creates a service endpoint resolver for the provided service name.
     /// </summary>
-    public ServiceEndPointResolver CreateResolver(string serviceName)
+    public ServiceEndPointWatcher CreateResolver(string serviceName)
     {
         ArgumentNullException.ThrowIfNull(serviceName);
 
@@ -47,7 +47,7 @@ public partial class ServiceEndPointResolverFactory(
         }
 
         Log.CreatingResolver(_logger, serviceName, resolvers);
-        return new ServiceEndPointResolver(
+        return new ServiceEndPointWatcher(
             resolvers: [.. resolvers],
             logger: _logger,
             serviceName: serviceName,

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverFactory.cs
@@ -31,7 +31,7 @@ public partial class ServiceEndPointResolverFactory(
     {
         ArgumentNullException.ThrowIfNull(serviceName);
 
-        List<IServiceEndPointResolver>? resolvers = null;
+        List<IServiceEndPointProvider>? resolvers = null;
         foreach (var factory in _resolverProviders)
         {
             if (factory.TryCreateResolver(serviceName, out var resolver))

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Primitives;
 namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 /// <summary>
-/// Options for <see cref="ServiceEndPointResolver"/>.
+/// Options for service endpoint resolvers.
 /// </summary>
 public sealed class ServiceEndPointResolverOptions
 {

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverRegistry.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointResolverRegistry.cs
@@ -162,9 +162,9 @@ public sealed class ServiceEndPointResolverRegistry : IAsyncDisposable
         return new ResolverEntry(resolver);
     }
 
-    private sealed class ResolverEntry(ServiceEndPointResolver resolver) : IAsyncDisposable
+    private sealed class ResolverEntry(ServiceEndPointWatcher resolver) : IAsyncDisposable
     {
-        private readonly ServiceEndPointResolver _resolver = resolver;
+        private readonly ServiceEndPointWatcher _resolver = resolver;
         private const ulong CountMask = ~(RecentUseFlag | DisposingFlag);
         private const ulong RecentUseFlag = 1UL << 62;
         private const ulong DisposingFlag = 1UL << 63;

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointWatcher.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointWatcher.Log.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 namespace Microsoft.Extensions.ServiceDiscovery;
 
-partial class ServiceEndPointResolver
+partial class ServiceEndPointWatcher
 {
     private sealed partial class Log
     {

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointWatcher.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointWatcher.Log.cs
@@ -28,7 +28,7 @@ partial class ServiceEndPointWatcher
 
             static string GetEndPointString(ServiceEndPoint ep)
             {
-                if (ep.Features.Get<IServiceEndPointResolver>() is { } resolver)
+                if (ep.Features.Get<IServiceEndPointProvider>() is { } resolver)
                 {
                     return $"{ep.GetEndPointString()} ({resolver})";
                 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointWatcher.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceEndPointWatcher.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.ServiceDiscovery;
 /// Watches for updates to the collection of resolved endpoints for a specified service.
 /// </summary>
 public sealed partial class ServiceEndPointWatcher(
-    IServiceEndPointResolver[] resolvers,
+    IServiceEndPointProvider[] resolvers,
     ILogger logger,
     string serviceName,
     TimeProvider timeProvider,
@@ -28,7 +28,7 @@ public sealed partial class ServiceEndPointWatcher(
     private readonly ILogger _logger = logger;
     private readonly TimeProvider _timeProvider = timeProvider;
     private readonly ServiceEndPointResolverOptions _options = options.Value;
-    private readonly IServiceEndPointResolver[] _resolvers = resolvers;
+    private readonly IServiceEndPointProvider[] _resolvers = resolvers;
     private readonly CancellationTokenSource _disposalCancellation = new();
     private ITimer? _pollingTimer;
     private ServiceEndPointCollection? _cachedEndPoints;

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.Dns.Tests;
 
 /// <summary>
 /// Tests for <see cref="DnsServiceEndPointResolverBase"/> and <see cref="DnsSrvServiceEndPointResolverProvider"/>.
-/// These also cover <see cref="ServiceEndPointResolver"/> and <see cref="ServiceEndPointResolverFactory"/> by extension.
+/// These also cover <see cref="ServiceEndPointWatcher"/> and <see cref="ServiceEndPointResolverFactory"/> by extension.
 /// </summary>
 public class DnsSrvServiceEndPointResolverTests
 {
@@ -104,7 +104,7 @@ public class DnsSrvServiceEndPointResolverTests
             .AddDnsSrvServiceEndPointResolver(options => options.QuerySuffix = ".ns")
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://basket")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);
@@ -191,7 +191,7 @@ public class DnsSrvServiceEndPointResolverTests
         };
         var services = serviceCollection.BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://basket")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.Tests;
 
 /// <summary>
 /// Tests for <see cref="ConfigurationServiceEndPointResolver"/> and <see cref="ConfigurationServiceEndPointResolverProvider"/>.
-/// These also cover <see cref="ServiceEndPointResolver"/> and <see cref="ServiceEndPointResolverFactory"/> by extension.
+/// These also cover <see cref="ServiceEndPointWatcher"/> and <see cref="ServiceEndPointResolverFactory"/> by extension.
 /// </summary>
 public class ConfigurationServiceEndPointResolverTests
 {
@@ -30,7 +30,7 @@ public class ConfigurationServiceEndPointResolverTests
             .AddConfigurationServiceEndPointResolver()
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://basket")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);
@@ -70,7 +70,7 @@ public class ConfigurationServiceEndPointResolverTests
             .AddConfigurationServiceEndPointResolver(options => options.ApplyHostNameMetadata = _ => true)
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://basket")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);
@@ -114,7 +114,7 @@ public class ConfigurationServiceEndPointResolverTests
             .AddConfigurationServiceEndPointResolver()
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://_grpc.basket")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/PassThroughServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/PassThroughServiceEndPointResolverTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.ServiceDiscovery.Tests;
 
 /// <summary>
 /// Tests for <see cref="PassThroughServiceEndPointResolverProvider"/>.
-/// These also cover <see cref="ServiceEndPointResolver"/> and <see cref="ServiceEndPointResolverFactory"/> by extension.
+/// These also cover <see cref="ServiceEndPointWatcher"/> and <see cref="ServiceEndPointResolverFactory"/> by extension.
 /// </summary>
 public class PassThroughServiceEndPointResolverTests
 {
@@ -26,7 +26,7 @@ public class PassThroughServiceEndPointResolverTests
             .AddPassThroughServiceEndPointResolver()
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://basket")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);
@@ -58,7 +58,7 @@ public class PassThroughServiceEndPointResolverTests
             .AddServiceDiscovery() // Adds the configuration and pass-through providers.
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://basket")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);
@@ -92,7 +92,7 @@ public class PassThroughServiceEndPointResolverTests
             .AddServiceDiscovery() // Adds the configuration and pass-through providers.
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://catalog")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndPointResolverTests.cs
@@ -65,9 +65,9 @@ public class ServiceEndPointResolverTests
         Assert.Equal("No resolver which supports the provided service name, 'http://foo', has been configured.", exception.Message);
     }
 
-    private sealed class FakeEndPointResolverProvider(Func<string, (bool Result, IServiceEndPointResolver? Resolver)> createResolverDelegate) : IServiceEndPointResolverProvider
+    private sealed class FakeEndPointResolverProvider(Func<string, (bool Result, IServiceEndPointProvider? Resolver)> createResolverDelegate) : IServiceEndPointResolverProvider
     {
-        public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointResolver? resolver)
+        public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointProvider? resolver)
         {
             bool result;
             (result, resolver) = createResolverDelegate(serviceName);
@@ -75,7 +75,7 @@ public class ServiceEndPointResolverTests
         }
     }
 
-    private sealed class FakeEndPointResolver(Func<ServiceEndPointCollectionSource, CancellationToken, ValueTask<ResolutionStatus>> resolveAsync, Func<ValueTask> disposeAsync) : IServiceEndPointResolver
+    private sealed class FakeEndPointResolver(Func<ServiceEndPointCollectionSource, CancellationToken, ValueTask<ResolutionStatus>> resolveAsync, Func<ValueTask> disposeAsync) : IServiceEndPointProvider
     {
         public ValueTask<ResolutionStatus> ResolveAsync(ServiceEndPointCollectionSource endPoints, CancellationToken cancellationToken) => resolveAsync(endPoints, cancellationToken);
         public ValueTask DisposeAsync() => disposeAsync();

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndPointResolverTests.cs
@@ -157,7 +157,7 @@ public class ServiceEndPointResolverTests
             .AddSingleton<IServiceEndPointResolverProvider>(resolverProvider)
             .AddServiceDiscoveryCore()
             .BuildServiceProvider();
-        var resolver = services.GetRequiredService<ServiceEndPointResolverRegistry>();
+        var resolver = services.GetRequiredService<ServiceEndPointResolver>();
 
         Assert.NotNull(resolver);
         var initialEndPoints = await resolver.GetEndPointsAsync("http://basket", CancellationToken.None).ConfigureAwait(false);

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndPointResolverTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace Microsoft.Extensions.ServiceDiscovery.Tests;
 
 /// <summary>
-/// Tests for <see cref="ServiceEndPointResolverFactory"/> and <see cref="ServiceEndPointResolver"/>.
+/// Tests for <see cref="ServiceEndPointResolverFactory"/> and <see cref="ServiceEndPointWatcher"/>.
 /// </summary>
 public class ServiceEndPointResolverTests
 {
@@ -36,7 +36,7 @@ public class ServiceEndPointResolverTests
         var services = new ServiceCollection()
             .AddServiceDiscoveryCore()
             .BuildServiceProvider();
-        var resolverFactory = new ServiceEndPointResolver([], NullLogger.Instance, "foo", TimeProvider.System, Options.Options.Create(new ServiceEndPointResolverOptions()));
+        var resolverFactory = new ServiceEndPointWatcher([], NullLogger.Instance, "foo", TimeProvider.System, Options.Options.Create(new ServiceEndPointResolverOptions()));
         var exception = Assert.Throws<InvalidOperationException>(resolverFactory.Start);
         Assert.Equal("No service endpoint resolvers are configured.", exception.Message);
         exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await resolverFactory.GetEndPointsAsync());
@@ -106,7 +106,7 @@ public class ServiceEndPointResolverTests
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
 
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://basket")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);
@@ -242,7 +242,7 @@ public class ServiceEndPointResolverTests
             .BuildServiceProvider();
         var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
 
-        ServiceEndPointResolver resolver;
+        ServiceEndPointWatcher resolver;
         await using ((resolver = resolverFactory.CreateResolver("http://basket")).ConfigureAwait(false))
         {
             Assert.NotNull(resolver);


### PR DESCRIPTION
This PR renames some of the core service discovery types for clarity, to better align their names with their purpose and behavior. The existing names have made me uncomfortable since I created them, but I did not want to stall progress by bikeshedding them.

* Rename `ServiceEndPointResolver` to `ServiceEndPointWatcher`: this class watches for changes in a single service's endpoints and publishes those changes to listeners. The lifecycle of the class is controlled by the object which created it (through `ServiceEndPointResolverFactory`, which should be renamed also). When disposed, the instance stops watching for changes in service endpoints.
  * Rationale for the rename: _Resolver_ is accurate, but better suited to the next class (below) and _Watcher_ is a closer fit to the behavior and alludes to the lifetime of the object, that it actively does something while alive.
* Rename `ServiceEndPointResolverRegistry` to `ServiceEndPointResolver`: this class is intended to be the main entry point for consumers performing on-demand service discovery outside of `HttpClient`. This class is registered as a singleton. It manages the lifetime of a `ServiceEndPointWatcher` for each resolved service, disposing them when they have been unused for some period of time.
  * Rationale for the rename: The suffix _Registry_ does not fit well with the consumer-facing API which this class exposes (there is no registration action).
* Rename `IServiceEndPointResolver` to `IServiceEndPointProvider`: this interface is implemented by the actual endpoint providers (config, DNS, pass-thru) and is consumed by `ServiceEndPointWatcher`. Each `ServiceEndPointWatcher` holds possibly multiple `IServiceEndPointProvider` instances and gives each a chance to modify the resulting `ServiceEndPointCollection`.
  * Rationale for the rename: These are resolvers at their core, but the `ServiceEndPointResolver` name seems more fit for the above class and since it does not implement this interface, I think it's best to choose a distinct name (it feels odd that `ServiceEndPointResolver` doesn't implement `IServiceEndPointResolver` when both exist). I also considered `IServiceEndPointSource` but _Provider_ seemed more appropriate.

Of course, I'm amenable to naming suggestions.

For PR reviewers, it is easier to review individual commits, since the combined diff is confusing due to the A -> B + C ->A rename.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1877)