### PR TITLE
Fix Storage Queue and Cosmos EF READMEs

### DIFF
--- a/src/Components/Aspire.Azure.Storage.Queues/README.md
+++ b/src/Components/Aspire.Azure.Storage.Queues/README.md
@@ -59,7 +59,7 @@ The recommended approach is to use a ServiceUri, which works with the `AzureStor
 ```json
 {
   "ConnectionStrings": {
-    "blobsConnectionName": "https://{account_name}.queue.core.windows.net/"
+    "queueConnectionName": "https://{account_name}.queue.core.windows.net/"
   }
 }
 ```

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
@@ -18,10 +18,10 @@ dotnet add package Aspire.Microsoft.EntityFrameworkCore.Cosmos
 
 ## Usage example
 
-In the _Program.cs_ file of your project, call the `AddCosmosDbContext` extension method to register a `DbContext` for use via the dependency injection container. The method takes a connection name parameter.
+In the _Program.cs_ file of your project, call the `AddCosmosDbContext` extension method to register a `DbContext` for use via the dependency injection container. The method takes connection name and database name parameters.
 
 ```csharp
-builder.AddCosmosDbContext<MyDbContext>("cosmosdb");
+builder.AddCosmosDbContext<MyDbContext>("cosmosdb", "mydb");
 ```
 
 You can then retrieve the `MyDbContext` instance using dependency injection. For example, to retrieve the context from a Web API controller:
@@ -44,7 +44,7 @@ The .NET Aspire Microsoft EntityFrameworkCore Cosmos component provides multiple
 When using a connection string from the `ConnectionStrings` configuration section, you can provide the name of the connection string when calling `builder.AddCosmosDbContext()`:
 
 ```csharp
-builder.AddCosmosDbContext<MyDbContext>("myConnection");
+builder.AddCosmosDbContext<MyDbContext>("myConnection", "mydb");
 ```
 
 And then the connection string will be retrieved from the `ConnectionStrings` configuration section:
@@ -83,7 +83,7 @@ The .NET Aspire Microsoft EntityFrameworkCore Cosmos component supports [Microso
 Also you can pass the `Action<EntityFrameworkCoreCosmosDBSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
-    builder.AddCosmosDbContext<MyDbContext>("cosmosdb", settings => settings.Tracing = false);
+    builder.AddCosmosDbContext<MyDbContext>("cosmosdb", "mydb", settings => settings.Tracing = false);
 ```
 
 ## AppHost extensions
@@ -106,7 +106,7 @@ var myService = builder.AddProject<Projects.MyService>()
 The `AddAzureCosmosDB` method will read connection information from the AppHost's configuration (for example, from "user secrets") under the `ConnectionStrings:cosmosdb` config key. The `WithReference` method passes that connection information into a connection string named `cosmosdb` in the `MyService` project. In the _Program.cs_ file of `MyService`, the connection can be consumed using:
 
 ```csharp
-builder.AddCosmosDbContext<MyDbContext>("cosmosdb");
+builder.AddCosmosDbContext<MyDbContext>("cosmosdb", "cosmosdb");
 ```
 
 ### Emulator usage


### PR DESCRIPTION
The ConnectionStrings setting had the wrong name, so it doesn't work with what is in the code section above it.

Fix #1679

Also fix CosmosDB README 

The extension method takes 2 strings: connection name and database name.

Fix #873

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1884)