### PR TITLE
Service Discovery: set port to 0 when scheme is not present, not -1

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceNameParts.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceNameParts.cs
@@ -46,6 +46,7 @@ internal readonly struct ServiceNameParts : IEquatable<ServiceNameParts>
             var segmentSeparatorIndex = uriHost.IndexOf('.');
             string host;
             string? endPointName = null;
+            var port = uri.Port > 0 ? uri.Port : 0;
             if (uriHost.StartsWith('_') && segmentSeparatorIndex > 1 && uriHost[^1] != '.')
             {
                 endPointName = uriHost[1..segmentSeparatorIndex];
@@ -62,7 +63,7 @@ internal readonly struct ServiceNameParts : IEquatable<ServiceNameParts>
                 }
             }
 
-            return new(host, endPointName, uri.Port);
+            return new(host, endPointName, port);
         }
     }
 

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/PassThroughServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/PassThroughServiceEndPointResolverTests.cs
@@ -109,4 +109,26 @@ public class PassThroughServiceEndPointResolverTests
             Assert.Equal(new DnsEndPoint("catalog", 80), initialResult.EndPoints[0].EndPoint);
         }
     }
+
+    // Ensures that pass-through resolution succeeds in scenarios where no scheme is specified during resolution.
+    [Fact]
+    public async Task ResolveServiceEndPoint_Fallback_NoScheme()
+    {
+        var configSource = new MemoryConfigurationSource
+        {
+            InitialData = new Dictionary<string, string?>
+            {
+                ["services:basket:0"] = "http://localhost:8080",
+            }
+        };
+        var config = new ConfigurationBuilder().Add(configSource);
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(config.Build())
+            .AddServiceDiscovery() // Adds the configuration and pass-through providers.
+            .BuildServiceProvider();
+
+        var resolver = services.GetRequiredService<ServiceEndPointResolverRegistry>();
+        var endPoints = await resolver.GetEndPointsAsync("catalog", default);
+        Assert.Equal(new DnsEndPoint("catalog", 0), endPoints[0].EndPoint);
+    }
 }


### PR DESCRIPTION
When the `serviceName` argument passed to `ServiceEndPointResolverRegistry.GetEndPointsAsync(...)` does not have a URI scheme (eg, `"catalog"` versus `"https://catalog"`), the call will throw because internally it infers a default port of `-1` since it has no URI scheme and hence does not know how to set a default port. This is not the intended behavior. I believe it's better to return a port of `0` instead, so that resolving `"catalog"` will result in a single endpoint, `DnsEndPoint("catalog", 0)`.

cc @DamianEdwards
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1885)