### PR TITLE
remove link in name column

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -12,7 +12,7 @@
 @if (unviewedErrorCount > 0)
 {
     <FluentCounterBadge Class="error-counter-badge" Max="9" BackgroundColor="@Color.Error" Color="Color.Fill"  Appearance="Appearance.Lightweight" Count="@unviewedErrorCount" HorizontalPosition="100">
-        <a href="@GetResourceErrorStructuredLogsUrl(Resource)" title="@FormatLogLinkTitle(unviewedErrorCount)"><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)" /></a>
+        <span title="@FormatName(Resource)"><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)"/></span>
     </FluentCounterBadge>
 }
 else

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Storage;
-using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components;
@@ -23,15 +21,5 @@ public partial class ResourceNameDisplay
 
         var application = TelemetryRepository.GetApplication(resource.Uid);
         return application is null ? 0 : UnviewedErrorCounts.GetValueOrDefault(application, 0);
-    }
-
-    private static string GetResourceErrorStructuredLogsUrl(ResourceViewModel resource)
-    {
-        return $"/StructuredLogs/{resource.Uid}?level=error";
-    }
-
-    private string FormatLogLinkTitle(int unviewedErrorCount)
-    {
-        return FormatName(Resource) + Environment.NewLine + string.Format(CultureInfo.CurrentCulture, Loc[nameof(Columns.UnreadLogErrors)], unviewedErrorCount);
     }
 }


### PR DESCRIPTION
This removes the purple link in the resources name column if there are unread error logs
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1886)