### PR TITLE
add failedtostart error icon to state

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -22,6 +22,12 @@
                     Class="severity-icon"/>
     }
 }
+else if (Resource is { State: ResourceStates.StartingState })
+{
+    <FluentIcon Icon="Icons.Filled.Size16.Circle"
+                Color="Color.Info"
+                Class="severity-icon"/>
+}
 else
 {
     <FluentIcon Icon="Icons.Filled.Size16.CheckmarkCircle"

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -3,7 +3,7 @@
 @using Aspire.Dashboard.Resources
 @inject IStringLocalizer<Columns> Loc
 
-@if (Resource is { State: ResourceStates.ExitedState /* containers */ or ResourceStates.FinishedState /* executables */ })
+@if (Resource is { State: ResourceStates.ExitedState /* containers */ or ResourceStates.FinishedState /* executables */ or ResourceStates.FailedToStartState })
 {
     if (Resource.TryGetExitCode(out int exitCode) && exitCode is not 0)
     {

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -74,4 +74,5 @@ public static class ResourceStates
 {
     public const string FinishedState = "Finished";
     public const string ExitedState = "Exited";
+    public const string FailedToStartState = "FailedToStart";
 }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -75,4 +75,5 @@ public static class ResourceStates
     public const string FinishedState = "Finished";
     public const string ExitedState = "Exited";
     public const string FailedToStartState = "FailedToStart";
+    public const string StartingState = "Starting";
 }


### PR DESCRIPTION
This is what it will look like for starting icon:

![image](https://github.com/dotnet/aspire/assets/9613109/a5c09b40-0af6-4f28-8a77-56a2e9ef7bef)

We might need to adjust color contrast, but will worry about that after the design changes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1887)