### PR TITLE
Fix grid layout issue

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -13,6 +13,6 @@
     margin-left: 3px;
 }
 
-::deep .resource-row > fluent-data-grid-cell {
-    overflow: visible;
+::deep .error-counter-badge {
+    padding: 1px;
 }


### PR DESCRIPTION
The overflow: visible was added to prevent the counter badge from being cut off. But it caused layout issues for the cells because they did not shrink properly. 

Instead I'll make the counter badge smaller as a temporary measure while we work to figure out what we want this indicator to look like long-term.

Before:
![image](https://github.com/dotnet/aspire/assets/9613109/c2f90b41-dee8-4659-b2d7-765c387ddd8f)


After:
![image](https://github.com/dotnet/aspire/assets/9613109/64c3643d-d40d-494c-94fc-cb96b1652155)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1889)