### PR TITLE
Remove unnecessary code from AppHost in Orleans playground 

### DIFF
--- a/playground/orleans/OrleansAppHost/Program.cs
+++ b/playground/orleans/OrleansAppHost/Program.cs
@@ -12,8 +12,8 @@ var orleans = builder.AddOrleans("my-app")
 // instead of using the emulator, one can use the in memory provider from Orleans:
 //
 // var orleans = builder.AddOrleans("my-app")
-//                     .WithDevelopmentClustering()
-//                     .WithMemoryGrainStorage("Default");
+//                      .WithDevelopmentClustering()
+//                      .WithMemoryGrainStorage("Default");
 
 builder.AddProject<Projects.OrleansServer>("silo")
        .WithReference(orleans);

--- a/playground/orleans/OrleansAppHost/Program.cs
+++ b/playground/orleans/OrleansAppHost/Program.cs
@@ -1,16 +1,6 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureStorage("storage");
-
-if (!args.Contains("--publisher")) // AZD UP passes in --publisher manifest
-{
-    storage.UseEmulator();
-}
-else
-{
-    builder.AddAzureProvisioning();
-}
-
+var storage = builder.AddAzureStorage("storage").UseEmulator();
 var clusteringTable = storage.AddTables("clustering");
 var grainStorage = storage.AddBlobs("grainstate");
 
@@ -18,10 +8,10 @@ var orleans = builder.AddOrleans("my-app")
                      .WithClustering(clusteringTable)
                      .WithGrainStorage("Default", grainStorage);
 
-// For local development, instead of using the emulator,
-// one can use the in memory provider from Orleans:
+// For local development (see https://github.com/dotnet/aspire/issues/1823 for how to detect),
+// instead of using the emulator, one can use the in memory provider from Orleans:
 //
-//var orleans = builder.AddOrleans("my-app")
+// var orleans = builder.AddOrleans("my-app")
 //                     .WithDevelopmentClustering()
 //                     .WithMemoryGrainStorage("Default");
 


### PR DESCRIPTION
In AppHost for Orleans playground:
- Remove unnecessary branch
- Remove unnecessary call to `AddAzureProvisioning` from AppHost in Orleans playground
- Add link to issue in comment as guidance on how to detect a local run.

This was tested both locally and in ACA using 8.0.0-preview.3.24076.8 Aspire NuGets
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1904)