### PR TITLE
Extending build timeout

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -98,7 +98,7 @@ stages:
       jobs:
 
       - job: windows
-        timeoutInMinutes: 30
+        timeoutInMinutes: 45
 
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -131,7 +131,7 @@ stages:
 
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: linux
-          timeoutInMinutes: 30
+          timeoutInMinutes: 45
 
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
Our builds in the release branch are timing out given they have to do real signing. Originally, @eerhardt  had changed the timeout to be 30 mins to fail fast when hitting a hanging test issue we had, and in main 30 mins was enough because we don't do real signing there. In release, however, this is hitting the limits some times as the build is taking very close to 30 mins. This is extending it for 15 additional minutes to avoid that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1910)