### PR TITLE
Extending the build timeout as signing is taking longer than expected.

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -98,7 +98,7 @@ stages:
       jobs:
 
       - job: windows
-        timeoutInMinutes: 45
+        timeoutInMinutes: 90
 
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -131,7 +131,7 @@ stages:
 
       - ${{ if eq(variables._RunAsPublic, True) }}:
         - job: linux
-          timeoutInMinutes: 45
+          timeoutInMinutes: 90
 
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1929)