### PR TITLE
Fix precondition in DcpHostService

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -49,9 +49,11 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
         _locations = locations;
     }
 
+    private bool IsSupported => _publishingOptions.Publisher is null or "dcp";
+
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
-        if (_publishingOptions.Publisher is not null and not "dcp")
+        if (!IsSupported)
         {
             return;
         }
@@ -67,7 +69,7 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
 
     public async Task StopAsync(CancellationToken cancellationToken = default)
     {
-        if (_publishingOptions.Publisher is not null and not "dcp")
+        if (!IsSupported)
         {
             return;
         }

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -51,7 +51,7 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
-        if (_publishingOptions.Publisher is not null && _publishingOptions.Publisher != "dcp")
+        if (_publishingOptions.Publisher is not null and not "dcp")
         {
             return;
         }
@@ -67,7 +67,7 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
 
     public async Task StopAsync(CancellationToken cancellationToken = default)
     {
-        if (_publishingOptions.Publisher != "dcp" || _publishingOptions.Publisher is not null)
+        if (_publishingOptions.Publisher is not null and not "dcp")
         {
             return;
         }


### PR DESCRIPTION
Two lines are changed here, though it's the second (in `StopAsync`) that has a functional change.

The first guard clause bails if:
- the publisher is not null, AND
- the publisher is not "dcp"

The second guard clause bails if:
- the publisher is not null, OR
- the publisher is not "dcp"

The key difference is the AND vs the OR. This looks like a bug to me as the start/stop methods pair up. The stop clause is more permissive, meaning we could try to stop something that was never started.

My interpretation of this code is that both clauses are intended to be the same, and this commit brings them in line with one another.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1943)