### PR TITLE
Bump Polly to 8.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,7 +90,7 @@
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.121" />
-    <PackageVersion Include="Polly" Version="8.2.1" />
+    <PackageVersion Include="Polly" Version="8.3.0" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.7.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -90,7 +90,7 @@
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.121" />
-    <PackageVersion Include="Polly" Version="8.2.0" />
+    <PackageVersion Include="Polly" Version="8.2.1" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.7.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.4" />


### PR DESCRIPTION
Update to latest Polly release, [8.3.0](https://github.com/App-vNext/Polly/releases/tag/8.3.0), which fixed a few small bugs and added support for chaos engineering.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1949)