### PR TITLE
Always show counts in span details

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -27,6 +27,12 @@
     <div class="property-grid-container">
         <FluentAccordion>
             <FluentAccordionItem Heading="Span" Expanded="true">
+                <div slot="end">
+                    <FluentBadge Appearance="Appearance.Neutral"
+                                 Circular="true">
+                        @FilteredItems.Count()
+                    </FluentBadge>
+                </div>
                 <PropertyGrid TItem="SpanPropertyViewModel"
                               Items="@FilteredItems"
                               GridTemplateColumns="1fr 2fr"
@@ -37,6 +43,12 @@
                               HighlightText="@_filter" />
             </FluentAccordionItem>
             <FluentAccordionItem Heading="Application">
+                <div slot="end">
+                    <FluentBadge Appearance="Appearance.Neutral"
+                                 Circular="true">
+                        @FilteredApplicationItems.Count()
+                    </FluentBadge>
+                </div>
                 <PropertyGrid TItem="SpanPropertyViewModel"
                               Items="@FilteredApplicationItems"
                               GridTemplateColumns="1fr 2fr"
@@ -47,15 +59,12 @@
                               HighlightText="@_filter" />
             </FluentAccordionItem>
             <FluentAccordionItem Heading="Events">
-                @if (FilteredSpanEvents.Count() > 0)
-                {
-                    <div slot="end">
-                        <FluentBadge Appearance="Appearance.Accent"
-                                     Circular="true">
-                            @FilteredSpanEvents.Count()
-                        </FluentBadge>
-                    </div>
-                }
+                <div slot="end">
+                    <FluentBadge Appearance="Appearance.Neutral"
+                                 Circular="true">
+                        @FilteredSpanEvents.Count()
+                    </FluentBadge>
+                </div>
                 <PropertyGrid TItem="OtlpSpanEvent"
                               Items="@FilteredSpanEvents"
                               GridTemplateColumns="1fr 2fr"

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -42,7 +42,7 @@
                               ValueSort="_valueSort"
                               HighlightText="@_filter" />
             </FluentAccordionItem>
-            <FluentAccordionItem Heading="Application">
+            <FluentAccordionItem Heading="Application" Expanded="true">
                 <div slot="end">
                     <FluentBadge Appearance="Appearance.Neutral"
                                  Circular="true">
@@ -58,7 +58,7 @@
                               ValueSort="_valueSort"
                               HighlightText="@_filter" />
             </FluentAccordionItem>
-            <FluentAccordionItem Heading="Events">
+            <FluentAccordionItem Heading="Events" Expanded="true">
                 <div slot="end">
                     <FluentBadge Appearance="Appearance.Neutral"
                                  Circular="true">

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -13,18 +13,18 @@ public partial class SpanDetails
     [Parameter, EditorRequired]
     public required SpanDetailsViewModel ViewModel { get; set; }
 
-    private IQueryable<SpanPropertyViewModel>? FilteredItems =>
+    private IQueryable<SpanPropertyViewModel> FilteredItems =>
         ViewModel.Properties.Where(vm =>
             vm.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) ||
             vm.Value?.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true
-        )?.AsQueryable();
+        ).AsQueryable();
 
-    private IQueryable<SpanPropertyViewModel>? FilteredApplicationItems =>
+    private IQueryable<SpanPropertyViewModel> FilteredApplicationItems =>
         ViewModel.Span.Source.AllProperties().Select(p => new SpanPropertyViewModel { Name = p.Key, Value = p.Value })
             .Where(vm =>
                 vm.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) ||
                 vm.Value?.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true
-        )?.AsQueryable();
+        ).AsQueryable();
 
     private IQueryable<OtlpSpanEvent> FilteredSpanEvents =>
         ViewModel.Span.Events.Where(e => e.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase)).OrderBy(e => e.Time).AsQueryable();


### PR DESCRIPTION
Resource details always shows counts. This PR makes the span details consistent with resource details.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1966)