### PR TITLE
Fix exception when app host has no ASPNETCORE_URLS

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -199,8 +199,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             throw new DistributedApplicationException("Error getting the resource service URL.", ex);
         }
 
+        // Matches DashboardWebApplication.DashboardUrlDefaultValue
+        const string defaultDashboardUrl = "http://localhost:18888";
+
         var otlpEndpointUrl = environmentVariables.GetString("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL");
-        var dashboardUrls = environmentVariables.GetString("ASPNETCORE_URLS") ?? throw new DistributedApplicationException("ASPNETCORE_URLS environment variable not set.");
+        var dashboardUrls = environmentVariables.GetString("ASPNETCORE_URLS") ?? defaultDashboardUrl;
         var aspnetcoreEnvironment = environmentVariables.GetString("ASPNETCORE_ENVIRONMENT");
 
         dashboardExecutableSpec.Env =


### PR DESCRIPTION
Fixes #1928

If an app host project's launch profile doesn't specify a `launchUrl` or `applicationUrl` then the running app host won't have a `ASPNETCORE_URLS` environment variable. We want to pass this variable's value to the dashboard process, and currently if it's missing we throw.

The dashboard executable has a fallback value when the `ASPNETCORE_URLS` variable is not present (of `http://localhost:18888`), so it's perfectly happy to run without this variable.

This change causes the app host to fall back to that same default value for the dashboard's `ASPNETCORE_URLS` variable. While we could pass no value at all, and have the dashboard choose the default, it's more helpful to the user if we log the dashboard URL. This allows the user to find the dashboard, as the IDE will not be launching it automatically when in this state.

---

NOTE I will backport this to p3 once approved here on `main`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1970)