### PR TITLE
Add KnownPublishers to centralise constant string values

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/Aspire.Hosting.Azure.Provisioning.csproj
+++ b/src/Aspire.Hosting.Azure.Provisioning/Aspire.Hosting.Azure.Provisioning.csproj
@@ -21,6 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)KnownPublishers.cs" Link="KnownPublishers.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -39,7 +39,7 @@ internal sealed class AzureProvisioner(
     public async Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
         // TODO: Make this more general purpose
-        if (publishingOptions.Value.Publisher == "manifest")
+        if (publishingOptions.Value.Publisher == KnownPublishers.Manifest)
         {
             return;
         }

--- a/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
+++ b/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)KnownPublishers.cs" Link="KnownPublishers.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -139,7 +139,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                 new EnvironmentCallbackAnnotation(
                     context =>
                     {
-                        if (context.PublisherName == "manifest")
+                        if (context.PublisherName == KnownPublishers.Manifest)
                         {
                             return;
                         }

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(SharedDir)KnownResourceNames.cs" Link="Utils\KnownResourceNames.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
     <Compile Include="$(SharedDir)KnownFormats.cs" Link="Utils\KnownFormats.cs" />
+    <Compile Include="$(SharedDir)KnownPublishers.cs" Link="Utils\KnownPublishers.cs" />
     <Compile Include="$(SharedDir)ValueStopwatch\*.cs" LinkBase="Utils" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
@@ -11,7 +11,7 @@ internal static class ConsoleLogsConfigurationExtensions
     {
         return builder.WithEnvironment((context) =>
         {
-            if (context.PublisherName == "manifest")
+            if (context.PublisherName == KnownPublishers.Manifest)
             {
                 return;
             }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -57,7 +57,7 @@ internal sealed class DashboardServiceHost : IHostedService
         _logger = loggerFactory.CreateLogger<DashboardServiceHost>();
 
         if (!options.DashboardEnabled ||
-            publishingOptions.Value.Publisher == "manifest") // HACK: Manifest publisher check is temporary until DcpHostService is integrated with DcpPublisher.
+            publishingOptions.Value.Publisher == KnownPublishers.Manifest) // HACK: Manifest publisher check is temporary until DcpHostService is integrated with DcpPublisher.
         {
             _logger.LogDebug("Dashboard is not enabled so skipping hosting the resource service.");
             _resourceServiceUri.SetCanceled();

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -602,7 +602,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 }
 
                 var config = new Dictionary<string, string>();
-                var context = new EnvironmentCallbackContext("dcp", config);
+                var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
                 // Need to apply configuration settings manually; see PrepareExecutables() for details.
                 if (er.ModelResource is ProjectResource project && project.SelectLaunchProfileName() is { } launchProfileName && project.GetLaunchSettings() is { } launchSettings)
@@ -836,7 +836,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
                 if (modelContainerResource.TryGetEnvironmentVariables(out var containerEnvironmentVariables))
                 {
-                    var context = new EnvironmentCallbackContext("dcp", config);
+                    var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
                     foreach (var v in containerEnvironmentVariables)
                     {

--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -15,9 +15,9 @@ internal sealed class DcpDistributedApplicationLifecycleHook(IOptions<Publishing
 
     public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
-        var publisher = _publishingOptions.Value?.Publisher == null ? "dcp" : _publishingOptions.Value.Publisher;
+        var publisher = _publishingOptions.Value?.Publisher ?? KnownPublishers.Dcp;
 
-        if (publisher == "dcp")
+        if (publisher == KnownPublishers.Dcp)
         {
             PrepareServices(appModel);
         }

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -49,7 +49,7 @@ internal sealed partial class DcpHostService : IHostedLifecycleService, IAsyncDi
         _locations = locations;
     }
 
-    private bool IsSupported => _publishingOptions.Publisher is null or "dcp";
+    private bool IsSupported => _publishingOptions.Publisher is null or KnownPublishers.Dcp;
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -51,7 +51,7 @@ internal sealed class DcpOptions
     public void ApplyApplicationConfiguration(DistributedApplicationOptions appOptions, IConfiguration dcpPublisherConfiguration, IConfiguration publishingConfiguration)
     {
         string? publisher = publishingConfiguration[nameof(PublishingOptions.Publisher)];
-        if (publisher is not null && publisher != "dcp")
+        if (publisher is not null && publisher != KnownPublishers.Dcp)
         {
             // If DCP is not set as the publisher, don't calculate the DCP config
             return;

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -136,7 +136,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     {
         var options = _host.Services.GetRequiredService<IOptions<PublishingOptions>>();
 
-        if (options.Value?.Publisher == "manifest")
+        if (options.Value?.Publisher == KnownPublishers.Manifest)
         {
             // If we are producing the manifest, don't write startup messages.
             return;

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -80,8 +80,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         ConfigurePublishingOptions(options);
         _innerBuilder.Services.AddLifecycleHook<AutomaticManifestPublisherBindingInjectionHook>();
         _innerBuilder.Services.AddLifecycleHook<Http2TransportMutationHook>();
-        _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, ManifestPublisher>("manifest");
-        _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, DcpPublisher>("dcp");
+        _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, ManifestPublisher>(KnownPublishers.Manifest);
+        _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, DcpPublisher>(KnownPublishers.Dcp);
     }
 
     private void ConfigurePublishingOptions(DistributedApplicationOptions options)

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -17,7 +17,7 @@ internal sealed class DistributedApplicationRunner(DistributedApplicationModel m
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var publisherName = _options.Value.Publisher?.ToLowerInvariant() ?? "dcp";
+        var publisherName = _options.Value.Publisher?.ToLowerInvariant() ?? KnownPublishers.Dcp;
 
         var publisher = _serviceProvider.GetKeyedService<IDistributedApplicationPublisher>(publisherName)
             ?? throw new DistributedApplicationException($"Could not find registered publisher '{publisherName}'");

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -156,7 +156,7 @@ public static class ResourceBuilderExtensions
         {
             var connectionStringName = $"{ConnectionStringEnvironmentName}{connectionName}";
 
-            if (context.PublisherName == "manifest")
+            if (context.PublisherName == KnownPublishers.Manifest)
             {
                 context.EnvironmentVariables[connectionStringName] = $"{{{resource.Name}.connectionString}}";
                 return;

--- a/src/Aspire.Hosting/Extensions/SecretResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/SecretResourceBuilderExtensions.cs
@@ -44,7 +44,7 @@ public static class SecretResourceBuilderExtensions
     {
         return builder.WithEnvironment(context =>
         {
-            if (context.PublisherName == "manifest")
+            if (context.PublisherName == KnownPublishers.Manifest)
             {
                 context.EnvironmentVariables[name] = $"{{{secret.Resource.Name}.value}}";
                 return;

--- a/src/Aspire.Hosting/Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Kafka/KafkaBuilderExtensions.cs
@@ -60,7 +60,7 @@ public static class KafkaBuilderExtensions
         // When not explicitly set default configuration is applied.
         // See https://github.com/confluentinc/kafka-images/blob/master/local/include/etc/confluent/docker/configureDefaults for more details.
 
-        var hostPort = context.PublisherName == "manifest"
+        var hostPort = context.PublisherName == KnownPublishers.Manifest
             ? KafkaBrokerPort
             : GetResourcePort(resource);
         context.EnvironmentVariables.Add("KAFKA_ADVERTISED_LISTENERS",

--- a/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class MySqlBuilderExtensions
                       .WithAnnotation(new ContainerImageAnnotation { Image = "mysql", Tag = "latest" })
                       .WithEnvironment(context =>
                       {
-                          if (context.PublisherName == "manifest")
+                          if (context.PublisherName == KnownPublishers.Manifest)
                           {
                               context.EnvironmentVariables.Add(PasswordEnvVarName, $"{{{mySqlContainer.Name}.inputs.password}}");
                           }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class OracleDatabaseBuilderExtensions
                       .WithAnnotation(new ContainerImageAnnotation { Image = "database/free", Tag = "latest", Registry = "container-registry.oracle.com" })
                       .WithEnvironment(context =>
                       {
-                          if (context.PublisherName == "manifest")
+                          if (context.PublisherName == KnownPublishers.Manifest)
                           {
                               context.EnvironmentVariables.Add(PasswordEnvVarName, $"{{{oracleDatabaseContainer.Name}.inputs.password}}");
                           }

--- a/src/Aspire.Hosting/Otlp/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Otlp/OtlpConfigurationExtensions.cs
@@ -29,7 +29,7 @@ public static class OtlpConfigurationExtensions
 
         resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
         {
-            if (context.PublisherName == "manifest")
+            if (context.PublisherName == KnownPublishers.Manifest)
             {
                 // REVIEW:  Do we want to set references to an imaginary otlp provider as a requirement?
                 return;

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class PostgresBuilderExtensions
                       .WithEnvironment("POSTGRES_INITDB_ARGS", "--auth-host=scram-sha-256 --auth-local=scram-sha-256")
                       .WithEnvironment(context =>
                       {
-                          if (context.PublisherName == "manifest")
+                          if (context.PublisherName == KnownPublishers.Manifest)
                           {
                               context.EnvironmentVariables.Add(PasswordEnvVarName, $"{{{postgresContainer.Name}.inputs.password}}");
                           }

--- a/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
+++ b/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
@@ -37,7 +37,7 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
 
     public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
-        if (_publishingOptions.Value.Publisher != "manifest")
+        if (_publishingOptions.Value.Publisher != KnownPublishers.Manifest)
         {
             return Task.CompletedTask;
         }

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -99,7 +99,7 @@ public sealed class ManifestPublishingContext(string manifestPath, Utf8JsonWrite
     public void WriteEnvironmentVariables(IResource resource)
     {
         var config = new Dictionary<string, string>();
-        var envContext = new EnvironmentCallbackContext("manifest", config);
+        var envContext = new EnvironmentCallbackContext(KnownPublishers.Manifest, config);
 
         if (resource.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var callbacks))
         {

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class RabbitMQBuilderExtensions
                        .WithEnvironment("RABBITMQ_DEFAULT_USER", "guest")
                        .WithEnvironment(context =>
                        {
-                           if (context.PublisherName == "manifest")
+                           if (context.PublisherName == KnownPublishers.Manifest)
                            {
                                context.EnvironmentVariables.Add("RABBITMQ_DEFAULT_PASS", $"{{{rabbitMq.Name}.inputs.password}}");
                            }

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class SqlServerBuilderExtensions
                       .WithEnvironment("ACCEPT_EULA", "Y")
                       .WithEnvironment(context =>
                       {
-                          if (context.PublisherName == "manifest")
+                          if (context.PublisherName == KnownPublishers.Manifest)
                           {
                               context.EnvironmentVariables.Add("MSSQL_SA_PASSWORD", $"{{{sqlServer.Name}.inputs.password}}");
                           }

--- a/src/Shared/KnownPublishers.cs
+++ b/src/Shared/KnownPublishers.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire;
+
+internal static class KnownPublishers
+{
+    public const string Dcp = "dcp";
+
+    public const string Manifest = "manifest";
+}

--- a/tests/Aspire.Hosting.Tests/AsHttp2ServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/AsHttp2ServiceTests.cs
@@ -13,10 +13,10 @@ public class AsHttp2ServiceTests
     [Fact]
     public void Http2TransportIsNotSetWhenHttp2ServiceAnnotationIsNotApplied()
     {
-        var testProgram = CreateTestProgram(["--publisher", "manifest"]);
+        var testProgram = CreateTestProgram(["--publisher", KnownPublishers.Manifest]);
 
         // Block DCP from actually starting anything up as we don't need it for this test.
-        testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>("manifest");
+        testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>(KnownPublishers.Manifest);
 
         testProgram.Build();
         testProgram.Run();
@@ -33,11 +33,11 @@ public class AsHttp2ServiceTests
     [Fact]
     public void Http2TransportIsSetWhenHttp2ServiceAnnotationIsApplied()
     {
-        var testProgram = CreateTestProgram(["--publisher", "manifest"]);
+        var testProgram = CreateTestProgram(["--publisher", KnownPublishers.Manifest]);
         testProgram.ServiceABuilder.AsHttp2Service();
 
         // Block DCP from actually starting anything up as we don't need it for this test.
-        testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>("manifest");
+        testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>(KnownPublishers.Manifest);
 
         testProgram.Build();
         testProgram.Run();
@@ -50,12 +50,12 @@ public class AsHttp2ServiceTests
     [Fact]
     public void Http2TransportIsNotAppliedToNonHttpEndpoints()
     {
-        var testProgram = CreateTestProgram(["--publisher", "manifest"]);
+        var testProgram = CreateTestProgram(["--publisher", KnownPublishers.Manifest]);
         testProgram.ServiceABuilder.WithEndpoint(9999, scheme: "tcp");
         testProgram.ServiceABuilder.AsHttp2Service();
 
         // Block DCP from actually starting anything up as we don't need it for this test.
-        testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>("manifest");
+        testProgram.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>(KnownPublishers.Manifest);
 
         testProgram.Build();
         testProgram.Run();

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
@@ -18,8 +18,8 @@ public class DistributedApplicationBuilderTests
         var appBuilder = DistributedApplication.CreateBuilder();
         var app = appBuilder.Build();
 
-        Assert.NotNull(app.Services.GetRequiredKeyedService<IDistributedApplicationPublisher>("manifest"));
-        Assert.NotNull(app.Services.GetRequiredKeyedService<IDistributedApplicationPublisher>("dcp"));
+        Assert.NotNull(app.Services.GetRequiredKeyedService<IDistributedApplicationPublisher>(KnownPublishers.Manifest));
+        Assert.NotNull(app.Services.GetRequiredKeyedService<IDistributedApplicationPublisher>(KnownPublishers.Dcp));
 
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
         Assert.Empty(appModel.Resources);
@@ -48,18 +48,18 @@ public class DistributedApplicationBuilderTests
     [Fact]
     public void BuilderConfiguresPublishingOptionsFromCommandLine()
     {
-        var appBuilder = DistributedApplication.CreateBuilder(["--publisher", "manifest", "--output-path", "/tmp/"]);
+        var appBuilder = DistributedApplication.CreateBuilder(["--publisher", KnownPublishers.Manifest, "--output-path", "/tmp/"]);
         var app = appBuilder.Build();
 
         var publishOptions = app.Services.GetRequiredService<IOptions<PublishingOptions>>();
-        Assert.Equal("manifest", publishOptions.Value.Publisher);
+        Assert.Equal(KnownPublishers.Manifest, publishOptions.Value.Publisher);
         Assert.Equal("/tmp/", publishOptions.Value.OutputPath);
     }
 
     [Fact]
     public void BuilderConfiguresPublishingOptionsFromConfig()
     {
-        var appBuilder = DistributedApplication.CreateBuilder(["--publisher", "manifest", "--output-path", "/tmp/"]);
+        var appBuilder = DistributedApplication.CreateBuilder(["--publisher", KnownPublishers.Manifest, "--output-path", "/tmp/"]);
         appBuilder.Configuration["Publishing:Publisher"] = "docker";
         appBuilder.Configuration["Publishing:OutputPath"] = "/path/";
         var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
@@ -41,7 +41,7 @@ internal static class JsonDocumentManifestPublisherExtensions
 {
     public static JsonDocumentManifestPublisher GetManifestPublisher(this TestProgram testProgram)
     {
-        var publisher = testProgram.App?.Services.GetRequiredKeyedService<IDistributedApplicationPublisher>("manifest") as JsonDocumentManifestPublisher;
+        var publisher = testProgram.App?.Services.GetRequiredKeyedService<IDistributedApplicationPublisher>(KnownPublishers.Manifest) as JsonDocumentManifestPublisher;
         return publisher ?? throw new InvalidOperationException($"Manifest publisher was not {nameof(JsonDocumentManifestPublisher)}");
     }
 }

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -572,8 +572,8 @@ public class ManifestGenerationTests
     private static TestProgram CreateTestProgramJsonDocumentManifestPublisher(bool includeNodeApp = false)
     {
         var manifestPath = Path.GetTempFileName();
-        var program = TestProgram.Create<ManifestGenerationTests>(["--publisher", "manifest", "--output-path", manifestPath], includeNodeApp: includeNodeApp);
-        program.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, JsonDocumentManifestPublisher>("manifest");
+        var program = TestProgram.Create<ManifestGenerationTests>(["--publisher", KnownPublishers.Manifest, "--output-path", manifestPath], includeNodeApp: includeNodeApp);
+        program.AppBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, JsonDocumentManifestPublisher>(KnownPublishers.Manifest);
         return program;
     }
 }

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -42,7 +42,7 @@ public class AddMySqlTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -90,7 +90,7 @@ public class AddMySqlTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -42,7 +42,7 @@ public class AddOracleDatabaseTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -90,7 +90,7 @@ public class AddOracleDatabaseTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -189,7 +189,7 @@ public class AddOracleDatabaseTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -44,7 +44,7 @@ public class AddPostgresTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -102,7 +102,7 @@ public class AddPostgresTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -211,7 +211,7 @@ public class AddPostgresTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -31,7 +31,7 @@ public class ProjectResourceTests
         var annotations = resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -152,9 +152,9 @@ public class ProjectResourceTests
 
     private static IDistributedApplicationBuilder CreateBuilder()
     {
-        var appBuilder = DistributedApplication.CreateBuilder(["--publisher", "manifest"]);
+        var appBuilder = DistributedApplication.CreateBuilder(["--publisher", KnownPublishers.Manifest]);
         // Block DCP from actually starting anything up as we don't need it for this test.
-        appBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>("manifest");
+        appBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, NoopPublisher>(KnownPublishers.Manifest);
 
         return appBuilder;
     }

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -123,7 +123,7 @@ public class AddRedisTests
         var envAnnotations = commander.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -154,7 +154,7 @@ public class AddRedisTests
         var envAnnotations = commander.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in envAnnotations)
         {

--- a/tests/Aspire.Hosting.Tests/SecretsTests.cs
+++ b/tests/Aspire.Hosting.Tests/SecretsTests.cs
@@ -18,7 +18,7 @@ public class SecretsTests
 
         var callbackAnnotations = container.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
-        var context = new EnvironmentCallbackContext("dcp");
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp);
 
         foreach (var callbackAnnotation in callbackAnnotations)
         {

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -31,7 +31,7 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -56,7 +56,7 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -83,7 +83,7 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -113,7 +113,7 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -31,7 +31,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -80,7 +80,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -129,7 +129,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -176,7 +176,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -221,7 +221,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -250,7 +250,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         Assert.Throws<DistributedApplicationException>(() =>
         {
@@ -275,7 +275,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -303,7 +303,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -332,7 +332,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -359,7 +359,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -398,7 +398,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -422,7 +422,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -448,7 +448,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         foreach (var annotation in annotations)
         {
@@ -473,7 +473,7 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var context = new EnvironmentCallbackContext(KnownPublishers.Dcp, config);
 
         Assert.Throws<DistributedApplicationException>(() =>
         {


### PR DESCRIPTION
Several places in code check which publisher is in use. The publisher is identified by a string, which doesn't get much support from the type system. Introducing a shared  type provides a bit more semantic clarity around these values.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1972)