### PR TITLE
Prevent ANE when resource state is null

### DIFF
--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -16,7 +16,7 @@ partial class Resource
             ResourceType = snapshot.ResourceType,
             DisplayName = snapshot.DisplayName,
             Uid = snapshot.Uid,
-            State = snapshot.State,
+            State = snapshot.State ?? "",
         };
 
         if (snapshot.CreationTimeStamp.HasValue)


### PR DESCRIPTION
Fixes #1930

Ideally we'd make the field nullable on the proto definition, but that's a breaking change at this point. So instead, we pass an empty string.

Having a protobuf code generator that produced null annotated code would catch this class of issue.

Other options are discussed in #1930.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1975)