### PR TITLE
Add ExcludeLaunchProfile method to model

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ExcludeLaunchProfileAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExcludeLaunchProfileAnnotation.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+[DebuggerDisplay("Type = {GetType().Name,nq}")]
+internal sealed class ExcludeLaunchProfileAnnotation : IResourceAnnotation
+{
+}

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -538,20 +538,17 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 // and the environment variables/application URLs inside CreateExecutableAsync().
                 exeSpec.Args.Add("--no-launch-profile");
 
-                if (!project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
+                var launchProfileName = project.SelectLaunchProfileName();
+                if (!string.IsNullOrEmpty(launchProfileName))
                 {
-                    string? launchProfileName = project.SelectLaunchProfileName();
-                    if (!string.IsNullOrEmpty(launchProfileName))
+                    var launchProfile = project.GetEffectiveLaunchProfile();
+                    if (launchProfile is not null && !string.IsNullOrWhiteSpace(launchProfile.CommandLineArgs))
                     {
-                        var launchProfile = project.GetEffectiveLaunchProfile();
-                        if (launchProfile is not null && !string.IsNullOrWhiteSpace(launchProfile.CommandLineArgs))
+                        var cmdArgs = launchProfile.CommandLineArgs.Split((string?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                        if (cmdArgs is not null && cmdArgs.Length > 0)
                         {
-                            var cmdArgs = launchProfile.CommandLineArgs.Split((string?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-                            if (cmdArgs is not null && cmdArgs.Length > 0)
-                            {
-                                exeSpec.Args.Add("--");
-                                exeSpec.Args.AddRange(cmdArgs);
-                            }
+                            exeSpec.Args.Add("--");
+                            exeSpec.Args.AddRange(cmdArgs);
                         }
                     }
                 }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -500,7 +500,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 // ExcludeLaunchProfileAnnotation takes precedence over LaunchProfileAnnotation. 
                 if (project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
                 {
-                    // TODO
+                    annotationHolder.Annotate(Executable.CSharpDisableLaunchProfileAnnotation, "true");
                 }
                 else if (project.TryGetLastAnnotation<LaunchProfileAnnotation>(out var lpa))
                 {

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -496,7 +496,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             if (!string.IsNullOrEmpty(configuration[DebugSessionPortVar]))
             {
                 exeSpec.ExecutionType = ExecutionType.IDE;
-                if (project.TryGetLastAnnotation<LaunchProfileAnnotation>(out var lpa))
+                if (project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
+                {
+                    // TODO
+                }
+                else if (project.TryGetLastAnnotation<LaunchProfileAnnotation>(out var lpa))
                 {
                     annotationHolder.Annotate(Executable.CSharpLaunchProfileAnnotation, lpa.LaunchProfileName);
                 }
@@ -532,17 +536,20 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 // and the environment variables/application URLs inside CreateExecutableAsync().
                 exeSpec.Args.Add("--no-launch-profile");
 
-                string? launchProfileName = project.SelectLaunchProfileName();
-                if (!string.IsNullOrEmpty(launchProfileName))
+                if (!project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
                 {
-                    var launchProfile = project.GetEffectiveLaunchProfile();
-                    if (launchProfile is not null && !string.IsNullOrWhiteSpace(launchProfile.CommandLineArgs))
+                    string? launchProfileName = project.SelectLaunchProfileName();
+                    if (!string.IsNullOrEmpty(launchProfileName))
                     {
-                        var cmdArgs = launchProfile.CommandLineArgs.Split((string?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-                        if (cmdArgs is not null && cmdArgs.Length > 0)
+                        var launchProfile = project.GetEffectiveLaunchProfile();
+                        if (launchProfile is not null && !string.IsNullOrWhiteSpace(launchProfile.CommandLineArgs))
                         {
-                            exeSpec.Args.Add("--");
-                            exeSpec.Args.AddRange(cmdArgs);
+                            var cmdArgs = launchProfile.CommandLineArgs.Split((string?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                            if (cmdArgs is not null && cmdArgs.Length > 0)
+                            {
+                                exeSpec.Args.Add("--");
+                                exeSpec.Args.AddRange(cmdArgs);
+                            }
                         }
                     }
                 }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -496,6 +496,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             if (!string.IsNullOrEmpty(configuration[DebugSessionPortVar]))
             {
                 exeSpec.ExecutionType = ExecutionType.IDE;
+
+                // ExcludeLaunchProfileAnnotation takes precedence over LaunchProfileAnnotation. 
                 if (project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
                 {
                     // TODO

--- a/src/Aspire.Hosting/Dcp/Model/Executable.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Executable.cs
@@ -114,6 +114,7 @@ internal sealed class Executable : CustomResource<ExecutableSpec, ExecutableStat
 {
     public const string CSharpProjectPathAnnotation = "csharp-project-path";
     public const string CSharpLaunchProfileAnnotation = "csharp-launch-profile";
+    public const string CSharpDisableLaunchProfileAnnotation = "csharp-disable-launch-profile";
     public const string OtelServiceNameAnnotation = "otel-service-name";
 
     [JsonConstructor]

--- a/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
@@ -110,6 +110,11 @@ public static class ProjectResourceBuilderExtensions
         return builder.WithAnnotation(launchProfileAnnotation);
     }
 
+    /// <summary>
+    /// Configures the project to exclude launch profile settings when running.
+    /// </summary>
+    /// <param name="builder">The project resource builder.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<ProjectResource> ExcludeLaunchProfile(this IResourceBuilder<ProjectResource> builder)
     {
         builder.WithAnnotation(new ExcludeLaunchProfileAnnotation());

--- a/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
@@ -109,4 +109,10 @@ public static class ProjectResourceBuilderExtensions
         var launchProfileAnnotation = new LaunchProfileAnnotation(launchProfileName);
         return builder.WithAnnotation(launchProfileAnnotation);
     }
+
+    public static IResourceBuilder<ProjectResource> ExcludeLaunchProfile(this IResourceBuilder<ProjectResource> builder)
+    {
+        builder.WithAnnotation(new ExcludeLaunchProfileAnnotation());
+        return builder;
+    }
 }

--- a/src/Aspire.Hosting/Utils/LaunchProfileExtensions.cs
+++ b/src/Aspire.Hosting/Utils/LaunchProfileExtensions.cs
@@ -19,6 +19,11 @@ internal static class LaunchProfileExtensions
             throw new DistributedApplicationException(Resources.ProjectDoesNotContainMetadataExceptionMessage);
         }
 
+        if (projectResource.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
+        {
+            return null;
+        }
+
         return projectMetadata.GetLaunchSettings();
     }
 
@@ -40,7 +45,7 @@ internal static class LaunchProfileExtensions
         return found == true ? launchProfile : null;
     }
 
-    internal static LaunchSettings? GetLaunchSettings(this IProjectMetadata projectMetadata)
+    private static LaunchSettings? GetLaunchSettings(this IProjectMetadata projectMetadata)
     {
         if (!File.Exists(projectMetadata.ProjectPath))
         {
@@ -62,7 +67,7 @@ internal static class LaunchProfileExtensions
         }
 
         using var stream = File.OpenRead(launchSettingsFilePath);
-        var settings = JsonSerializer.Deserialize(stream, LaunchSetttingsSerializerContext.Default.LaunchSettings);
+        var settings = JsonSerializer.Deserialize(stream, LaunchSettingsSerializerContext.Default.LaunchSettings);
         return settings;
     }
 
@@ -130,6 +135,11 @@ internal static class LaunchProfileExtensions
 
     internal static string? SelectLaunchProfileName(this ProjectResource projectResource)
     {
+        if (projectResource.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
+        {
+            return null;
+        }
+
         foreach (var launchProfileSelector in s_launchProfileSelectors)
         {
             if (launchProfileSelector(projectResource, out var launchProfile))
@@ -146,7 +156,7 @@ internal delegate bool LaunchProfileSelector(ProjectResource project, out string
 
 [JsonSerializable(typeof(LaunchSettings))]
 [JsonSourceGenerationOptions(ReadCommentHandling = JsonCommentHandling.Skip)]
-internal sealed partial class LaunchSetttingsSerializerContext : JsonSerializerContext
+internal sealed partial class LaunchSettingsSerializerContext : JsonSerializerContext
 {
 
 }

--- a/src/Aspire.Hosting/Utils/LaunchProfileExtensions.cs
+++ b/src/Aspire.Hosting/Utils/LaunchProfileExtensions.cs
@@ -19,6 +19,8 @@ internal static class LaunchProfileExtensions
             throw new DistributedApplicationException(Resources.ProjectDoesNotContainMetadataExceptionMessage);
         }
 
+        // ExcludeLaunchProfileAnnotation disables getting launch settings. This ensures consumers of launch settings
+        // never get a copy and can't use values from it to configure the application.
         if (projectResource.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
         {
             return null;
@@ -135,6 +137,7 @@ internal static class LaunchProfileExtensions
 
     internal static string? SelectLaunchProfileName(this ProjectResource projectResource)
     {
+        // ExcludeLaunchProfileAnnotation takes precedence over all other launch profile selectors.
         if (projectResource.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
         {
             return null;

--- a/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
+++ b/tests/Aspire.Hosting.Tests/LaunchSettingsSerializerContextTests.cs
@@ -30,6 +30,6 @@ public class LaunchSettingsSerializerContextTests
         """;
 
         // should not throw
-        JsonSerializer.Deserialize(launchSettingsJson, LaunchSetttingsSerializerContext.Default.LaunchSettings);
+        JsonSerializer.Deserialize(launchSettingsJson, LaunchSettingsSerializerContext.Default.LaunchSettings);
     }
 }

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -62,6 +62,24 @@ public class ManifestGenerationTests
     }
 
     [Fact]
+    public void ExcludeLaunchProfileOmitsBindings()
+    {
+        var program = CreateTestProgramJsonDocumentManifestPublisher();
+        program.ServiceABuilder.ExcludeLaunchProfile();
+
+        program.Build();
+        var publisher = program.GetManifestPublisher();
+
+        program.Run();
+
+        var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
+
+        Assert.False(
+            resources.GetProperty("servicea").TryGetProperty("bindings", out _),
+            "Server has no bindings because they weren't populated from the launch profile.");
+    }
+
+    [Fact]
     public void EnsureContainerWithEndpointsEmitsContainerPort()
     {
         var program = CreateTestProgramJsonDocumentManifestPublisher();

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -76,7 +76,7 @@ public class ManifestGenerationTests
 
         Assert.False(
             resources.GetProperty("servicea").TryGetProperty("bindings", out _),
-            "Server has no bindings because they weren't populated from the launch profile.");
+            "Service has no bindings because they weren't populated from the launch profile.");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -139,6 +139,24 @@ public class ProjectResourceTests
     }
 
     [Fact]
+    public void ExcludeLaunchProfileAddsAnnotationToProject()
+    {
+        var appBuilder = CreateBuilder();
+
+        appBuilder.AddProject<Projects.ServiceA>("projectName")
+            .ExcludeLaunchProfile();
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var projectResources = appModel.GetProjectResources();
+
+        var resource = Assert.Single(projectResources);
+        // ExcludeLaunchProfileAnnotation isn't public, so we just check the type name
+        Assert.Contains(resource.Annotations, a => a.GetType().Name == "ExcludeLaunchProfileAnnotation");
+    }
+
+    [Fact]
     public void ProjectWithoutServiceMetadataFailsWithLaunchProfile()
     {
         var appBuilder = CreateBuilder();


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1849

There appears to be two ways to launch a project:
* Via IDE
* Via dotnet watch

ExcludeLaunchProfile has been added to dotnet watch path by skipping reading launch profile.

I'm guessing ExcludeLaunchProfile needs to be passed to the IDE as an annotation. Does one exist today? What should the name/value be?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1978)