### PR TITLE
Add process metrics to service defaults

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,6 +108,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.4" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.6.0-beta.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.13" />

--- a/playground/Playground.ServiceDefaults/Extensions.cs
+++ b/playground/Playground.ServiceDefaults/Extensions.cs
@@ -47,6 +47,7 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
+                       .AddProcessInstrumentation()
                        .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>

--- a/playground/Playground.ServiceDefaults/Playground.ServiceDefaults.csproj
+++ b/playground/Playground.ServiceDefaults/Playground.ServiceDefaults.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
 
     <ProjectReference Include="..\..\src\Microsoft.Extensions.ServiceDiscovery.Dns\Microsoft.Extensions.ServiceDiscovery.Dns.csproj" />

--- a/playground/eShopLite/ServiceDefaults/Extensions.cs
+++ b/playground/eShopLite/ServiceDefaults/Extensions.cs
@@ -44,6 +44,7 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
+                       .AddProcessInstrumentation()
                        .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>

--- a/playground/eShopLite/ServiceDefaults/ServiceDefaults.csproj
+++ b/playground/eShopLite/ServiceDefaults/ServiceDefaults.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/playground/orleans/OrleansServiceDefaults/Extensions.cs
+++ b/playground/orleans/OrleansServiceDefaults/Extensions.cs
@@ -44,6 +44,7 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
+                       .AddProcessInstrumentation()
                        .AddRuntimeInstrumentation()
                        .AddMeter("Microsoft.Orleans");
             })

--- a/playground/orleans/OrleansServiceDefaults/OrleansServiceDefaults.csproj
+++ b/playground/orleans/OrleansServiceDefaults/OrleansServiceDefaults.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
   </ItemGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
@@ -44,6 +44,7 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
+                       .AddProcessInstrumentation()
                        .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Aspire.ServiceDefaults1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Aspire.ServiceDefaults1.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
   </ItemGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
@@ -44,6 +44,7 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
+                       .AddProcessInstrumentation()
                        .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/AspireStarterApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/AspireStarterApplication.1.ServiceDefaults.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.2" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.6.0-beta.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.1" />
   </ItemGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
@@ -44,6 +44,7 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                        .AddHttpClientInstrumentation()
+                       .AddProcessInstrumentation()
                        .AddRuntimeInstrumentation();
             })
             .WithTracing(tracing =>


### PR DESCRIPTION
Add OpenTelemetry.Instrumentation.Process to the default template and playgrounds.

Resolves #1911.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1981)