### PR TITLE
Update to Mongo's AddDatabase() method

### DIFF
--- a/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
@@ -60,7 +60,7 @@ public static class MongoDBBuilderExtensions
     /// <param name="builder">The MongoDB server resource builder.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<MongoDBDatabaseResource> AddDatabase(this IResourceBuilder<MongoDBContainerResource> builder, string name)
+    public static IResourceBuilder<MongoDBDatabaseResource> AddDatabase(this IResourceBuilder<IMongoDBParentResource> builder, string name)
     {
         var mongoDBDatabase = new MongoDBDatabaseResource(name, builder.Resource);
 


### PR DESCRIPTION
The `AddDatabase()` method is currently an extension method on `IResourceBuilder<MongoDBContainerResource>` and cannot be used after `AddMongoDB()` which returns `IResourceBuilder<MongoDBServerResource>` instance. If `AddDatabase()` is made an extension method on `IResourceBuilder<IMongoDBParentResource>` it will be usable after both `AddMongoDBContainer()` and `AddMongoDB()`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1987)