### PR TITLE
Remove PublishBuildArtifacts

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -64,13 +64,6 @@ steps:
 
     - task: PublishBuildArtifacts@1
       inputs:
-        pathToPublish: '$(Build.SourcesDirectory)/artifacts/packages'
-        artifactName: PackageArtifacts
-        artifactType: container
-      displayName: Publish Package Artifacts
-
-    - task: PublishBuildArtifacts@1
-      inputs:
         pathToPublish: '$(Build.SourcesDirectory)/artifacts/VSSetup/$(_BuildConfig)'
         artifactName: VSDropInsertion
         artifactType: container


### PR DESCRIPTION
This already happens as part of the publish step in the build. Doing this over again (especially to the same container) will overwrite the previous results in some cases, and also unnecessarily duplicate files. It also will cause the wixpacks to get picked up for signing validation.