### PR TITLE
Fix presentation of resource exit code

### DIFF
--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -34,7 +34,7 @@ internal abstract class ResourceSnapshot
             yield return (KnownProperties.Resource.Type, Value.ForString(ResourceType));
             yield return (KnownProperties.Resource.DisplayName, Value.ForString(DisplayName));
             yield return (KnownProperties.Resource.State, Value.ForString(State));
-            yield return (KnownProperties.Resource.ExitCode, ExitCode is null ? Value.ForNull() : Value.ForString(ExitCode.Value.ToString("N", CultureInfo.InvariantCulture)));
+            yield return (KnownProperties.Resource.ExitCode, ExitCode is null ? Value.ForNull() : Value.ForString(ExitCode.Value.ToString("D", CultureInfo.InvariantCulture)));
             yield return (KnownProperties.Resource.CreateTime, CreationTimeStamp is null ? Value.ForNull() : Value.ForString(CreationTimeStamp.Value.ToString("O")));
 
             foreach (var pair in GetProperties())


### PR DESCRIPTION
Relates to #1641

The resource exit code is an integer, but gRPC `Value` cannot represent integers (only `Number`, akin to `double`). Therefore we convert the integer to a string and send that.

The previous conversion used format string `N` which produces values of form `1.00`. This change moves to `D`, which produces values of form `1`. Negative exit codes are supported too.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1994)