### PR TITLE
Default exit code to null rather than -1

### DIFF
--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -178,9 +178,9 @@ internal sealed class ContainerStatus : V1Status
     public DateTimeOffset? FinishTimestamp { get; set; }
 
     // Exit code of the Container.
-    // Default is -1, meaning the exit code is not known, or the container is still running.
+    // Default is null, meaning the exit code is not known, or the container is still running.
     [JsonPropertyName("exitCode")]
-    public int ExitCode { get; set; } = Conventions.UnknownExitCode;
+    public int? ExitCode { get; set; }
 
     // Effective values of environment variables, after all substitutions have been applied
     [JsonPropertyName("effectiveEnv")]

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -105,9 +105,6 @@ internal static class Conventions
 {
     // Indicates that process ID of some process is not known
     public const int UnknownPID = -1;
-
-    // Indicates that the exit code of some process is not known
-    public const int UnknownExitCode = -1;
 }
 
 internal sealed class ServiceProducerAnnotation


### PR DESCRIPTION
Fixes #1641

Exit codes only exist once the process actually exits. While a process is running, we need a value to represent the absence of an exit code.

Previously this was `Conventions.UnknownExitCode` which had value -1.

With this change we make the value nullable, and use null to indicate no value is available. This avoids the potential for confusion between integer values, and forces the consumer to think about and cater for the absence of a value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/1999)