### PR TITLE
Map DCP's unknown container exit code to null in resource service

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -203,7 +203,8 @@ internal sealed class DcpDataSource
             CreationTimeStamp = container.Metadata.CreationTimestamp?.ToLocalTime(),
             Image = container.Spec.Image!,
             State = container.Status?.State,
-            ExitCode = container.Status?.ExitCode,
+            // Map a container exit code of -1 (unknown) to null
+            ExitCode = container.Status?.ExitCode is null or Conventions.UnknownExitCode ? null : container.Status.ExitCode,
             ExpectedEndpointsCount = GetExpectedEndpointsCount(container),
             Environment = environment,
             Endpoints = endpoints,


### PR DESCRIPTION
Fixes #1641
Replaces PR #1999

DCP uses a sentinel value of -1 to indicate that a container's exit code is unknown. In our resource service protocol we use a null for this value. We cannot use -1, as that is a valid exit code for Windows proceses.

This change maps a container exit code of -1 to a null value, for container resources only. This avoids us displaying -1 in the dashboard UI, which is confusing.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2001)