### PR TITLE
Use HashSet for constant time perf

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -414,7 +414,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
         // We need to ensure that Services have unique names (otherwise we cannot really distinguish between
         // services produced by different resources).
-        List<string> serviceNames = new();
+        HashSet<string> serviceNames = [];
 
         void addServiceAppResource(Service svc, IResource producingResource, EndpointAnnotation sba)
         {
@@ -952,12 +952,12 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         return maybeWithSuffix(resource.Name);
     }
 
-    private static string GenerateUniqueServiceName(List<string> serviceNames, string candidateName)
+    private static string GenerateUniqueServiceName(HashSet<string> serviceNames, string candidateName)
     {
         int suffix = 1;
         string uniqueName = candidateName;
 
-        while (serviceNames.Contains(uniqueName))
+        while (!serviceNames.Add(uniqueName))
         {
             uniqueName = $"{candidateName}_{suffix}";
             suffix++;
@@ -968,8 +968,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             }
         }
 
-        serviceNames.Add(uniqueName);
         return uniqueName;
     }
-
 }


### PR DESCRIPTION
The `PrepareServices` method calls `GenerateUniqueServiceName` for every annotation of every service producer. The previous `Contains` call is O(N) on the number of resources.

This changes the `List<>` to a `HashSet<>` for more even perf across differing numbers of resources.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2002)