### PR TITLE
Use the slim builder to avoid loading static assets

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -66,7 +66,10 @@ internal sealed class DashboardServiceHost : IHostedService
 
         try
         {
-            var builder = WebApplication.CreateBuilder();
+            var builder = WebApplication.CreateSlimBuilder();
+
+            // Turn on HTTPS
+            builder.WebHost.UseKestrelHttpsConfiguration();
 
             // Environment
             builder.Services.AddSingleton<IEnvironmentVariables, EnvironmentVariables>();


### PR DESCRIPTION
- We're exposing a simple gRPC endpoint for the dashboard to talk to. We can avoid loading static assets completely (which causes all kinds of problems when things get out of sync).

Fixes #2012
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2013)