### PR TITLE
Update dashboard discovery to use .dll instead of executable

### DIFF
--- a/eng/dashboardpack/Sdk.targets
+++ b/eng/dashboardpack/Sdk.targets
@@ -5,8 +5,7 @@
   <PropertyGroup>
     <AspireDashboardDir Condition=" '$(AspireDashboardDir)' == '' ">$([MSBuild]::NormalizeDirectory($(MSBuildThisFileDirectory), '..', 'tools'))</AspireDashboardDir>
     <AspireDashboardDir>$([MSBuild]::EnsureTrailingSlash('$(AspireDashboardDir)'))</AspireDashboardDir>
-    <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard'))</AspireDashboardPath>
-    <AspireDashboardPath Condition=" '$(OS)' == 'Windows_NT' and !$(AspireDashboardPath.EndsWith('.exe')) ">$(AspireDashboardPath).exe</AspireDashboardPath>
+    <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard.dll'))</AspireDashboardPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/dashboardpack/Sdk.targets
+++ b/eng/dashboardpack/Sdk.targets
@@ -5,7 +5,9 @@
   <PropertyGroup>
     <AspireDashboardDir Condition=" '$(AspireDashboardDir)' == '' ">$([MSBuild]::NormalizeDirectory($(MSBuildThisFileDirectory), '..', 'tools'))</AspireDashboardDir>
     <AspireDashboardDir>$([MSBuild]::EnsureTrailingSlash('$(AspireDashboardDir)'))</AspireDashboardDir>
-    <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard.dll'))</AspireDashboardPath>
+    <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard'))</AspireDashboardPath>
+    <AspireDashboardPath Condition=" '$(OS)' == 'Windows_NT' and !$(AspireDashboardPath.EndsWith('.exe')) ">$(AspireDashboardPath).exe</AspireDashboardPath>
+    <AspireDashboardPath Condition="$([MSBuild]::IsOsPlatform('OSX')) and !$(AspireDashboardPath.EndsWith('.dll'))">$(AspireDashboardPath).dll</AspireDashboardPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -17,7 +17,7 @@
     </ItemGroup>
 
   </Target>
-  
+
   <!-- Generate the data structures for doing the codegen for project resources -->
   <Target Name="CreateAspireProjectMetadataSources"
           DependsOnTargets="_CreateAspireProjectResources">
@@ -111,7 +111,7 @@ internal static class ]]>%(ClassName)<![CDATA[
       <Code Type="Fragment" Language="cs">
         <![CDATA[
           HashSet<ITaskItem> nonExecutableReferences = new HashSet<ITaskItem>();
-          
+
           foreach (var appProject in AppProjectTargetFramework)
           {
             var additionalProperties = appProject.GetMetadata("AdditionalPropertiesFromProject");
@@ -120,7 +120,7 @@ internal static class ]]>%(ClassName)<![CDATA[
               // Skip any projects that don't contain the right metadata
               continue;
             }
-                
+
             var additionalPropertiesXml = XElement.Parse(additionalProperties);
             foreach (var targetFrameworkElement in additionalPropertiesXml.Elements())
             {
@@ -209,8 +209,7 @@ internal static class ]]>%(ClassName)<![CDATA[
   <Target Name="SetDashboardDiscoveryAttributes" BeforeTargets="GetAssemblyAttributes" Condition=" '$(AspireDashboardDir)' != '' ">
     <PropertyGroup>
       <AspireDashboardDir>$([MSBuild]::EnsureTrailingSlash('$(AspireDashboardDir)'))</AspireDashboardDir>
-      <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard'))</AspireDashboardPath>
-      <AspireDashboardPath Condition=" '$(OS)' == 'Windows_NT' and !$(AspireDashboardPath.EndsWith('.exe')) ">$(AspireDashboardPath).exe</AspireDashboardPath>
+      <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard.dll'))</AspireDashboardPath>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -209,7 +209,9 @@ internal static class ]]>%(ClassName)<![CDATA[
   <Target Name="SetDashboardDiscoveryAttributes" BeforeTargets="GetAssemblyAttributes" Condition=" '$(AspireDashboardDir)' != '' ">
     <PropertyGroup>
       <AspireDashboardDir>$([MSBuild]::EnsureTrailingSlash('$(AspireDashboardDir)'))</AspireDashboardDir>
-      <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard.dll'))</AspireDashboardPath>
+      <AspireDashboardPath Condition=" '$(AspireDashboardPath)' == '' ">$([MSBuild]::NormalizePath($(AspireDashboardDir), 'Aspire.Dashboard'))</AspireDashboardPath>
+      <AspireDashboardPath Condition=" '$(OS)' == 'Windows_NT' and !$(AspireDashboardPath.EndsWith('.exe')) ">$(AspireDashboardPath).exe</AspireDashboardPath>
+      <AspireDashboardPath Condition="$([MSBuild]::IsOsPlatform('OSX')) and !$(AspireDashboardPath.EndsWith('.dll'))">$(AspireDashboardPath).dll</AspireDashboardPath>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Executable was having issues on Mac, so switching to reference the .dll since Aspire.Hosting can already handle that scenario.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2018)