### PR TITLE
Move SB metadata to intermediates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -33,11 +33,6 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
       <Sha>c63655a995fb1dfc8b8fd9cf149d5e6ad225a185</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23516.4">
-      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>b4fa7f2e1e65ef49881be2ab2df27624280a8c55</Sha>
-      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
-    </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
@@ -110,12 +105,17 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-efcore</Uri>
       <Sha>4c95cefe39426014c24cdaa8688518618bc0040f</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.23516.4">
+      <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
+      <Sha>b4fa7f2e1e65ef49881be2ab2df27624280a8c55</Sha>
+      <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24075.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>07cf24f27ee58b5d1a9662334a101d84bd1e07e5</Sha>
-      <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Installers" Version="8.0.0-beta.24075.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
@@ -142,6 +142,17 @@
       <Sha>07cf24f27ee58b5d1a9662334a101d84bd1e07e5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/xliff-tasks</Uri>
+      <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="8.0.0-beta.24075.5">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>61ae141d2bf3534619265c8f691fd55dc3e75147</Sha>
+      <SourceBuild RepoName="arcade" ManagedOnly="true" />
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.xliff-tasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
       <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />


### PR DESCRIPTION
The changes in this pull request aim to [improve the UX and guideance around the SourceBuild metadata](https://github.com/dotnet/source-build/issues/3373) by placing the metadata on explicit source-build intermediates.

The changes include:

- Removing existing SourceBuild metadata from all non-intermediate dependencies.
- Defining new explicit intermediate dependencies and adding SourceBuild metadata to those dependencies.

Related to https://github.com/dotnet/source-build/issues/3373 and https://github.com/dotnet/source-build/issues/4073
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2023)