### PR TITLE
Proof of concept for signing Dashboard MacOS executable for workload

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Sign MacOS binaries for Aspire Dashboard -->
-    <ItemsToSign Include="$(ArtifactsTmpDir)MacSigning\**\*.zip" Condition="'$(PostBuildSign)' != 'true'" />
+    <!-- Sign MacOS binaries for Aspire Dashboard during build -->
+    <ItemsToSign Include="$(ArtifactsTmpDir)MacSigning\**\*.zip" />
     <ItemsToSign Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSignPostBuild Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' == 'true'" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <!-- Sign MacOS binaries for Aspire Dashboard -->
-    <ItemsToSign Include="$(ArtifactsBinDir)Aspire.Dashboard\**\*.zip" Condition="'$(PostBuildSign)' != 'true'" />
+    <ItemsToSign Include="$(ArtifactsTmpDir)MacSigning\**\*.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSign Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSignPostBuild Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' == 'true'" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -21,11 +21,14 @@
     <FileSignInfo Include="Grpc.Net.Client.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Grpc.Net.ClientFactory.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Grpc.Net.Common.dll" CertificateName="3PartySHA2" />
+    <!-- Sign MacOS binaries for Aspire dashboard -->
     <FileSignInfo Include="Aspire.Dashboard.osx-x64.zip" CertificateName="MacDeveloperHarden" />
     <FileSignInfo Include="Aspire.Dashboard.osx-arm64.zip" CertificateName="MacDeveloperHarden" />
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Sign MacOS binaries for Aspire Dashboard -->
+    <ItemsToSign Include="$(ArtifactsBinDir)Aspire.Dashboard\**\*.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSign Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSign Include="$(ArtifactsPackagesDir)**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />
     <ItemsToSignPostBuild Include="$(VisualStudioSetupInsertionPath)\**\*.msi" Condition="'$(PostBuildSign)' == 'true'" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -21,6 +21,8 @@
     <FileSignInfo Include="Grpc.Net.Client.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Grpc.Net.ClientFactory.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Grpc.Net.Common.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Aspire.Dashboard.osx-x64.zip" CertificateName="MacDeveloperHarden" />
+    <FileSignInfo Include="Aspire.Dashboard.osx-arm64.zip" CertificateName="MacDeveloperHarden" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -26,12 +26,14 @@
 
   <Target Name="Build" />
 
-  <Target Name="UpdateSignedFiles" Condition="Exists('$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip')">
+  <!-- For MacOS, we need to update the publish output with final signed binaries -->
+  <Target Name="UpdateSignedFiles" Condition="Exists('$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip') and '$(Sign)' == 'true'">
     <Unzip SourceFiles="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip"
            DestinationFolder="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/" />
     <Delete Files="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip" />
   </Target>
 
+  <!-- The dashboard should have been published for all appropriate RIDs during the normal build -->
   <Target Name="BeforeBuild" BeforeTargets="Build" DependsOnTargets="UpdateSignedFiles">
     <ItemGroup>
       <_PublishItems Include="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/**/*" />

--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -20,6 +20,7 @@
   <PropertyGroup>
     <DashboardPlatformType Condition=" '$(DashboardPlatformType)' == '' and $(DcpPlatform.StartsWith('win-')) ">Windows</DashboardPlatformType>
     <DashboardPlatformType Condition=" '$(DashboardPlatformType)' == '' ">Unix</DashboardPlatformType>
+    <DashboardPublishDir>$(DotNetOutputPath)Aspire.Dashboard/$(DashboardRuntime)/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/</DashboardPublishDir
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
@@ -29,13 +30,13 @@
   <!-- For MacOS, we need to update the publish output with final signed binaries -->
   <Target Name="UpdateSignedFiles" Condition="Exists('$(ArtifactsTmpDir)MacSigning/Aspire.Dashboard.$(RuntimeIdentifier).zip') and '$(Sign)' == 'true'">
     <Unzip SourceFiles="$(ArtifactsTmpDir)MacSigning/Aspire.Dashboard.$(RuntimeIdentifier).zip"
-           DestinationFolder="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/" />
+           DestinationFolder="$(DashboardPublishDir)" />
   </Target>
 
   <!-- The dashboard should have been published for all appropriate RIDs during the normal build -->
   <Target Name="BeforeBuild" BeforeTargets="Build" DependsOnTargets="UpdateSignedFiles">
     <ItemGroup>
-      <_PublishItems Include="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/**/*" />
+      <_PublishItems Include="$(DashboardPublishDir)**/*" />
       <None Include="@(_PublishItems)" Pack="true" PackagePath="tools/" />
     </ItemGroup>
 

--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -27,10 +27,9 @@
   <Target Name="Build" />
 
   <!-- For MacOS, we need to update the publish output with final signed binaries -->
-  <Target Name="UpdateSignedFiles" Condition="Exists('$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip') and '$(Sign)' == 'true'">
-    <Unzip SourceFiles="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip"
+  <Target Name="UpdateSignedFiles" Condition="Exists('$(ArtifactsTmpDir)MacSigning/$(TargetFramework)/$(Configuration)/Aspire.Dashboard.$(RuntimeIdentifier).zip') and '$(Sign)' == 'true'">
+    <Unzip SourceFiles="$(ArtifactsTmpDir)MacSigning/$(TargetFramework)/$(Configuration)/Aspire.Dashboard.$(RuntimeIdentifier).zip"
            DestinationFolder="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/" />
-    <Delete Files="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip" />
   </Target>
 
   <!-- The dashboard should have been published for all appropriate RIDs during the normal build -->

--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -20,7 +20,7 @@
   <PropertyGroup>
     <DashboardPlatformType Condition=" '$(DashboardPlatformType)' == '' and $(DcpPlatform.StartsWith('win-')) ">Windows</DashboardPlatformType>
     <DashboardPlatformType Condition=" '$(DashboardPlatformType)' == '' ">Unix</DashboardPlatformType>
-    <DashboardPublishDir>$(DotNetOutputPath)Aspire.Dashboard/$(DashboardRuntime)/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/</DashboardPublishDir
+    <DashboardPublishDir>$(DotNetOutputPath)Aspire.Dashboard/$(DashboardRuntime)/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/</DashboardPublishDir>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
@@ -31,6 +31,7 @@
   <Target Name="UpdateSignedFiles" Condition="Exists('$(ArtifactsTmpDir)MacSigning/Aspire.Dashboard.$(RuntimeIdentifier).zip') and '$(Sign)' == 'true'">
     <Unzip SourceFiles="$(ArtifactsTmpDir)MacSigning/Aspire.Dashboard.$(RuntimeIdentifier).zip"
            DestinationFolder="$(DashboardPublishDir)" />
+    <Delete Files="$(ArtifactsTmpDir)MacSigning/Aspire.Dashboard.$(RuntimeIdentifier).zip" />
   </Target>
 
   <!-- The dashboard should have been published for all appropriate RIDs during the normal build -->

--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -26,10 +26,13 @@
 
   <Target Name="Build" />
 
-  <Target Name="BeforeBuild" BeforeTargets="Build">
-    <MSBuild Projects="../../src/Aspire.Dashboard/Aspire.Dashboard.csproj" Targets="publish" Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=$(TargetFramework);RuntimeIdentifier=$(DashboardRuntime)" />
+  <Target Name="UpdateSignedFiles" Condition="Exists('$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip')">
+    <Unzip SourceFiles="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip"
+           DestinationFolder="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/" />
+    <Delete Files="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/Aspire.Dashboard.$(DashboardRuntime).zip" />
+  </Target>
 
-    <!-- After publishing the project, we ensure that the published assets get packed in the nuspec. -->
+  <Target Name="BeforeBuild" BeforeTargets="Build" DependsOnTargets="UpdateSignedFiles">
     <ItemGroup>
       <_PublishItems Include="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/**/*" />
       <None Include="@(_PublishItems)" Pack="true" PackagePath="tools/" />

--- a/eng/dashboardpack/dashboardpack.csproj
+++ b/eng/dashboardpack/dashboardpack.csproj
@@ -27,8 +27,8 @@
   <Target Name="Build" />
 
   <!-- For MacOS, we need to update the publish output with final signed binaries -->
-  <Target Name="UpdateSignedFiles" Condition="Exists('$(ArtifactsTmpDir)MacSigning/$(TargetFramework)/$(Configuration)/Aspire.Dashboard.$(RuntimeIdentifier).zip') and '$(Sign)' == 'true'">
-    <Unzip SourceFiles="$(ArtifactsTmpDir)MacSigning/$(TargetFramework)/$(Configuration)/Aspire.Dashboard.$(RuntimeIdentifier).zip"
+  <Target Name="UpdateSignedFiles" Condition="Exists('$(ArtifactsTmpDir)MacSigning/Aspire.Dashboard.$(RuntimeIdentifier).zip') and '$(Sign)' == 'true'">
+    <Unzip SourceFiles="$(ArtifactsTmpDir)MacSigning/Aspire.Dashboard.$(RuntimeIdentifier).zip"
            DestinationFolder="$(DotNetOutputPath)Aspire.Dashboard/$(Configuration)/$(TargetFramework)/$(DashboardRuntime)/publish/" />
   </Target>
 

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -47,7 +47,7 @@ steps:
               -publish $(_PublishArgs)
               -configuration ${{ parameters.buildConfig }}
               /bl:${{ parameters.repoLogPath }}/pack.binlog
-              /p:Restore=false
+              /p:Restore=false /p:Build=false
               $(_OfficialBuildIdArgs)
       displayName: Pack, Sign, and Publish
 

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -47,7 +47,7 @@ steps:
               -publish $(_PublishArgs)
               -configuration ${{ parameters.buildConfig }}
               /bl:${{ parameters.repoLogPath }}/pack.binlog
-              /p:Restore=false /p:Build=false
+              /p:Restore=false
               $(_OfficialBuildIdArgs)
       displayName: Pack, Sign, and Publish
 

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -10,6 +10,25 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
+  <Target Name="PublishAllRids" AfterTargets="Build" Condition="'$(RuntimeIdentifier)' == ''">
+    <ItemGroup>
+      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
+
+      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
+        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity)</AdditionalProperties>
+      </ProjectToPublish>
+    </ItemGroup>
+
+    <MSBuild Projects="@(ProjectToPublish)"
+             Targets="Publish"
+             BuildInParallel="true" />
+  </Target>
+
+  <Target Name="ZipMacBinary" AfterTargets="Publish" Condition="$(RuntimeIdentifier.StartsWith('osx-'))">
+    <Copy SourceFiles="$(PublishDir)Aspire.Dashboard" DestinationFolder="$(IntermediateOutputPath)Signing" />
+    <ZipDirectory SourceDirectory="$(IntermediateOutputPath)Signing" DestinationFile="$(PublishDir)Aspire.Dashboard.$(RuntimeIdentifier).zip" />
+  </Target>
+
   <ItemGroup>
     <Protobuf Include="**/*.proto" GrpcServices="Server">
       <ProtoRoot>Otlp</ProtoRoot>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -28,7 +28,7 @@
   <!-- For MacOS, we need to zip the executable for signing -->
   <Target Name="ZipMacBinary" AfterTargets="Publish" Condition="$(RuntimeIdentifier.StartsWith('osx-')) and '$(Sign)' == 'true'">
     <PropertyGroup>
-      <_ArtifactsMacSigningDir>$(ArtifactsTmpDir)MacSigning/$(TargetFramework)/$(Configuration)/</_ArtifactsMacSigningDir>
+      <_ArtifactsMacSigningDir>$(ArtifactsTmpDir)MacSigning/</_ArtifactsMacSigningDir>
     </PropertyGroup>
     <RemoveDir Directories="$(_ArtifactsMacSigningDir)$(AssemblyName).$(RuntimeIdentifier)" />
     <Delete Files="$(_ArtifactsMacSigningDir)$(AssemblyName).$(RuntimeIdentifier).zip" />

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -13,10 +13,10 @@
   <!-- We want to publish the dashboard for every supported RID -->
   <Target Name="PublishAllRids" AfterTargets="Build" Condition="'$(RuntimeIdentifier)' == ''">
     <ItemGroup>
-      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
+      <_RuntimeIdentifier Include="$(RuntimeIdentifiers)" />
 
-      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity)</AdditionalProperties>
+      <ProjectToPublish Include="@(_RuntimeIdentifier->'$(MSBuildProjectFullPath)')">
+        <AdditionalProperties>RuntimeIdentifier=%(_RuntimeIdentifier.Identity);PlatformName=%(_RuntimeIdentifier.Identity)</AdditionalProperties>
       </ProjectToPublish>
     </ItemGroup>
 

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -26,7 +26,7 @@
   </Target>
 
   <!-- For MacOS, we need to zip the executable for signing -->
-  <Target Name="ZipMacBinary" AfterTargets="Publish" Condition="$(RuntimeIdentifier.StartsWith('osx-')) and '$(Sign)' == 'true'">
+  <Target Name="ZipMacBinary" AfterTargets="Publish" Condition="$(RuntimeIdentifier.StartsWith('osx-'))">
     <PropertyGroup>
       <_ArtifactsMacSigningDir>$(ArtifactsTmpDir)MacSigning/</_ArtifactsMacSigningDir>
     </PropertyGroup>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -25,8 +25,10 @@
   </Target>
 
   <Target Name="ZipMacBinary" AfterTargets="Publish" Condition="$(RuntimeIdentifier.StartsWith('osx-'))">
-    <Copy SourceFiles="$(PublishDir)Aspire.Dashboard" DestinationFolder="$(IntermediateOutputPath)Signing" />
-    <ZipDirectory SourceDirectory="$(IntermediateOutputPath)Signing" DestinationFile="$(PublishDir)Aspire.Dashboard.$(RuntimeIdentifier).zip" />
+    <RemoveDir Directories="$(ArtifactsTmpDir)MacSigning\$(AssemblyName)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)" />
+    <Delete Files="$(PublishDir)Aspire.Dashboard.$(RuntimeIdentifier).zip" />
+    <Copy SourceFiles="$(PublishDir)$(AssemblyName)" DestinationFolder="$(ArtifactsTmpDir)MacSigning\$(AssemblyName)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)" />
+    <ZipDirectory SourceDirectory="$(ArtifactsTmpDir)MacSigning\$(AssemblyName)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)" DestinationFile="$(PublishDir)Aspire.Dashboard.$(RuntimeIdentifier).zip" />
   </Target>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -27,10 +27,13 @@
 
   <!-- For MacOS, we need to zip the executable for signing -->
   <Target Name="ZipMacBinary" AfterTargets="Publish" Condition="$(RuntimeIdentifier.StartsWith('osx-')) and '$(Sign)' == 'true'">
-    <RemoveDir Directories="$(ArtifactsTmpDir)MacSigning\$(AssemblyName)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)" />
-    <Delete Files="$(PublishDir)Aspire.Dashboard.$(RuntimeIdentifier).zip" />
-    <Copy SourceFiles="$(PublishDir)$(AssemblyName)" DestinationFolder="$(ArtifactsTmpDir)MacSigning\$(AssemblyName)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)" />
-    <ZipDirectory SourceDirectory="$(ArtifactsTmpDir)MacSigning\$(AssemblyName)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)" DestinationFile="$(PublishDir)Aspire.Dashboard.$(RuntimeIdentifier).zip" />
+    <PropertyGroup>
+      <_ArtifactsMacSigningDir>$(ArtifactsTmpDir)MacSigning/$(TargetFramework)/$(Configuration)/</_ArtifactsMacSigningDir>
+    </PropertyGroup>
+    <RemoveDir Directories="$(_ArtifactsMacSigningDir)$(AssemblyName).$(RuntimeIdentifier)" />
+    <Delete Files="$(_ArtifactsMacSigningDir)$(AssemblyName).$(RuntimeIdentifier).zip" />
+    <Copy SourceFiles="$(PublishDir)$(AssemblyName)" DestinationFolder="$(_ArtifactsMacSigningDir)$(AssemblyName).$(RuntimeIdentifier)/" />
+    <ZipDirectory SourceDirectory="$(_ArtifactsMacSigningDir)$(AssemblyName).$(RuntimeIdentifier)" DestinationFile="$(_ArtifactsMacSigningDir)$(AssemblyName).$(RuntimeIdentifier).zip" />
   </Target>
 
   <ItemGroup>

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -10,6 +10,7 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
+  <!-- We want to publish the dashboard for every supported RID -->
   <Target Name="PublishAllRids" AfterTargets="Build" Condition="'$(RuntimeIdentifier)' == ''">
     <ItemGroup>
       <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
@@ -24,7 +25,8 @@
              BuildInParallel="true" />
   </Target>
 
-  <Target Name="ZipMacBinary" AfterTargets="Publish" Condition="$(RuntimeIdentifier.StartsWith('osx-'))">
+  <!-- For MacOS, we need to zip the executable for signing -->
+  <Target Name="ZipMacBinary" AfterTargets="Publish" Condition="$(RuntimeIdentifier.StartsWith('osx-')) and '$(Sign)' == 'true'">
     <RemoveDir Directories="$(ArtifactsTmpDir)MacSigning\$(AssemblyName)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)" />
     <Delete Files="$(PublishDir)Aspire.Dashboard.$(RuntimeIdentifier).zip" />
     <Copy SourceFiles="$(PublishDir)$(AssemblyName)" DestinationFolder="$(ArtifactsTmpDir)MacSigning\$(AssemblyName)\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)" />


### PR DESCRIPTION
MacOS requires executables to be signed. Submitting files for MacOS signing requires them to be zipped.

This is a first pass at working MacOS signing for dashboard executables into builds with minimal pipeline changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2026)