### PR TITLE
Fix for unit tests failing.

### DIFF
--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -111,8 +111,8 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// <inheritdoc cref="IHost.StartAsync" />
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
-        await _host.StartAsync(cancellationToken).ConfigureAwait(false);
         await ExecuteBeforeStartHooksAsync(cancellationToken).ConfigureAwait(false);
+        await _host.StartAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc cref="IHost.StopAsync" />

--- a/tests/Aspire.Hosting.Tests/TestProgramFixture.cs
+++ b/tests/Aspire.Hosting.Tests/TestProgramFixture.cs
@@ -39,7 +39,7 @@ public abstract class TestProgramFixture : IAsyncLifetime
 
         _httpClient = _app.Services.GetRequiredService<IHttpClientFactory>().CreateClient();
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 
         await _app.StartAsync(cts.Token);
 
@@ -105,7 +105,11 @@ public class IntegrationServicesFixture : TestProgramFixture
             .AddHttpClient()
             .ConfigureHttpClientDefaults(b =>
             {
-                b.UseSocketsHttpHandler((handler, sp) => handler.PooledConnectionLifetime = TimeSpan.FromSeconds(5));
+                b.UseSocketsHttpHandler((handler, sp) =>
+                {
+                    handler.PooledConnectionLifetime = TimeSpan.FromSeconds(5);
+                    handler.ConnectTimeout = TimeSpan.FromSeconds(5);
+                });
 
                 // Ensure transient errors are retried.
                 b.AddStandardResilienceHandler();

--- a/tests/Aspire.Hosting.Tests/XunitAttributes.cs
+++ b/tests/Aspire.Hosting.Tests/XunitAttributes.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
This PR fixes the ordering of when I run the before start lifecycle hook. I accidentally moved it after start in the DistributedApplication.StartAsync. Most folks don't use this, but we do in our local only CI tests.

This change increases the timeout waiting for the endpoints to be allocated (we need to optimize all this in P4) but also reverts the bug that I introduced.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2028)