### PR TITLE
PublishAsConnectionString

### DIFF
--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Program.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.Configuration;
-
 var builder = DistributedApplication.CreateBuilder(args);
 
 // Use launch profiles to change DOTNET_ENVIRONMENT. If you use the "UseConnectionString"
@@ -17,12 +15,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 // The expression below is a bit more complex than the average developer app would
 // probably have, but in our repo we'll probably want to experiment with seperately
 // deployed resources a little bit.
-var simulateProduction = builder.Configuration.GetValue<bool>("SimulateProduction", false);
-var db = builder.Environment.EnvironmentName switch
-{
-    "Production" => builder.AddConnectionString("db"),
-    _ => simulateProduction ? builder.AddConnectionString("db") : builder.AddSqlServer("sql").AddDatabase("db")
-};
+var db = builder.AddSqlServer("sql")
+                .PublishAsConnectionString()
+                .AddDatabase("db");
 
 var insertionrows = builder.AddParameter("insertionrows");
 

--- a/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/Program.cs
+++ b/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/Program.cs
@@ -17,6 +17,9 @@ var pg6 = builder.AddPostgres("pg6").WithPgAdmin().PublishAsContainer();
 var db7 = pg6.AddDatabase("db7");
 var db8 = pg6.AddDatabase("db8");
 
+// External resources.
+var db9 = builder.AddPostgres("pg9").WithPgAdmin().PublishAsConnectionString().AddDatabase("db9");
+
 builder.AddProject<Projects.PostgresEndToEnd_ApiService>("api")
        .WithReference(db1)
        .WithReference(db2)
@@ -25,7 +28,8 @@ builder.AddProject<Projects.PostgresEndToEnd_ApiService>("api")
        .WithReference(db5)
        .WithReference(db6)
        .WithReference(db7)
-       .WithReference(db8);
+       .WithReference(db8)
+       .WithReference(db9);
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code

--- a/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
@@ -14,7 +14,5 @@ internal sealed class ResourceWithConnectionStringSurrogate(IResource innerResou
         return callback();
     }
 
-    public string ConnectionStringReferenceExpression => $"{{{Name}.value}}";
-
     public string? ConnectionStringEnvironmentVariable => environmentVariableName;
 }

--- a/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
@@ -29,16 +29,26 @@ public static class ParameterResourceBuilderExtensions
         }, secret: secret);
     }
 
-    internal static IResourceBuilder<ParameterResource> AddParameter(this IDistributedApplicationBuilder builder, string name, Func<string> callback, bool secret = false)
+    internal static IResourceBuilder<ParameterResource> AddParameter(this IDistributedApplicationBuilder builder,
+                                                                     string name,
+                                                                     Func<string> callback,
+                                                                     bool secret = false,
+                                                                     bool connectionString = false)
     {
         var resource = new ParameterResource(name, callback, secret);
         return builder.AddResource(resource)
-                      .WithManifestPublishingCallback(context => WriteParameterResourceToManifest(context, resource));
+                      .WithManifestPublishingCallback(context => WriteParameterResourceToManifest(context, resource, connectionString));
     }
 
-    private static void WriteParameterResourceToManifest(ManifestPublishingContext context, ParameterResource resource)
+    private static void WriteParameterResourceToManifest(ManifestPublishingContext context, ParameterResource resource, bool connectionString)
     {
         context.Writer.WriteString("type", "parameter.v0");
+
+        if (connectionString)
+        {
+            context.Writer.WriteString("connectionString", $"{{{resource.Name}.value}}");
+        }
+
         context.Writer.WriteString("value", $"{{{resource.Name}.inputs.value}}");
         context.Writer.WriteStartObject("inputs");
         context.Writer.WriteStartObject("value");
@@ -67,9 +77,34 @@ public static class ParameterResourceBuilderExtensions
         {
             return builder.Configuration.GetConnectionString(name) ?? throw new DistributedApplicationException($"Connection string parameter resource could not be used because connection string `{name}` is missing.");
         },
-        secret: true);
+        secret: true,
+        connectionString: true);
 
         var surrogate = new ResourceWithConnectionStringSurrogate(parameterBuilder.Resource, () => parameterBuilder.Resource.Value, environmentVariableName);
         return builder.CreateResourceBuilder(surrogate);
+    }
+
+    /// <summary>
+    /// Changes the resource to be published as a connection string reference in the manifest.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <returns>The configured <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> PublishAsConnectionString<T>(this IResourceBuilder<T> builder)
+        where T : ContainerResource, IResourceWithConnectionString
+    {
+        ConfigureConnectionStringManifestPublisher(builder);
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the manifest writer for this resource to be a parameter resource.
+    /// </summary>
+    /// <param name="builder">The <see cref="IResourceBuilder{T}"/>.</param>
+    public static void ConfigureConnectionStringManifestPublisher(IResourceBuilder<IResourceWithConnectionString> builder)
+    {
+        // Create a parameter resource that we use to write to the manifest
+        var parameter = new ParameterResource(builder.Resource.Name, () => "", secret: true);
+        builder.WithManifestPublishingCallback(context => WriteParameterResourceToManifest(context, parameter, connectionString: true));
     }
 }

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -359,7 +359,7 @@ public static class ResourceBuilderExtensions
     /// <param name="callback">Callback that modifies the endpoint.</param>
     /// <param name="createIfNotExists">Create endpoint if it does not exist.</param>
     /// <returns></returns>
-    public static IResourceBuilder<T> WithEndpoint<T>(this IResourceBuilder<T> builder, string endpointName, Action<EndpointAnnotation> callback, bool createIfNotExists = true) where T: IResourceWithEndpoints
+    public static IResourceBuilder<T> WithEndpoint<T>(this IResourceBuilder<T> builder, string endpointName, Action<EndpointAnnotation> callback, bool createIfNotExists = true) where T : IResourceWithEndpoints
     {
         var endpoint = builder.Resource.Annotations
             .OfType<EndpointAnnotation>()
@@ -530,11 +530,6 @@ public static class ResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<T> ExcludeFromManifest<T>(this IResourceBuilder<T> builder) where T : IResource
     {
-        foreach (var annotation in builder.Resource.Annotations.OfType<ManifestPublishingCallbackAnnotation>())
-        {
-            builder.Resource.Annotations.Remove(annotation);
-        }
-
         return builder.WithAnnotation(ManifestPublishingCallbackAnnotation.Ignore);
     }
 

--- a/tests/Aspire.Hosting.Tests/PublishAsConnnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsConnnectionStringTests.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Publishing;
+using System.Text.Json.Nodes;
+using System.Text.Json;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+public class PublishAsConnnectionStringTests
+{
+    [Fact]
+    public void PublishAsConnectionStringConfiguresManifestAsParameter()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var redis = builder.AddRedis("redis").PublishAsConnectionString();
+
+        Assert.True(redis.Resource.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var annotation));
+
+        var manifest = GetManifest(annotation.Callback!);
+
+        Assert.NotNull(manifest);
+        Assert.Equal("parameter.v0", manifest?["type"]?.ToString());
+        Assert.Equal("{redis.value}", manifest?["connectionString"]?.ToString());
+        Assert.Equal("{redis.inputs.value}", manifest?["value"]?.ToString());
+    }
+
+    private static JsonNode GetManifest(Action<ManifestPublishingContext> writeManifest)
+    {
+        using var ms = new MemoryStream();
+        var writer = new Utf8JsonWriter(ms);
+        writer.WriteStartObject();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        writeManifest(new ManifestPublishingContext(executionContext, Environment.CurrentDirectory, writer));
+        writer.WriteEndObject();
+        writer.Flush();
+        ms.Position = 0;
+        var obj = JsonNode.Parse(ms);
+        Assert.NotNull(obj);
+        return obj;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -369,7 +369,7 @@ public class WithReferenceTests
             annotation.Callback(context);
         }
 
-        Assert.Equal("{resource.value}", config["ConnectionStrings__resource"]);
+        Assert.Equal("{resource.connectionString}", config["ConnectionStrings__resource"]);
     }
 
     [Fact]
@@ -394,7 +394,7 @@ public class WithReferenceTests
             annotation.Callback(context);
         }
 
-        Assert.Equal("{resource.value}", config["MY_ENV"]);
+        Assert.Equal("{resource.connectionString}", config["MY_ENV"]);
     }
 
     [Fact]


### PR DESCRIPTION
Building on top of Parameter support, we can now add `PublishAsConnectionString`.

```C#
var redis = builder.AddRedis("cache").PublishAsConnectionString();

builder.AddProject<Projects.Api>("api");
           .WithReference(redis);
```

The above will use a container when running but will publish a parameter to the manifest. This is a short cut for the very common scenario:

```C#
var redis = builder.ExecutionContext.Operation switch
{
    DistributedApplicationOperation.Run => builder.AddRedis("redis"),
    _ => builder.AddConnectionString("redis")
};

builder.AddProject<Projects.Api>("api");
           .WithReference(redis);
```

Contributes to https://github.com/dotnet/aspire/issues/1960

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2052)