### PR TITLE
Fix missing uninstrumented peer icons in dashboard tracing for HTTP requests

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -103,7 +103,7 @@ public partial class TraceDetail : ComponentBase
             var labelIsRight = (relativeStart + span.Duration / 2) < (span.Trace.Duration / 2);
 
             // A span may indicate a call to another service but the service isn't instrumented.
-            var hasPeerService = span.Attributes.Any(a => a.Key == OtlpSpan.PeerServiceAttributeKey);
+            var hasPeerService = span.Attributes.HasKey(OtlpSpan.PeerServiceAttributeKey) || span.Attributes.HasKey(OtlpSpan.UrlFullAttributeKey);
             var isUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
             var uninstrumentedPeer = isUninstrumentedPeer ? ResolveUninstrumentedPeerName(span, state.OutgoingPeerResolvers) : null;
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -103,7 +103,7 @@ public partial class TraceDetail : ComponentBase
             var labelIsRight = (relativeStart + span.Duration / 2) < (span.Trace.Duration / 2);
 
             // A span may indicate a call to another service but the service isn't instrumented.
-            var hasPeerService = OtlpHelpers.GetPeerValue(span.Attributes) != null;
+            var hasPeerService = OtlpHelpers.GetPeerAddress(span.Attributes) != null;
             var isUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
             var uninstrumentedPeer = isUninstrumentedPeer ? ResolveUninstrumentedPeerName(span, state.OutgoingPeerResolvers) : null;
 
@@ -144,7 +144,7 @@ public partial class TraceDetail : ComponentBase
         }
 
         // Fallback to the peer address.
-        return OtlpHelpers.GetPeerValue(span.Attributes);
+        return OtlpHelpers.GetPeerAddress(span.Attributes);
     }
 
     protected override void OnParametersSet()

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -103,7 +103,7 @@ public partial class TraceDetail : ComponentBase
             var labelIsRight = (relativeStart + span.Duration / 2) < (span.Trace.Duration / 2);
 
             // A span may indicate a call to another service but the service isn't instrumented.
-            var hasPeerService = span.Attributes.HasKey(OtlpSpan.PeerServiceAttributeKey) || span.Attributes.HasKey(OtlpSpan.UrlFullAttributeKey);
+            var hasPeerService = OtlpHelpers.GetPeerValue(span.Attributes) != null;
             var isUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
             var uninstrumentedPeer = isUninstrumentedPeer ? ResolveUninstrumentedPeerName(span, state.OutgoingPeerResolvers) : null;
 
@@ -144,7 +144,7 @@ public partial class TraceDetail : ComponentBase
         }
 
         // Fallback to the peer address.
-        return OtlpHelpers.GetValue(span.Attributes, OtlpSpan.PeerServiceAttributeKey);
+        return OtlpHelpers.GetPeerValue(span.Attributes);
     }
 
     protected override void OnParametersSet()

--- a/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
@@ -33,7 +33,9 @@ public sealed class BrowserLinkOutgoingPeerResolver : IOutgoingPeerResolver
         // A long term improvement here is to add tags to the BrowserLink client and then detect the
         // values in the span's attributes.
         const string lastSegment = "getScriptTag";
-        var url = OtlpHelpers.GetValue(attributes, "http.url");
+
+        // url.full replaces http.url but look for both for backwards compatibility.
+        var url = OtlpHelpers.GetValue(attributes, "url.full") ?? OtlpHelpers.GetValue(attributes, "http.url");
 
         // Quick check of URL with EndsWith before more expensive Uri parsing.
         if (url != null && url.EndsWith(lastSegment, StringComparison.OrdinalIgnoreCase))

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -57,7 +57,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
 
     internal static bool TryResolvePeerNameCore(IDictionary<string, ResourceViewModel> resources, KeyValuePair<string, string>[] attributes, out string? name)
     {
-        var address = OtlpHelpers.GetValue(attributes, OtlpSpan.PeerServiceAttributeKey) ?? OtlpHelpers.GetValue(attributes, OtlpSpan.UrlFullAttributeKey);
+        var address = OtlpHelpers.GetPeerValue(attributes);
         if (address != null)
         {
             // Match exact value.

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -57,7 +57,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
 
     internal static bool TryResolvePeerNameCore(IDictionary<string, ResourceViewModel> resources, KeyValuePair<string, string>[] attributes, out string? name)
     {
-        var address = OtlpHelpers.GetValue(attributes, OtlpSpan.PeerServiceAttributeKey);
+        var address = OtlpHelpers.GetValue(attributes, OtlpSpan.PeerServiceAttributeKey) ?? OtlpHelpers.GetValue(attributes, OtlpSpan.UrlFullAttributeKey);
         if (address != null)
         {
             // Match exact value.

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -57,7 +57,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
 
     internal static bool TryResolvePeerNameCore(IDictionary<string, ResourceViewModel> resources, KeyValuePair<string, string>[] attributes, out string? name)
     {
-        var address = OtlpHelpers.GetPeerValue(attributes);
+        var address = OtlpHelpers.GetPeerAddress(attributes);
         if (address != null)
         {
             // Match exact value.

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -159,6 +159,37 @@ public static class OtlpHelpers
         return null;
     }
 
+    public static string? GetPeerValue(this KeyValuePair<string, string>[] values)
+    {
+        var address = GetValue(values, OtlpSpan.PeerServiceAttributeKey);
+        if (address != null)
+        {
+            return address;
+        }
+
+        // OTEL HTTP 1.7.0 doesn't return peer.service. Fallback to server.address and server.port.
+        if (GetValue(values, OtlpSpan.ServerAddressAttributeKey) is { } server)
+        {
+            if (GetValue(values, OtlpSpan.ServerPortAttributeKey) is { } serverPort)
+            {
+                server += ":" + serverPort;
+            }
+            return server;
+        }
+
+        // Fallback to older names of net.peer.name and net.peer.port.
+        if (GetValue(values, OtlpSpan.NetPeerNameAttributeKey) is { } peer)
+        {
+            if (GetValue(values, OtlpSpan.NetPeerPortAttributeKey) is { } peerPort)
+            {
+                peer += ":" + peerPort;
+            }
+            return peer;
+        }
+
+        return null;
+    }
+
     public static bool HasKey(this KeyValuePair<string, string>[] values, string name)
     {
         for (var i = 0; i < values.Length; i++)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -159,7 +159,7 @@ public static class OtlpHelpers
         return null;
     }
 
-    public static string? GetPeerValue(this KeyValuePair<string, string>[] values)
+    public static string? GetPeerAddress(this KeyValuePair<string, string>[] values)
     {
         var address = GetValue(values, OtlpSpan.PeerServiceAttributeKey);
         if (address != null)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -12,6 +12,7 @@ namespace Aspire.Dashboard.Otlp.Model;
 public class OtlpSpan
 {
     public const string PeerServiceAttributeKey = "peer.service";
+    public const string UrlFullAttributeKey = "url.full";
     public const string SpanKindAttributeKey = "span.kind";
 
     public string TraceId => Trace.TraceId;

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -13,6 +13,10 @@ public class OtlpSpan
 {
     public const string PeerServiceAttributeKey = "peer.service";
     public const string UrlFullAttributeKey = "url.full";
+    public const string ServerAddressAttributeKey = "server.address";
+    public const string ServerPortAttributeKey = "server.port";
+    public const string NetPeerNameAttributeKey = "net.peer.name";
+    public const string NetPeerPortAttributeKey = "net.peer.port";
     public const string SpanKindAttributeKey = "span.kind";
 
     public string TraceId => Trace.TraceId;

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -113,4 +113,18 @@ public class ResourceOutgoingPeerResolverTests
         Assert.True(ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, [KeyValuePair.Create("peer.service", "127.0.0.1,5000")], out var value));
         Assert.Equal("test", value);
     }
+
+    [Fact]
+    public void ServerAddressAndPort_Match()
+    {
+        // Arrange
+        var resources = new Dictionary<string, ResourceViewModel>
+        {
+            ["test"] = CreateResource("test", "localhost", 5000)
+        };
+
+        // Act & Assert
+        Assert.True(ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, [KeyValuePair.Create("server.address", "localhost"), KeyValuePair.Create("server.port", "5000")], out var value));
+        Assert.Equal("test", value);
+    }
 }


### PR DESCRIPTION
Uninstrumented peer was broken for HTTP requests by OTEL 1.7.0. Dependency was updated in https://github.com/dotnet/aspire/pull/2022.

The fix is to fallback to look for `server.address` attribute.

Issue created for OTEL: https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1761
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2079)