### PR TITLE
Adds Mongo Express 

### DIFF
--- a/playground/mongo/Mongo.ApiService/Mongo.ApiService.http
+++ b/playground/mongo/Mongo.ApiService/Mongo.ApiService.http
@@ -1,6 +1,7 @@
-@CosmosEndToEnd.ApiService_HostAddress = http://localhost:5301
+@ApiService_HostAddress = http://localhost:5301
 
-GET {{CosmosEndToEnd.ApiService_HostAddress}}/weatherforecast/
+GET {{ApiService_HostAddress}}/
 Accept: application/json
 
 ###
+

--- a/playground/mongo/Mongo.AppHost/Program.cs
+++ b/playground/mongo/Mongo.AppHost/Program.cs
@@ -3,7 +3,8 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var db = builder.AddMongoDB("mongo");
+var db = builder.AddMongoDBContainer("mongo")
+    .WithMongoExpress();
 
 builder.AddProject<Projects.Mongo_ApiService>("api")
        .WithReference(db);

--- a/src/Aspire.Hosting/MongoDB/MongoExpressContainerResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoExpressContainerResource.cs
@@ -4,9 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.MongoDB;
-internal sealed class MongoExpressContainerResource : ContainerResource
+internal sealed class MongoExpressContainerResource(string name) : ContainerResource(name)
 {
-    public MongoExpressContainerResource(string name) : base(name)
-    {
-    }
 }

--- a/src/Aspire.Hosting/MongoDB/MongoExpressContainerResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoExpressContainerResource.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.MongoDB;
+internal sealed class MongoExpressContainerResource : ContainerResource
+{
+    public MongoExpressContainerResource(string name) : base(name)
+    {
+    }
+}

--- a/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
+using Aspire.Hosting.MongoDB;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -95,5 +96,24 @@ public class AddMongoDBTests
         var connectionString = connectionStringResource.GetConnectionString();
 
         Assert.Equal("mongodb://localhost:27017/mydatabase", connectionString);
+    }
+
+    [Fact]
+    public void WithMongoExpressAddsContainer()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddMongoDB("mongo").WithMongoExpress();
+
+        Assert.Single(builder.Resources.OfType<MongoExpressContainerResource>());
+    }
+
+    [Fact]
+    public void WithMongoExpressOnMultipleResources()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddMongoDB("mongo").WithMongoExpress();
+        builder.AddMongoDB("mongo2").WithMongoExpress();
+
+        Assert.Equal(2, builder.Resources.OfType<MongoExpressContainerResource>().Count());
     }
 }

--- a/tests/Aspire.Hosting.Tests/MongoDB/MongoDBFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/MongoDBFunctionalTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.MongoDB;
 using Aspire.Hosting.Tests.Helpers;
 using Xunit;
 
@@ -29,24 +28,5 @@ public class MongoDBFunctionalTests
         var responseContent = await response.Content.ReadAsStringAsync();
 
         Assert.True(response.IsSuccessStatusCode, responseContent);
-    }
-
-    [Fact]
-    public void WithMongoExpressAddsContainer()
-    {
-        var builder = DistributedApplication.CreateBuilder();
-        builder.AddMongoDB("mongo").WithMongoExpress();
-
-        Assert.Single(builder.Resources.OfType<MongoExpressContainerResource>());
-    }
-
-    [Fact]
-    public void WithMongoExpressOnMultipleResources()
-    {
-        var builder = DistributedApplication.CreateBuilder();
-        builder.AddMongoDB("mongo").WithMongoExpress();
-        builder.AddMongoDB("mongo2").WithMongoExpress();
-
-        Assert.Equal(2, builder.Resources.OfType<MongoExpressContainerResource>().Count());
     }
 }

--- a/tests/Aspire.Hosting.Tests/MongoDB/MongoDBFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/MongoDBFunctionalTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.MongoDB;
 using Aspire.Hosting.Tests.Helpers;
 using Xunit;
 
@@ -28,5 +29,24 @@ public class MongoDBFunctionalTests
         var responseContent = await response.Content.ReadAsStringAsync();
 
         Assert.True(response.IsSuccessStatusCode, responseContent);
+    }
+
+    [Fact]
+    public void WithMongoExpressAddsContainer()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddMongoDB("mongo").WithMongoExpress();
+
+        Assert.Single(builder.Resources.OfType<MongoExpressContainerResource>());
+    }
+
+    [Fact]
+    public void WithMongoExpressOnMultipleResources()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.AddMongoDB("mongo").WithMongoExpress();
+        builder.AddMongoDB("mongo2").WithMongoExpress();
+
+        Assert.Equal(2, builder.Resources.OfType<MongoExpressContainerResource>().Count());
     }
 }


### PR DESCRIPTION
Addresses #1920 by adding `mongo-express` to the MongoDB extensions (with resource tests)

Some notes:
- Mongo Express cannot handle multiple hosts (https://github.com/mongo-express/mongo-express/issues/458) at this time so there is a diff express instance per mongodb instance (no shared admin)
- Basic auth is used on the admin portal using default creds for mongo-express (should this be configurable in the extension method?)
- Uses the endpoint port instead of the direct container port to handle reliable connection within the bridge docker network
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2091)