### PR TITLE
Revert http resilience upgrade

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,9 +29,9 @@
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
       <Sha>f23c6b82666380446b0b78993b88df03d5f29925</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="8.2.0-preview.24105.1">
+    <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="8.1.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>
-      <Sha>31f4d22bda2231ffa05d85e40208cc02170bf367</Sha>
+      <Sha>c63655a995fb1dfc8b8fd9cf149d5e6ad225a185</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,7 +24,7 @@
     <MicrosoftDotNetXUnitExtensionsPackageVersion>8.0.0-beta.24081.5</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftDotNetBuildTasksInstallersPackageVersion>8.0.0-beta.24081.5</MicrosoftDotNetBuildTasksInstallersPackageVersion>
     <MicrosoftDotNetBuildTasksWorkloadsPackageVersion>8.0.0-beta.24081.5</MicrosoftDotNetBuildTasksWorkloadsPackageVersion>
-    <MicrosoftExtensionsHttpResiliencePackageVersion>8.2.0-preview.24105.1</MicrosoftExtensionsHttpResiliencePackageVersion>
+    <MicrosoftExtensionsHttpResiliencePackageVersion>8.1.0</MicrosoftExtensionsHttpResiliencePackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>8.0.0</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
     <MicrosoftExtensionsConfigurationBinderPackageVersion>8.0.1</MicrosoftExtensionsConfigurationBinderPackageVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>8.0.0</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
@@ -112,6 +112,12 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
         services.AddHttpClient()
             .ConfigureHttpClientDefaults(b =>
             {
+                b.ConfigureHttpClient(client =>
+                {
+                    // Disable the HttpClient timeout to allow the timeout strategies to control the timeout.
+                    client.Timeout = Timeout.InfiniteTimeSpan;
+                });
+
                 b.UseSocketsHttpHandler((handler, sp) =>
                 {
                     handler.PooledConnectionLifetime = TimeSpan.FromSeconds(5);


### PR DESCRIPTION
There is a breaking change with Grpc clients in this version. See https://github.com/dotnet/extensions/issues/4924

```
InvalidOperationException: The ConfigureHttpClient method is not supported when creating gRPC clients. Unable to create client with name 'BasketClient'.
Grpc.Net.ClientFactory.Internal.GrpcCallInvokerFactory.CreateInvoker(EntryKey key)
System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>.GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
Grpc.Net.ClientFactory.Internal.GrpcCallInvokerFactory.CreateInvoker(string name, Type type)
Grpc.Net.ClientFactory.Internal.DefaultGrpcClientFactory.CreateClient<TClient>(string name)
Microsoft.Extensions.DependencyInjection.GrpcClientServiceExtensions+<>c__DisplayClass7_0<TClient>.<AddGrpcHttpClient>b__2(IServiceProvider s)
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor<TArgument, TResult>.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitDisposeCache(ServiceCallSite transientCallSite, RuntimeResolverContext context)
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor<TArgument, TResult>.VisitCallSite(ServiceCallSite callSite, TArgument argument)
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, RuntimeResolverContext context)
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor<TArgument, TResult>.VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitRootCache(ServiceCallSite callSite, RuntimeResolverContext context)
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteVisitor<TArgument, TResult>.VisitCallSite(ServiceCallSite callSite, TArgument argument)
Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.Resolve(ServiceCallSite callSite, ServiceProviderEngineScope scope)
Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>.GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.GetService(Type serviceType)
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2107)