### PR TITLE
Fix mapping internal span kind

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -518,13 +518,14 @@ public class TelemetryRepository
         };
     }
 
-    private static OtlpSpanKind ConvertSpanKind(SpanKind? kind)
+    internal static OtlpSpanKind ConvertSpanKind(SpanKind? kind)
     {
         return kind switch
         {
             // Unspecified to Internal is intentional.
             // "Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED."
             SpanKind.Unspecified => OtlpSpanKind.Internal,
+            SpanKind.Internal => OtlpSpanKind.Internal,
             SpanKind.Client => OtlpSpanKind.Client,
             SpanKind.Server => OtlpSpanKind.Server,
             SpanKind.Producer => OtlpSpanKind.Producer,

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -15,6 +15,19 @@ public class TraceTests
 {
     private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
+    [Theory]
+    [InlineData(OtlpSpanKind.Server, Span.Types.SpanKind.Server)]
+    [InlineData(OtlpSpanKind.Client, Span.Types.SpanKind.Client)]
+    [InlineData(OtlpSpanKind.Consumer, Span.Types.SpanKind.Consumer)]
+    [InlineData(OtlpSpanKind.Producer, Span.Types.SpanKind.Producer)]
+    [InlineData(OtlpSpanKind.Internal, Span.Types.SpanKind.Internal)]
+    [InlineData(OtlpSpanKind.Internal, Span.Types.SpanKind.Unspecified)]
+    public void ConvertSpanKind(OtlpSpanKind expected, Span.Types.SpanKind value)
+    {
+        var result = TelemetryRepository.ConvertSpanKind(value);
+        Assert.Equal(expected, result);
+    }
+
     [Fact]
     public void AddTraces()
     {

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -22,6 +22,7 @@ public class TraceTests
     [InlineData(OtlpSpanKind.Producer, Span.Types.SpanKind.Producer)]
     [InlineData(OtlpSpanKind.Internal, Span.Types.SpanKind.Internal)]
     [InlineData(OtlpSpanKind.Internal, Span.Types.SpanKind.Unspecified)]
+    [InlineData(OtlpSpanKind.Unspecified, (Span.Types.SpanKind)1000)]
     public void ConvertSpanKind(OtlpSpanKind expected, Span.Types.SpanKind value)
     {
         var result = TelemetryRepository.ConvertSpanKind(value);


### PR DESCRIPTION
Trace service was incorrectly mapping Internal to Unspecified. Fix so that Internal maps to Internal.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2112)