### PR TITLE
Add connection security to dashboard OTLP

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Security/IOtlpConnectionFeature.cs
+++ b/src/Aspire.Dashboard/Otlp/Security/IOtlpConnectionFeature.cs
@@ -1,9 +1,11 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Dashboard.Otlp.Security;
 
+/// <summary>
+/// This feature's presence on a connection indicates that the connection is for OTLP.
+/// </summary>
 internal interface IOtlpConnectionFeature
 {
-
 }

--- a/src/Aspire.Dashboard/Otlp/Security/IOtlpConnectionFeature.cs
+++ b/src/Aspire.Dashboard/Otlp/Security/IOtlpConnectionFeature.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Otlp.Security;
+
+internal interface IOtlpConnectionFeature
+{
+
+}

--- a/src/Aspire.Dashboard/Otlp/Security/ListenOptionsOtlpExtensions.cs
+++ b/src/Aspire.Dashboard/Otlp/Security/ListenOptionsOtlpExtensions.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+
+namespace Aspire.Dashboard.Otlp.Security;
+
+internal static class ListenOptionsOtlpExtensions
+{
+    public static void UseOtlpConnection(this ListenOptions listenOptions)
+    {
+        listenOptions.Use(next => new OtlpConnectionMiddleware(next).OnConnectionAsync);
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Security/OtlpConnectionMiddleware.cs
+++ b/src/Aspire.Dashboard/Otlp/Security/OtlpConnectionMiddleware.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Connections;
+
+namespace Aspire.Dashboard.Otlp.Security;
+
+/// <summary>
+/// This connection middleware registers an OTLP feature on the connection.
+/// OTLP services check for this feature when authorizing incoming requests to
+/// ensure OTLP is only available on specified connections.
+/// </summary>
+internal sealed class OtlpConnectionMiddleware
+{
+    private readonly ConnectionDelegate _next;
+
+    public OtlpConnectionMiddleware(ConnectionDelegate next)
+    {
+        _next = next ?? throw new ArgumentNullException(nameof(next));
+    }
+
+    public async Task OnConnectionAsync(ConnectionContext context)
+    {
+        context.Features.Set<IOtlpConnectionFeature>(new OtlpConnectionFeature());
+        await _next(context).ConfigureAwait(false);
+    }
+
+    private sealed class OtlpConnectionFeature : IOtlpConnectionFeature
+    {
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Security/OtlpInterceptor.cs
+++ b/src/Aspire.Dashboard/Otlp/Security/OtlpInterceptor.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
+namespace Aspire.Dashboard.Otlp.Security;
+
+internal sealed class OtlpInterceptor : Interceptor
+{
+    // Only need to override the UnaryServerHandler method, as the other method types are not used by OTLP.
+    public override Task<TResponse> UnaryServerHandler<TRequest, TResponse>(TRequest request, ServerCallContext context, UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        var httpContext = context.GetHttpContext();
+        if (httpContext.Features.Get<IOtlpConnectionFeature>() == null)
+        {
+            throw new RpcException(new Status(StatusCode.PermissionDenied, "OTLP is not enabled on this connection."));
+        }
+
+        return base.UnaryServerHandler(request, context, continuation);
+    }
+}


### PR DESCRIPTION
This PR ensures that only requests on the OTLP endpoint are allowed to call OTLP services. It adds:

* Connection middleware that registers a feature.
* Adds connection middleware to the OTLP endpoint.
* A gRPC interceptor that looks for the feature and rejects the request if it is missing.

I chose this approach over using host headers or compare the connection's local endpoint to the configured address. Connection middleware + feature feels very safe because there's no dependency on OTLP endpoint address configuration.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2114)