### PR TITLE
Fix build error on UpdateConfigurationSchema

### DIFF
--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -98,7 +98,8 @@
   </Target>
 
   <Target Name="CopyNewConfigurationSchema"
-          Condition="'$(ConfigurationSchemaExists)' != 'true' OR '$(UpdateConfigurationSchema)' == 'true'">
+          Condition="('$(ConfigurationSchemaExists)' != 'true' OR '$(UpdateConfigurationSchema)' == 'true')
+                     AND Exists('$(GeneratedConfigurationSchemaOutputPath)')">
 
     <Copy SourceFiles="$(GeneratedConfigurationSchemaOutputPath)"
           DestinationFiles="$(ConfigurationSchemaPath)" />


### PR DESCRIPTION
When a component doesn't use the ConfigurationSchemaGenerator (like Confluent.Kafka does), building with /p:UpdateConfigurationSchema=true causes a build error.

The fix is to check if the output file exists before trying to copy it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2124)