### PR TITLE
Show OLTP timestamps using user's time format preferences

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
@@ -13,8 +14,27 @@ using OpenTelemetry.Proto.Resource.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
 
-public static class OtlpHelpers
+public static partial class OtlpHelpers
 {
+    private static readonly string s_longTimePatternWithMilliseconds = GetLongTimePatternWithMilliseconds();
+
+    static string GetLongTimePatternWithMilliseconds()
+    {
+        // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
+
+        // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
+        var longTimePattern = DateTimeFormatInfo.CurrentInfo.LongTimePattern;
+
+        // Create a format similar to .fff but based on the current culture.
+        var millisecondFormat = $"{NumberFormatInfo.CurrentInfo.NumberDecimalSeparator}fff";
+
+        // Append millisecond pattern to current culture's long time pattern.
+        return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1{millisecondFormat}");
+    }
+
+    [GeneratedRegex("(:ss|:s)")]
+    private static partial Regex MatchSecondsInTimeFormatPattern();
+
     public static string? GetServiceId(this Resource resource)
     {
         string? serviceName = null;
@@ -44,7 +64,7 @@ public static class OtlpHelpers
 
     public static string FormatTimeStamp(DateTime timestamp)
     {
-        return timestamp.ToLocalTime().ToString("h:mm:ss.fff tt", CultureInfo.CurrentCulture);
+        return timestamp.ToLocalTime().ToString(s_longTimePatternWithMilliseconds, CultureInfo.CurrentCulture);
     }
 
     public static string ToHexString(ReadOnlyMemory<byte> bytes)


### PR DESCRIPTION
Fixes #1551

We want to show certain timestamps with millisecond-level precision, however there's no built-in format that respects the user's time formatting preferences while also showing milliseconds. Microsoft docs provided the approach taken here, which uses the user's default pattern (which comes from the machines culture and may be overridden by the user at the system level), and modifies it to append milliseconds after the seconds. It respects the user's preference for decimal separators too.

## Resources view

![image](https://github.com/dotnet/aspire/assets/350947/3e3e5aad-2fd6-42ea-a654-d48852ea781f)

## Structured logs

![image](https://github.com/dotnet/aspire/assets/350947/f18ca763-7e46-41ed-8a33-edc038b988b4)

## Traces

![image](https://github.com/dotnet/aspire/assets/350947/b1b0b18c-45b6-4257-b272-e3b91055fe53)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2135)