### PR TITLE
Only build manifest when building in VMR in general

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,11 +1,11 @@
 <Project>
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true' and '$(DotNetBuildSourceOnly)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true' and '$(DotNetBuild)' != 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\**\*.csproj" Exclude="$(RepoRoot)src\Aspire.ProjectTemplates\templates\**\*.csproj" />
     <ProjectToBuild Include="$(RepoRoot)tests\**\*.csproj"  />
     <ProjectToBuild Include="$(RepoRoot)samples\**\*.csproj" />
   </ItemGroup>
   <!-- If we are building for SourceBuild, then we only want to build the Aspire manifest package -->
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' or '$(DotNetBuildSourceOnly)' == 'true'">
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' or '$(DotNetBuild)' == 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\Microsoft.NET.Sdk.Aspire\Microsoft.NET.Sdk.Aspire.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
No need to build anything but the SDK manifest asset when building in VMR mode.