### PR TITLE
Fix mysql playground build break

### DIFF
--- a/playground/mysql/MySqlDb.AppHost/Program.cs
+++ b/playground/mysql/MySqlDb.AppHost/Program.cs
@@ -4,7 +4,7 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var catalogDbName = "catalog"; // MySql database & table names are case-sensitive on non-Windows.
-var catalogDb = builder.AddMySqlContainer("mysql")
+var catalogDb = builder.AddMySql("mysql")
     .WithEnvironment("MYSQL_DATABASE", catalogDbName)
     .WithVolumeMount("../MySql.ApiService/data", "/docker-entrypoint-initdb.d", VolumeMountType.Bind)
     .WithPhpMyAdmin()


### PR DESCRIPTION
It looks like #2127 changed the mysql extension methods, but didn't update the playground app that used it, leading to a build break. I guess CI doesn't build the playground apps so this wasn't caught?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2143)