### PR TITLE
Theme the scrollbars in dark theme, and refactor theming support

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -37,43 +37,9 @@ public partial class MainLayout : IDisposable
             {
                 var newValue = ThemeManager.Theme!;
 
-                var newLuminanceValue = await GetBaseLayerLuminanceForSetting(newValue);
-
-                await _jsModule.InvokeVoidAsync("setDefaultBaseLayerLuminance", newLuminanceValue);
-                await _jsModule.InvokeVoidAsync("setThemeCookie", newValue);
-                await _jsModule.InvokeVoidAsync("setThemeOnDocument", newValue);
+                await _jsModule.InvokeVoidAsync("updateTheme", newValue);
             }
         });
-    }
-
-    private Task<float> GetBaseLayerLuminanceForSetting(string setting)
-    {
-        if (setting == ThemeManager.ThemeSettingLight)
-        {
-            return Task.FromResult(ThemeManager.LightThemeLuminance);
-        }
-        else if (setting == ThemeManager.ThemeSettingDark)
-        {
-            return Task.FromResult(ThemeManager.DarkThemeLuminance);
-        }
-        else // "System"
-        {
-            return GetSystemThemeLuminance();
-        }
-    }
-
-    private async Task<float> GetSystemThemeLuminance()
-    {
-        if (_jsModule is not null)
-        {
-            var systemTheme = await _jsModule.InvokeAsync<string>("getSystemTheme");
-            if (systemTheme == ThemeManager.ThemeSettingDark)
-            {
-                return ThemeManager.DarkThemeLuminance;
-            }
-        }
-
-        return ThemeManager.LightThemeLuminance;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/src/Aspire.Dashboard/Model/ThemeManager.cs
+++ b/src/Aspire.Dashboard/Model/ThemeManager.cs
@@ -5,8 +5,6 @@ namespace Aspire.Dashboard.Model;
 
 public sealed class ThemeManager
 {
-    public const float DarkThemeLuminance = 0.19f;
-    public const float LightThemeLuminance = 1.0f;
     public const string ThemeSettingSystem = "System";
     public const string ThemeSettingDark = "Dark";
     public const string ThemeSettingLight = "Light";

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -52,6 +52,12 @@ fluent-toolbar[orientation=horizontal] {
     --error-ui-accent-foreground-color: #512bd4;
     --reconnection-ui-bg: #D6D6D6;
     --error-counter-badge-foreground-color: #ffffff;
+
+    color-scheme: dark;
+}
+
+[data-theme="light"] {
+    color-scheme: light;
 }
 
  #components-reconnect-modal :is(h5, p) {

--- a/src/Aspire.Dashboard/wwwroot/js/theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/theme.js
@@ -14,10 +14,29 @@ const darkThemeLuminance = 0.19;
 const lightThemeLuminance = 1.0;
 
 /**
+ * Updates the current theme on the site based on the specified theme
+ * @param {string} specifiedTheme
+ */
+export function updateTheme(specifiedTheme) {
+    const effectiveTheme = getEffectiveTheme(specifiedTheme);
+
+    applyTheme(effectiveTheme);
+    setThemeCookie(specifiedTheme);
+}
+
+/**
+ * Returns the value of the currentTheme cookie, or System if the cookie is not set.
+ * @returns {string}
+ */
+export function getThemeCookieValue() {
+    return getCookieValue(currentThemeCookieName) ?? themeSettingSystem;
+}
+
+/**
  * Returns the current system theme (Light or Dark)
  * @returns {string}
  */
-export function getSystemTheme() {
+function getSystemTheme() {
     let matched = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
     if (matched) {
@@ -31,19 +50,15 @@ export function getSystemTheme() {
  * Sets the currentTheme cookie to the specified value.
  * @param {string} theme
  */
-export function setThemeCookie(theme) {
+function setThemeCookie(theme) {
     document.cookie = `${currentThemeCookieName}=${theme}`;
 }
 
 /**
  * Sets the document data-theme attribute to the specified value.
- * @param {string} theme
+ * @param {string} theme The theme to set. Should be Light or Dark.
  */
-export function setThemeOnDocument(theme) {
-
-    if (!theme || theme === themeSettingSystem) {
-        theme = getSystemTheme();
-    }
+function setThemeOnDocument(theme) {
 
     if (theme === themeSettingDark) {
         document.documentElement.setAttribute('data-theme', 'dark');
@@ -53,15 +68,12 @@ export function setThemeOnDocument(theme) {
 }
 
 /**
- * Returns the value of the currentTheme cookie, or System if the cookie is not set.
- * @returns {string}
+ * 
+ * @param {string} theme The theme to use. Should be Light or Dark.
  */
-export function getThemeCookieValue() {
-    return getCookieValue(currentThemeCookieName) ?? themeSettingSystem;
-}
-
-export function setDefaultBaseLayerLuminance(value) {
-    baseLayerLuminance.withDefault(value);
+function setBaseLayerLuminance(theme) {
+    const baseLayerLuminanceValue = getBaseLayerLuminanceForTheme(theme);
+    baseLayerLuminance.withDefault(baseLayerLuminanceValue);
 }
 
 /**
@@ -83,23 +95,37 @@ function getCookieValue(cookieName) {
     return "";
 }
 
-function setInitialBaseLayerLuminance() {
-    let theme = getThemeCookieValue();
-
-    if (!theme || theme === themeSettingSystem) {
-        theme = getSystemTheme();
+/**
+ * Converts a setting value for the theme (Light, Dark, System or null/empty) into the effective theme that should be applied
+ * @param {string} specifiedTheme The setting value to use to determine the effective theme. Anything other than Light or Dark will be treated as System
+ * @returns {string} The actual theme to use based on the supplied setting. Will be either Light or Dark.
+ */
+function getEffectiveTheme(specifiedTheme) {
+    if (specifiedTheme === themeSettingLight ||
+        specifiedTheme === themeSettingDark) {
+        return specifiedTheme;
+    } else {
+        return getSystemTheme();
     }
-
-    if (theme === themeSettingDark) {
-        baseLayerLuminance.withDefault(darkThemeLuminance);
-    } else /* Light */ {
-        baseLayerLuminance.withDefault(lightThemeLuminance);
-    }
-
-    setThemeOnDocument(theme);
 }
 
-function setInitialAccentColor() {
+/**
+ * 
+ * @param {string} theme The theme to use. Should be Light or Dark
+ * @returns {string}
+ */
+function getBaseLayerLuminanceForTheme(theme) {
+    if (theme === themeSettingDark) {
+        return darkThemeLuminance;
+    } else /* Light */ {
+        return lightThemeLuminance;
+    }
+}
+
+/**
+ * Configures the accent color palette based on the .NET purple
+ */
+function setAccentColor() {
     // Convert the base color ourselves to avoid pulling in the
     // @microsoft/fast-colors library just for one call to parseColorHexRGB
     const baseColor = { // #512BD4
@@ -112,6 +138,9 @@ function setInitialAccentColor() {
     accentBaseColor.withDefault(accentBase);
 }
 
+/**
+ * Configures the default background color to use for the body
+ */
 function setFillColor() {
     // Design specs say we should use --neutral-layer-2 as the fill color
     // for the body. Most of the web components use --fill-color as their
@@ -120,6 +149,22 @@ function setFillColor() {
     fillColor.setValueFor(document.body, neutralLayerL2);
 }
 
-setInitialBaseLayerLuminance();
-setInitialAccentColor();
-setFillColor();
+/**
+ * Applies the Light or Dark theme to the entire site
+ * @param {string} theme The theme to use. Should be Light or Dark
+ */
+function applyTheme(theme) {
+    setBaseLayerLuminance(theme);
+    setAccentColor();
+    setFillColor();
+    setThemeOnDocument(theme);
+}
+
+function initializeTheme() {
+    const themeCookieValue = getThemeCookieValue();
+    const effectiveTheme = getEffectiveTheme(themeCookieValue);
+
+    applyTheme(effectiveTheme);
+}
+
+initializeTheme();


### PR DESCRIPTION
@drewnoakes had wondered in #1882 if we could change the scrollbar theming to match our theming. I finally got around to doing that.

I also refactored some of the theming support generally now that things have mostly stabilized - was able to remove a bit of code on the C# side and get rid of several of the exports on the JS side, while consolidating the "initial" and "update" theming setups. Added a few more doc comments as well.

Before:
![ThemedScrollbars-Dark-Before](https://github.com/dotnet/aspire/assets/9613109/12cbe936-492a-49a8-98fd-f2aa287119d3)

After:
![ThemedScrollbars-Dark](https://github.com/dotnet/aspire/assets/9613109/10e4352d-aa82-477f-a9a6-3ea424dcdb05)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2145)