### PR TITLE
Display "start time" in local time, not UTC, and omit date if today

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -48,7 +48,7 @@
                         OnDismiss="() => ClearSelectedResource()"
                         ViewKey="ResourcesList">
         <Summary>
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1.25fr 2fr 2.5fr 2fr 1fr 1fr" RowClass="GetRowClass">
+            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr" RowClass="GetRowClass">
                 <ChildContent>
                     <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" />
                     <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort">
@@ -57,7 +57,9 @@
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort">
                         <StateColumnDisplay Resource="@context" UnviewedErrorCounts ="@_applicationUnviewedErrorCounts" />
                     </TemplateColumn>
-                    <PropertyColumn Property="@(c => c.CreationTimeStamp)" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" Tooltip="true" />
+                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" Tooltip="true">
+                        <StartTimeColumnDisplay Resource="@context" />
+                    </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]">
                         <SourceColumnDisplay Resource="context" FilterText="@_filter" />
                     </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -80,6 +80,7 @@ public partial class Resources : ComponentBase, IDisposable
 
     private readonly GridSort<ResourceViewModel> _nameSort = GridSort<ResourceViewModel>.ByAscending(p => p.Name);
     private readonly GridSort<ResourceViewModel> _stateSort = GridSort<ResourceViewModel>.ByAscending(p => p.State);
+    private readonly GridSort<ResourceViewModel> _startTimeSort = GridSort<ResourceViewModel>.ByDescending(p => p.CreationTimeStamp);
 
     protected override void OnInitialized()
     {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
@@ -1,0 +1,24 @@
+﻿@using Aspire.Dashboard.Model
+@using Aspire.Dashboard.Resources
+@using System.Globalization
+
+@if (Resource.CreationTimeStamp is not null)
+{
+    var localTime = Resource.CreationTimeStamp.Value.ToLocalTime();
+
+    if (localTime.Date == DateTime.Now.Date)
+    {
+        // e.g. "08:57:44" (based on user's culture and preferences)
+        @localTime.TimeOfDay.ToString()
+    }
+    else
+    {
+        // e.g. "9/02/2024 08:57:44" (based on user's culture and preferences)
+        @localTime.ToString(CultureInfo.CurrentCulture)
+    }
+}
+
+@code {
+    [Parameter, EditorRequired]
+    public required ResourceViewModel Resource { get; set; }
+}


### PR DESCRIPTION
Fixes #2150
Fixes #2149

This PR makes two functional changes:

- #2150
- #2149

## Before

![image](https://github.com/dotnet/aspire/assets/350947/df8ef1de-6730-4e67-acad-37c95dfffc1e)

## After

![image](https://github.com/dotnet/aspire/assets/350947/fd180979-153d-42b3-bb0c-1b06a37e69a6)

> [!NOTE]
> If these resources had started yesterday, the date would be displayed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2152)