### PR TITLE
Use standard otel properties for rabbitmq logs

### DIFF
--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
@@ -154,7 +154,7 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
                     return index switch
                     {
                         1 => new("exception.type", exData["Type"]),
-                        2 => new("exception.message", exData["Message"] ),
+                        2 => new("exception.message", exData["Message"]),
                         3 => new("exception.stacktrace", exData["StackTrace"]),
                         4 => new("exception.innerexception", exData["InnerException"]),
                         _ => throw new UnreachableException()

--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
@@ -153,12 +153,26 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
 
                     return index switch
                     {
-                        1 => new("ex.Type", exData["Type"]),
-                        2 => new("ex.Message", exData["Message"]),
-                        3 => new("ex.StackTrace", exData["StackTrace"]),
-                        4 => new("ex.InnerException", exData["InnerException"]),
+                        1 => new("exception.type", exData["Type"]),
+                        2 => new("exception.message", exData["Message"] is string message ? GetRabbitMQExceptionMessage(message) : null),
+                        3 => new("exception.stacktrace", exData["StackTrace"] is string { Length: 0 } && exData["Message"] is string message ? GetRabbitMQExceptionStackTrace(message) : exData["StackTrace"]),
+                        4 => new("exception.innerexception", exData["InnerException"]),
                         _ => throw new UnreachableException()
                     };
+
+                    string GetRabbitMQExceptionMessage(string rawMessage)
+                    {
+                        // rabbitmq message contains both message + stack trace. only take the first line
+                        var firstNewLineIndex = rawMessage.IndexOf(Environment.NewLine, StringComparison.Ordinal);
+                        return firstNewLineIndex is -1 ? rawMessage : rawMessage[..firstNewLineIndex];
+                    }
+
+                    string? GetRabbitMQExceptionStackTrace(string rawMessage)
+                    {
+                        // rabbitmq message contains both message + stack trace. only take subsequent lines
+                        var firstNewLineIndex = rawMessage.IndexOf(Environment.NewLine, StringComparison.Ordinal);
+                        return firstNewLineIndex is -1 || firstNewLineIndex == rawMessage.Length - Environment.NewLine.Length ? null : rawMessage[(firstNewLineIndex + Environment.NewLine.Length)..];
+                    }
                 }
             }
         }

--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
@@ -154,25 +154,11 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
                     return index switch
                     {
                         1 => new("exception.type", exData["Type"]),
-                        2 => new("exception.message", exData["Message"] is string message ? GetRabbitMQExceptionMessage(message) : null),
-                        3 => new("exception.stacktrace", exData["StackTrace"] is string { Length: 0 } && exData["Message"] is string message ? GetRabbitMQExceptionStackTrace(message) : exData["StackTrace"]),
+                        2 => new("exception.message", exData["Message"] ),
+                        3 => new("exception.stacktrace", exData["StackTrace"]),
                         4 => new("exception.innerexception", exData["InnerException"]),
                         _ => throw new UnreachableException()
                     };
-
-                    string GetRabbitMQExceptionMessage(string rawMessage)
-                    {
-                        // rabbitmq message contains both message + stack trace. only take the first line
-                        var firstNewLineIndex = rawMessage.IndexOf(Environment.NewLine, StringComparison.Ordinal);
-                        return firstNewLineIndex is -1 ? rawMessage : rawMessage[..firstNewLineIndex];
-                    }
-
-                    string? GetRabbitMQExceptionStackTrace(string rawMessage)
-                    {
-                        // rabbitmq message contains both message + stack trace. only take subsequent lines
-                        var firstNewLineIndex = rawMessage.IndexOf(Environment.NewLine, StringComparison.Ordinal);
-                        return firstNewLineIndex is -1 || firstNewLineIndex == rawMessage.Length - Environment.NewLine.Length ? null : rawMessage[(firstNewLineIndex + Environment.NewLine.Length)..];
-                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #2118. Uses standard otel properties (exception.message, exception.stacktrace, etc) for RabbitMQ logs. 

Also, when the exception message that rabbitmq returns contains both the message and stacktrace and the actual stacktrace property is empty, parses the Message (exception.message is the first line, exception.stacktrace all subsequent lines) to return the proper value for exception.message / exception.stacktrace.

![image](https://github.com/dotnet/aspire/assets/20359921/a4fd12ae-86d3-41af-954e-84c11491c17c)
