### PR TITLE
Remove inner tooltip in exception info tooltip

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
@@ -36,7 +36,6 @@
                     <FluentIcon Class="copy-icon align-text-bottom" Style="display:inline;" Icon="Icons.Regular.Size16.Copy"/>
                     <FluentIcon Class="checkmark-icon align-text-bottom" Style="display:none;" Icon="Icons.Regular.Size16.Checkmark"/>
                 </FluentButton>
-                <FluentTooltip Anchor="@copyButtonId" Position="TooltipPosition.Top">@ControlsStringsLoc[nameof(ControlsStrings.GridValueCopyToClipboard)]</FluentTooltip>
             </div>
         </div>
     </FluentTooltip>

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -63,19 +63,27 @@ window.copyTextToClipboard = function (id, text, precopy, postcopy) {
 
     const copyIcon = button.querySelector('.copy-icon');
     const checkmarkIcon = button.querySelector('.checkmark-icon');
-    const tooltipDiv = document.querySelector(`fluent-tooltip[anchor="${id}"]`).children[0];
+    const anchoredTooltip = document.querySelector(`fluent-tooltip[anchor="${id}"]`);
+    const tooltipDiv = anchoredTooltip ? anchoredTooltip.children[0] : null;
     navigator.clipboard.writeText(text)
         .then(() => {
-            tooltipDiv.innerText = postcopy;
+            if (tooltipDiv) {
+                tooltipDiv.innerText = postcopy;
+            }
             copyIcon.style.display = 'none';
             checkmarkIcon.style.display = 'inline';
         })
         .catch(() => {
-            tooltipDiv.innerText = 'Could not access clipboard';
+            if (tooltipDiv) {
+                tooltipDiv.innerText = 'Could not access clipboard';
+            }
         });
 
     button.dataset.copyTimeout = setTimeout(function () {
-        tooltipDiv.innerText = precopy;
+        if (tooltipDiv) {
+            tooltipDiv.innerText = precopy;
+        }
+
         copyIcon.style.display = 'inline';
         checkmarkIcon.style.display = 'none';
         delete button.dataset.copyTimeout;


### PR DESCRIPTION
Fixes #2146 (note: this only repros sometimes?) - previously, `window.copyTextToClipboard` had required a tooltip reference to update text of - which isn't really necessary here as we are already in a tooltip, especially because the copy/checkmark already indicate to the user that the text has been copied.

Makes the tooltip optional in `window.copyTextToClipboard`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2158)