### PR TITLE
Fix RabbitMQ StackTrace tag

### DIFF
--- a/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
@@ -172,7 +172,7 @@ public static class AspireRabbitMQExtensions
                 if (connectAttemptActivity is not null)
                 {
                     connectAttemptActivity.AddTag("exception.message", ex.Message);
-                    connectAttemptActivity.AddTag("exception.stacktrace", ex.ToString());
+                    connectAttemptActivity.AddTag("exception.stacktrace", ex.StackTrace);
                     connectAttemptActivity.AddTag("exception.type", ex.GetType().FullName);
                     connectAttemptActivity.SetStatus(ActivityStatusCode.Error);
                 }

--- a/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
@@ -172,7 +172,10 @@ public static class AspireRabbitMQExtensions
                 if (connectAttemptActivity is not null)
                 {
                     connectAttemptActivity.AddTag("exception.message", ex.Message);
-                    connectAttemptActivity.AddTag("exception.stacktrace", ex.StackTrace);
+                    // Note that "exception.stacktrace" is the full exception detail, not just the StackTrace property. 
+                    // See https://opentelemetry.io/docs/specs/semconv/attributes-registry/exception/
+                    // and https://github.com/open-telemetry/opentelemetry-specification/pull/697#discussion_r453662519
+                    connectAttemptActivity.AddTag("exception.stacktrace", ex.ToString());
                     connectAttemptActivity.AddTag("exception.type", ex.GetType().FullName);
                     connectAttemptActivity.SetStatus(ActivityStatusCode.Error);
                 }


### PR DESCRIPTION
We are logging the full exception.ToString() in the exception.stacktrace tag.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2163)