### PR TITLE
Remove unnecessary link in Aspire.Hosting.Orleans

### DIFF
--- a/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
+++ b/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
@@ -11,10 +11,4 @@
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\Components\Aspire.Microsoft.Orleans.Server\Shared\**\*.*">
-      <Link>Shared\%(RecursiveDir)%(FileName)%(Extension)</Link>
-    </Compile>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This folder doesn't exist.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2164)