### PR TITLE
[ci] Use .Open helix queues only for public builds

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -40,9 +40,15 @@ steps:
         HelixProjectArguments: /p:RunWithCodeCoverage=true /p:RepoTestResultsPath=${{ parameters.repoTestResultsPath }}
 
         ${{ if eq(parameters.isWindows, 'true') }}:
-          HelixTargetQueues: Windows.11.Amd64.Client.Open
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            HelixTargetQueues: Windows.11.Amd64.Client.Open
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            HelixTargetQueues: Windows.11.Amd64.Client
         ${{ if ne(parameters.isWindows, 'true') }}:
-          HelixTargetQueues: Ubuntu.2204.Amd64.Open
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
+            HelixTargetQueues: Ubuntu.2204.Amd64.Open
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            HelixTargetQueues: Ubuntu.2204.Amd64
 
         IsWindows: ${{ parameters.isWindows }}
         Creator: $(Build.DefinitionName)

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -51,7 +51,8 @@ steps:
             HelixTargetQueues: Ubuntu.2204.Amd64
 
         IsWindows: ${{ parameters.isWindows }}
-        Creator: $(Build.DefinitionName)
+        ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          Creator: $(Build.DefinitionName)
         HelixBuild: $(Build.BuildNumber)
         HelixAccessToken: $(HelixApiAccessToken)
 


### PR DESCRIPTION
Fixes internal pipeline build.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2166)