### PR TITLE
Improvements to structured logs error tooltip

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
@@ -28,7 +28,7 @@
 
     <FluentTooltip Anchor="@iconId" MaxWidth="650px">
         <div style="padding: 10px">
-            <h3>@Loc[nameof(Columns.LogMessageColumnExceptionDetailsTitle)]</h3>
+            <h4>@Loc[nameof(Columns.LogMessageColumnExceptionDetailsTitle)]</h4>
 
             <pre style="white-space: pre-wrap; overflow-wrap: break-word; max-height: 300px; overflow: auto;">@errorInfo</pre>
 

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
@@ -11,7 +11,14 @@
 @if (TryGetErrorInformation(out var errorInfo))
 {
     var iconId = Guid.NewGuid().ToString();
-    <FluentIcon Title="@Loc[nameof(Columns.LogMessageColumnExceptionDetailsTitle)]"
+
+    @*
+        We don't want a browser tooltip to display when hovering over the error icon.
+        Use alt instead of title for screen readers. Also, the column has a title set
+        so add a whitespace title to prevent a browser tooltip from displaying.
+    *@
+    <FluentIcon alt="@Loc[nameof(Columns.LogMessageColumnExceptionDetailsTitle)]"
+                title=" "
                 Id="@iconId"
                 Icon="Icons.Filled.Size16.DocumentError"
                 Color="Color.Accent"
@@ -23,7 +30,7 @@
         <div style="padding: 10px">
             <h3>@Loc[nameof(Columns.LogMessageColumnExceptionDetailsTitle)]</h3>
 
-            <pre style="white-space: pre-wrap; overflow-wrap: break-word; max-height: 400px; overflow: auto;">@errorInfo</pre>
+            <pre style="white-space: pre-wrap; overflow-wrap: break-word; max-height: 300px; overflow: auto;">@errorInfo</pre>
 
             <div style="float: right; margin-bottom: 10px;">
                 <FluentButton

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
@@ -12,6 +12,8 @@ public partial class LogMessageColumnDisplay
 {
     private bool TryGetErrorInformation([NotNullWhen(true)] out string? errorInfo)
     {
+        // exception.stacktrace includes the exception message and type.
+        // https://opentelemetry.io/docs/specs/semconv/attributes-registry/exception/
         if (GetProperty("exception.stacktrace") is { Length: > 0 } stackTrace)
         {
             errorInfo = stackTrace;

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
@@ -12,25 +12,25 @@ public partial class LogMessageColumnDisplay
 {
     private bool TryGetErrorInformation([NotNullWhen(true)] out string? errorInfo)
     {
-        var stackTrace = GetProperty("exception.stacktrace") ?? GetProperty("ex.StackTrace");
-        if (stackTrace is null)
-        {
-            errorInfo = null;
-            return false;
-        }
-
-        if (string.IsNullOrEmpty(stackTrace))
-        {
-            var message = GetProperty("exception.message") ?? GetProperty("ex.Message");
-            var type = GetProperty("exception.type") ?? GetProperty("ex.Type");
-            errorInfo = $"{type}: {message}";
-        }
-        else
+        if (GetProperty("exception.stacktrace") is { Length: > 0 } stackTrace)
         {
             errorInfo = stackTrace;
+            return true;
+        }
+        if (GetProperty("exception.message") is { Length: > 0 } message)
+        {
+            if (GetProperty("exception.type") is { Length: > 0 } type)
+            {
+                errorInfo = $"{type}: {message}";
+                return true;
+            }
+
+            errorInfo = message;
+            return true;
         }
 
-        return true;
+        errorInfo = null;
+        return false;
 
         string? GetProperty(string propertyName)
         {


### PR DESCRIPTION
Changes:
* Prevent browser from displaying a browser tooltip of `Exception details` along with the exception popup tooltip. We just want our popup. @adamint Is this ok from a11y perspective?
* Reduce tooltip height to help avoid going off screen in lower resolutions. During the original PR the height grew a bit from adding a title.
* Remove RabbitMQ specific property lookups, e.g. `ex.Message`. No longer needed with https://github.com/dotnet/aspire/pull/2157
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2170)