### PR TITLE
Cosmos DB Emualtor container surrogate.

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureCosmosDBEmulatorResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBEmulatorResource.cs
@@ -6,6 +6,10 @@ using Aspire.Hosting.Azure.Data.Cosmos;
 
 namespace Aspire.Hosting.Azure;
 
+/// <summary>
+/// Wraps an <see cref="AzureCosmosDBResource" /> in a type that exposes container extension methods.
+/// </summary>
+/// <param name="innerResource">The inner resource used to store annotations.</param>
 public class AzureCosmosDBEmulatorResource(AzureCosmosDBResource innerResource) : ContainerResource(innerResource.Name), IResource
 {
     private readonly AzureCosmosDBResource _innerResource = innerResource;

--- a/src/Aspire.Hosting.Azure/AzureCosmosDBEmulatorResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBEmulatorResource.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.Data.Cosmos;
+
+namespace Aspire.Hosting.Azure;
+
+public class AzureCosmosDBEmulatorResource(AzureCosmosDBResource innerResource) : ContainerResource(innerResource.Name), IResource
+{
+    private readonly AzureCosmosDBResource _innerResource = innerResource;
+
+    public new string Name => _innerResource.Name;
+
+    public new ResourceMetadataCollection Annotations => _innerResource.Annotations;
+}

--- a/src/Aspire.Hosting.Azure/AzureStorageEmulatorResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureStorageEmulatorResource.cs
@@ -5,6 +5,10 @@ using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Azure;
 
+/// <summary>
+/// Wraps an <see cref="AzureStorageResource" /> in a type that exposes container extension methods.
+/// </summary>
+/// <param name="innerResource">The inner resource used to store annotations.</param>
 public class AzureStorageEmulatorResource(AzureStorageResource innerResource) : ContainerResource(innerResource.Name), IResource
 {
     private readonly AzureStorageResource _innerResource = innerResource;

--- a/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
@@ -24,44 +24,6 @@ public class AzureResourceExtensionsTests
         Assert.Equal(VolumeMountType.Bind, volumeAnnotation.Type);
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData(8081)]
-    [InlineData(9007)]
-    public void AddAzureCosmosDBWithEmulatorGetsExpectedPort(int? port = null)
-    {
-        var builder = DistributedApplication.CreateBuilder();
-
-        var cosmos = builder.AddAzureCosmosDB("cosmos");
-
-        cosmos.UseEmulator(port);
-
-        var endpointAnnotation = cosmos.Resource.Annotations.OfType<EndpointAnnotation>().FirstOrDefault();
-        Assert.NotNull(endpointAnnotation);
-
-        var actualPort = endpointAnnotation.Port;
-        Assert.Equal(port, actualPort);
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("2.3.97-preview")]
-    [InlineData("1.0.7")]
-    public void AddAzureCosmosDBWithEmulatorGetsExpectedImageTag(string? imageTag = null)
-    {
-        var builder = DistributedApplication.CreateBuilder();
-
-        var cosmos = builder.AddAzureCosmosDB("cosmos");
-
-        cosmos.UseEmulator(imageTag: imageTag);
-
-        var containerImageAnnotation = cosmos.Resource.Annotations.OfType<ContainerImageAnnotation>().FirstOrDefault();
-        Assert.NotNull(containerImageAnnotation);
-
-        var actualTag = containerImageAnnotation.Tag;
-        Assert.Equal(imageTag ?? "latest", actualTag);
-    }
-
     [Fact]
     public void WithReferenceAppInsightsWritesEnvVariableToManifest()
     {


### PR DESCRIPTION
This PR enables developers to customize the Cosmos DB Emulator container using the following code:

```csharp
var builder = DistributedApplication.CreateBuilder(args);

var db = builder.AddCosmosDB("cosmos")
                .UseEmulator(container =>
                {
                  container.WithEnvironment("AZURE_COSMOS_EMULATOR_ENABLE_DATA_PERSISTENCE");
                  container.WithVolumeMount("named-volume-name", "/tmp/cosmos/appdata", VolumeMountType.Named, isReadOnly: false);
                })
                .AddDatabase("db");
```

This PR is similar to #2132. Unfortunately I can't seem to get the Cosmos DB emulator working with bind mounts so `UsePersistence(...)` would need to use named mounts. The problem with named mounts is that we would need to name them such that two apphosts running on the same machine wouldn't conflict with one another.

One option is taking the hash of the apphost directory as a prefix for the volume name.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2175)