### PR TITLE
Clean up WithReference logic

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
@@ -21,4 +21,7 @@ public sealed class AzureApplicationInsightsResource(string name, string? connec
     /// </summary>
     /// <returns>The connection string for the Azure Application Insights resource.</returns>
     public string? GetConnectionString() => ConnectionString;
+
+    // UseAzureMonitor is looking for this specific environment variable name.
+    string IResourceWithConnectionString.ConnectionStringEnvironmentVariable => "APPLICATIONINSIGHTS_CONNECTION_STRING";
 }

--- a/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
@@ -6,8 +6,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.Data.Cosmos;
 using Aspire.Hosting.Publishing;
-using Aspire.Hosting.Utils;
-using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Hosting;
 
@@ -346,63 +344,5 @@ public static class AzureResourceExtensions
         // "type": "azure.appinsights.v0",
 
         context.Writer.WriteString("type", "azure.appinsights.v0");
-    }
-
-    /// <summary>
-    /// Injects a connection string as an environment variable from the source resource into the destination resource.
-    /// The environment variable will be "APPLICATIONINSIGHTS_CONNECTION_STRING={connectionString}."
-    /// <para>
-    /// Each resource defines the format of the connection string value. The
-    /// underlying connection string value can be retrieved using <see cref="IResourceWithConnectionString.GetConnectionString"/>.
-    /// </para>
-    /// <para>
-    /// Connection strings are also resolved by the configuration system (appSettings.json in the AppHost project, or environment variables). If a connection string is not found on the resource, the configuration system will be queried for a connection string
-    /// using the resource's name.
-    /// </para>
-    /// </summary>
-    /// <typeparam name="TDestination">The destination resource.</typeparam>
-    /// <param name="builder">The resource where connection string will be injected.</param>
-    /// <param name="source">The Azure Application Insights resource from which to extract the connection string.</param>
-    /// <param name="optional"><see langword="true"/> to allow a missing connection string; <see langword="false"/> to throw an exception if the connection string is not found.</param>
-    /// <exception cref="DistributedApplicationException">Throws an exception if the connection string resolves to null. It can be null if the resource has no connection string, and if the configuration has no connection string for the source resource.</exception>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<TDestination> WithReference<TDestination>(this IResourceBuilder<TDestination> builder,
-        IResourceBuilder<AzureApplicationInsightsResource> source, bool optional = false)
-        where TDestination : IResourceWithEnvironment
-    {
-        var resource = source.Resource;
-
-        return builder.WithEnvironment(context =>
-        {
-            // UseAzureMonitor is looking for this specific environment variable name.
-            var connectionStringName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
-
-            if (context.PublisherName == "manifest")
-            {
-                context.EnvironmentVariables[connectionStringName] = $"{{{resource.Name}.connectionString}}";
-                return;
-            }
-
-            var connectionString = resource.GetConnectionString() ??
-                builder.ApplicationBuilder.Configuration.GetConnectionString(resource.Name);
-
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                if (optional)
-                {
-                    // This is an optional connection string, so we can just return.
-                    return;
-                }
-
-                throw new DistributedApplicationException($"A connection string for '{resource.Name}' could not be retrieved.");
-            }
-
-            if (builder.Resource is ContainerResource)
-            {
-                connectionString = HostNameResolver.ReplaceLocalhostWithContainerHost(connectionString, builder.ApplicationBuilder.Configuration);
-            }
-
-            context.EnvironmentVariables[connectionStringName] = connectionString;
-        });
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -21,8 +21,28 @@ public sealed class EndpointReference(IResourceWithEndpoints owner, string endpo
     public string EndpointName { get; } = endpointName;
 
     /// <summary>
+    /// Gets the expression used in the manifest to reference the value of the endpoint.
+    /// </summary>
+    public string ValueExpression => $"{{{Owner.Name}.bindings.{EndpointName}.url}}";
+
+    /// <summary>
     /// Gets the URI string for the endpoint reference.
     /// </summary>
+    public string Value
+    {
+        get
+        {
+            var allocatedEndpoint = Owner.Annotations.OfType<AllocatedEndpointAnnotation>().SingleOrDefault(a => a.Name == EndpointName);
+
+            return allocatedEndpoint?.UriString ??
+                throw new InvalidOperationException($"The endpoint `{EndpointName}` is not allocated for the resource `{Owner.Name}`.");
+        }
+    }
+
+    /// <summary>
+    /// Gets the URI string for the endpoint reference.
+    /// </summary>
+    [Obsolete("Use Value instead.")]
     public string UriString
     {
         get

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
@@ -13,4 +13,14 @@ public interface IResourceWithConnectionString : IResource
     /// </summary>
     /// <returns>The connection string associated with the resource, when one is available.</returns>
     public string? GetConnectionString();
+
+    /// <summary>
+    /// The expression used in the manifest to reference the connection string.
+    /// </summary>
+    public string ConnectionStringExpression => $"{{{Name}.connectionString}}";
+
+    /// <summary>
+    /// The environment variable name to use for the connection string.
+    /// </summary>
+    public string? ConnectionStringEnvironmentVariable => null;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -20,4 +20,9 @@ public sealed class ParameterResource(string name, Func<string> callback, bool s
     /// Gets a value indicating whether the parameter is secret.
     /// </summary>
     public bool Secret { get; } = secret;
+
+    /// <summary>
+    /// Gets the expression used in the manifest to reference the value of the parameter.
+    /// </summary>
+    public string ValueExpression => $"{{{Name}.value}}";
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
@@ -13,4 +13,6 @@ internal sealed class ResourceWithConnectionStringSurrogate(IResource innerResou
     {
         return callback();
     }
+
+    public string ConnectionStringExpression => $"{{{Name}.value}}";
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
@@ -3,7 +3,7 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-internal sealed class ResourceWithConnectionStringSurrogate(IResource innerResource, Func<string> callback) : IResourceWithConnectionString
+internal sealed class ResourceWithConnectionStringSurrogate(IResource innerResource, Func<string> callback, string? environmentVariableName) : IResourceWithConnectionString
 {
     public string Name => innerResource.Name;
 
@@ -15,4 +15,6 @@ internal sealed class ResourceWithConnectionStringSurrogate(IResource innerResou
     }
 
     public string ConnectionStringExpression => $"{{{Name}.value}}";
+
+    public string? ConnectionStringEnvironmentVariable => environmentVariableName;
 }

--- a/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
@@ -58,16 +58,18 @@ public static class ParameterResourceBuilderExtensions
     /// </summary>
     /// <param name="builder">Distributed application builder</param>
     /// <param name="name">Name of parameter resource</param>
+    /// <param name="environmentVariableName">Environment variable name to set when WithReference is used.</param>
     /// <returns>Resource builder for the parameter.</returns>
     /// <exception cref="DistributedApplicationException"></exception>
-    public static IResourceBuilder<IResourceWithConnectionString> AddConnectionString(this IDistributedApplicationBuilder builder, string name)
+    public static IResourceBuilder<IResourceWithConnectionString> AddConnectionString(this IDistributedApplicationBuilder builder, string name, string? environmentVariableName = null)
     {
         var parameterBuilder = builder.AddParameter(name, () =>
         {
             return builder.Configuration.GetConnectionString(name) ?? throw new DistributedApplicationException($"Connection string parameter resource could not be used because connection string `{name}` is missing.");
-        }, secret: true);
+        },
+        secret: true);
 
-        var surrogate = new ResourceWithConnectionStringSurrogate(parameterBuilder.Resource, () => parameterBuilder.Resource.Value);
+        var surrogate = new ResourceWithConnectionStringSurrogate(parameterBuilder.Resource, () => parameterBuilder.Resource.Value, environmentVariableName);
         return builder.CreateResourceBuilder(surrogate);
     }
 }

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -363,6 +363,30 @@ public class WithReferenceTests
     }
 
     [Fact]
+    public void ParameterAsConnectionStringResourceInjectsCorrectEnvWhenPublishingManifest()
+    {
+        var testProgram = CreateTestProgram();
+
+        // Get the service provider.
+        var resource = testProgram.AppBuilder.AddConnectionString("resource", "MY_ENV");
+        testProgram.ServiceBBuilder.WithReference(resource);
+        testProgram.Build();
+
+        // Call environment variable callbacks.
+        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
+
+        var config = new Dictionary<string, string>();
+        var context = new EnvironmentCallbackContext("manifest", config);
+
+        foreach (var annotation in annotations)
+        {
+            annotation.Callback(context);
+        }
+
+        Assert.Equal("{resource.value}", config["MY_ENV"]);
+    }
+
+    [Fact]
     public void ConnectionStringResourceWithConnectionString()
     {
         var testProgram = CreateTestProgram();

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -421,33 +421,6 @@ public class WithReferenceTests
     }
 
     [Fact]
-    public void ConnectionStringResourceMissingConnectionStringFallbackToConfig()
-    {
-        var testProgram = CreateTestProgram();
-
-        // Get the service provider.
-        var resource = testProgram.AppBuilder.AddResource(new TestResource("resource"));
-        testProgram.ServiceBBuilder.WithReference(resource);
-        testProgram.AppBuilder.Configuration["ConnectionStrings:resource"] = "test";
-        testProgram.Build();
-
-        // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
-
-        foreach (var annotation in annotations)
-        {
-            annotation.Callback(context);
-        }
-
-        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
-        Assert.Equal(1, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "ConnectionStrings__resource" && kvp.Value == "test");
-    }
-
-    [Fact]
     public void WithReferenceHttpRelativeUriThrowsException()
     {
         var testProgram = CreateTestProgram();


### PR DESCRIPTION
- Remove code that falls back to runtime connection string lookup now that we have AddConnectionString. This also fixes the resource being provisioned by DCP even when there's a configuration value.
- Have the resource express the connection string expression as well as the value for the connection string.
- Do the same for parameters, bicep outptus, and endpoint references. We can make this more generic.
- Allow resources to override which environment variable gets set for connection strings. This removes duplicate code from app insights.
- Clean up some duplicate string interpolation logic.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2178)