### PR TITLE
Use existing constants rather than computing them

### DIFF
--- a/spelling.dic
+++ b/spelling.dic
@@ -32,12 +32,14 @@ mssql
 mysql
 noreferrer
 noopener
+npgsql
 oninput
 openai
 orleans
 otel
 otlp
 pgadmin
+postgre
 postgres
 protoc
 rabbitmq
@@ -47,8 +49,7 @@ runtimeconfig
 sqlserver
 trce
 uninstrumented
+unix
 upsert
 uris
 urls
-Npgsql
-Postgre

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -114,21 +114,16 @@ public static partial class OtlpHelpers
         buffer[startingIndex] = (char)(packedResult >> 8);
     }
 
-    public static DateTime UnixNanoSecondsToDateTime(ulong unixTimeNanoSeconds)
+    public static DateTime UnixNanoSecondsToDateTime(ulong unixTimeNanoseconds)
     {
-        var ticks = NanoSecondsToTicks(unixTimeNanoSeconds);
+        var ticks = NanosecondsToTicks(unixTimeNanoseconds);
 
-        // Create a DateTime object for the Unix epoch (January 1, 1970)
-        var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        unixEpoch = unixEpoch.AddTicks(ticks);
-
-        return unixEpoch;
+        return DateTime.UnixEpoch.AddTicks(ticks);
     }
 
-    private static long NanoSecondsToTicks(ulong nanoSeconds)
+    private static long NanosecondsToTicks(ulong nanoseconds)
     {
-        const ulong nanosecondsPerTick = 100; // 100 nanoseconds per tick
-        return (long)(nanoSeconds / nanosecondsPerTick);
+        return (long)(nanoseconds / TimeSpan.NanosecondsPerTick);
     }
 
     public static KeyValuePair<string, string>[] ToKeyValuePairs(this RepeatedField<KeyValue> attributes)


### PR DESCRIPTION
Constants exist for both the Unix epoch, and the number of nanoseconds per tick.

Also adjust capitalisation of "nanoseconds" and add "unix" to spelling exclusion dictionary.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2184)