### PR TITLE
Revert fluentui-blazor upgrade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,8 +80,8 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="13.0.11" />
     <PackageVersion Include="JsonSchema.Net" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.4.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.4.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.2.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.23.1" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.3.0" />
     <PackageVersion Include="Microsoft.Orleans.Client" Version="8.1.0-nightly.20240111.1" />


### PR DESCRIPTION
After #2160, we are running into fluentui-blazor issues with the data grid (or possibly button?) component. We should revert this package upgrade now and separately investigate what the issue is.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2190)