### PR TITLE
Avoid adding non-HTTP URLs to ASPNETCORE_URLS during launch

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -930,6 +930,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         return uniqueName;
     }
 
+    // Returns true if this resource represents an HTTP service endpoint which does not specify an environment variable for the endpoint.
+    // This is used to decide whether the endpoint should be propagated via the ASPNETCORE_URLS environment variable.
     private static bool IsUnspecifiedHttpService(ServiceAppResource serviceAppResource)
     {
         return serviceAppResource.EndpointAnnotation is

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -576,7 +576,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                     {
                         if (er.ModelResource is ProjectResource)
                         {
-                            var urls = er.ServicesProduced.Where(s => s.EndpointAnnotation.UriScheme is "http" or "https").Select(sar =>
+                            var urls = er.ServicesProduced.Where(IsUnspecifiedHttpService).Select(sar =>
                             {
                                 var url = sar.EndpointAnnotation.UriScheme + "://localhost:{{- portForServing \"" + sar.Service.Metadata.Name + "\" -}}";
                                 return url;
@@ -641,7 +641,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         {
             if (executableResource.DcpResource is ExecutableReplicaSet)
             {
-                var urls = executableResource.ServicesProduced.Select(sar =>
+                var urls = executableResource.ServicesProduced.Where(IsUnspecifiedHttpService).Select(sar =>
                 {
                     var url = sar.EndpointAnnotation.UriScheme + "://localhost:{{- portForServing \"" + sar.Service.Metadata.Name + "\" -}}";
                     return url;
@@ -928,5 +928,14 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         }
 
         return uniqueName;
+    }
+
+    private static bool IsUnspecifiedHttpService(ServiceAppResource serviceAppResource)
+    {
+        return serviceAppResource.EndpointAnnotation is
+        {
+            UriScheme: "http" or "https",
+            EnvironmentVariable: null or { Length: 0 }
+        };
     }
 }


### PR DESCRIPTION
Currently, all endpoint annotations are contributing to `ASPNETCORE_URLS`. I believe we should not be adding "tcp://" endpoints there. This currently blows up Kestrel when trying to get Aspire to allocate ports for an Orleans silo, for example.

There is precedent for the filtering added by this PR here: https://github.com/dotnet/aspire/blob/5f19c77227ccb5637960b07d8a7e4b7257a6a013/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs#L579
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2239)