### PR TITLE
Orleans: configure ports automatically

### DIFF
--- a/playground/orleans/OrleansAppHost/Program.cs
+++ b/playground/orleans/OrleansAppHost/Program.cs
@@ -16,7 +16,8 @@ var orleans = builder.AddOrleans("my-app")
 //                      .WithMemoryGrainStorage("Default");
 
 builder.AddProject<Projects.OrleansServer>("silo")
-       .WithReference(orleans);
+       .WithReference(orleans)
+       .WithReplicas(3);
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code

--- a/playground/orleans/OrleansServer/Program.cs
+++ b/playground/orleans/OrleansServer/Program.cs
@@ -5,7 +5,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 builder.AddKeyedAzureTableService("clustering");
 builder.AddKeyedAzureBlobService("grainstate");
-builder.UseOrleans(siloBuilder => siloBuilder.AddActivityPropagation());
+builder.UseOrleans();
 
 var app = builder.Build();
 

--- a/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
@@ -358,6 +358,11 @@ public static class OrleansServiceExtensions
             builder.WithEnvironment("Orleans__ServiceId", res.ServiceId);
         }
 
+        // Set silo-to-silo and client-to-gateway ports
+        // Note that we sets these ports even when adding a reference to a client.
+        builder.WithEndpoint(scheme: "tcp", name: "orleans-silo", env: "Orleans__Endpoints__SiloPort");
+        builder.WithEndpoint(scheme: "tcp", name: "orleans-gateway", env: "Orleans__Endpoints__GatewayPort");
+
         // Enable distributed tracing by default
         if (res.EnableDistributedTracing != false)
         {


### PR DESCRIPTION
Currently, we aren't letting DCP configure ports for Orleans when running locally.
This PR fixes that by adding endpoint annotations for Orleans to any service which refers to an Orleans service.

The impact of the existing logic is that if an application contains multiple silos, the developer will need to insert some code like the following into their service to select distinct ports to listen on:

```csharp
builder.UseOrleans(orleansBuilder =>
{
    if (builder.Environment.IsDevelopment())
    {
        orleansBuilder.ConfigureEndpoints(Random.Shared.Next(10_000, 50_000), Random.Shared.Next(10_000, 50_000));
    }
});
```

After this change, adding Orleans is again a one-liner

```csharp
builder.UseOrleans();
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2243)