### PR TITLE
Add WithBindMount method

### DIFF
--- a/playground/mysql/MySqlDb.AppHost/Program.cs
+++ b/playground/mysql/MySqlDb.AppHost/Program.cs
@@ -6,7 +6,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var catalogDbName = "catalog"; // MySql database & table names are case-sensitive on non-Windows.
 var catalogDb = builder.AddMySql("mysql")
     .WithEnvironment("MYSQL_DATABASE", catalogDbName)
-    .WithVolumeMount("../MySql.ApiService/data", "/docker-entrypoint-initdb.d", VolumeMountType.Bind)
+    .WithBindMount("../MySql.ApiService/data", "/docker-entrypoint-initdb.d")
     .WithPhpMyAdmin()
     .AddDatabase(catalogDbName);
 

--- a/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
@@ -187,7 +187,7 @@ public static class AzureResourceExtensions
     {
         path = path ?? $".azurite/{builder.Resource.Name}";
         var fullyQualifiedPath = Path.GetFullPath(path, builder.ApplicationBuilder.AppHostDirectory);
-        return builder.WithVolumeMount(fullyQualifiedPath, "/data", VolumeMountType.Bind, false);
+        return builder.WithBindMount(fullyQualifiedPath, "/data", isReadOnly: false);
 
     }
 

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepStorageResource.cs
@@ -194,7 +194,7 @@ public static class AzureBicepSqlResourceExtensions
 
         if (storagePath is not null)
         {
-            var volumeAnnotation = new VolumeMountAnnotation(storagePath, "/data", VolumeMountType.Bind, false);
+            var volumeAnnotation = new ContainerMountAnnotation(storagePath, "/data", ContainerMountType.Bind, false);
             return builder.WithAnnotation(volumeAnnotation);
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/ContainerMountAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerMountAnnotation.cs
@@ -6,19 +6,19 @@ using System.Diagnostics;
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents a volume mount annotation for a resource.
+/// Represents a mount annotation for a container resource.
 /// </summary>
 [DebuggerDisplay("Type = {GetType().Name,nq}, Source = {Source}, Target = {Target}")]
-public sealed class VolumeMountAnnotation : IResourceAnnotation
+public sealed class ContainerMountAnnotation : IResourceAnnotation
 {
     /// <summary>
-    /// Instantiates a volume mount annotation that specifies the source and target paths for a volume mount.
+    /// Instantiates a mount annotation that specifies the source and target paths for a mount.
     /// </summary>
-    /// <param name="source">The source path of the volume mount.</param>
-    /// <param name="target">The target path of the volume mount.</param>
-    /// <param name="type">The type of the volume mount.</param>
-    /// <param name="isReadOnly">A value indicating whether the volume mount is read-only.</param>
-    public VolumeMountAnnotation(string source, string target, VolumeMountType type = default, bool isReadOnly = false)
+    /// <param name="source">The source path of the mount.</param>
+    /// <param name="target">The target path of the mount.</param>
+    /// <param name="type">The type of the mount.</param>
+    /// <param name="isReadOnly">A value indicating whether the mount is read-only.</param>
+    public ContainerMountAnnotation(string? source, string target, ContainerMountType type, bool isReadOnly)
     {
         Source = source;
         Target = target;
@@ -27,19 +27,19 @@ public sealed class VolumeMountAnnotation : IResourceAnnotation
     }
 
     /// <summary>
-    /// Gets or sets the source of the volume mount.
+    /// Gets or sets the source of the mount.
     /// </summary>
-    public string Source { get; set; }
+    public string? Source { get; set; }
 
     /// <summary>
-    /// Gets or sets the target of the volume mount.
+    /// Gets or sets the target of the mount.
     /// </summary>
     public string Target { get; set; }
 
     /// <summary>
-    /// Gets or sets the type of the volume mount.
+    /// Gets or sets the type of the mount.
     /// </summary>
-    public VolumeMountType Type { get; set; }
+    public ContainerMountType Type { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the volume mount is read-only.
@@ -48,9 +48,9 @@ public sealed class VolumeMountAnnotation : IResourceAnnotation
 }
 
 /// <summary>
-/// Represents the type of a volume mount.
+/// Represents the type of a container mount.
 /// </summary>
-public enum VolumeMountType
+public enum ContainerMountType
 {
     /// <summary>
     /// A local folder that is mounted into the container.

--- a/src/Aspire.Hosting/ApplicationModel/ContainerMountAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerMountAnnotation.cs
@@ -20,6 +20,11 @@ public sealed class ContainerMountAnnotation : IResourceAnnotation
     /// <param name="isReadOnly">A value indicating whether the mount is read-only.</param>
     public ContainerMountAnnotation(string? source, string target, ContainerMountType type, bool isReadOnly)
     {
+        if (source == null && ContainerMountType.Bind == type)
+        {
+            throw new ArgumentException("The source path must be specified for a bind mount.", nameof(source));
+        }
+
         Source = source;
         Target = target;
         Type = type;

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -742,7 +742,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                     {
                         Source = resolvedSource,
                         Target = mount.Target,
-                        Type = isBound ? VolumeMountType.Bind : VolumeMountType.Named,
+                        Type = isBound ? VolumeMountType.Bind : VolumeMountType.Volume,
                         IsReadOnly = mount.IsReadOnly
                     };
                     ctr.Spec.VolumeMounts.Add(volumeSpec);

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -716,11 +716,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             ctr.Annotate(Container.ResourceNameAnnotation, container.Name);
             ctr.Annotate(Container.OtelServiceNameAnnotation, container.Name);
 
-            if (container.TryGetVolumeMounts(out var volumeMounts))
+            if (container.TryGetContainerMounts(out var containerMounts))
             {
                 ctr.Spec.VolumeMounts = new();
 
-                foreach (var mount in volumeMounts)
+                foreach (var mount in containerMounts)
                 {
                     var isBound = mount.Type == ContainerMountType.Bind;
                     var resolvedSource = mount.Source;

--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -51,8 +51,8 @@ internal static class VolumeMountType
     // A volume mount to a host directory
     public const string Bind = "bind";
 
-    // A volume mount to a named volume managed by the container orchestrator
-    public const string Named = "volume";
+    // A volume mount to a volume managed by the container orchestrator
+    public const string Volume = "volume";
 }
 
 internal sealed class VolumeMount

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -42,14 +42,28 @@ public static class ContainerResourceBuilderExtensions
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="source">The source path of the volume. This is the physical location on the host.</param>
-    /// <param name="target">The target path in the container.</param>
-    /// <param name="type">The type of volume mount.</param>
+    /// <param name="name">The name of the volume. If the name is <c>null</c> then an anonymous volume is mounted.</param>
+    /// <param name="target">The target path where the file or directory is mounted in the container.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only mount.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> WithVolumeMount<T>(this IResourceBuilder<T> builder, string source, string target, VolumeMountType type = default, bool isReadOnly = false) where T : ContainerResource
+    public static IResourceBuilder<T> WithVolumeMount<T>(this IResourceBuilder<T> builder, string? name, string target, bool isReadOnly = false) where T : ContainerResource
     {
-        var annotation = new VolumeMountAnnotation(source, target, type, isReadOnly);
+        var annotation = new ContainerMountAnnotation(name, target, ContainerMountType.Named, isReadOnly);
+        return builder.WithAnnotation(annotation);
+    }
+
+    /// <summary>
+    /// Adds a bind mount to a container resource.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="source">The source path of the mount. This is the path to the file or directory on the host.</param>
+    /// <param name="target">The target path where the file or directory is mounted in the container.</param>
+    /// <param name="isReadOnly">A flag that indicates if this is a read-only mount.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithBindMount<T>(this IResourceBuilder<T> builder, string source, string target, bool isReadOnly = false) where T : ContainerResource
+    {
+        var annotation = new ContainerMountAnnotation(source, target, ContainerMountType.Bind, isReadOnly);
         return builder.WithAnnotation(annotation);
     }
 

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -42,13 +42,13 @@ public static class ContainerResourceBuilderExtensions
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. If the name is <c>null</c> then an anonymous volume is mounted.</param>
+    /// <param name="source">The source name of the volume. If the name is <c>null</c> then an anonymous volume is mounted.</param>
     /// <param name="target">The target path where the file or directory is mounted in the container.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only mount.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> WithVolumeMount<T>(this IResourceBuilder<T> builder, string? name, string target, bool isReadOnly = false) where T : ContainerResource
+    public static IResourceBuilder<T> WithVolumeMount<T>(this IResourceBuilder<T> builder, string? source, string target, bool isReadOnly = false) where T : ContainerResource
     {
-        var annotation = new ContainerMountAnnotation(name, target, ContainerMountType.Named, isReadOnly);
+        var annotation = new ContainerMountAnnotation(source, target, ContainerMountType.Named, isReadOnly);
         return builder.WithAnnotation(annotation);
     }
 

--- a/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
@@ -66,12 +66,12 @@ public static class ResourceExtensions
     }
 
     /// <summary>
-    /// Attempts to get the volume mounts for the specified resource.
+    /// Attempts to get the container mounts for the specified resource.
     /// </summary>
     /// <param name="resource">The resource to get the volume mounts for.</param>
     /// <param name="volumeMounts">When this method returns, contains the volume mounts for the specified resource, if found; otherwise, <c>null</c>.</param>
     /// <returns><c>true</c> if the volume mounts were successfully retrieved; otherwise, <c>false</c>.</returns>
-    public static bool TryGetVolumeMounts(this IResource resource, [NotNullWhen(true)] out IEnumerable<ContainerMountAnnotation>? volumeMounts)
+    public static bool TryGetContainerMounts(this IResource resource, [NotNullWhen(true)] out IEnumerable<ContainerMountAnnotation>? volumeMounts)
     {
         return TryGetAnnotationsOfType<ContainerMountAnnotation>(resource, out volumeMounts);
     }

--- a/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
@@ -71,9 +71,9 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the volume mounts for.</param>
     /// <param name="volumeMounts">When this method returns, contains the volume mounts for the specified resource, if found; otherwise, <c>null</c>.</param>
     /// <returns><c>true</c> if the volume mounts were successfully retrieved; otherwise, <c>false</c>.</returns>
-    public static bool TryGetVolumeMounts(this IResource resource, [NotNullWhen(true)] out IEnumerable<VolumeMountAnnotation>? volumeMounts)
+    public static bool TryGetVolumeMounts(this IResource resource, [NotNullWhen(true)] out IEnumerable<ContainerMountAnnotation>? volumeMounts)
     {
-        return TryGetAnnotationsOfType<VolumeMountAnnotation>(resource, out volumeMounts);
+        return TryGetAnnotationsOfType<ContainerMountAnnotation>(resource, out volumeMounts);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
@@ -82,7 +82,7 @@ public static class MySqlBuilderExtensions
         builder.ApplicationBuilder.AddResource(phpMyAdminContainer)
                                   .WithAnnotation(new ContainerImageAnnotation { Image = "phpmyadmin", Tag = "latest" })
                                   .WithHttpEndpoint(containerPort: 80, hostPort: hostPort, name: containerName)
-                                  .WithVolumeMount(Path.GetTempFileName(), "/etc/phpmyadmin/config.user.inc.php")
+                                  .WithBindMount(Path.GetTempFileName(), "/etc/phpmyadmin/config.user.inc.php")
                                   .ExcludeFromManifest();
         
         return builder;

--- a/src/Aspire.Hosting/MySql/PhpMyAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting/MySql/PhpMyAdminConfigWriterHook.cs
@@ -11,7 +11,7 @@ internal class PhpMyAdminConfigWriterHook : IDistributedApplicationLifecycleHook
     public Task AfterEndpointsAllocatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
     {
         var adminResource = appModel.Resources.OfType<PhpMyAdminContainerResource>().Single();
-        var serverFileMount = adminResource.Annotations.OfType<VolumeMountAnnotation>().Single(v => v.Target == "/etc/phpmyadmin/config.user.inc.php");
+        var serverFileMount = adminResource.Annotations.OfType<ContainerMountAnnotation>().Single(v => v.Target == "/etc/phpmyadmin/config.user.inc.php");
         var mySqlInstances = appModel.Resources.OfType<MySqlServerResource>();
 
         if (appModel.Resources.OfType<PhpMyAdminContainerResource>().SingleOrDefault() is not { } myAdminResource)
@@ -42,7 +42,7 @@ internal class PhpMyAdminConfigWriterHook : IDistributedApplicationLifecycleHook
         }
         else
         {
-            using var stream = new FileStream(serverFileMount.Source, FileMode.Create);
+            using var stream = new FileStream(serverFileMount.Source!, FileMode.Create);
             using var writer = new StreamWriter(stream);
 
             writer.WriteLine("<?php");

--- a/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
@@ -13,12 +13,12 @@ internal class PgAdminConfigWriterHook : IDistributedApplicationLifecycleHook
     public Task AfterEndpointsAllocatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
     {
         var adminResource = appModel.Resources.OfType<PgAdminContainerResource>().Single();
-        var serverFileMount = adminResource.Annotations.OfType<VolumeMountAnnotation>().Single(v => v.Target == "/pgadmin4/servers.json");
+        var serverFileMount = adminResource.Annotations.OfType<ContainerMountAnnotation>().Single(v => v.Target == "/pgadmin4/servers.json");
         var postgresInstances = appModel.Resources.OfType<PostgresServerResource>();
 
         var serverFileBuilder = new StringBuilder();
 
-        using var stream = new FileStream(serverFileMount.Source, FileMode.Create);
+        using var stream = new FileStream(serverFileMount.Source!, FileMode.Create);
         using var writer = new Utf8JsonWriter(stream);
 
         var serverIndex = 1;

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -85,7 +85,7 @@ public static class PostgresBuilderExtensions
                                   .WithAnnotation(new ContainerImageAnnotation { Image = "dpage/pgadmin4", Tag = "latest" })
                                   .WithHttpEndpoint(containerPort: 80, hostPort: hostPort, name: containerName)
                                   .WithEnvironment(SetPgAdminEnviromentVariables)
-                                  .WithVolumeMount(Path.GetTempFileName(), "/pgadmin4/servers.json")
+                                  .WithBindMount(Path.GetTempFileName(), "/pgadmin4/servers.json")
                                   .ExcludeFromManifest();
 
         return builder;

--- a/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
@@ -18,10 +18,10 @@ public class AzureResourceExtensionsTests
 
         var computedPath = Path.GetFullPath("mydata");
 
-        var volumeAnnotation = storage.Resource.Annotations.OfType<VolumeMountAnnotation>().Single();
+        var volumeAnnotation = storage.Resource.Annotations.OfType<ContainerMountAnnotation>().Single();
         Assert.Equal(computedPath, volumeAnnotation.Source);
         Assert.Equal("/data", volumeAnnotation.Target);
-        Assert.Equal(VolumeMountType.Bind, volumeAnnotation.Type);
+        Assert.Equal(ContainerMountType.Bind, volumeAnnotation.Type);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
-using VolumeMountType = Aspire.Hosting.ApplicationModel.VolumeMountType;
 
 namespace Aspire.Hosting.Tests;
 
@@ -332,7 +331,7 @@ public class DistributedApplicationTests
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         testProgram.AppBuilder.AddContainer("redis-cli", "redis")
-            .WithVolumeMount("/etc/path-here", $"path-here", VolumeMountType.Bind);
+            .WithBindMount("/etc/path-here", $"path-here");
 
         await using var app = testProgram.Build();
 
@@ -362,7 +361,7 @@ public class DistributedApplicationTests
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         testProgram.AppBuilder.AddContainer("redis-cli", "redis")
-            .WithVolumeMount("etc/path-here", $"path-here", VolumeMountType.Bind);
+            .WithBindMount("etc/path-here", $"path-here");
 
         await using var app = testProgram.Build();
 

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -386,6 +386,66 @@ public class DistributedApplicationTests
     }
 
     [LocalOnlyFact("docker")]
+    public async Task VerifyDockerWithVolumeMountWorksWithName()
+    {
+        var testProgram = CreateTestProgram();
+        testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
+
+        testProgram.AppBuilder.AddContainer("redis-cli", "redis")
+            .WithVolumeMount("test-volume-name", $"/path-here");
+
+        await using var app = testProgram.Build();
+
+        await app.StartAsync();
+
+        var s = app.Services.GetRequiredService<IKubernetesService>();
+
+        using var cts = new CancellationTokenSource(Debugger.IsAttached ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(10));
+        var token = cts.Token;
+
+        var redisContainer = await KubernetesHelper.GetResourceByNameAsync<Container>(
+                s,
+                "redis-cli", r => r.Spec.VolumeMounts != null,
+                token);
+
+        Assert.NotNull(redisContainer.Spec.VolumeMounts);
+        Assert.NotEmpty(redisContainer.Spec.VolumeMounts);
+        Assert.Equal("test-volume-name", redisContainer.Spec.VolumeMounts[0].Source);
+
+        await app.StopAsync();
+    }
+
+    [LocalOnlyFact("docker")]
+    public async Task VerifyDockerWithVolumeMountWorksWithoutName()
+    {
+        var testProgram = CreateTestProgram();
+        testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
+
+        testProgram.AppBuilder.AddContainer("redis-cli", "redis")
+            .WithVolumeMount(source: null, $"/path-here");
+
+        await using var app = testProgram.Build();
+
+        await app.StartAsync();
+
+        var s = app.Services.GetRequiredService<IKubernetesService>();
+
+        using var cts = new CancellationTokenSource(Debugger.IsAttached ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(10));
+        var token = cts.Token;
+
+        var redisContainer = await KubernetesHelper.GetResourceByNameAsync<Container>(
+                s,
+                "redis-cli", r => r.Spec.VolumeMounts != null,
+                token);
+
+        Assert.NotNull(redisContainer.Spec.VolumeMounts);
+        Assert.NotEmpty(redisContainer.Spec.VolumeMounts);
+        Assert.Equal("", redisContainer.Spec.VolumeMounts[0].Source);
+
+        await app.StopAsync();
+    }
+
+    [LocalOnlyFact("docker")]
     public async Task KubernetesHasResourceNameForContainersAndExes()
     {
         var testProgram = CreateTestProgram(includeIntegrationServices: true, includeNodeApp: true);

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -325,7 +325,7 @@ public class DistributedApplicationTests
     }
 
     [LocalOnlyFact("docker")]
-    public async Task VerifyDockerWithBoundVolumeMountWorksWithAbsolutePaths()
+    public async Task VerifyDockerWithBindMountWorksWithAbsolutePaths()
     {
         var testProgram = CreateTestProgram();
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
@@ -355,7 +355,7 @@ public class DistributedApplicationTests
     }
 
     [LocalOnlyFact("docker")]
-    public async Task VerifyDockerWithBoundVolumeMountWorksWithRelativePaths()
+    public async Task VerifyDockerWithBindMountWorksWithRelativePaths()
     {
         var testProgram = CreateTestProgram();
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -231,7 +231,7 @@ public class AddMySqlTests
         var hook = new PhpMyAdminConfigWriterHook();
         hook.AfterEndpointsAllocatedAsync(appModel, CancellationToken.None);
 
-        using var stream = File.OpenRead(volume.Source);
+        using var stream = File.OpenRead(volume.Source!);
         var fileContents = new StreamReader(stream).ReadToEnd();
 
         // check to see that the two hosts are in the file

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -205,7 +205,7 @@ public class AddMySqlTests
         builder.AddMySql("mySql").WithPhpMyAdmin();
 
         var container = builder.Resources.Single(r => r.Name == "mySql-phpmyadmin");
-        var volume = container.Annotations.OfType<VolumeMountAnnotation>().Single();
+        var volume = container.Annotations.OfType<ContainerMountAnnotation>().Single();
 
         Assert.True(File.Exists(volume.Source)); // File should exist, but will be empty.
         Assert.Equal("/etc/phpmyadmin/config.user.inc.php", volume.Target);
@@ -223,7 +223,7 @@ public class AddMySqlTests
         mysql2.WithAnnotation(new AllocatedEndpointAnnotation("tcp", ProtocolType.Tcp, "host.docker.internal", 5002, "tcp"));
 
         var myAdmin = builder.Resources.Single(r => r.Name.EndsWith("-phpmyadmin"));
-        var volume = myAdmin.Annotations.OfType<VolumeMountAnnotation>().Single();
+        var volume = myAdmin.Annotations.OfType<ContainerMountAnnotation>().Single();
 
         var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -243,7 +243,7 @@ public class AddPostgresTests
         builder.AddPostgres("mypostgres").WithPgAdmin(8081);
 
         var container = builder.Resources.Single(r => r.Name == "mypostgres-pgadmin");
-        var volume = container.Annotations.OfType<VolumeMountAnnotation>().Single();
+        var volume = container.Annotations.OfType<ContainerMountAnnotation>().Single();
 
         Assert.True(File.Exists(volume.Source)); // File should exist, but will be empty.
         Assert.Equal("/pgadmin4/servers.json", volume.Target);
@@ -271,7 +271,7 @@ public class AddPostgresTests
         pg2.WithAnnotation(new AllocatedEndpointAnnotation("tcp", ProtocolType.Tcp, "host.docker.internal", 5002, "tcp"));
 
         var pgadmin = builder.Resources.Single(r => r.Name.EndsWith("-pgadmin"));
-        var volume = pgadmin.Annotations.OfType<VolumeMountAnnotation>().Single();
+        var volume = pgadmin.Annotations.OfType<ContainerMountAnnotation>().Single();
 
         var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -279,7 +279,7 @@ public class AddPostgresTests
         var hook = new PgAdminConfigWriterHook();
         hook.AfterEndpointsAllocatedAsync(appModel, CancellationToken.None);
 
-        using var stream = File.OpenRead(volume.Source);
+        using var stream = File.OpenRead(volume.Source!);
         var document = JsonDocument.Parse(stream);
 
         var servers = document.RootElement.GetProperty("Servers");


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1437

The `WithVolumeMount` method today confuses two container concepts:

* Volumes mount - https://docs.docker.com/storage/volumes/
* Bind mounts - https://docs.docker.com/storage/bind-mounts/

I noticed that DCP [does the same thing](https://github.com/dotnet/aspire/blob/f63f1e97c141b657125b0a20c74a3adb142d4753/src/Aspire.Hosting/Dcp/Model/Container.cs#L49-L75). I'm not sure who influenced who, but while it doesn't matter to a user's experience what things are called in DCP data, the Aspire.Hosting model should use the right terminology.

Changes:

* Add `WithBindMount`
* Remove mount type argument from `WithVolumeMount`. Now you must either use `WithVolumeMount` or `WithBindMount` to get the mount you want. **IMPORTANT:** The mount type on `WithVolumeMount` previously defaulted to binding mount. IMO this was confusing. However, with the change to split the method in two, `WithVolumeMount` now always creates a volume mount. This is a breaking change.
  * **Before:** `WithVolumeMount(@"c:\data", @"/etc/data")` creates a binding mount with `c:\data` as source path
  * **After:** `WithVolumeMount(@"c:\data", @"/etc/data")` creates a volume mount with the name `c:\data`.
* Changed `WithVolumeMount`'s `source` parameter to be nullable. A volume can have a name or be anonymous. I haven't tested that DCP is cool with anonymous volumes yet. @karolz-ms Do you know?
* Renamed various types from `VolumeMountXXX` to `ContainerMountXXX`.

New API:
```cs
public static IResourceBuilder<T> WithVolumeMount<T>(
    this IResourceBuilder<T> builder, string? source, string target, bool isReadOnly = false) where T : ContainerResource

public static IResourceBuilder<T> WithBindMount<T>(
    this IResourceBuilder<T> builder, string source, string target, bool isReadOnly = false) where T : ContainerResource
```

There are experiments with making volumes a first-class concept: https://github.com/dotnet/aspire/pull/1521. If this is implemented, then I expect `WithVolumeMount` will have an overload that takes the volume as source instead of a string:

```cs
public static IResourceBuilder<T> WithVolumeMount<T>(
    this IResourceBuilder<T> builder, Volume source, string target, bool isReadOnly = false) where T : ContainerResource
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2245)