### PR TITLE
Fix resource start time formatting

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -169,7 +170,7 @@ public partial class ResourceDetails
             // Use try parse to check if a value matches ISO 8601 format. If there is a match then convert to a friendly format.
             if (DateTime.TryParseExact(value, "o", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
             {
-                value = date.ToString(CultureInfo.CurrentCulture);
+                value = FormatHelpers.FormatDateTime(date);
             }
         }
 

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -2,6 +2,7 @@
 @using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model
+@using Aspire.Dashboard.Utils
 @using Microsoft.Extensions.Logging
 @using System.Web
 @using Aspire.Dashboard.Resources
@@ -72,7 +73,7 @@
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
                                 <LogLevelColumnDisplay LogEntry="@context" />
                             </TemplateColumn>
-                            <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" Property="@(context => OtlpHelpers.FormatTimeStamp(context.TimeStamp))" Tooltip="true" />
+                            <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" Property="@(context => FormatHelpers.FormatTimeStamp(context.TimeStamp))" Tooltip="true" />
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">
                                 <LogMessageColumnDisplay FilterText="@(ViewModel.FilterText)" LogEntry="@context" />
                             </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -5,6 +5,7 @@
 @using Aspire.Dashboard.Otlp.Model
 @using System.Globalization
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 @inject IStringLocalizer<Dashboard.Resources.TraceDetail> Loc
 @inject IStringLocalizer<ControlsStrings> ControlStringsLoc
 
@@ -19,7 +20,7 @@
         </div>
         <FluentToolbar Orientation="Orientation.Horizontal">
             <div>
-                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)] <strong>@_trace.FirstSpan.StartTime.ToString("MMMM d yyyy"), @OtlpHelpers.FormatTimeStamp(_trace.FirstSpan.StartTime)</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)] <strong>@_trace.FirstSpan.StartTime.ToString("MMMM d yyyy"), @FormatHelpers.FormatTimeStamp(_trace.FirstSpan.StartTime)</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -4,6 +4,7 @@
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 @inject NavigationManager NavigationManager
 @inject IDashboardClient DashboardClient
 @inject IJSRuntime JS
@@ -33,7 +34,7 @@
     <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
         <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr">
             <ChildContent>
-                <PropertyColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" Property="@(context => OtlpHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
+                <PropertyColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" Property="@(context => FormatHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
                 <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@((t) => $"{t.FullName}: {OtlpHelpers.ToShortenedId(t.TraceId)}")">
                     <span><FluentHighlighter HighlightedText="@(TracesViewModel.FilterText)" Text="@(context.FullName)" /></span>
                     <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
@@ -1,20 +1,20 @@
 ﻿@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Resources
 @using System.Globalization
+@using Aspire.Dashboard.Utils
 
-@if (Resource.CreationTimeStamp is not null)
+@if (Resource.CreationTimeStamp is {} timeStamp)
 {
-    var localTime = Resource.CreationTimeStamp.Value.ToLocalTime();
-
-    if (localTime.Date == DateTime.Now.Date)
+    if (timeStamp.ToLocalTime().Date == DateTime.Now.Date)
     {
         // e.g. "08:57:44" (based on user's culture and preferences)
-        @localTime.TimeOfDay.ToString()
+        // Don't include milliseconds as resource server returned time stamp is second precision.
+        @FormatHelpers.FormatTime(timeStamp)
     }
     else
     {
         // e.g. "9/02/2024 08:57:44" (based on user's culture and preferences)
-        @localTime.ToString(CultureInfo.CurrentCulture)
+        @FormatHelpers.FormatDateTime(timeStamp)
     }
 }
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Text.RegularExpressions;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
@@ -14,27 +13,8 @@ using OpenTelemetry.Proto.Resource.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
 
-public static partial class OtlpHelpers
+public static class OtlpHelpers
 {
-    private static readonly string s_longTimePatternWithMilliseconds = GetLongTimePatternWithMilliseconds();
-
-    static string GetLongTimePatternWithMilliseconds()
-    {
-        // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
-
-        // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
-        var longTimePattern = DateTimeFormatInfo.CurrentInfo.LongTimePattern;
-
-        // Create a format similar to .fff but based on the current culture.
-        var millisecondFormat = $"{NumberFormatInfo.CurrentInfo.NumberDecimalSeparator}fff";
-
-        // Append millisecond pattern to current culture's long time pattern.
-        return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1{millisecondFormat}");
-    }
-
-    [GeneratedRegex("(:ss|:s)")]
-    private static partial Regex MatchSecondsInTimeFormatPattern();
-
     public static string? GetServiceId(this Resource resource)
     {
         string? serviceName = null;
@@ -61,11 +41,6 @@ public static partial class OtlpHelpers
 
     public static string ToShortenedId(string id) =>
         id.Length > 7 ? id[..7] : id;
-
-    public static string FormatTimeStamp(DateTime timestamp)
-    {
-        return timestamp.ToLocalTime().ToString(s_longTimePatternWithMilliseconds, CultureInfo.CurrentCulture);
-    }
 
     public static string ToHexString(ReadOnlyMemory<byte> bytes)
     {

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Aspire.Dashboard.Utils;
+
+internal static partial class FormatHelpers
+{
+    static string GetLongTimePatternWithMilliseconds()
+    {
+        // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
+
+        // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
+        var longTimePattern = DateTimeFormatInfo.CurrentInfo.LongTimePattern;
+
+        // Create a format similar to .fff but based on the current culture.
+        var millisecondFormat = $"{NumberFormatInfo.CurrentInfo.NumberDecimalSeparator}fff";
+
+        // Append millisecond pattern to current culture's long time pattern.
+        return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1{millisecondFormat}");
+    }
+
+    [GeneratedRegex("(:ss|:s)")]
+    private static partial Regex MatchSecondsInTimeFormatPattern();
+
+    private static readonly string s_longTimePatternWithMilliseconds = GetLongTimePatternWithMilliseconds();
+
+    public static string FormatTimeStamp(DateTime time)
+    {
+        // Long time with milliseconds
+        return time.ToLocalTime().ToString(s_longTimePatternWithMilliseconds, CultureInfo.CurrentCulture);
+    }
+
+    public static string FormatTime(DateTime time)
+    {
+        // Long time
+        return time.ToLocalTime().ToString("T", CultureInfo.CurrentCulture);
+    }
+
+    public static string FormatDateTime(DateTime dateTime)
+    {
+        // Short date, long time
+        return dateTime.ToLocalTime().ToString("G", CultureInfo.CurrentCulture);
+    }
+}


### PR DESCRIPTION
The resource page displays an inconsistent format for the start date because `DateTime.TimeOfDay` is a `TimeSpan` and doesn't use proper date formatting with ToString.

* Add shared date formatting methods
* Update resource date formatting

**Resource page before:**
![image](https://github.com/dotnet/aspire/assets/303201/77bd6ad8-7c71-4633-a19e-0fdece904cb1)

**Resource page after:**
![image](https://github.com/dotnet/aspire/assets/303201/5d7e44cb-8cd6-456b-b901-67df61ffe210)

**Telemetry page for reference:**
![image](https://github.com/dotnet/aspire/assets/303201/3732e316-98fc-411a-8348-5a57f68b282a)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2253)