### PR TITLE
use resource name in metrics and traces page instead of instance id

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Metrics"
-@page "/Metrics/{applicationInstanceId}"
-@page "/Metrics/{applicationInstanceId}/Meter/{meterName}"
-@page "/Metrics/{applicationInstanceId}/Meter/{meterName}/Instrument/{instrumentName}"
+@page "/Metrics/{resourceName}"
+@page "/Metrics/{resourceName}/Meter/{meterName}"
+@page "/Metrics/{resourceName}/Meter/{meterName}/Instrument/{instrumentName}"
 
 @using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Model.Otlp

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Metrics"
-@page "/Metrics/{resourceName}"
-@page "/Metrics/{resourceName}/Meter/{meterName}"
-@page "/Metrics/{resourceName}/Meter/{meterName}/Instrument/{instrumentName}"
+@page "/Metrics/{applicationName}"
+@page "/Metrics/{applicationName}/Meter/{meterName}"
+@page "/Metrics/{applicationName}/Meter/{meterName}/Instrument/{instrumentName}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Resources

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -105,7 +105,8 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     {
         viewModel.SelectedDuration = _durations.SingleOrDefault(d => (int)d.Id.TotalMinutes == DurationMinutes) ?? _durations.Single(d => d.Id == s_defaultDuration);
         viewModel.SelectedApplication = _applications.SingleOrDefault(e => string.Equals(ResourceName, e.Name, StringComparisons.ResourceName)) ?? _selectApplication;
-        viewModel.Instruments = !string.IsNullOrEmpty(viewModel.SelectedApplication.Id) ? TelemetryRepository.GetInstrumentsSummary(viewModel.SelectedApplication.Id) : null;
+        var selectedInstance = viewModel.SelectedApplication.Id?.InstanceId;
+        viewModel.Instruments = !string.IsNullOrEmpty(selectedInstance) ? TelemetryRepository.GetInstrumentsSummary(selectedInstance) : null;
 
         viewModel.SelectedMeter = null;
         viewModel.SelectedInstrument = null;
@@ -116,7 +117,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
             {
                 viewModel.SelectedInstrument = TelemetryRepository.GetInstrument(new GetInstrumentRequest
                 {
-                    ApplicationServiceId = viewModel.SelectedApplication.Id!,
+                    ApplicationServiceId = viewModel.SelectedApplication.Id?.InstanceId!,
                     MeterName = MeterName,
                     InstrumentName = InstrumentName
                 });

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -104,7 +104,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     public void UpdateViewModelFromQuery(MetricsViewModel viewModel)
     {
         viewModel.SelectedDuration = _durations.SingleOrDefault(d => (int)d.Id.TotalMinutes == DurationMinutes) ?? _durations.Single(d => d.Id == s_defaultDuration);
-        viewModel.SelectedApplication = _applications.SingleOrDefault(e => e.Id?.Type is OtlpApplicationType.Singleton or OtlpApplicationType.ReplicaInstance && e.Id?.InstanceId == ApplicationInstanceId) ?? _selectApplication;
+        viewModel.SelectedApplication = _applications.SingleOrDefault(e => string.Equals(ResourceName, e.Name, StringComparisons.ResourceName)) ?? _selectApplication;
         var selectedInstance = viewModel.SelectedApplication.Id?.InstanceId;
         viewModel.Instruments = !string.IsNullOrEmpty(selectedInstance) ? TelemetryRepository.GetInstrumentsSummary(selectedInstance) : null;
 

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -28,7 +28,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     public MetricsViewModel PageViewModel { get; set; } = null!;
 
     [Parameter]
-    public string? ResourceName { get; set; }
+    public string? ApplicationName { get; set; }
 
     [Parameter]
     public string? MeterName { get; set; }
@@ -104,7 +104,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     public void UpdateViewModelFromQuery(MetricsViewModel viewModel)
     {
         viewModel.SelectedDuration = _durations.SingleOrDefault(d => (int)d.Id.TotalMinutes == DurationMinutes) ?? _durations.Single(d => d.Id == s_defaultDuration);
-        viewModel.SelectedApplication = _applications.SingleOrDefault(e => string.Equals(ResourceName, e.Name, StringComparisons.ResourceName)) ?? _selectApplication;
+        viewModel.SelectedApplication = _applications.SingleOrDefault(e => string.Equals(ApplicationName, e.Name, StringComparisons.ResourceName)) ?? _selectApplication;
         var selectedInstance = viewModel.SelectedApplication.Id?.InstanceId;
         viewModel.Instruments = !string.IsNullOrEmpty(selectedInstance) ? TelemetryRepository.GetInstrumentsSummary(selectedInstance) : null;
 

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -1,4 +1,4 @@
-﻿@page "/StructuredLogs/{resourceName?}"
+﻿@page "/StructuredLogs/{applicationName?}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -32,7 +32,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     public StructuredLogsPageViewModel PageViewModel { get; set; } = null!;
 
     [Parameter]
-    public string? ResourceName { get; set; }
+    public string? ApplicationName { get; set; }
 
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; set; }
@@ -314,7 +314,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
 
     public void UpdateViewModelFromQuery(StructuredLogsPageViewModel viewModel)
     {
-        PageViewModel.SelectedApplication = _applicationViewModels.SingleOrDefault(e => string.Equals(ResourceName, e.Name, StringComparisons.ResourceName)) ?? _allApplication;
+        PageViewModel.SelectedApplication = _applicationViewModels.SingleOrDefault(e => string.Equals(ApplicationName, e.Name, StringComparisons.ResourceName)) ?? _allApplication;
         ViewModel.ApplicationServiceId = PageViewModel.SelectedApplication.Id?.InstanceId;
 
         if (LogLevelText is not null && Enum.TryParse<LogLevel>(LogLevelText, ignoreCase: true, out var logLevel))

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -1,11 +1,9 @@
-﻿@page "/Traces/{applicationInstanceId?}"
+﻿@page "/Traces/{resourceName?}"
 
-@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
 @inject NavigationManager NavigationManager
-@inject IDashboardClient DashboardClient
 @inject IJSRuntime JS
 @inject IStringLocalizer<Dashboard.Resources.Traces> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -1,4 +1,4 @@
-﻿@page "/Traces/{resourceName?}"
+﻿@page "/Traces/{applicationName?}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -28,7 +28,7 @@ public partial class Traces
     private string _filter = string.Empty;
 
     [Parameter]
-    public string? ApplicationInstanceId { get; set; }
+    public string? ResourceName { get; set; }
 
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; set; }
@@ -85,7 +85,7 @@ public partial class Traces
 
     protected override void OnParametersSet()
     {
-        _selectedApplication = _applicationViewModels.SingleOrDefault(e => e.Id == ApplicationInstanceId) ?? _allApplication;
+        _selectedApplication = _applicationViewModels.SingleOrDefault(e => string.Equals(ResourceName, e.Name, StringComparisons.ResourceName)) ?? _allApplication;
         TracesViewModel.ApplicationServiceId = _selectedApplication.Id;
         UpdateSubscription();
     }
@@ -100,7 +100,7 @@ public partial class Traces
 
     private Task HandleSelectedApplicationChangedAsync()
     {
-        NavigationManager.NavigateTo($"/Traces/{_selectedApplication.Id}");
+        NavigationManager.NavigateTo($"/Traces/{_selectedApplication.Name}");
         _applicationChanged = true;
 
         return Task.CompletedTask;

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -85,7 +85,7 @@ public partial class Traces
 
     protected override void OnParametersSet()
     {
-        _selectedApplication = _applicationViewModels.SingleOrDefault(e => e.Id?.Type is OtlpApplicationType.Singleton or OtlpApplicationType.ReplicaInstance && e.Id?.InstanceId == ApplicationInstanceId) ?? _allApplication;
+        _selectedApplication = _applicationViewModels.SingleOrDefault(e => string.Equals(ResourceName, e.Name, StringComparisons.ResourceName)) ?? _allApplication;
         TracesViewModel.ApplicationServiceId = _selectedApplication.Id?.InstanceId;
         UpdateSubscription();
     }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -28,7 +28,7 @@ public partial class Traces
     private string _filter = string.Empty;
 
     [Parameter]
-    public string? ResourceName { get; set; }
+    public string? ApplicationName { get; set; }
 
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; set; }
@@ -85,7 +85,7 @@ public partial class Traces
 
     protected override void OnParametersSet()
     {
-        _selectedApplication = _applicationViewModels.SingleOrDefault(e => string.Equals(ResourceName, e.Name, StringComparisons.ResourceName)) ?? _allApplication;
+        _selectedApplication = _applicationViewModels.SingleOrDefault(e => string.Equals(ApplicationName, e.Name, StringComparisons.ResourceName)) ?? _allApplication;
         TracesViewModel.ApplicationServiceId = _selectedApplication.Id?.InstanceId;
         UpdateSubscription();
     }


### PR DESCRIPTION
Use resource name as a more friendly name, so that we have one common method across all of the pages
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2255)