### PR TITLE
Don't set `ASPNETCORE_URLS` etc. in DCP at all

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -70,16 +70,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
     private readonly IDashboardAvailability _dashboardAvailability = dashboardAvailability;
     private readonly List<AppResource> _appResources = [];
 
-    // These environment variables should never be inherited from app host;
-    // they only make sense if they come from a launch profile of a service project.
-    private static readonly string[] s_doNotInheritEnvironmentVars =
-    {
-        "ASPNETCORE_URLS",
-        "DOTNET_LAUNCH_PROFILE",
-        "ASPNETCORE_ENVIRONMENT",
-        "DOTNET_ENVIRONMENT"
-    };
-
     public async Task RunApplicationAsync(CancellationToken cancellationToken = default)
     {
         AspireEventSource.Instance.DcpModelCreationStart();
@@ -566,12 +556,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 }
                 else
                 {
-                    // If there is no launch profile, we want to make sure that certain environment variables are NOT inherited
-                    foreach (var envVar in s_doNotInheritEnvironmentVars)
-                    {
-                        config.Add(envVar, "");
-                    }
-
                     if (er.ServicesProduced.Count > 0)
                     {
                         if (er.ModelResource is ProjectResource)

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -150,6 +150,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
             Arguments = arguments,
             OnOutputData = Console.Out.Write,
             OnErrorData = Console.Error.Write,
+            InheritEnv = false,
         };
 
         _logger.LogInformation("Starting DCP with arguments: {Arguments}", dcpProcessSpec.Arguments);

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -28,6 +28,15 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
     private readonly IDcpDependencyCheckService _dependencyCheckService;
     private readonly Locations _locations;
 
+    // These environment variables should never be inherited by DCP from app host.
+    private static readonly string[] s_doNotInheritEnvironmentVars =
+    {
+        "ASPNETCORE_URLS",
+        "DOTNET_LAUNCH_PROFILE",
+        "ASPNETCORE_ENVIRONMENT",
+        "DOTNET_ENVIRONMENT"
+    };
+
     public DcpHostService(
         DistributedApplicationModel applicationModel,
         ILoggerFactory loggerFactory,
@@ -149,7 +158,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         {
             var key = de.Key?.ToString();
             var val = de.Value?.ToString();
-            if (key is not null && val is not null)
+            if (key is not null && val is not null && !s_doNotInheritEnvironmentVars.Contains(key))
             {
                 dcpProcessSpec.EnvironmentVariables.Add(key, val);
             }

--- a/src/Aspire.Hosting/Dcp/Process/ProcessSpec.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessSpec.cs
@@ -8,6 +8,7 @@ internal sealed class ProcessSpec
     public string ExecutablePath { get; }
     public string? WorkingDirectory { get; init; }
     public IDictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();
+    public bool InheritEnv { get; init; } = true;
     public string? Arguments { get; init; }
     public Action<string>? OnOutputData { get; init; }
     public Action<string>? OnErrorData { get; init; }

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -34,6 +34,11 @@ internal static partial class ProcessUtil
             EnableRaisingEvents = true
         };
 
+        if (!processSpec.InheritEnv)
+        {
+            process.StartInfo.Environment.Clear();
+        }
+
         foreach (var (key, value) in processSpec.EnvironmentVariables)
         {
             process.StartInfo.Environment[key] = value;


### PR DESCRIPTION
Related to https://github.com/dotnet/aspire/issues/225#issuecomment-1803300975. Potentially fixes or more accurately works around https://github.com/microsoft/usvc/issues/118. Fixes #2101.

`ASPNETCORE_URLS`, `DOTNET_LAUNCH_PROFILE`, `ASPNETCORE_ENVIRONMENT`, `DOTNET_ENVIRONMENT` will no longer be inherited by DCP from the AppHost, which removes the need to set those variables to empty values in each executable's spec.

Verified that this does not regress:
- [x] #1277
- [x] #225

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2257)