### PR TITLE
Introduce execution context and expose operation.

### DIFF
--- a/spelling.dic
+++ b/spelling.dic
@@ -53,3 +53,4 @@ unix
 upsert
 uris
 urls
+kubernetes

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -7,7 +7,6 @@ using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Lifecycle;
-using Aspire.Hosting.Publishing;
 using Azure;
 using Azure.Core;
 using Azure.Identity;
@@ -25,7 +24,7 @@ namespace Aspire.Hosting.Azure;
 // Provisions azure resources for development purposes
 internal sealed class AzureProvisioner(
     IOptions<AzureProvisionerOptions> options,
-    IOptions<PublishingOptions> publishingOptions,
+    DistributedApplicationExecutionContext executionContext,
     IConfiguration configuration,
     IHostEnvironment environment,
     ILogger<AzureProvisioner> logger,
@@ -39,7 +38,7 @@ internal sealed class AzureProvisioner(
     public async Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
         // TODO: Make this more general purpose
-        if (publishingOptions.Value.Publisher == "manifest")
+        if (executionContext.Operation == DistributedApplicationOperation.Publish)
         {
             return;
         }

--- a/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
@@ -441,7 +441,7 @@ public static class AzureResourceExtensions
             // UseAzureMonitor is looking for this specific environment variable name.
             var connectionStringName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
 
-            if (context.PublisherName == "manifest")
+            if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
             {
                 context.EnvironmentVariables[connectionStringName] = $"{{{resource.Name}.connectionString}}";
                 return;

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepResource.cs
@@ -340,7 +340,7 @@ public static class AzureBicepTemplateResourceExtensions
     {
         return builder.WithEnvironment(ctx =>
         {
-            if (ctx.PublisherName == "manifest")
+            if (ctx.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
             {
                 ctx.EnvironmentVariables[name] = bicepOutputReference.ValueExpression;
                 return;

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -139,7 +139,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                 new EnvironmentCallbackAnnotation(
                     context =>
                     {
-                        if (context.PublisherName == "manifest")
+                        if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
                         {
                             return;
                         }

--- a/src/Aspire.Hosting/ApplicationModel/DistributedApplicationOperation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DistributedApplicationOperation.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Describes the context in which the AppHost is being executed.
+/// </summary>
+public enum DistributedApplicationOperation
+{
+    /// <summary>
+    /// AppHost is being run for the purpose of debugging locally.
+    /// </summary>
+    Run,
+
+    /// <summary>
+    /// AppHostis being run for the purpose of publishing a manifest for deployment.
+    /// </summary>
+    Publish
+}

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
@@ -11,6 +11,12 @@ namespace Aspire.Hosting.ApplicationModel;
 public class EnvironmentCallbackContext(DistributedApplicationExecutionContext executionContext, Dictionary<string, string>? environmentVariables = null)
 {
     /// <summary>
+    /// Obsolete. Use ExecutionContext instead. Will be removed in next preview.
+    /// </summary>
+    [Obsolete("Use ExecutionContext instead")]
+    public string PublisherName => ExecutionContext.Operation == DistributedApplicationOperation.Publish ? "manifest" : "dcp";
+
+    /// <summary>
     /// Gets the environment variables associated with the callback context.
     /// </summary>
     public Dictionary<string, string> EnvironmentVariables { get; } = environmentVariables ?? new();

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
@@ -6,9 +6,9 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a callback context for environment variables associated with a publisher.
 /// </summary>
-/// <param name="publisherName">The name of the publisher.</param>
-/// <param name="environmentVariables">The environment variables associated with the publisher.</param>
-public class EnvironmentCallbackContext(string publisherName, Dictionary<string, string>? environmentVariables = null)
+/// <param name="executionContext">The execution context for this invocation of the AppHost.</param>
+/// <param name="environmentVariables">The environment variables associated with this execution.</param>
+public class EnvironmentCallbackContext(DistributedApplicationExecutionContext executionContext, Dictionary<string, string>? environmentVariables = null)
 {
     /// <summary>
     /// Gets the environment variables associated with the callback context.
@@ -16,7 +16,7 @@ public class EnvironmentCallbackContext(string publisherName, Dictionary<string,
     public Dictionary<string, string> EnvironmentVariables { get; } = environmentVariables ?? new();
 
     /// <summary>
-    /// Gets the name of the publisher associated with the callback context.
+    /// Gets the execution context associated with this invocation of the AppHost.
     /// </summary>
-    public string PublisherName { get; } = publisherName;
+    public DistributedApplicationExecutionContext ExecutionContext { get; } = executionContext;
 }

--- a/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogsConfigurationExtensions.cs
@@ -11,7 +11,7 @@ internal static class ConsoleLogsConfigurationExtensions
     {
         return builder.WithEnvironment((context) =>
         {
-            if (context.PublisherName == "manifest")
+            if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
             {
                 return;
             }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceHost.cs
@@ -4,7 +4,6 @@
 using System.Net;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp;
-using Aspire.Hosting.Publishing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
@@ -51,14 +50,13 @@ internal sealed class DashboardServiceHost : IHostedService
         DistributedApplicationModel applicationModel,
         IKubernetesService kubernetesService,
         IConfiguration configuration,
-        IOptions<PublishingOptions> publishingOptions,
+        DistributedApplicationExecutionContext executionContext,
         ILoggerFactory loggerFactory,
         IConfigureOptions<LoggerFilterOptions> loggerOptions)
     {
         _logger = loggerFactory.CreateLogger<DashboardServiceHost>();
 
-        if (!options.DashboardEnabled ||
-            publishingOptions.Value.Publisher == "manifest") // HACK: Manifest publisher check is temporary until DcpHostService is integrated with DcpPublisher.
+        if (!options.DashboardEnabled || executionContext.Operation == DistributedApplicationOperation.Publish)
         {
             _logger.LogDebug("Dashboard is not enabled so skipping hosting the resource service.");
             _resourceServiceUri.SetCanceled();

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -58,7 +58,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                                           IConfiguration configuration,
                                           IOptions<DcpOptions> options,
                                           IDashboardEndpointProvider dashboardEndpointProvider,
-                                          IDashboardAvailability dashboardAvailability)
+                                          IDashboardAvailability dashboardAvailability,
+                                          DistributedApplicationExecutionContext executionContext)
 {
     private const string DebugSessionPortVar = "DEBUG_SESSION_PORT";
 
@@ -68,6 +69,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
     private readonly IOptions<DcpOptions> _options = options;
     private readonly IDashboardEndpointProvider _dashboardEndpointProvider = dashboardEndpointProvider;
     private readonly IDashboardAvailability _dashboardAvailability = dashboardAvailability;
+    private readonly DistributedApplicationExecutionContext _executionContext = executionContext;
     private readonly List<AppResource> _appResources = [];
 
     // These environment variables should never be inherited from app host;
@@ -557,7 +559,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 }
 
                 var config = new Dictionary<string, string>();
-                var context = new EnvironmentCallbackContext("dcp", config);
+                var context = new EnvironmentCallbackContext(_executionContext, config);
 
                 // Need to apply configuration settings manually; see PrepareExecutables() for details.
                 if (er.ModelResource is ProjectResource project && project.SelectLaunchProfileName() is { } launchProfileName && project.GetLaunchSettings() is { } launchSettings)
@@ -794,7 +796,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
                 if (modelContainerResource.TryGetEnvironmentVariables(out var containerEnvironmentVariables))
                 {
-                    var context = new EnvironmentCallbackContext("dcp", config);
+                    var context = new EnvironmentCallbackContext(_executionContext, config);
 
                     foreach (var v in containerEnvironmentVariables)
                     {

--- a/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDistributedApplicationLifecycleHook.cs
@@ -3,21 +3,15 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
-using Aspire.Hosting.Publishing;
-using Microsoft.Extensions.Options;
 using System.Net.Sockets;
 
 namespace Aspire.Hosting.Dcp;
 
-internal sealed class DcpDistributedApplicationLifecycleHook(IOptions<PublishingOptions> publishingOptions) : IDistributedApplicationLifecycleHook
+internal sealed class DcpDistributedApplicationLifecycleHook(DistributedApplicationExecutionContext executionContext) : IDistributedApplicationLifecycleHook
 {
-    private readonly IOptions<PublishingOptions> _publishingOptions = publishingOptions;
-
     public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
-        var publisher = _publishingOptions.Value?.Publisher == null ? "dcp" : _publishingOptions.Value.Publisher;
-
-        if (publisher == "dcp")
+        if (executionContext.Operation == DistributedApplicationOperation.Run)
         {
             PrepareServices(appModel);
         }

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -8,7 +8,6 @@ using System.Net.Sockets;
 using System.Text;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
-using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -24,7 +23,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
     private readonly DcpOptions _dcpOptions;
-    private readonly PublishingOptions _publishingOptions;
+    private readonly DistributedApplicationExecutionContext _executionContext;
     private readonly IDcpDependencyCheckService _dependencyCheckService;
     private readonly Locations _locations;
 
@@ -32,7 +31,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         DistributedApplicationModel applicationModel,
         ILoggerFactory loggerFactory,
         IOptions<DcpOptions> dcpOptions,
-        IOptions<PublishingOptions> publishingOptions,
+        DistributedApplicationExecutionContext executionContext,
         ApplicationExecutor appExecutor,
         IDcpDependencyCheckService dependencyCheckService,
         Locations locations)
@@ -41,13 +40,13 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<DcpHostService>();
         _dcpOptions = dcpOptions.Value;
-        _publishingOptions = publishingOptions.Value;
+        _executionContext = executionContext;
         _appExecutor = appExecutor;
         _dependencyCheckService = dependencyCheckService;
         _locations = locations;
     }
 
-    private bool IsSupported => _publishingOptions.Publisher is null or "dcp";
+    private bool IsSupported => _executionContext.Operation == DistributedApplicationOperation.Run;
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -34,6 +34,9 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     public string AppHostDirectory { get; }
 
     /// <inheritdoc />
+    public DistributedApplicationExecutionContext ExecutionContext { get; }
+
+    /// <inheritdoc />
     public IResourceCollection Resources { get; } = new ResourceCollection();
 
     /// <summary>
@@ -85,6 +88,14 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddLifecycleHook<Http2TransportMutationHook>();
         _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, ManifestPublisher>("manifest");
         _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, DcpPublisher>("dcp");
+
+        ExecutionContext = _innerBuilder.Configuration["Publishing:Publisher"] switch
+        {
+            "manifest" => new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
+            _ => new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
+        };
+
+        _innerBuilder.Services.AddSingleton<DistributedApplicationExecutionContext>(ExecutionContext);
     }
 
     private void ConfigurePublishingOptions(DistributedApplicationOptions options)

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -6,15 +6,11 @@ namespace Aspire.Hosting;
 /// <summary>
 /// Exposes the global contextual information for this invocation of the AppHost.
 /// </summary>
-public class DistributedApplicationExecutionContext
+/// <param name="operation">The operation being performed in this invocation of the AppHost.</param>
+public class DistributedApplicationExecutionContext(DistributedApplicationOperation operation)
 {
-    internal DistributedApplicationExecutionContext(DistributedApplicationOperation operation)
-    {
-        Operation = operation;
-    }
-
     /// <summary>
     /// The operation currently being performed by the AppHost.
     /// </summary>
-    public DistributedApplicationOperation Operation { get; } 
+    public DistributedApplicationOperation Operation { get; } = operation;
 }

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Exposes the global contextual information for this invocation of the AppHost.
+/// </summary>
+public class DistributedApplicationExecutionContext
+{
+    internal DistributedApplicationExecutionContext(DistributedApplicationOperation operation)
+    {
+        Operation = operation;
+    }
+
+    /// <summary>
+    /// The operation currently being performed by the AppHost.
+    /// </summary>
+    public DistributedApplicationOperation Operation { get; } 
+}

--- a/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
+++ b/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
@@ -1,26 +1,22 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting;
 
-internal sealed class DistributedApplicationLifecycle(ILogger<DistributedApplication> logger, IConfiguration configuration, IOptions<PublishingOptions> publishingOptions) : IHostedLifecycleService
+internal sealed class DistributedApplicationLifecycle(ILogger<DistributedApplication> logger, IConfiguration configuration, DistributedApplicationExecutionContext executionContext) : IHostedLifecycleService
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _ = logger;
-        _ = publishingOptions;
         return Task.CompletedTask;
     }
 
     public Task StartedAsync(CancellationToken cancellationToken)
     {
-        if (publishingOptions.Value.Publisher != "manifest")
+        if (executionContext.Operation == DistributedApplicationOperation.Run)
         {
             logger.LogInformation("Distributed application started. Press CTRL-C to stop.");
         }
@@ -30,7 +26,7 @@ internal sealed class DistributedApplicationLifecycle(ILogger<DistributedApplica
 
     public Task StartingAsync(CancellationToken cancellationToken)
     {
-        if (publishingOptions.Value.Publisher != "manifest")
+        if (executionContext.Operation == DistributedApplicationOperation.Run)
         {
             logger.LogInformation("Distributed application starting.");
             logger.LogInformation("Application host directory is: {AppHostDirectory}", configuration["AppHost:Directory"]);

--- a/src/Aspire.Hosting/DistributedApplicationRunner.cs
+++ b/src/Aspire.Hosting/DistributedApplicationRunner.cs
@@ -5,23 +5,19 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting;
 
-internal sealed class DistributedApplicationRunner(DistributedApplicationModel model, IOptions<PublishingOptions> options, IServiceProvider serviceProvider) : BackgroundService
+internal sealed class DistributedApplicationRunner(DistributedApplicationExecutionContext executionContext, DistributedApplicationModel model, IServiceProvider serviceProvider) : BackgroundService
 {
-    private readonly DistributedApplicationModel _model = model;
-    private readonly IOptions<PublishingOptions> _options = options;
-    private readonly IServiceProvider _serviceProvider = serviceProvider;
-
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var publisherName = _options.Value.Publisher?.ToLowerInvariant() ?? "dcp";
+        var publisher = executionContext.Operation switch
+        {
+            DistributedApplicationOperation.Publish => serviceProvider.GetRequiredKeyedService<IDistributedApplicationPublisher>("manifest"),
+            _ => serviceProvider.GetRequiredKeyedService<IDistributedApplicationPublisher>("dcp")
+        };
 
-        var publisher = _serviceProvider.GetKeyedService<IDistributedApplicationPublisher>(publisherName)
-            ?? throw new DistributedApplicationException($"Could not find registered publisher '{publisherName}'");
-
-        await publisher.PublishAsync(_model, stoppingToken).ConfigureAwait(false);
+        await publisher.PublishAsync(model, stoppingToken).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class ResourceBuilderExtensions
     {
         return builder.WithEnvironment(context =>
         {
-            if (context.PublisherName == "manifest")
+            if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
             {
                 context.EnvironmentVariables[name] = endpointReference.ValueExpression;
                 return;
@@ -91,7 +91,7 @@ public static class ResourceBuilderExtensions
     {
         return builder.WithEnvironment(context =>
         {
-            if (context.PublisherName == "manifest")
+            if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
             {
                 context.EnvironmentVariables[name] = parameter.Resource.ValueExpression;
                 return;
@@ -184,7 +184,7 @@ public static class ResourceBuilderExtensions
         {
             var connectionStringName = resource.ConnectionStringEnvironmentVariable ?? $"{ConnectionStringEnvironmentName}{connectionName}";
 
-            if (context.PublisherName == "manifest")
+            if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
             {
                 context.EnvironmentVariables[connectionStringName] = resource.ConnectionStringReferenceExpression;
                 return;

--- a/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
@@ -28,6 +28,11 @@ public interface IDistributedApplicationBuilder
     public IServiceCollection Services { get; }
 
     /// <summary>
+    /// Execution context for this invocation of the AppHost.
+    /// </summary>
+    public DistributedApplicationExecutionContext ExecutionContext { get; }
+
+    /// <summary>
     /// Gets the collection of resources for the distributed application.
     /// </summary>
     /// <remarks>

--- a/src/Aspire.Hosting/Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Kafka/KafkaBuilderExtensions.cs
@@ -58,7 +58,7 @@ public static class KafkaBuilderExtensions
         // When not explicitly set default configuration is applied.
         // See https://github.com/confluentinc/kafka-images/blob/master/local/include/etc/confluent/docker/configureDefaults for more details.
 
-        var hostPort = context.PublisherName == "manifest"
+        var hostPort = context.ExecutionContext.Operation == DistributedApplicationOperation.Publish
             ? KafkaBrokerPort
             : GetResourcePort(resource);
         context.EnvironmentVariables.Add("KAFKA_ADVERTISED_LISTENERS",

--- a/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class MySqlBuilderExtensions
                       .WithAnnotation(new ContainerImageAnnotation { Image = "mysql", Tag = "latest" })
                       .WithEnvironment(context =>
                       {
-                          if (context.PublisherName == "manifest")
+                          if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
                           {
                               context.EnvironmentVariables.Add(PasswordEnvVarName, $"{{{resource.Name}.inputs.password}}");
                           }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
@@ -34,7 +34,7 @@ public static class OracleDatabaseBuilderExtensions
                       .WithAnnotation(new ContainerImageAnnotation { Image = "database/free", Tag = "latest", Registry = "container-registry.oracle.com" })
                       .WithEnvironment(context =>
                       {
-                          if (context.PublisherName == "manifest")
+                          if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
                           {
                               context.EnvironmentVariables.Add(PasswordEnvVarName, $"{{{oracleDatabaseServer.Name}.inputs.password}}");
                           }

--- a/src/Aspire.Hosting/Otlp/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/Otlp/OtlpConfigurationExtensions.cs
@@ -29,7 +29,7 @@ public static class OtlpConfigurationExtensions
 
         resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
         {
-            if (context.PublisherName == "manifest")
+            if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
             {
                 // REVIEW:  Do we want to set references to an imaginary otlp provider as a requirement?
                 return;

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -38,7 +38,7 @@ public static class PostgresBuilderExtensions
                       .WithEnvironment("POSTGRES_INITDB_ARGS", "--auth-host=scram-sha-256 --auth-local=scram-sha-256")
                       .WithEnvironment(context =>
                       {
-                          if (context.PublisherName == "manifest")
+                          if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
                           {
                               context.EnvironmentVariables.Add(PasswordEnvVarName, $"{{{postgresServer.Name}.inputs.password}}");
                           }

--- a/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
+++ b/src/Aspire.Hosting/Publishing/AutomaticManifestPublisherBindingInjectionHook.cs
@@ -4,14 +4,11 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Publishing;
 
-internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<PublishingOptions> publishingOptions) : IDistributedApplicationLifecycleHook
+internal sealed class AutomaticManifestPublisherBindingInjectionHook(DistributedApplicationExecutionContext executionContext) : IDistributedApplicationLifecycleHook
 {
-    private readonly IOptions<PublishingOptions> _publishingOptions = publishingOptions;
-
     private static bool IsKestrelHttp2ConfigurationPresent(ProjectResource projectResource)
     {
         var projectMetadata = projectResource.GetProjectMetadata();
@@ -37,7 +34,7 @@ internal sealed class AutomaticManifestPublisherBindingInjectionHook(IOptions<Pu
 
     public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
-        if (_publishingOptions.Value.Publisher != "manifest")
+        if (executionContext.Operation == DistributedApplicationOperation.Run)
         {
             return Task.CompletedTask;
         }

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -11,11 +11,13 @@ namespace Aspire.Hosting.Publishing;
 
 internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
                                IOptions<PublishingOptions> options,
-                               IHostApplicationLifetime lifetime) : IDistributedApplicationPublisher
+                               IHostApplicationLifetime lifetime,
+                               DistributedApplicationExecutionContext executionContext) : IDistributedApplicationPublisher
 {
     private readonly ILogger<ManifestPublisher> _logger = logger;
     private readonly IOptions<PublishingOptions> _options = options;
     private readonly IHostApplicationLifetime _lifetime = lifetime;
+    private readonly DistributedApplicationExecutionContext _executionContext = executionContext;
 
     public Utf8JsonWriter? JsonWriter { get; set; }
 
@@ -46,7 +48,7 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
     protected async Task WriteManifestAsync(DistributedApplicationModel model, Utf8JsonWriter jsonWriter, CancellationToken cancellationToken)
     {
         var manifestPath = _options.Value.OutputPath ?? throw new DistributedApplicationException("The '--output-path [path]' option was not specified even though '--publisher manifest' argument was used.");
-        var context = new ManifestPublishingContext(manifestPath, jsonWriter);
+        var context = new ManifestPublishingContext(_executionContext, manifestPath, jsonWriter);
 
         jsonWriter.WriteStartObject();
         WriteResources(model, context);

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -8,24 +8,30 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Publishing;
 
 /// <summary>
-/// TODO: Doc Comments
+/// Contextual information used for manifest publishing during this execution of the AppHost.
 /// </summary>
-/// <param name="manifestPath"></param>
-/// <param name="writer"></param>
-public sealed class ManifestPublishingContext(string manifestPath, Utf8JsonWriter writer)
+/// <param name="executionContext">Global contextual information for this invocation of the AppHost.</param>
+/// <param name="manifestPath">Manifest path passed in for this invocation of the AppHost.</param>
+/// <param name="writer">JSON writer used to writing the manifest.</param>
+public sealed class ManifestPublishingContext(DistributedApplicationExecutionContext executionContext, string manifestPath, Utf8JsonWriter writer)
 {
     /// <summary>
-    /// TODO: Doc Comments
+    /// Gets execution context for this invocation of the AppHost.
+    /// </summary>
+    public DistributedApplicationExecutionContext ExecutionContext { get; } = executionContext;
+
+    /// <summary>
+    /// Gets manifest path specified for this invocation of the AppHost.
     /// </summary>
     public string ManifestPath { get; } = manifestPath;
 
     /// <summary>
-    /// TODO: Doc Comments
+    /// Gets JSON writer for writing manifest entries.
     /// </summary>
     public Utf8JsonWriter Writer { get; } = writer;
 
     /// <summary>
-    /// TODO: Doc Comments
+    /// Generates a relative path based on the location of the manifest path.
     /// </summary>
     /// <param name="path"></param>
     /// <returns></returns>
@@ -130,7 +136,8 @@ public sealed class ManifestPublishingContext(string manifestPath, Utf8JsonWrite
     public void WriteEnvironmentVariables(IResource resource)
     {
         var config = new Dictionary<string, string>();
-        var envContext = new EnvironmentCallbackContext("manifest", config);
+        
+        var envContext = new EnvironmentCallbackContext(ExecutionContext, config);
 
         if (resource.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var callbacks))
         {

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class RabbitMQBuilderExtensions
                        .WithEnvironment("RABBITMQ_DEFAULT_USER", "guest")
                        .WithEnvironment(context =>
                        {
-                           if (context.PublisherName == "manifest")
+                           if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
                            {
                                context.EnvironmentVariables.Add("RABBITMQ_DEFAULT_PASS", $"{{{rabbitMq.Name}.inputs.password}}");
                            }

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class SqlServerBuilderExtensions
                       .WithEnvironment("ACCEPT_EULA", "Y")
                       .WithEnvironment(context =>
                       {
-                          if (context.PublisherName == "manifest")
+                          if (context.ExecutionContext.Operation == DistributedApplicationOperation.Publish)
                           {
                               context.EnvironmentVariables.Add("MSSQL_SA_PASSWORD", $"{{{sqlServer.Name}.inputs.password}}");
                           }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -266,7 +266,8 @@ public class AzureBicepResourceTests
         using var ms = new MemoryStream();
         var writer = new Utf8JsonWriter(ms);
         writer.WriteStartObject();
-        writeManifest(new ManifestPublishingContext(Environment.CurrentDirectory, writer));
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        writeManifest(new ManifestPublishingContext(executionContext, Environment.CurrentDirectory, writer));
         writer.WriteEndObject();
         writer.Flush();
         ms.Position = 0;

--- a/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
@@ -100,7 +100,8 @@ public class AzureResourceExtensionsTests
         var annotations = serviceA.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("manifest", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -126,7 +127,8 @@ public class AzureResourceExtensionsTests
         var annotations = serviceA.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {

--- a/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
@@ -70,6 +70,8 @@ public class ApplicationExecutorTests
                 DashboardPath = "./dashboard"
             }),
             new MockDashboardEndpointProvider(),
-            new MockDashboardAvailability());
+            new MockDashboardAvailability(),
+            new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
+            );
     }
 }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
@@ -12,6 +12,15 @@ namespace Aspire.Hosting.Tests;
 
 public class DistributedApplicationBuilderTests
 {
+    [Theory]
+    [InlineData(new string[0], DistributedApplicationOperation.Run)]
+    [InlineData(new string[] { "--publisher", "manifest" }, DistributedApplicationOperation.Publish)]
+    public void BuilderExecutionContextExposesCorrectOperation(string[] args, DistributedApplicationOperation operation)
+    {
+        var builder = DistributedApplication.CreateBuilder(args);
+        Assert.Equal(operation, builder.ExecutionContext.Operation);
+    }
+
     [Fact]
     public void BuilderAddsDefaultServices()
     {

--- a/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/JsonDocumentManifestPublisher.cs
@@ -13,7 +13,8 @@ namespace Aspire.Hosting.Tests.Helpers;
 internal sealed class JsonDocumentManifestPublisher(
     ILogger<ManifestPublisher> logger,
     IOptions<PublishingOptions> options,
-    IHostApplicationLifetime lifetime) : ManifestPublisher(logger, options, lifetime)
+    IHostApplicationLifetime lifetime, DistributedApplicationExecutionContext executionContext
+    ) : ManifestPublisher(logger, options, lifetime, executionContext)
 {
     protected override async Task PublishInternalAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
     {

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -44,7 +44,8 @@ public class AddMySqlTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -92,7 +93,8 @@ public class AddMySqlTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -186,7 +188,8 @@ public class AddMySqlTests
         var envAnnotations = myAdmin.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -42,7 +42,8 @@ public class AddOracleDatabaseTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -90,7 +91,8 @@ public class AddOracleDatabaseTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -189,7 +191,8 @@ public class AddOracleDatabaseTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -44,7 +44,8 @@ public class AddPostgresTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -102,7 +103,8 @@ public class AddPostgresTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -211,7 +213,8 @@ public class AddPostgresTests
         var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -31,7 +31,8 @@ public class ProjectResourceTests
         var annotations = resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -123,7 +123,8 @@ public class AddRedisTests
         var envAnnotations = commander.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {
@@ -154,7 +155,8 @@ public class AddRedisTests
         var envAnnotations = commander.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in envAnnotations)
         {

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -31,7 +31,8 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -56,7 +57,8 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -83,7 +85,8 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -109,7 +112,8 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -132,7 +136,8 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("manifest", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -155,7 +160,8 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         var exception = Assert.Throws<DistributedApplicationException>(() =>
         {
@@ -186,7 +192,8 @@ public class WithEnvironmentTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -31,7 +31,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -80,7 +81,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -129,7 +131,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -176,7 +179,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -221,7 +225,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -250,7 +255,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         Assert.Throws<DistributedApplicationException>(() =>
         {
@@ -275,7 +281,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -300,7 +307,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         var exception = Assert.Throws<DistributedApplicationException>(() =>
         {
@@ -328,7 +336,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -352,7 +361,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("manifest", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -376,7 +386,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("manifest", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -403,7 +414,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -432,7 +444,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {
@@ -471,7 +484,8 @@ public class WithReferenceTests
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
         var config = new Dictionary<string, string>();
-        var context = new EnvironmentCallbackContext("dcp", config);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
 
         foreach (var annotation in annotations)
         {


### PR DESCRIPTION
Fixes #1770 and #1823 

Introduce a new execution context which can be used on the builder and via DI.

## Old approach

```csharp
.WithEnvironment(context =>
{
    if (context.PublisherName == "manifest")
    {
        context.EnvironmentVariables.Add("MSSQL_SA_PASSWORD", $"{{{sqlServer.Name}.inputs.password}}");
        return
    }
    ...
```

## New approach

```csharp
.WithEnvironment(context =>
{
    if (context.ExecutionContext.Operation == DistributedAppliationOperation.Publish)
    {
        context.EnvironmentVariables.Add("MSSQL_SA_PASSWORD", $"{{{sqlServer.Name}.inputs.password}}");
        return
    }
    ...
```

Note that the execution context is also available on the builder - example usage:

```csharp
var builder = DistributedApplication.CreateBuilder(args);
var db = builder.ExecutionContext.Operation switch {
  Publish => builder.AddConnectionString("db"),
  _ => builder.AddPostgres("pgsql").AddDatabase("db")
};
```