### PR TITLE
Make resource details sections more obvious

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -2,7 +2,7 @@
 @using Aspire.Dashboard.Resources
 @inject IStringLocalizer<ControlsStrings> ControlStringsLoc
 
-<div class="environment-variables-layout">
+<div class="resource-details-layout">
 
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ConsoleLogs/{Resource?.Name}")" slot="end">View logs</FluentAnchor>

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.css
@@ -1,4 +1,4 @@
-::deep.environment-variables-layout {
+::deep.resource-details-layout {
     display: grid;
     grid-template-rows: auto 1fr;
     grid-template-areas:
@@ -8,7 +8,7 @@
     gap: calc(var(--design-unit) * 1px);
 }
 
-::deep.environment-variables-layout > fluent-toolbar {
+::deep.resource-details-layout > fluent-toolbar {
     grid-area: toolbar;
 }
 
@@ -24,17 +24,28 @@
     --fill-color: var(--neutral-layer-1);
 }
 
+/* Under the current light theme, --neutral-layer-1 is too white, so we'll
+   use something that's halfway between --neutral-layer-2 and --neutral-layer1.
+*/
+[data-theme="light"] .resource-details-layout ::deep fluent-accordion {
+    --fill-color: var(--neutral-fill-rest);
+}
+
 ::deep fluent-accordion-item {
     margin:0 calc(var(--design-unit) * 1px);
 }
 
+::deep fluent-accordion-item::part(heading),
 ::deep fluent-accordion-item::part(region) {
     background-color: var(--fill-color);
+}
+
+::deep fluent-accordion-item::part(region) {
     padding-bottom: 0;
 }
 
 ::deep fluent-accordion-item::part(heading-content) {
-    font-weight: bold;
+    font-weight: 600;
     font-size: var(--type-ramp-plus-1-font-size);
 }
 
@@ -50,4 +61,9 @@
 ::deep fluent-accordion fluent-data-grid fluent-button[appearance=stealth]:hover::part(control),
 ::deep fluent-accordion fluent-data-grid fluent-button[appearance=lightweight]:hover::part(control) {
     background-color: var(--neutral-fill-stealth-hover-on-neutral-fill-layer-rest);
+}
+
+/* Under the current dark theme, the fluent-badge background color was too dark on --neutral-layer-1 */
+[data-theme="dark"] .resource-details-layout ::deep fluent-accordion-item fluent-badge::part(control) {
+    background-color: var(--neutral-fill-active);
 }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.css
@@ -5,6 +5,7 @@
         "toolbar"
         "main";
     overflow: auto;
+    gap: calc(var(--design-unit) * 1px);
 }
 
 ::deep.environment-variables-layout > fluent-toolbar {
@@ -20,20 +21,28 @@
 
 ::deep fluent-accordion {
     gap: calc(var(--design-unit) * 2px);
+    --fill-color: var(--neutral-layer-1);
 }
 
 ::deep fluent-accordion-item {
-    border-color: transparent; /* A zero width border adds a horizontal scroll bar for some reason */
-    background: unset;
+    margin:0 calc(var(--design-unit) * 1px);
 }
 
 ::deep fluent-accordion-item::part(region) {
-    border-color: transparent; /* A zero width border adds a horizontal scroll bar for some reason */
-    background: unset;
-    padding: 0;
+    background-color: var(--fill-color);
 }
 
 ::deep fluent-accordion-item::part(heading-content) {
     font-weight: bold;
     font-size: var(--type-ramp-plus-1-font-size);
+}
+
+::deep fluent-accordion fluent-data-grid fluent-button[appearance=stealth]:not(:hover)::part(control),
+::deep fluent-accordion fluent-data-grid fluent-button[appearance=lightweight]:not(:hover)::part(control) {
+    background-color: var(--fill-color);
+}
+
+::deep fluent-accordion fluent-data-grid fluent-button[appearance=stealth]:hover::part(control),
+::deep fluent-accordion fluent-data-grid fluent-button[appearance=lightweight]:hover::part(control) {
+    background-color: var(--neutral-fill-stealth-hover-on-neutral-fill-layer-rest);
 }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.css
@@ -30,11 +30,16 @@
 
 ::deep fluent-accordion-item::part(region) {
     background-color: var(--fill-color);
+    padding-bottom: 0;
 }
 
 ::deep fluent-accordion-item::part(heading-content) {
     font-weight: bold;
     font-size: var(--type-ramp-plus-1-font-size);
+}
+
+::deep fluent-accordion fluent-data-grid-row:last-of-type {
+    border-bottom: none;
 }
 
 ::deep fluent-accordion fluent-data-grid fluent-button[appearance=stealth]:not(:hover)::part(control),

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.css
@@ -17,6 +17,8 @@
     overflow: auto;
     width: 100%;
     height: 100%;
+    padding: calc(var(--design-unit) * 1px);
+    padding-top: 0;
 }
 
 ::deep fluent-accordion {
@@ -31,13 +33,17 @@
     --fill-color: var(--neutral-fill-rest);
 }
 
-::deep fluent-accordion-item {
-    margin:0 calc(var(--design-unit) * 1px);
-}
-
-::deep fluent-accordion-item::part(heading),
+::deep fluent-accordion-item,
 ::deep fluent-accordion-item::part(region) {
     background-color: var(--fill-color);
+}
+
+/* This is a hack because we can't do a selector that selects inside of a ::part,
+   which is what we'd need to do to access `::part(heading):not(:hover) .icon`.
+   So instead we just change the color token the non-hovered state uses.
+*/
+[data-theme="light"] .resource-details-layout ::deep fluent-accordion-item::part(icon) {
+    --neutral-fill-stealth-rest-on-neutral-fill-layer-rest: var(--fill-color);
 }
 
 ::deep fluent-accordion-item::part(region) {


### PR DESCRIPTION
(Hopefully) resolves #1612 

I worked on this for a while and, given the relatively small color palette we have to work with, coming up with an accordion item header color that worked well didn't seem to be an easy task. So I went back to the drawing board a bit and this is what I came up with. I think this accomplishes the actual goal of making the individual sections much more easily identifiable. Though I acknowledge it doesn't do it in the specific way that the issue suggested, so I'm certainly open to feedback. 

Some screenshots of how it looks:

![ResourceDetails_Dark_PanelOnly](https://github.com/dotnet/aspire/assets/9613109/935c202f-73c7-4358-9d7c-3859c7b1c122)
![ResourceDetails_Light_PanelOnly](https://github.com/dotnet/aspire/assets/9613109/8a9fefad-d622-41ef-aa7c-b8ce96faaeea)
![ResourceDetails_Dark_FullPage](https://github.com/dotnet/aspire/assets/9613109/82faf556-2c92-45ed-8dcf-446e99834012)
![ResourceDetails_Light_FullPage](https://github.com/dotnet/aspire/assets/9613109/c2655bf3-4326-49d7-a32c-dca97e6013bd)
![ResourceDetails_Dark_Collapsed](https://github.com/dotnet/aspire/assets/9613109/57a20441-887a-4d11-8497-ca07904bdb62)
![ResourceDetails_Light_Collapsed](https://github.com/dotnet/aspire/assets/9613109/f137acc8-89d0-4fe9-8e7b-672324e04e47)

This has the effect of somewhat resembling the way messages are displayed in new Outlook/outlook.com (though I left off the drop-shadow for now at least):
![image](https://github.com/dotnet/aspire/assets/9613109/f588c570-5f4f-4ad0-a8a1-0b93907b8fa3)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2270)