### PR TITLE
Clean up resource output modeling

### DIFF
--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepAppConfigurationResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepAppConfigurationResource.cs
@@ -14,18 +14,20 @@ public class AzureBicepAppConfigurationResource(string name) :
     IResourceWithConnectionString
 {
     /// <summary>
+    /// Gets the appConfigEndpoint output reference for the Azure App Configuration resource.
+    /// </summary>
+    public BicepOutputReference Endpoint => new("appConfigEndpoint", this);
+
+    /// <summary>
     /// Gets the connection string template for the manifest for the Azure App Configuration resource.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Name}.outputs.appConfigEndpoint}}";
+    public string ConnectionStringExpression => Endpoint.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure App Configuration resource.
     /// </summary>
     /// <returns>The connection string for the Azure App Configuration resource.</returns>
-    public string? GetConnectionString()
-    {
-        return Outputs["appConfigEndpoint"];
-    }
+    public string? GetConnectionString() => Endpoint.Value;
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepApplicationInsightsResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepApplicationInsightsResource.cs
@@ -14,18 +14,20 @@ public class AzureBicepApplicationInsightsResource(string name) :
     IResourceWithConnectionString
 {
     /// <summary>
+    /// Gets the "appInsightsConnectionString" output reference for the Azure Application Insights resource.
+    /// </summary>
+    public BicepOutputReference ConnectionString => new("appInsightsConnectionString", this);
+
+    /// <summary>
     /// Gets the connection string template for the manifest for the Azure Application Insights resource.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Name}.outputs.appInsightsConnectionString}}";
+    public string ConnectionStringExpression => ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure Application Insights resource.
     /// </summary>
     /// <returns>The connection string for the Azure Application Insights resource.</returns>
-    public string? GetConnectionString()
-    {
-        return Outputs["appInsightsConnectionString"];
-    }
+    public string? GetConnectionString() => ConnectionString.Value;
 
     // UseAzureMonitor is looks for this specific environment variable name.
     string IResourceWithConnectionString.ConnectionStringEnvironmentVariable => "APPLICATIONINSIGHTS_CONNECTION_STRING";

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepCosmosDBResource.cs
@@ -18,6 +18,11 @@ public class AzureBicepCosmosDBResource(string name) :
     internal List<string> Databases { get; } = [];
 
     /// <summary>
+    /// Gets the "connectionString" reference from the secret outputs of the Azure Cosmos DB resource.
+    /// </summary>
+    public BicepSecretOutputReference ConnectionString => new("connectionString", this);
+
+    /// <summary>
     /// Gets a value indicating whether the Azure Cosmos DB resource is running in the local emulator.
     /// </summary>
     public bool IsEmulator => this.IsContainer();
@@ -25,7 +30,7 @@ public class AzureBicepCosmosDBResource(string name) :
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Cosmos DB resource.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Name}.secretOutputs.connectionString}}";
+    public string ConnectionStringExpression => ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string to use for this database.
@@ -38,7 +43,7 @@ public class AzureBicepCosmosDBResource(string name) :
             return AzureCosmosDBEmulatorConnectionString.Create(GetEmulatorPort("emulator"));
         }
 
-        return SecretOutputs["connectionString"];
+        return ConnectionString.Value;
     }
 
     private int GetEmulatorPort(string endpointName) =>

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepKeyVaultResource.cs
@@ -14,18 +14,20 @@ public class AzureBicepKeyVaultResource(string name) :
     IResourceWithConnectionString
 {
     /// <summary>
+    /// Gets the "vaultUri" output reference for the Azure Key Vault resource.
+    /// </summary>
+    public BicepOutputReference VaultUri => new("vaultUri", this);
+
+    /// <summary>
     /// Gets the connection string template for the manifest for the Azure Key Vault resource.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Name}.outputs.vaultUri}}";
+    public string ConnectionStringExpression => VaultUri.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure Key Vault resource.
     /// </summary>
     /// <returns>The connection string for the Azure Key Vault resource.</returns>
-    public string? GetConnectionString()
-    {
-        return Outputs["vaultUri"];
-    }
+    public string? GetConnectionString() => VaultUri.Value;
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepPostgresResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepPostgresResource.cs
@@ -17,19 +17,20 @@ public class AzureBicepPostgresResource(string name) :
     internal List<string> Databases { get; } = [];
 
     /// <summary>
+    /// Gets the "connectionString" secret output reference from the bicep template for the Azure Postgres Flexible Server.
+    /// </summary>
+    public BicepSecretOutputReference ConnectionString => new("connectionString", this);
+
+    /// <summary>
     /// Gets the connection template for the manifest for the Azure Postgres Flexible Server.
     /// </summary>
-    public string ConnectionStringExpression =>
-        $"{{{Name}.secretOutputs.connectionString}}";
+    public string ConnectionStringExpression => ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure Postgres Flexible Server.
     /// </summary>
     /// <returns>The connection string.</returns>
-    public string? GetConnectionString()
-    {
-        return SecretOutputs["connectionString"];
-    }
+    public string? GetConnectionString() => ConnectionString.Value;
 }
 
 /// <summary>
@@ -49,7 +50,7 @@ public class AzureBicepPostgresDbResource(string name, string databaseName, Azur
     public AzureBicepPostgresResource Parent { get; } = parent;
 
     /// <summary>
-    /// TODO: Doc Comments
+    /// Gets the connection template for the manifest for the Azure Postgres Flexible Server database.
     /// </summary>
     public string ConnectionStringExpression =>
         $"{{{Parent.Name}.connectionString}};Database={databaseName}";

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepRedisResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepRedisResource.cs
@@ -14,19 +14,20 @@ public class AzureBicepRedisResource(string name) :
     IResourceWithConnectionString
 {
     /// <summary>
+    /// Gets the "connectionString" output reference from the bicep template for the Azure Redis resource.
+    /// </summary>
+    public BicepSecretOutputReference ConnectionString => new("connectionString", this);
+
+    /// <summary>
     /// Gets the connection string template for the manifest for the Azure Redis resource.
     /// </summary>
-    public string ConnectionStringExpression =>
-        $"{{{Name}.secretOutputs.connectionString}}";
+    public string ConnectionStringExpression => ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure Redis resource.
     /// </summary>
     /// <returns>The connection string for the Azure Redis resource.</returns>
-    public string? GetConnectionString()
-    {
-        return SecretOutputs["connectionString"];
-    }
+    public string? GetConnectionString() => ConnectionString.Value;
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepResource.cs
@@ -247,6 +247,44 @@ public readonly struct BicepTemplateFile(string path, bool deleteFileOnDispose) 
 }
 
 /// <summary>
+/// A reference to a secret output from a bicep template.
+/// </summary>
+/// <param name="name">The name of the secret output.</param>
+/// <param name="resource">The <see cref="AzureBicepResource"/>.</param>
+public class BicepSecretOutputReference(string name, AzureBicepResource resource)
+{
+    /// <summary>
+    /// Name of the output.
+    /// </summary>
+    public string Name { get; } = name;
+
+    /// <summary>
+    /// The instance of the bicep resource.
+    /// </summary>
+    public AzureBicepResource Resource { get; } = resource;
+
+    /// <summary>
+    /// The value of the output.
+    /// </summary>
+    public string? Value
+    {
+        get
+        {
+            if (!Resource.SecretOutputs.TryGetValue(Name, out var value))
+            {
+                throw new InvalidOperationException($"No secret output for {Name}");
+            }
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// The expression used in the manifest to reference the value of the secret output.
+    /// </summary>
+    public string ValueExpression => $"{{{Resource.Name}.secretOutputs.{Name}}}";
+}
+
+/// <summary>
 /// A reference to an output from a bicep template.
 /// </summary>
 /// <param name="name">The name of the output</param>

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepServiceBusResource.cs
@@ -14,17 +14,19 @@ public class AzureBicepServiceBusResource(string name) :
     IResourceWithConnectionString
 {
     /// <summary>
+    /// Gets the "serviceBusEndpoint" output reference from the bicep template for the Azure Service Bus endpoint.
+    /// </summary>
+    public BicepOutputReference ServiceBusEndpoint => new("serviceBusEndpoint", this);
+
+    /// <summary>
     /// Gets the connection string template for the manifest for the Azure Service Bus endpoint.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Name}.outputs.serviceBusEndpoint}}";
+    public string ConnectionStringExpression => ServiceBusEndpoint.ValueExpression;
     /// <summary>
     /// Gets the connection string for the Azure Service Bus endpoint.
     /// </summary>
     /// <returns>The connection string for the Azure Service Bus endpoint.</returns>
-    public string? GetConnectionString()
-    {
-        return Outputs["serviceBusEndpoint"];
-    }
+    public string? GetConnectionString() => ServiceBusEndpoint.Value;
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepSqlServerResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepSqlServerResource.cs
@@ -14,13 +14,18 @@ public class AzureBicepSqlServerResource(string name) :
     AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.sql.bicep"),
     IResourceWithConnectionString
 {
+    /// <summary>
+    /// Gets the fully qualified domain name (FQDN) output reference from the bicep template for the Azure SQL Server resource.
+    /// </summary>
+    public BicepOutputReference FullyQualifiedDomainName => new("sqlServerFqdn", this);
+
     internal List<string> Databases { get; } = [];
 
     /// <summary>
     /// Gets the connection template for the manifest for the Azure SQL Server resource.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"Server=tcp:{{{Name}.outputs.sqlServerFqdn}},1433;Encrypt=True;Authentication=\"Active Directory Default\"";
+        $"Server=tcp:{FullyQualifiedDomainName.ValueExpression},1433;Encrypt=True;Authentication=\"Active Directory Default\"";
 
     /// <summary>
     /// Gets the connection string for the Azure SQL Server resource.
@@ -28,7 +33,7 @@ public class AzureBicepSqlServerResource(string name) :
     /// <returns>The connection string for the Azure SQL Server resource.</returns>
     public string? GetConnectionString()
     {
-        return $"Server=tcp:{Outputs["sqlServerFqdn"]},1433;Encrypt=True;Authentication=\"Active Directory Default\"";
+        return $"Server=tcp:{FullyQualifiedDomainName.Value},1433;Encrypt=True;Authentication=\"Active Directory Default\"";
     }
 }
 

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepStorageResource.cs
@@ -17,21 +17,36 @@ public class AzureBicepStorageResource(string name) :
     AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.storage.bicep")
 {
     /// <summary>
+    /// Gets the "blobEndpoint" output reference from the bicep template for the Azure Storage resource.
+    /// </summary>
+    public BicepOutputReference BlobEndpoint => new("blobEndpoint", this);
+
+    /// <summary>
+    /// Gets the "queueEndpoint" output reference from the bicep template for the Azure Storage resource.
+    /// </summary>
+    public BicepOutputReference QueueEndpoint => new("queueEndpoint", this);
+
+    /// <summary>
+    /// Gets the "tableEndpoint" output reference from the bicep template for the Azure Storage resource.
+    /// </summary>
+    public BicepOutputReference TableEndpoint => new("tableEndpoint", this);
+
+    /// <summary>
     /// Gets a value indicating whether the Azure Storage resource is running in the local emulator.
     /// </summary>
     public bool IsEmulator => this.IsContainer();
 
     internal string? GetTableConnectionString() => IsEmulator
         ? AzureStorageEmulatorConnectionString.Create(tablePort: GetEmulatorPort("table"))
-        : Outputs["tableEndpoint"];
+        : TableEndpoint.Value;
 
     internal string? GetQueueConnectionString() => IsEmulator
         ? AzureStorageEmulatorConnectionString.Create(queuePort: GetEmulatorPort("queue"))
-        : Outputs["queueEndpoint"];
+        : QueueEndpoint.Value;
 
     internal string? GetBlobConnectionString() => IsEmulator
         ? AzureStorageEmulatorConnectionString.Create(blobPort: GetEmulatorPort("blob"))
-        : Outputs["blobEndpoint"];
+        : BlobEndpoint.Value;
 
     private int GetEmulatorPort(string endpointName) =>
         Annotations
@@ -58,7 +73,7 @@ public class AzureBicepBlobStorageResource(string name, AzureBicepStorageResourc
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Blob Storage resource.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Parent.Name}.outputs.blobEndpoint}}";
+    public string ConnectionStringExpression => Parent.BlobEndpoint.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure Blob Storage resource.
@@ -95,7 +110,7 @@ public class AzureBicepTableStorageResource(string name, AzureBicepStorageResour
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Blob Storage resource.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Parent.Name}.outputs.tableEndpoint}}";
+    public string ConnectionStringExpression => Parent.TableEndpoint.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure Blob Storage resource.
@@ -132,7 +147,7 @@ public class AzureBicepQueueStorageResource(string name, AzureBicepStorageResour
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Blob Storage resource.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Parent.Name}.outputs.queueEndpoint}}";
+    public string ConnectionStringExpression => Parent.QueueEndpoint.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure Blob Storage resource.


### PR DESCRIPTION
- Added properties typed as BicepOutputReference or BicepSecretOutputReference. Removes lots of duplicate code and error prone string formatting.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2286)