### PR TITLE
Fix SQL Server Bicep generated connection string.

### DIFF
--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepSqlServerResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepSqlServerResource.cs
@@ -54,7 +54,7 @@ public class AzureBicepSqlDbResource(string name, string databaseName, AzureBice
     /// Gets the connection template for the manifest for the Azure SQL Database resource.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"{{{Parent.Name}.connectionString}};Intial Catalog={databaseName}";
+        $"{{{Parent.Name}.connectionString}};Initial Catalog={databaseName}";
 
     /// <summary>
     /// Gets the connection string for the Azure SQL Database resource.


### PR DESCRIPTION
Quick fix, this is breaking the Bicep sample on deployment.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2297)