### PR TITLE
Update Blazor Fluent UI package to 4.4.2 preview

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -81,7 +81,7 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="13.0.11" />
     <PackageVersion Include="JsonSchema.Net" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.2.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.4.2-preview.24048.2" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.2.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.23.1" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.3.0" />

--- a/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ChartContainer.razor
@@ -57,7 +57,7 @@ else
                                                   Appearance="@(context.AreAllValuesSelected is true ? Appearance.Stealth : Appearance.Accent)"
                                                   @onclick="() => context.PopupVisible = !context.PopupVisible"
                                                   aria-label="@(context.AreAllValuesSelected is true ? Loc[nameof(ControlsStrings.ChartContainerAllTags)] : Loc[nameof(ControlsStrings.ChartContainerFilteredTags)])" />
-                                    <FluentPopover AnchorId="@($"typeFilterButton-{context.SanitizedHtmlId}")" @bind-Open="context.PopupVisible">
+                                    <FluentPopover AnchorId="@($"typeFilterButton-{context.SanitizedHtmlId}")" @bind-Open="context.PopupVisible" VerticalThreshold="200">
                                         <Header>@context.Name</Header>
                                         <Body>
                                             <FluentStack Orientation="Orientation.Vertical" Class="dimension-popup">


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2064

Fixes some issues with Blazor FluentUI controls:

* Metrics filter popup now goes up instead of off the page when there isn't room
* Overflow count in tracing and metrics grids now reports an accurate value

It's important to use a preview now to help find any regressions. We can update to 4.4.2 final when it is available.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2301)