### PR TITLE
More changes to make dates and times consistent across dashboard

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
@@ -174,7 +174,7 @@ public partial class PlotlyChart : ComponentBase
 
     private string FormatTooltip(string name, double yValue, DateTime xValue)
     {
-        return $"<b>{InstrumentViewModel.Instrument?.Name}</b><br />{name}: {yValue.ToString("##,0.######", CultureInfo.CurrentCulture)}<br />Time: {FormatHelpers.FormatTime(xValue)}";
+        return $"<b>{InstrumentViewModel.Instrument?.Name}</b><br />{name}: {FormatHelpers.FormatNumberWithOptionalDecimalPlaces(yValue, CultureInfo.CurrentCulture)}<br />Time: {FormatHelpers.FormatTime(xValue)}";
     }
 
     private static HistogramValue GetHistogramValue(MetricValueBase metric)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -2,6 +2,7 @@
 @using Aspire.Dashboard.Components.ResourcesGridColumns
 @using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 @inject IStringLocalizer<Dashboard.Resources.Resources> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
@@ -57,7 +58,7 @@
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort">
                         <StateColumnDisplay Resource="@context" UnviewedErrorCounts ="@_applicationUnviewedErrorCounts" />
                     </TemplateColumn>
-                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" Tooltip="true">
+                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" TooltipText="@(context => context.CreationTimeStamp != null ? FormatHelpers.FormatDateTime(context.CreationTimeStamp.Value, false) : null)" Tooltip="true">
                         <StartTimeColumnDisplay Resource="@context" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -75,7 +75,9 @@
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
                                 <LogLevelColumnDisplay LogEntry="@context" />
                             </TemplateColumn>
-                            <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" Property="@(context => FormatHelpers.FormatTimeStamp(context.TimeStamp))" Tooltip="true" />
+                            <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(context.TimeStamp, true))" Tooltip="true">
+                                @FormatHelpers.FormatTimeWithOptionalDate(context.TimeStamp, includeMilliseconds: true)
+                            </TemplateColumn>
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">
                                 <LogMessageColumnDisplay FilterText="@(ViewModel.FilterText)" LogEntry="@context" />
                             </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -20,7 +20,7 @@
         </div>
         <FluentToolbar Orientation="Orientation.Horizontal">
             <div>
-                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)] <strong>@_trace.FirstSpan.StartTime.ToString("MMMM d yyyy"), @FormatHelpers.FormatTimeStamp(_trace.FirstSpan.StartTime)</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)] <strong>@FormatHelpers.FormatDateTime(_trace.FirstSpan.StartTime, includeMilliseconds: true)</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -35,7 +35,9 @@
     <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
         <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr">
             <ChildContent>
-                <PropertyColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" Property="@(context => FormatHelpers.FormatTimeStamp(context.FirstSpan.StartTime))" />
+                <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(context.FirstSpan.StartTime, true))" Tooltip="true">
+                    @FormatHelpers.FormatTimeWithOptionalDate(context.FirstSpan.StartTime, includeMilliseconds: true)
+                </TemplateColumn>
                 <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@((t) => $"{t.FullName}: {OtlpHelpers.ToShortenedId(t.TraceId)}")">
                     <span><FluentHighlighter HighlightedText="@(TracesViewModel.FilterText)" Text="@(context.FullName)" /></span>
                     <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
@@ -5,17 +5,8 @@
 
 @if (Resource.CreationTimeStamp is {} timeStamp)
 {
-    if (timeStamp.ToLocalTime().Date == DateTime.Now.Date)
-    {
-        // e.g. "08:57:44" (based on user's culture and preferences)
-        // Don't include milliseconds as resource server returned time stamp is second precision.
-        @FormatHelpers.FormatTime(timeStamp)
-    }
-    else
-    {
-        // e.g. "9/02/2024 08:57:44" (based on user's culture and preferences)
-        @FormatHelpers.FormatDateTime(timeStamp)
-    }
+    // Don't include milliseconds as resource server returned time stamp is second precision.
+    @FormatHelpers.FormatTimeWithOptionalDate(timeStamp)
 }
 
 @code {

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -66,4 +66,9 @@ internal static partial class FormatHelpers
             return FormatDateTime(local, includeMilliseconds);
         }
     }
+
+    public static string FormatNumberWithOptionalDecimalPlaces(double value, IFormatProvider? provider = null)
+    {
+        return value.ToString("##,0.######", provider ?? CultureInfo.CurrentCulture);
+    }
 }

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -27,7 +27,7 @@ internal static partial class FormatHelpers
     private static partial Regex MatchSecondsInTimeFormatPattern();
 
     private static readonly string s_longTimePatternWithMilliseconds = GetLongTimePatternWithMilliseconds();
-    private static readonly string s_shortDateLongTimePatternWithMilliseconds = DateTimeFormatInfo.CurrentInfo.ShortDatePattern + " " + GetLongTimePatternWithMilliseconds();
+    private static readonly string s_shortDateLongTimePatternWithMilliseconds = DateTimeFormatInfo.CurrentInfo.ShortDatePattern + " " + s_longTimePatternWithMilliseconds;
 
     public static string FormatTime(DateTime value, bool includeMilliseconds = false)
     {

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -16,6 +16,7 @@ internal static partial class FormatHelpers
         var longTimePattern = DateTimeFormatInfo.CurrentInfo.LongTimePattern;
 
         // Create a format similar to .fff but based on the current culture.
+        // Intentionally use fff here instead of FFF so output has a consistent length.
         var millisecondFormat = $"{NumberFormatInfo.CurrentInfo.NumberDecimalSeparator}fff";
 
         // Append millisecond pattern to current culture's long time pattern.
@@ -26,22 +27,43 @@ internal static partial class FormatHelpers
     private static partial Regex MatchSecondsInTimeFormatPattern();
 
     private static readonly string s_longTimePatternWithMilliseconds = GetLongTimePatternWithMilliseconds();
+    private static readonly string s_shortDateLongTimePatternWithMilliseconds = DateTimeFormatInfo.CurrentInfo.ShortDatePattern + " " + GetLongTimePatternWithMilliseconds();
 
-    public static string FormatTimeStamp(DateTime time)
+    public static string FormatTime(DateTime value, bool includeMilliseconds = false)
     {
-        // Long time with milliseconds
-        return time.ToLocalTime().ToString(s_longTimePatternWithMilliseconds, CultureInfo.CurrentCulture);
-    }
+        var local = value.ToLocalTime();
 
-    public static string FormatTime(DateTime time)
-    {
         // Long time
-        return time.ToLocalTime().ToString("T", CultureInfo.CurrentCulture);
+        return includeMilliseconds
+            ? local.ToString(s_longTimePatternWithMilliseconds, CultureInfo.CurrentCulture)
+            : local.ToString("T", CultureInfo.CurrentCulture);
     }
 
-    public static string FormatDateTime(DateTime dateTime)
+    public static string FormatDateTime(DateTime value, bool includeMilliseconds = false)
     {
+        var local = value.ToLocalTime();
+
         // Short date, long time
-        return dateTime.ToLocalTime().ToString("G", CultureInfo.CurrentCulture);
+        return includeMilliseconds
+            ? local.ToString(s_shortDateLongTimePatternWithMilliseconds, CultureInfo.CurrentCulture)
+            : local.ToString("G", CultureInfo.CurrentCulture);
+    }
+
+    public static string FormatTimeWithOptionalDate(DateTime value, bool includeMilliseconds = false)
+    {
+        var local = value.ToLocalTime();
+
+        // If the date is today then only return time, otherwise return entire date time text.
+        if (local.Date == DateTime.Now.Date)
+        {
+            // e.g. "08:57:44" (based on user's culture and preferences)
+            // Don't include milliseconds as resource server returned time stamp is second precision.
+            return FormatTime(local, includeMilliseconds);
+        }
+        else
+        {
+            // e.g. "9/02/2024 08:57:44" (based on user's culture and preferences)
+            return FormatDateTime(local, includeMilliseconds);
+        }
     }
 }

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -149,7 +149,7 @@ window.updateChart = function (id, traces, xValues, rangeStartTime, rangeEndTime
             type: 'date',
             range: [rangeEndTime, rangeStartTime],
             fixedrange: true,
-            tickformat: "%-I:%M:%S %p",
+            tickformat: "%X",
             color: themeColors.textColor
         }
     };
@@ -159,7 +159,9 @@ window.updateChart = function (id, traces, xValues, rangeStartTime, rangeEndTime
     fixTraceLineRendering(chartDiv);
 };
 
-window.initializeChart = function (id, traces, xValues, rangeStartTime, rangeEndTime) {
+window.initializeChart = function (id, traces, xValues, rangeStartTime, rangeEndTime, serverLocale) {
+    registerLocale(serverLocale);
+
     var chartContainerDiv = document.getElementById(id);
 
     // Reusing a div can create issues with chart lines appearing beyond the end range.
@@ -191,7 +193,7 @@ window.initializeChart = function (id, traces, xValues, rangeStartTime, rangeEnd
             type: 'date',
             range: [rangeEndTime, rangeStartTime],
             fixedrange: true,
-            tickformat: "%-I:%M:%S %p",
+            tickformat: "%X",
             color: themeColors.textColor
         },
         yaxis: {
@@ -218,3 +220,38 @@ window.initializeChart = function (id, traces, xValues, rangeStartTime, rangeEnd
 
     fixTraceLineRendering(chartDiv);
 };
+
+function registerLocale(serverLocale) {
+    // Register the locale for Plotly.js. This is to enable localization of time format shown by the charts.
+    // Changing plotly.js time formatting is better than supplying values from the server which is very difficult to do correctly.
+
+    // Right now necessary changes are to:
+    // -Update AM/PM
+    // -Update time format to 12/24 hour.
+    var locale = {
+        moduleType: 'locale',
+        name: 'en',
+        dictionary: {
+            'Click to enter Colorscale title': 'Click to enter Colourscale title'
+        },
+        format: {
+            days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+            shortDays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+            months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+            shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+            periods: serverLocale.periods,
+            dateTime: '%a %b %e %X %Y',
+            date: '%d/%m/%Y',
+            time: serverLocale.time,
+            decimal: '.',
+            thousands: ',',
+            grouping: [3],
+            currency: ['$', ''],
+            year: '%Y',
+            month: '%b %Y',
+            dayMonth: '%b %-d',
+            dayMonthYear: '%b %-d, %Y'
+        }
+    };
+    Plotly.register(locale);
+}

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -17,7 +17,7 @@ public class FormatHelpersTests
     [InlineData("1.234568", 1.23456789d)]
     public void FormatNumberWithOptionalDecimalPlaces_InvariantCulture(string expected, double value)
     {
-        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.InvariantCulture));
+        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.InvariantCulture), StringComparer.Ordinal);
     }
 
     [Theory]
@@ -28,6 +28,6 @@ public class FormatHelpersTests
     [InlineData("1,234568", 1.23456789d)]
     public void FormatNumberWithOptionalDecimalPlaces_FrenchCulture(string expected, double value)
     {
-        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.GetCultureInfo("fr-FR")));
+        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.GetCultureInfo("fr-FR")), StringComparer.Ordinal);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Dashboard.Utils;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class FormatHelpersTests
+{
+    [Theory]
+    [InlineData("9", 9d)]
+    [InlineData("9.9", 9.9d)]
+    [InlineData("0.9", 0.9d)]
+    [InlineData("12,345,678.9", 12345678.9d)]
+    public void FormatNumberWithOptionalDecimalPlaces_InvariantCulture(string expected, double value)
+    {
+        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData("9", 9d)]
+    [InlineData("9,9", 9.9d)]
+    [InlineData("0,9", 0.9d)]
+    [InlineData("12345678,9", 12345678.9d)]
+    public void FormatNumberWithOptionalDecimalPlaces_FrenchCulture(string expected, double value)
+    {
+        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.GetCultureInfo("fr-FR")));
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -24,7 +24,7 @@ public class FormatHelpersTests
     [InlineData("9", 9d)]
     [InlineData("9,9", 9.9d)]
     [InlineData("0,9", 0.9d)]
-    [InlineData("12 345 678,9", 12345678.9d)]
+    [InlineData("12 345 678,9", 12345678.9d)]
     [InlineData("1,234568", 1.23456789d)]
     public void FormatNumberWithOptionalDecimalPlaces_FrenchCulture(string expected, double value)
     {

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -17,17 +17,17 @@ public class FormatHelpersTests
     [InlineData("1.234568", 1.23456789d)]
     public void FormatNumberWithOptionalDecimalPlaces_InvariantCulture(string expected, double value)
     {
-        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.InvariantCulture), StringComparer.Ordinal);
+        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.InvariantCulture));
     }
 
     [Theory]
     [InlineData("9", 9d)]
     [InlineData("9,9", 9.9d)]
     [InlineData("0,9", 0.9d)]
-    [InlineData("12 345 678,9", 12345678.9d)]
+    [InlineData("12.345.678,9", 12345678.9d)]
     [InlineData("1,234568", 1.23456789d)]
-    public void FormatNumberWithOptionalDecimalPlaces_FrenchCulture(string expected, double value)
+    public void FormatNumberWithOptionalDecimalPlaces_GermanCulture(string expected, double value)
     {
-        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.GetCultureInfo("fr-FR")), StringComparer.Ordinal);
+        Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.GetCultureInfo("de-DE")));
     }
 }

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -14,6 +14,7 @@ public class FormatHelpersTests
     [InlineData("9.9", 9.9d)]
     [InlineData("0.9", 0.9d)]
     [InlineData("12,345,678.9", 12345678.9d)]
+    [InlineData("1.234568", 1.23456789d)]
     public void FormatNumberWithOptionalDecimalPlaces_InvariantCulture(string expected, double value)
     {
         Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.InvariantCulture));
@@ -23,7 +24,8 @@ public class FormatHelpersTests
     [InlineData("9", 9d)]
     [InlineData("9,9", 9.9d)]
     [InlineData("0,9", 0.9d)]
-    [InlineData("12345678,9", 12345678.9d)]
+    [InlineData("12 345 678,9", 12345678.9d)]
+    [InlineData("1,234568", 1.23456789d)]
     public void FormatNumberWithOptionalDecimalPlaces_FrenchCulture(string expected, double value)
     {
         Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.GetCultureInfo("fr-FR")));


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2303

Make formatting consistent and respect user's 12/24 hour preference.

* Chart ticks and tooltips shows 12/24 hour time
* Chart period suffixes are localized
* Trace detail date time is now consistent with other date times
* Structured logs and traces timestamp now includes date if a different day
* Resources start, structured logs timestamp, traces timestamp has a tooltip with date and time

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2306)