### PR TITLE
Fix date formatting with milliseconds

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
@@ -174,7 +174,7 @@ public partial class PlotlyChart : ComponentBase
 
     private string FormatTooltip(string name, double yValue, DateTime xValue)
     {
-        return $"<b>{InstrumentViewModel.Instrument?.Name}</b><br />{name}: {FormatHelpers.FormatNumberWithOptionalDecimalPlaces(yValue, CultureInfo.CurrentCulture)}<br />Time: {FormatHelpers.FormatTime(xValue)}";
+        return $"<b>{InstrumentViewModel.Instrument?.Name}</b><br />{name}: {FormatHelpers.FormatNumberWithOptionalDecimalPlaces(yValue, CultureInfo.CurrentCulture)}<br />Time: {FormatHelpers.FormatTime(xValue, provider: CultureInfo.CurrentCulture)}";
     }
 
     private static HistogramValue GetHistogramValue(MetricValueBase metric)

--- a/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PlotlyChart.razor.cs
@@ -174,7 +174,7 @@ public partial class PlotlyChart : ComponentBase
 
     private string FormatTooltip(string name, double yValue, DateTime xValue)
     {
-        return $"<b>{InstrumentViewModel.Instrument?.Name}</b><br />{name}: {FormatHelpers.FormatNumberWithOptionalDecimalPlaces(yValue, CultureInfo.CurrentCulture)}<br />Time: {FormatHelpers.FormatTime(xValue, provider: CultureInfo.CurrentCulture)}";
+        return $"<b>{InstrumentViewModel.Instrument?.Name}</b><br />{name}: {FormatHelpers.FormatNumberWithOptionalDecimalPlaces(yValue, CultureInfo.CurrentCulture)}<br />Time: {FormatHelpers.FormatTime(xValue, cultureInfo: CultureInfo.CurrentCulture)}";
     }
 
     private static HistogramValue GetHistogramValue(MetricValueBase metric)

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -170,7 +170,7 @@ public partial class ResourceDetails
             // Use try parse to check if a value matches ISO 8601 format. If there is a match then convert to a friendly format.
             if (DateTime.TryParseExact(value, "o", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
             {
-                value = FormatHelpers.FormatDateTime(date, provider: CultureInfo.CurrentCulture);
+                value = FormatHelpers.FormatDateTime(date, cultureInfo: CultureInfo.CurrentCulture);
             }
         }
 

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -170,7 +170,7 @@ public partial class ResourceDetails
             // Use try parse to check if a value matches ISO 8601 format. If there is a match then convert to a friendly format.
             if (DateTime.TryParseExact(value, "o", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
             {
-                value = FormatHelpers.FormatDateTime(date);
+                value = FormatHelpers.FormatDateTime(date, provider: CultureInfo.CurrentCulture);
             }
         }
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -3,6 +3,7 @@
 @using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils
+@using System.Globalization
 @inject IStringLocalizer<Dashboard.Resources.Resources> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
@@ -58,7 +59,7 @@
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort">
                         <StateColumnDisplay Resource="@context" UnviewedErrorCounts ="@_applicationUnviewedErrorCounts" />
                     </TemplateColumn>
-                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" TooltipText="@(context => context.CreationTimeStamp != null ? FormatHelpers.FormatDateTime(context.CreationTimeStamp.Value, false) : null)" Tooltip="true">
+                    <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" TooltipText="@(context => context.CreationTimeStamp != null ? FormatHelpers.FormatDateTime(context.CreationTimeStamp.Value, false, CultureInfo.CurrentCulture) : null)" Tooltip="true">
                         <StartTimeColumnDisplay Resource="@context" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -6,6 +6,7 @@
 @using Microsoft.Extensions.Logging
 @using System.Web
 @using Aspire.Dashboard.Resources
+@using System.Globalization
 @inject IJSRuntime JS
 @implements IDisposable
 @inject IStringLocalizer<Dashboard.Resources.StructuredLogs> Loc
@@ -75,7 +76,7 @@
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">
                                 <LogLevelColumnDisplay LogEntry="@context" />
                             </TemplateColumn>
-                            <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(context.TimeStamp, true))" Tooltip="true">
+                            <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(context.TimeStamp, true, CultureInfo.CurrentCulture))" Tooltip="true">
                                 @FormatHelpers.FormatTimeWithOptionalDate(context.TimeStamp, includeMilliseconds: true)
                             </TemplateColumn>
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageColumnHeader)]" Tooltip="true" TooltipText="(e) => e.Message">

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -4,6 +4,7 @@
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils
+@using System.Globalization
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 @inject IStringLocalizer<Dashboard.Resources.Traces> Loc
@@ -35,7 +36,7 @@
     <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
         <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr">
             <ChildContent>
-                <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(context.FirstSpan.StartTime, true))" Tooltip="true">
+                <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(context.FirstSpan.StartTime, true, CultureInfo.CurrentCulture))" Tooltip="true">
                     @FormatHelpers.FormatTimeWithOptionalDate(context.FirstSpan.StartTime, includeMilliseconds: true)
                 </TemplateColumn>
                 <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@((t) => $"{t.FullName}: {OtlpHelpers.ToShortenedId(t.TraceId)}")">

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -14,61 +14,64 @@ internal static partial class FormatHelpers
     // Use culture name as key. Culture name isn't case sensitive.
     private static readonly ConcurrentDictionary<string, MillisecondFormatStrings> s_formatStrings = new(StringComparer.OrdinalIgnoreCase);
 
-    static string GetLongTimePatternWithMillisecondsCore(CultureInfo cultureInfo)
-    {
-        // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
-
-        // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
-        var longTimePattern = cultureInfo.DateTimeFormat.LongTimePattern;
-
-        // Create a format similar to .fff but based on the current culture.
-        // Intentionally use fff here instead of FFF so output has a consistent length.
-        var millisecondFormat = $"'{cultureInfo.NumberFormat.NumberDecimalSeparator}'fff";
-
-        // Append millisecond pattern to current culture's long time pattern.
-        return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1{millisecondFormat}");
-    }
-
     [GeneratedRegex("(:ss|:s)")]
     private static partial Regex MatchSecondsInTimeFormatPattern();
 
     private static MillisecondFormatStrings GetMillisecondFormatStrings(CultureInfo cultureInfo)
     {
+        // The culture name is used as the key for the cache. The name is used to avoid unbounded growth from custom CultureInfo instances.
+        // Note that the culture name must match to a cached readonly instance of CultureInfo.
+        // If the passed in culture info has customizations then they won't be used. The cached CultureInfo with a name is the source of truth.
         return s_formatStrings.GetOrAdd(cultureInfo.Name, static name =>
         {
             var c = CultureInfo.GetCultureInfo(name);
             var longTimePatternWithMilliseconds = GetLongTimePatternWithMillisecondsCore(c);
             return new MillisecondFormatStrings(longTimePatternWithMilliseconds, c.DateTimeFormat.ShortDatePattern + " " + longTimePatternWithMilliseconds);
         });
+
+        static string GetLongTimePatternWithMillisecondsCore(CultureInfo cultureInfo)
+        {
+            // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
+
+            // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
+            var longTimePattern = cultureInfo.DateTimeFormat.LongTimePattern;
+
+            // Create a format similar to .fff but based on the current culture.
+            // Intentionally use fff here instead of FFF so output has a consistent length.
+            var millisecondFormat = $"'{cultureInfo.NumberFormat.NumberDecimalSeparator}'fff";
+
+            // Append millisecond pattern to current culture's long time pattern.
+            return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1{millisecondFormat}");
+        }
     }
 
     private static string GetLongTimePatternWithMilliseconds(CultureInfo cultureInfo) => GetMillisecondFormatStrings(cultureInfo).LongTimePattern;
 
     private static string GetShortDateLongTimePatternWithMilliseconds(CultureInfo cultureInfo) => GetMillisecondFormatStrings(cultureInfo).ShortDateLongTimePattern;
 
-    public static string FormatTime(DateTime value, bool includeMilliseconds = false, CultureInfo? provider = null)
+    public static string FormatTime(DateTime value, bool includeMilliseconds = false, CultureInfo? cultureInfo = null)
     {
-        provider ??= CultureInfo.CurrentCulture;
+        cultureInfo ??= CultureInfo.CurrentCulture;
         var local = value.ToLocalTime();
 
         // Long time
         return includeMilliseconds
-            ? local.ToString(GetLongTimePatternWithMilliseconds(provider), provider)
-            : local.ToString("T", provider);
+            ? local.ToString(GetLongTimePatternWithMilliseconds(cultureInfo), cultureInfo)
+            : local.ToString("T", cultureInfo);
     }
 
-    public static string FormatDateTime(DateTime value, bool includeMilliseconds = false, CultureInfo? provider = null)
+    public static string FormatDateTime(DateTime value, bool includeMilliseconds = false, CultureInfo? cultureInfo = null)
     {
-        provider ??= CultureInfo.CurrentCulture;
+        cultureInfo ??= CultureInfo.CurrentCulture;
         var local = value.ToLocalTime();
 
         // Short date, long time
         return includeMilliseconds
-            ? local.ToString(GetShortDateLongTimePatternWithMilliseconds(provider), provider)
-            : local.ToString("G", provider);
+            ? local.ToString(GetShortDateLongTimePatternWithMilliseconds(cultureInfo), cultureInfo)
+            : local.ToString("G", cultureInfo);
     }
 
-    public static string FormatTimeWithOptionalDate(DateTime value, bool includeMilliseconds = false, CultureInfo? provider = null)
+    public static string FormatTimeWithOptionalDate(DateTime value, bool includeMilliseconds = false, CultureInfo? cultureInfo = null)
     {
         var local = value.ToLocalTime();
 
@@ -77,12 +80,12 @@ internal static partial class FormatHelpers
         {
             // e.g. "08:57:44" (based on user's culture and preferences)
             // Don't include milliseconds as resource server returned time stamp is second precision.
-            return FormatTime(local, includeMilliseconds, provider);
+            return FormatTime(local, includeMilliseconds, cultureInfo);
         }
         else
         {
             // e.g. "9/02/2024 08:57:44" (based on user's culture and preferences)
-            return FormatDateTime(local, includeMilliseconds, provider);
+            return FormatDateTime(local, includeMilliseconds, cultureInfo);
         }
     }
 

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
@@ -8,16 +9,21 @@ namespace Aspire.Dashboard.Utils;
 
 internal static partial class FormatHelpers
 {
-    static string GetLongTimePatternWithMilliseconds()
+    private sealed record MillisecondFormatStrings(string LongTimePattern, string ShortDateLongTimePattern);
+
+    // Use culture name as key. Culture name isn't case sensitive.
+    private static readonly ConcurrentDictionary<string, MillisecondFormatStrings> s_formatStrings = new(StringComparer.OrdinalIgnoreCase);
+
+    static string GetLongTimePatternWithMillisecondsCore(CultureInfo cultureInfo)
     {
         // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
 
         // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
-        var longTimePattern = DateTimeFormatInfo.CurrentInfo.LongTimePattern;
+        var longTimePattern = cultureInfo.DateTimeFormat.LongTimePattern;
 
         // Create a format similar to .fff but based on the current culture.
         // Intentionally use fff here instead of FFF so output has a consistent length.
-        var millisecondFormat = $"{NumberFormatInfo.CurrentInfo.NumberDecimalSeparator}fff";
+        var millisecondFormat = $"'{cultureInfo.NumberFormat.NumberDecimalSeparator}'fff";
 
         // Append millisecond pattern to current culture's long time pattern.
         return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1{millisecondFormat}");
@@ -26,30 +32,43 @@ internal static partial class FormatHelpers
     [GeneratedRegex("(:ss|:s)")]
     private static partial Regex MatchSecondsInTimeFormatPattern();
 
-    private static readonly string s_longTimePatternWithMilliseconds = GetLongTimePatternWithMilliseconds();
-    private static readonly string s_shortDateLongTimePatternWithMilliseconds = DateTimeFormatInfo.CurrentInfo.ShortDatePattern + " " + s_longTimePatternWithMilliseconds;
-
-    public static string FormatTime(DateTime value, bool includeMilliseconds = false)
+    private static MillisecondFormatStrings GetMillisecondFormatStrings(CultureInfo cultureInfo)
     {
+        return s_formatStrings.GetOrAdd(cultureInfo.Name, static name =>
+        {
+            var c = CultureInfo.GetCultureInfo(name);
+            var longTimePatternWithMilliseconds = GetLongTimePatternWithMillisecondsCore(c);
+            return new MillisecondFormatStrings(longTimePatternWithMilliseconds, c.DateTimeFormat.ShortDatePattern + " " + longTimePatternWithMilliseconds);
+        });
+    }
+
+    private static string GetLongTimePatternWithMilliseconds(CultureInfo cultureInfo) => GetMillisecondFormatStrings(cultureInfo).LongTimePattern;
+
+    private static string GetShortDateLongTimePatternWithMilliseconds(CultureInfo cultureInfo) => GetMillisecondFormatStrings(cultureInfo).ShortDateLongTimePattern;
+
+    public static string FormatTime(DateTime value, bool includeMilliseconds = false, CultureInfo? provider = null)
+    {
+        provider ??= CultureInfo.CurrentCulture;
         var local = value.ToLocalTime();
 
         // Long time
         return includeMilliseconds
-            ? local.ToString(s_longTimePatternWithMilliseconds, CultureInfo.CurrentCulture)
-            : local.ToString("T", CultureInfo.CurrentCulture);
+            ? local.ToString(GetLongTimePatternWithMilliseconds(provider), provider)
+            : local.ToString("T", provider);
     }
 
-    public static string FormatDateTime(DateTime value, bool includeMilliseconds = false)
+    public static string FormatDateTime(DateTime value, bool includeMilliseconds = false, CultureInfo? provider = null)
     {
+        provider ??= CultureInfo.CurrentCulture;
         var local = value.ToLocalTime();
 
         // Short date, long time
         return includeMilliseconds
-            ? local.ToString(s_shortDateLongTimePatternWithMilliseconds, CultureInfo.CurrentCulture)
-            : local.ToString("G", CultureInfo.CurrentCulture);
+            ? local.ToString(GetShortDateLongTimePatternWithMilliseconds(provider), provider)
+            : local.ToString("G", provider);
     }
 
-    public static string FormatTimeWithOptionalDate(DateTime value, bool includeMilliseconds = false)
+    public static string FormatTimeWithOptionalDate(DateTime value, bool includeMilliseconds = false, CultureInfo? provider = null)
     {
         var local = value.ToLocalTime();
 
@@ -58,16 +77,16 @@ internal static partial class FormatHelpers
         {
             // e.g. "08:57:44" (based on user's culture and preferences)
             // Don't include milliseconds as resource server returned time stamp is second precision.
-            return FormatTime(local, includeMilliseconds);
+            return FormatTime(local, includeMilliseconds, provider);
         }
         else
         {
             // e.g. "9/02/2024 08:57:44" (based on user's culture and preferences)
-            return FormatDateTime(local, includeMilliseconds);
+            return FormatDateTime(local, includeMilliseconds, provider);
         }
     }
 
-    public static string FormatNumberWithOptionalDecimalPlaces(double value, IFormatProvider? provider = null)
+    public static string FormatNumberWithOptionalDecimalPlaces(double value, CultureInfo? provider = null)
     {
         return value.ToString("##,0.######", provider ?? CultureInfo.CurrentCulture);
     }

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -30,4 +30,45 @@ public class FormatHelpersTests
     {
         Assert.Equal(expected, FormatHelpers.FormatNumberWithOptionalDecimalPlaces(value, CultureInfo.GetCultureInfo("de-DE")));
     }
+
+    [Theory]
+    [InlineData("06/15/2009 13:45:30.000", true, "2009-06-15T13:45:30.0000000Z")]
+    [InlineData("06/15/2009 13:45:30.123", true, "2009-06-15T13:45:30.1234567Z")]
+    [InlineData("06/15/2009 13:45:30", false, "2009-06-15T13:45:30.0000000Z")]
+    [InlineData("06/15/2009 13:45:30", false, "2009-06-15T13:45:30.1234567Z")]
+    public void FormatDateTime_WithMilliseconds_InvariantCulture(string expected, bool includeMilliseconds, string value)
+    {
+        var date = GetLocalDateTime(value);
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(date, includeMilliseconds, provider: CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData("15.06.2009 13:45:30,000", true, "2009-06-15T13:45:30.0000000Z")]
+    [InlineData("15.06.2009 13:45:30,123", true, "2009-06-15T13:45:30.1234567Z")]
+    [InlineData("15.06.2009 13:45:30", false, "2009-06-15T13:45:30.0000000Z")]
+    [InlineData("15.06.2009 13:45:30", false, "2009-06-15T13:45:30.1234567Z")]
+    public void FormatDateTime_WithMilliseconds_GermanCulture(string expected, bool includeMilliseconds, string value)
+    {
+        var date = GetLocalDateTime(value);
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(date, includeMilliseconds, provider: CultureInfo.GetCultureInfo("de-DE")));
+    }
+
+    [Theory]
+    [InlineData("15/06/2009 1:45:30.000 pm", true, "2009-06-15T13:45:30.0000000Z")]
+    [InlineData("15/06/2009 1:45:30.123 pm", true, "2009-06-15T13:45:30.1234567Z")]
+    [InlineData("15/06/2009 1:45:30 pm", false, "2009-06-15T13:45:30.0000000Z")]
+    [InlineData("15/06/2009 1:45:30 pm", false, "2009-06-15T13:45:30.1234567Z")]
+    public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, bool includeMilliseconds, string value)
+    {
+        var date = GetLocalDateTime(value);
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(date, includeMilliseconds, provider: CultureInfo.GetCultureInfo("en-NZ")));
+    }
+
+    private static DateTime GetLocalDateTime(string value)
+    {
+        Assert.True(DateTime.TryParseExact(value, "o", CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var date));
+        Assert.Equal(DateTimeKind.Utc, date.Kind);
+        date = DateTime.SpecifyKind(date, DateTimeKind.Local);
+        return date;
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -39,7 +39,7 @@ public class FormatHelpersTests
     public void FormatDateTime_WithMilliseconds_InvariantCulture(string expected, bool includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(date, includeMilliseconds, provider: CultureInfo.InvariantCulture));
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(date, includeMilliseconds, cultureInfo: CultureInfo.InvariantCulture));
     }
 
     [Theory]
@@ -50,7 +50,7 @@ public class FormatHelpersTests
     public void FormatDateTime_WithMilliseconds_GermanCulture(string expected, bool includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(date, includeMilliseconds, provider: CultureInfo.GetCultureInfo("de-DE")));
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("de-DE")));
     }
 
     [Theory]
@@ -61,7 +61,7 @@ public class FormatHelpersTests
     public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, bool includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(date, includeMilliseconds, provider: CultureInfo.GetCultureInfo("en-NZ")));
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ")));
     }
 
     private static DateTime GetLocalDateTime(string value)


### PR DESCRIPTION
Milliseconds format strings were stored statically. That means the culture of the first request is used to create the format strings.

Static format strings are ok when the dashboard runs on a local computer. There is one culture. It isn't ok when the dashboard is hosted and can serve multiple cultures. The culture of the current request needs to be used.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2313)