### PR TITLE
Remove URI reserved characters from password generator

### DIFF
--- a/src/Aspire.Hosting/Utils/PasswordGenerator.cs
+++ b/src/Aspire.Hosting/Utils/PasswordGenerator.cs
@@ -10,12 +10,12 @@ internal static class PasswordGenerator
 {
     // Some chars are excluded:
     // - prevent potential confusions, e.g., 0,o,O and i,I,l
-    // - exclude special chars which could interfere with command line arguments or connection strings, e.g. =,$,...
+    // - exclude special chars which could interfere with command line arguments, URL (rfc3986), or connection strings, e.g. =,$,...
 
     internal const string LowerCaseChars = "abcdefghjkmnpqrstuvwxyz"; // exclude i,l,o
     internal const string UpperCaseChars = "ABCDEFGHJKMNPQRSTUVWXYZ"; // exclude I,L,O
     internal const string DigitChars = "0123456789";
-    internal const string SpecialChars = "-_#@!./:[]{}+*()~"; // exclude &<>=;,`'^%$
+    internal const string SpecialChars = "-_.{}~"; // exclude &<>=;,`'^%$#@!/:[]()*
 
     /// <summary>
     /// Creates a cryptographically random password.

--- a/src/Aspire.Hosting/Utils/PasswordGenerator.cs
+++ b/src/Aspire.Hosting/Utils/PasswordGenerator.cs
@@ -10,12 +10,12 @@ internal static class PasswordGenerator
 {
     // Some chars are excluded:
     // - prevent potential confusions, e.g., 0,o,O and i,I,l
-    // - exclude special chars which could interfere with command line arguments, URL (rfc3986), or connection strings, e.g. =,$,...
+    // - exclude special chars which could interfere with command line arguments, URL (rfc3986 gen-delims), or connection strings, e.g. =,$,...
 
     internal const string LowerCaseChars = "abcdefghjkmnpqrstuvwxyz"; // exclude i,l,o
     internal const string UpperCaseChars = "ABCDEFGHJKMNPQRSTUVWXYZ"; // exclude I,L,O
     internal const string DigitChars = "0123456789";
-    internal const string SpecialChars = "-_.{}~"; // exclude &<>=;,`'^%$#@!/:[]()*
+    internal const string SpecialChars = "-_.{}~()*+!"; // exclude &<>=;,`'^%$#@/:[]
 
     /// <summary>
     /// Creates a cryptographically random password.

--- a/tests/Aspire.Hosting.Tests/Utils/PasswordGeneratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/PasswordGeneratorTests.cs
@@ -3,11 +3,19 @@
 
 using Aspire.Hosting.Utils;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests.Utils;
 
 public class PasswordGeneratorTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public PasswordGeneratorTests(ITestOutputHelper output)
+    {
+        this._output = output;
+    }
+
     [Fact]
     public void ThrowsArgumentOutOfRangeException()
     {
@@ -79,5 +87,23 @@ public class PasswordGeneratorTests
         Assert.Equal(length, password.Count(PasswordGenerator.UpperCaseChars.Contains));
         Assert.Equal(length, password.Count(PasswordGenerator.DigitChars.Contains));
         Assert.Equal(length, password.Count(PasswordGenerator.SpecialChars.Contains));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    [InlineData(10)]
+    public void ValidUriCharacters(int length)
+    {
+        var password = PasswordGenerator.GeneratePassword(length, length, length, length);
+        var fakeUri = new Uri($"https://guest:{password}@localhost:12345");
+
+        _output.WriteLine($"Generated password: {password}");
+        _output.WriteLine($"Fake URI: {fakeUri.OriginalString}");
+
+        Assert.Equal(length * 4, password.Length);
+
+        // validate that the password contains only valid URI characters
+        Assert.True(Uri.IsWellFormedUriString(fakeUri.AbsoluteUri, UriKind.Absolute));
     }
 }

--- a/tests/Aspire.Hosting.Tests/Utils/PasswordGeneratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/PasswordGeneratorTests.cs
@@ -3,19 +3,11 @@
 
 using Aspire.Hosting.Utils;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Hosting.Tests.Utils;
 
 public class PasswordGeneratorTests
 {
-    private readonly ITestOutputHelper _output;
-
-    public PasswordGeneratorTests(ITestOutputHelper output)
-    {
-        this._output = output;
-    }
-
     [Fact]
     public void ThrowsArgumentOutOfRangeException()
     {
@@ -95,15 +87,11 @@ public class PasswordGeneratorTests
     [InlineData(10)]
     public void ValidUriCharacters(int length)
     {
-        var password = PasswordGenerator.GeneratePassword(length, length, length, length);
-        var fakeUri = new Uri($"https://guest:{password}@localhost:12345");
+        var password = PasswordGenerator.GeneratePassword(length, length, length, 0);
+        password += PasswordGenerator.SpecialChars;
 
-        _output.WriteLine($"Generated password: {password}");
-        _output.WriteLine($"Fake URI: {fakeUri.OriginalString}");
+        Exception exception = Record.Exception(() => new Uri($"https://guest:{password}@localhost:12345"));
 
-        Assert.Equal(length * 4, password.Length);
-
-        // validate that the password contains only valid URI characters
-        Assert.True(Uri.IsWellFormedUriString(fakeUri.AbsoluteUri, UriKind.Absolute));
+        Assert.True((exception is null), $"Password contains invalid chars: {password}");
     }
 }


### PR DESCRIPTION
Fixes #2321 by removing URI reserved characters.

This would change it globally so that any resource builder using the util doesn't have to worry about potential server/URI conflicts with special characters reserved for server/URI host names.  Other potential is to just use no special characters in the places where this might be an issue (e.g., RabbitMQ where I discovered it). 

This PR takes the global approach.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2323)