### PR TITLE
Don't try to cleanup DCP resources on shtudown

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -70,14 +70,9 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         await _appExecutor.RunApplicationAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task StopAsync(CancellationToken cancellationToken = default)
+    public Task StopAsync(CancellationToken cancellationToken = default)
     {
-        if (!IsSupported)
-        {
-            return;
-        }
-
-        await _appExecutor.StopApplicationAsync(cancellationToken).ConfigureAwait(false);
+        return Task.CompletedTask;
     }
 
     public async ValueTask DisposeAsync()
@@ -87,7 +82,6 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
             return;
         }
 
-        await _appExecutor.StopApplicationAsync().ConfigureAwait(false);
         await _dcpRunDisposable.DisposeAsync().ConfigureAwait(false);
         _dcpRunDisposable = null;
     }


### PR DESCRIPTION
On Mac (and probably Linux), the logic to try and cleanup orchestrator resources on shutdown causes more issues than it tries to solve; the resources aren't fully cleaned up by the time the delete request completes and it leaves several of the resources in a bad state such that the subsequent DCP cleanup logic can't fully remove them either and we only clean everything up after the one minute graceful shutdown timeout expires. This means it takes up to a minute for the child executables to be deleted.

Since DCP already has built in cleanup logic when the AppHost goes away (which is how resources get cleaned up when running in Visual Studio), there's no real reason for the AppHost to duplicate the effort.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2324)