### PR TITLE
Clean up log listener socket during shutdown

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -82,7 +82,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Error in logging socket processor: {ex}");
+                _logger.LogError(ex, "Error in logging socket processor.");
             }
         }
     }
@@ -119,7 +119,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Failed to enable orchestration logging: {ex}");
+                _logger.LogError(ex, "Failed to enable orchestration logging.");
             }
             finally
             {

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Text;
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -18,14 +17,15 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
 {
     private const int LoggingSocketConnectionBacklog = 3;
     private readonly ApplicationExecutor _appExecutor;
-    private readonly DistributedApplicationModel _applicationModel;
-    private IAsyncDisposable? _dcpRunDisposable;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
     private readonly DcpOptions _dcpOptions;
     private readonly DistributedApplicationExecutionContext _executionContext;
     private readonly IDcpDependencyCheckService _dependencyCheckService;
     private readonly Locations _locations;
+    private readonly CancellationTokenSource _shutdownCts = new();
+    private Task? _logProcessorTask;
+    private IAsyncDisposable? _dcpRunDisposable;
 
     // These environment variables should never be inherited by DCP from app host.
     private static readonly string[] s_doNotInheritEnvironmentVars =
@@ -37,7 +37,6 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
     };
 
     public DcpHostService(
-        DistributedApplicationModel applicationModel,
         ILoggerFactory loggerFactory,
         IOptions<DcpOptions> dcpOptions,
         DistributedApplicationExecutionContext executionContext,
@@ -45,7 +44,6 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         IDcpDependencyCheckService dependencyCheckService,
         Locations locations)
     {
-        _applicationModel = applicationModel;
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<DcpHostService>();
         _dcpOptions = dcpOptions.Value;
@@ -70,9 +68,13 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         await _appExecutor.RunApplicationAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public Task StopAsync(CancellationToken cancellationToken = default)
+    public async Task StopAsync(CancellationToken cancellationToken = default)
     {
-        return Task.CompletedTask;
+        _shutdownCts.Cancel();
+        if (_logProcessorTask is { } task)
+        {
+            await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+        }
     }
 
     public async ValueTask DisposeAsync()
@@ -98,12 +100,12 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
             try
             {
                 AspireEventSource.Instance.DcpLogSocketCreateStart();
-                Socket loggingSocket = CreateLoggingSocket(_locations.DcpLogSocket);
+                var loggingSocket = CreateLoggingSocket(_locations.DcpLogSocket);
                 loggingSocket.Listen(LoggingSocketConnectionBacklog);
 
                 dcpProcessSpec.EnvironmentVariables.Add("DCP_LOG_SOCKET", _locations.DcpLogSocket);
 
-                _ = Task.Run(() => StartLoggingSocketAsync(loggingSocket), CancellationToken.None);
+                _logProcessorTask = StartLoggingSocketAsync(loggingSocket);
             }
             catch (Exception ex)
             {
@@ -197,23 +199,31 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
 
     private async Task StartLoggingSocketAsync(Socket socket)
     {
-        while (true)
+        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
+        List<Task> outputLoggers = [];
+        while (!_shutdownCts.IsCancellationRequested)
         {
             try
             {
-                Socket acceptedSocket = await socket.AcceptAsync().ConfigureAwait(false);
-                _ = Task.Run(() => LogSocketOutputAsync(acceptedSocket), CancellationToken.None);
+                Socket acceptedSocket = await socket.AcceptAsync(_shutdownCts.Token).ConfigureAwait(false);
+                outputLoggers.Add(LogSocketOutputAsync(acceptedSocket, _shutdownCts.Token));
             }
             catch
             {
                 // Suppress exceptions reading logs from DCP controllers
             }
         }
+
+        await Task.WhenAll(outputLoggers).ConfigureAwait(false);
+        socket.Dispose();
     }
 
-    private async Task LogSocketOutputAsync(Socket socket)
+    private async Task LogSocketOutputAsync(Socket socket, CancellationToken cancellationToken)
     {
-        var reader = PipeReader.Create(new NetworkStream(socket));
+        await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
+        using var stream = new NetworkStream(socket, ownsSocket: true);
+        using var _ = cancellationToken.Register(s => ((NetworkStream)s!).Close(), stream);
+        var reader = PipeReader.Create(stream);
 
         // Logger cache to avoid creating a new string per log line, for a few categories
         var loggerCache = new Dictionary<int, ILogger>();
@@ -287,11 +297,11 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
                 position = seq.Position;
             }
 
-            while (true)
+            while (!cancellationToken.IsCancellationRequested)
             {
-                var result = await reader.ReadAsync().ConfigureAwait(false);
+                var result = await reader.ReadAsync(CancellationToken.None).ConfigureAwait(false);
 
-                if (result.IsCompleted)
+                if (result.IsCompleted || result.IsCanceled)
                 {
                     break;
                 }


### PR DESCRIPTION
During shutdown, we should close the logging sockets and wait for them to close before continuing.
This avoids an `ObjectDisposedException` thrown while resolving loggers in the socket logging loop after the `IServiceProvider` has been disposed.

cc @danegsta
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2326)