### PR TITLE
Remove custom resource types for containers

### DIFF
--- a/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/aspire-manifest.json
@@ -1,33 +1,112 @@
 {
   "resources": {
     "pg1": {
-      "type": "postgres.server.v0"
+      "connectionString": "Host={pg1.bindings.tcp.host};Port={pg1.bindings.tcp.port};Username=postgres;Password={pg1.inputs.password}",
+      "type": "container.v0",
+      "image": "postgres:16.2",
+      "env": {
+        "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
+        "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_PASSWORD": "{pg1.inputs.password}"
+      },
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "containerPort": 5432
+        }
+      },
+      "inputs": {
+        "password": {
+          "type": "string",
+          "secret": true,
+          "default": {
+            "generate": {
+              "minLength": 10
+            }
+          }
+        }
+      }
     },
     "db1": {
-      "type": "postgres.database.v0",
-      "parent": "pg1"
+      "connectionString": "{pg1.connectionString};Database=db1",
+      "type": "value.v0"
     },
     "pg2": {
-      "type": "postgres.server.v0"
+      "connectionString": "Host={pg2.bindings.tcp.host};Port={pg2.bindings.tcp.port};Username=postgres;Password={pg2.inputs.password}",
+      "type": "container.v0",
+      "image": "postgres:16.2",
+      "env": {
+        "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
+        "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_PASSWORD": "{pg2.inputs.password}"
+      },
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "containerPort": 5432
+        }
+      },
+      "inputs": {
+        "password": {
+          "type": "string",
+          "secret": true,
+          "default": {
+            "generate": {
+              "minLength": 10
+            }
+          }
+        }
+      }
     },
     "db2": {
-      "type": "postgres.database.v0",
-      "parent": "pg2"
+      "connectionString": "{pg2.connectionString};Database=db2",
+      "type": "value.v0"
     },
     "pg3": {
-      "type": "postgres.server.v0"
+      "connectionString": "Host={pg3.bindings.tcp.host};Port={pg3.bindings.tcp.port};Username=postgres;Password={pg3.inputs.password}",
+      "type": "container.v0",
+      "image": "postgres:16.2",
+      "env": {
+        "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
+        "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_PASSWORD": "{pg3.inputs.password}"
+      },
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "containerPort": 5432
+        }
+      },
+      "inputs": {
+        "password": {
+          "type": "string",
+          "secret": true,
+          "default": {
+            "generate": {
+              "minLength": 10
+            }
+          }
+        }
+      }
     },
     "db3": {
-      "type": "postgres.database.v0",
-      "parent": "pg3"
+      "connectionString": "{pg3.connectionString};Database=db3",
+      "type": "value.v0"
     },
     "db4": {
-      "type": "postgres.database.v0",
-      "parent": "pg3"
+      "connectionString": "{pg3.connectionString};Database=db4",
+      "type": "value.v0"
     },
     "pg4": {
+      "connectionString": "Host={pg4.bindings.tcp.host};Port={pg4.bindings.tcp.port};Username=postgres;Password={pg4.inputs.password}",
       "type": "container.v0",
-      "image": "postgres:latest",
+      "image": "postgres:16.2",
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
@@ -41,7 +120,6 @@
           "containerPort": 5432
         }
       },
-      "connectionString": "Host={pg4.bindings.tcp.host};Port={pg4.bindings.tcp.port};Username=postgres;Password={pg4.inputs.password};",
       "inputs": {
         "password": {
           "type": "string",
@@ -55,12 +133,13 @@
       }
     },
     "db5": {
-      "type": "postgres.database.v0",
-      "parent": "pg4"
+      "connectionString": "{pg4.connectionString};Database=db5",
+      "type": "value.v0"
     },
     "pg5": {
+      "connectionString": "Host={pg5.bindings.tcp.host};Port={pg5.bindings.tcp.port};Username=postgres;Password={pg5.inputs.password}",
       "type": "container.v0",
-      "image": "postgres:latest",
+      "image": "postgres:16.2",
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
@@ -74,7 +153,6 @@
           "containerPort": 5432
         }
       },
-      "connectionString": "Host={pg5.bindings.tcp.host};Port={pg5.bindings.tcp.port};Username=postgres;Password={pg5.inputs.password};",
       "inputs": {
         "password": {
           "type": "string",
@@ -88,12 +166,13 @@
       }
     },
     "db6": {
-      "type": "postgres.database.v0",
-      "parent": "pg5"
+      "connectionString": "{pg5.connectionString};Database=db6",
+      "type": "value.v0"
     },
     "pg6": {
+      "connectionString": "Host={pg6.bindings.tcp.host};Port={pg6.bindings.tcp.port};Username=postgres;Password={pg6.inputs.password}",
       "type": "container.v0",
-      "image": "postgres:latest",
+      "image": "postgres:16.2",
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
@@ -107,7 +186,6 @@
           "containerPort": 5432
         }
       },
-      "connectionString": "Host={pg6.bindings.tcp.host};Port={pg6.bindings.tcp.port};Username=postgres;Password={pg6.inputs.password};",
       "inputs": {
         "password": {
           "type": "string",
@@ -121,12 +199,12 @@
       }
     },
     "db7": {
-      "type": "postgres.database.v0",
-      "parent": "pg6"
+      "connectionString": "{pg6.connectionString};Database=db7",
+      "type": "value.v0"
     },
     "db8": {
-      "type": "postgres.database.v0",
-      "parent": "pg6"
+      "connectionString": "{pg6.connectionString};Database=db8",
+      "type": "value.v0"
     },
     "api": {
       "type": "project.v0",

--- a/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/aspire-manifest.json
@@ -1,13 +1,39 @@
 {
   "resources": {
     "sql1": {
-      "type": "sqlserver.server.v0"
+      "connectionString": "Server={sql1.bindings.tcp.host},{sql1.bindings.tcp.port};User ID=sa;Password={sql1.inputs.password};TrustServerCertificate=true",
+      "type": "container.v0",
+      "image": "mcr.microsoft.com/mssql/server:2022-latest",
+      "env": {
+        "ACCEPT_EULA": "Y",
+        "MSSQL_SA_PASSWORD": "{sql1.inputs.password}"
+      },
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "containerPort": 1433
+        }
+      },
+      "inputs": {
+        "password": {
+          "type": "string",
+          "secret": true,
+          "default": {
+            "generate": {
+              "minLength": 10
+            }
+          }
+        }
+      }
     },
     "db1": {
-      "type": "sqlserver.database.v0",
-      "parent": "sql1"
+      "connectionString": "{sql1.connectionString};Database=db1",
+      "type": "value.v0"
     },
     "sql2": {
+      "connectionString": "Server={sql2.bindings.tcp.host},{sql2.bindings.tcp.port};User ID=sa;Password={sql2.inputs.password};TrustServerCertificate=true",
       "type": "container.v0",
       "image": "mcr.microsoft.com/mssql/server:2022-latest",
       "env": {
@@ -22,7 +48,6 @@
           "containerPort": 1433
         }
       },
-      "connectionString": "Server={sql2.bindings.tcp.host},{sql2.bindings.tcp.port};User ID=sa;Password={sql2.inputs.password};TrustServerCertificate=true;",
       "inputs": {
         "password": {
           "type": "string",
@@ -36,8 +61,8 @@
       }
     },
     "db2": {
-      "type": "sqlserver.database.v0",
-      "parent": "sql2"
+      "connectionString": "{sql2.connectionString};Database=db2",
+      "type": "value.v0"
     },
     "api": {
       "type": "project.v0",

--- a/playground/TestShop/AppHost/aspire-manifest.json
+++ b/playground/TestShop/AppHost/aspire-manifest.json
@@ -1,14 +1,50 @@
 {
   "resources": {
     "postgres": {
-      "type": "postgres.server.v0"
+      "connectionString": "Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres.inputs.password}",
+      "type": "container.v0",
+      "image": "postgres:16.2",
+      "env": {
+        "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
+        "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_PASSWORD": "{postgres.inputs.password}"
+      },
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "containerPort": 5432
+        }
+      },
+      "inputs": {
+        "password": {
+          "type": "string",
+          "secret": true,
+          "default": {
+            "generate": {
+              "minLength": 10
+            }
+          }
+        }
+      }
     },
     "catalogdb": {
-      "type": "postgres.database.v0",
-      "parent": "postgres"
+      "connectionString": "{postgres.connectionString};Database=catalogdb",
+      "type": "value.v0"
     },
     "basketcache": {
-      "type": "redis.v0"
+      "connectionString": "{basketcache.bindings.tcp.host}:{basketcache.bindings.tcp.port}",
+      "type": "container.v0",
+      "image": "redis:7.2.4",
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "containerPort": 6379
+        }
+      }
     },
     "catalogservice": {
       "type": "project.v0",
@@ -32,6 +68,7 @@
       }
     },
     "messaging": {
+      "connectionString": "amqp://guest:{messaging.inputs.password}@{messaging.bindings.tcp.host}:{messaging.bindings.tcp.port}",
       "type": "container.v0",
       "image": "rabbitmq:3",
       "env": {
@@ -46,7 +83,6 @@
           "containerPort": 5672
         }
       },
-      "connectionString": "amqp://guest:{messaging.inputs.password}@{messaging.bindings.tcp.host}:{messaging.bindings.tcp.port}",
       "inputs": {
         "password": {
           "type": "string",

--- a/playground/mongo/Mongo.AppHost/aspire-manifest.json
+++ b/playground/mongo/Mongo.AppHost/aspire-manifest.json
@@ -1,0 +1,38 @@
+{
+  "resources": {
+    "mongo": {
+      "connectionString": "mongodb://{mongo.bindings.tcp.host}:{mongo.bindings.tcp.port}",
+      "type": "container.v0",
+      "image": "mongo:7.0.5",
+      "bindings": {
+        "tcp": {
+          "scheme": "tcp",
+          "protocol": "tcp",
+          "transport": "tcp",
+          "containerPort": 27017
+        }
+      }
+    },
+    "api": {
+      "type": "project.v0",
+      "path": "../Mongo.ApiService/Mongo.ApiService.csproj",
+      "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
+        "ConnectionStrings__mongo": "{mongo.connectionString}"
+      },
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
+        }
+      }
+    }
+  }
+}

--- a/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
@@ -38,6 +38,6 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
     internal void WriteToManifest(ManifestPublishingContext context)
     {
         context.Writer.WriteString("type", "value.v0");
-        context.Writer.WriteString("connectionString", ConnectionStringExpression);
+        context.WriteConnectionString(this);
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
@@ -34,6 +34,6 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
     internal void WriteToManifest(ManifestPublishingContext context)
     {
         context.Writer.WriteString("type", "value.v0");
-        context.Writer.WriteString("connectionString", ConnectionStringExpression);
+        context.WriteConnectionString(this);
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
@@ -34,6 +34,6 @@ public class AzureTableStorageResource(string name, AzureStorageResource storage
     internal void WriteToManifest(ManifestPublishingContext context)
     {
         context.Writer.WriteString("type", "value.v0");
-        context.Writer.WriteString("connectionString", ConnectionStringExpression);
+        context.WriteConnectionString(this);
     }
 }

--- a/src/Aspire.Hosting.Azure/Bicep/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/Bicep/AzureBicepResource.cs
@@ -161,11 +161,8 @@ public class AzureBicepResource(string name, string? templateFile = null, string
         using var template = GetBicepTemplateFile(Path.GetDirectoryName(context.ManifestPath), deleteTemporaryFileOnDispose: false);
         var path = template.Path;
 
-        // REVIEW: This should be in the ManifestPublisher
-        if (this is IResourceWithConnectionString c && c.ConnectionStringExpression is string connectionString)
-        {
-            context.Writer.WriteString("connectionString", connectionString);
-        }
+        // Write a connection string if it exists.
+        context.WriteConnectionString(this);
 
         // REVIEW: Consider multiple files.
         context.Writer.WriteString("path", context.GetManifestRelativePath(path));

--- a/src/Aspire.Hosting/ApplicationModel/DistributedApplicationOperation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DistributedApplicationOperation.cs
@@ -14,7 +14,7 @@ public enum DistributedApplicationOperation
     Run,
 
     /// <summary>
-    /// AppHostis being run for the purpose of publishing a manifest for deployment.
+    /// AppHost is being run for the purpose of publishing a manifest for deployment.
     /// </summary>
     Publish
 }

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -152,6 +152,15 @@ public static class ContainerResourceBuilderExtensions
         return builder;
     }
 
+    /// <summary>
+    /// Changes the Kafka resource to be published as a container in the manifest.
+    /// </summary>
+    /// <param name="builder">Resource builder.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> PublishAsContainer<T>(this IResourceBuilder<T> builder) where T : ContainerResource
+    {
+        return builder.WithManifestPublishingCallback(context => context.WriteContainer(builder.Resource));
+    }
 }
 
 internal static class IListExtensions

--- a/src/Aspire.Hosting/Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Kafka/KafkaBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting;
 
@@ -12,22 +11,6 @@ namespace Aspire.Hosting;
 public static class KafkaBuilderExtensions
 {
     private const int KafkaBrokerPort = 9092;
-
-    /// <summary>
-    /// Changes the Kafka resource to be published as a container in the manifest.
-    /// </summary>
-    /// <param name="builder">Resource builder for <see cref="KafkaServerResource"/>.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<KafkaServerResource> PublishAsContainer(this IResourceBuilder<KafkaServerResource> builder)
-    {
-        return builder.WithManifestPublishingCallback(context => WriteKafkaContainerToManifest(context, builder.Resource));
-    }
-
-    private static void WriteKafkaContainerToManifest(ManifestPublishingContext context, KafkaServerResource resource)
-    {
-        context.WriteContainer(resource);
-        context.Writer.WriteString("connectionString", $"{{{resource.Name}.bindings.tcp.host}}:{{{resource.Name}.bindings.tcp.port}}");
-    }
 
     /// <summary>
     /// Adds a Kafka resource to the application. A container is used for local development.  This version the package defaults to the 7.6.0 tag of the confluentinc/confluent-local container image.
@@ -41,14 +24,9 @@ public static class KafkaBuilderExtensions
         var kafka = new KafkaServerResource(name);
         return builder.AddResource(kafka)
             .WithEndpoint(containerPort: KafkaBrokerPort, hostPort: port)
-            .WithAnnotation(new ContainerImageAnnotation{ Image = "confluentinc/confluent-local", Tag = "7.6.0" })
-            .WithManifestPublishingCallback(WriteKafkaServerToManifest)
-            .WithEnvironment(context => ConfigureKafkaContainer(context, kafka));
-
-        static void WriteKafkaServerToManifest(ManifestPublishingContext context)
-        {
-            context.Writer.WriteString("type", "kafka.server.v0");
-        }
+            .WithAnnotation(new ContainerImageAnnotation { Image = "confluentinc/confluent-local", Tag = "7.6.0" })
+            .WithEnvironment(context => ConfigureKafkaContainer(context, kafka))
+            .PublishAsContainer();
     }
 
     private static void ConfigureKafkaContainer(EnvironmentCallbackContext context, IResource resource)

--- a/src/Aspire.Hosting/Kafka/KafkaServerResource.cs
+++ b/src/Aspire.Hosting/Kafka/KafkaServerResource.cs
@@ -12,6 +12,12 @@ namespace Aspire.Hosting;
 public class KafkaServerResource(string name) : ContainerResource(name), IResourceWithConnectionString, IResourceWithEnvironment
 {
     /// <summary>
+    /// Gets the connection string expression for Kafka broker for the manifest.
+    /// </summary>
+    public string ConnectionStringExpression =>
+        $"{{{Name}.bindings.tcp.host}}:{{{Name}.bindings.tcp.port}}";
+
+    /// <summary>
     /// Gets the connection string for Kafka broker.
     /// </summary>
     /// <returns>A connection string for the Kafka in the form "host:port" to be passed as <see href="https://docs.confluent.io/platform/current/clients/confluent-kafka-dotnet/_site/api/Confluent.Kafka.ClientConfig.html#Confluent_Kafka_ClientConfig_BootstrapServers">BootstrapServers</see>.</returns>

--- a/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
@@ -4,7 +4,6 @@
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.MongoDB;
-using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting;
 
@@ -28,9 +27,9 @@ public static class MongoDBBuilderExtensions
 
         return builder
             .AddResource(mongoDBContainer)
-            .WithManifestPublishingCallback(WriteMongoDBServerToManifest)
             .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: DefaultContainerPort)) // Internal port is always 27017.
-            .WithAnnotation(new ContainerImageAnnotation { Image = "mongo", Tag = "7.0.5" });
+            .WithAnnotation(new ContainerImageAnnotation { Image = "mongo", Tag = "7.0.5" })
+            .PublishAsContainer();
     }
 
     /// <summary>
@@ -45,7 +44,7 @@ public static class MongoDBBuilderExtensions
 
         return builder.ApplicationBuilder
             .AddResource(mongoDBDatabase)
-            .WithManifestPublishingCallback(context => context.WriteMongoDBDatabaseToManifest(mongoDBDatabase));
+            .WithManifestPublishingCallback(MongoDBDatabaseResource.WriteMongoDBDatabaseToManifest);
     }
 
     /// <summary>
@@ -86,34 +85,5 @@ public static class MongoDBBuilderExtensions
 
             return allocatedEndpoints.Single().Port;
         }
-    }
-
-    /// <summary>
-    /// Changes the MongoDB resource to be published as a container in the manifest.
-    /// </summary>
-    /// <param name="builder">Resource builder for <see cref="MongoDBServerResource"/>.</param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<MongoDBServerResource> PublishAsContainer(this IResourceBuilder<MongoDBServerResource> builder)
-    {
-        return builder.WithManifestPublishingCallback(context => WriteMongoDBContainerToManifest(context, builder.Resource));
-    }
-
-    private static void WriteMongoDBContainerToManifest(this ManifestPublishingContext context, MongoDBServerResource resource)
-    {
-        context.WriteContainer(resource);
-        context.Writer.WriteString(                     // "connectionString": "...",
-            "connectionString",
-            $"{{{resource.Name}.bindings.tcp.host}}:{{{resource.Name}.bindings.tcp.port}}");
-    }
-
-    private static void WriteMongoDBServerToManifest(this ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "mongodb.server.v0");
-    }
-
-    private static void WriteMongoDBDatabaseToManifest(this ManifestPublishingContext context, MongoDBDatabaseResource mongoDbDatabase)
-    {
-        context.Writer.WriteString("type", "mongodb.database.v0");
-        context.Writer.WriteString("parent", mongoDbDatabase.Parent.Name);
     }
 }

--- a/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
@@ -44,7 +44,7 @@ public static class MongoDBBuilderExtensions
 
         return builder.ApplicationBuilder
             .AddResource(mongoDBDatabase)
-            .WithManifestPublishingCallback(MongoDBDatabaseResource.WriteMongoDBDatabaseToManifest);
+            .WithManifestPublishingCallback(mongoDBDatabase.WriteMongoDBDatabaseToManifest);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
@@ -39,8 +39,9 @@ public class MongoDBDatabaseResource(string name, MongoDBServerResource parent) 
         throw new DistributedApplicationException("Parent resource connection string was null.");
     }
 
-    internal static void WriteMongoDBDatabaseToManifest(ManifestPublishingContext context)
+    internal void WriteMongoDBDatabaseToManifest(ManifestPublishingContext context)
     {
         context.Writer.WriteString("type", "value.v0");
+        context.WriteConnectionString(this);
     }
 }

--- a/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Publishing;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -10,6 +12,12 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="parent">The MongoDB server resource associated with this database.</param>
 public class MongoDBDatabaseResource(string name, MongoDBServerResource parent) : Resource(name), IResourceWithParent<MongoDBServerResource>, IResourceWithConnectionString
 {
+    /// <summary>
+    /// Gets the connection string expression for the MongoDB database.
+    /// </summary>
+    public string ConnectionStringExpression
+        => $"{{{Parent.Name}.connectionString}}/{Name}";
+
     /// <summary>
     /// Gets the parent MongoDB container resource.
     /// </summary>
@@ -29,5 +37,10 @@ public class MongoDBDatabaseResource(string name, MongoDBServerResource parent) 
         }
 
         throw new DistributedApplicationException("Parent resource connection string was null.");
+    }
+
+    internal static void WriteMongoDBDatabaseToManifest(ManifestPublishingContext context)
+    {
+        context.Writer.WriteString("type", "value.v0");
     }
 }

--- a/src/Aspire.Hosting/MongoDB/MongoDBServerResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBServerResource.cs
@@ -14,6 +14,12 @@ public class MongoDBServerResource(string name) : ContainerResource(name), IReso
     /// <summary>
     /// Gets the connection string for the MongoDB server.
     /// </summary>
+    public string ConnectionStringExpression =>
+        $"mongodb://{{{Name}.bindings.tcp.host}}:{{{Name}.bindings.tcp.port}}";
+
+    /// <summary>
+    /// Gets the connection string for the MongoDB server.
+    /// </summary>
     /// <returns>A connection string for the MongoDB server in the form "mongodb://host:port".</returns>
     public string? GetConnectionString()
     {

--- a/src/Aspire.Hosting/MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlDatabaseResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Publishing;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -16,6 +18,12 @@ public class MySqlDatabaseResource(string name, MySqlServerResource parent) : Re
     public MySqlServerResource Parent { get; } = parent;
 
     /// <summary>
+    /// Gets the connection string expression for the MySQL database.
+    /// </summary>
+    public string ConnectionStringExpression =>
+        $"{{{Parent.Name}.connectionString}};Database={Name}";
+
+    /// <summary>
     /// Gets the connection string for the MySQL database.
     /// </summary>
     /// <returns>A connection string for the MySQL database.</returns>
@@ -23,11 +31,17 @@ public class MySqlDatabaseResource(string name, MySqlServerResource parent) : Re
     {
         if (Parent.GetConnectionString() is { } connectionString)
         {
-            return $"{connectionString}Database={Name}";
+            return $"{connectionString};Database={Name}";
         }
         else
         {
             throw new DistributedApplicationException("Parent resource connection string was null.");
         }
+    }
+
+    internal void WriteToManifest(ManifestPublishingContext context)
+    {
+        context.Writer.WriteString("type", "value.v0");
+        context.WriteConnectionString(this);
     }
 }

--- a/src/Aspire.Hosting/MySql/MySqlServerResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlServerResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -18,6 +19,12 @@ public class MySqlServerResource(string name, string password) : ContainerResour
     public string Password { get; } = password;
 
     /// <summary>
+    /// Gets the connection string expression for the MySQL server.
+    /// </summary>
+    public string ConnectionStringExpression =>
+        $"Server={{{Name}.bindings.tcp.host}};Port={{{Name}.bindings.tcp.port}};User ID=root;Password={{{Name}.inputs.password}}";
+
+    /// <summary>
     /// Gets the connection string for the MySQL server.
     /// </summary>
     /// <returns>A connection string for the MySQL server in the form "Server=host;Port=port;User ID=root;Password=password".</returns>
@@ -30,7 +37,24 @@ public class MySqlServerResource(string name, string password) : ContainerResour
 
         var allocatedEndpoint = allocatedEndpoints.Single(); // We should only have one endpoint for MySQL.
 
-        var connectionString = $"Server={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};User ID=root;Password=\"{PasswordUtil.EscapePassword(Password)}\";";
+        var connectionString = $"Server={allocatedEndpoint.Address};Port={allocatedEndpoint.Port};User ID=root;Password=\"{PasswordUtil.EscapePassword(Password)}\"";
         return connectionString;
+    }
+
+    internal void WriteToManifest(ManifestPublishingContext context)
+    {
+        context.WriteContainer(this);
+
+        context.Writer.WriteStartObject("inputs");      // "inputs": {
+        context.Writer.WriteStartObject("password");    //   "password": {
+        context.Writer.WriteString("type", "string");   //     "type": "string",
+        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
+        context.Writer.WriteStartObject("default");     //     "default": {
+        context.Writer.WriteStartObject("generate");    //       "generate": {
+        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
+        context.Writer.WriteEndObject();                //       }
+        context.Writer.WriteEndObject();                //     }
+        context.Writer.WriteEndObject();                //   }
+        context.Writer.WriteEndObject();                // }
     }
 }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
@@ -29,7 +28,6 @@ public static class OracleDatabaseBuilderExtensions
 
         var oracleDatabaseServer = new OracleDatabaseServerResource(name, password);
         return builder.AddResource(oracleDatabaseServer)
-                      .WithManifestPublishingCallback(WriteOracleDatabaseContainerToManifest)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 1521))
                       .WithAnnotation(new ContainerImageAnnotation { Image = "database/free", Tag = "23.3.0.0", Registry = "container-registry.oracle.com" })
                       .WithEnvironment(context =>
@@ -42,7 +40,8 @@ public static class OracleDatabaseBuilderExtensions
                           {
                               context.EnvironmentVariables.Add(PasswordEnvVarName, oracleDatabaseServer.Password);
                           }
-                      });
+                      })
+                      .PublishAsContainer();
     }
 
     /// <summary>
@@ -55,18 +54,7 @@ public static class OracleDatabaseBuilderExtensions
     {
         var oracleDatabase = new OracleDatabaseResource(name, builder.Resource);
         return builder.ApplicationBuilder.AddResource(oracleDatabase)
-                                         .WithManifestPublishingCallback(context => WriteOracleDatabaseToManifest(context, oracleDatabase));
-    }
-
-    private static void WriteOracleDatabaseContainerToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "oracle.server.v0");
-    }
-
-    private static void WriteOracleDatabaseToManifest(ManifestPublishingContext context, OracleDatabaseResource oracleDatabase)
-    {
-        context.Writer.WriteString("type", "oracle.database.v0");
-        context.Writer.WriteString("parent", oracleDatabase.Parent.Name);
+                                         .WithManifestPublishingCallback(oracleDatabase.WriteToManifest);
     }
 
     /// <summary>
@@ -76,25 +64,6 @@ public static class OracleDatabaseBuilderExtensions
     /// <returns></returns>
     public static IResourceBuilder<OracleDatabaseServerResource> PublishAsContainer(this IResourceBuilder<OracleDatabaseServerResource> builder)
     {
-        return builder.WithManifestPublishingCallback(context => WriteOracleDatabaseContainerResourceToManifest(context, builder.Resource));
-    }
-
-    private static void WriteOracleDatabaseContainerResourceToManifest(ManifestPublishingContext context, OracleDatabaseServerResource resource)
-    {
-        context.WriteContainer(resource);
-        context.Writer.WriteString(                     // "connectionString": "...",
-            "connectionString",
-            $"user id=system;password={{{resource.Name}.inputs.password}};data source={{{resource.Name}.bindings.tcp.host}}:{{{resource.Name}.bindings.tcp.port}};");
-        context.Writer.WriteStartObject("inputs");      // "inputs": {
-        context.Writer.WriteStartObject("password");    //   "password": {
-        context.Writer.WriteString("type", "string");   //     "type": "string",
-        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
-        context.Writer.WriteStartObject("default");     //     "default": {
-        context.Writer.WriteStartObject("generate");    //       "generate": {
-        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
-        context.Writer.WriteEndObject();                //       }
-        context.Writer.WriteEndObject();                //     }
-        context.Writer.WriteEndObject();                //   }
-        context.Writer.WriteEndObject();                // }
+        return builder.WithManifestPublishingCallback(builder.Resource.WriteToManifest);
     }
 }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Publishing;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -16,6 +18,11 @@ public class OracleDatabaseResource(string name, OracleDatabaseServerResource pa
     public OracleDatabaseServerResource Parent { get; } = parent;
 
     /// <summary>
+    /// Gets the connection string expression for the Oracle Database.
+    /// </summary>
+    public string ConnectionStringExpression => $"{{{Parent.Name}.connectionString}}/{Name}";
+
+    /// <summary>
     /// Gets the connection string for the Oracle Database.
     /// </summary>
     /// <returns>A connection string for the Oracle Database.</returns>
@@ -29,5 +36,11 @@ public class OracleDatabaseResource(string name, OracleDatabaseServerResource pa
         {
             throw new DistributedApplicationException("Parent resource connection string was null.");
         }
+    }
+
+    internal void WriteToManifest(ManifestPublishingContext context)
+    {
+        context.Writer.WriteString("type", "value.v0");
+        context.WriteConnectionString(this);
     }
 }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -18,6 +19,12 @@ public class OracleDatabaseServerResource(string name, string password) : Contai
     public string Password { get; } = password;
 
     /// <summary>
+    /// Gets the connection string expression for the Oracle Database server.
+    /// </summary>
+    public string ConnectionStringExpression =>
+        $"user id=system;password={{{Name}.inputs.password}};data source={{{Name}.bindings.tcp.host}}:{{{Name}.bindings.tcp.port}};";
+
+    /// <summary>
     /// Gets the connection string for the Oracle Database server.
     /// </summary>
     /// <returns>A connection string for the Oracle Database server in the form "user id=system;password=password;data source=host:port".</returns>
@@ -32,5 +39,22 @@ public class OracleDatabaseServerResource(string name, string password) : Contai
 
         var connectionString = $"user id=system;password={PasswordUtil.EscapePassword(Password)};data source={allocatedEndpoint.Address}:{allocatedEndpoint.Port}";
         return connectionString;
+    }
+
+    internal void WriteToManifest(ManifestPublishingContext context)
+    {
+        context.WriteContainer(this);
+
+        context.Writer.WriteStartObject("inputs");      // "inputs": {
+        context.Writer.WriteStartObject("password");    //   "password": {
+        context.Writer.WriteString("type", "string");   //     "type": "string",
+        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
+        context.Writer.WriteStartObject("default");     //     "default": {
+        context.Writer.WriteStartObject("generate");    //       "generate": {
+        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
+        context.Writer.WriteEndObject();                //       }
+        context.Writer.WriteEndObject();                //     }
+        context.Writer.WriteEndObject();                //   }
+        context.Writer.WriteEndObject();                // }
     }
 }

--- a/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Publishing;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -16,6 +18,11 @@ public class PostgresDatabaseResource(string name, PostgresServerResource postgr
     public PostgresServerResource Parent { get; } = postgresParentResource;
 
     /// <summary>
+    /// Gets the connection string expression for the Postgres database for the manifest.
+    /// </summary>
+    public string ConnectionStringExpression => $"{{{Parent.Name}.connectionString}};Database={Name}";
+
+    /// <summary>
     /// Gets the connection string for the Postgres database.
     /// </summary>
     /// <returns>A connection string for the Postgres database.</returns>
@@ -29,5 +36,11 @@ public class PostgresDatabaseResource(string name, PostgresServerResource postgr
         {
             throw new DistributedApplicationException("Parent resource connection string was null.");
         }
+    }
+
+    internal void WriteToManifest(ManifestPublishingContext context)
+    {
+        context.Writer.WriteString("type", "value.v0");
+        context.WriteConnectionString(this);
     }
 }

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -67,7 +67,7 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
         context.Writer.WriteEndObject();
     }
 
-    private static void WriteResource(IResource resource, ManifestPublishingContext context)
+    internal static void WriteResource(IResource resource, ManifestPublishingContext context)
     {
         // First see if the resource has a callback annotation with overrides the behavior for rendering
         // out the JSON. If so use that callback, otherwise use the fallback logic that we have.
@@ -129,6 +129,9 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
     private static void WriteExecutable(ExecutableResource executable, ManifestPublishingContext context)
     {
         context.Writer.WriteString("type", "executable.v0");
+
+        // Write the connection string if it exists.
+        context.WriteConnectionString(executable);
 
         var relativePathToProjectFile = context.GetManifestRelativePath(executable.WorkingDirectory);
 

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -60,6 +60,9 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
     {
         Writer.WriteString("type", "container.v0");
 
+        // Attempt to write the connection string for the container (if this resource has one).
+        WriteConnectionString(container);
+
         if (!container.TryGetContainerImageName(out var image))
         {
             throw new DistributedApplicationException("Could not get container image name.");
@@ -94,6 +97,19 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
 
         WriteEnvironmentVariables(container);
         WriteBindings(container, emitContainerPort: true);
+    }
+
+    /// <summary>
+    /// Writes the "connectionString" field for the underlying resource.
+    /// </summary>
+    /// <param name="resource"></param>
+    public void WriteConnectionString(IResource resource)
+    {
+        if (resource is IResourceWithConnectionString resourceWithConnectionString &&
+            resourceWithConnectionString.ConnectionStringExpression is string connectionString)
+        {
+            Writer.WriteString("connectionString", connectionString);
+        }
     }
 
     /// <summary>
@@ -136,7 +152,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
     public void WriteEnvironmentVariables(IResource resource)
     {
         var config = new Dictionary<string, string>();
-        
+
         var envContext = new EnvironmentCallbackContext(ExecutionContext, config);
 
         if (resource.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var callbacks))

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
@@ -28,7 +27,6 @@ public static class RabbitMQBuilderExtensions
         return builder.AddResource(rabbitMq)
                        .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 5672))
                        .WithAnnotation(new ContainerImageAnnotation { Image = "rabbitmq", Tag = "3" })
-                       .WithManifestPublishingCallback(WriteRabbitMQServerToManifest)
                        .WithEnvironment("RABBITMQ_DEFAULT_USER", "guest")
                        .WithEnvironment(context =>
                        {
@@ -40,12 +38,8 @@ public static class RabbitMQBuilderExtensions
                            {
                                context.EnvironmentVariables.Add("RABBITMQ_DEFAULT_PASS", rabbitMq.Password);
                            }
-                       });
-    }
-
-    private static void WriteRabbitMQServerToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "rabbitmq.server.v0");
+                       })
+                       .PublishAsContainer();
     }
 
     /// <summary>
@@ -55,25 +49,6 @@ public static class RabbitMQBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<RabbitMQServerResource> PublishAsContainer(this IResourceBuilder<RabbitMQServerResource> builder)
     {
-        return builder.WithManifestPublishingCallback(context => WriteRabbitMQContainerToManifest(context, builder.Resource));
-    }
-
-    private static void WriteRabbitMQContainerToManifest(ManifestPublishingContext context, RabbitMQServerResource resource)
-    {
-        context.WriteContainer(resource);
-        context.Writer.WriteString(                     // "connectionString": "...",
-            "connectionString",
-            $"amqp://guest:{{{resource.Name}.inputs.password}}@{{{resource.Name}.bindings.tcp.host}}:{{{resource.Name}.bindings.tcp.port}}");
-        context.Writer.WriteStartObject("inputs");      // "inputs": {
-        context.Writer.WriteStartObject("password");    //   "password": {
-        context.Writer.WriteString("type", "string");   //     "type": "string",
-        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
-        context.Writer.WriteStartObject("default");     //     "default": {
-        context.Writer.WriteStartObject("generate");    //       "generate": {
-        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
-        context.Writer.WriteEndObject();                //       }
-        context.Writer.WriteEndObject();                //     }
-        context.Writer.WriteEndObject();                //   }
-        context.Writer.WriteEndObject();                // }
+        return builder.WithManifestPublishingCallback(builder.Resource.WriteToManifest);
     }
 }

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Publishing;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -16,6 +18,12 @@ public class RabbitMQServerResource(string name, string password) : ContainerRes
     public string Password { get; } = password;
 
     /// <summary>
+    /// Gets the connection string expression for the RabbitMQ server for the manifest.
+    /// </summary>
+    public string ConnectionStringExpression =>
+        $"amqp://guest:{{{Name}.inputs.password}}@{{{Name}.bindings.tcp.host}}:{{{Name}.bindings.tcp.port}}";
+
+    /// <summary>
     /// Gets the connection string for the RabbitMQ server.
     /// </summary>
     /// <returns>A connection string for the RabbitMQ server in the form "amqp://user:password@host:port".</returns>
@@ -28,5 +36,22 @@ public class RabbitMQServerResource(string name, string password) : ContainerRes
 
         var endpoint = allocatedEndpoints.Where(a => a.Name != "management").Single();
         return $"amqp://guest:{Password}@{endpoint.EndPointString}";
+    }
+
+    internal void WriteToManifest(ManifestPublishingContext context)
+    {
+        context.WriteContainer(this);
+
+        context.Writer.WriteStartObject("inputs");      // "inputs": {
+        context.Writer.WriteStartObject("password");    //   "password": {
+        context.Writer.WriteString("type", "string");   //     "type": "string",
+        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
+        context.Writer.WriteStartObject("default");     //     "default": {
+        context.Writer.WriteStartObject("generate");    //       "generate": {
+        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
+        context.Writer.WriteEndObject();                //       }
+        context.Writer.WriteEndObject();                //     }
+        context.Writer.WriteEndObject();                //   }
+        context.Writer.WriteEndObject();                // }
     }
 }

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -10,6 +10,22 @@ namespace Aspire.Hosting.ApplicationModel;
 public class RedisResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
     /// <summary>
+    /// Gets the connection string expression for the Redis server for the manifest.
+    /// </summary>
+    public string? ConnectionStringExpression
+    {
+        get
+        {
+            if (this.TryGetLastAnnotation<ConnectionStringRedirectAnnotation>(out var connectionStringAnnotation))
+            {
+                return connectionStringAnnotation.Resource.ConnectionStringExpression;
+            }
+
+            return $"{{{Name}.bindings.tcp.host}}:{{{Name}.bindings.tcp.port}}";
+        }
+    }
+
+    /// <summary>
     /// Gets the connection string for the Redis server.
     /// </summary>
     /// <returns>A connection string for the redis server in the form "host:port".</returns>

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
@@ -29,7 +28,6 @@ public static class SqlServerBuilderExtensions
         var sqlServer = new SqlServerServerResource(name, password);
 
         return builder.AddResource(sqlServer)
-                      .WithManifestPublishingCallback(WriteSqlServerToManifest)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 1433))
                       .WithAnnotation(new ContainerImageAnnotation { Registry = "mcr.microsoft.com", Image = "mssql/server", Tag = "2022-latest" })
                       .WithEnvironment("ACCEPT_EULA", "Y")
@@ -43,12 +41,8 @@ public static class SqlServerBuilderExtensions
                           {
                               context.EnvironmentVariables.Add("MSSQL_SA_PASSWORD", sqlServer.Password);
                           }
-                      });
-    }
-
-    private static void WriteSqlServerToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "sqlserver.server.v0");
+                      })
+                      .PublishAsContainer();
     }
 
     /// <summary>
@@ -58,32 +52,7 @@ public static class SqlServerBuilderExtensions
     /// <returns></returns>
     public static IResourceBuilder<SqlServerServerResource> PublishAsContainer(this IResourceBuilder<SqlServerServerResource> builder)
     {
-        return builder.WithManifestPublishingCallback(context => WriteSqlServerContainerToManifest(context, builder.Resource));
-    }
-
-    private static void WriteSqlServerContainerToManifest(ManifestPublishingContext context, SqlServerServerResource resource)
-    {
-        context.WriteContainer(resource);
-        context.Writer.WriteString(                     // "connectionString": "...",
-            "connectionString",
-            $"Server={{{resource.Name}.bindings.tcp.host}},{{{resource.Name}.bindings.tcp.port}};User ID=sa;Password={{{resource.Name}.inputs.password}};TrustServerCertificate=true;");
-        context.Writer.WriteStartObject("inputs");      // "inputs": {
-        context.Writer.WriteStartObject("password");    //   "password": {
-        context.Writer.WriteString("type", "string");   //     "type": "string",
-        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
-        context.Writer.WriteStartObject("default");     //     "default": {
-        context.Writer.WriteStartObject("generate");    //       "generate": {
-        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
-        context.Writer.WriteEndObject();                //       }
-        context.Writer.WriteEndObject();                //     }
-        context.Writer.WriteEndObject();                //   }
-        context.Writer.WriteEndObject();                // }
-    }
-
-    private static void WriteSqlServerDatabaseToManifest(ManifestPublishingContext context, SqlServerDatabaseResource sqlServerDatabase)
-    {
-        context.Writer.WriteString("type", "sqlserver.database.v0");
-        context.Writer.WriteString("parent", sqlServerDatabase.Parent.Name);
+        return builder.WithManifestPublishingCallback(builder.Resource.WriteToManifest);
     }
 
     /// <summary>
@@ -96,6 +65,6 @@ public static class SqlServerBuilderExtensions
     {
         var sqlServerDatabase = new SqlServerDatabaseResource(name, builder.Resource);
         return builder.ApplicationBuilder.AddResource(sqlServerDatabase)
-                                         .WithManifestPublishingCallback(context => WriteSqlServerDatabaseToManifest(context, sqlServerDatabase));
+                                         .WithManifestPublishingCallback(sqlServerDatabase.WriteToManifest);
     }
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Publishing;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -16,6 +18,11 @@ public class SqlServerDatabaseResource(string name, SqlServerServerResource pare
     public SqlServerServerResource Parent { get; } = parent;
 
     /// <summary>
+    /// Gets the connection string expression for the SQL Server database for use in the manifest.
+    /// </summary>
+    public string ConnectionStringExpression => $"{{{Parent.Name}.connectionString}};Database={Name}";
+
+    /// <summary>
     /// Gets the connection string for the database resource.
     /// </summary>
     /// <returns>The connection string for the database resource.</returns>
@@ -24,11 +31,17 @@ public class SqlServerDatabaseResource(string name, SqlServerServerResource pare
     {
         if (Parent.GetConnectionString() is { } connectionString)
         {
-            return $"{connectionString}Database={Name}";
+            return $"{connectionString};Database={Name}";
         }
         else
         {
             throw new DistributedApplicationException("Parent resource connection string was null.");
         }
+    }
+
+    internal void WriteToManifest(ManifestPublishingContext context)
+    {
+        context.Writer.WriteString("type", "value.v0");
+        context.WriteConnectionString(this);
     }
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -18,9 +19,15 @@ public class SqlServerServerResource(string name, string password) : ContainerRe
     public string Password { get; } = password;
 
     /// <summary>
+    /// Gets the connection string expression for the SQL Server for the manifest.
+    /// </summary>
+    public string ConnectionStringExpression =>
+        $"Server={{{Name}.bindings.tcp.host}},{{{Name}.bindings.tcp.port}};User ID=sa;Password={{{Name}.inputs.password}};TrustServerCertificate=true";
+
+    /// <summary>
     /// Gets the connection string for the SQL Server.
     /// </summary>
-    /// <returns>A connection string for the SQL Server in the form "Server=host,port;User ID=sa;Password=password;TrustServerCertificate=true;".</returns>
+    /// <returns>A connection string for the SQL Server in the form "Server=host,port;User ID=sa;Password=password;TrustServerCertificate=true".</returns>
     public string? GetConnectionString()
     {
         if (!this.TryGetAnnotationsOfType<AllocatedEndpointAnnotation>(out var allocatedEndpoints))
@@ -32,6 +39,23 @@ public class SqlServerServerResource(string name, string password) : ContainerRe
 
         // HACK: Use the 127.0.0.1 address because localhost is resolving to [::1] following
         //       up with DCP on this issue.
-        return $"Server=127.0.0.1,{endpoint.Port};User ID=sa;Password={PasswordUtil.EscapePassword(Password)};TrustServerCertificate=true;";
+        return $"Server=127.0.0.1,{endpoint.Port};User ID=sa;Password={PasswordUtil.EscapePassword(Password)};TrustServerCertificate=true";
+    }
+
+    internal void WriteToManifest(ManifestPublishingContext context)
+    {
+        context.WriteContainer(this);
+
+        context.Writer.WriteStartObject("inputs");      // "inputs": {
+        context.Writer.WriteStartObject("password");    //   "password": {
+        context.Writer.WriteString("type", "string");   //     "type": "string",
+        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
+        context.Writer.WriteStartObject("default");     //     "default": {
+        context.Writer.WriteStartObject("generate");    //       "generate": {
+        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
+        context.Writer.WriteEndObject();                //       }
+        context.Writer.WriteEndObject();                //     }
+        context.Writer.WriteEndObject();                //   }
+        context.Writer.WriteEndObject();                // }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -24,4 +24,8 @@
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="RabbitMQ\" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.Sockets;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Kafka;
+public class AddKafkaTests
+{
+    [Fact]
+    public void AddKafkaContainerWithDefaultsAddsAnnotationMetadata()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        appBuilder.AddKafka("kafka");
+
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var containerResource = Assert.Single(appModel.Resources.OfType<KafkaServerResource>());
+        Assert.Equal("kafka", containerResource.Name);
+
+        var manifestAnnotation = Assert.Single(containerResource.Annotations.OfType<ManifestPublishingCallbackAnnotation>());
+        Assert.NotNull(manifestAnnotation.Callback);
+
+        var endpoint = Assert.Single(containerResource.Annotations.OfType<EndpointAnnotation>());
+        Assert.Equal(9092, endpoint.ContainerPort);
+        Assert.False(endpoint.IsExternal);
+        Assert.Equal("tcp", endpoint.Name);
+        Assert.Null(endpoint.Port);
+        Assert.Equal(ProtocolType.Tcp, endpoint.Protocol);
+        Assert.Equal("tcp", endpoint.Transport);
+        Assert.Equal("tcp", endpoint.UriScheme);
+
+        var containerAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("7.6.0", containerAnnotation.Tag);
+        Assert.Equal("confluentinc/confluent-local", containerAnnotation.Image);
+        Assert.Null(containerAnnotation.Registry);
+    }
+
+    [Fact]
+    public void KafkaCreatesConnectionString()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder
+            .AddKafka("kafka")
+            .WithAnnotation(
+                new AllocatedEndpointAnnotation("mybinding",
+                ProtocolType.Tcp,
+                "localhost",
+                27017,
+                "tcp"
+            ));
+
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var connectionStringResource = Assert.Single(appModel.Resources.OfType<KafkaServerResource>());
+        var connectionString = connectionStringResource.GetConnectionString();
+
+        Assert.Equal("localhost:27017", connectionString);
+        Assert.Equal("{kafka.bindings.tcp.host}:{kafka.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
+    }
+
+    [Fact]
+    public void VerifyManifest()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var kafka = appBuilder.AddKafka("kafka");
+
+        var manifest = ManifestUtils.GetManifest(kafka.Resource);
+
+        Assert.Equal("container.v0", manifest["type"]?.ToString());
+        Assert.Equal(kafka.Resource.ConnectionStringExpression, manifest["connectionString"]?.ToString());
+    }
+}

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -263,8 +263,7 @@ public class ManifestGenerationTests
     {
         var program = CreateTestProgramJsonDocumentManifestPublisher();
 
-        program.AppBuilder.AddRedis("redisabstract");
-        program.AppBuilder.AddRedis("rediscontainer").PublishAsContainer();
+        program.AppBuilder.AddRedis("rediscontainer");
 
         // Build AppHost so that publisher can be resolved.
         program.Build();
@@ -273,9 +272,6 @@ public class ManifestGenerationTests
         program.Run();
 
         var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
-
-        var connection = resources.GetProperty("redisabstract");
-        Assert.Equal("redis.v0", connection.GetProperty("type").GetString());
 
         var container = resources.GetProperty("rediscontainer");
         Assert.Equal("container.v0", container.GetProperty("type").GetString());
@@ -286,7 +282,7 @@ public class ManifestGenerationTests
     {
         var program = CreateTestProgramJsonDocumentManifestPublisher();
 
-        program.AppBuilder.AddRedis("rediscontainer").PublishAsContainer();
+        program.AppBuilder.AddRedis("rediscontainer");
 
         // Build AppHost so that publisher can be resolved.
         program.Build();
@@ -307,8 +303,7 @@ public class ManifestGenerationTests
     {
         var program = CreateTestProgramJsonDocumentManifestPublisher();
 
-        program.AppBuilder.AddPostgres("postgresabstract");
-        program.AppBuilder.AddPostgres("postgrescontainer").PublishAsContainer().AddDatabase("postgresdatabase");
+        program.AppBuilder.AddPostgres("postgrescontainer").AddDatabase("postgresdatabase");
 
         // Build AppHost so that publisher can be resolved.
         program.Build();
@@ -317,9 +312,6 @@ public class ManifestGenerationTests
         program.Run();
 
         var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
-
-        var connection = resources.GetProperty("postgresabstract");
-        Assert.Equal("postgres.server.v0", connection.GetProperty("type").GetString());
 
         var server = resources.GetProperty("postgrescontainer");
         Assert.Equal("container.v0", server.GetProperty("type").GetString());
@@ -333,8 +325,7 @@ public class ManifestGenerationTests
     {
         var program = CreateTestProgramJsonDocumentManifestPublisher();
 
-        program.AppBuilder.AddRabbitMQ("rabbitabstract");
-        program.AppBuilder.AddRabbitMQ("rabbitcontainer").PublishAsContainer();
+        program.AppBuilder.AddRabbitMQ("rabbitcontainer");
 
         // Build AppHost so that publisher can be resolved.
         program.Build();
@@ -343,9 +334,6 @@ public class ManifestGenerationTests
         program.Run();
 
         var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
-
-        var connection = resources.GetProperty("rabbitabstract");
-        Assert.Equal("rabbitmq.server.v0", connection.GetProperty("type").GetString());
 
         var server = resources.GetProperty("rabbitcontainer");
         Assert.Equal("container.v0", server.GetProperty("type").GetString());
@@ -356,8 +344,7 @@ public class ManifestGenerationTests
     {
         var program = CreateTestProgramJsonDocumentManifestPublisher();
 
-        program.AppBuilder.AddKafka("kafkaabstract");
-        program.AppBuilder.AddKafka("kafkacontainer").PublishAsContainer();
+        program.AppBuilder.AddKafka("kafkacontainer");
 
         // Build AppHost so that publisher can be resolved.
         program.Build();
@@ -366,9 +353,6 @@ public class ManifestGenerationTests
         program.Run();
 
         var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
-
-        var connection = resources.GetProperty("kafkaabstract");
-        Assert.Equal("kafka.server.v0", connection.GetProperty("type").GetString());
 
         var server = resources.GetProperty("kafkacontainer");
         Assert.Equal("container.v0", server.GetProperty("type").GetString());

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -144,7 +144,8 @@ public class AddPostgresTests
                                  ));
 
         var connectionString = postgres.Resource.GetConnectionString();
-        Assert.Equal($"Host=localhost;Port=2000;Username=postgres;Password={PasswordUtil.EscapePassword(postgres.Resource.Password)};", connectionString);
+        Assert.Equal("Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres.inputs.password}", postgres.Resource.ConnectionStringExpression);
+        Assert.Equal($"Host=localhost;Port=2000;Username=postgres;Password={PasswordUtil.EscapePassword(postgres.Resource.Password)}", connectionString);
     }
 
     [Fact]
@@ -170,7 +171,7 @@ public class AddPostgresTests
         var postgresDatabaseResource = Assert.Single(appModel.Resources.OfType<PostgresDatabaseResource>());
         var dbConnectionString = postgresDatabaseResource.GetConnectionString();
 
-        Assert.EndsWith(";", postgresConnectionString);
+        Assert.Equal("{postgres.connectionString};Database=db", postgresDatabaseResource.ConnectionStringExpression);
         Assert.Equal(postgresConnectionString + ";Database=db", dbConnectionString);
     }
 
@@ -232,6 +233,23 @@ public class AddPostgresTests
                 Assert.Equal("POSTGRES_PASSWORD", env.Key);
                 Assert.Equal("pass", env.Value);
             });
+    }
+
+    [Fact]
+    public void VerifyManifest()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var pgServer = appBuilder.AddPostgres("pg");
+        var db = pgServer.AddDatabase("db");
+
+        var serverManifest = ManifestUtils.GetManifest(pgServer.Resource);
+        var dbManifest = ManifestUtils.GetManifest(db.Resource);
+
+        Assert.Equal("container.v0", serverManifest["type"]?.ToString());
+        Assert.Equal(pgServer.Resource.ConnectionStringExpression, serverManifest["connectionString"]?.ToString());
+
+        Assert.Equal("value.v0", dbManifest["type"]?.ToString());
+        Assert.Equal(db.Resource.ConnectionStringExpression, dbManifest["connectionString"]?.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.Sockets;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.RabbitMQ;
+
+public class AddRabbitMQTests
+{
+    [Fact]
+    public void AddRabbitMQContainerWithDefaultsAddsAnnotationMetadata()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        appBuilder.AddRabbitMQ("rabbit");
+
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var containerResource = Assert.Single(appModel.Resources.OfType<RabbitMQServerResource>());
+        Assert.Equal("rabbit", containerResource.Name);
+
+        var manifestAnnotation = Assert.Single(containerResource.Annotations.OfType<ManifestPublishingCallbackAnnotation>());
+        Assert.NotNull(manifestAnnotation.Callback);
+
+        var endpoint = Assert.Single(containerResource.Annotations.OfType<EndpointAnnotation>());
+        Assert.Equal(5672, endpoint.ContainerPort);
+        Assert.False(endpoint.IsExternal);
+        Assert.Equal("tcp", endpoint.Name);
+        Assert.Null(endpoint.Port);
+        Assert.Equal(ProtocolType.Tcp, endpoint.Protocol);
+        Assert.Equal("tcp", endpoint.Transport);
+        Assert.Equal("tcp", endpoint.UriScheme);
+
+        var containerAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("3", containerAnnotation.Tag);
+        Assert.Equal("rabbitmq", containerAnnotation.Image);
+        Assert.Null(containerAnnotation.Registry);
+    }
+
+    [Fact]
+    public void RabbitMQCreatesConnectionString()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder
+            .AddRabbitMQ("rabbit")
+            .WithAnnotation(
+                new AllocatedEndpointAnnotation("mybinding",
+                ProtocolType.Tcp,
+                "localhost",
+                27011,
+                "tcp"
+            ));
+
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var connectionStringResource = Assert.Single(appModel.Resources.OfType<RabbitMQServerResource>());
+        var connectionString = connectionStringResource.GetConnectionString();
+        var password = connectionStringResource.Password;
+
+        Assert.Equal($"amqp://guest:{password}@localhost:27011", connectionString);
+        Assert.Equal("amqp://guest:{rabbit.inputs.password}@{rabbit.bindings.tcp.host}:{rabbit.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -1,0 +1,137 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.Sockets;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.SqlServer;
+
+public class AddSqlServerTests
+{
+    [Fact]
+    public void AddSqlServerContainerWithDefaultsAddsAnnotationMetadata()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        appBuilder.AddSqlServer("sqlserver");
+
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var containerResource = Assert.Single(appModel.Resources.OfType<SqlServerServerResource>());
+        Assert.Equal("sqlserver", containerResource.Name);
+
+        var manifestAnnotation = Assert.Single(containerResource.Annotations.OfType<ManifestPublishingCallbackAnnotation>());
+        Assert.NotNull(manifestAnnotation.Callback);
+
+        var endpoint = Assert.Single(containerResource.Annotations.OfType<EndpointAnnotation>());
+        Assert.Equal(1433, endpoint.ContainerPort);
+        Assert.False(endpoint.IsExternal);
+        Assert.Equal("tcp", endpoint.Name);
+        Assert.Null(endpoint.Port);
+        Assert.Equal(ProtocolType.Tcp, endpoint.Protocol);
+        Assert.Equal("tcp", endpoint.Transport);
+        Assert.Equal("tcp", endpoint.UriScheme);
+
+        var containerAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerImageAnnotation>());
+        Assert.Equal("2022-latest", containerAnnotation.Tag);
+        Assert.Equal("mssql/server", containerAnnotation.Image);
+        Assert.Equal("mcr.microsoft.com", containerAnnotation.Registry);
+
+        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
+
+        var config = new Dictionary<string, string>();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var context = new EnvironmentCallbackContext(executionContext, config);
+
+        foreach (var annotation in envAnnotations)
+        {
+            annotation.Callback(context);
+        }
+
+        Assert.Collection(config,
+            env =>
+            {
+                Assert.Equal("ACCEPT_EULA", env.Key);
+                Assert.Equal("Y", env.Value);
+            },
+            env =>
+            {
+                Assert.Equal("MSSQL_SA_PASSWORD", env.Key);
+                Assert.NotNull(env.Value);
+                Assert.True(env.Value.Length >= 8);
+            });
+    }
+
+    [Fact]
+    public void SqlServerCreatesConnectionString()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder
+            .AddSqlServer("sqlserver")
+            .WithAnnotation(
+                    new AllocatedEndpointAnnotation("mybinding",
+                    ProtocolType.Tcp,
+                    "localhost",
+                    1433,
+                    "tcp"
+             ));
+
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var connectionStringResource = Assert.Single(appModel.Resources.OfType<SqlServerServerResource>());
+        var connectionString = connectionStringResource.GetConnectionString();
+        var password = PasswordUtil.EscapePassword(connectionStringResource.Password);
+
+        Assert.Equal($"Server=127.0.0.1,1433;User ID=sa;Password={password};TrustServerCertificate=true", connectionString);
+        Assert.Equal("Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver.inputs.password};TrustServerCertificate=true", connectionStringResource.ConnectionStringExpression);
+    }
+
+    [Fact]
+    public void SqlServerDatabaseCreatesConnectionString()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder
+            .AddSqlServer("sqlserver")
+            .WithAnnotation(
+                    new AllocatedEndpointAnnotation("mybinding",
+                    ProtocolType.Tcp,
+                    "localhost",
+                    1433,
+                    "tcp"
+             )).AddDatabase("mydb");
+
+        var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var connectionStringResource = Assert.Single(appModel.Resources.OfType<SqlServerDatabaseResource>());
+        var connectionString = connectionStringResource.GetConnectionString();
+        var password = PasswordUtil.EscapePassword(connectionStringResource.Parent.Password);
+
+        Assert.Equal($"Server=127.0.0.1,1433;User ID=sa;Password={password};TrustServerCertificate=true;Database=mydb", connectionString);
+        Assert.Equal("{sqlserver.connectionString};Database=mydb", connectionStringResource.ConnectionStringExpression);
+    }
+
+    [Fact]
+    public void VerifyManifest()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var sqlServer = appBuilder.AddSqlServer("sqlserver");
+        var db = sqlServer.AddDatabase("db");
+
+        var serverManifest = ManifestUtils.GetManifest(sqlServer.Resource);
+        var dbManifest = ManifestUtils.GetManifest(db.Resource);
+
+        Assert.Equal("container.v0", serverManifest["type"]?.ToString());
+        Assert.Equal(sqlServer.Resource.ConnectionStringExpression, serverManifest["connectionString"]?.ToString());
+
+        Assert.Equal("value.v0", dbManifest["type"]?.ToString());
+        Assert.Equal(db.Resource.ConnectionStringExpression, dbManifest["connectionString"]?.ToString());
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Utils/ManifestUtils.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/ManifestUtils.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Publishing;
+using System.Text.Json.Nodes;
+using System.Text.Json;
+using Xunit;
+
+namespace Aspire.Hosting.Utils;
+
+internal sealed class ManifestUtils
+{
+    public static JsonNode GetManifest(Action<ManifestPublishingContext> writeManifest)
+    {
+        using var ms = new MemoryStream();
+        var writer = new Utf8JsonWriter(ms);
+        writer.WriteStartObject();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        writeManifest(new ManifestPublishingContext(executionContext, Environment.CurrentDirectory, writer));
+        writer.WriteEndObject();
+        writer.Flush();
+        ms.Position = 0;
+        var obj = JsonNode.Parse(ms);
+        Assert.NotNull(obj);
+        return obj;
+    }
+
+    public static JsonNode GetManifest(IResource resource)
+    {
+        using var ms = new MemoryStream();
+        var writer = new Utf8JsonWriter(ms);
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        writer.WriteStartObject();
+        ManifestPublisher.WriteResource(resource, new ManifestPublishingContext(executionContext, Environment.CurrentDirectory, writer));
+        writer.WriteEndObject();
+        writer.Flush();
+        ms.Position = 0;
+        var obj = JsonNode.Parse(ms);
+        Assert.NotNull(obj);
+        var resourceNode = obj[resource.Name];
+        Assert.NotNull(resourceNode);
+        return resourceNode;
+    }
+}


### PR DESCRIPTION
- Containers are containers by default and the manifest writing can change to modify publish time behavior. This simplifies the manifest for tool writers.
- Remove all custom resource types and settle on a few primitives

After a long discussion we've decided to reduce the number of primitives in the application model to make it easier for tool writers to build provisioning support into the manifest. Our special container resources will no longer be special. They are just containers. 

```C#
var redis = builder.AddRedis("cache");

builder.AddProject<Projects.Api>("api")
          .WithReference(redis);
```

Publishing this as is will result in a container reference in the manifest instead of redis.v0. This means that azd and other tools will publish containers by default and users have to opt in to change that (PublishAsX). We can decide later if that is can be a single cross cutting API or a call per resource. Likely both.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2331)