### PR TITLE
Remove invalid CNAME record support from DNS SRV resolver

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.Log.cs
@@ -23,5 +23,8 @@ internal partial class DnsServiceEndPointResolverBase
 
         [LoggerMessage(5, LogLevel.Debug, "DNS SRV query cannot be constructed for service name '{ServiceName}' because no DNS namespace was configured or detected.", EventName = "NoDnsSuffixFound")]
         public static partial void NoDnsSuffixFound(ILogger logger, string serviceName);
+
+        [LoggerMessage(6, LogLevel.Warning, "DNS SRV query returned a record with an unsupported type '{RecordType}' for service name '{ServiceName}'.", EventName = "UnsupportedDnsSrvRecord")]
+        public static partial void UnsupportedDnsSrvRecord(ILogger logger, string recordType, string serviceName);
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverBase.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 internal abstract partial class DnsServiceEndPointResolverBase : IServiceEndPointResolver
 {
     private readonly object _lock = new();
-    private readonly ILogger _logger;
     private readonly CancellationTokenSource _disposeCancellation = new();
     private readonly TimeProvider _timeProvider;
     private long _lastRefreshTimeStamp;
@@ -36,7 +35,7 @@ internal abstract partial class DnsServiceEndPointResolverBase : IServiceEndPoin
         TimeProvider timeProvider)
     {
         ServiceName = serviceName;
-        _logger = logger;
+        Logger = logger;
         _lastEndPointCollection = null;
         _timeProvider = timeProvider;
         _lastRefreshTimeStamp = _timeProvider.GetTimestamp();
@@ -58,13 +57,15 @@ internal abstract partial class DnsServiceEndPointResolverBase : IServiceEndPoin
 
     protected CancellationToken ShutdownToken => _disposeCancellation.Token;
 
+    protected ILogger Logger { get; }
+
     /// <inheritdoc/>
     public async ValueTask<ResolutionStatus> ResolveAsync(ServiceEndPointCollectionSource endPoints, CancellationToken cancellationToken)
     {
         // Only add endpoints to the collection if a previous provider (eg, a configuration override) did not add them.
         if (endPoints.EndPoints.Count != 0)
         {
-            Log.SkippedResolution(_logger, ServiceName, "Collection has existing endpoints");
+            Log.SkippedResolution(Logger, ServiceName, "Collection has existing endpoints");
             return ResolutionStatus.None;
         }
 

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolver.cs
@@ -59,14 +59,13 @@ internal sealed partial class DnsSrvServiceEndPointResolver(
             }
 
             ttl = MinTtl(record, ttl);
-            if (targetRecord is AddressRecord addressRecord)
+            if (targetRecord is not AddressRecord addressRecord)
             {
-                endPoints.Add(CreateEndPoint(new IPEndPoint(addressRecord.Address, record.Port)));
+                Log.UnsupportedDnsSrvRecord(Logger, record.RecordType.ToString(), ServiceName);
+                continue;
             }
-            else if (targetRecord is CNameRecord canonicalNameRecord)
-            {
-                endPoints.Add(CreateEndPoint(new DnsEndPoint(canonicalNameRecord.CanonicalName.Value.TrimEnd('.'), record.Port)));
-            }
+
+            endPoints.Add(CreateEndPoint(new IPEndPoint(addressRecord.Address, record.Port)));
         }
 
         SetResult(endPoints, ttl);


### PR DESCRIPTION
CNAMEs are not valid in the results of a DNS SRV query according to [RFC2782](https://datatracker.ietf.org/doc/html/rfc2782)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2340)