### PR TITLE
Add RabbitMQ logging tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -127,6 +127,7 @@
     <!-- unit test dependencies -->
     <PackageVersion Include="bUnit" Version="1.26.64" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="$(MicrosoftExtensionsDiagnosticsTestingPackageVersion)" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="3.7.0" />
     <!-- Pinned version for Component Governance - Remove when root dependencies are updated -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <!-- Introduced by Microsoft.Azure.Cosmos, https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4302 -->

--- a/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
+++ b/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
@@ -22,4 +22,8 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.RabbitMQ.Client.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Aspire.RabbitMQ.Client.Tests/Aspire.RabbitMQ.Client.Tests.csproj
+++ b/tests/Aspire.RabbitMQ.Client.Tests/Aspire.RabbitMQ.Client.Tests.csproj
@@ -9,6 +9,8 @@
 
     <ProjectReference Include="..\..\src\Components\Aspire.RabbitMQ.Client\Aspire.RabbitMQ.Client.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
+
+    <PackageReference Include="Testcontainers.RabbitMq" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -52,7 +52,7 @@ public class AspireRabbitMQLoggingTests
 
         await rabbitMqContainer.StopAsync();
 
-        await tsc.Task;
+        await tsc.Task.WaitAsync(TimeSpan.FromMinutes(1));
 
         Assert.True(logger.Logs.Count >= 2, "Should be at least 2 logs written.");
 

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -1,0 +1,183 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Logging;
+using Testcontainers.RabbitMq;
+using Xunit;
+
+namespace Aspire.RabbitMQ.Client.Tests;
+
+public class AspireRabbitMQLoggingTests
+{
+    /// <summary>
+    /// Tests that the RabbitMQ client logs are forwarded to the M.E.Logging correctly in an end-to-end scenario.
+    ///
+    /// The easiest way to ensure a log is written is to start the RabbitMQ container, establish the connection,
+    /// and then stop the container. This will cause the RabbitMQ client to log an error message.
+    /// </summary>
+    [LocalOnlyFact]
+    public async Task EndToEndLoggingTest()
+    {
+        await using var rabbitMqContainer = new RabbitMqBuilder().Build();
+        await rabbitMqContainer.StartAsync();
+
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>("ConnectionStrings:messaging", rabbitMqContainer.GetConnectionString())
+        ]);
+
+        builder.AddRabbitMQ("messaging");
+
+        var tsc = new TaskCompletionSource();
+        var logger = new TestLogger();
+        logger.LoggedMessage = () =>
+        {
+            // wait for at least 2 logs to be written
+            if (logger.Logs.Count >= 2)
+            {
+                tsc.SetResult();
+            }
+        };
+
+        builder.Services.AddSingleton<ILoggerProvider>(sp => new LoggerProvider(logger));
+
+        using var host = builder.Build();
+        using var connection = host.Services.GetRequiredService<IConnection>();
+
+        await rabbitMqContainer.StopAsync();
+
+        await tsc.Task;
+
+        Assert.True(logger.Logs.Count >= 2, "Should be at least 2 logs written.");
+
+        Assert.Contains(logger.Logs, l => l.Level == LogLevel.Information && l.Message == "Performing automatic recovery");
+        Assert.Contains(logger.Logs, l => l.Level == LogLevel.Error && l.Message == "Connection recovery exception.");
+    }
+
+    [Fact]
+    public void TestInfoAndWarn()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddSingleton<RabbitMQEventSourceLogForwarder>();
+
+        var logger = new TestLogger();
+        builder.Services.AddSingleton<ILoggerProvider>(sp => new LoggerProvider(logger));
+
+        using var host = builder.Build();
+        host.Services.GetRequiredService<RabbitMQEventSourceLogForwarder>().Start();
+
+        var message = "This is an informational message.";
+        RabbitMqClientEventSource.Log.Info(message);
+
+        Assert.Single(logger.Logs);
+        Assert.Equal(LogLevel.Information, logger.Logs[0].Level);
+        Assert.Equal(message, logger.Logs[0].Message);
+
+        var warningMessage = "This is a warning message.";
+        RabbitMqClientEventSource.Log.Warn(warningMessage);
+
+        Assert.Equal(2, logger.Logs.Count);
+        Assert.Equal(LogLevel.Warning, logger.Logs[1].Level);
+        Assert.Equal(warningMessage, logger.Logs[1].Message);
+    }
+
+    [Fact]
+    public void TestException()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.Services.AddSingleton<RabbitMQEventSourceLogForwarder>();
+
+        var logger = new TestLogger();
+        builder.Services.AddSingleton<ILoggerProvider>(sp => new LoggerProvider(logger));
+
+        using var host = builder.Build();
+        host.Services.GetRequiredService<RabbitMQEventSourceLogForwarder>().Start();
+
+        var exceptionMessage = "Test exception";
+        Exception testException;
+        try
+        {
+            throw new InvalidOperationException(exceptionMessage);
+        }
+        catch (Exception ex)
+        {
+            testException = ex;
+        }
+
+        Assert.NotNull(testException);
+        var logMessage = "This is an error message.";
+        RabbitMqClientEventSource.Log.Error(logMessage, testException);
+
+        Assert.Single(logger.Logs);
+        Assert.Equal(LogLevel.Error, logger.Logs[0].Level);
+        Assert.Equal(logMessage, logger.Logs[0].Message);
+
+        var errorEvent = Assert.IsAssignableFrom<IReadOnlyList<KeyValuePair<string, object?>>>(logger.Logs[0].State);
+        Assert.Equal(5, errorEvent.Count);
+
+        Assert.Equal("message", errorEvent[0].Key);
+        Assert.Equal(logMessage, errorEvent[0].Value);
+
+        Assert.Equal("exception.type", errorEvent[1].Key);
+        Assert.Equal("System.InvalidOperationException", errorEvent[1].Value);
+
+        Assert.Equal("exception.message", errorEvent[2].Key);
+        Assert.Equal(exceptionMessage, errorEvent[2].Value);
+
+        Assert.Equal("exception.stacktrace", errorEvent[3].Key);
+        Assert.Contains("AspireRabbitMQLoggingTests.TestException", errorEvent[3].Value?.ToString());
+
+        Assert.Equal("exception.innerexception", errorEvent[4].Key);
+        Assert.True(string.IsNullOrEmpty(errorEvent[4].Value?.ToString()));
+    }
+
+    sealed class LoggerProvider(TestLogger logger) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => logger;
+
+        public void Dispose() { }
+    }
+
+    sealed class TestLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message, object? State)> Logs { get; } = new();
+        public Action? LoggedMessage { get; set; }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull =>
+            NullLogger.Instance.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Logs.Add((logLevel, formatter(state, exception), state));
+            LoggedMessage?.Invoke();
+        }
+    }
+
+    // TODO: remove this attribute when the above tests are running in CI
+
+    public class LocalOnlyFactAttribute : FactAttribute
+    {
+        public override string Skip
+        {
+            get
+            {
+                // BUILD_BUILDID is defined by Azure Dev Ops
+
+                if (Environment.GetEnvironmentVariable("BUILD_BUILDID") != null)
+                {
+                    return "LocalOnlyFactAttribute tests are not run as part of CI.";
+                }
+
+                return null!;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds 2 different types of tests.

- Unit tests that directly call the RabbitMQ EventSource with specific inputs. The most interesting thing to verify here is exception information is serialized properly.
- An end-to-end test that stops the RabbitMQ server and ensures the client logs messages.

Fix #674
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2343)