### PR TITLE
Update protocol for resource commands

### DIFF
--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -31,11 +31,11 @@ message ResourceCommand {
     // When present, this message must be shown to the user and their confirmation obtained
     // before sending the request for this command to be executed.
     // The user will be presented with Ok/Cancel options.
-    optional string confirmation_message = 4;
+    optional string confirmation_message = 3;
     // Optional parameter that configures the command in some way.
     // Clients must return any value provided by the server when invoking
     // the command.
-    optional google.protobuf.Value parameter = 5;
+    optional google.protobuf.Value parameter = 4;
 }
 
 // Represents a request to execute a command.

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -28,8 +28,6 @@ message ResourceCommand {
     string command_type = 1;
     // The display name of the command, to be shown in the UI. May be localized.
     string display_name = 2;
-    // The unique name of the resource type. Matches ResourceType.unique_name and Resource.resource_type.
-    string resource_type = 3;
     // When present, this message must be shown to the user and their confirmation obtained
     // before sending the request for this command to be executed.
     // The user will be presented with Ok/Cancel options.

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -19,9 +19,16 @@ message ApplicationInformationResponse {
 
 ////////////////////////////////////////////
 
-message ResourceCommandRequest {
+// Defines a command that may be invoked on a resource.
+// Defined by the resource service and sent to the dashboard.
+// When a command is to be executed, an instance of ResourceCommandRequest is constructed
+// using data from this message.
+message ResourceCommand {
+    // Unique identifier for the command. Not intended for display.
     string command_type = 1;
-    string name = 2;
+    // The display name of the command, to be shown in the UI. May be localized.
+    string display_name = 2;
+    // The unique name of the resource type. Matches ResourceType.unique_name and Resource.resource_type.
     string resource_type = 3;
     // When present, this message must be shown to the user and their confirmation obtained
     // before sending the request for this command to be executed.
@@ -31,6 +38,24 @@ message ResourceCommandRequest {
     // Clients must return any value provided by the server when invoking
     // the command.
     optional google.protobuf.Value parameter = 5;
+}
+
+// Represents a request to execute a command.
+// Sent by the dashboard to DashboardService.ExecuteResourceCommand.
+// Constructed with data from a corresponding 
+message ResourceCommandRequest {
+    // Unique identifier for the command.
+    // Copied from the ResourceCommand that this request object is initialized from.
+    string command_type = 1;
+    // The name of the resource to apply the command to. Matches Resource.name.
+    // Copied from the ResourceCommand that this request object is initialized from.
+    string resource_name = 2;
+    // The unique name of the resource type. Matches ResourceType.unique_name and Resource.resource_type.
+    // Copied from the ResourceCommand that this request object is initialized from.
+    string resource_type = 3;
+    // An optional parameter to accompany the command.
+    // Copied from the ResourceCommand that this request object is initialized from.
+    optional google.protobuf.Value parameter = 4;
 }
 
 enum ResourceCommandResponseKind {
@@ -63,7 +88,7 @@ message ResourceType {
     //
     // If the set of commands changes over time, use the "commands" property
     // of the Resource itself.
-    repeated ResourceCommandRequest commands = 3;
+    repeated ResourceCommand commands = 3;
 }
 
 ////////////////////////////////////////////
@@ -107,7 +132,7 @@ message Resource {
     optional int32 expected_endpoints_count = 8;
     repeated Endpoint endpoints = 9;
     repeated Service services = 10;
-    repeated ResourceCommandRequest commands = 11;
+    repeated ResourceCommand commands = 11;
 
     // Properties holding data not modeled directly on the message.
     //


### PR DESCRIPTION
As we've started investigating implementing these commands, the protocol proved insufficient.

This adds the resource name to the request, and clarifies that the name on the command is a display name for the command, rather than the name of the resource. `ResourceCommandRequest` no longer does double-duty as both definition of the command and request to execute one. We split the former out into `ResourceCommand`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2347)