### PR TITLE
Fix migrations service in playground

### DIFF
--- a/playground/DatabaseMigration/DatabaseMigration.MigrationService/ApiDbInitializer.cs
+++ b/playground/DatabaseMigration/DatabaseMigration.MigrationService/ApiDbInitializer.cs
@@ -28,12 +28,12 @@ public class ApiDbInitializer(
     {
         using var activity = s_activitySource.StartActivity("Migrating database", ActivityKind.Client);
 
+        await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+
         var strategy = dbContext.Database.CreateExecutionStrategy();
         await strategy.ExecuteAsync(async () =>
         {
-            await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
             await dbContext.Database.MigrateAsync(cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
         });
     }
 }

--- a/playground/DatabaseMigration/DatabaseMigration.MigrationService/ApiDbInitializer.cs
+++ b/playground/DatabaseMigration/DatabaseMigration.MigrationService/ApiDbInitializer.cs
@@ -28,8 +28,6 @@ public class ApiDbInitializer(
     {
         using var activity = s_activitySource.StartActivity("Migrating database", ActivityKind.Client);
 
-        await dbContext.Database.EnsureCreatedAsync(cancellationToken);
-
         var strategy = dbContext.Database.CreateExecutionStrategy();
         await strategy.ExecuteAsync(async () =>
         {

--- a/playground/DatabaseMigration/DatabaseMigration.MigrationService/ApiDbInitializer.cs
+++ b/playground/DatabaseMigration/DatabaseMigration.MigrationService/ApiDbInitializer.cs
@@ -3,6 +3,8 @@
 
 using System.Diagnostics;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Logging;
 
 namespace DatabaseMigration.MigrationService;
@@ -18,20 +20,32 @@ public class ApiDbInitializer(
     {
         using var scope = serviceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<MyDb1Context>();
+        var dbCreator = dbContext.GetService<IRelationalDatabaseCreator>();
 
-        await InitializeDatabaseAsync(dbContext, cancellationToken);
+        await InitializeDatabaseAsync(dbContext, dbCreator, cancellationToken);
 
         hostApplicationLifetime.StopApplication();
     }
 
-    private static async Task InitializeDatabaseAsync(MyDb1Context dbContext, CancellationToken cancellationToken)
+    private static async Task InitializeDatabaseAsync(MyDb1Context dbContext, IRelationalDatabaseCreator dbCreator, CancellationToken cancellationToken)
     {
         using var activity = s_activitySource.StartActivity("Migrating database", ActivityKind.Client);
 
+        // Database container might not be ready yet, so we need to retry.
         var strategy = dbContext.Database.CreateExecutionStrategy();
         await strategy.ExecuteAsync(async () =>
         {
+            // Create the database if it does not exist.
+            // Do this first so there is then a database to start a transaction against.
+            if (!await dbCreator.ExistsAsync(cancellationToken))
+            {
+                await dbCreator.CreateAsync(cancellationToken);
+            }
+
+            // Run migration in a transaction to avoid partial migration if it fails.
+            await using var transaction = await dbContext.Database.BeginTransactionAsync(cancellationToken);
             await dbContext.Database.MigrateAsync(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
         });
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2308

Creating a transaction failed if starting from a blank slate because there isn't a database to create a transaction on. Removing the transaction fixes this problem.

However, it would be ideal to keep the transaction to make this safe to transient errors. To follow best practice, we need to:
1. Create the database
2. Start transaction
3. Apply migratio
4. Commit transaction.

@AndriySvyryd How do you instruct EF to just create the database? I looked at `DbContext.Database.EnsureCreatedAsync`, but it also creates tables.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2351)