### PR TITLE
Change Aspire URLs so trace detail is selected

### DIFF
--- a/spelling.dic
+++ b/spelling.dic
@@ -13,6 +13,7 @@ brightred
 brightwhite
 brightyellow
 chmod
+consolelogs
 csproj
 dbug
 dcpctrl
@@ -47,6 +48,7 @@ redis
 rediscommander
 runtimeconfig
 sqlserver
+structuredlogs
 trce
 uninstrumented
 unix

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -5,7 +5,7 @@
 <div class="environment-variables-layout">
 
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ConsoleLogs/{Resource?.Name}")" slot="end">View logs</FluentAnchor>
+        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/consolelogs/resource/{Resource?.Name}")" slot="end">View logs</FluentAnchor>
 
         @if (ShowSpecOnlyToggle)
         {

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -16,7 +16,7 @@
         <div>
             @((MarkupString)string.Format(ControlsStrings.SpanDetailsStartTime, DurationFormatter.FormatDuration(ViewModel.Span.StartTime - ViewModel.Span.Trace.FirstSpan.StartTime)))
         </div>
-        <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?spanId={ViewModel.Span.SpanId}")">@Loc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
+        <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/structuredlogs?spanId={ViewModel.Span.SpanId}")">@Loc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <FluentSearch Placeholder="@Loc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"

--- a/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
@@ -13,23 +13,23 @@
             SecondaryIcon="ResourcesIcon(secondary: true)"
             Text="@Loc[nameof(Layout.NavMenuResourcesTab)]" />
         <FluentAppBarItem
-            Href="/ConsoleLogs"
+            Href="/consolelogs"
             Icon="ConsoleLogsIcon()"
             SecondaryIcon="ConsoleLogsIcon(secondary: true)"
             Text="@Loc[nameof(Layout.NavMenuConsoleLogsTab)]" />
     }
     <FluentAppBarItem
-        Href="/StructuredLogs"
+        Href="/structuredlogs"
         Icon="StructuredLogsIcon()"
         SecondaryIcon="StructuredLogsIcon(secondary: true)"
         Text="@Loc[nameof(Layout.NavMenuStructuredLogsTab)]" />
     <FluentAppBarItem
-        Href="/Traces"
+        Href="/traces"
         Icon="TracesIcon()"
         SecondaryIcon="TracesIcon(secondary: true)"
         Text="@Loc[nameof(Layout.NavMenuTracesTab)]" />
     <FluentAppBarItem
-        Href="/Metrics"
+        Href="/metrics"
         Icon="MetricsIcon()"
         SecondaryIcon="MetricsIcon(secondary: true)"
         Text="@Loc[nameof(Layout.NavMenuMetricsTab)]" />

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -1,5 +1,5 @@
-﻿@page "/ConsoleLogs"
-@page "/ConsoleLogs/Resource/{resourceName}"
+﻿@page "/consolelogs"
+@page "/consolelogs/resource/{resourceName}"
 
 @using Aspire.Dashboard.Resources
 @namespace Aspire.Dashboard.Components.Pages

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -1,4 +1,6 @@
-﻿@page "/ConsoleLogs/{resourceName?}"
+﻿@page "/ConsoleLogs"
+@page "/ConsoleLogs/Resource/{resourceName}"
+
 @using Aspire.Dashboard.Resources
 @namespace Aspire.Dashboard.Components.Pages
 @inject IStringLocalizer<Dashboard.Resources.ConsoleLogs> Loc

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -330,7 +330,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     {
         if (serializable.SelectedResource is { } selectedOption)
         {
-            return new UrlState($"{BasePath}/{selectedOption}", null);
+            return new UrlState($"{BasePath}/Resource/{selectedOption}", null);
         }
 
         return new UrlState($"/{BasePath}", null);

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -45,7 +45,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     // State
     public ConsoleLogsViewModel PageViewModel { get; set; } = null!;
 
-    public string BasePath => "ConsoleLogs";
+    public string BasePath => "consolelogs";
     public string SessionStorageKey => "ConsoleLogs_PageState";
 
     protected override void OnInitialized()
@@ -330,7 +330,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     {
         if (serializable.SelectedResource is { } selectedOption)
         {
-            return new UrlState($"{BasePath}/Resource/{selectedOption}", null);
+            return new UrlState($"{BasePath}/resource/{selectedOption}", null);
         }
 
         return new UrlState($"/{BasePath}", null);

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -1,7 +1,7 @@
-﻿@page "/Metrics"
-@page "/Metrics/Resource/{applicationName}"
-@page "/Metrics/Resource/{applicationName}/Meter/{meterName}"
-@page "/Metrics/Resource/{applicationName}/Meter/{meterName}/Instrument/{instrumentName}"
+﻿@page "/metrics"
+@page "/metrics/resource/{applicationName}"
+@page "/metrics/resource/{applicationName}/meter/{meterName}"
+@page "/metrics/resource/{applicationName}/meter/{meterName}/instrument/{instrumentName}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Resources
@@ -69,7 +69,7 @@
                             <FluentDataGrid Style="max-width:1100px;" Items="@PageViewModel.Instruments.Where(i => i.Parent == PageViewModel.SelectedMeter).OrderBy(i => i.Name).AsQueryable()" GridTemplateColumns="3fr 5fr" TGridItem="OtlpInstrument">
                                 <ChildContent>
                                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Metrics.MetricsInsturementNameGridNameColumnHeader)]">
-                                        <FluentAnchor Href="@($"/Metrics/Resource/{PageViewModel.SelectedApplication.Name}/Meter/{context.Parent.MeterName}/Instrument/{context.Name}")" Appearance="Appearance.Lightweight">
+                                        <FluentAnchor Href="@($"/metrics/resource/{PageViewModel.SelectedApplication.Name}/meter/{context.Parent.MeterName}/instrument/{context.Name}")" Appearance="Appearance.Lightweight">
                                             @context.Name
                                         </FluentAnchor>
                                     </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -1,7 +1,7 @@
 ﻿@page "/Metrics"
-@page "/Metrics/{applicationName}"
-@page "/Metrics/{applicationName}/Meter/{meterName}"
-@page "/Metrics/{applicationName}/Meter/{meterName}/Instrument/{instrumentName}"
+@page "/Metrics/Resource/{applicationName}"
+@page "/Metrics/Resource/{applicationName}/Meter/{meterName}"
+@page "/Metrics/Resource/{applicationName}/Meter/{meterName}/Instrument/{instrumentName}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Resources
@@ -69,7 +69,7 @@
                             <FluentDataGrid Style="max-width:1100px;" Items="@PageViewModel.Instruments.Where(i => i.Parent == PageViewModel.SelectedMeter).OrderBy(i => i.Name).AsQueryable()" GridTemplateColumns="3fr 5fr" TGridItem="OtlpInstrument">
                                 <ChildContent>
                                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Metrics.MetricsInsturementNameGridNameColumnHeader)]">
-                                        <FluentAnchor Href="@($"/Metrics/{PageViewModel.SelectedApplication.Name}/Meter/{context.Parent.MeterName}/Instrument/{context.Name}")" Appearance="Appearance.Lightweight">
+                                        <FluentAnchor Href="@($"/Metrics/Resource/{PageViewModel.SelectedApplication.Name}/Meter/{context.Parent.MeterName}/Instrument/{context.Name}")" Appearance="Appearance.Lightweight">
                                             @context.Name
                                         </FluentAnchor>
                                     </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -210,12 +210,12 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
         if (serializable.ApplicationName is not null && serializable.MeterName is not null)
         {
             path = serializable.InstrumentName is not null
-                ? $"/{BasePath}/{serializable.ApplicationName}/Meter/{serializable.MeterName}/Instrument/{serializable.InstrumentName}"
-                : $"/{BasePath}/{serializable.ApplicationName}/Meter/{serializable.MeterName}";
+                ? $"/{BasePath}/Resource/{serializable.ApplicationName}/Meter/{serializable.MeterName}/Instrument/{serializable.InstrumentName}"
+                : $"/{BasePath}/Resource/{serializable.ApplicationName}/Meter/{serializable.MeterName}";
         }
         else if (serializable.ApplicationName is not null)
         {
-            path = $"/{BasePath}/{serializable.ApplicationName}";
+            path = $"/{BasePath}/Resource/{serializable.ApplicationName}";
         }
         else
         {

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -23,7 +23,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     private Subscription? _applicationsSubscription;
     private Subscription? _metricsSubscription;
 
-    public string BasePath => "Metrics";
+    public string BasePath => "metrics";
     public string SessionStorageKey => "Metrics_PageState";
     public MetricsViewModel PageViewModel { get; set; } = null!;
 
@@ -210,12 +210,12 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
         if (serializable.ApplicationName is not null && serializable.MeterName is not null)
         {
             path = serializable.InstrumentName is not null
-                ? $"/{BasePath}/Resource/{serializable.ApplicationName}/Meter/{serializable.MeterName}/Instrument/{serializable.InstrumentName}"
-                : $"/{BasePath}/Resource/{serializable.ApplicationName}/Meter/{serializable.MeterName}";
+                ? $"/{BasePath}/resource/{serializable.ApplicationName}/meter/{serializable.MeterName}/instrument/{serializable.InstrumentName}"
+                : $"/{BasePath}/resource/{serializable.ApplicationName}/meter/{serializable.MeterName}";
         }
         else if (serializable.ApplicationName is not null)
         {
-            path = $"/{BasePath}/Resource/{serializable.ApplicationName}";
+            path = $"/{BasePath}/resource/{serializable.ApplicationName}";
         }
         else
         {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -69,7 +69,7 @@
                         <EndpointsColumnDisplay Resource="context" HasMultipleReplicas="HasMultipleReplicas(context)" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesLogsColumnHeader)]">
-                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/ConsoleLogs/{context.Name}")">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
+                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/consolelogs/resource/{context.Name}")">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesDetailsColumnHeader)]" Sortable="false">
                         <FluentButton Appearance="Appearance.Lightweight"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -86,7 +86,7 @@
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
                                 @if (!string.IsNullOrEmpty(context.TraceId))
                                 {
-                                    <a href="@($"/Trace/{HttpUtility.UrlEncode(context.TraceId)}")" class="long-inner-content">
+                                    <a href="@($"/Traces/Detail/{HttpUtility.UrlEncode(context.TraceId)}")" class="long-inner-content">
                                         @OtlpHelpers.ToShortenedId(context.TraceId)
                                     </a>
                                 }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -1,4 +1,5 @@
-﻿@page "/StructuredLogs/{applicationName?}"
+﻿@page "/StructuredLogs"
+@page "/StructuredLogs/Resource/{applicationName}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -1,5 +1,5 @@
-﻿@page "/StructuredLogs"
-@page "/StructuredLogs/Resource/{applicationName}"
+﻿@page "/structuredlogs"
+@page "/structuredlogs/resource/{applicationName}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model
@@ -86,7 +86,7 @@
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
                                 @if (!string.IsNullOrEmpty(context.TraceId))
                                 {
-                                    <a href="@($"/Traces/Detail/{HttpUtility.UrlEncode(context.TraceId)}")" class="long-inner-content">
+                                    <a href="@($"/traces/detail/{HttpUtility.UrlEncode(context.TraceId)}")" class="long-inner-content">
                                         @OtlpHelpers.ToShortenedId(context.TraceId)
                                     </a>
                                 }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -27,7 +27,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     private bool _applicationChanged;
     private CancellationTokenSource? _filterCts;
 
-    public string BasePath => "StructuredLogs";
+    public string BasePath => "structuredlogs";
     public string SessionStorageKey => "StructuredLogs_PageState";
     public StructuredLogsPageViewModel PageViewModel { get; set; } = null!;
 
@@ -92,7 +92,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         }
         if (!string.IsNullOrEmpty(SpanId))
         {
-            ViewModel.AddFilter(new LogFilter { Field = "SpanId", Condition = FilterCondition.Equals, Value = SpanId  });
+            ViewModel.AddFilter(new LogFilter { Field = "SpanId", Condition = FilterCondition.Equals, Value = SpanId });
         }
 
         _allApplication = new()
@@ -285,7 +285,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
 
     public UrlState GetUrlFromSerializableViewModel(StructuredLogsPageState serializable)
     {
-        var path = serializable.SelectedApplication is not null ? $"/StructuredLogs/Resource/{serializable.SelectedApplication}" : "/StructuredLogs";
+        var path = serializable.SelectedApplication is not null ? $"/structuredlogs/resource/{serializable.SelectedApplication}" : "/structuredlogs";
         var queryParameters = new Dictionary<string, string?>();
 
         if (serializable.LogLevelText is not null)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -285,7 +285,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
 
     public UrlState GetUrlFromSerializableViewModel(StructuredLogsPageState serializable)
     {
-        var path = serializable.SelectedApplication is not null ? $"/StructuredLogs/{serializable.SelectedApplication}" : "/StructuredLogs";
+        var path = serializable.SelectedApplication is not null ? $"/StructuredLogs/Resource/{serializable.SelectedApplication}" : "/StructuredLogs";
         var queryParameters = new Dictionary<string, string?>();
 
         if (serializable.LogLevelText is not null)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -1,4 +1,4 @@
-﻿@page "/Traces/Detail/{traceId}"
+﻿@page "/traces/detail/{traceId}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model
@@ -37,7 +37,7 @@
             <div>
                 @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTotalSpansHeader)] <strong>@_trace.Spans.Count</strong>
             </div>
-            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/StructuredLogs?traceId={_trace.TraceId}")">@ControlStringsLoc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
+            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/structuredlogs?traceId={_trace.TraceId}")">@ControlStringsLoc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
         </FluentToolbar>
 
         <SummaryDetailsView ShowDetails="SelectedSpan is not null" OnDismiss="() => ClearSelectedSpan()" ViewKey="TraceDetail">

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -1,4 +1,4 @@
-﻿@page "/Trace/{traceId}"
+﻿@page "/Traces/Detail/{traceId}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -1,4 +1,5 @@
-﻿@page "/Traces/{applicationName?}"
+﻿@page "/Traces"
+@page "/Traces/Resource/{applicationName}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model
@@ -93,7 +94,7 @@
                 </TemplateColumn>
 
                 <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.DetailsColumnHeader)]">
-                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/Trace/{context.TraceId}")">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
+                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/Traces/Detail/{context.TraceId}")">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
                 </TemplateColumn>
             </ChildContent>
             <EmptyContent>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -1,5 +1,5 @@
-﻿@page "/Traces"
-@page "/Traces/Resource/{applicationName}"
+﻿@page "/traces"
+@page "/traces/resource/{applicationName}"
 
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model
@@ -94,7 +94,7 @@
                 </TemplateColumn>
 
                 <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.DetailsColumnHeader)]">
-                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/Traces/Detail/{context.TraceId}")">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
+                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/traces/detail/{context.TraceId}")">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
                 </TemplateColumn>
             </ChildContent>
             <EmptyContent>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -100,7 +100,7 @@ public partial class Traces
 
     private Task HandleSelectedApplicationChangedAsync()
     {
-        NavigationManager.NavigateTo($"/Traces/Resource/{_selectedApplication.Name}");
+        NavigationManager.NavigateTo($"/traces/resource/{_selectedApplication.Name}");
         _applicationChanged = true;
 
         return Task.CompletedTask;

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -100,7 +100,7 @@ public partial class Traces
 
     private Task HandleSelectedApplicationChangedAsync()
     {
-        NavigationManager.NavigateTo($"/Traces/{_selectedApplication.Name}");
+        NavigationManager.NavigateTo($"/Traces/Resource/{_selectedApplication.Name}");
         _applicationChanged = true;
 
         return Task.CompletedTask;

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor
@@ -6,7 +6,7 @@
 @if (_unviewedCount > 0)
 {
     <FluentAnchor aria-label="@(_unviewedCount == 1 ? nameof(Columns.UnreadLogErrorsBadgeOneErrorLog) : string.Format(Loc[nameof(Columns.UnreadLogErrorsBadgeErrorLogs)], _unviewedCount))"
-                  Href="@GetResourceErrorStructuredLogsUrl(Resource)"
+                  Href="@GetResourceErrorStructuredLogsUrl()"
                   Appearance="Appearance.Stealth"
                   Class="unread-logs-errors-link">
         <FluentBadge

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
@@ -50,6 +50,6 @@ public partial class UnreadLogErrorsBadge
 
     private static string GetResourceErrorStructuredLogsUrl(ResourceViewModel resource)
     {
-        return $"/structuredlogs/{resource.Uid}?level=error";
+        return $"/structuredlogs/resource/{resource.Name}?level=error";
     }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
@@ -50,6 +50,6 @@ public partial class UnreadLogErrorsBadge
 
     private static string GetResourceErrorStructuredLogsUrl(ResourceViewModel resource)
     {
-        return $"/StructuredLogs/{resource.Uid}?level=error";
+        return $"/structuredlogs/{resource.Uid}?level=error";
     }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
@@ -10,6 +10,7 @@ namespace Aspire.Dashboard.Components;
 
 public partial class UnreadLogErrorsBadge
 {
+    private string? _applicationName;
     private int _unviewedCount;
 
     [Parameter, EditorRequired]
@@ -24,32 +25,37 @@ public partial class UnreadLogErrorsBadge
 
     protected override void OnParametersSet()
     {
-        _unviewedCount = GetUnviewedErrorCount(Resource);
+        (_applicationName, _unviewedCount) = GetUnviewedErrorCount(Resource);
     }
 
-    private int GetUnviewedErrorCount(ResourceViewModel resource)
+    private (string? applicationName, int unviewedErrorCount) GetUnviewedErrorCount(ResourceViewModel resource)
     {
         if (UnviewedErrorCounts is null)
         {
-            return 0;
+            return (null, 0);
         }
 
-        var application = TelemetryRepository.GetApplication(resource.Uid);
+        var application = TelemetryRepository.GetApplication(resource.Name);
         if (application is null)
         {
-            return 0;
+            return (null, 0);
         }
 
-        if (!UnviewedErrorCounts.TryGetValue(application, out var count))
+        if (!UnviewedErrorCounts.TryGetValue(application, out var count) || count == 0)
         {
-            return 0;
+            return (null, 0);
         }
 
-        return count;
+        var applications = TelemetryRepository.GetApplications();
+        var applicationName = applications.Count(a => a.ApplicationName == application.ApplicationName) > 1
+            ? application.InstanceId
+            : application.ApplicationName;
+
+        return (applicationName, count);
     }
 
-    private static string GetResourceErrorStructuredLogsUrl(ResourceViewModel resource)
+    private string GetResourceErrorStructuredLogsUrl()
     {
-        return $"/structuredlogs/resource/{resource.Name}?level=error";
+        return $"/structuredlogs/resource/{_applicationName}?level=error";
     }
 }

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -129,7 +129,7 @@ public class DashboardWebApplication : IAsyncDisposable
             logger.LogInformation("OTLP server running at: {OtlpEndpointUri}", reportedOtlpUri.AbsoluteUri.TrimEnd('/'));
         }
 
-        // Redirect browser directly to /StructuredLogs address if the dashboard is running without a resource service.
+        // Redirect browser directly to /structuredlogs address if the dashboard is running without a resource service.
         // This is done to avoid immediately navigating in the Blazor app.
         _app.Use(async (context, next) =>
         {

--- a/src/Aspire.Dashboard/Model/TargetLocationInterceptor.cs
+++ b/src/Aspire.Dashboard/Model/TargetLocationInterceptor.cs
@@ -8,7 +8,7 @@ namespace Aspire.Dashboard.Model;
 internal static class TargetLocationInterceptor
 {
     public const string ResourcesPath = "/";
-    public const string StructuredLogsPath = "/StructuredLogs";
+    public const string StructuredLogsPath = "/structuredlogs";
 
     public static bool InterceptTargetLocation(string appBaseUri, string originalTargetLocation, [NotNullWhen(true)] out string? newTargetLocation)
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2357

The menu bar highlights items based on the URL. The start of URL path needs to match the item URL.

This PR changes URLs. The most notable change is the resource name in the URL follows a `/Resource/` segment:
* Before: `/ConsoleLogs/xxx`, After: `/ConsoleLogs/Resource/xxx`
* Before: `/Traces/xxx`, After: `/Traces/Resource/xxx`
* Before: `/Trace/xxx`, After: `/Traces/Detail/xxx` <- problem URL. New URL starts with `/Traces` so the menu bar is highlighted.

After:
![image](https://github.com/dotnet/aspire/assets/303201/0e067af1-ed83-45f1-b136-97c29e345e49)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2368)