### PR TITLE
Make the log analytics workspace visible a magic parameter

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/BicepProvisioner.cs
@@ -234,6 +234,12 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger) : Azure
             resource.Parameters[AzureBicepResource.KnownParameters.PrincipalType] = "User";
         }
 
+        if (resource.Parameters.TryGetValue(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, out var logAnalyticsWorkspaceId) && logAnalyticsWorkspaceId is null)
+        {
+            // We don't have a log analytics workspace for environments so we will just let the bicep file create one
+            resource.Parameters.Remove(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId);
+        }
+
         // Always specify the location
         resource.Parameters[AzureBicepResource.KnownParameters.Location] = context.Location.Name;
     }
@@ -333,6 +339,7 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger) : Azure
         AzureBicepResource.KnownParameters.PrincipalType,
         AzureBicepResource.KnownParameters.KeyVaultName,
         AzureBicepResource.KnownParameters.Location,
+        AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId,
     ];
 
     // Converts the parameters to a JSON object compatible with the ARM template

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -199,6 +199,11 @@ public class AzureBicepResource(string name, string? templateFile = null, string
         /// The location of the resource. This is required for all resources.
         /// </summary>
         public static readonly string Location = "location";
+
+        /// <summary>
+        /// The resource id of the log analytics workspace.
+        /// </summary>
+        public static readonly string LogAnalyticsWorkspaceId = "logAnalyticsWorkspaceId";
     }
 }
 

--- a/src/Aspire.Hosting.Azure/Extensions/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureApplicationInsightsExtensions.cs
@@ -22,6 +22,7 @@ public static class AzureApplicationInsightsExtensions
         var resource = new AzureApplicationInsightsResource(name);
         return builder.AddResource(resource)
                 .WithParameter("appInsightsName", resource.CreateBicepResourceName())
+                .WithParameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId)
                 .WithManifestPublishingCallback(resource.WriteToManifest);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -99,7 +99,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AddBicepCosmosDb()
+    public void AddAzureCosmosDb()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -147,6 +147,7 @@ public class AzureBicepResourceTests
         Assert.Equal("Aspire.Hosting.Azure.Bicep.appinsights.bicep", appInsights.Resource.TemplateResourceName);
         Assert.Equal("appInsights", appInsights.Resource.Name);
         Assert.Equal("appinsights", appInsights.Resource.Parameters["appInsightsName"]);
+        Assert.True(appInsights.Resource.Parameters.ContainsKey(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId));
         Assert.Equal("myinstrumentationkey", appInsights.Resource.GetConnectionString());
         Assert.Equal("{appInsights.outputs.appInsightsConnectionString}", appInsights.Resource.ConnectionStringExpression);
 
@@ -337,7 +338,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AddBicepServiceBus()
+    public void AddAzureServiceBus()
     {
         var builder = DistributedApplication.CreateBuilder();
         var serviceBus = builder.AddAzureServiceBus("sb");
@@ -370,7 +371,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AddBicepStorage()
+    public void AddAzureStorage()
     {
         var builder = DistributedApplication.CreateBuilder();
 


### PR DESCRIPTION
- In local development the bicep file will create the resource
- azd treat this like a known parameter in deployed scenarios
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2374)