### PR TITLE
Remove DbContextPooling from appsettings tests and docs

### DIFF
--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
@@ -79,7 +79,6 @@ The .NET Aspire Microsoft EntityFrameworkCore Cosmos component supports [Microso
     "Microsoft": {
       "EntityFrameworkCore": {
         "Cosmos": {
-          "DbContextPooling": true,
           "Tracing": false
         }
       }
@@ -99,7 +98,7 @@ Also you can pass the `Action<EntityFrameworkCoreCosmosDBSettings> configureSett
 or
 
 ```csharp
-    builder.EnrichCosmosDbContext<MyDbContext>(settings => settings.HealthChecks = false);
+    builder.EnrichCosmosDbContext<MyDbContext>(settings => settings.Tracing = false);
 ```
 
 ## AppHost extensions

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
@@ -44,7 +44,6 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
                 "SqlServer": {
                   "ConnectionString": "YOUR_CONNECTION_STRING",
                   "HealthChecks": false,
-                  "DbContextPooling": true,
                   "Tracing": true,
                   "Metrics": true
                 }

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -62,7 +62,6 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
                 "PostgreSQL": {
                   "ConnectionString": "YOUR_CONNECTION_STRING",
                   "HealthChecks": false,
-                  "DbContextPooling": true,
                   "Tracing": true,
                   "Metrics": true
                 }

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
@@ -55,7 +55,6 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
                 "MySql": {
                   "ConnectionString": "YOUR_CONNECTION_STRING",
                   "HealthChecks": false,
-                  "DbContextPooling": true,
                   "Tracing": true,
                   "Metrics": true
                 }


### PR DESCRIPTION
This setting is no longer valid.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2381)