### PR TITLE
Fix ServiceBus endpoint logic

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,28 +6,19 @@
     <!-- Azure SDK for .NET dependencies -->
     <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.13" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.3" />
-    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.0" />
+    <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
     <PackageVersion Include="Azure.Identity" Version="1.10.4" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.2" />
-    <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.7.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0-beta.2" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.3" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.17.1" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.25.0" />
-    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.1" />
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.ResourceManager.CosmosDB" Version="1.4.0-beta.5" />
-    <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.2.0" />
-    <PackageVersion Include="Azure.ResourceManager.ServiceBus" Version="1.1.0-beta.4" />
-    <PackageVersion Include="Azure.ResourceManager.Storage" Version="1.2.0" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.0" />
-    <PackageVersion Include="Azure.ResourceManager.Redis" Version="1.3.0" />
-    <PackageVersion Include="Azure.ResourceManager.AppConfiguration" Version="1.2.0" />
-    <PackageVersion Include="Azure.ResourceManager.Sql" Version="1.2.0" />
-    <PackageVersion Include="Azure.ResourceManager.ApplicationInsights" Version="1.0.0-beta.4" />
-    <PackageVersion Include="Azure.ResourceManager.OperationalInsights" Version="1.2.0" />
+    <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.2.0" />
+    <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.7.0" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion)" />

--- a/src/Aspire.Hosting.Azure/Bicep/servicebus.bicep
+++ b/src/Aspire.Hosting.Azure/Bicep/servicebus.bicep
@@ -51,4 +51,4 @@ resource ServiceBusRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-output serviceBusEndpoint string = replace(serviceBusNamespace.properties.serviceBusEndpoint, 'https://', '')
+output serviceBusEndpoint string = serviceBusNamespace.properties.serviceBusEndpoint


### PR DESCRIPTION
In previous versions of the ServiceBus SDK, it didn't accept `https://` URIs as the fully qualified namespace, but the ResourceManager APIs only return URIs with `https://`. So we had logic in our bicep template to remove the https. However, this doesn't work with the runtime component because it expected sb://.

The fix is to update to the latest ServiceBus version, which accepts https:// for the namespace URI. And also remove our bicp logic to just pass the endpoint through unmodified.

Also clean up the Directory.Packages.props file.

Fix #2378
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2385)