### PR TITLE
Fixing issue where AspireManifestPublishOutputPath is specified

### DIFF
--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -224,15 +224,24 @@ internal static class ]]>%(ClassName)<![CDATA[
 
   <PropertyGroup>
     <AspirePublisher Condition="'$(AspirePublisher)' == ''">manifest</AspirePublisher>
-    <AspireManifestPublishOutputPath Condition="'$(AspireManifestPublishOutputPath)' == ''">$(_AspireIntermediatePath)manifest.json</AspireManifestPublishOutputPath>
+    <AspireManifestPublishOutputPath Condition="'$(AspireManifestPublishOutputPath)' == ''">$(_AspireIntermediatePath)</AspireManifestPublishOutputPath>
   </PropertyGroup>
 
+  <Target Name="_EnsureAspireManifestPublishOutputPathExists" BeforeTargets="GenerateAspireManifest">
+    <PropertyGroup>
+      <AspireManifestPublishOutputPath>$([MSBuild]::NormalizeDirectory($(AspireManifestPublishOutputPath)))</AspireManifestPublishOutputPath>
+      <_AspireManifestPublishOutputFile>$([MSBuild]::NormalizePath('$(AspireManifestPublishOutputPath)', 'manifest.json'))</_AspireManifestPublishOutputFile>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(AspireManifestPublishOutputPath)" />
+  </Target>
+
   <!-- Entrypoint to allow for generation of an aspire manifest to a given location -->
-  <Target Name="GenerateAspireManifest" DependsOnTargets="Build" Inputs="$(TargetFileName)" Outputs="$(AspireManifestPublishOutputPath)">
+  <Target Name="GenerateAspireManifest" DependsOnTargets="Build;_EnsureAspireManifestPublishOutputPathExists" Inputs="$(TargetFileName)" Outputs="$(_AspireManifestPublishOutputFile)">
     <ItemGroup>
       <_AspireManifestPublishArg Include="%22$(DOTNET_HOST_PATH)%22; %22$(TargetPath)%22;"/>
       <_AspireManifestPublishArg Include="--publisher; $(AspirePublisher);" />
-      <_AspireManifestPublishArg Include="--output-path; %22$(AspireManifestPublishOutputPath)%22" />
+      <_AspireManifestPublishArg Include="--output-path; %22$(_AspireManifestPublishOutputFile)%22" />
     </ItemGroup>
 
     <Exec Command="@(_AspireManifestPublishArg, ' ')"

--- a/src/Aspire.Hosting/build/Aspire.Hosting.targets
+++ b/src/Aspire.Hosting/build/Aspire.Hosting.targets
@@ -227,7 +227,7 @@ internal static class ]]>%(ClassName)<![CDATA[
     <AspireManifestPublishOutputPath Condition="'$(AspireManifestPublishOutputPath)' == ''">$(_AspireIntermediatePath)</AspireManifestPublishOutputPath>
   </PropertyGroup>
 
-  <Target Name="_EnsureAspireManifestPublishOutputPathExists" BeforeTargets="GenerateAspireManifest">
+  <Target Name="_EnsureAspireManifestPublishOutputPathExists">
     <PropertyGroup>
       <AspireManifestPublishOutputPath>$([MSBuild]::NormalizeDirectory($(AspireManifestPublishOutputPath)))</AspireManifestPublishOutputPath>
       <_AspireManifestPublishOutputFile>$([MSBuild]::NormalizePath('$(AspireManifestPublishOutputPath)', 'manifest.json'))</_AspireManifestPublishOutputFile>


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1076

Before this change, setting AspireManifestPublishOutputPath would only work if you passed in a path with a filename, as well as ensuring the output directory existed. With this change, AspireManifestPublishOutputPath will now be pointing to the output folder where manifest.json file will be created, and it won't be required for t he folder to exist. This will allow people to set the property in their AppHost projects and work as expected.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2388)