### PR TITLE
Add support for showing custom resources in the dashboard

### DIFF
--- a/Aspire.sln
+++ b/Aspire.sln
@@ -277,7 +277,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DatabaseMigration.AppHost",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DatabaseMigration.MigrationService", "playground\DatabaseMigration\DatabaseMigration.MigrationService\DatabaseMigration.MigrationService.csproj", "{E7DB736B-C316-460E-A609-2200E58BF0C2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DatabaseMigration.ApiModel", "playground\DatabaseMigration\DatabaseMigration.ApiModel\DatabaseMigration.ApiModel.csproj", "{C15F3F13-AB63-47CF-AAFE-D319F02E7B33}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DatabaseMigration.ApiModel", "playground\DatabaseMigration\DatabaseMigration.ApiModel\DatabaseMigration.ApiModel.csproj", "{C15F3F13-AB63-47CF-AAFE-D319F02E7B33}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "signalr", "signalr", "{E6985EED-47E3-4EAC-8222-074E5410CEDC}"
 EndProject
@@ -290,6 +290,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProxylessEndToEnd.ApiService", "playground\ProxylessEndToEnd\ProxylessEndToEnd.ApiService\ProxylessEndToEnd.ApiService.csproj", "{51654CD7-2E05-4664-B2EB-95308A300609}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProxylessEndToEnd.AppHost", "playground\ProxylessEndToEnd\ProxylessEndToEnd.AppHost\ProxylessEndToEnd.AppHost.csproj", "{0244203D-7491-4414-9C88-10BFED9C5B2D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CustomResources", "CustomResources", "{867A00A7-AF8E-4396-9583-982FBB31762C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomResources.AppHost", "playground\CustomResources\CustomResources.AppHost\CustomResources.AppHost.csproj", "{4231B6F1-1110-4992-A727-8F1176A47440}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -761,6 +765,10 @@ Global
 		{0244203D-7491-4414-9C88-10BFED9C5B2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0244203D-7491-4414-9C88-10BFED9C5B2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0244203D-7491-4414-9C88-10BFED9C5B2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4231B6F1-1110-4992-A727-8F1176A47440}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4231B6F1-1110-4992-A727-8F1176A47440}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4231B6F1-1110-4992-A727-8F1176A47440}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4231B6F1-1110-4992-A727-8F1176A47440}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -900,6 +908,8 @@ Global
 		{9C30FFD6-2262-45E7-B010-24B30E0433C2} = {D173887B-AF42-4576-B9C1-96B9E9B3D9C0}
 		{51654CD7-2E05-4664-B2EB-95308A300609} = {9C30FFD6-2262-45E7-B010-24B30E0433C2}
 		{0244203D-7491-4414-9C88-10BFED9C5B2D} = {9C30FFD6-2262-45E7-B010-24B30E0433C2}
+		{867A00A7-AF8E-4396-9583-982FBB31762C} = {D173887B-AF42-4576-B9C1-96B9E9B3D9C0}
+		{4231B6F1-1110-4992-A727-8F1176A47440} = {867A00A7-AF8E-4396-9583-982FBB31762C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6DCEDFEC-988E-4CB3-B45B-191EB5086E0C}

--- a/playground/CustomResources/CustomResources.AppHost/CustomResources.AppHost.csproj
+++ b/playground/CustomResources/CustomResources.AppHost/CustomResources.AppHost.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(SharedDir)KnownResourceNames.cs" Link="KnownResourceNames.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
+    <ProjectReference Include="..\..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" IsAspireProjectResource="false" />
+  </ItemGroup>
+
+</Project>

--- a/playground/CustomResources/CustomResources.AppHost/Directory.Build.props
+++ b/playground/CustomResources/CustomResources.AppHost/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!-- NOTE: This line is only required because we are using P2P references, not NuGet. It will not exist in real apps. -->
+  <Import Project="../../../src/Aspire.Hosting/build/Aspire.Hosting.props" />
+
+</Project>

--- a/playground/CustomResources/CustomResources.AppHost/Directory.Build.targets
+++ b/playground/CustomResources/CustomResources.AppHost/Directory.Build.targets
@@ -1,0 +1,9 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!-- NOTE: These lines are only required because we are using P2P references, not NuGet. They will not exist in real apps. -->
+  <Import Project="..\..\..\src\Aspire.Hosting\build\Aspire.Hosting.targets" />
+  <Import Project="..\..\..\src\Aspire.Hosting.Sdk\SDK\Sdk.targets" />
+  
+</Project>

--- a/playground/CustomResources/CustomResources.AppHost/Program.cs
+++ b/playground/CustomResources/CustomResources.AppHost/Program.cs
@@ -1,16 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureStorage("storage").RunAsEmulator(container =>
-{
-    container.UsePersistence();
-});
+builder.AddTestResource("test");
 
-var blobs = storage.AddBlobs("blobs");
-
-builder.AddProject<Projects.AzureStorageEndToEnd_ApiService>("api")
-       .WithReference(blobs);
+builder.AddParameter("p0");
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
@@ -20,4 +15,3 @@ builder.AddProject<Projects.AzureStorageEndToEnd_ApiService>("api")
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
 
 builder.Build().Run();
-

--- a/playground/CustomResources/CustomResources.AppHost/Properties/launchSettings.json
+++ b/playground/CustomResources/CustomResources.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
+    "generate-manifest": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+      "applicationUrl": "http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175"
+      }
+    }
+  }
+}

--- a/playground/CustomResources/CustomResources.AppHost/TestResource.cs
+++ b/playground/CustomResources/CustomResources.AppHost/TestResource.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Hosting.Dashboard;
+using Aspire.Hosting.Lifecycle;
+
+static class TestResourceExtensions
+{
+    public static IResourceBuilder<TestResource> AddTestResource(this IDistributedApplicationBuilder builder, string name)
+    {
+        builder.Services.AddLifecycleHook<TestResourceLifecycleHook>();
+
+        var rb = builder.AddResource(new TestResource(name))
+                      .WithDashboardState(() => new()
+                      {
+                          ResourceType = "Test Resource",
+                          State = "Starting",
+                          Properties = [
+                              ("P1", "P2"),
+                              (DashboardKnownProperties.Source, "Custom")
+                          ]
+                      })
+                      .ExcludeFromManifest();
+
+        return rb;
+    }
+}
+
+internal sealed class TestResourceLifecycleHook : IDistributedApplicationLifecycleHook, IAsyncDisposable
+{
+    private readonly CancellationTokenSource _tokenSource = new();
+
+    public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
+    {
+        foreach (var item in appModel.Resources.OfType<TestResource>())
+        {
+            if (item.TryGetLastAnnotation<DashboardAnnotation>(out var annotation))
+            {
+                var states = new[] { "Starting", "Running", "Finished" };
+
+                Task.Run(async () =>
+                {
+                    // The background thread
+                    var state = annotation.GetIntialState();
+                    var seconds = Random.Shared.Next(2, 12);
+
+                    state = state with
+                    {
+                        Properties = [.. state.Properties, ("Interval", seconds.ToString(CultureInfo.InvariantCulture))]
+                    };
+
+                    // This might run before the dashboard is ready to receive updates, but it will be queued.
+                    await annotation.UpdateStateAsync(state);
+
+                    using var timer = new PeriodicTimer(TimeSpan.FromSeconds(seconds));
+
+                    while (await timer.WaitForNextTickAsync(_tokenSource.Token))
+                    {
+                        state = state with
+                        {
+                            State = states[Random.Shared.Next(0, states.Length)]
+                        };
+
+                        await annotation.UpdateStateAsync(state);
+                    }
+                },
+                cancellationToken);
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _tokenSource.Cancel();
+        return default;
+    }
+}
+
+sealed class TestResource(string name) : Resource(name)
+{
+
+}

--- a/playground/CustomResources/CustomResources.AppHost/TestResource.cs
+++ b/playground/CustomResources/CustomResources.AppHost/TestResource.cs
@@ -41,7 +41,7 @@ internal sealed class TestResourceLifecycleHook : IDistributedApplicationLifecyc
 
                 Task.Run(async () =>
                 {
-                    // The background thread
+                    // Simulate custom resource state changes
                     var state = annotation.GetIntialState();
                     var seconds = Random.Shared.Next(2, 12);
 

--- a/playground/CustomResources/CustomResources.AppHost/TestResource.cs
+++ b/playground/CustomResources/CustomResources.AppHost/TestResource.cs
@@ -41,7 +41,7 @@ internal sealed class TestResourceLifecycleHook : IDistributedApplicationLifecyc
                 Task.Run(async () =>
                 {
                     // Simulate custom resource state changes
-                    var state = annotation.GetInitialState();
+                    var state = annotation.GetInitialSnapshot();
                     var seconds = Random.Shared.Next(2, 12);
 
                     state = state with

--- a/playground/CustomResources/CustomResources.AppHost/TestResource.cs
+++ b/playground/CustomResources/CustomResources.AppHost/TestResource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Lifecycle;
 
 static class TestResourceExtensions
@@ -12,13 +11,13 @@ static class TestResourceExtensions
         builder.Services.AddLifecycleHook<TestResourceLifecycleHook>();
 
         var rb = builder.AddResource(new TestResource(name))
-                      .WithDashboardState(() => new()
+                      .WithCustomResourceState(() => new()
                       {
                           ResourceType = "Test Resource",
                           State = "Starting",
                           Properties = [
                               ("P1", "P2"),
-                              (DashboardKnownProperties.Source, "Custom")
+                              (CustomResourceKnownProperties.Source, "Custom")
                           ]
                       })
                       .ExcludeFromManifest();
@@ -35,14 +34,14 @@ internal sealed class TestResourceLifecycleHook : IDistributedApplicationLifecyc
     {
         foreach (var item in appModel.Resources.OfType<TestResource>())
         {
-            if (item.TryGetLastAnnotation<DashboardAnnotation>(out var annotation))
+            if (item.TryGetLastAnnotation<CustomResourceAnnotation>(out var annotation))
             {
                 var states = new[] { "Starting", "Running", "Finished" };
 
                 Task.Run(async () =>
                 {
                     // Simulate custom resource state changes
-                    var state = annotation.GetIntialState();
+                    var state = annotation.GetInitialState();
                     var seconds = Random.Shared.Next(2, 12);
 
                     state = state with

--- a/playground/CustomResources/CustomResources.AppHost/appsettings.Development.json
+++ b/playground/CustomResources/CustomResources.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/playground/CustomResources/CustomResources.AppHost/appsettings.json
+++ b/playground/CustomResources/CustomResources.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -28,9 +28,9 @@
                         ShowIndeterminate="false"
                         ThreeStateOrderUncheckToIntermediate="true"
                         @bind-CheckState="AreAllTypesVisible" />
-                    @foreach (var resourceType in _allResourceTypes)
+                    @foreach (var (resourceType, _) in _allResourceTypes)
                     {
-                        var isChecked = _visibleResourceTypes.Contains(resourceType);
+                        var isChecked = _visibleResourceTypes.ContainsKey(resourceType);
                         <FluentCheckbox
                             Label="@resourceType"
                             @bind-Value:get="isChecked"

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -38,9 +38,13 @@ else if (Resource.TryGetContainerImage(out var containerImage))
                PreCopyToolTip="@Loc[nameof(Columns.SourceColumnSourceCopyContainerToClipboard)]"
                ToolTip="@containerImage" />
 }
-else
+else if (Resource.Properties.TryGetValue(KnownProperties.Resource.Source, out var value) && value.HasStringValue)
 {
-    // TODO we need to add support for arbitrary resource types. Until then, they'll just show an empty source column.
+    <GridValue Value="@value.StringValue"
+               EnableHighlighting="true"
+               HighlightText="@FilterText"
+               PreCopyToolTip="@Loc[nameof(Columns.SourceColumnSourceCopyContainerToClipboard)]"
+               ToolTip="@value.StringValue" />
 }
 
 @code {

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceAnnotation.cs
@@ -4,34 +4,33 @@
 using System.Collections.Immutable;
 using System.Threading.Channels;
 using Aspire.Dashboard.Model;
-using Aspire.Hosting.ApplicationModel;
 
-namespace Aspire.Hosting.Dashboard;
+namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
 /// The annotation that reflects how a resource shows up in the dashboard.
 /// This is a single producer, single consumer channel model for pushing updates to the dashboard.
 /// The resource server will be the only caller of WatchAsync.
 /// </summary>
-public class DashboardAnnotation(Func<DashboardResourceState> initialState) : IResourceAnnotation
+public sealed class CustomResourceAnnotation(Func<CustomResourceState> initialState) : IResourceAnnotation
 {
-    private readonly Channel<DashboardResourceState> _channel = Channel.CreateUnbounded<DashboardResourceState>();
+    private readonly Channel<CustomResourceState> _channel = Channel.CreateUnbounded<CustomResourceState>();
 
     /// <summary>
     /// Watch for changes to the dashboard state for a resource.
     /// </summary>
-    public IAsyncEnumerable<DashboardResourceState> WatchAsync(CancellationToken cancellationToken = default) => _channel.Reader.ReadAllAsync(cancellationToken);
+    public IAsyncEnumerable<CustomResourceState> WatchAsync(CancellationToken cancellationToken = default) => _channel.Reader.ReadAllAsync(cancellationToken);
 
     /// <summary>
     /// Gets the initial snapshot of the dashboard state for this resource.
     /// </summary>
-    public DashboardResourceState GetIntialState() => initialState();
+    public CustomResourceState GetInitialState() => initialState();
 
     /// <summary>
     /// Updates the snapshot of the dashboard state for a resource.
     /// </summary>
-    /// <param name="state">The new <see cref="DashboardResourceState"/>.</param>
-    public async Task UpdateStateAsync(DashboardResourceState state)
+    /// <param name="state">The new <see cref="CustomResourceState"/>.</param>
+    public async Task UpdateStateAsync(CustomResourceState state)
     {
         await _channel.Writer.WriteAsync(state).ConfigureAwait(false);
     }
@@ -40,7 +39,7 @@ public class DashboardAnnotation(Func<DashboardResourceState> initialState) : IR
 /// <summary>
 /// The context for a all of the properties and URLs that should show up in the dashboard for a resource.
 /// </summary>
-public record DashboardResourceState
+public record CustomResourceState
 {
     /// <summary>
     /// The type of the resource.
@@ -68,11 +67,11 @@ public record DashboardResourceState
     public ImmutableArray<string> Urls { get; init; } = [];
 
     /// <summary>
-    /// Creates a new <see cref="DashboardResourceState"/> for a resource using the well known annotations.
+    /// Creates a new <see cref="CustomResourceState"/> for a resource using the well known annotations.
     /// </summary>
     /// <param name="resource">The resource.</param>
-    /// <returns>The new <see cref="DashboardResourceState"/>.</returns>
-    public static DashboardResourceState Create(IResource resource)
+    /// <returns>The new <see cref="CustomResourceState"/>.</returns>
+    public static CustomResourceState Create(IResource resource)
     {
         ImmutableArray<string> urls = [];
 
@@ -104,7 +103,7 @@ public record DashboardResourceState
         }
 
         // Initialize the state with the well known annotations
-        return new DashboardResourceState()
+        return new CustomResourceState()
         {
             ResourceType = resource.GetType().Name.Replace("Resource", ""),
             EnviromentVariables = environmentVariables,
@@ -117,7 +116,7 @@ public record DashboardResourceState
 /// <summary>
 /// Known properties for resources that show up in the dashboard.
 /// </summary>
-public static class DashboardKnownProperties
+public static class CustomResourceKnownProperties
 {
     /// <summary>
     /// The source of the resource

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceExtensions.cs
@@ -3,25 +3,25 @@
 
 using Aspire.Hosting.ApplicationModel;
 
-namespace Aspire.Hosting.Dashboard;
+namespace Aspire.Hosting;
 
 /// <summary>
 /// Extension methods for applying dashboard annotations to resources.
 /// </summary>
-public static class DashboardResourceExtensions
+public static class CustomResourceExtensions
 {
     /// <summary>
     /// Adds a callback to configure the dashboard context for a resource.
     /// </summary>
     /// <typeparam name="TResource">The resource.</typeparam>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="initialState">The callback to create the initial <see cref="DashboardResourceState"/>.</param>
+    /// <param name="initialState">The callback to create the initial <see cref="CustomResourceState"/>.</param>
     /// <returns>The resource builder.</returns>
-    public static IResourceBuilder<TResource> WithDashboardState<TResource>(this IResourceBuilder<TResource> builder, Func<DashboardResourceState>? initialState = null)
+    public static IResourceBuilder<TResource> WithCustomResourceState<TResource>(this IResourceBuilder<TResource> builder, Func<CustomResourceState>? initialState = null)
         where TResource : IResource
     {
-        initialState ??= () => DashboardResourceState.Create(builder.Resource);
+        initialState ??= () => CustomResourceState.Create(builder.Resource);
 
-        return builder.WithAnnotation(new DashboardAnnotation(initialState), ResourceAnnotationMutationBehavior.Replace);
+        return builder.WithAnnotation(new CustomResourceAnnotation(initialState), ResourceAnnotationMutationBehavior.Replace);
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceExtensions.cs
@@ -15,13 +15,13 @@ public static class CustomResourceExtensions
     /// </summary>
     /// <typeparam name="TResource">The resource.</typeparam>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="initialState">The callback to create the initial <see cref="CustomResourceState"/>.</param>
+    /// <param name="initialSnapshotFactory">The factory to create the initial <see cref="CustomResourceSnapshot"/> for this resource.</param>
     /// <returns>The resource builder.</returns>
-    public static IResourceBuilder<TResource> WithCustomResourceState<TResource>(this IResourceBuilder<TResource> builder, Func<CustomResourceState>? initialState = null)
+    public static IResourceBuilder<TResource> WithCustomResourceState<TResource>(this IResourceBuilder<TResource> builder, Func<CustomResourceSnapshot>? initialSnapshotFactory = null)
         where TResource : IResource
     {
-        initialState ??= () => CustomResourceState.Create(builder.Resource);
+        initialSnapshotFactory ??= () => CustomResourceSnapshot.Create(builder.Resource);
 
-        return builder.WithAnnotation(new CustomResourceAnnotation(initialState), ResourceAnnotationMutationBehavior.Replace);
+        return builder.WithAnnotation(new CustomResourceAnnotation(initialSnapshotFactory), ResourceAnnotationMutationBehavior.Replace);
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResourceExtensions.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -18,25 +16,6 @@ public static class ProjectResourceExtensions
     public static IEnumerable<ProjectResource> GetProjectResources(this DistributedApplicationModel model)
     {
         return model.Resources.OfType<ProjectResource>();
-    }
-
-    /// <summary>
-    /// Tries to get the project resource with the specified path from the distributed application model.
-    /// </summary>
-    /// <param name="model">The distributed application model.</param>
-    /// <param name="name">The DCP resource name.</param>
-    /// <param name="path">The path of the project resource.</param>
-    /// <param name="projectResource">When this method returns, contains the project resource with the specified path, if it is found; otherwise, null.</param>
-    /// <returns><see langword="true"/> if the project resource with the specified path is found; otherwise, <see langword="false"/>.</returns>
-    internal static bool TryGetProjectWithPath(this DistributedApplicationModel model, string name, string path, [NotNullWhen(true)] out ProjectResource? projectResource)
-    {
-        projectResource = model.GetProjectResources()
-            // HACK: Until we use the DistributedApplicationModel as the source of truth, we will use
-            // the name of the project resource as the DCP resource name. If this is a replica, it'll be projectname-{id}.
-            .Where(p => p.Name == name || name.StartsWith(p.Name + "-"))
-            .SingleOrDefault(p => p.Annotations.OfType<IProjectMetadata>().FirstOrDefault()?.ProjectPath == path);
-
-        return projectResource is not null;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
@@ -79,10 +79,10 @@ internal sealed class ConsoleLogPublisher(
         }
     }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
     private static async LogsEnumerable SubscribeGenericResource()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
     {
-        await Task.Yield();
-
         yield return [("No logs available", false)];
     }
 }

--- a/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
@@ -31,6 +31,7 @@ internal sealed class ConsoleLogPublisher(
             {
                 ExecutableSnapshot executable => SubscribeExecutableResource(executable),
                 ContainerSnapshot container => SubscribeContainerResource(container),
+                GenericResourceSnapshot => SubscribeGenericResource(),
                 _ => throw new NotSupportedException($"Unsupported resource type {resource.GetType()}.")
             };
         }
@@ -40,6 +41,7 @@ internal sealed class ConsoleLogPublisher(
             {
                 ExecutableSnapshot executable => SubscribeExecutable(executable),
                 ContainerSnapshot container => SubscribeContainer(container),
+                GenericResourceSnapshot => SubscribeGenericResource(),
                 _ => throw new NotSupportedException($"Unsupported resource type {resource.GetType()}.")
             };
         }
@@ -75,5 +77,12 @@ internal sealed class ConsoleLogPublisher(
 
             return new DockerContainerLogSource(container.ContainerId);
         }
+    }
+
+    private static async LogsEnumerable SubscribeGenericResource()
+    {
+        await Task.Yield();
+
+        yield return [("No logs available", false)];
     }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardAnnotation.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardAnnotation.cs
@@ -1,0 +1,126 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Threading.Channels;
+using Aspire.Dashboard.Model;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Dashboard;
+
+/// <summary>
+/// The annotation that reflects how a resource shows up in the dashboard.
+/// This is a single producer, single consumer channel model for pushing updates to the dashboard.
+/// The resource server will be the only caller of WatchAsync.
+/// </summary>
+public class DashboardAnnotation(Func<DashboardResourceState> initialState) : IResourceAnnotation
+{
+    private readonly Channel<DashboardResourceState> _channel = Channel.CreateUnbounded<DashboardResourceState>();
+
+    /// <summary>
+    /// Watch for changes to the dashboard state for a resource.
+    /// </summary>
+    public IAsyncEnumerable<DashboardResourceState> WatchAsync(CancellationToken cancellationToken = default) => _channel.Reader.ReadAllAsync(cancellationToken);
+
+    /// <summary>
+    /// Gets the initial snapshot of the dashboard state for this resource.
+    /// </summary>
+    public DashboardResourceState GetIntialState() => initialState();
+
+    /// <summary>
+    /// Updates the snapshot of the dashboard state for a resource.
+    /// </summary>
+    /// <param name="state">The new <see cref="DashboardResourceState"/>.</param>
+    public async Task UpdateStateAsync(DashboardResourceState state)
+    {
+        await _channel.Writer.WriteAsync(state).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// The context for a all of the properties and URLs that should show up in the dashboard for a resource.
+/// </summary>
+public record DashboardResourceState
+{
+    /// <summary>
+    /// The type of the resource.
+    /// </summary>
+    public required string ResourceType { get; init; }
+
+    /// <summary>
+    /// The properties that should show up in the dashboard for this resource.
+    /// </summary>
+    public required ImmutableArray<(string Key, string Value)> Properties { get; init; }
+
+    /// <summary>
+    /// Represents the state of the resource.
+    /// </summary>
+    public string? State { get; init; }
+
+    /// <summary>
+    /// The environment variables that should show up in the dashboard for this resource.
+    /// </summary>
+    public ImmutableArray<(string Name, string Value)> EnviromentVariables { get; init; } = [];
+
+    /// <summary>
+    /// The URLs that should show up in the dashboard for this resource.
+    /// </summary>
+    public ImmutableArray<string> Urls { get; init; } = [];
+
+    /// <summary>
+    /// Creates a new <see cref="DashboardResourceState"/> for a resource using the well known annotations.
+    /// </summary>
+    /// <param name="resource">The resource.</param>
+    /// <returns>The new <see cref="DashboardResourceState"/>.</returns>
+    public static DashboardResourceState Create(IResource resource)
+    {
+        ImmutableArray<string> urls = [];
+
+        if (resource.TryGetAnnotationsOfType<EndpointAnnotation>(out var endpointAnnotations))
+        {
+            static string GetUrl(EndpointAnnotation e) =>
+                $"{e.UriScheme}://localhost:{e.Port}";
+
+            urls = [.. endpointAnnotations.Where(e => e.Port is not null).Select(e => GetUrl(e))];
+        }
+
+        ImmutableArray<(string, string)> environmentVariables = [];
+
+        if (resource.TryGetAnnotationsOfType<EnvironmentCallbackAnnotation>(out var environmentCallbacks))
+        {
+            var envContext = new EnvironmentCallbackContext(new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run));
+            foreach (var annotation in environmentCallbacks)
+            {
+                annotation.Callback(envContext);
+            }
+
+            environmentVariables = [.. envContext.EnvironmentVariables.Select(e => (e.Key, e.Value))];
+        }
+
+        ImmutableArray<(string, string)> properties = [];
+        if (resource is IResourceWithConnectionString connectionStringResource)
+        {
+            properties = [("ConnectionString", connectionStringResource.GetConnectionString() ?? "")];
+        }
+
+        // Initialize the state with the well known annotations
+        return new DashboardResourceState()
+        {
+            ResourceType = resource.GetType().Name.Replace("Resource", ""),
+            EnviromentVariables = environmentVariables,
+            Urls = urls,
+            Properties = properties
+        };
+    }
+}
+
+/// <summary>
+/// Known properties for resources that show up in the dashboard.
+/// </summary>
+public static class DashboardKnownProperties
+{
+    /// <summary>
+    /// The source of the resource
+    /// </summary>
+    public static string Source { get; } = KnownProperties.Resource.Source;
+}

--- a/src/Aspire.Hosting/Dashboard/DashboardResourceExtensions.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardResourceExtensions.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Dashboard;
+
+/// <summary>
+/// Extension methods for applying dashboard annotations to resources.
+/// </summary>
+public static class DashboardResourceExtensions
+{
+    /// <summary>
+    /// Adds a callback to configure the dashboard context for a resource.
+    /// </summary>
+    /// <typeparam name="TResource">The resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="initialState">The callback to create the initial <see cref="DashboardResourceState"/>.</param>
+    /// <returns>The resource builder.</returns>
+    public static IResourceBuilder<TResource> WithDashboardState<TResource>(this IResourceBuilder<TResource> builder, Func<DashboardResourceState>? initialState = null)
+        where TResource : IResource
+    {
+        initialState ??= () => DashboardResourceState.Create(builder.Resource);
+
+        return builder.WithAnnotation(new DashboardAnnotation(initialState), ResourceAnnotationMutationBehavior.Replace);
+    }
+}

--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -197,11 +197,11 @@ internal sealed class DcpDataSource
 
             await _onResourceChanged(snapshot, ResourceSnapshotChangeType.Upsert).ConfigureAwait(false);
         }
-        else if (resource.TryGetLastAnnotation<DashboardAnnotation>(out var dashboardAnnotation))
+        else if (resource.TryGetLastAnnotation<CustomResourceAnnotation>(out var dashboardAnnotation))
         {
             // We have a dashboard annotation, so we want to create a snapshot for the resource
             // and update data immediately. We also want to watch for changes to the dashboard state.
-            var state = dashboardAnnotation.GetIntialState();
+            var state = dashboardAnnotation.GetInitialState();
             var creationTimestamp = DateTime.UtcNow;
 
             var snapshot = CreateResourceSnapshot(resource, creationTimestamp, state);
@@ -228,7 +228,7 @@ internal sealed class DcpDataSource
         }
     }
 
-    private static GenericResourceSnapshot CreateResourceSnapshot(IResource resource, DateTime creationTimestamp, DashboardResourceState dashboardState)
+    private static GenericResourceSnapshot CreateResourceSnapshot(IResource resource, DateTime creationTimestamp, CustomResourceState dashboardState)
     {
         ImmutableArray<EnvironmentVariableSnapshot> environmentVariables = [..
             dashboardState.EnviromentVariables.Select(e => new EnvironmentVariableSnapshot(e.Name, e.Value, false))];

--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -273,9 +273,9 @@ internal sealed class DcpDataSource
             string? resourceName = null;
             resource.Metadata.Annotations?.TryGetValue(Executable.ResourceNameAnnotation, out resourceName);
 
-            if (resourceName is not null && _placeHolderResources.TryRemove(resourceName, out var dummy))
+            if (resourceName is not null && _placeHolderResources.TryRemove(resourceName, out var placeHolder))
             {
-                await _onResourceChanged(dummy, ResourceSnapshotChangeType.Delete).ConfigureAwait(false);
+                await _onResourceChanged(placeHolder, ResourceSnapshotChangeType.Delete).ConfigureAwait(false);
             }
         }
 

--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -201,7 +201,7 @@ internal sealed class DcpDataSource
         {
             // We have a dashboard annotation, so we want to create a snapshot for the resource
             // and update data immediately. We also want to watch for changes to the dashboard state.
-            var state = dashboardAnnotation.GetInitialState();
+            var state = dashboardAnnotation.GetInitialSnapshot();
             var creationTimestamp = DateTime.UtcNow;
 
             var snapshot = CreateResourceSnapshot(resource, creationTimestamp, state);
@@ -228,7 +228,7 @@ internal sealed class DcpDataSource
         }
     }
 
-    private static GenericResourceSnapshot CreateResourceSnapshot(IResource resource, DateTime creationTimestamp, CustomResourceState dashboardState)
+    private static GenericResourceSnapshot CreateResourceSnapshot(IResource resource, DateTime creationTimestamp, CustomResourceSnapshot dashboardState)
     {
         ImmutableArray<EnvironmentVariableSnapshot> environmentVariables = [..
             dashboardState.EnviromentVariables.Select(e => new EnvironmentVariableSnapshot(e.Name, e.Value, false))];

--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -350,15 +350,12 @@ internal sealed class DcpDataSource
         var containerId = container.Status?.ContainerId;
         var (endpoints, services) = GetEndpointsAndServices(container, "Container");
 
-        string? resourceName = null;
-        container.Metadata.Annotations?.TryGetValue(Container.ResourceNameAnnotation, out resourceName);
-
         var environment = GetEnvironmentVariables(container.Status?.EffectiveEnv ?? container.Spec.Env, container.Spec.Env);
 
         return new ContainerSnapshot
         {
-            Name = resourceName ?? container.Metadata.Name,
-            DisplayName = resourceName ?? container.Metadata.Name,
+            Name = container.Metadata.Name,
+            DisplayName = container.Metadata.Name,
             Uid = container.Metadata.Uid,
             ContainerId = containerId,
             CreationTimeStamp = container.Metadata.CreationTimestamp?.ToLocalTime(),
@@ -451,7 +448,6 @@ internal sealed class DcpDataSource
         static string GetDisplayName(Executable executable)
         {
             var displayName = executable.Metadata.Name;
-
             var replicaSetOwner = executable.Metadata.OwnerReferences?.FirstOrDefault(
                 or => or.Kind == Dcp.Model.Dcp.ExecutableReplicaSetKind
             );

--- a/src/Aspire.Hosting/Dashboard/ExecutableSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ExecutableSnapshot.cs
@@ -24,8 +24,8 @@ internal class ExecutableSnapshot : ResourceSnapshot
 
     protected override IEnumerable<(string Key, Value Value)> GetProperties()
     {
-        yield return (KnownProperties.Executable.Path, Value.ForString(ExecutablePath));
-        yield return (KnownProperties.Executable.WorkDir, WorkingDirectory is null ? Value.ForNull() :Value.ForString(WorkingDirectory));
+        yield return (KnownProperties.Executable.Path, ExecutablePath is null ? Value.ForNull() : Value.ForString(ExecutablePath));
+        yield return (KnownProperties.Executable.WorkDir, WorkingDirectory is null ? Value.ForNull() : Value.ForString(WorkingDirectory));
         yield return (KnownProperties.Executable.Args, Arguments is null ? Value.ForNull() : Value.ForList(Arguments.Value.Select(arg => Value.ForString(arg)).ToArray()));
         yield return (KnownProperties.Executable.Pid, ProcessId is null ? Value.ForNull() : Value.ForString(ProcessId.Value.ToString("D", CultureInfo.InvariantCulture)));
         // TODO decide whether to send StdOut/StdErr file paths or not, and what we could use them for in the client.

--- a/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Google.Protobuf.WellKnownTypes;
+
+namespace Aspire.Hosting.Dashboard;
+
+internal class GenericResourceSnapshot(DashboardResourceState state) : ResourceSnapshot
+{
+    // Default to the resource type name without the "Resource" suffix.
+    public override string ResourceType => state.ResourceType;
+
+    protected override IEnumerable<(string Key, Value Value)> GetProperties()
+    {
+        foreach (var (key, value) in state.Properties)
+        {
+            yield return (key, Value.ForString(value));
+        }
+    }
+}

--- a/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
@@ -1,11 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Hosting.Dashboard;
 
-internal class GenericResourceSnapshot(DashboardResourceState state) : ResourceSnapshot
+internal class GenericResourceSnapshot(CustomResourceState state) : ResourceSnapshot
 {
     // Default to the resource type name without the "Resource" suffix.
     public override string ResourceType => state.ResourceType;

--- a/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
@@ -6,7 +6,7 @@ using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Hosting.Dashboard;
 
-internal class GenericResourceSnapshot(CustomResourceState state) : ResourceSnapshot
+internal class GenericResourceSnapshot(CustomResourceSnapshot state) : ResourceSnapshot
 {
     // Default to the resource type name without the "Resource" suffix.
     public override string ResourceType => state.ResourceType;

--- a/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
@@ -39,7 +39,7 @@ public static class ParameterResourceBuilderExtensions
         return builder.AddResource(resource)
                       .WithCustomResourceState(() =>
                       {
-                          var state = new CustomResourceState()
+                          var state = new CustomResourceSnapshot()
                           {
                               ResourceType = "Parameter",
                               Properties = [

--- a/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.Configuration;
 
@@ -38,14 +37,14 @@ public static class ParameterResourceBuilderExtensions
     {
         var resource = new ParameterResource(name, callback, secret);
         return builder.AddResource(resource)
-                      .WithDashboardState(() =>
+                      .WithCustomResourceState(() =>
                       {
-                          var state = new DashboardResourceState()
+                          var state = new CustomResourceState()
                           {
                               ResourceType = "Parameter",
                               Properties = [
                                 ("Secret", secret.ToString()),
-                                (DashboardKnownProperties.Source, connectionString ? $"ConnectionStrings:{name}" : $"Parameters:{name}")
+                                (CustomResourceKnownProperties.Source, connectionString ? $"ConnectionStrings:{name}" : $"Parameters:{name}")
                               ]
                           };
 

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -21,6 +21,7 @@ internal static class KnownProperties
         public const string State = "resource.state";
         public const string ExitCode = "resource.exitCode";
         public const string CreateTime = "resource.createTime";
+        public const string Source = "resource.source";
     }
 
     public static class Container

--- a/tests/Aspire.Hosting.Tests/CustomResourceStateTests.cs
+++ b/tests/Aspire.Hosting.Tests/CustomResourceStateTests.cs
@@ -1,12 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Dashboard;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
 
-public class DashboardResourceStateTests
+public class CustomResourceStateTests
 {
     [Fact]
     public void CreatePopulatesStateFromResource()
@@ -16,13 +15,13 @@ public class DashboardResourceStateTests
         var custom = builder.AddResource(new CustomResource("myResource"))
             .WithEndpoint(name: "ep", scheme: "http", hostPort: 8080)
             .WithEnvironment("x", "1000")
-            .WithDashboardState();
+            .WithCustomResourceState();
 
-        var annotation = custom.Resource.Annotations.OfType<DashboardAnnotation>().SingleOrDefault();
+        var annotation = custom.Resource.Annotations.OfType<CustomResourceAnnotation>().SingleOrDefault();
 
         Assert.NotNull(annotation);
 
-        var state = annotation.GetIntialState();
+        var state = annotation.GetInitialState();
 
         Assert.Equal("Custom", state.ResourceType);
 
@@ -45,24 +44,24 @@ public class DashboardResourceStateTests
     }
 
     [Fact]
-    public void InitialDashboardStateCanBeSpecified()
+    public void InitialStateCanBeSpecified()
     {
         var builder = DistributedApplication.CreateBuilder();
 
         var custom = builder.AddResource(new CustomResource("myResource"))
             .WithEndpoint(name: "ep", scheme: "http", hostPort: 8080)
             .WithEnvironment("x", "1000")
-            .WithDashboardState(() => new()
+            .WithCustomResourceState(() => new()
             {
                 ResourceType = "MyResource",
                 Properties = [("A", "B")],
             });
 
-        var annotation = custom.Resource.Annotations.OfType<DashboardAnnotation>().SingleOrDefault();
+        var annotation = custom.Resource.Annotations.OfType<CustomResourceAnnotation>().SingleOrDefault();
 
         Assert.NotNull(annotation);
 
-        var state = annotation.GetIntialState();
+        var state = annotation.GetInitialState();
 
         Assert.Equal("MyResource", state.ResourceType);
         Assert.Empty(state.EnviromentVariables);
@@ -81,13 +80,13 @@ public class DashboardResourceStateTests
         var custom = builder.AddResource(new CustomResource("myResource"))
             .WithEndpoint(name: "ep", scheme: "http", hostPort: 8080)
             .WithEnvironment("x", "1000")
-            .WithDashboardState();
+            .WithCustomResourceState();
 
-        var annotation = custom.Resource.Annotations.OfType<DashboardAnnotation>().SingleOrDefault();
+        var annotation = custom.Resource.Annotations.OfType<CustomResourceAnnotation>().SingleOrDefault();
 
         Assert.NotNull(annotation);
 
-        var state = annotation.GetIntialState();
+        var state = annotation.GetInitialState();
 
         state = state with { Properties = state.Properties.Add(("A", "value")) };
 

--- a/tests/Aspire.Hosting.Tests/CustomResourceStateTests.cs
+++ b/tests/Aspire.Hosting.Tests/CustomResourceStateTests.cs
@@ -21,7 +21,7 @@ public class CustomResourceStateTests
 
         Assert.NotNull(annotation);
 
-        var state = annotation.GetInitialState();
+        var state = annotation.GetInitialSnapshot();
 
         Assert.Equal("Custom", state.ResourceType);
 
@@ -61,7 +61,7 @@ public class CustomResourceStateTests
 
         Assert.NotNull(annotation);
 
-        var state = annotation.GetInitialState();
+        var state = annotation.GetInitialSnapshot();
 
         Assert.Equal("MyResource", state.ResourceType);
         Assert.Empty(state.EnviromentVariables);
@@ -86,7 +86,7 @@ public class CustomResourceStateTests
 
         Assert.NotNull(annotation);
 
-        var state = annotation.GetInitialState();
+        var state = annotation.GetInitialSnapshot();
 
         state = state with { Properties = state.Properties.Add(("A", "value")) };
 

--- a/tests/Aspire.Hosting.Tests/DashboardResourceStateTests.cs
+++ b/tests/Aspire.Hosting.Tests/DashboardResourceStateTests.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dashboard;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class DashboardResourceStateTests
+{
+    [Fact]
+    public void CreatePopulatesStateFromResource()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var custom = builder.AddResource(new CustomResource("myResource"))
+            .WithEndpoint(name: "ep", scheme: "http", hostPort: 8080)
+            .WithEnvironment("x", "1000")
+            .WithDashboardState();
+
+        var annotation = custom.Resource.Annotations.OfType<DashboardAnnotation>().SingleOrDefault();
+
+        Assert.NotNull(annotation);
+
+        var state = annotation.GetIntialState();
+
+        Assert.Equal("Custom", state.ResourceType);
+
+        Assert.Collection(state.EnviromentVariables, a =>
+        {
+            Assert.Equal("x", a.Name);
+            Assert.Equal("1000", a.Value);
+        });
+
+        Assert.Collection(state.Properties, c =>
+        {
+            Assert.Equal("ConnectionString", c.Key);
+            Assert.Equal("CustomConnectionString", c.Value);
+        });
+
+        Assert.Collection(state.Urls, u =>
+        {
+            Assert.Equal("http://localhost:8080", u);
+        });
+    }
+
+    [Fact]
+    public void InitialDashboardStateCanBeSpecified()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var custom = builder.AddResource(new CustomResource("myResource"))
+            .WithEndpoint(name: "ep", scheme: "http", hostPort: 8080)
+            .WithEnvironment("x", "1000")
+            .WithDashboardState(() => new()
+            {
+                ResourceType = "MyResource",
+                Properties = [("A", "B")],
+            });
+
+        var annotation = custom.Resource.Annotations.OfType<DashboardAnnotation>().SingleOrDefault();
+
+        Assert.NotNull(annotation);
+
+        var state = annotation.GetIntialState();
+
+        Assert.Equal("MyResource", state.ResourceType);
+        Assert.Empty(state.EnviromentVariables);
+        Assert.Collection(state.Properties, c =>
+        {
+            Assert.Equal("A", c.Key);
+            Assert.Equal("B", c.Value);
+        });
+    }
+
+    [Fact]
+    public async Task ResourceUpdatesAreQueued()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var custom = builder.AddResource(new CustomResource("myResource"))
+            .WithEndpoint(name: "ep", scheme: "http", hostPort: 8080)
+            .WithEnvironment("x", "1000")
+            .WithDashboardState();
+
+        var annotation = custom.Resource.Annotations.OfType<DashboardAnnotation>().SingleOrDefault();
+
+        Assert.NotNull(annotation);
+
+        var state = annotation.GetIntialState();
+
+        state = state with { Properties = state.Properties.Add(("A", "value")) };
+
+        await annotation.UpdateStateAsync(state);
+
+        state = state with { Properties = state.Properties.Add(("B", "value")) };
+
+        await annotation.UpdateStateAsync(state);
+
+        var enumerator = annotation.WatchAsync().GetAsyncEnumerator();
+
+        await enumerator.MoveNextAsync();
+
+        Assert.Equal("value", enumerator.Current.Properties.Single(p => p.Key == "A").Value);
+
+        await enumerator.MoveNextAsync();
+
+        Assert.Equal("value", enumerator.Current.Properties.Single(p => p.Key == "B").Value);
+    }
+
+    private sealed class CustomResource(string name) : Resource(name),
+        IResourceWithEnvironment,
+        IResourceWithConnectionString
+    {
+        public string? GetConnectionString() => "CustomConnectionString";
+    }
+}


### PR DESCRIPTION
- Added DashboardAnnotation which allows changing a dashboard state. There are 2 methods, one to create the initial state from resource annotations and another to send updates to the dashboard. These are immutable snapshots to avoid thread safety issues.
- Show all resources based on the app model before watching dcp for updates.


https://github.com/dotnet/aspire/assets/95136/487352a7-ac73-4a1d-8e5f-0194341daae0



Left TODO:
- ~Replicas are broken on the resources view with this change. We need to delete the existing project resources if there are replicas.~
- ~Tests?~

Follow up work to enable logging.

Fixes #436 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2390)