### PR TITLE
Update Azure PostgreSQL flexible server defaults

### DIFF
--- a/src/Aspire.Hosting.Azure/Bicep/postgres.bicep
+++ b/src/Aspire.Hosting.Azure/Bicep/postgres.bicep
@@ -5,12 +5,12 @@ param keyVaultName string
 param administratorLoginPassword string
 param location string = resourceGroup().location
 param serverName string
-param serverEdition string = 'GeneralPurpose'
-param skuSizeGB int = 128
-param dbInstanceType string = 'Standard_D4ds_v4'
-param haMode string = 'ZoneRedundant'
+param serverEdition string = 'Burstable'
+param skuSizeGB int = 32
+param dbInstanceType string = 'Standard_B1ms'
+param haMode string = 'Disabled'
 param availabilityZone string = '1'
-param version string = '12'
+param version string = '16'
 param databases array = []
 
 var resourceToken = uniqueString(resourceGroup().id)


### PR DESCRIPTION
Use the same defaults as the portal does for "Development" mode. This makes the default configuration cheaper for people who are developing/testing. It also uses the latest version (16) instead of 12 by default. Here's the current defaults in the portal:

![image](https://github.com/dotnet/aspire/assets/8291187/29ef875a-a01d-4a32-8bcb-4cadd4f0fa09)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2391)