### PR TITLE
Add better caching support for reusing configuration values

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -3,8 +3,10 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+builder.AddAzureProvisioning();
+
 var db = builder.AddAzureCosmosDB("cosmos")
-                .AddDatabase("db");
+                .AddDatabase("db2");
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithReference(db);

--- a/src/Aspire.Hosting.Azure.Provisioning/Aspire.Hosting.Azure.Provisioning.csproj
+++ b/src/Aspire.Hosting.Azure.Provisioning/Aspire.Hosting.Azure.Provisioning.csproj
@@ -27,4 +27,7 @@
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/BicepProvisioner.cs
@@ -1,18 +1,19 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Diagnostics;
+using System.IO.Hashing;
 using System.Text;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
 using Azure;
-using Azure.ResourceManager.KeyVault.Models;
 using Azure.ResourceManager.KeyVault;
+using Azure.ResourceManager.KeyVault.Models;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
+using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Azure.Security.KeyVault.Secrets;
 
 namespace Aspire.Hosting.Azure.Provisioning;
 
@@ -30,16 +31,13 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger) : Azure
             return false;
         }
 
-        // TODO: Cache contents by their checksum so we don't reuse changed outputs from potentially changed templates
+        var currentCheckSum = GetCurrentChecksum(resource, section);
+        var configCheckSum = section["CheckSum"];
 
-        //var checkSum = resource.GetChecksum();
-
-        //var checkSumSection = section.GetSection(checkSum);
-
-        //if (!checkSumSection.Exists())
-        //{
-        //    return false;
-        //}
+        if (currentCheckSum != configCheckSum)
+        {
+            return false;
+        }
 
         foreach (var item in section.GetSection("Outputs").GetChildren())
         {
@@ -136,29 +134,7 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger) : Azure
 
         // Convert the parameters to a JSON object
         var parameters = new JsonObject();
-        foreach (var parameter in resource.Parameters)
-        {
-            // Execute parameter values which are deferred.
-            object? parameterValue = parameter.Value is Func<object?> f ? f() : parameter.Value;
-
-            parameters[parameter.Key] = new JsonObject()
-            {
-                ["value"] = parameterValue switch
-                {
-                    string s => s,
-                    IEnumerable<string> s => new JsonArray(s.Select(s => JsonValue.Create(s)).ToArray()),
-                    int i => i,
-                    bool b => b,
-                    JsonNode node => node,
-                    IResourceBuilder<IResourceWithConnectionString> c => c.Resource.GetConnectionString(),
-                    IResourceBuilder<ParameterResource> p => p.Resource.Value,
-                    // TODO: Support this
-                    BicepOutputReference reference => throw new NotSupportedException("Referencing bicep outputs is not supported"),
-                    object o => o.ToString()!,
-                    null => null,
-                }
-            };
-        }
+        SetParameters(parameters, resource);
 
         var sw = Stopwatch.StartNew();
         var operation = await deployments.CreateOrUpdateAsync(WaitUntil.Completed, resource.Name, new ArmDeploymentContent(new(ArmDeploymentMode.Incremental)
@@ -189,18 +165,21 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger) : Azure
 
         var outputObj = outputs?.ToObjectFromJson<JsonObject>();
 
+        var resourceConfig = context.UserSecrets
+            .Prop("Azure")
+            .Prop("Deployments")
+            .Prop(resource.Name);
+
+        // Stash all parameters as a single JSON string
+        resourceConfig["Parameters"] = parameters.ToJsonString();
+
+        // Save the checksum to the configuration
+        resourceConfig["CheckSum"] = GetChecksum(resource, parameters);
+
         if (outputObj is not null)
         {
             // TODO: Make this more robust
-            // Cache contents by their checksum so we don't reuse changed outputs from potentially changed templates
-            // var checkSum = resource.GetChecksum();
-
-            var configOutputs = context.UserSecrets
-                .Prop("Azure")
-                .Prop("Deployments")
-                .Prop(resource.Name)
-                // .Prop(checkSum)
-                .Prop("Outputs");
+            var configOutputs = resourceConfig.Prop("Outputs");
 
             foreach (var item in outputObj.AsObject())
             {
@@ -219,12 +198,7 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger) : Azure
         // Populate secret outputs from key vault (if any)
         if (keyVault is not null)
         {
-            var configOutputs = context.UserSecrets
-                .Prop("Azure")
-                .Prop("Deployments")
-                .Prop(resource.Name)
-                // .Prop(checkSum)
-                .Prop("SecretOutputs");
+            var configOutputs = resourceConfig.Prop("SecretOutputs");
 
             var client = new SecretClient(keyVault.Data.Properties.VaultUri, context.Credential);
 
@@ -259,6 +233,9 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger) : Azure
         {
             resource.Parameters[AzureBicepResource.KnownParameters.PrincipalType] = "User";
         }
+
+        // Always specify the location
+        resource.Parameters[AzureBicepResource.KnownParameters.Location] = context.Location.Name;
     }
 
     private static async Task<bool> ExecuteCommand(ProcessSpec processSpec)
@@ -301,5 +278,94 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger) : Azure
         }
 
         return null;
+    }
+
+    internal static string GetChecksum(AzureBicepResource resource, JsonObject parameters)
+    {
+        // TODO: PERF Inefficient
+
+        // Combine the parameter values with the bicep template to create a unique value
+        var input = parameters.ToJsonString() + resource.GetBicepTemplateString();
+
+        // Hash the contents
+        var hashedContents = Crc32.Hash(Encoding.UTF8.GetBytes(input));
+
+        // Convert the hash to a string
+        return Convert.ToHexString(hashedContents).ToLowerInvariant();
+    }
+
+    internal static string? GetCurrentChecksum(AzureBicepResource resource, IConfiguration section)
+    {
+        // Fill in parameters from configuration
+        if (section["Parameters"] is not string jsonString)
+        {
+            return null;
+        }
+
+        try
+        {
+            var parameters = JsonNode.Parse(jsonString)?.AsObject();
+
+            if (parameters is null)
+            {
+                return null;
+            }
+
+            // Now overwite with live object values skipping known values.
+            // This is important because the provisioner will fill in the known values
+            SetParameters(parameters, resource, skipKnownValues: true);
+
+            // Get the checksum of the new values
+            return GetChecksum(resource, parameters);
+        }
+        catch
+        {
+            // Unable to parse the JSON, to treat it as not existing
+            return null;
+        }
+    }
+
+    // Known values since they will be filled in by the provisioner
+    private static readonly string[] s_knownParameterNames =
+    [
+        AzureBicepResource.KnownParameters.PrincipalName,
+        AzureBicepResource.KnownParameters.PrincipalId,
+        AzureBicepResource.KnownParameters.PrincipalType,
+        AzureBicepResource.KnownParameters.KeyVaultName,
+        AzureBicepResource.KnownParameters.Location,
+    ];
+
+    // Converts the parameters to a JSON object compatible with the ARM template
+    internal static void SetParameters(JsonObject parameters, AzureBicepResource resource, bool skipKnownValues = false)
+    {
+        // Convert the parameters to a JSON object
+        foreach (var parameter in resource.Parameters)
+        {
+            if (skipKnownValues && s_knownParameterNames.Contains(parameter.Key))
+            {
+                continue;
+            }
+
+            // Execute parameter values which are deferred.
+            var parameterValue = parameter.Value is Func<object?> f ? f() : parameter.Value;
+
+            parameters[parameter.Key] = new JsonObject()
+            {
+                ["value"] = parameterValue switch
+                {
+                    string s => s,
+                    IEnumerable<string> s => new JsonArray(s.Select(s => JsonValue.Create(s)).ToArray()),
+                    int i => i,
+                    bool b => b,
+                    JsonNode node => node,
+                    IResourceBuilder<IResourceWithConnectionString> c => c.Resource.GetConnectionString(),
+                    IResourceBuilder<ParameterResource> p => p.Resource.Value,
+                    // TODO: Support this
+                    BicepOutputReference reference => throw new NotSupportedException("Referencing bicep outputs is not supported"),
+                    object o => o.ToString()!,
+                    null => null,
+                }
+            };
+        }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Provisioning\Aspire.Hosting.Azure.Provisioning.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting\Aspire.Hosting.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\testproject\TestProject.AppHost\TestProject.AppHost.csproj" IsAspireProjectResource="false" />

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
@@ -1,0 +1,150 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Nodes;
+using Aspire.Hosting.Azure;
+using Aspire.Hosting.Azure.Provisioning;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Azure;
+
+public class AzureBicepProvisionerTests
+{
+    [Fact]
+    public void SetParametersTranslatesParametersToARMCompatibleJsonParameters()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
+               .WithParameter("name", "david");
+
+        var parameters = new JsonObject();
+        BicepProvisioner.SetParameters(parameters, bicep0.Resource);
+
+        Assert.Single(parameters);
+        Assert.Equal("david", parameters["name"]?["value"]?.ToString());
+    }
+
+    [Fact]
+    public void SetParametersTranslatesCompatibleParameterTypes()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var connectionStringResource = builder.CreateResourceBuilder(
+            new ResourceWithConnectionString("A", "connection string"));
+
+        var param = builder.AddParameter("param", () => "paramValue");
+
+        var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
+               .WithParameter("name", "john")
+               .WithParameter("age", () => 20)
+               .WithParameter("values", ["a", "b", "c"])
+               .WithParameter("conn", connectionStringResource)
+               .WithParameter("jsonObj", new JsonObject { ["key"] = "value" })
+               .WithParameter("param", param);
+
+        var parameters = new JsonObject();
+        BicepProvisioner.SetParameters(parameters, bicep0.Resource);
+
+        Assert.Equal(6, parameters.Count);
+        Assert.Equal("john", parameters["name"]?["value"]?.ToString());
+        Assert.Equal(20, parameters["age"]?["value"]?.GetValue<int>());
+        Assert.Equal(["a", "b", "c"], parameters["values"]?["value"]?.AsArray()?.Select(v => v?.ToString()) ?? []);
+        Assert.Equal("connection string", parameters["conn"]?["value"]?.ToString());
+        Assert.Equal("value", parameters["jsonObj"]?["value"]?["key"]?.ToString());
+        Assert.Equal("paramValue", parameters["param"]?["value"]?.ToString());
+    }
+
+    [Fact]
+    public void ResourceWithTheSameBicepTemplateAndParametersHaveTheSameCheckSum()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
+                       .WithParameter("name", "david")
+                       .WithParameter("age", () => 20)
+                       .WithParameter("values", ["a", "b", "c"])
+                       .WithParameter("jsonObj", new JsonObject { ["key"] = "value" });
+
+        var bicep1 = builder.AddBicepTemplateString("bicep1", "param name string")
+                       .WithParameter("name", "david")
+                       .WithParameter("age", () => 20)
+                       .WithParameter("values", ["a", "b", "c"])
+                       .WithParameter("jsonObj", new JsonObject { ["key"] = "value" });
+
+        var parameters0 = new JsonObject();
+        BicepProvisioner.SetParameters(parameters0, bicep0.Resource);
+        var checkSum0 = BicepProvisioner.GetChecksum(bicep0.Resource, parameters0);
+
+        var parameters1 = new JsonObject();
+        BicepProvisioner.SetParameters(parameters1, bicep1.Resource);
+        var checkSum1 = BicepProvisioner.GetChecksum(bicep1.Resource, parameters1);
+
+        Assert.Equal(checkSum0, checkSum1);
+    }
+
+    [Fact]
+    public void ResourceWithSameTemplateButDifferentParametersHaveDifferentChecksums()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
+                       .WithParameter("name", "david")
+                       .WithParameter("age", () => 20)
+                       .WithParameter("values", ["a", "b", "c"]);
+
+        var bicep1 = builder.AddBicepTemplateString("bicep1", "param name string")
+                       .WithParameter("name", "david")
+                       .WithParameter("age", () => 20)
+                       .WithParameter("values", ["a", "b", "c"])
+                       .WithParameter("jsonObj", new JsonObject { ["key"] = "value" });
+
+        var parameters0 = new JsonObject();
+        BicepProvisioner.SetParameters(parameters0, bicep0.Resource);
+        var checkSum0 = BicepProvisioner.GetChecksum(bicep0.Resource, parameters0);
+
+        var parameters1 = new JsonObject();
+        BicepProvisioner.SetParameters(parameters1, bicep1.Resource);
+        var checkSum1 = BicepProvisioner.GetChecksum(bicep1.Resource, parameters1);
+
+        Assert.NotEqual(checkSum0, checkSum1);
+    }
+
+    [Fact]
+    public void GetCurrentChecksumSkipsKnownValuesForCheckSumCreation()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
+                       .WithParameter("name", "david")
+                       .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName);
+
+        // Simulate the case where a known parameter has a value
+        var bicep1 = builder.AddBicepTemplateString("bicep1", "param name string")
+                       .WithParameter("name", "david")
+                       .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName, "blah")
+                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalId, "id")
+                       .WithParameter(AzureBicepResource.KnownParameters.Location, "tomorrow")
+                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalType, "type");
+
+        var parameters0 = new JsonObject();
+        BicepProvisioner.SetParameters(parameters0, bicep0.Resource);
+        var checkSum0 = BicepProvisioner.GetChecksum(bicep0.Resource, parameters0);
+
+        // Save the old version of this resource's parameters to config
+        var config = new ConfigurationManager();
+        config["Parameters"] = parameters0.ToJsonString();
+
+        var checkSum1 = BicepProvisioner.GetCurrentChecksum(bicep1.Resource, config);
+
+        Assert.Equal(checkSum0, checkSum1);
+    }
+
+    private sealed class ResourceWithConnectionString(string name, string connectionString) :
+        Resource(name),
+        IResourceWithConnectionString
+    {
+        public string? GetConnectionString() => connectionString;
+    }
+}


### PR DESCRIPTION
- Store a crc32 hash of the parameters and bicep template in config. We'll only re-use the outputs if the hash matches. This should handle template and parameter changes when using the bicep provisioner.
- Moved check sum calculation to the bicep provisioner.
- Also added the location as a required parameter to any bicep module
- Avoid going remote if checksum is OK (lazily access the azure configuration).
- Don't continue running if azure configuration is needed and isn't provided.

Fixes https://github.com/dotnet/aspire/issues/2384
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2392)