### PR TITLE
Use Polly.Core resilience strategies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,7 +89,6 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.121" />
     <PackageVersion Include="Polly" Version="8.3.0" />
-    <PackageVersion Include="Polly.Extensions" Version="8.3.0" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.17" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,6 +89,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.121" />
     <PackageVersion Include="Polly" Version="8.3.0" />
+    <PackageVersion Include="Polly.Core" Version="8.3.0" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.17" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,6 +89,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.121" />
     <PackageVersion Include="Polly" Version="8.3.0" />
+    <PackageVersion Include="Polly.Extensions" Version="8.3.0" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.17" />

--- a/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
+++ b/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="Polly" />
+    <PackageReference Include="Polly.Core" />
     <PackageReference Include="RabbitMQ.Client" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>

--- a/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
+++ b/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="Polly" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="RabbitMQ.Client" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
+++ b/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Polly" />
+    <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="RabbitMQ.Client" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>

--- a/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
+++ b/src/Components/Aspire.RabbitMQ.Client/Aspire.RabbitMQ.Client.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="Polly.Extensions" />
+    <PackageReference Include="Polly" />
     <PackageReference Include="RabbitMQ.Client" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>

--- a/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
@@ -173,7 +173,7 @@ public static class AspireRabbitMQExtensions
         using var activity = s_activitySource.StartActivity("rabbitmq connect", ActivityKind.Client);
         AddRabbitMQTags(activity);
 
-        return resiliencePipeline.Execute(() =>
+        return resiliencePipeline.Execute(static factory =>
         {
             using var connectAttemptActivity = s_activitySource.StartActivity("rabbitmq connect attempt", ActivityKind.Client);
             AddRabbitMQTags(connectAttemptActivity, "connect");
@@ -196,7 +196,7 @@ public static class AspireRabbitMQExtensions
                 }
                 throw;
             }
-        });
+        }, factory);
     }
 
     private static void AddRabbitMQTags(Activity? activity, string? operation = null)

--- a/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
@@ -152,9 +152,6 @@ public static class AspireRabbitMQExtensions
 
     private static IConnection CreateConnection(IConnectionFactory factory, int retryCount)
     {
-        using var activity = s_activitySource.StartActivity("rabbitmq connect", ActivityKind.Client);
-        AddRabbitMQTags(activity);
-
         var resiliencePipelineBuilder = new ResiliencePipelineBuilder();
         if (retryCount > 0)
         {
@@ -169,6 +166,9 @@ public static class AspireRabbitMQExtensions
             });
         }
         var resiliencePipeline = resiliencePipelineBuilder.Build();
+
+        using var activity = s_activitySource.StartActivity("rabbitmq connect", ActivityKind.Client);
+        AddRabbitMQTags(activity);
 
         return resiliencePipeline.Execute(static factory =>
         {

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -20,7 +20,6 @@
     <ProjectReference Include="..\..\src\Components\Aspire.Oracle.EntityFrameworkCore\Aspire.Oracle.EntityFrameworkCore.csproj" IsAspireProjectResource="false" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
-    <PackageReference Include="Polly" />
 
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
   </ItemGroup>

--- a/tests/testproject/TestProject.IntegrationServiceA/TestProject.IntegrationServiceA.csproj
+++ b/tests/testproject/TestProject.IntegrationServiceA/TestProject.IntegrationServiceA.csproj
@@ -13,6 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Polly" />
+    
     <ProjectReference Include="..\..\..\src\Components\Aspire.Confluent.Kafka\Aspire.Confluent.Kafka.csproj" />
     <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.Azure.Cosmos\Aspire.Microsoft.Azure.Cosmos.csproj" />
     <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.Data.SqlClient\Aspire.Microsoft.Data.SqlClient.csproj" />


### PR DESCRIPTION
Fixes #2077

- Use `ResiliencePipeline` instead of Policy directly, as per https://www.pollydocs.org/migration-v8.html#retry-results-in-v8.
- Convert `TimeSpan.FromSeconds(Max.Pow())` to `DelayBackoffType.Exponential`.
- Test `args.Outcome` (instead of using `Handle<TException>`) for better performance.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2400)