### PR TITLE
Show all resource endpoints on resource grid

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -74,13 +74,13 @@
                     <TemplateColumn Title="@ControlStringsLoc[nameof(ControlsStrings.PropertyGridValueColumnHeader)]" Class="valueColumn">
                         <GridValue Value="@context.Address" MaxDisplayLength="0">
                             <ContentAfterValue>
-                                @if (context.IsHttp)
+                                @if (context.Url != null)
                                 {
-                                    <a href="@context.Address" target="_blank">@context.Address</a>
+                                    <a href="@context.Url" target="_blank">@context.Url</a>
                                 }
                                 else
                                 {
-                                    @context.Address
+                                    @context.Text
                                 }
                             </ContentAfterValue>
                         </GridValue>

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -33,8 +33,8 @@ public partial class ResourceDetails
             vm.Value?.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true)
         ).AsQueryable();
 
-    private IQueryable<Endpoint> FilteredEndpoints => GetEndpoints()
-        .Where(v => v.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) || v.Address?.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true)
+    private IQueryable<DisplayedEndpoint> FilteredEndpoints => GetEndpoints()
+        .Where(v => v.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) || v.Text.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true)
         .AsQueryable();
 
     private IQueryable<SummaryValue> FilteredResourceValues => GetResourceValues()
@@ -96,17 +96,9 @@ public partial class ResourceDetails
         }
     }
 
-    private IEnumerable<Endpoint> GetEndpoints()
+    private IEnumerable<DisplayedEndpoint> GetEndpoints()
     {
-        foreach (var endpoint in Resource.Endpoints)
-        {
-            yield return new Endpoint { Name = Loc[Resources.Resources.ResourceDetailsEndpointUrl], IsHttp = true, Address = endpoint.EndpointUrl };
-            yield return new Endpoint { Name = Loc[Resources.Resources.ResourceDetailsProxyUrl], IsHttp = true, Address = endpoint.ProxyUrl };
-        }
-        foreach (var service in Resource.Services)
-        {
-            yield return new Endpoint { Name = service.Name, IsHttp = false, Address = service.AddressAndPort };
-        }
+        return ResourceEndpointHelpers.GetEndpoints(Resource, excludeServices: false, includeEndpointUrl: true);
     }
 
     private IEnumerable<SummaryValue> GetResourceValues()
@@ -205,13 +197,6 @@ public partial class ResourceDetails
             true when !foundUnmasked => true,
             _ => _areEnvironmentVariablesMasked
         };
-    }
-
-    private sealed class Endpoint
-    {
-        public bool IsHttp { get; init; }
-        public required string Name { get; init; }
-        public string? Address { get; init; }
     }
 
     private sealed class SummaryValue

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -22,6 +22,9 @@ public partial class ResourceDetails
     [Inject]
     public required IStringLocalizer<Resources.Resources> Loc { get; init; }
 
+    [Inject]
+    public required ILogger<ResourceDetails> Logger { get; init; }
+
     private bool IsSpecOnlyToggleDisabled => !Resource.Environment.All(i => !i.FromSpec) && !GetResourceValues().Any(v => v.KnownProperty == null);
 
     private bool _showAll;
@@ -98,7 +101,7 @@ public partial class ResourceDetails
 
     private IEnumerable<DisplayedEndpoint> GetEndpoints()
     {
-        return ResourceEndpointHelpers.GetEndpoints(Resource, excludeServices: false, includeEndpointUrl: true);
+        return ResourceEndpointHelpers.GetEndpoints(Logger, Resource, excludeServices: false, includeEndpointUrl: true);
     }
 
     private IEnumerable<SummaryValue> GetResourceValues()

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -1,41 +1,54 @@
 ﻿@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Resources
+@namespace Aspire.Dashboard.Components
 @inject IStringLocalizer<Columns> Loc
 
-<FluentStack Orientation="Orientation.Vertical">
-    @* If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None *@
-    @if (Resource.Endpoints.Length == 0 && (Resource.State == ResourceStates.FinishedState || Resource.ExpectedEndpointsCount == 0))
+@{
+    List<DisplayedEndpoint> displayedEndpoints;
+    string? additionalMessage = null;
+    if (Resource.Endpoints.Length == 0 && (Resource.State == ResourceStates.FinishedState || Resource.ExpectedEndpointsCount == 0))
     {
-        <span class="long-inner-content">@Loc[nameof(Columns.EndpointsColumnDisplayNone)]</span>
+        if (Resource.Services.Length == 0)
+        {
+            // If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None
+            additionalMessage = Loc[nameof(Columns.EndpointsColumnDisplayNone)];
+            displayedEndpoints = [];
+        }
+        else
+        {
+            displayedEndpoints = GetEndpoints(Resource);
+        }
+    }
+    else if (Resource.State != ResourceStates.FinishedState
+        && (Resource.ExpectedEndpointsCount is null || Resource.ExpectedEndpointsCount > Resource.Endpoints.Length))
+    {
+        // If we're expecting more endpoints, say Starting..., unless the app isn't running anymore.
+        // Don't include service only endpoints in the list until finished loading endpoints.
+        displayedEndpoints = GetEndpoints(Resource, excludeServices: true);
+        additionalMessage = Loc[nameof(Columns.EndpointsColumnDisplayPlaceholder)];
     }
     else
     {
-        @* If we have any, regardless of the state, go ahead and display them *@
-        foreach (var endpoint in Resource.Endpoints.OrderBy(e => e.ProxyUrl))
-        {
-            if (HasMultipleReplicas)
+        displayedEndpoints = GetEndpoints(Resource);
+    }
+}
+
+<ul class="endpoint-list">
+    @foreach (var displayedEndpoint in displayedEndpoints)
+    {
+        <li>
+            @if (displayedEndpoint.Url != null)
             {
-                <a href="@endpoint.ProxyUrl" target="_blank" class="long-inner-content">@endpoint.ProxyUrl</a>
-                <span class="long-inner-content">(<a href="@endpoint.EndpointUrl" target="_blank">@endpoint.EndpointUrl</a>)</span>
+                <a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Url</a>
             }
             else
             {
-                <a href="@endpoint.ProxyUrl" target="_blank" class="long-inner-content">@endpoint.ProxyUrl</a>
+                @displayedEndpoint.Text
             }
-        }
-        @* If we're expecting more, say Starting..., unless the app isn't running anymore *@
-        if (Resource.State != ResourceStates.FinishedState
-        && (Resource.ExpectedEndpointsCount is null || Resource.ExpectedEndpointsCount > Resource.Endpoints.Length))
-        {
-            <span class="long-inner-content">@Loc[nameof(Columns.EndpointsColumnDisplayPlaceholder)]</span>
-        }
+        </li>
     }
-</FluentStack>
-
-@code {
-    [Parameter, EditorRequired]
-    public required ResourceViewModel Resource { get; set; }
-
-    [Parameter, EditorRequired]
-    public required bool HasMultipleReplicas { get; set; }
-}
+    @if (!string.IsNullOrEmpty(additionalMessage))
+    {
+        <li>@additionalMessage</li>
+    }
+</ul>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components;
+
+public partial class EndpointsColumnDisplay
+{
+    [Parameter, EditorRequired]
+    public required ResourceViewModel Resource { get; set; }
+
+    [Parameter, EditorRequired]
+    public required bool HasMultipleReplicas { get; set; }
+
+    /// <summary>
+    /// A resource has services and endpoints. These can overlap. This method attempts to return a single list without duplicates.
+    /// </summary>
+    private static List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool excludeServices = false)
+    {
+        var displayedEndpoints = new List<DisplayedEndpoint>();
+
+        if (!excludeServices)
+        {
+            foreach (var service in resource.Services)
+            {
+                displayedEndpoints.Add(new DisplayedEndpoint
+                {
+                    Text = service.AddressAndPort,
+                    Address = service.AllocatedAddress,
+                    Port = service.AllocatedPort
+                });
+            }
+        }
+
+        foreach (var endpoint in resource.Endpoints)
+        {
+            Uri uri;
+            try
+            {
+                uri = new Uri(endpoint.ProxyUrl, UriKind.Absolute);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Couldn't parse '{endpoint.ProxyUrl}' to a URI.", ex);
+            }
+
+            // There isn't a good way to match services and endpoints other than by address and port.
+            var existingMatches = displayedEndpoints.Where(e => string.Equals(e.Address, uri.Host, StringComparisons.UrlHost) && e.Port == uri.Port).ToList();
+
+            if (existingMatches.Count > 0)
+            {
+                foreach (var e in existingMatches)
+                {
+                    e.Url = uri.OriginalString;
+                }
+            }
+            else
+            {
+                displayedEndpoints.Add(new DisplayedEndpoint
+                {
+                    Text = endpoint.ProxyUrl,
+                    Address = uri.Host,
+                    Port = uri.Port,
+                    Url = uri.OriginalString
+                });
+            }
+        }
+
+        // Display endpoints with a URL first, then by address and port.
+        return displayedEndpoints.OrderBy(e => e.Url != null).ThenBy(e => e.Address).ThenBy(e => e.Port).ToList();
+    }
+
+    private sealed class DisplayedEndpoint
+    {
+        public required string Text { get; set; }
+        public string? Address { get; set; }
+        public int? Port { get; set; }
+        public string? Url { get; set; }
+    }
+}

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
@@ -19,64 +19,6 @@ public partial class EndpointsColumnDisplay
     /// </summary>
     private static List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool excludeServices = false)
     {
-        var displayedEndpoints = new List<DisplayedEndpoint>();
-
-        if (!excludeServices)
-        {
-            foreach (var service in resource.Services)
-            {
-                displayedEndpoints.Add(new DisplayedEndpoint
-                {
-                    Text = service.AddressAndPort,
-                    Address = service.AllocatedAddress,
-                    Port = service.AllocatedPort
-                });
-            }
-        }
-
-        foreach (var endpoint in resource.Endpoints)
-        {
-            Uri uri;
-            try
-            {
-                uri = new Uri(endpoint.ProxyUrl, UriKind.Absolute);
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException($"Couldn't parse '{endpoint.ProxyUrl}' to a URI.", ex);
-            }
-
-            // There isn't a good way to match services and endpoints other than by address and port.
-            var existingMatches = displayedEndpoints.Where(e => string.Equals(e.Address, uri.Host, StringComparisons.UrlHost) && e.Port == uri.Port).ToList();
-
-            if (existingMatches.Count > 0)
-            {
-                foreach (var e in existingMatches)
-                {
-                    e.Url = uri.OriginalString;
-                }
-            }
-            else
-            {
-                displayedEndpoints.Add(new DisplayedEndpoint
-                {
-                    Text = endpoint.ProxyUrl,
-                    Address = uri.Host,
-                    Port = uri.Port,
-                    Url = uri.OriginalString
-                });
-            }
-        }
-
-        // Display endpoints with a URL first, then by address and port.
-        return displayedEndpoints.OrderBy(e => e.Url != null).ThenBy(e => e.Address).ThenBy(e => e.Port).ToList();
-    }
-
-    private sealed class DisplayedEndpoint
-    {
-        public required string Text { get; set; }
-        public string? Address { get; set; }
-        public int? Port { get; set; }
-        public string? Url { get; set; }
+        return ResourceEndpointHelpers.GetEndpoints(resource, excludeServices, includeEndpointUrl: false);
     }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
@@ -14,11 +14,14 @@ public partial class EndpointsColumnDisplay
     [Parameter, EditorRequired]
     public required bool HasMultipleReplicas { get; set; }
 
+    [Inject]
+    public required ILogger<EndpointsColumnDisplay> Logger { get; init; }
+
     /// <summary>
     /// A resource has services and endpoints. These can overlap. This method attempts to return a single list without duplicates.
     /// </summary>
-    private static List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool excludeServices = false)
+    private List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool excludeServices = false)
     {
-        return ResourceEndpointHelpers.GetEndpoints(resource, excludeServices, includeEndpointUrl: false);
+        return ResourceEndpointHelpers.GetEndpoints(Logger, resource, excludeServices, includeEndpointUrl: false);
     }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
@@ -1,0 +1,10 @@
+::deep.endpoint-list {
+    margin: 0;
+    padding: 0;
+}
+
+::deep.endpoint-list li {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -215,7 +215,7 @@ public class DashboardWebApplication : IAsyncDisposable
     {
         foreach (var uri in uris)
         {
-            if (string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(uri.Host, "localhost", StringComparisons.UrlHost))
             {
                 kestrelOptions.ListenLocalhost(uri.Port, ConfigureListenOptions);
             }

--- a/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/BrowserLinkOutgoingPeerResolver.cs
@@ -38,14 +38,14 @@ public sealed class BrowserLinkOutgoingPeerResolver : IOutgoingPeerResolver
         var url = OtlpHelpers.GetValue(attributes, "url.full") ?? OtlpHelpers.GetValue(attributes, "http.url");
 
         // Quick check of URL with EndsWith before more expensive Uri parsing.
-        if (url != null && url.EndsWith(lastSegment, StringComparison.OrdinalIgnoreCase))
+        if (url != null && url.EndsWith(lastSegment, StringComparisons.UrlPath))
         {
-            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && string.Equals(uri.Host, "localhost", StringComparisons.UrlHost))
             {
                 var parts = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Length == 2)
                 {
-                    if (Guid.TryParse(parts[0], out _) && string.Equals(parts[1], lastSegment, StringComparison.OrdinalIgnoreCase))
+                    if (Guid.TryParse(parts[0], out _) && string.Equals(parts[1], lastSegment, StringComparisons.UrlPath))
                     {
                         name = "Browser Link";
                         return true;

--- a/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
@@ -1,0 +1,89 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Dashboard.Model;
+
+internal static class ResourceEndpointHelpers
+{
+    /// <summary>
+    /// A resource has services and endpoints. These can overlap. This method attempts to return a single list without duplicates.
+    /// </summary>
+    public static List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool excludeServices = false, bool includeEndpointUrl = false)
+    {
+        var displayedEndpoints = new List<DisplayedEndpoint>();
+
+        if (!excludeServices)
+        {
+            foreach (var service in resource.Services)
+            {
+                displayedEndpoints.Add(new DisplayedEndpoint
+                {
+                    Name = service.Name,
+                    Text = service.AddressAndPort,
+                    Address = service.AllocatedAddress,
+                    Port = service.AllocatedPort
+                });
+            }
+        }
+
+        foreach (var endpoint in resource.Endpoints)
+        {
+            ProcessUrl(displayedEndpoints, endpoint.ProxyUrl, "ProxyUrl");
+            if (includeEndpointUrl)
+            {
+                ProcessUrl(displayedEndpoints, endpoint.EndpointUrl, "EndpointUrl");
+            }
+        }
+
+        // Display endpoints with a URL first, then by address and port.
+        return displayedEndpoints.OrderBy(e => e.Url == null).ThenBy(e => e.Address).ThenBy(e => e.Port).ToList();
+    }
+
+    private static void ProcessUrl(List<DisplayedEndpoint> displayedEndpoints, string url, string name)
+    {
+        Uri uri;
+        try
+        {
+            uri = new Uri(url, UriKind.Absolute);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Couldn't parse '{url}' to a URI.", ex);
+        }
+
+        // There isn't a good way to match services and endpoints other than by address and port.
+        var existingMatches = displayedEndpoints.Where(e => string.Equals(e.Address, uri.Host, StringComparisons.UrlHost) && e.Port == uri.Port).ToList();
+
+        if (existingMatches.Count > 0)
+        {
+            foreach (var e in existingMatches)
+            {
+                e.Url = uri.OriginalString;
+                e.Text = uri.OriginalString;
+            }
+        }
+        else
+        {
+            displayedEndpoints.Add(new DisplayedEndpoint
+            {
+                Name = name,
+                Text = url,
+                Address = uri.Host,
+                Port = uri.Port,
+                Url = uri.OriginalString
+            });
+        }
+    }
+}
+
+[DebuggerDisplay("Name = {Name}, Text = {Text}, Address = {Address}:{Port}, Url = {Url}")]
+public sealed class DisplayedEndpoint
+{
+    public required string Name { get; set; }
+    public required string Text { get; set; }
+    public string? Address { get; set; }
+    public int? Port { get; set; }
+    public string? Url { get; set; }
+}

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -3,10 +3,12 @@
 
 using System.Collections.Frozen;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Dashboard.Model;
 
+[DebuggerDisplay("Name = {Name}, ResourceType = {ResourceType}, State = {State}, Properties = {Properties.Count}")]
 public sealed class ResourceViewModel
 {
     public required string Name { get; init; }

--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -12,6 +12,7 @@ internal static class StringComparers
     public static StringComparer UserTextSearch => StringComparer.CurrentCultureIgnoreCase;
     public static StringComparer EnvironmentVariableName => StringComparer.InvariantCultureIgnoreCase;
     public static StringComparer UrlPath => StringComparer.OrdinalIgnoreCase;
+    public static StringComparer UrlHost => StringComparer.OrdinalIgnoreCase;
 }
 
 internal static class StringComparisons
@@ -23,4 +24,5 @@ internal static class StringComparisons
     public static StringComparison UserTextSearch => StringComparison.CurrentCultureIgnoreCase;
     public static StringComparison EnvironmentVariableName => StringComparison.InvariantCultureIgnoreCase;
     public static StringComparison UrlPath => StringComparison.OrdinalIgnoreCase;
+    public static StringComparison UrlHost => StringComparison.OrdinalIgnoreCase;
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -1,0 +1,142 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Frozen;
+using System.Collections.Immutable;
+using Aspire.Dashboard.Model;
+using Google.Protobuf.WellKnownTypes;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class ResourceEndpointHelpersTests
+{
+    [Fact]
+    public void GetEndpoints_Empty_NoResults()
+    {
+        var endpoints = ResourceEndpointHelpers.GetEndpoints(CreateResource(
+            endpoints: ImmutableArray<EndpointViewModel>.Empty,
+            services: ImmutableArray<ResourceServiceViewModel>.Empty));
+
+        Assert.Empty(endpoints);
+    }
+
+    [Fact]
+    public void GetEndpoints_HasServices_Results()
+    {
+        var endpoints = ResourceEndpointHelpers.GetEndpoints(CreateResource(
+            endpoints: ImmutableArray<EndpointViewModel>.Empty,
+            services: [new ResourceServiceViewModel("Test", "localhost", 8080)]));
+
+        Assert.Collection(endpoints,
+            e =>
+            {
+                Assert.Equal("localhost:8080", e.Text);
+                Assert.Equal("Test", e.Name);
+                Assert.Null(e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8080, e.Port);
+            });
+    }
+
+    [Fact]
+    public void GetEndpoints_HasEndpointAndService_Results()
+    {
+        var endpoints = ResourceEndpointHelpers.GetEndpoints(CreateResource(
+            endpoints: [new EndpointViewModel("http://localhost:8080", "http://localhost:8081")],
+            services: [new ResourceServiceViewModel("Test", "localhost", 8080), new ResourceServiceViewModel("Test2", "localhost", 8083)]));
+
+        Assert.Collection(endpoints,
+            e =>
+            {
+                Assert.Equal("localhost:8080", e.Text);
+                Assert.Equal("Test", e.Name);
+                Assert.Null(e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8080, e.Port);
+            },
+            e =>
+            {
+                Assert.Equal("localhost:8083", e.Text);
+                Assert.Equal("Test2", e.Name);
+                Assert.Null(e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8083, e.Port);
+            },
+            e =>
+            {
+                Assert.Equal("http://localhost:8081", e.Text);
+                Assert.Equal("ProxyUrl", e.Name);
+                Assert.Equal("http://localhost:8081", e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8081, e.Port);
+            });
+    }
+
+    [Fact]
+    public void GetEndpoints_IncludeEndpointUrl_HasEndpointAndService_Results()
+    {
+        var endpoints = ResourceEndpointHelpers.GetEndpoints(CreateResource(
+            endpoints: [
+                    new EndpointViewModel("https://localhost:8080/test", "https://localhost:8081/test2")
+                ],
+            services: [
+                    new ResourceServiceViewModel("First", "localhost", 80),
+                    new ResourceServiceViewModel("Test", "localhost", 8080),
+                    new ResourceServiceViewModel("Test2", "localhost", 8083)
+                ]),
+            includeEndpointUrl: true);
+
+        Assert.Collection(endpoints,
+            e =>
+            {
+                Assert.Equal("https://localhost:8080/test", e.Text);
+                Assert.Equal("Test", e.Name);
+                Assert.Equal("https://localhost:8080/test", e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8080, e.Port);
+            },
+            e =>
+            {
+                Assert.Equal("https://localhost:8081/test2", e.Text);
+                Assert.Equal("ProxyUrl", e.Name);
+                Assert.Equal("https://localhost:8081/test2", e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8081, e.Port);
+            },
+            e =>
+            {
+                Assert.Equal("localhost:80", e.Text);
+                Assert.Equal("First", e.Name);
+                Assert.Null(e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(80, e.Port);
+            },
+            e =>
+            {
+                Assert.Equal("localhost:8083", e.Text);
+                Assert.Equal("Test2", e.Name);
+                Assert.Null(e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8083, e.Port);
+            });
+    }
+
+    private static ResourceViewModel CreateResource(ImmutableArray<EndpointViewModel> endpoints, ImmutableArray<ResourceServiceViewModel> services)
+    {
+        return new ResourceViewModel
+        {
+            Name = "Name!",
+            ResourceType = "Container",
+            DisplayName = "Display name!",
+            Uid = Guid.NewGuid().ToString(),
+            CreationTimeStamp = DateTime.UtcNow,
+            Environment = ImmutableArray<EnvironmentVariableViewModel>.Empty,
+            Endpoints = endpoints,
+            Services = services,
+            ExpectedEndpointsCount = 0,
+            Properties = FrozenDictionary<string, Value>.Empty,
+            State = null
+        };
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -49,6 +49,14 @@ public sealed class ResourceEndpointHelpersTests
         Assert.Collection(endpoints,
             e =>
             {
+                Assert.Equal("http://localhost:8081", e.Text);
+                Assert.Equal("ProxyUrl", e.Name);
+                Assert.Equal("http://localhost:8081", e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8081, e.Port);
+            },
+            e =>
+            {
                 Assert.Equal("localhost:8080", e.Text);
                 Assert.Equal("Test", e.Name);
                 Assert.Null(e.Url);
@@ -62,14 +70,6 @@ public sealed class ResourceEndpointHelpersTests
                 Assert.Null(e.Url);
                 Assert.Equal("localhost", e.Address);
                 Assert.Equal(8083, e.Port);
-            },
-            e =>
-            {
-                Assert.Equal("http://localhost:8081", e.Text);
-                Assert.Equal("ProxyUrl", e.Name);
-                Assert.Equal("http://localhost:8081", e.Url);
-                Assert.Equal("localhost", e.Address);
-                Assert.Equal(8081, e.Port);
             });
     }
 

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -5,16 +5,28 @@ using System.Collections.Frozen;
 using System.Collections.Immutable;
 using Aspire.Dashboard.Model;
 using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.Model;
 
 public sealed class ResourceEndpointHelpersTests
 {
+    public static List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool excludeServices = false, bool includeEndpointUrl = false, ILogger? logger = null)
+    {
+        return ResourceEndpointHelpers.GetEndpoints(
+            logger ?? NullLogger.Instance,
+            resource,
+            excludeServices: excludeServices,
+            includeEndpointUrl: includeEndpointUrl);
+    }
+
     [Fact]
     public void GetEndpoints_Empty_NoResults()
     {
-        var endpoints = ResourceEndpointHelpers.GetEndpoints(CreateResource(
+        var endpoints = GetEndpoints(CreateResource(
             endpoints: ImmutableArray<EndpointViewModel>.Empty,
             services: ImmutableArray<ResourceServiceViewModel>.Empty));
 
@@ -24,7 +36,7 @@ public sealed class ResourceEndpointHelpersTests
     [Fact]
     public void GetEndpoints_HasServices_Results()
     {
-        var endpoints = ResourceEndpointHelpers.GetEndpoints(CreateResource(
+        var endpoints = GetEndpoints(CreateResource(
             endpoints: ImmutableArray<EndpointViewModel>.Empty,
             services: [new ResourceServiceViewModel("Test", "localhost", 8080)]));
 
@@ -42,7 +54,7 @@ public sealed class ResourceEndpointHelpersTests
     [Fact]
     public void GetEndpoints_HasEndpointAndService_Results()
     {
-        var endpoints = ResourceEndpointHelpers.GetEndpoints(CreateResource(
+        var endpoints = GetEndpoints(CreateResource(
             endpoints: [new EndpointViewModel("http://localhost:8080", "http://localhost:8081")],
             services: [new ResourceServiceViewModel("Test", "localhost", 8080), new ResourceServiceViewModel("Test2", "localhost", 8083)]));
 
@@ -74,9 +86,45 @@ public sealed class ResourceEndpointHelpersTests
     }
 
     [Fact]
+    public void GetEndpoints_HasEndpointAndService_InvalidEndpointUrl_Results()
+    {
+        var testSink = new TestSink();
+        var testLogger = new TestLogger("Test", testSink, enabled: true);
+
+        var endpoints = GetEndpoints(CreateResource(
+            endpoints: [new EndpointViewModel("INVALID_URL!@32:TEST", "http://localhost:8081")],
+            services: [new ResourceServiceViewModel("Test", "localhost", 8080)]), includeEndpointUrl: true, logger: testLogger);
+
+        Assert.Collection(endpoints,
+            e =>
+            {
+                Assert.Equal("http://localhost:8081", e.Text);
+                Assert.Equal("ProxyUrl", e.Name);
+                Assert.Equal("http://localhost:8081", e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8081, e.Port);
+            },
+            e =>
+            {
+                Assert.Equal("localhost:8080", e.Text);
+                Assert.Equal("Test", e.Name);
+                Assert.Null(e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8080, e.Port);
+            });
+
+        Assert.Collection(testSink.Writes,
+            w =>
+            {
+                Assert.Equal(LogLevel.Warning, w.LogLevel);
+                Assert.Equal("Couldn't parse 'INVALID_URL!@32:TEST' to a URI for resource Name!.", w.Message);
+            });
+    }
+
+    [Fact]
     public void GetEndpoints_IncludeEndpointUrl_HasEndpointAndService_Results()
     {
-        var endpoints = ResourceEndpointHelpers.GetEndpoints(CreateResource(
+        var endpoints = GetEndpoints(CreateResource(
             endpoints: [
                     new EndpointViewModel("https://localhost:8080/test", "https://localhost:8081/test2")
                 ],


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1489

* Displays a merged list of endpoints/services in the dashboard grid
* Only includes endpoint proxy URL. The underlying endpoint URL is still available in the details view.

The implementaiton is messy because:
* The data is split between endpoint and service collections on a resource.
* There is duplicate data between the two collections (endpoints appear to always have a service) and we don't want to display both
* There isn't a good way to match endpoints to a service. Forced to parse endpoint URL to a Uri and match with host/port.
* Services are immediately available while endpoints load in as they become available.

I think the model around endpoints and services returned from the resource service needs to be improved. At the very least, endpoints should have their service name to make matching them together easier.

**Demo:**
![resources-endpoints](https://github.com/dotnet/aspire/assets/303201/700acf4c-8e07-47b0-8c6e-83643fb37bac)
