### PR TITLE
Remove IgnoreEmulatorCertificate from Cosmos EF integration

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/CosmosEndToEnd.ApiService.csproj
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/CosmosEndToEnd.ApiService.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.Azure.Cosmos\Aspire.Microsoft.Azure.Cosmos.csproj" />
+    <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.EntityFrameworkCore.Cosmos\Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj" />
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
@@ -49,6 +49,7 @@ app.MapGet("/ef", async (TestCosmosContext context) =>
     await context.Database.EnsureCreatedAsync();
 
     context.Entries.Add(new EntityFrameworkEntry());
+    await context.SaveChangesAsync();
 
     return await context.Entries.ToListAsync();
 });

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -3,10 +3,9 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureProvisioning();
-
 var db = builder.AddAzureCosmosDB("cosmos")
-                .AddDatabase("db2");
+                .AddDatabase("db")
+                .UseEmulator();
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithReference(db);

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -3,6 +3,8 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+builder.AddAzureProvisioning();
+
 var db = builder.AddAzureCosmosDB("cosmos")
                 .AddDatabase("db")
                 .RunAsEmulator();

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -5,7 +5,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var db = builder.AddAzureCosmosDB("cosmos")
                 .AddDatabase("db")
-                .UseEmulator();
+                .RunAsEmulator();
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithReference(db);

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -81,7 +81,7 @@ internal sealed class AzureProvisioner(
 
         var armClientLazy = new Lazy<ArmClient>(() =>
         {
-            var subscriptionId = _options.SubscriptionId ?? throw new MissingConfigurationException("An azure subscription id is required. Set the Azure:SubscriptionId configuration value.");
+            var subscriptionId = _options.SubscriptionId ?? throw new MissingConfigurationException("An Azure subscription id is required. Set the Azure:SubscriptionId configuration value.");
 
             return new ArmClient(credential, subscriptionId);
         });

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -140,14 +140,11 @@ Aspire supports the usage of the Azure Cosmos DB emulator to use the emulator, a
 var cosmosdb = builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
 ```
 
-When the AppHost starts up a local container running the Azure CosmosDB will also be started. Inside the project that uses CosmosDB you can specify that you want to ignore the server certificate, so you don't need to manually download and install it:
+When the AppHost starts up a local container running the Azure CosmosDB will also be started:
 
 ```csharp
 // Service code
-builder.AddCosmosDB("cosmos", (settings) =>
-{
-    settings.IgnoreEmulatorCertificate = true;
-});
+builder.AddCosmosDB("cosmos");
 ```
 
 ## Additional documentation

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosDBExtensions.cs
@@ -99,12 +99,8 @@ public static class AspireAzureEFCoreCosmosDBExtensions
                 builder.Region(settings.Region);
             }
 
-            if (settings.IgnoreEmulatorCertificate && CosmosUtils.IsEmulatorConnectionString(settings.ConnectionString))
+            if (CosmosUtils.IsEmulatorConnectionString(settings.ConnectionString))
             {
-                builder.HttpClientFactory(() => new HttpClient(new HttpClientHandler()
-                {
-                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-                }));
                 builder.ConnectionMode(ConnectionMode.Gateway);
                 builder.LimitToEndpoint(true);
             }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
@@ -48,10 +48,6 @@
                       "type": "string",
                       "description": "The connection string of the Azure Cosmos DB server database to connect to."
                     },
-                    "IgnoreEmulatorCertificate": {
-                      "type": "boolean",
-                      "description": "Controls whether the Cosmos DB emulator certificate is ignored when its use is detected."
-                    },
                     "Metrics": {
                       "type": "boolean",
                       "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosDBSettings.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosDBSettings.cs
@@ -50,9 +50,4 @@ public sealed class EntityFrameworkCoreCosmosDBSettings
     /// Gets or sets a string value that indicates what Azure region this client will run in.
     /// </summary>
     public string? Region { get; set; }
-
-    /// <summary>
-    /// Controls whether the Cosmos DB emulator certificate is ignored when its use is detected.
-    /// </summary>
-    public bool IgnoreEmulatorCertificate { get; set; }
 }

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
@@ -133,14 +133,11 @@ Aspire supports the usage of the Azure Cosmos DB emulator to use the emulator, a
 var cosmosdb = builder.AddAzureCosmosDB("cosmos").RunAsEmulator();
 ```
 
-When the AppHost starts up a local container running the Azure CosmosDB will also be started. Inside the project that uses CosmosDB you also need to specify that you want to ignore the server certificate (so you don't need to manually download and install it):
+When the AppHost starts up a local container running the Azure CosmosDB will also be started:
 
 ```csharp
 // Service code
-builder.AddCosmosDbContext<MyDbContext>("cosmos", "mydb", (settings) =>
-{
-    settings.IgnoreEmulatorCertificate = true;
-});
+builder.AddCosmosDbContext<MyDbContext>("cosmos", "mydb");
 
 ```
 

--- a/src/Shared/Cosmos/CosmosUtils.cs
+++ b/src/Shared/Cosmos/CosmosUtils.cs
@@ -16,7 +16,11 @@ internal static class CosmosUtils
 
         var builder = new DbConnectionStringBuilder();
         builder.ConnectionString = connectionString;
-        var accountKeyFromConnectionString = builder["AccountKey"].ToString();
+        if (!builder.TryGetValue("AccountKey", out var v))
+        {
+            return false;
+        }
+        var accountKeyFromConnectionString = v.ToString();
         return accountKeyFromConnectionString == CosmosConstants.EmulatorAccountKey;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2424
Fixes https://github.com/dotnet/aspire/issues/2410

IgnoreEmulatorCertificate wasn't removed from EF settings.

Tested EF context works with Cosmos emulator in E2E.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2425)