### PR TITLE
Update the `DistributedApplicationLifecycle` to use shared terminology

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
+++ b/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
@@ -19,7 +19,7 @@ internal sealed class DistributedApplicationLifecycle(ILogger<DistributedApplica
     {
         if (executionContext.IsRunMode)
         {
-            logger.LogInformation("Distributed application started. Press CTRL-C to stop.");
+            logger.LogInformation("Distributed application started. Press Ctrl+C to shut down.");
         }
 
         return Task.CompletedTask;


### PR DESCRIPTION
When I first saw the text used to describe the shutting down of the app when reviewing the new Aspire Learn module, I thought it was a typo. We should really be consistent with the other app hosts in the .NET ecosystem.

For example, consider the `Microsoft.Hosting.Lifetime`:

![image](https://github.com/dotnet/aspire/assets/7679720/95538f6c-7e93-4d1f-ba41-bc98a9ae0517)

```diff
-Distributed application started. Press CTRL-C to stop.
+Distributed application started. Press Ctrl+C to shut down.
```

> [!NOTE]
> The casing of the `Ctrl`, a `+` instead of a `-`, and the term "shut down".
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2432)