### PR TITLE
Deferred endpoint mutation.

### DIFF
--- a/playground/TestShop/AppHost/Program.cs
+++ b/playground/TestShop/AppHost/Program.cs
@@ -19,7 +19,13 @@ var basketService = builder.AddProject("basketservice", @"..\BasketService\Baske
 
 builder.AddProject<Projects.MyFrontend>("frontend")
        .WithReference(basketService)
-       .WithReference(catalogService.GetEndpoint("http"));
+       .WithReference(catalogService.GetEndpoint("http"))
+       .WithEndpoint("https", endpoint =>
+       {
+           endpoint.IsExternal = true;
+       },
+       createIfNotExists: false,
+       deferred: true);
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor")
        .WithReference(messaging)

--- a/playground/TestShop/AppHost/Program.cs
+++ b/playground/TestShop/AppHost/Program.cs
@@ -23,9 +23,7 @@ builder.AddProject<Projects.MyFrontend>("frontend")
        .WithEndpoint("https", endpoint =>
        {
            endpoint.IsExternal = true;
-       },
-       createIfNotExists: false,
-       deferred: true);
+       });
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor")
        .WithReference(messaging)

--- a/playground/TestShop/AppHost/aspire-manifest.json
+++ b/playground/TestShop/AppHost/aspire-manifest.json
@@ -1,8 +1,8 @@
 {
   "resources": {
     "postgres": {
-      "connectionString": "Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres.inputs.password}",
       "type": "container.v0",
+      "connectionString": "Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres.inputs.password}",
       "image": "postgres:16.2",
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
@@ -30,12 +30,12 @@
       }
     },
     "catalogdb": {
-      "connectionString": "{postgres.connectionString};Database=catalogdb",
-      "type": "value.v0"
+      "type": "value.v0",
+      "connectionString": "{postgres.connectionString};Database=catalogdb"
     },
     "basketcache": {
-      "connectionString": "{basketcache.bindings.tcp.host}:{basketcache.bindings.tcp.port}",
       "type": "container.v0",
+      "connectionString": "{basketcache.bindings.tcp.host}:{basketcache.bindings.tcp.port}",
       "image": "redis:7.2.4",
       "bindings": {
         "tcp": {
@@ -68,8 +68,8 @@
       }
     },
     "messaging": {
-      "connectionString": "amqp://guest:{messaging.inputs.password}@{messaging.bindings.tcp.host}:{messaging.bindings.tcp.port}",
       "type": "container.v0",
+      "connectionString": "amqp://guest:{messaging.inputs.password}@{messaging.bindings.tcp.host}:{messaging.bindings.tcp.port}",
       "image": "rabbitmq:3",
       "env": {
         "RABBITMQ_DEFAULT_USER": "guest",
@@ -136,7 +136,8 @@
         "https": {
           "scheme": "https",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "external": true
         }
       }
     },

--- a/src/Aspire.Hosting/ApplicationModel/DeferredEndpointConfigurationCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DeferredEndpointConfigurationCallbackAnnotation.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+internal class DeferredEndpointConfigurationCallbackAnnotation(string endpointName, Action<EndpointAnnotation> callback) : IResourceAnnotation
+{
+    public string EndpointName { get; } = endpointName;
+    public Action<EndpointAnnotation> Callback { get; } = callback;
+}

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -360,7 +360,7 @@ public static class ResourceBuilderExtensions
     /// <param name="endpointName">Name of endpoint to change.</param>
     /// <param name="callback">Callback that modifies the endpoint.</param>
     /// <param name="createIfNotExists">Create endpoint if it does not exist.</param>
-    /// <param name="deferred">Defers execution of callback until before start.</param>
+    /// <param name="deferred">Defers execution of <paramref name="callback"/> until before start.</param>
     /// <returns></returns>
     public static IResourceBuilder<T> WithEndpoint<T>(this IResourceBuilder<T> builder, string endpointName, Action<EndpointAnnotation> callback, bool createIfNotExists = true, bool deferred = false) where T : IResourceWithEndpoints
     {

--- a/src/Aspire.Hosting/Lifecycle/DeferredEndpointConfigurationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Lifecycle/DeferredEndpointConfigurationLifecycleHook.cs
@@ -15,7 +15,8 @@ internal class DeferredEndpointConfigurationLifecycleHook : IDistributedApplicat
 
             if (endpointAnnotations.Any())
             {
-                var deferredAnnotations = resource.Annotations.OfType<DeferredEndpointConfigurationCallbackAnnotation>().ToDictionary(a => a.EndpointName);
+                var deferredAnnotations = resource.Annotations.OfType<DeferredEndpointConfigurationCallbackAnnotation>()
+                    .ToDictionary(a => a.EndpointName, StringComparers.EndpointAnnotationName);
 
                 foreach (var endpoint in endpointAnnotations)
                 {

--- a/src/Aspire.Hosting/Lifecycle/DeferredEndpointConfigurationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Lifecycle/DeferredEndpointConfigurationLifecycleHook.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Lifecycle;
+
+internal class DeferredEndpointConfigurationLifecycleHook : IDistributedApplicationLifecycleHook
+{
+    public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
+    {
+        foreach (var resource in appModel.Resources)
+        {
+            var endpointAnnotations = resource.Annotations.OfType<EndpointAnnotation>();
+
+            if (endpointAnnotations.Any())
+            {
+                var deferredAnnotations = resource.Annotations.OfType<DeferredEndpointConfigurationCallbackAnnotation>().ToDictionary(a => a.EndpointName);
+
+                foreach (var endpoint in endpointAnnotations)
+                {
+                    if (deferredAnnotations.TryGetValue(endpoint.Name, out var deferredAnnotation))
+                    {
+                        deferredAnnotation.Callback(endpoint);
+                    }
+                }
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -504,7 +504,7 @@ public class DistributedApplicationTests
     public async Task ProxylessEndpointWithoutPortThrows()
     {
         var testProgram = CreateTestProgram();
-        testProgram.ServiceABuilder.WithEndpoint("http", endpoint =>
+        testProgram.ServiceABuilder.ExcludeLaunchProfile().WithEndpoint("http", endpoint =>
         {
             endpoint.IsProxied = false;
         });
@@ -675,7 +675,7 @@ public class DistributedApplicationTests
                 b.UseSocketsHttpHandler((handler, sp) => handler.PooledConnectionLifetime = TimeSpan.FromSeconds(5));
             });
 
-        testProgram.ServiceABuilder.WithEndpoint("http", e => e.IsProxied = false, createIfNotExists: false, deferred: true);
+        testProgram.ServiceABuilder.WithEndpoint("http", e => e.IsProxied = false);
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         await using var app = testProgram.Build();

--- a/tests/Aspire.Hosting.Tests/Utils/TestUtils.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestUtils.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Lifecycle;
+
+namespace Aspire.Hosting.Tests;
+internal static class TestUtils
+{
+    public sealed class ThrowLifecycleHook : IDistributedApplicationLifecycleHook
+    {
+        public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -20,7 +20,7 @@ public class WithEndpointTests
         });
 
         // Throw before ApplicationExecutor starts doing real work
-        testProgram.AppBuilder.Services.AddLifecycleHook<ThrowLifecycleHook>();
+        testProgram.AppBuilder.Services.AddLifecycleHook<TestUtils.ThrowLifecycleHook>();
 
         var app = testProgram.Build();
 
@@ -48,7 +48,7 @@ public class WithEndpointTests
         Assert.False(testProgram.ServiceABuilder.Resource.TryGetAnnotationsOfType<EndpointAnnotation>(out _));
 
         // Throw before ApplicationExecutor starts doing real work
-        testProgram.AppBuilder.Services.AddLifecycleHook<ThrowLifecycleHook>();
+        testProgram.AppBuilder.Services.AddLifecycleHook<TestUtils.ThrowLifecycleHook>();
 
         var app = testProgram.Build();
 
@@ -124,7 +124,7 @@ public class WithEndpointTests
         Assert.False(testProgram.ServiceABuilder.Resource.TryGetAnnotationsOfType<EndpointAnnotation>(out _));
 
         // Throw before ApplicationExecutor starts doing real work
-        testProgram.AppBuilder.Services.AddLifecycleHook<ThrowLifecycleHook>();
+        testProgram.AppBuilder.Services.AddLifecycleHook<TestUtils.ThrowLifecycleHook>();
 
         var app = testProgram.Build();
 
@@ -140,13 +140,4 @@ public class WithEndpointTests
     }
 
     private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithEndpointTests>(args);
-
-    private sealed class ThrowLifecycleHook : IDistributedApplicationLifecycleHook
-    {
-        public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
-        {
-            throw new InvalidOperationException();
-        }
-    }
-
 }


### PR DESCRIPTION
Addresses #2099 

This still needs work, but this builds on the endpoint mutation API:

```csharp
builder.AddProject<Projects.MyFrontend>("frontend")
       .WithReference(basketService)
       .WithReference(catalogService.GetEndpoint("http"))
       .WithEndpoint("https", endpoint =>
       {
           endpoint.IsExternal = true;
       },
       createIfNotExists: false,
       deferred: true);
```

This is not the API that we would expect users to use, we probably want to be able to something like this:

```csharp
builder.AddProject<Projects.MyFrontend>("frontend")
       .WithReference(basketService)
       .WithReference(catalogService.GetEndpoint("http"))
       .WithPublicEndpoint("https"); // Sets deferred callback.
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2448)