### PR TITLE
workaround broken dependabot

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <!-- Workaround https://github.com/dependabot/dependabot-core/issues/8490 -->
-  <Import Project="eng/Versions.props" />
+  <Import Project="eng/Versions.props" Condition="'$(MajorVersion)' == ''"/>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,6 @@
 <Project>
+  <!-- Workaround https://github.com/dependabot/dependabot-core/issues/8490 -->
+  <Import Project="eng/Versions.props" />
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>


### PR DESCRIPTION
This should work around https://github.com/dependabot/dependabot-core/issues/8490 but it will create 232 warnings like 

```
C:\git\aspire\Directory.Packages.props(3,3): warning MSB4011: "C:\git\aspire\eng\Versions.props" cannot be imported aga
in. It was already imported at "C:\Users\danmose\.nuget\packages\microsoft.dotnet.arcade.sdk\8.0.0-beta.24113.2\tools\D
efaultVersions.props (15,3)". This is most likely a build authoring error. This subsequent import will be ignored. [C:\
git\aspire\playground\ProxylessEndToEnd\ProxylessEndToEnd.ApiService\ProxylessEndToEnd.ApiService.csproj]
```

@joperezr do you know a way to disable these warnings centrally these days? If not, we can put this into another branch, and periodically set that to the default branch temporarily (so it's dependabot's target) and manually run dependabot, then merge any dependabot changes to main.. or something ...
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2455)