### PR TITLE
Fix keyboard shortcuts, url casing and JSDisconnectedException

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
@@ -184,7 +184,7 @@ public partial class SummaryDetailsView<T>
 
     public async Task OnPageKeyDownAsync(KeyboardEventArgs args)
     {
-        if (_splitterRef is null || !args.ShiftKey)
+        if (_splitterRef is null || !args.ShiftKey || args.AltKey || args.CtrlKey)
         {
             return;
         }

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
@@ -184,7 +185,7 @@ public partial class SummaryDetailsView<T>
 
     public async Task OnPageKeyDownAsync(KeyboardEventArgs args)
     {
-        if (_splitterRef is null || !args.ShiftKey || args.AltKey || args.CtrlKey)
+        if (_splitterRef is null || !args.OnlyShiftPressed())
         {
             return;
         }

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Components.Dialogs;
+using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -148,7 +149,7 @@ public partial class MainLayout
 
     public async Task OnPageKeyDownAsync(KeyboardEventArgs args)
     {
-        if (args.ShiftKey && !args.CtrlKey && !args.AltKey)
+        if (args.OnlyShiftPressed())
         {
             if (args.Key is "?")
             {
@@ -159,7 +160,7 @@ public partial class MainLayout
                 await LaunchSettingsAsync();
             }
         }
-        else if (!args.ShiftKey && !args.CtrlKey && !args.AltKey)
+        else if (args.NoModifiersPressed())
         {
             var url = args.Key.ToLower() switch
             {

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -148,7 +148,7 @@ public partial class MainLayout
 
     public async Task OnPageKeyDownAsync(KeyboardEventArgs args)
     {
-        if (args.ShiftKey)
+        if (args.ShiftKey && !args.CtrlKey && !args.AltKey)
         {
             if (args.Key is "?")
             {
@@ -159,15 +159,15 @@ public partial class MainLayout
                 await LaunchSettingsAsync();
             }
         }
-        else
+        else if (!args.ShiftKey && !args.CtrlKey && !args.AltKey)
         {
             var url = args.Key.ToLower() switch
             {
                 "r" => "/",
-                "c" => "/ConsoleLogs",
-                "s" => "/StructuredLogs",
-                "t" => "/Traces",
-                "m" => "/Metrics",
+                "c" => "/consolelogs",
+                "s" => "/structuredlogs",
+                "t" => "/traces",
+                "m" => "/metrics",
                 _ => null
             };
 

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -187,6 +187,14 @@ public partial class MainLayout
 
     public async ValueTask DisposeAsync()
     {
-        await JS.InvokeVoidAsync("window.unregisterGlobalKeydownListener", _keyboardHandlers);
+        try
+        {
+            await JS.InvokeVoidAsync("window.unregisterGlobalKeydownListener", _keyboardHandlers);
+        }
+        catch (JSDisconnectedException)
+        {
+            // Per https://learn.microsoft.com/aspnet/core/blazor/javascript-interoperability/?view=aspnetcore-7.0#javascript-interop-calls-without-a-circuit
+            // this is one of the calls that will fail if the circuit is disconnected, and we just need to catch the exception so it doesn't pollute the logs
+        }
     }
 }

--- a/src/Aspire.Dashboard/Extensions/KeyboardEventArgsExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/KeyboardEventArgsExtensions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Aspire.Dashboard.Extensions;
+
+internal static class KeyboardEventArgsExtensions
+{
+    public static bool NoModifiersPressed(this KeyboardEventArgs args)
+    {
+        return !args.AltKey && !args.CtrlKey && !args.MetaKey && !args.ShiftKey;
+    }
+
+    public static bool OnlyShiftPressed(this KeyboardEventArgs args)
+    {
+        return args.ShiftKey && !args.AltKey && !args.CtrlKey && !args.MetaKey;
+    }
+}


### PR DESCRIPTION
Fixes #2458 
Fixes #2461
Fixes #2462 

I'm a little surprised KeyboardEventArgs doesn't have a modifierkeys flags enum or something, so the checks to ensure other modifier keys (alt, ctrl) are not pressed are a little uglier than they could be. But this ensures they're only getting fired when the appropriate modifier keys (shift in some cases, none in others) are pressed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2466)