### PR TITLE
Fix shortcuts changing multiple browser windows

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -1,6 +1,5 @@
 ﻿@using Aspire.Dashboard.Resources
 @inject IStringLocalizer<ControlsStrings> Loc
-@implements Aspire.Dashboard.Model.IGlobalKeydownListener
 @typeparam T
 
 <div class="summary-details-container">

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
@@ -11,7 +12,7 @@ using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Controls;
 
-public partial class SummaryDetailsView<T>
+public partial class SummaryDetailsView<T> : IGlobalKeydownListener, IDisposable
 {
     [Parameter]
     public RenderFragment? Summary { get; set; }
@@ -59,6 +60,9 @@ public partial class SummaryDetailsView<T>
 
     [Inject]
     public required IJSRuntime JS { get; set; }
+
+    [Inject]
+    public required ShortcutManager ShortcutManager { get; set; }
 
     private readonly Icon _splitHorizontalIcon = new Icons.Regular.Size16.SplitHorizontal();
     private readonly Icon _splitVerticalIcon = new Icons.Regular.Size16.SplitVertical();

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -1,8 +1,6 @@
 ﻿@using Aspire.Dashboard.Components.CustomIcons;
 @using Aspire.Dashboard.Resources
 @inherits LayoutComponentBase
-@implements Aspire.Dashboard.Model.IGlobalKeydownListener
-@implements IAsyncDisposable
 
 <div class="layout">
     <div class="aspire-icon">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -11,12 +11,13 @@ using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Layout;
 
-public partial class MainLayout
+public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 {
     private IDisposable? _themeChangedSubscription;
     private IDisposable? _locationChangingRegistration;
     private IJSObjectReference? _jsModule;
     private IJSObjectReference? _keyboardHandlers;
+    private DotNetObjectReference<ShortcutManager>? _shortcutManagerReference;
     private IDialogReference? _openPageDialog;
 
     private const string SettingsDialogId = "SettingsDialog";
@@ -39,6 +40,9 @@ public partial class MainLayout
 
     [Inject]
     public required IDashboardClient DashboardClient { get; init; }
+
+    [Inject]
+    public required ShortcutManager ShortcutManager { get; init; }
 
     protected override void OnInitialized()
     {
@@ -75,7 +79,8 @@ public partial class MainLayout
         if (firstRender)
         {
             _jsModule = await JS.InvokeAsync<IJSObjectReference>("import", "/js/theme.js");
-            _keyboardHandlers = await JS.InvokeAsync<IJSObjectReference>("window.registerGlobalKeydownListener", typeof(App).Assembly.GetName().Name);
+            _shortcutManagerReference = DotNetObjectReference.Create(ShortcutManager);
+            _keyboardHandlers = await JS.InvokeAsync<IJSObjectReference>("window.registerGlobalKeydownListener", _shortcutManagerReference);
             ShortcutManager.AddGlobalKeydownListener(this);
 
             DialogService.OnDialogCloseRequested += (reference, _) =>
@@ -178,15 +183,21 @@ public partial class MainLayout
         }
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
+        _shortcutManagerReference?.Dispose();
         _themeChangedSubscription?.Dispose();
         _locationChangingRegistration?.Dispose();
         ShortcutManager.RemoveGlobalKeydownListener(this);
-    }
 
-    public async ValueTask DisposeAsync()
-    {
-        await JS.InvokeVoidAsync("window.unregisterGlobalKeydownListener", _keyboardHandlers);
+        try
+        {
+            await JS.InvokeVoidAsync("window.unregisterGlobalKeydownListener", _keyboardHandlers);
+        }
+        catch (JSDisconnectedException)
+        {
+            // Per https://learn.microsoft.com/aspnet/core/blazor/javascript-interoperability/?view=aspnetcore-7.0#javascript-interop-calls-without-a-circuit
+            // this is one of the calls that will fail if the circuit is disconnected, and we just need to catch the exception so it doesn't pollute the logs
+        }
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -224,7 +224,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         await StopWatchingLogsAsync();
         await ClearLogsAsync();
 
-        PageViewModel.SelectedResource = PageViewModel.SelectedOption.Id?.InstanceId is null ? null : _resourceByName[PageViewModel.SelectedOption.Id.InstanceId];
+        PageViewModel.SelectedResource = PageViewModel.SelectedOption?.Id?.InstanceId is null ? null : _resourceByName[PageViewModel.SelectedOption.Id.InstanceId];
         await this.AfterViewModelChangedAsync();
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -224,7 +224,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         await StopWatchingLogsAsync();
         await ClearLogsAsync();
 
-        PageViewModel.SelectedResource = PageViewModel.SelectedOption?.Id?.InstanceId is null ? null : _resourceByName[PageViewModel.SelectedOption.Id.InstanceId];
+        PageViewModel.SelectedResource = PageViewModel.SelectedOption.Id?.InstanceId is null ? null : _resourceByName[PageViewModel.SelectedOption.Id.InstanceId];
         await this.AfterViewModelChangedAsync();
     }
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -104,6 +104,8 @@ public class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddFluentUIComponents();
 
         builder.Services.AddSingleton<ThemeManager>();
+        // ShortcutManager is scoped because we want shortcuts to apply one browser window.
+        builder.Services.AddScoped<ShortcutManager>();
 
         builder.Services.AddLocalization();
 

--- a/src/Aspire.Dashboard/Model/IGlobalKeydownListener.cs
+++ b/src/Aspire.Dashboard/Model/IGlobalKeydownListener.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Components.Web;
 
 namespace Aspire.Dashboard.Model;
 
-public interface IGlobalKeydownListener : IDisposable
+public interface IGlobalKeydownListener
 {
     Task OnPageKeyDownAsync(KeyboardEventArgs args);
 }

--- a/src/Aspire.Dashboard/ShortcutManager.cs
+++ b/src/Aspire.Dashboard/ShortcutManager.cs
@@ -8,23 +8,28 @@ using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard;
 
-public static class ShortcutManager
+public sealed class ShortcutManager : IDisposable
 {
-    private static readonly ConcurrentDictionary<IGlobalKeydownListener, IGlobalKeydownListener> s_globalKeydownListenerComponents = [];
+    private readonly ConcurrentDictionary<IGlobalKeydownListener, IGlobalKeydownListener> _keydownListenerComponents = [];
 
-    public static void AddGlobalKeydownListener(IGlobalKeydownListener listener)
+    public void AddGlobalKeydownListener(IGlobalKeydownListener listener)
     {
-        s_globalKeydownListenerComponents[listener] = listener;
+        _keydownListenerComponents[listener] = listener;
     }
 
-    public static void RemoveGlobalKeydownListener(IGlobalKeydownListener listener)
+    public void RemoveGlobalKeydownListener(IGlobalKeydownListener listener)
     {
-        s_globalKeydownListenerComponents.Remove(listener, out _);
+        _keydownListenerComponents.Remove(listener, out _);
     }
 
     [JSInvokable]
-    public static Task OnGlobalKeyDown(KeyboardEventArgs args)
+    public Task OnGlobalKeyDown(KeyboardEventArgs args)
     {
-        return Task.WhenAll(s_globalKeydownListenerComponents.Values.Select(component => component.OnPageKeyDownAsync(args)));
+        return Task.WhenAll(_keydownListenerComponents.Values.Select(component => component.OnPageKeyDownAsync(args)));
+    }
+
+    public void Dispose()
+    {
+        _keydownListenerComponents.Clear();
     }
 }

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -275,12 +275,16 @@ function isInputElement(element, isRoot, isShadowRoot) {
     const tag = element.tagName.toLowerCase();
     // comes from https://developer.mozilla.org/en-US/docs/Web/API/Element/input_event
     // fluent-select does not use <select /> element
-    if (tag === "input" || tag === "textarea" || tag === "select" || tag === "fluent-select") return true;
+    if (tag === "input" || tag === "textarea" || tag === "select" || tag === "fluent-select") {
+        return true;
+    }
 
     if (isShadowRoot || isRoot) {
         const elementChildren = element.children;
         for (let i = 0; i < elementChildren.length; i++) {
-            if (isInputElement(elementChildren[i], false, isShadowRoot)) return true;
+            if (isInputElement(elementChildren[i], false, isShadowRoot)) {
+                return true;
+            }
         }
     }
 
@@ -288,14 +292,16 @@ function isInputElement(element, isRoot, isShadowRoot) {
     if (shadowRoot) {
         const shadowRootChildren = shadowRoot.children;
         for (let i = 0; i < shadowRootChildren.length; i++) {
-            if (isInputElement(shadowRootChildren[i], false, true)) return true;
+            if (isInputElement(shadowRootChildren[i], false, true)) {
+                return true;
+            }
         }
     }
 
     return false;
 }
 
-window.registerGlobalKeydownListener = function(assemblyName) {
+window.registerGlobalKeydownListener = function(shortcutManager) {
     const serializeEvent = function (e) {
         if (e) {
             return {
@@ -314,7 +320,7 @@ window.registerGlobalKeydownListener = function(assemblyName) {
 
     const keydownListener = function (e) {
         if (!isActiveElementInput()) {
-            DotNet.invokeMethodAsync(assemblyName, 'OnGlobalKeyDown', serializeEvent(e))
+            shortcutManager.invokeMethodAsync('OnGlobalKeyDown', serializeEvent(e));
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2467
Fixes https://github.com/dotnet/aspire/issues/2459

* Change `ShortcutManager` to an instance type and inject with scope lifetime
* Pass manager instance to JavaScript and call instance method on it
* IGlobalKeydownListener no longer implements `IDisposable`. We now rely on the implementing type to do clean up however it sees fit. This change was made because if a type implements `IDisposable` _and_ `IAsyncDisposable` then only `DisposeAsync` is called. This was causing leaks in `MainLayout` which never called cleanup code in `Dispose`. Each instance was never unregistered from the shortcut manager.
* Reference interfaces in code behind (prefer code behind when possible) 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2470)