### PR TITLE
Use OnDialogClosing instead of OnDialogResult to remove dialog reference in MainLayout

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -83,14 +83,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             _shortcutManagerReference = DotNetObjectReference.Create(ShortcutManager);
             _keyboardHandlers = await JS.InvokeAsync<IJSObjectReference>("window.registerGlobalKeydownListener", _shortcutManagerReference);
             ShortcutManager.AddGlobalKeydownListener(this);
-
-            DialogService.OnDialogCloseRequested += (reference, _) =>
-            {
-                if (reference.Id is HelpDialogId or SettingsDialogId)
-                {
-                    _openPageDialog = null;
-                }
-            };
+    
         }
     }
 


### PR DESCRIPTION
#2465 used OnDialogResult instead of OnDialogClosing to remove the dialog reference. This doesn't work when pressing outside of the dialog (it works when you click the X button or escape)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2476)