### PR TITLE
[tests] add a xunit.runner.json to get `[Long Running Test]` message

### DIFF
--- a/eng/testing/xunit.runner.json
+++ b/eng/testing/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "longRunningTestSeconds": 120
+}

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.Build.targets" />
   <PropertyGroup>
     <DeployRunSettingsFile Condition="'$(DeployRunSettingsFile)' == ''">true</DeployRunSettingsFile>
+    <XunitTestRunnerJson Condition="'$(XunitTestRunnerJson)' == ''">$(RepositoryEngineeringDir)testing\xunit.runner.json</XunitTestRunnerJson>
 
     <RunTestsOnHelix Condition="'$(RunTestsOnHelix)' == ''">false</RunTestsOnHelix>
     <SkipTests Condition="'$(SkipTests)' == '' and ('$(IsTestSupportProject)' == 'true' or '$(RunTestsOnHelix)' == 'true')">true</SkipTests>
@@ -9,6 +10,7 @@
 
   <ItemGroup>
     <None Include="$(RepositoryEngineeringDir)testing\.runsettings" CopyToOutputDirectory="PreserveNewest" Condition="'$(DeployRunSettingsFile)' == 'true'" />
+    <None Include="$(XunitTestRunnerJson)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <Target Name="ZipTestArchive" AfterTargets="Build" Condition="'$(ArchiveTests)' == 'true' and '$(RunTestsOnHelix)' == 'true'">


### PR DESCRIPTION
This will cause a message like:
`[xUnit.net 00:03:54.91] Aspire.EndToEnd.Tests: [Long Running Test] 'Aspire.EndToEnd.Tests.IntegrationServicesTests.VerifyComponentWorks(resourceName: sqlserver)', Elapsed: ...`
.. to be printed whenever a test runs over 2 minutes. This will help in debugging tests that might take too long to run, and crash or timeout on CI with no other information.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2501)