### PR TITLE
Fix console logs page subscribing twice

### DIFF
--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -68,13 +68,13 @@ internal sealed class DashboardClient : IDashboardClient
         if (address is null)
         {
             _state = StateDisabled;
-            _logger.LogInformation($"{ResourceServiceUrlVariableName} is not specified. Dashboard client services are unavailable.");
+            _logger.LogDebug($"{ResourceServiceUrlVariableName} is not specified. Dashboard client services are unavailable.");
             _cts.Cancel();
             _whenConnected.TrySetCanceled();
             return;
         }
 
-        _logger.LogInformation("Dashboard configured to connect to: {Address}", address);
+        _logger.LogDebug("Dashboard configured to connect to: {Address}", address);
 
         // Create the gRPC channel. This channel performs automatic reconnects.
         // We will dispose it when we are disposed.

--- a/src/Aspire.Dashboard/appsettings.Development.json
+++ b/src/Aspire.Dashboard/appsettings.Development.json
@@ -2,7 +2,9 @@
   "DetailedErrors": true,
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Debug",
+      "Grpc": "Information",
+      "Microsoft.Extensions": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   }


### PR DESCRIPTION
The dashboard was:
1. Subscribing to console log updates in initialize
2. Immediately canceling the subscription and starting a new one in parameters update

This PR removes the subscribe in initialize, improves logging, and some general clean up on this page.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2509)