### PR TITLE
Fixing argument name typo

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 public class AzureAppConfigurationResource(string name) :
-    AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.appconfig.bicep"),
+    AzureBicepResource(name, templateResourceName: "Aspire.Hosting.Azure.Bicep.appconfig.bicep"),
     IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="name">The resource name.</param>
 public class AzureApplicationInsightsResource(string name) :
-    AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.appinsights.bicep"),
+    AzureBicepResource(name, templateResourceName: "Aspire.Hosting.Azure.Bicep.appinsights.bicep"),
     IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -15,8 +15,8 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">Name of the resource. This will be the name of the deployment.</param>
 /// <param name="templateFile">The path to the bicep file.</param>
 /// <param name="templateString">A bicep snippet.</param>
-/// <param name="templateResouceName">The name of an embedded resource that represents the bicep file.</param>
-public class AzureBicepResource(string name, string? templateFile = null, string? templateString = null, string? templateResouceName = null) :
+/// <param name="templateResourceName">The name of an embedded resource that represents the bicep file.</param>
+public class AzureBicepResource(string name, string? templateFile = null, string? templateString = null, string? templateResourceName = null) :
     Resource(name),
     IAzureResource
 {
@@ -24,7 +24,7 @@ public class AzureBicepResource(string name, string? templateFile = null, string
 
     internal string? TemplateString { get; } = templateString;
 
-    internal string? TemplateResourceName { get; } = templateResouceName;
+    internal string? TemplateResourceName { get; } = templateResourceName;
 
     /// <summary>
     /// Parameters that will be passed into the bicep template.

--- a/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting;
 /// A resource that represents an Azure Cosmos DB.
 /// </summary>
 public class AzureCosmosDBResource(string name) :
-    AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.cosmosdb.bicep"),
+    AzureBicepResource(name, templateResourceName: "Aspire.Hosting.Azure.Bicep.cosmosdb.bicep"),
     IResourceWithConnectionString
 {
     internal List<string> Databases { get; } = [];

--- a/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 public class AzureKeyVaultResource(string name) :
-    AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.keyvault.bicep"),
+    AzureBicepResource(name, templateResourceName: "Aspire.Hosting.Azure.Bicep.keyvault.bicep"),
     IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzurePostgresResource.cs
+++ b/src/Aspire.Hosting.Azure/AzurePostgresResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="innerResource"><see cref="PostgresServerResource"/> that this resource wraps.</param>
 public class AzurePostgresResource(PostgresServerResource innerResource) :
-    AzureBicepResource(innerResource.Name, templateResouceName: "Aspire.Hosting.Azure.Bicep.postgres.bicep"),
+    AzureBicepResource(innerResource.Name, templateResourceName: "Aspire.Hosting.Azure.Bicep.postgres.bicep"),
     IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureRedisResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureRedisResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="innerResource">The inner resource.</param>
 public class AzureRedisResource(RedisResource innerResource) :
-    AzureBicepResource(innerResource.Name, templateResouceName: "Aspire.Hosting.Azure.Bicep.redis.bicep"),
+    AzureBicepResource(innerResource.Name, templateResourceName: "Aspire.Hosting.Azure.Bicep.redis.bicep"),
     IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureSearchResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureSearchResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 public class AzureSearchResource(string name) :
-    AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.search.bicep"),
+    AzureBicepResource(name, templateResourceName: "Aspire.Hosting.Azure.Bicep.search.bicep"),
     IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 public class AzureServiceBusResource(string name) :
-    AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.servicebus.bicep"),
+    AzureBicepResource(name, templateResourceName: "Aspire.Hosting.Azure.Bicep.servicebus.bicep"),
     IResourceWithConnectionString
 {
     internal List<string> Queues { get; } = [];

--- a/src/Aspire.Hosting.Azure/AzureSignalRResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureSignalRResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 public class AzureSignalRResource(string name) :
-    AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.signalr.bicep"),
+    AzureBicepResource(name, templateResourceName: "Aspire.Hosting.Azure.Bicep.signalr.bicep"),
     IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureSqlServerResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureSqlServerResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="innerResource">The <see cref="SqlServerServerResource"/> that this resource wraps.</param>
 public class AzureSqlServerResource(SqlServerServerResource innerResource) :
-    AzureBicepResource(innerResource.Name, templateResouceName: "Aspire.Hosting.Azure.Bicep.sql.bicep"),
+    AzureBicepResource(innerResource.Name, templateResourceName: "Aspire.Hosting.Azure.Bicep.sql.bicep"),
     IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureStorageResource.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 /// <param name="name"></param>
 public class AzureStorageResource(string name) :
-    AzureBicepResource(name, templateResouceName: "Aspire.Hosting.Azure.Bicep.storage.bicep")
+    AzureBicepResource(name, templateResourceName: "Aspire.Hosting.Azure.Bicep.storage.bicep")
 {
     /// <summary>
     /// Gets the "blobEndpoint" output reference from the bicep template for the Azure Storage resource.


### PR DESCRIPTION
The "templateResouceName" argument for an AzureBicepResource has a typo in the name. This minor PR fixes it and all dependencies that use it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2517)