### PR TITLE
Rename the annotations

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceExtensions.cs
@@ -11,18 +11,18 @@ namespace Aspire.Hosting;
 public static class CustomResourceExtensions
 {
     /// <summary>
-    /// Adds a callback to configure the dashboard context for a resource.
+    /// Initializes the resource with a <see cref="ResourceUpdatesAnnotation"/> that allows publishing and subscribing to changes in the state of this resource.
     /// </summary>
     /// <typeparam name="TResource">The resource.</typeparam>
     /// <param name="builder">The resource builder.</param>
     /// <param name="initialSnapshotFactory">The factory to create the initial <see cref="CustomResourceSnapshot"/> for this resource.</param>
     /// <returns>The resource builder.</returns>
-    public static IResourceBuilder<TResource> WithCustomResourceState<TResource>(this IResourceBuilder<TResource> builder, Func<CustomResourceSnapshot>? initialSnapshotFactory = null)
+    public static IResourceBuilder<TResource> WithResourceUpdates<TResource>(this IResourceBuilder<TResource> builder, Func<CustomResourceSnapshot>? initialSnapshotFactory = null)
         where TResource : IResource
     {
         initialSnapshotFactory ??= () => CustomResourceSnapshot.Create(builder.Resource);
 
-        return builder.WithAnnotation(new CustomResourceAnnotation(initialSnapshotFactory), ResourceAnnotationMutationBehavior.Replace);
+        return builder.WithAnnotation(new ResourceUpdatesAnnotation(initialSnapshotFactory), ResourceAnnotationMutationBehavior.Replace);
     }
 
     /// <summary>
@@ -34,6 +34,6 @@ public static class CustomResourceExtensions
     public static IResourceBuilder<TResource> WithResourceLogger<TResource>(this IResourceBuilder<TResource> builder)
         where TResource : IResource
     {
-        return builder.WithAnnotation(new CustomResourceLoggerAnnotation(), ResourceAnnotationMutationBehavior.Replace);
+        return builder.WithAnnotation(new ResourceLoggerAnnotation(), ResourceAnnotationMutationBehavior.Replace);
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceUpdatesAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceUpdatesAnnotation.cs
@@ -103,7 +103,7 @@ public sealed record CustomResourceSnapshot
     /// <summary>
     /// The environment variables that should show up in the dashboard for this resource.
     /// </summary>
-    public ImmutableArray<(string Name, string Value)> EnviromentVariables { get; init; } = [];
+    public ImmutableArray<(string Name, string Value)> EnvironmentVariables { get; init; } = [];
 
     /// <summary>
     /// The URLs that should show up in the dashboard for this resource.
@@ -150,7 +150,7 @@ public sealed record CustomResourceSnapshot
         return new CustomResourceSnapshot()
         {
             ResourceType = resource.GetType().Name.Replace("Resource", ""),
-            EnviromentVariables = environmentVariables,
+            EnvironmentVariables = environmentVariables,
             Urls = urls,
             Properties = properties
         };

--- a/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ConsoleLogPublisher.cs
@@ -83,7 +83,7 @@ internal sealed class ConsoleLogPublisher(
 
     private static LogsEnumerable SubscribeGenericResource(IResource resource)
     {
-        if (resource.TryGetLastAnnotation<CustomResourceLoggerAnnotation>(out var loggerAnnotation))
+        if (resource.TryGetLastAnnotation<ResourceLoggerAnnotation>(out var loggerAnnotation))
         {
             return loggerAnnotation.WatchAsync();
         }

--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -231,7 +231,7 @@ internal sealed class DcpDataSource
     private static GenericResourceSnapshot CreateResourceSnapshot(IResource resource, DateTime creationTimestamp, CustomResourceSnapshot dashboardState)
     {
         ImmutableArray<EnvironmentVariableSnapshot> environmentVariables = [..
-            dashboardState.EnviromentVariables.Select(e => new EnvironmentVariableSnapshot(e.Name, e.Value, false))];
+            dashboardState.EnvironmentVariables.Select(e => new EnvironmentVariableSnapshot(e.Name, e.Value, false))];
 
         ImmutableArray<EndpointSnapshot> endpoints = [..
             dashboardState.Urls.Select(u => new EndpointSnapshot(u, u))];

--- a/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DcpDataSource.cs
@@ -197,11 +197,11 @@ internal sealed class DcpDataSource
 
             await _onResourceChanged(snapshot, ResourceSnapshotChangeType.Upsert).ConfigureAwait(false);
         }
-        else if (resource.TryGetLastAnnotation<CustomResourceAnnotation>(out var dashboardAnnotation))
+        else if (resource.TryGetLastAnnotation<ResourceUpdatesAnnotation>(out var resourceUpdates))
         {
             // We have a dashboard annotation, so we want to create a snapshot for the resource
             // and update data immediately. We also want to watch for changes to the dashboard state.
-            var state = dashboardAnnotation.GetInitialSnapshot();
+            var state = resourceUpdates.GetInitialSnapshot();
             var creationTimestamp = DateTime.UtcNow;
 
             var snapshot = CreateResourceSnapshot(resource, creationTimestamp, state);
@@ -210,7 +210,7 @@ internal sealed class DcpDataSource
 
             _ = Task.Run(async () =>
             {
-                await foreach (var state in dashboardAnnotation.WatchAsync(cancellationToken))
+                await foreach (var state in resourceUpdates.WatchAsync().WithCancellation(cancellationToken))
                 {
                     try
                     {

--- a/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
@@ -37,7 +37,7 @@ public static class ParameterResourceBuilderExtensions
     {
         var resource = new ParameterResource(name, callback, secret);
         return builder.AddResource(resource)
-                      .WithCustomResourceState(() =>
+                      .WithResourceUpdates(() =>
                       {
                           var state = new CustomResourceSnapshot()
                           {

--- a/tests/Aspire.Hosting.Tests/ResourceLoggerTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceLoggerTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Aspire.Hosting.Tests;
 
-public class CustomResourceLoggerTests
+public class ResourceLoggerTests
 {
     [Fact]
     public void AddingResourceLoggerAnnotationAllowsLogging()
@@ -16,7 +16,7 @@ public class CustomResourceLoggerTests
         var testResource = builder.AddResource(new TestResource("myResource"))
             .WithResourceLogger();
 
-        var annotation = testResource.Resource.Annotations.OfType<CustomResourceLoggerAnnotation>().SingleOrDefault();
+        var annotation = testResource.Resource.Annotations.OfType<ResourceLoggerAnnotation>().SingleOrDefault();
 
         Assert.NotNull(annotation);
 
@@ -48,7 +48,7 @@ public class CustomResourceLoggerTests
         var testResource = builder.AddResource(new TestResource("myResource"))
             .WithResourceLogger();
 
-        var annotation = testResource.Resource.Annotations.OfType<CustomResourceLoggerAnnotation>().SingleOrDefault();
+        var annotation = testResource.Resource.Annotations.OfType<ResourceLoggerAnnotation>().SingleOrDefault();
 
         Assert.NotNull(annotation);
 

--- a/tests/Aspire.Hosting.Tests/ResourceUpdatesTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceUpdatesTests.cs
@@ -25,7 +25,7 @@ public class ResourceUpdatesTests
 
         Assert.Equal("Custom", state.ResourceType);
 
-        Assert.Collection(state.EnviromentVariables, a =>
+        Assert.Collection(state.EnvironmentVariables, a =>
         {
             Assert.Equal("x", a.Name);
             Assert.Equal("1000", a.Value);
@@ -64,7 +64,7 @@ public class ResourceUpdatesTests
         var state = annotation.GetInitialSnapshot();
 
         Assert.Equal("MyResource", state.ResourceType);
-        Assert.Empty(state.EnviromentVariables);
+        Assert.Empty(state.EnvironmentVariables);
         Assert.Collection(state.Properties, c =>
         {
             Assert.Equal("A", c.Key);

--- a/tests/Aspire.Hosting.Tests/ResourceUpdatesTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceUpdatesTests.cs
@@ -86,7 +86,7 @@ public class ResourceUpdatesTests
 
         Assert.NotNull(annotation);
 
-        var enumerableTask = Task.Run(async () =>
+        async Task<List<CustomResourceSnapshot>> GetValuesAsync()
         {
             var values = new List<CustomResourceSnapshot>();
 
@@ -96,7 +96,9 @@ public class ResourceUpdatesTests
             }
 
             return values;
-        });
+        }
+
+        var enumerableTask = GetValuesAsync();
 
         var state = annotation.GetInitialSnapshot();
 


### PR DESCRIPTION
- Reamed CustomResourceAnnotation to  ResourceUpdatesAnnotation, and CustomResourceLogger to ResourceLoggerAnnotattion. Make it possible to have multiple subscribers to resource updates.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2523)