### PR TITLE
CI: publish non-helix testresults to artifacts

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -34,6 +34,14 @@ steps:
               "${{ parameters.buildScript }} -testnobuild -test -configuration ${{ parameters.buildConfig }} /bl:${{ parameters.repoLogPath }}/tests.binlog $(_OfficialBuildIdArgs)"
       displayName: Run non-helix tests
 
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/TestResults'
+        PublishLocation: Container
+        ArtifactName: 'TestResults_NonHelix_$(Agent.Os)_$(Agent.JobName)'
+      displayName: Publish non-helix TestResults
+      condition: always()
+
     - template: /eng/pipelines/templates/send-to-helix.yml
       parameters:
         HelixProjectPath: '$(Build.SourcesDirectory)/tests/send-to-helix.proj'


### PR DESCRIPTION
These will show up in `TestResults_NonHelix_*` container in `Artifacts`
on azdo, and contain all the `.html`, and `.trx` files for the tests.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2525)