### PR TITLE
Add limits to OTEL attribute count and length

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -70,7 +70,6 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
             new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastThreeHours)], Id = TimeSpan.FromHours(3) },
             new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastSixHours)], Id = TimeSpan.FromHours(6) },
             new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastTwelveHours)], Id = TimeSpan.FromHours(12) },
-            new() { Name = Loc[nameof(Dashboard.Resources.Metrics.MetricsLastTwentyFourHours)], Id = TimeSpan.FromHours(24) },
         };
 
         _selectApplication = new SelectViewModel<ResourceTypeDetails>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor.cs
@@ -36,7 +36,7 @@ public partial class LogMessageColumnDisplay
 
         string? GetProperty(string propertyName)
         {
-            return LogEntry.Properties.GetValue(propertyName);
+            return LogEntry.Attributes.GetValue(propertyName);
         }
     }
 

--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -89,7 +89,7 @@ public class LogFilter
             "SpanId" => x.SpanId,
             "OriginalFormat" => x.OriginalFormat,
             "Category" => x.Scope.ScopeName,
-            _ => x.Properties.GetValue(Field)
+            _ => x.Attributes.GetValue(Field)
         };
     }
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
+using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Metrics.V1;
@@ -18,7 +19,7 @@ public class OtlpInstrument
     public required string Unit { get; init; }
     public required OtlpInstrumentType Type { get; init; }
     public required OtlpMeter Parent { get; init; }
-    public required int Capacity { get; init; }
+    public required TelemetryOptions Options { get; init; }
 
     public Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> Dimensions { get; } = new(ScopeAttributesComparer.Instance);
     public Dictionary<string, List<string>> KnownAttributeValues { get; } = new();
@@ -54,10 +55,10 @@ public class OtlpInstrument
     {
         // We want to find the dimension scope that matches the attributes, but we don't want to allocate.
         // Copy values to a temporary reusable array.
-        OtlpHelpers.CopyKeyValuePairs(attributes, ref tempAttributes);
-        Array.Sort(tempAttributes, 0, attributes.Count, KeyValuePairComparer.Instance);
+        OtlpHelpers.CopyKeyValuePairs(attributes, Options, out var copyCount, ref tempAttributes);
+        Array.Sort(tempAttributes, 0, copyCount, KeyValuePairComparer.Instance);
 
-        var comparableAttributes = tempAttributes.AsMemory(0, attributes.Count);
+        var comparableAttributes = tempAttributes.AsMemory(0, copyCount);
 
         if (!Dimensions.TryGetValue(comparableAttributes, out var dimension))
         {
@@ -70,7 +71,7 @@ public class OtlpInstrument
     {
         var isFirst = Dimensions.Count == 0;
         var durableAttributes = comparableAttributes.ToArray();
-        var dimension = new DimensionScope(Capacity, durableAttributes);
+        var dimension = new DimensionScope(Options.MetricsCountLimit, durableAttributes);
         Dimensions.Add(durableAttributes, dimension);
 
         var keys = KnownAttributeValues.Keys.Union(durableAttributes.Select(a => a.Key)).Distinct();
@@ -111,7 +112,7 @@ public class OtlpInstrument
             Parent = instrument.Parent,
             Type = instrument.Type,
             Unit = instrument.Unit,
-            Capacity = instrument.Capacity,
+            Options = instrument.Options,
         };
 
         if (cloneData)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Dashboard.Otlp.Storage;
 using OpenTelemetry.Proto.Common.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
@@ -12,12 +13,12 @@ public class OtlpMeter
     public string MeterName { get; init; }
     public string Version { get; init; }
 
-    public KeyValuePair<string, string>[] Properties { get; }
+    public ReadOnlyMemory<KeyValuePair<string, string>> Attributes { get; }
 
-    public OtlpMeter(InstrumentationScope scope)
+    public OtlpMeter(InstrumentationScope scope, TelemetryOptions options)
     {
         MeterName = scope.Name;
         Version = scope.Version;
-        Properties = scope.Attributes.ToKeyValuePairs();
+        Attributes = scope.Attributes.ToKeyValuePairs(options);
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Otlp.Storage;
 using OpenTelemetry.Proto.Common.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
@@ -15,22 +16,20 @@ public class OtlpScope
     public string ScopeName { get; }
     public string Version { get; }
 
-    public KeyValuePair<string, string>[] Properties { get; }
-
-    public string ServiceProperties => Properties.ConcatProperties();
+    public ReadOnlyMemory<KeyValuePair<string, string>> Attributes { get; }
 
     private OtlpScope()
     {
         ScopeName = string.Empty;
-        Properties = Array.Empty<KeyValuePair<string, string>>();
+        Attributes = Array.Empty<KeyValuePair<string, string>>();
         Version = string.Empty;
     }
 
-    public OtlpScope(InstrumentationScope scope)
+    public OtlpScope(InstrumentationScope scope, TelemetryOptions options)
     {
         ScopeName = scope.Name;
 
-        Properties = scope.Attributes.ToKeyValuePairs();
+        Attributes = scope.Attributes.ToKeyValuePairs(options);
         Version = scope.Version;
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -14,25 +14,40 @@ using static OpenTelemetry.Proto.Trace.V1.Span.Types;
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
-public class TelemetryRepository
+public sealed class TelemetryOptions
 {
-    internal const string MaxLogCountKey = "MaxLogCount";
-    internal const string MaxTraceCountKey = "MaxTraceCount";
-    internal const string MaxMetricsCountKey = "MaxMetricsCount";
+    public int LogCountLimit { get; init; }
+    public int TraceCountLimit { get; init; }
+    public int MetricsCountLimit { get; init; }
+    public int AttributeCountLimit { get; init; }
+    public int AttributeLengthLimit { get; init; }
+    public int SpanEventCountLimit { get; init; }
+}
 
-    private const int DefaultMaxTelemetryCount = 10_000;
-    private const int DefaultMaxMetricsCount = 100_000; // Allows for 1 metric point per second for over 24 hours.
+public sealed class TelemetryRepository
+{
+    internal const string LogCountLimitKey = "DOTNET_DASHBOARD_OTEL_LOG_COUNT_LIMIT";
+    internal const string TraceCountLimitKey = "DOTNET_DASHBOARD_OTEL_TRACE_COUNT_LIMIT";
+    internal const string MetricsCountLimitKey = "DOTNET_DASHBOARD_OTEL_METRIC_COUNT_LIMIT";
+    internal const string AttributeCountLimitKey = "DOTNET_DASHBOARD_OTEL_ATTRIBUTE_COUNT_LIMIT";
+    internal const string AttributeLengthLimitKey = "DOTNET_DASHBOARD_OTEL_ATTRIBUTE_LENGTH_LIMIT";
+    internal const string SpanEventCountLimitKey = "DOTNET_DASHBOARD_OTEL_SPAN_EVENT_COUNT_LIMIT";
+
+    private const int DefaultTraceCountLimit = 10_000;
+    private const int DefaultMetricsCountLimit = 50_000; // Allows for 1 metric point per second for over 12 hours.
+    private const int DefaultAttributeCountLimit = 128;
+    private const int DefaultAttributeLengthLimit = int.MaxValue;
+    private const int DefaultSpanEventCountLimit = int.MaxValue;
 
     private readonly object _lock = new();
     private readonly ILogger _logger;
-
+    private readonly TelemetryOptions _options;
     private readonly List<Subscription> _applicationSubscriptions = new();
     private readonly List<Subscription> _logSubscriptions = new();
     private readonly List<Subscription> _metricsSubscriptions = new();
     private readonly List<Subscription> _tracesSubscriptions = new();
 
     private readonly ConcurrentDictionary<string, OtlpApplication> _applications = new();
-    private readonly int _maxMetricsCount;
 
     private readonly ReaderWriterLockSlim _logsLock = new();
     private readonly Dictionary<string, OtlpScope> _logScopes = new();
@@ -48,9 +63,18 @@ public class TelemetryRepository
     {
         _logger = loggerFactory.CreateLogger(typeof(TelemetryRepository));
 
-        _logs = new(config.GetValue(MaxLogCountKey, DefaultMaxTelemetryCount));
-        _traces = new(config.GetValue(MaxTraceCountKey, DefaultMaxTelemetryCount));
-        _maxMetricsCount = config.GetValue(MaxMetricsCountKey, DefaultMaxMetricsCount);
+        _options = new TelemetryOptions
+        {
+            LogCountLimit = config.GetValue(LogCountLimitKey, DefaultTraceCountLimit),
+            TraceCountLimit = config.GetValue(TraceCountLimitKey, DefaultTraceCountLimit),
+            MetricsCountLimit = config.GetValue(MetricsCountLimitKey, DefaultMetricsCountLimit),
+            AttributeCountLimit = config.GetValue(AttributeCountLimitKey, DefaultAttributeCountLimit),
+            AttributeLengthLimit = config.GetValue(AttributeLengthLimitKey, DefaultAttributeLengthLimit),
+            SpanEventCountLimit = config.GetValue(SpanEventCountLimitKey, DefaultSpanEventCountLimit),
+        };
+
+        _logs = new(_options.LogCountLimit);
+        _traces = new(_options.TraceCountLimit);
     }
 
     public List<OtlpApplication> GetApplications()
@@ -176,7 +200,7 @@ public class TelemetryRepository
             var application = _applications.GetOrAdd(serviceId, _ =>
             {
                 newApplication = true;
-                return new OtlpApplication(resource, _applications, _logger, _maxMetricsCount);
+                return new OtlpApplication(resource, _applications, _logger, _options);
             });
             return (application, newApplication);
         }
@@ -271,7 +295,7 @@ public class TelemetryRepository
                     var name = sl.Scope?.Name ?? string.Empty;
                     if (!_logScopes.TryGetValue(name, out scope))
                     {
-                        scope = (sl.Scope != null) ? new OtlpScope(sl.Scope) : OtlpScope.Empty;
+                        scope = (sl.Scope != null) ? new OtlpScope(sl.Scope, _options) : OtlpScope.Empty;
                         _logScopes.Add(name, scope);
                     }
                 }
@@ -286,7 +310,7 @@ public class TelemetryRepository
                 {
                     try
                     {
-                        var logEntry = new OtlpLogEntry(record, application, scope);
+                        var logEntry = new OtlpLogEntry(record, application, scope, _options);
 
                         // Insert log entry in the correct position based on timestamp.
                         // Logs can be added out of order by different services.
@@ -323,7 +347,7 @@ public class TelemetryRepository
                             }
                         }
 
-                        foreach (var kvp in logEntry.Properties)
+                        foreach (var kvp in logEntry.Attributes)
                         {
                             _logPropertyKeys.Add((application, kvp.Key));
                         }
@@ -548,7 +572,7 @@ public class TelemetryRepository
                     var name = scopeSpan.Scope?.Name ?? string.Empty;
                     if (!_traceScopes.TryGetValue(name, out scope))
                     {
-                        scope = (scopeSpan.Scope != null) ? new OtlpScope(scopeSpan.Scope) : OtlpScope.Empty;
+                        scope = (scopeSpan.Scope != null) ? new OtlpScope(scopeSpan.Scope, _options) : OtlpScope.Empty;
                         _traceScopes.Add(name, scope);
                     }
                 }
@@ -579,7 +603,7 @@ public class TelemetryRepository
                             newTrace = true;
                         }
 
-                        var newSpan = CreateSpan(application, span, trace);
+                        var newSpan = CreateSpan(application, span, trace, _options);
                         trace.AddSpan(newSpan);
 
                         // Traces are sorted by the start time of the first span.
@@ -688,7 +712,7 @@ public class TelemetryRepository
         }
     }
 
-    private static OtlpSpan CreateSpan(OtlpApplication application, Span span, OtlpTrace trace)
+    private static OtlpSpan CreateSpan(OtlpApplication application, Span span, OtlpTrace trace, TelemetryOptions options)
     {
         var id = span.SpanId?.ToHexString();
         if (id is null)
@@ -703,8 +727,13 @@ public class TelemetryRepository
             {
                 Name = e.Name,
                 Time = OtlpHelpers.UnixNanoSecondsToDateTime(e.TimeUnixNano),
-                Attributes = e.Attributes.ToKeyValuePairs()
+                Attributes = e.Attributes.ToKeyValuePairs(options)
             });
+
+            if (events.Count >= options.SpanEventCountLimit)
+            {
+                break;
+            }
         }
 
         var newSpan = new OtlpSpan(application, trace)
@@ -717,7 +746,7 @@ public class TelemetryRepository
             EndTime = OtlpHelpers.UnixNanoSecondsToDateTime(span.EndTimeUnixNano),
             Status = ConvertStatus(span.Status),
             StatusMessage = span.Status?.Message,
-            Attributes = span.Attributes.ToKeyValuePairs(),
+            Attributes = span.Attributes.ToKeyValuePairs(options),
             State = span.TraceState,
             Events = events
         };

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
+using Aspire.Dashboard.Otlp.Storage;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Proto.Common.V1;
@@ -49,16 +50,17 @@ public class PlotlyChartTests : TestContext
         Services.AddSingleton<IInstrumentUnitResolver, TestInstrumentUnitResolver>();
         Services.AddSingleton<TimeProvider, TestTimeProvider>();
 
+        var options = new TelemetryOptions();
         var instrument = new OtlpInstrument
         {
             Name = "Name-<b>Bold</b>",
             Unit = "Unit-<b>Bold</b>",
-            Capacity = 100,
+            Options = options,
             Description = "Description-<b>Bold</b>",
             Parent = new OtlpMeter(new InstrumentationScope
             {
                 Name = "Parent-Name-<b>Bold</b>"
-            }),
+            }, options),
             Type = OtlpInstrumentType.Sum
         };
 

--- a/tests/Aspire.Dashboard.Tests/BrowserLinkOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/BrowserLinkOutgoingPeerResolverTests.cs
@@ -15,7 +15,7 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.False(resolver.TryResolvePeerName([], out _));
+        Assert.False(TryResolvePeerName(resolver, [], out _));
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "")], out _));
+        Assert.False(TryResolvePeerName(resolver, [KeyValuePair.Create("http.url", "")], out _));
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create<string, string>("http.url", null!)], out _));
+        Assert.False(TryResolvePeerName(resolver, [KeyValuePair.Create<string, string>("http.url", null!)], out _));
     }
 
     // http://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag
@@ -47,7 +47,7 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out _));
+        Assert.False(TryResolvePeerName(resolver, [KeyValuePair.Create("http.url", "/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out _));
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://dummy:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out _));
+        Assert.False(TryResolvePeerName(resolver, [KeyValuePair.Create("http.url", "http://dummy:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out _));
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://localhost:59267/getScriptTag")], out _));
+        Assert.False(TryResolvePeerName(resolver, [KeyValuePair.Create("http.url", "http://localhost:59267/getScriptTag")], out _));
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "ht$tp://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out _));
+        Assert.False(TryResolvePeerName(resolver, [KeyValuePair.Create("http.url", "ht$tp://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out _));
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://localhost:59267/")], out _));
+        Assert.False(TryResolvePeerName(resolver, [KeyValuePair.Create("http.url", "http://localhost:59267/")], out _));
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.False(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://localhost:59267/not-a-guid/getScriptTag")], out _));
+        Assert.False(TryResolvePeerName(resolver, [KeyValuePair.Create("http.url", "http://localhost:59267/not-a-guid/getScriptTag")], out _));
     }
 
     [Fact]
@@ -107,7 +107,12 @@ public class BrowserLinkOutgoingPeerResolverTests
         var resolver = new BrowserLinkOutgoingPeerResolver();
 
         // Act & Assert
-        Assert.True(resolver.TryResolvePeerName([KeyValuePair.Create("http.url", "http://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out var name));
+        Assert.True(TryResolvePeerName(resolver, [KeyValuePair.Create("http.url", "http://localhost:59267/6eed7c2dedc14419901b813e8fe87a86/getScriptTag")], out var name));
         Assert.Equal("Browser Link", name);
+    }
+
+    private static bool TryResolvePeerName(IOutgoingPeerResolver resolver, KeyValuePair<string, string>[] attributes, out string? peerName)
+    {
+        return resolver.TryResolvePeerName(attributes, out peerName);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -44,7 +44,7 @@ public class ResourceOutgoingPeerResolverTests
         };
 
         // Act & Assert
-        Assert.False(ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, [], out _));
+        Assert.False(TryResolvePeerName(resources, [], out _));
     }
 
     [Fact]
@@ -57,7 +57,7 @@ public class ResourceOutgoingPeerResolverTests
         };
 
         // Act & Assert
-        Assert.False(ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, [KeyValuePair.Create("peer.service", "")], out _));
+        Assert.False(TryResolvePeerName(resources, [KeyValuePair.Create("peer.service", "")], out _));
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public class ResourceOutgoingPeerResolverTests
         };
 
         // Act & Assert
-        Assert.False(ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, [KeyValuePair.Create<string, string>("peer.service", null!)], out _));
+        Assert.False(TryResolvePeerName(resources, [KeyValuePair.Create<string, string>("peer.service", null!)], out _));
     }
 
     [Fact]
@@ -83,7 +83,7 @@ public class ResourceOutgoingPeerResolverTests
         };
 
         // Act & Assert
-        Assert.True(ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, [KeyValuePair.Create("peer.service", "localhost:5000")], out var value));
+        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("peer.service", "localhost:5000")], out var value));
         Assert.Equal("test", value);
     }
 
@@ -97,7 +97,7 @@ public class ResourceOutgoingPeerResolverTests
         };
 
         // Act & Assert
-        Assert.True(ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, [KeyValuePair.Create("peer.service", "127.0.0.1:5000")], out var value));
+        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("peer.service", "127.0.0.1:5000")], out var value));
         Assert.Equal("test", value);
     }
 
@@ -111,7 +111,7 @@ public class ResourceOutgoingPeerResolverTests
         };
 
         // Act & Assert
-        Assert.True(ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, [KeyValuePair.Create("peer.service", "127.0.0.1,5000")], out var value));
+        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("peer.service", "127.0.0.1,5000")], out var value));
         Assert.Equal("test", value);
     }
 
@@ -125,7 +125,12 @@ public class ResourceOutgoingPeerResolverTests
         };
 
         // Act & Assert
-        Assert.True(ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, [KeyValuePair.Create("server.address", "localhost"), KeyValuePair.Create("server.port", "5000")], out var value));
+        Assert.True(TryResolvePeerName(resources, [KeyValuePair.Create("server.address", "localhost"), KeyValuePair.Create("server.port", "5000")], out var value));
         Assert.Equal("test", value);
+    }
+
+    private static bool TryResolvePeerName(IDictionary<string, ResourceViewModel> resources, KeyValuePair<string, string>[] attributes, out string? peerName)
+    {
+        return ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, attributes, out peerName);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Aspire.Dashboard.Otlp.Storage;
@@ -95,6 +96,120 @@ public class MetricsTests
     }
 
     [Fact]
+    public void AddMetrics_AttributeLimits_LimitsApplied()
+    {
+        // Arrange
+        var repository = CreateRepository(attributeCountLimit: 5, attributeLengthLimit: 16);
+
+        var metricAttributes = new List<KeyValuePair<string, string>>();
+        var meterAttributes = new List<KeyValuePair<string, string>>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var value = GetValue((i + 1) * 5);
+            metricAttributes.Add(new KeyValuePair<string, string>($"Metric_Key{i}", value));
+            meterAttributes.Add(new KeyValuePair<string, string>($"Meter_Key{i}", value));
+        }
+
+        // Act
+        var addContext = new AddContext();
+        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter", attributes: meterAttributes),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), attributes: metricAttributes)
+                        }
+                    }
+                }
+            }
+        });
+
+        // Assert
+        Assert.Equal(0, addContext.FailureCount);
+
+        var applications = repository.GetApplications();
+        Assert.Collection(applications,
+            app =>
+            {
+                Assert.Equal("TestService", app.ApplicationName);
+                Assert.Equal("TestId", app.InstanceId);
+            });
+
+        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        {
+            ApplicationServiceId = applications[0].InstanceId,
+            InstrumentName = "test",
+            MeterName = "test-meter",
+            StartTime = DateTime.MinValue,
+            EndTime = DateTime.MaxValue
+        })!;
+
+        Assert.Collection(MemoryMarshal.ToEnumerable(instrument.Parent.Attributes),
+            p =>
+            {
+                Assert.Equal("Meter_Key0", p.Key);
+                Assert.Equal("01234", p.Value);
+            },
+            p =>
+            {
+                Assert.Equal("Meter_Key1", p.Key);
+                Assert.Equal("0123456789", p.Value);
+            },
+            p =>
+            {
+                Assert.Equal("Meter_Key2", p.Key);
+                Assert.Equal("012345678901234", p.Value);
+            },
+            p =>
+            {
+                Assert.Equal("Meter_Key3", p.Key);
+                Assert.Equal("0123456789012345", p.Value);
+            },
+            p =>
+            {
+                Assert.Equal("Meter_Key4", p.Key);
+                Assert.Equal("0123456789012345", p.Value);
+            });
+
+        var dimensionAttributes = instrument.Dimensions.Single().Key;
+
+        Assert.Collection(MemoryMarshal.ToEnumerable(dimensionAttributes),
+            p =>
+            {
+                Assert.Equal("Metric_Key0", p.Key);
+                Assert.Equal("01234", p.Value);
+            },
+            p =>
+            {
+                Assert.Equal("Metric_Key1", p.Key);
+                Assert.Equal("0123456789", p.Value);
+            },
+            p =>
+            {
+                Assert.Equal("Metric_Key2", p.Key);
+                Assert.Equal("012345678901234", p.Value);
+            },
+            p =>
+            {
+                Assert.Equal("Metric_Key3", p.Key);
+                Assert.Equal("0123456789012345", p.Value);
+            },
+            p =>
+            {
+                Assert.Equal("Metric_Key4", p.Key);
+                Assert.Equal("0123456789012345", p.Value);
+            });
+    }
+
+    [Fact]
     public void RoundtripSeconds()
     {
         var start = s_testTime.AddMinutes(1);
@@ -184,7 +299,7 @@ public class MetricsTests
     public void AddMetrics_Capacity_ValuesRemoved()
     {
         // Arrange
-        var repository = CreateRepository(maxMetricsCount: 3);
+        var repository = CreateRepository(metricsCountLimit: 3);
 
         // Act
         var addContext = new AddContext();
@@ -262,7 +377,7 @@ public class MetricsTests
     private static void AssertDimensionValues(Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> dimensions, ReadOnlyMemory<KeyValuePair<string, string>> key, int valueCount)
     {
         var scope = dimensions[key];
-        Assert.True(Enumerable.SequenceEqual(key.ToArray(), scope.Attributes), "Key and attributes don't match.");
+        Assert.True(Enumerable.SequenceEqual(MemoryMarshal.ToEnumerable(key), scope.Attributes), "Key and attributes don't match.");
 
         Assert.Equal(valueCount, scope.Values.Count);
     }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
@@ -33,9 +33,19 @@ internal static class TestHelpers
         return OtlpHelpers.ToHexString(id);
     }
 
-    public static InstrumentationScope CreateScope(string? name = null)
+    public static InstrumentationScope CreateScope(string? name = null, IEnumerable<KeyValuePair<string, string>>? attributes = null)
     {
-        return new InstrumentationScope() { Name = name ?? "TestScope" };
+        var scope = new InstrumentationScope() { Name = name ?? "TestScope" };
+
+        if (attributes != null)
+        {
+            foreach (var attribute in attributes)
+            {
+                scope.Attributes.Add(new KeyValue { Key = attribute.Key, Value = new AnyValue { StringValue = attribute.Value } });
+            }
+        }
+
+        return scope;
     }
 
     public static Metric CreateHistogramMetric(string metricName, DateTime startTime)
@@ -63,7 +73,7 @@ internal static class TestHelpers
         };
     }
 
-    public static Metric CreateSumMetric(string metricName, DateTime startTime, KeyValuePair<string, string>[]? attributes = null, int? value = null)
+    public static Metric CreateSumMetric(string metricName, DateTime startTime, IEnumerable<KeyValuePair<string, string>>? attributes = null, int? value = null)
     {
         return new Metric
         {
@@ -82,7 +92,7 @@ internal static class TestHelpers
         };
     }
 
-    private static NumberDataPoint CreateNumberPoint(DateTime startTime, int value, KeyValuePair<string, string>[]? attributes = null)
+    private static NumberDataPoint CreateNumberPoint(DateTime startTime, int value, IEnumerable<KeyValuePair<string, string>>? attributes = null)
     {
         var point = new NumberDataPoint
         {
@@ -101,7 +111,25 @@ internal static class TestHelpers
         return point;
     }
 
-    public static Span CreateSpan(string traceId, string spanId, DateTime startTime, DateTime endTime, string? parentSpanId = null, List<Span.Types.Event>? events = null)
+    public static Span.Types.Event CreateSpanEvent(string name, int startTime, IEnumerable<KeyValuePair<string, string>>? attributes = null)
+    {
+        var e = new Span.Types.Event
+        {
+            Name = name,
+            TimeUnixNano = (ulong)startTime
+        };
+        if (attributes != null)
+        {
+            foreach (var attribute in attributes)
+            {
+                e.Attributes.Add(new KeyValue { Key = attribute.Key, Value = new AnyValue { StringValue = attribute.Value } });
+            }
+        }
+
+        return e;
+    }
+
+    public static Span CreateSpan(string traceId, string spanId, DateTime startTime, DateTime endTime, string? parentSpanId = null, List<Span.Types.Event>? events = null, IEnumerable<KeyValuePair<string, string>>? attributes = null)
     {
         var span = new Span
         {
@@ -116,25 +144,36 @@ internal static class TestHelpers
         {
             span.Events.AddRange(events);
         }
+        if (attributes != null)
+        {
+            foreach (var attribute in attributes)
+            {
+                span.Attributes.Add(new KeyValue { Key = attribute.Key, Value = new AnyValue { StringValue = attribute.Value } });
+            }
+        }
 
         return span;
     }
 
-    public static LogRecord CreateLogRecord(DateTime? time = null, string? message = null, SeverityNumber? severity = null)
+    public static LogRecord CreateLogRecord(DateTime? time = null, string? message = null, SeverityNumber? severity = null, IEnumerable<KeyValuePair<string, string>>? attributes = null)
     {
-        return new LogRecord
+        attributes ??= [new KeyValuePair<string, string>("{OriginalFormat}", "Test {Log}"), new KeyValuePair<string, string>("Log", "Value!")];
+
+        var logRecord = new LogRecord
         {
             Body = new AnyValue { StringValue = message ?? "Test Value!" },
             TraceId = ByteString.CopyFrom(Convert.FromHexString("5465737454726163654964")),
             SpanId = ByteString.CopyFrom(Convert.FromHexString("546573745370616e4964")),
             TimeUnixNano = time != null ? DateTimeToUnixNanoseconds(time.Value) : 1000,
-            SeverityNumber = severity ?? SeverityNumber.Info,
-            Attributes =
-            {
-                new KeyValue { Key = "{OriginalFormat}", Value = new AnyValue { StringValue = "Test {Log}" } },
-                new KeyValue { Key = "Log", Value = new AnyValue { StringValue = "Value!" } }
-            }
+            SeverityNumber = severity ?? SeverityNumber.Info
         };
+
+        foreach (var attribute in attributes)
+        {
+            logRecord.Attributes.Add(new KeyValue { Key = attribute.Key, Value = new AnyValue { StringValue = attribute.Value } });
+        }
+
+        return logRecord;
     }
 
     public static Resource CreateResource(string? name = null, string? instanceId = null)
@@ -149,12 +188,28 @@ internal static class TestHelpers
         };
     }
 
-    public static TelemetryRepository CreateRepository(int? maxMetricsCount = null)
+    public static TelemetryRepository CreateRepository(
+        int? metricsCountLimit = null,
+        int? attributeCountLimit = null,
+        int? attributeLengthLimit = null,
+        int? spanEventCountLimit = null)
     {
         var inMemorySettings = new Dictionary<string, string?>();
-        if (maxMetricsCount != null)
+        if (metricsCountLimit != null)
         {
-            inMemorySettings[TelemetryRepository.MaxMetricsCountKey] = maxMetricsCount.Value.ToString(CultureInfo.InvariantCulture);
+            inMemorySettings[TelemetryRepository.MetricsCountLimitKey] = metricsCountLimit.Value.ToString(CultureInfo.InvariantCulture);
+        }
+        if (attributeCountLimit != null)
+        {
+            inMemorySettings[TelemetryRepository.AttributeCountLimitKey] = attributeCountLimit.Value.ToString(CultureInfo.InvariantCulture);
+        }
+        if (attributeLengthLimit != null)
+        {
+            inMemorySettings[TelemetryRepository.AttributeLengthLimitKey] = attributeLengthLimit.Value.ToString(CultureInfo.InvariantCulture);
+        }
+        if (spanEventCountLimit != null)
+        {
+            inMemorySettings[TelemetryRepository.SpanEventCountLimitKey] = spanEventCountLimit.Value.ToString(CultureInfo.InvariantCulture);
         }
 
         var configuration = new ConfigurationBuilder()
@@ -170,5 +225,16 @@ internal static class TestHelpers
         var timeSinceEpoch = dateTime.ToUniversalTime() - unixEpoch;
 
         return (ulong)timeSinceEpoch.Ticks * 100;
+    }
+
+    public static string GetValue(int valueLength)
+    {
+        var value = new StringBuilder(valueLength);
+        for (var i = 0; i < valueLength; i++)
+        {
+            value.Append((i % 10).ToString(CultureInfo.InvariantCulture));
+        }
+
+        return value.ToString();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2066

* Apply limits to attributes, re: https://opentelemetry.io/docs/specs/otel/common/#attribute-limits
* Apply limits to spans, re: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-limits
* Configuration values to customize attribute limits
* Reduced maximum metric count and max duration is now 12 hours
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2531)