### PR TITLE
Improve logging for flaky OTLP integration test

### DIFF
--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -7,6 +7,7 @@ using Grpc.Net.Client;
 using Grpc.Net.Client.Configuration;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit.Abstractions;
@@ -28,6 +29,10 @@ public static class IntegrationTestHelpers
 
         var dashboardWebApplication = new DashboardWebApplication(builder =>
         {
+            builder.Services.Configure<LoggerFilterOptions>(o =>
+            {
+                o.Rules.Clear();
+            });
             builder.Configuration.AddConfiguration(config);
             builder.Logging.AddXunit(testOutputHelper);
             builder.Logging.SetMinimumLevel(LogLevel.Trace);

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -29,7 +29,7 @@ public static class IntegrationTestHelpers
 
         var dashboardWebApplication = new DashboardWebApplication(builder =>
         {
-            builder.Services.Configure<LoggerFilterOptions>(o =>
+            builder.Services.PostConfigure<LoggerFilterOptions>(o =>
             {
                 o.Rules.Clear();
             });

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -45,7 +45,7 @@ public static class IntegrationTestHelpers
         return dashboardWebApplication;
     }
 
-    public static GrpcChannel CreateGrpcChannel(string address, ITestOutputHelper testOutputHelper, Action<X509Certificate2?>? validationCallback = null, int? retryCount = 3)
+    public static GrpcChannel CreateGrpcChannel(string address, ITestOutputHelper testOutputHelper, Action<X509Certificate2?>? validationCallback = null, int? retryCount = null)
     {
         ServiceConfig? serviceConfig = null;
         if (retryCount > 0)


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/2536

Unfortunately, the build was canceled and removed logs. I couldn't access the output logs to see the exact reason, but I'm guessing the problem is the server wasn't completely ready. I've added a couple of retries, and improved logging.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2537)