### PR TITLE
Add InputAnnotation

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
@@ -18,10 +18,13 @@ public sealed class InputAnnotation : IResourceAnnotation
     /// <summary>
     /// Initializes a new instance of <see cref="InputAnnotation"/>.
     /// </summary>
+    /// <param name="name">The name of the input.</param>
+    /// <param name="type">An optional type name of the input. "string" is the default, if not specified.</param>
+    /// <param name="secret">A flag indicating whether the input is secret.</param>
     public InputAnnotation(string name, string? type = null, bool secret = false)
     {
         Name = name;
-        Type = type;
+        Type = type ?? "string";
         Secret = secret;
     }
 
@@ -33,7 +36,7 @@ public sealed class InputAnnotation : IResourceAnnotation
     /// <summary>
     /// The type of the input.
     /// </summary>
-    public string? Type { get; set; }
+    public string Type { get; set; }
 
     /// <summary>
     /// Indicates if the input is a secret.
@@ -41,7 +44,7 @@ public sealed class InputAnnotation : IResourceAnnotation
     public bool Secret { get; set; }
 
     /// <summary>
-    /// Represents what the
+    /// Represents how the default value of the input should be retrieved.
     /// </summary>
     public InputDefault? Default { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Hosting.Publishing;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a input annotation that describes an input value.
+/// </summary>
+/// <remarks>
+/// This class is used to specify generated passwords, usernames, etc.
+/// </remarks>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}")]
+public sealed class InputAnnotation : IResourceAnnotation
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="InputAnnotation"/>.
+    /// </summary>
+    public InputAnnotation(string name, string? type = null, bool secret = false)
+    {
+        Name = name;
+        Type = type;
+        Secret = secret;
+    }
+
+    /// <summary>
+    /// Name of the input.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// The type of the input.
+    /// </summary>
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// Indicates if the input is a secret.
+    /// </summary>
+    public bool Secret { get; set; }
+
+    /// <summary>
+    /// Represents what the
+    /// </summary>
+    public InputDefault? Default { get; set; }
+}
+
+/// <summary>
+/// Represents how a default value should be retrieved.
+/// </summary>
+public abstract class InputDefault
+{
+    /// <summary>
+    /// Writes the current <see cref="InputDefault"/> to the manifest context.
+    /// </summary>
+    /// <param name="context">The context for the manifest publishing operation.</param>
+    public abstract void WriteToManifest(ManifestPublishingContext context);
+}
+
+/// <summary>
+/// Represents that a default value should be generated.
+/// </summary>
+public sealed class GenerateInputDefault : InputDefault
+{
+    /// <summary>
+    /// The minimum length of the generated value.
+    /// </summary>
+    public int MinLength { get; set; }
+
+    /// <inheritdoc/>
+    public override void WriteToManifest(ManifestPublishingContext context)
+    {
+        context.Writer.WriteStartObject("generate");
+        context.Writer.WriteNumber("minLength", MinLength);
+        context.Writer.WriteEndObject();
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/InputAnnotationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputAnnotationExtensions.cs
@@ -8,8 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 internal static class InputAnnotationExtensions
 {
-    internal static T WithDefaultGeneratedPasswordAnnotation<T>(this T builder)
-        where T : IResourceBuilder<ContainerResource>
+    internal static IResourceBuilder<T> WithDefaultPassword<T>(this IResourceBuilder<T> builder) where T : IResource
     {
         builder.WithAnnotation(new InputAnnotation("password", secret: true)
         {

--- a/src/Aspire.Hosting/ApplicationModel/InputAnnotationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputAnnotationExtensions.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Provides extension methods for <see cref="InputAnnotation"/>.
+/// </summary>
+internal static class InputAnnotationExtensions
+{
+    internal static T WithDefaultGeneratedPasswordAnnotation<T>(this T builder)
+        where T : IResourceBuilder<ContainerResource>
+    {
+        builder.WithAnnotation(new InputAnnotation("password", secret: true)
+        {
+            Default = new GenerateInputDefault { MinLength = 10 }
+        });
+
+        return builder;
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -6,20 +6,33 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a parameter resource.
 /// </summary>
-/// <param name="name">The name of the parameter resource.</param>
-/// <param name="callback">The callback function to retrieve the value of the parameter.</param>
-/// <param name="secret">A flag indicating whether the parameter is secret.</param>
-public sealed class ParameterResource(string name, Func<string> callback, bool secret = false) : Resource(name)
+public sealed class ParameterResource : Resource
 {
+    private readonly Func<string> _callback;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ParameterResource"/>.
+    /// </summary>
+    /// <param name="name">The name of the parameter resource.</param>
+    /// <param name="callback">The callback function to retrieve the value of the parameter.</param>
+    /// <param name="secret">A flag indicating whether the parameter is secret.</param>
+    public ParameterResource(string name, Func<string> callback, bool secret = false) : base(name)
+    {
+        _callback = callback;
+        Secret = secret;
+
+        Annotations.Add(new InputAnnotation("value", secret: secret));
+    }
+
     /// <summary>
     /// Gets the value of the parameter.
     /// </summary>
-    public string Value => callback();
+    public string Value => _callback();
 
     /// <summary>
     /// Gets a value indicating whether the parameter is secret.
     /// </summary>
-    public bool Secret { get; } = secret;
+    public bool Secret { get; }
 
     /// <summary>
     /// Gets the expression used in the manifest to reference the value of the parameter.

--- a/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
@@ -70,17 +70,7 @@ public static class ParameterResourceBuilderExtensions
         }
 
         context.Writer.WriteString("value", $"{{{resource.Name}.inputs.value}}");
-        context.Writer.WriteStartObject("inputs");
-        context.Writer.WriteStartObject("value");
-        context.Writer.WriteString("type", "string");
-
-        if (resource.Secret)
-        {
-            context.Writer.WriteBoolean("secret", resource.Secret);
-        }
-
-        context.Writer.WriteEndObject();
-        context.Writer.WriteEndObject();
+        context.WriteInputs(resource);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class MySqlBuilderExtensions
         return builder.AddResource(resource)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 3306)) // Internal port is always 3306.
                       .WithAnnotation(new ContainerImageAnnotation { Image = "mysql", Tag = "8.3.0" })
-                      .WithDefaultGeneratedPasswordAnnotation()
+                      .WithDefaultPassword()
                       .WithEnvironment(context =>
                       {
                           if (context.ExecutionContext.IsPublishMode)

--- a/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
@@ -32,6 +32,7 @@ public static class MySqlBuilderExtensions
         return builder.AddResource(resource)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 3306)) // Internal port is always 3306.
                       .WithAnnotation(new ContainerImageAnnotation { Image = "mysql", Tag = "8.3.0" })
+                      .WithDefaultGeneratedPasswordAnnotation()
                       .WithEnvironment(context =>
                       {
                           if (context.ExecutionContext.IsPublishMode)
@@ -99,6 +100,6 @@ public static class MySqlBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<MySqlServerResource> PublishAsContainer(this IResourceBuilder<MySqlServerResource> builder)
     {
-        return builder.WithManifestPublishingCallback(builder.Resource.WriteToManifestAsync);
+        return builder.WithManifestPublishingCallback(context => context.WriteContainerAsync(builder.Resource));
     }
 }

--- a/src/Aspire.Hosting/MySql/MySqlServerResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlServerResource.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -51,22 +50,5 @@ public class MySqlServerResource(string name, string password) : ContainerResour
     internal void AddDatabase(string name, string databaseName)
     {
         _databases.TryAdd(name, databaseName);
-    }
-
-    internal async Task WriteToManifestAsync(ManifestPublishingContext context)
-    {
-        await context.WriteContainerAsync(this).ConfigureAwait(false);
-
-        context.Writer.WriteStartObject("inputs");      // "inputs": {
-        context.Writer.WriteStartObject("password");    //   "password": {
-        context.Writer.WriteString("type", "string");   //     "type": "string",
-        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
-        context.Writer.WriteStartObject("default");     //     "default": {
-        context.Writer.WriteStartObject("generate");    //       "generate": {
-        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
-        context.Writer.WriteEndObject();                //       }
-        context.Writer.WriteEndObject();                //     }
-        context.Writer.WriteEndObject();                //   }
-        context.Writer.WriteEndObject();                // }
     }
 }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
@@ -30,6 +30,7 @@ public static class OracleDatabaseBuilderExtensions
         return builder.AddResource(oracleDatabaseServer)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 1521))
                       .WithAnnotation(new ContainerImageAnnotation { Image = "database/free", Tag = "23.3.0.0", Registry = "container-registry.oracle.com" })
+                      .WithDefaultGeneratedPasswordAnnotation()
                       .WithEnvironment(context =>
                       {
                           if (context.ExecutionContext.IsPublishMode)
@@ -69,6 +70,6 @@ public static class OracleDatabaseBuilderExtensions
     /// <returns></returns>
     public static IResourceBuilder<OracleDatabaseServerResource> PublishAsContainer(this IResourceBuilder<OracleDatabaseServerResource> builder)
     {
-        return builder.WithManifestPublishingCallback(builder.Resource.WriteToManifestAsync);
+        return builder.WithManifestPublishingCallback(context => context.WriteContainerAsync(builder.Resource));
     }
 }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class OracleDatabaseBuilderExtensions
         return builder.AddResource(oracleDatabaseServer)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 1521))
                       .WithAnnotation(new ContainerImageAnnotation { Image = "database/free", Tag = "23.3.0.0", Registry = "container-registry.oracle.com" })
-                      .WithDefaultGeneratedPasswordAnnotation()
+                      .WithDefaultPassword()
                       .WithEnvironment(context =>
                       {
                           if (context.ExecutionContext.IsPublishMode)

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -51,22 +50,5 @@ public class OracleDatabaseServerResource(string name, string password) : Contai
     internal void AddDatabase(string name, string databaseName)
     {
         _databases.TryAdd(name, databaseName);
-    }
-
-    internal async Task WriteToManifestAsync(ManifestPublishingContext context)
-    {
-        await context.WriteContainerAsync(this).ConfigureAwait(false);
-
-        context.Writer.WriteStartObject("inputs");      // "inputs": {
-        context.Writer.WriteStartObject("password");    //   "password": {
-        context.Writer.WriteString("type", "string");   //     "type": "string",
-        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
-        context.Writer.WriteStartObject("default");     //     "default": {
-        context.Writer.WriteStartObject("generate");    //       "generate": {
-        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
-        context.Writer.WriteEndObject();                //       }
-        context.Writer.WriteEndObject();                //     }
-        context.Writer.WriteEndObject();                //   }
-        context.Writer.WriteEndObject();                // }
     }
 }

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class PostgresBuilderExtensions
         return builder.AddResource(postgresServer)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 5432)) // Internal port is always 5432.
                       .WithAnnotation(new ContainerImageAnnotation { Image = "postgres", Tag = "16.2" })
-                      .WithDefaultGeneratedPasswordAnnotation()
+                      .WithDefaultPassword()
                       .WithEnvironment("POSTGRES_HOST_AUTH_METHOD", "scram-sha-256")
                       .WithEnvironment("POSTGRES_INITDB_ARGS", "--auth-host=scram-sha-256 --auth-local=scram-sha-256")
                       .WithEnvironment(context =>

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -32,6 +32,7 @@ public static class PostgresBuilderExtensions
         return builder.AddResource(postgresServer)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 5432)) // Internal port is always 5432.
                       .WithAnnotation(new ContainerImageAnnotation { Image = "postgres", Tag = "16.2" })
+                      .WithDefaultGeneratedPasswordAnnotation()
                       .WithEnvironment("POSTGRES_HOST_AUTH_METHOD", "scram-sha-256")
                       .WithEnvironment("POSTGRES_INITDB_ARGS", "--auth-host=scram-sha-256 --auth-local=scram-sha-256")
                       .WithEnvironment(context =>
@@ -113,6 +114,6 @@ public static class PostgresBuilderExtensions
     /// <returns></returns>
     public static IResourceBuilder<PostgresServerResource> PublishAsContainer(this IResourceBuilder<PostgresServerResource> builder)
     {
-        return builder.WithManifestPublishingCallback(builder.Resource.WriteToManifestAsync);
+        return builder.WithManifestPublishingCallback(context => context.WriteContainerAsync(builder.Resource));
     }
 }

--- a/src/Aspire.Hosting/Postgres/PostgresServerResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresServerResource.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -81,22 +80,5 @@ public class PostgresServerResource(string name, string password) : ContainerRes
     internal void AddDatabase(string name, string databaseName)
     {
         _databases.TryAdd(name, databaseName);
-    }
-
-    internal async Task WriteToManifestAsync(ManifestPublishingContext context)
-    {
-        await context.WriteContainerAsync(this).ConfigureAwait(false);
-
-        context.Writer.WriteStartObject("inputs");      // "inputs": {
-        context.Writer.WriteStartObject("password");    //   "password": {
-        context.Writer.WriteString("type", "string");   //     "type": "string",
-        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
-        context.Writer.WriteStartObject("default");     //     "default": {
-        context.Writer.WriteStartObject("generate");    //       "generate": {
-        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
-        context.Writer.WriteEndObject();                //       }
-        context.Writer.WriteEndObject();                //     }
-        context.Writer.WriteEndObject();                //   }
-        context.Writer.WriteEndObject();                // }
     }
 }

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -198,7 +198,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
             foreach (var input in inputs)
             {
                 Writer.WriteStartObject(input.Name);
-                Writer.WriteString("type", input.Type ?? "string");
+                Writer.WriteString("type", input.Type);
 
                 if (input.Secret)
                 {

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -27,6 +27,7 @@ public static class RabbitMQBuilderExtensions
         return builder.AddResource(rabbitMq)
                        .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 5672))
                        .WithAnnotation(new ContainerImageAnnotation { Image = "rabbitmq", Tag = "3" })
+                       .WithDefaultGeneratedPasswordAnnotation()
                        .WithEnvironment("RABBITMQ_DEFAULT_USER", "guest")
                        .WithEnvironment(context =>
                        {
@@ -49,6 +50,6 @@ public static class RabbitMQBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<RabbitMQServerResource> PublishAsContainer(this IResourceBuilder<RabbitMQServerResource> builder)
     {
-        return builder.WithManifestPublishingCallback(builder.Resource.WriteToManifestAsync);
+        return builder.WithManifestPublishingCallback(context => context.WriteContainerAsync(builder.Resource));
     }
 }

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class RabbitMQBuilderExtensions
         return builder.AddResource(rabbitMq)
                        .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 5672))
                        .WithAnnotation(new ContainerImageAnnotation { Image = "rabbitmq", Tag = "3" })
-                       .WithDefaultGeneratedPasswordAnnotation()
+                       .WithDefaultPassword()
                        .WithEnvironment("RABBITMQ_DEFAULT_USER", "guest")
                        .WithEnvironment(context =>
                        {

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -36,22 +34,5 @@ public class RabbitMQServerResource(string name, string password) : ContainerRes
 
         var endpoint = allocatedEndpoints.Where(a => a.Name != "management").Single();
         return $"amqp://guest:{Password}@{endpoint.EndPointString}";
-    }
-
-    internal async Task WriteToManifestAsync(ManifestPublishingContext context)
-    {
-        await context.WriteContainerAsync(this).ConfigureAwait(false);
-
-        context.Writer.WriteStartObject("inputs");      // "inputs": {
-        context.Writer.WriteStartObject("password");    //   "password": {
-        context.Writer.WriteString("type", "string");   //     "type": "string",
-        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
-        context.Writer.WriteStartObject("default");     //     "default": {
-        context.Writer.WriteStartObject("generate");    //       "generate": {
-        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
-        context.Writer.WriteEndObject();                //       }
-        context.Writer.WriteEndObject();                //     }
-        context.Writer.WriteEndObject();                //   }
-        context.Writer.WriteEndObject();                // }
     }
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -30,6 +30,7 @@ public static class SqlServerBuilderExtensions
         return builder.AddResource(sqlServer)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 1433))
                       .WithAnnotation(new ContainerImageAnnotation { Registry = "mcr.microsoft.com", Image = "mssql/server", Tag = "2022-latest" })
+                      .WithDefaultGeneratedPasswordAnnotation()
                       .WithEnvironment("ACCEPT_EULA", "Y")
                       .WithEnvironment(context =>
                       {
@@ -52,7 +53,7 @@ public static class SqlServerBuilderExtensions
     /// <returns></returns>
     public static IResourceBuilder<SqlServerServerResource> PublishAsContainer(this IResourceBuilder<SqlServerServerResource> builder)
     {
-        return builder.WithManifestPublishingCallback(builder.Resource.WriteToManifestAsync);
+        return builder.WithManifestPublishingCallback(context => context.WriteContainerAsync(builder.Resource));
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -30,7 +30,7 @@ public static class SqlServerBuilderExtensions
         return builder.AddResource(sqlServer)
                       .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 1433))
                       .WithAnnotation(new ContainerImageAnnotation { Registry = "mcr.microsoft.com", Image = "mssql/server", Tag = "2022-latest" })
-                      .WithDefaultGeneratedPasswordAnnotation()
+                      .WithDefaultPassword()
                       .WithEnvironment("ACCEPT_EULA", "Y")
                       .WithEnvironment(context =>
                       {

--- a/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.ApplicationModel;
@@ -82,22 +81,5 @@ public class SqlServerServerResource(string name, string password) : ContainerRe
     internal void AddDatabase(string name, string databaseName)
     {
         _databases.TryAdd(name, databaseName);
-    }
-
-    internal async Task WriteToManifestAsync(ManifestPublishingContext context)
-    {
-        await context.WriteContainerAsync(this).ConfigureAwait(false);
-
-        context.Writer.WriteStartObject("inputs");      // "inputs": {
-        context.Writer.WriteStartObject("password");    //   "password": {
-        context.Writer.WriteString("type", "string");   //     "type": "string",
-        context.Writer.WriteBoolean("secret", true);    //     "secret": true,
-        context.Writer.WriteStartObject("default");     //     "default": {
-        context.Writer.WriteStartObject("generate");    //       "generate": {
-        context.Writer.WriteNumber("minLength", 10);    //         "minLength": 10,
-        context.Writer.WriteEndObject();                //       }
-        context.Writer.WriteEndObject();                //     }
-        context.Writer.WriteEndObject();                //   }
-        context.Writer.WriteEndObject();                // }
     }
 }

--- a/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
@@ -74,7 +74,24 @@ public class AddKafkaTests
 
         var manifest = await ManifestUtils.GetManifest(kafka.Resource);
 
-        Assert.Equal("container.v0", manifest["type"]?.ToString());
-        Assert.Equal(kafka.Resource.ConnectionStringExpression, manifest["connectionString"]?.ToString());
+        var expectedManifest = """
+            {
+              "type": "container.v0",
+              "connectionString": "{kafka.bindings.tcp.host}:{kafka.bindings.tcp.port}",
+              "image": "confluentinc/confluent-local:7.6.0",
+              "env": {
+                "KAFKA_ADVERTISED_LISTENERS": "PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:9092"
+              },
+              "bindings": {
+                "tcp": {
+                  "scheme": "tcp",
+                  "protocol": "tcp",
+                  "transport": "tcp",
+                  "containerPort": 9092
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
     }
 }

--- a/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
@@ -130,12 +130,31 @@ public class AddMongoDBTests
 
         var mongoManifest = await ManifestUtils.GetManifest(mongo.Resource);
         var dbManifest = await ManifestUtils.GetManifest(db.Resource);
-        
-        Assert.Equal("container.v0", mongoManifest["type"]?.ToString());
-        Assert.Equal(mongo.Resource.ConnectionStringExpression, mongoManifest["connectionString"]?.ToString());
 
-        Assert.Equal("value.v0", dbManifest["type"]?.ToString());
-        Assert.Equal(db.Resource.ConnectionStringExpression, dbManifest["connectionString"]?.ToString());
+        var expectedManifest = """
+            {
+              "type": "container.v0",
+              "connectionString": "mongodb://{mongo.bindings.tcp.host}:{mongo.bindings.tcp.port}",
+              "image": "mongo:7.0.5",
+              "bindings": {
+                "tcp": {
+                  "scheme": "tcp",
+                  "protocol": "tcp",
+                  "transport": "tcp",
+                  "containerPort": 27017
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, mongoManifest.ToString());
+
+        expectedManifest = """
+            {
+              "type": "value.v0",
+              "connectionString": "{mongo.connectionString}/mydb"
+            }
+            """;
+        Assert.Equal(expectedManifest, dbManifest.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -171,11 +171,44 @@ public class AddMySqlTests
         var mySqlManifest = await ManifestUtils.GetManifest(mysql.Resource);
         var dbManifest = await ManifestUtils.GetManifest(db.Resource);
 
-        Assert.Equal("container.v0", mySqlManifest["type"]?.ToString());
-        Assert.Equal(mysql.Resource.ConnectionStringExpression, mySqlManifest["connectionString"]?.ToString());
+        var expectedManifest = """
+            {
+              "type": "container.v0",
+              "connectionString": "Server={mysql.bindings.tcp.host};Port={mysql.bindings.tcp.port};User ID=root;Password={mysql.inputs.password}",
+              "image": "mysql:8.3.0",
+              "env": {
+                "MYSQL_ROOT_PASSWORD": "{mysql.inputs.password}"
+              },
+              "bindings": {
+                "tcp": {
+                  "scheme": "tcp",
+                  "protocol": "tcp",
+                  "transport": "tcp",
+                  "containerPort": 3306
+                }
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, mySqlManifest.ToString());
 
-        Assert.Equal("value.v0", dbManifest["type"]?.ToString());
-        Assert.Equal(db.Resource.ConnectionStringExpression, dbManifest["connectionString"]?.ToString());
+        expectedManifest = """
+            {
+              "type": "value.v0",
+              "connectionString": "{oracle.connectionString}/db"
+            }
+            """;
+        Assert.Equal(expectedManifest, dbManifest.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -205,7 +205,7 @@ public class AddMySqlTests
         expectedManifest = """
             {
               "type": "value.v0",
-              "connectionString": "{oracle.connectionString}/db"
+              "connectionString": "{mysql.connectionString};Database=db"
             }
             """;
         Assert.Equal(expectedManifest, dbManifest.ToString());

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -220,11 +220,44 @@ public class AddOracleDatabaseTests
         var serverManifest = await ManifestUtils.GetManifest(oracleServer.Resource);
         var dbManifest = await ManifestUtils.GetManifest(db.Resource);
 
-        Assert.Equal("container.v0", serverManifest["type"]?.ToString());
-        Assert.Equal(oracleServer.Resource.ConnectionStringExpression, serverManifest["connectionString"]?.ToString());
+        var expectedManifest = """
+            {
+              "type": "container.v0",
+              "connectionString": "user id=system;password={oracle.inputs.password};data source={oracle.bindings.tcp.host}:{oracle.bindings.tcp.port};",
+              "image": "container-registry.oracle.com/database/free:23.3.0.0",
+              "env": {
+                "ORACLE_PWD": "{oracle.inputs.password}"
+              },
+              "bindings": {
+                "tcp": {
+                  "scheme": "tcp",
+                  "protocol": "tcp",
+                  "transport": "tcp",
+                  "containerPort": 1521
+                }
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, serverManifest.ToString());
 
-        Assert.Equal("value.v0", dbManifest["type"]?.ToString());
-        Assert.Equal(db.Resource.ConnectionStringExpression, dbManifest["connectionString"]?.ToString());
+        expectedManifest = """
+            {
+              "type": "value.v0",
+              "connectionString": "{oracle.connectionString}/db"
+            }
+            """;
+        Assert.Equal(expectedManifest, dbManifest.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -245,11 +245,46 @@ public class AddPostgresTests
         var serverManifest = await ManifestUtils.GetManifest(pgServer.Resource);
         var dbManifest = await ManifestUtils.GetManifest(db.Resource);
 
-        Assert.Equal("container.v0", serverManifest["type"]?.ToString());
-        Assert.Equal(pgServer.Resource.ConnectionStringExpression, serverManifest["connectionString"]?.ToString());
+        var expectedManifest = """
+            {
+              "type": "container.v0",
+              "connectionString": "Host={pg.bindings.tcp.host};Port={pg.bindings.tcp.port};Username=postgres;Password={pg.inputs.password}",
+              "image": "postgres:16.2",
+              "env": {
+                "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
+                "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+                "POSTGRES_PASSWORD": "{pg.inputs.password}"
+              },
+              "bindings": {
+                "tcp": {
+                  "scheme": "tcp",
+                  "protocol": "tcp",
+                  "transport": "tcp",
+                  "containerPort": 5432
+                }
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, serverManifest.ToString());
 
-        Assert.Equal("value.v0", dbManifest["type"]?.ToString());
-        Assert.Equal(db.Resource.ConnectionStringExpression, dbManifest["connectionString"]?.ToString());
+        expectedManifest = """
+            {
+              "type": "value.v0",
+              "connectionString": "{pg.connectionString};Database=db"
+            }
+            """;
+        Assert.Equal(expectedManifest, dbManifest.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -104,8 +104,22 @@ public class AddRedisTests
 
         var manifest = await ManifestUtils.GetManifest(redis.Resource);
 
-        Assert.Equal("container.v0", manifest["type"]?.ToString());
-        Assert.Equal(redis.Resource.ConnectionStringExpression, manifest["connectionString"]?.ToString());
+        var expectedManifest = """
+            {
+              "type": "container.v0",
+              "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port}",
+              "image": "redis:7.2.4",
+              "bindings": {
+                "tcp": {
+                  "scheme": "tcp",
+                  "protocol": "tcp",
+                  "transport": "tcp",
+                  "containerPort": 6379
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
This annotation allows for "inputs" to be written to the manifest when needing to generate a value, like a password, at publish time.

It is also used in Parameters to model the "input.value" of the parameter.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2546)