### PR TITLE
Improve resources page performance with many resources

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -61,7 +61,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
         var loadingTcs = new TaskCompletionSource();
 
-        TrackResourceSnapshots();
+        await TrackResourceSnapshotsAsync();
 
         // Wait for resource to be selected. If selected resource isn't available after a few seconds then stop waiting.
         try
@@ -74,14 +74,14 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             Logger.LogWarning(ex, "Load timeout while waiting for resource {ResourceName}.", ResourceName);
         }
 
-        void TrackResourceSnapshots()
+        async Task TrackResourceSnapshotsAsync()
         {
             if (!DashboardClient.IsEnabled)
             {
                 return;
             }
 
-            var (snapshot, subscription) = DashboardClient.SubscribeResources();
+            var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_resourceSubscriptionCancellation.Token);
 
             Logger.LogDebug("Received initial resource snapshot with {ResourceCount} resources.", snapshot.Length);
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -100,13 +100,13 @@ public partial class Resources : ComponentBase, IDisposable
     private readonly GridSort<ResourceViewModel> _stateSort = GridSort<ResourceViewModel>.ByAscending(p => p.State);
     private readonly GridSort<ResourceViewModel> _startTimeSort = GridSort<ResourceViewModel>.ByDescending(p => p.CreationTimeStamp);
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         _applicationUnviewedErrorCounts = TelemetryRepository.GetApplicationUnviewedErrorLogsCount();
 
         if (DashboardClient.IsEnabled)
         {
-            SubscribeResources();
+            await SubscribeResourcesAsync();
         }
 
         _logsSubscription = TelemetryRepository.OnNewLogs(null, SubscriptionType.Other, async () =>
@@ -115,9 +115,9 @@ public partial class Resources : ComponentBase, IDisposable
             await InvokeAsync(StateHasChanged);
         });
 
-        void SubscribeResources()
+        async Task SubscribeResourcesAsync()
         {
-            var (snapshot, subscription) = DashboardClient.SubscribeResources();
+            var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_watchTaskCancellationTokenSource.Token);
 
             // Apply snapshot.
             foreach (var resource in snapshot)

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -324,7 +324,7 @@ internal sealed class DashboardClient : IDashboardClient
     {
         EnsureInitialized();
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(_clientCancellationToken, cancellationToken);
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(_clientCancellationToken, cancellationToken);
 
         // Wait for initial data to be received from the server. This allows initial data to be returned with subscription when client is starting.
         await _initialDataReceivedTcs.Task.WaitAsync(cts.Token).ConfigureAwait(false);
@@ -355,6 +355,7 @@ internal sealed class DashboardClient : IDashboardClient
             }
             finally
             {
+                cts.Dispose();
                 ImmutableInterlocked.Update(ref _outgoingChannels, static (set, channel) => set.Remove(channel), channel);
             }
         }

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -341,16 +341,14 @@ internal sealed class DashboardClient : IDashboardClient
 
             return new ResourceViewModelSubscription(
                 InitialState: _resourceByName.Values.ToImmutableArray(),
-                Subscription: StreamUpdatesAsync(cancellationToken));
+                Subscription: StreamUpdatesAsync(cts.Token));
         }
 
         async IAsyncEnumerable<ResourceViewModelChange> StreamUpdatesAsync([EnumeratorCancellation] CancellationToken enumeratorCancellationToken = default)
         {
             try
             {
-                using var streamCts = CancellationTokenSource.CreateLinkedTokenSource(clientCancellationToken, enumeratorCancellationToken);
-
-                await foreach (var batch in channel.Reader.ReadAllAsync(streamCts.Token).ConfigureAwait(false))
+                await foreach (var batch in channel.Reader.ReadAllAsync(enumeratorCancellationToken).ConfigureAwait(false))
                 {
                     yield return batch;
                 }

--- a/src/Aspire.Dashboard/Model/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/IDashboardClient.cs
@@ -37,7 +37,7 @@ public interface IDashboardClient : IAsyncDisposable
     /// Callers are required to manage the lifetime of the subscription,
     /// using cancellation during enumeration.
     /// </remarks>
-    ResourceViewModelSubscription SubscribeResources();
+    Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets a stream of console log messages for the specified resource.

--- a/src/Aspire.Dashboard/Protos/Partials.cs
+++ b/src/Aspire.Dashboard/Protos/Partials.cs
@@ -21,7 +21,7 @@ partial class Resource
             ResourceType = ValidateNotNull(ResourceType),
             DisplayName = ValidateNotNull(DisplayName),
             Uid = ValidateNotNull(Uid),
-            CreationTimeStamp = CreatedAt.ToDateTime(),
+            CreationTimeStamp = ValidateNotNull(CreatedAt).ToDateTime(),
             Properties = Properties.ToFrozenDictionary(property => ValidateNotNull(property.Name), property => ValidateNotNull(property.Value), StringComparers.ResourcePropertyName),
             Endpoints = GetEndpoints(),
             Environment = GetEnvironment(),

--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -151,7 +151,7 @@ public class ResourceLoggerService
 
                 try
                 {
-                    await foreach (var entry in channel.GetBatches(cancellationToken))
+                    await foreach (var entry in channel.GetBatchesAsync(cancellationToken))
                     {
                         yield return entry;
                     }

--- a/src/Aspire.Hosting/Dashboard/DockerContainerLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DockerContainerLogSource.cs
@@ -45,7 +45,7 @@ internal sealed class DockerContainerLogSource(string containerId) : IAsyncEnume
             // Don't forward cancellationToken here, because it's handled internally in WaitForExit
             _ = Task.Run(() => WaitForExit(tcs, ctr), CancellationToken.None);
 
-            await foreach (var batch in channel.GetBatches(cancellationToken))
+            await foreach (var batch in channel.GetBatchesAsync(cancellationToken))
             {
                 yield return batch;
             }

--- a/src/Aspire.Hosting/Dashboard/FileLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/FileLogSource.cs
@@ -27,7 +27,7 @@ internal sealed partial class FileLogSource(string stdOutPath, string stdErrPath
         var stdOut = Task.Run(() => WatchFileAsync(stdOutPath, isError: false), cancellationToken);
         var stdErr = Task.Run(() => WatchFileAsync(stdErrPath, isError: true), cancellationToken);
 
-        await foreach (var batch in channel.GetBatches(cancellationToken))
+        await foreach (var batch in channel.GetBatchesAsync(cancellationToken))
         {
             yield return batch;
         }

--- a/src/Aspire.Hosting/Dashboard/ResourceLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceLogSource.cs
@@ -47,7 +47,7 @@ internal sealed class ResourceLogSource<TResource>(
             TaskContinuationOptions.None,
             TaskScheduler.Default).ConfigureAwait(false);
 
-        await foreach (var batch in channel.GetBatches(cancellationToken))
+        await foreach (var batch in channel.GetBatchesAsync(cancellationToken))
         {
             yield return batch;
         }

--- a/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
@@ -49,7 +49,7 @@ internal sealed class ResourcePublisher(CancellationToken cancellationToken)
 
                 try
                 {
-                    await foreach (var batch in channel.GetBatches(linked.Token).ConfigureAwait(false))
+                    await foreach (var batch in channel.GetBatchesAsync(linked.Token).ConfigureAwait(false))
                     {
                         yield return batch;
                     }

--- a/src/Shared/ChannelExtensions.cs
+++ b/src/Shared/ChannelExtensions.cs
@@ -21,7 +21,7 @@ internal static class ChannelExtensions
     /// <param name="channel">The channel to read values from.</param>
     /// <param name="cancellationToken">A token that signals a loss of interest in the operation.</param>
     /// <returns></returns>
-    public static async IAsyncEnumerable<IReadOnlyList<T>> GetBatches<T>(
+    public static async IAsyncEnumerable<IReadOnlyList<T>> GetBatchesAsync<T>(
         this Channel<T> channel,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
@@ -51,6 +51,6 @@ public class ApplicationNameTests : TestContext
         public string ApplicationName => "<marquee>An HTML title!</marquee>";
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public ResourceViewModelSubscription SubscribeResources() => throw new NotImplementedException();
+        public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
The dashboard resource's page subscribes to resource updates. Along with the subscription is a collection of initial data that were cached resources.

This didn't work quite as intended. The subscription (plus initial data) returned to the UI didn't wait for the data to be populated from the server, so it was always empty when Aspire started up or the user refreshed the browser on the resources page.

This PR updates the dashboard client to wait until initial data is populated before returning the subscription + initial data. The UI has more data to immediately render and the page finishes loading much faster.

Dashboard with 100 resources...

**10+ seconds to load before (note the page scroll bar as data loads):**
![resources-before](https://github.com/dotnet/aspire/assets/303201/697e1494-850a-4c36-af0e-1fdfe50ed4bb)

**1-2 seconds to load after:**
![resources-after](https://github.com/dotnet/aspire/assets/303201/15caf831-55a4-4ed7-9503-b792d51799e4)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2556)