### PR TITLE
AssignParameter(...) for CDK resources

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,10 +20,10 @@
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.ResourceManager" Version="1.11.0-alpha.20240222.6" />
-    <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.0" />
+    <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.2.0-alpha.20240227.2" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.0-alpha.20240222.2" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.8.0-alpha.20240222.2" />
-    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240229.1" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240229.2" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion)" />

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -16,7 +16,7 @@ var construct1 = builder.AddAzureConstruct("construct1", (construct) =>
         kind: StorageKind.BlobStorage,
         sku: StorageSkuName.StandardLrs
         );
-    account.AssignParameter(a => a.Sku.Name, construct.AddParameter(sku));
+    account.AssignParameter(a => a.Sku.Name, sku);
 
     account.AddOutput(data => data.PrimaryEndpoints.TableUri, "tableUri", isSecure: true);
 });

--- a/playground/cdk/CdkSample.AppHost/construct1.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/construct1.module.bicep
@@ -7,7 +7,7 @@ param location string = resourceGroup().location
 param storagesku string
 
 
-resource storageAccount_unUi1Obb4 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+resource storageAccount_WFnvkltok 'Microsoft.Storage/storageAccounts@2022-09-01' = {
   name: toLower(take(concat('bob', uniqueString(resourceGroup().id)), 24))
   location: location
   sku: {
@@ -18,4 +18,4 @@ resource storageAccount_unUi1Obb4 'Microsoft.Storage/storageAccounts@2022-09-01'
   }
 }
 
-output tableUri string = storageAccount_unUi1Obb4.properties.primaryEndpoints.table
+output tableUri string = storageAccount_WFnvkltok.properties.primaryEndpoints.table

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/BicepProvisioner.cs
@@ -240,11 +240,8 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger) : Azure
             resource.Parameters.Remove(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId);
         }
 
-        if (resource.Parameters.TryGetValue(AzureBicepResource.KnownParameters.Location, out var location) && location is null)
-        {
-            // Always specify the location
-            resource.Parameters[AzureBicepResource.KnownParameters.Location] = context.Location.Name;
-        }
+        // Always specify the location
+        resource.Parameters[AzureBicepResource.KnownParameters.Location] = context.Location.Name;
     }
 
     private static async Task<bool> ExecuteCommand(ProcessSpec processSpec)

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -75,21 +75,11 @@ public static class AzureConstructResourceExtensions
     /// <param name="resource">The CDK resource.</param>
     /// <param name="propertySelector">Property selection expression.</param>
     /// <param name="parameterResourceBuilder">Aspire parameter resource builder.</param>
-    public static void AssignParameter<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, IResourceBuilder<ParameterResource> parameterResourceBuilder) where T : notnull
-    {
-        resource.AssignParameter(propertySelector, parameterResourceBuilder.Resource.Name, parameterResourceBuilder);
-    }
-
-    /// <summary>
-    /// Assigns an Aspire parameter resource to an Azure construct resource.
-    /// </summary>
-    /// <typeparam name="T">Type of the CDK resource.</typeparam>
-    /// <param name="resource">The CDK resource.</param>
-    /// <param name="propertySelector">Property selection expression.</param>
     /// <param name="parameterName">The name of the parameter to be assigned.</param>
-    /// <param name="parameterResourceBuilder">Aspire parameter resource builder.</param>
-    public static void AssignParameter<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, string parameterName, IResourceBuilder<ParameterResource> parameterResourceBuilder) where T: notnull
+    public static void AssignParameter<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, IResourceBuilder<ParameterResource> parameterResourceBuilder, string? parameterName = null) where T: notnull
     {
+        parameterName ??= parameterResourceBuilder.Resource.Name;
+
         if (resource.Scope is not ResourceModuleConstruct construct)
         {
             throw new ArgumentException("Cannot bind Aspire parameter resource to this construct.", nameof(resource));
@@ -115,22 +105,12 @@ public static class AzureConstructResourceExtensions
     /// <typeparam name="T">Type of the CDK resource.</typeparam>
     /// <param name="resource">The CDK resource.</param>
     /// <param name="propertySelector">Property selection expression.</param>
-    /// <param name="outputReference">Aspire parameter resource builder.</param>
-    public static void AssignParameter<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, BicepOutputReference outputReference) where T : notnull
-    {
-        resource.AssignParameter(propertySelector, outputReference.Name, outputReference);
-    }
-
-    /// <summary>
-    /// Assigns an Aspire Bicep output reference to an Azure construct resource.
-    /// </summary>
-    /// <typeparam name="T">Type of the CDK resource.</typeparam>
-    /// <param name="resource">The CDK resource.</param>
-    /// <param name="propertySelector">Property selection expression.</param>
     /// <param name="parameterName">The name of the parameter to be assigned.</param>
     /// <param name="outputReference">Aspire parameter resource builder.</param>
-    public static void AssignParameter<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, string parameterName, BicepOutputReference outputReference) where T : notnull
+    public static void AssignParameter<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, BicepOutputReference outputReference, string? parameterName = null) where T : notnull
     {
+        parameterName ??= outputReference.Resource.Name;
+
         if (resource.Scope is not ResourceModuleConstruct construct)
         {
             throw new ArgumentException("Cannot bind Aspire parameter resource to this construct.", nameof(resource));

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -204,35 +204,33 @@ public class AzureBicepResourceTests
         Assert.Equal("construct1.module.bicep", manifest["path"]?.ToString());
     }
 
-    // TODO: This test to be reenabled once we figure out what is going on in CDK
-    //       around parameters being injected twice.
-    //[Fact]
-    //public void AddParameterOnResourceModuleConstructPopulatesParametersEverywhere()
-    //{
-    //    var builder = DistributedApplication.CreateBuilder();
-    //    builder.Configuration["Parameters:skuName"] = "Standard_ZRS";
+   [Fact]
+    public async Task AddParameterOnResourceModuleConstructPopulatesParametersEverywhere()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.Configuration["Parameters:skuName"] = "Standard_ZRS";
 
-    //    var skuName = builder.AddParameter("skuName");
+        var skuName = builder.AddParameter("skuName");
 
-    //    ResourceModuleConstruct? moduleConstruct = null;
-    //    var construct1 = builder.AddAzureConstruct("construct1", (construct) =>
-    //    {
-    //        var storage = construct.AddStorageAccount(
-    //            kind: StorageKind.StorageV2,
-    //            sku: StorageSkuName.StandardLrs
-    //            );
-    //        storage.AssignParameter(sa => sa.Sku.Name, construct.AddParameter(skuName));
-    //        moduleConstruct = construct;
-    //    });
+        ResourceModuleConstruct? moduleConstruct = null;
+        var construct1 = builder.AddAzureConstruct("construct1", (construct) =>
+        {
+            var storage = construct.AddStorageAccount(
+                kind: StorageKind.StorageV2,
+                sku: StorageSkuName.StandardLrs
+                );
+            storage.AssignParameter(sa => sa.Sku.Name, skuName);
+            moduleConstruct = construct;
+        });
 
-    //    var manifest = ManifestUtils.GetManifest(construct1.Resource);
+        var manifest = await ManifestUtils.GetManifest(construct1.Resource);
 
-    //    Assert.NotNull(moduleConstruct);
-    //    var constructParameters = moduleConstruct.GetParameters(false).ToDictionary(p => p.Name);
-    //    Assert.True(constructParameters.ContainsKey("skuName"));
-    //    Assert.Equal(skuName.Resource, construct1.Resource.Parameters["skuName"]);
-    //    Assert.Equal("{skuName.value}", manifest["params"]?["skuName"]?.ToString());
-    //}
+        Assert.NotNull(moduleConstruct);
+        var constructParameters = moduleConstruct.GetParameters(false).ToDictionary(p => p.Name);
+        Assert.True(constructParameters.ContainsKey("skuName"));
+        Assert.Equal(skuName, construct1.Resource.Parameters["skuName"]);
+        Assert.Equal("{skuName.value}", manifest["params"]?["skuName"]?.ToString());
+    }
 
     [Fact]
     public async Task PublishAsRedisPublishesRedisAsAzureRedis()

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -228,8 +228,17 @@ public class AzureBicepResourceTests
         Assert.NotNull(moduleConstruct);
         var constructParameters = moduleConstruct.GetParameters(false).ToDictionary(p => p.Name);
         Assert.True(constructParameters.ContainsKey("skuName"));
-        Assert.Equal(skuName, construct1.Resource.Parameters["skuName"]);
-        Assert.Equal("{skuName.value}", manifest["params"]?["skuName"]?.ToString());
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v0",
+              "path": "construct1.module.bicep",
+              "params": {
+                "skuName": "{skuName.value}"
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
     }
 
     [Fact]
@@ -256,8 +265,17 @@ public class AzureBicepResourceTests
         Assert.NotNull(moduleConstruct);
         var constructParameters = moduleConstruct.GetParameters(false).ToDictionary(p => p.Name);
         Assert.True(constructParameters.ContainsKey("sku"));
-        Assert.Equal(skuName, construct1.Resource.Parameters["sku"]);
-        Assert.Equal("{skuName.value}", manifest["params"]?["sku"]?.ToString());
+
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v0",
+              "path": "construct1.module.bicep",
+              "params": {
+                "sku": "{skuName.value}"
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -247,7 +247,7 @@ public class AzureBicepResourceTests
                 kind: StorageKind.StorageV2,
                 sku: StorageSkuName.StandardLrs
                 );
-            storage.AssignParameter(sa => sa.Sku.Name, "sku", skuName);
+            storage.AssignParameter(sa => sa.Sku.Name, skuName, parameterName: "sku");
             moduleConstruct = construct;
         });
 


### PR DESCRIPTION
This PR removes the specialized `AddParameter(..)` API we had for CDK and opts for a simpler pattern where we just have an `AssignParameter` extension which is available on `Resource<T>` objects (CDK resources that is). It follows the same pattern as the CDK variant and delegates to it, but it also correctly wires up the Aspire parameters so that AZD and the provisioner can work.

Sample code:

```csharp
using Azure.Provisioning.Storage;
using Azure.ResourceManager.Storage.Models;

var builder = DistributedApplication.CreateBuilder(args);
builder.AddAzureProvisioning();

var sku = builder.AddParameter("storagesku");

var construct1 = builder.AddAzureConstruct("construct1", (construct) =>
{
    var account = construct.AddStorageAccount(
        name: "bob",
        kind: StorageKind.BlobStorage,
        sku: StorageSkuName.StandardLrs
        );
    account.AssignParameter(a => a.Sku.Name, sku);

    account.AddOutput(data => data.PrimaryEndpoints.TableUri, "tableUri", isSecure: true);
});

builder.AddProject<Projects.CdkSample_ApiService>("api")
       .WithEnvironment("TABLE_URI", construct1.GetOutput("tableUri"));

builder.Build().Run();
```

There is also a variant of the method that takes an string parameter support overriding the parameter name that is inserted. Its the functional equivalent of `WithParameter(string, parameter)`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2558)