### PR TITLE
Resource Command Support

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -17,7 +17,7 @@
         }
     </FluentButton>
 
-     <FluentMenu Anchor="@_buttonId" aria-labelledby="button" @bind-Open="@_visible">
+    <FluentMenu Anchor="@_buttonId" aria-labelledby="button" @bind-Open="@_visible">
         @foreach (TItem command in Items)
         {
             <FluentMenuItem OnClick="() => HandleItemClicked(command)">@ItemText(command)</FluentMenuItem>

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -1,0 +1,26 @@
+﻿@namespace Aspire.Dashboard.Components
+@using Aspire.Dashboard.Model
+@using Microsoft.FluentUI.AspNetCore.Components.DesignTokens
+@inherits FluentComponentBase
+@typeparam TItem
+
+<div class="aspire-menubutton-container" style="width:100px;">
+    <FluentButton Id="@_buttonId" Appearance="@ButtonAppearance" aria-haspopup="true" aria-expanded="@_visible" @onclick="ToggleMenu" @onkeydown="OnKeyDown" Disabled="@(!Items.Any())">
+        @if (string.IsNullOrWhiteSpace(Text))
+        {
+            <FluentIcon Value="@_icon" />
+        }
+        else
+        {
+            @Text
+            <FluentIcon Value="@_icon" Slot="end" />
+        }
+    </FluentButton>
+
+     <FluentMenu Anchor="@_buttonId" aria-labelledby="button" @bind-Open="@_visible">
+        @foreach (TItem command in Items)
+        {
+            <FluentMenuItem OnClick="() => HandleItemClicked(command)">@ItemText(command)</FluentMenuItem>
+        }
+    </FluentMenu>
+</div>

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components;
+
+public partial class AspireMenuButton<TItem> : FluentComponentBase
+{
+    private static readonly Icon s_defaultIcon = new Icons.Regular.Size24.ChevronDown();
+
+    private bool _visible;
+    private Icon? _icon { get; set; }
+
+    private readonly string _buttonId = Identifier.NewId();
+
+    [Parameter]
+    public string? Text { get; set; }
+
+    [Parameter]
+    public Icon? Icon { get; set; }
+
+    [Parameter]
+    public required IList<TItem> Items { get; set; }
+
+    [Parameter]
+    public required Func<TItem, string> ItemText { get; set; }
+
+    [Parameter]
+    public Appearance? ButtonAppearance { get; set; }
+
+    [Parameter]
+    public EventCallback<TItem> OnItemClicked { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        _icon = Icon ?? s_defaultIcon;
+    }
+
+    private void ToggleMenu()
+    {
+        _visible = !_visible;
+    }
+
+    private async Task HandleItemClicked(TItem item)
+    {
+        if (item is not null)
+        {
+            await OnItemClicked.InvokeAsync(item);
+        }
+        _visible = false;
+    }
+
+    private void OnKeyDown(KeyboardEventArgs args)
+    {
+        if (args is not null && args.Key == "Escape")
+        {
+            _visible = false;
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -12,7 +12,7 @@ public partial class AspireMenuButton<TItem> : FluentComponentBase
     private static readonly Icon s_defaultIcon = new Icons.Regular.Size24.ChevronDown();
 
     private bool _visible;
-    private Icon? _icon { get; set; }
+    private Icon? _icon;
 
     private readonly string _buttonId = Identifier.NewId();
 

--- a/src/Aspire.Dashboard/Components/Controls/ResourceCommands.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceCommands.razor
@@ -1,0 +1,10 @@
+﻿@namespace Aspire.Dashboard.Components
+@using Aspire.Dashboard.Model
+
+<AspireMenuButton TItem="CommandViewModel"
+    ButtonAppearance="Appearance.Lightweight"
+    Icon="@(new Icons.Regular.Size24.MoreHorizontal())"
+    Items="@Commands"
+    ItemText="c => c.DisplayName"
+    OnItemClicked="CommandSelected">
+</AspireMenuButton>

--- a/src/Aspire.Dashboard/Components/Controls/ResourceCommands.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceCommands.razor.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Microsoft.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Components;
+
+public partial class ResourceCommands : ComponentBase
+{
+    [Parameter]
+    public required IList<CommandViewModel> Commands { get; set; }
+
+    [Parameter]
+    public EventCallback<CommandViewModel> CommandSelected { get; set; }
+}

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 ﻿@using Aspire.Dashboard.Components.CustomIcons;
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 @inherits LayoutComponentBase
 
 <div class="layout">
@@ -32,6 +33,7 @@
     </FluentHeader>
     <NavMenu />
     <FluentBodyContent Class="custom-body-content">
+        <FluentToastProvider />
         @Body
     </FluentBodyContent>
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -82,7 +82,7 @@
                     </TemplateColumn>
                     @if (HasResourcesWithCommands)
                     {
-                        <TemplateColumn Title="Commands">
+                        <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesCommandsColumnHeader)]">
                             <ResourceCommands Commands="@context.Commands"
                                               CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)" />
                         </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -51,7 +51,10 @@
                         SelectedValue="@SelectedResource"
                         ViewKey="ResourcesList">
         <Summary>
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr" RowClass="GetRowClass">
+            @{
+                var gridTemplateColumns = HasResourcesWithCommands ? "1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr 1fr" : "1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr";
+            }
+            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass">
                 <ChildContent>
                     <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" />
                     <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort">
@@ -77,6 +80,13 @@
                                       Title="@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]"
                                       OnClick="() => ShowResourceDetails(context)">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
                     </TemplateColumn>
+                    @if (HasResourcesWithCommands)
+                    {
+                        <TemplateColumn Title="Commands">
+                            <ResourceCommands Commands="@context.Commands"
+                                              CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)" />
+                        </TemplateColumn>
+                    }
                 </ChildContent>
                 <EmptyContent>
                     <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;@Loc[nameof(Dashboard.Resources.Resources.ResourcesNoResources)]

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -27,11 +27,21 @@
     padding: 1px;
 }
 
+/* Forces the grid to always take up the width of its rows,
+   and the rows to always take up the width of the cells.
+   This fixes a few odd rendering things, but also enables us
+   to set overflow-x: clip on the grid to prevent an odd visual
+   glitch with the menu when it is at the far right of the viewport
+*/
 ::deep fluent-data-grid,
 ::deep fluent-data-grid-row {
     min-width: min-content;
 }
 
+/* Ensures that any popups (e.g. menus) don't overflow past
+   the right edge of the grid causing a visual flicker of
+   the horizontal scrollbar appearing and disappearing
+*/
 ::deep fluent-data-grid {
     overflow-x: clip;
 }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -26,3 +26,12 @@
 ::deep .error-counter-badge {
     padding: 1px;
 }
+
+::deep fluent-data-grid,
+::deep fluent-data-grid-row {
+    min-width: min-content;
+}
+
+::deep fluent-data-grid {
+    overflow-x: clip;
+}

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -390,7 +390,7 @@ internal sealed class DashboardClient : IDashboardClient
 
         try
         {
-            using var combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken);
+            using var combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(_clientCancellationToken, cancellationToken);
 
             var response = await _client!.ExecuteResourceCommandAsync(request, cancellationToken: combinedTokens.Token);
 

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -390,7 +390,9 @@ internal sealed class DashboardClient : IDashboardClient
 
         try
         {
-            var response = await _client!.ExecuteResourceCommandAsync(request, cancellationToken: cancellationToken);
+            using var combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken);
+
+            var response = await _client!.ExecuteResourceCommandAsync(request, cancellationToken: combinedTokens.Token);
 
             return response.ToViewModel();
         }

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -376,6 +376,38 @@ internal sealed class DashboardClient : IDashboardClient
         }
     }
 
+    public async Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken)
+    {
+        EnsureInitialized();
+
+        var request = new ResourceCommandRequest()
+        {
+            CommandType = command.CommandType,
+            Parameter = command.Parameter,
+            ResourceName = resourceName,
+            ResourceType = resourceType
+        };
+
+        try
+        {
+            var response = await _client!.ExecuteResourceCommandAsync(request, cancellationToken: cancellationToken);
+
+            return response.ToViewModel();
+        }
+        catch (RpcException ex)
+        {
+            _logger.LogError(ex, "Error executing command \"{CommandType}\" on resource \"{ResourceName}\": {StatusCode}", command.CommandType, resourceName, ex.StatusCode);
+
+            var errorMessage = ex.StatusCode == StatusCode.Unimplemented ? "Command not implemented" : "Unknown error. See logs for details";
+
+            return new ResourceCommandResponseViewModel()
+            {
+                Kind = ResourceCommandResponseKind.Failed,
+                ErrorMessage = errorMessage
+            };
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _state, StateDisposed) is not StateDisposed)

--- a/src/Aspire.Dashboard/Model/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/IDashboardClient.cs
@@ -50,6 +50,8 @@ public interface IDashboardClient : IAsyncDisposable
     /// <para>It is important that callers trigger <paramref name="cancellationToken"/>
     /// so that resources owned by the sequence and its consumers can be freed.</para>
     IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken);
+
+    Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken);
 }
 
 public sealed record ResourceViewModelSubscription(

--- a/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public class ResourceCommandResponseViewModel
+{
+    public required ResourceCommandResponseKind Kind { get; init; }
+    public string? ErrorMessage { get; init; }
+}
+
+// Must be kept in sync with ResourceCommandResponseKind in the resource_service.proto file
+public enum ResourceCommandResponseKind
+{
+    Undefined = 0,
+    Succeeded = 1,
+    Failed = 2,
+    Cancelled = 3
+}

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -22,6 +22,7 @@ public sealed class ResourceViewModel
     public required ImmutableArray<ResourceServiceViewModel> Services { get; init; }
     public required int? ExpectedEndpointsCount { get; init; }
     public required FrozenDictionary<string, Value> Properties { get; init; }
+    public required ImmutableArray<CommandViewModel> Commands { get; init; }
 
     internal bool MatchesFilter(string filter)
     {
@@ -45,6 +46,25 @@ public sealed class ResourceViewModel
         }
 
         return resource.DisplayName;
+    }
+}
+
+public sealed class CommandViewModel
+{
+    public string CommandType { get; }
+    public string DisplayName { get; }
+    public string? ConfirmationMessage { get; }
+    public Value? Parameter { get; }
+
+    public CommandViewModel(string commandType, string displayName, string? confirmationMessage, Value? parameter)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(commandType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+
+        CommandType = commandType;
+        DisplayName = displayName;
+        ConfirmationMessage = confirmationMessage;
+        Parameter = parameter;
     }
 }
 

--- a/src/Aspire.Dashboard/Protos/Partials.cs
+++ b/src/Aspire.Dashboard/Protos/Partials.cs
@@ -27,7 +27,8 @@ partial class Resource
             Environment = GetEnvironment(),
             ExpectedEndpointsCount = ExpectedEndpointsCount,
             Services = GetServices(),
-            State = HasState ? State : null
+            State = HasState ? State : null,
+            Commands = GetCommands()
         };
 
         ImmutableArray<ResourceServiceViewModel> GetServices()
@@ -51,6 +52,13 @@ partial class Resource
                 .ToImmutableArray();
         }
 
+        ImmutableArray<CommandViewModel> GetCommands()
+        {
+            return Commands
+                .Select(c => new CommandViewModel(c.CommandType, c.DisplayName, c.ConfirmationMessage, c.Parameter))
+                .ToImmutableArray();
+        }
+
         T ValidateNotNull<T>(T value, [CallerArgumentExpression(nameof(value))] string? expression = null) where T : class
         {
             if (value is null)
@@ -60,5 +68,17 @@ partial class Resource
 
             return value;
         }
+    }
+}
+
+partial class ResourceCommandResponse
+{
+    public ResourceCommandResponseViewModel ToViewModel()
+    {
+        return new ResourceCommandResponseViewModel()
+        {
+            ErrorMessage = ErrorMessage,
+            Kind = (Dashboard.Model.ResourceCommandResponseKind)Kind
+        };
     }
 }

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Commands.
+        /// </summary>
+        public static string ResourcesCommandsColumnHeader {
+            get {
+                return ResourceManager.GetString("ResourcesCommandsColumnHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Details.
         /// </summary>
         public static string ResourcesDetailsColumnHeader {

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &quot;{0}&quot; command failed.
+        /// </summary>
+        public static string ResourceCommandFailed {
+            get {
+                return ResourceManager.GetString("ResourceCommandFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &quot;{0}&quot; command succeeded.
+        /// </summary>
+        public static string ResourceCommandSuccess {
+            get {
+                return ResourceManager.GetString("ResourceCommandSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View Logs.
+        /// </summary>
+        public static string ResourceCommandToastViewLogs {
+            get {
+                return ResourceManager.GetString("ResourceCommandToastViewLogs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Endpoint URL.
         /// </summary>
         public static string ResourceDetailsEndpointUrl {

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -214,5 +214,16 @@
   </data>
   <data name="ResourcesDetailsStateProperty" xml:space="preserve">
     <value>State</value>
+  </data>
+  <data name="ResourceCommandFailed" xml:space="preserve">
+    <value>"{0}" command failed</value>
+    <comment>{0} is the display name of the command that failed</comment>
+  </data>
+  <data name="ResourceCommandSuccess" xml:space="preserve">
+    <value>"{0}" command succeeded</value>
+    <comment>{0} is the display name of the command that succeeded</comment>
+  </data>
+  <data name="ResourceCommandToastViewLogs" xml:space="preserve">
+    <value>View Logs</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -226,4 +226,7 @@
   <data name="ResourceCommandToastViewLogs" xml:space="preserve">
     <value>View Logs</value>
   </data>
+  <data name="ResourcesCommandsColumnHeader" xml:space="preserve">
+    <value>Commands</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="ResourceCommandFailed">
+        <source>"{0}" command failed</source>
+        <target state="new">"{0}" command failed</target>
+        <note>{0} is the display name of the command that failed</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandSuccess">
+        <source>"{0}" command succeeded</source>
+        <target state="new">"{0}" command succeeded</target>
+        <note>{0} is the display name of the command that succeeded</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandToastViewLogs">
+        <source>View Logs</source>
+        <target state="new">View Logs</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">
         <source>Endpoint URL</source>
         <target state="new">Endpoint URL</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="new">Proxy URL</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesCommandsColumnHeader">
+        <source>Commands</source>
+        <target state="new">Commands</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsColumnHeader">
         <source>Details</source>
         <target state="new">Details</target>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -342,3 +342,11 @@ fluent-switch.table-switch::part(label) {
     padding-left: calc(var(--design-unit) * 2.5px);
     padding-bottom: calc(var(--design-unit) * 2.5px);
 }
+
+/* Align the toast with the top of the body/bottom of the header
+   and the right edge of the filter box
+*/
+.layout .fluent-toast-provider.position-topright {
+    top: 50px;
+    right: calc(var(--design-unit) * 1.5px);
+}

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -142,21 +142,4 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
             }
         }
     }
-
-    // REMOVE THIS BEFORE MERGING
-
-    public override Task<ResourceCommandResponse> ExecuteResourceCommand(ResourceCommandRequest request, ServerCallContext context)
-    {
-        ResourceCommandResponse response;
-        if (request.CommandType == "restart")
-        {
-            response = new ResourceCommandResponse { Kind = ResourceCommandResponseKind.Succeeded };
-        }
-        else
-        {
-            response = new ResourceCommandResponse { Kind = ResourceCommandResponseKind.Failed, ErrorMessage = "Command not implemented" };
-        }
-
-        return Task.FromResult(response);
-    }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -142,4 +142,21 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
             }
         }
     }
+
+    // REMOVE THIS BEFORE MERGING
+
+    public override Task<ResourceCommandResponse> ExecuteResourceCommand(ResourceCommandRequest request, ServerCallContext context)
+    {
+        ResourceCommandResponse response;
+        if (request.CommandType == "restart")
+        {
+            response = new ResourceCommandResponse { Kind = ResourceCommandResponseKind.Succeeded };
+        }
+        else
+        {
+            response = new ResourceCommandResponse { Kind = ResourceCommandResponseKind.Failed, ErrorMessage = "Command not implemented" };
+        }
+
+        return Task.FromResult(response);
+    }
 }

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -61,6 +61,30 @@ partial class Resource
             resource.Properties.Add(new ResourceProperty { Name = property.Name, Value = property.Value });
         }
 
+        // REMOVE THIS BEFORE MREGING
+        if (Random.Shared.Next(2) == 0)
+        {
+            resource.Commands.Add(new ResourceCommand()
+            {
+                CommandType = "start",
+                DisplayName = "Start",
+                ConfirmationMessage = "Are you sure you want to start this resource?"
+            });
+
+            resource.Commands.Add(new ResourceCommand()
+            {
+                CommandType = "stop",
+                DisplayName = "Stop"
+            });
+
+            resource.Commands.Add(new ResourceCommand()
+            {
+                CommandType = "restart",
+                DisplayName = "Restart",
+                ConfirmationMessage = "Are you sure you want to restart this resource?"
+            });
+        }
+
         return resource;
     }
 }

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -61,30 +61,6 @@ partial class Resource
             resource.Properties.Add(new ResourceProperty { Name = property.Name, Value = property.Value });
         }
 
-        // REMOVE THIS BEFORE MREGING
-        if (Random.Shared.Next(2) == 0)
-        {
-            resource.Commands.Add(new ResourceCommand()
-            {
-                CommandType = "start",
-                DisplayName = "Start",
-                ConfirmationMessage = "Are you sure you want to start this resource?"
-            });
-
-            resource.Commands.Add(new ResourceCommand()
-            {
-                CommandType = "stop",
-                DisplayName = "Stop"
-            });
-
-            resource.Commands.Add(new ResourceCommand()
-            {
-                CommandType = "restart",
-                DisplayName = "Restart",
-                ConfirmationMessage = "Are you sure you want to restart this resource?"
-            });
-        }
-
         return resource;
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
@@ -50,6 +50,7 @@ public class ApplicationNameTests : TestContext
         public Task WhenConnected => Task.CompletedTask;
         public string ApplicationName => "<marquee>An HTML title!</marquee>";
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public ResourceViewModelSubscription SubscribeResources() => throw new NotImplementedException();
     }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -184,7 +184,8 @@ public sealed class ResourceEndpointHelpersTests
             Services = services,
             ExpectedEndpointsCount = 0,
             Properties = FrozenDictionary<string, Value>.Empty,
-            State = null
+            State = null,
+            Commands = []
         };
     }
 }

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -29,7 +29,8 @@ public class ResourceOutgoingPeerResolverTests
             Services = resourceServices,
             ExpectedEndpointsCount = 0,
             Properties = FrozenDictionary<string, Value>.Empty,
-            State = null
+            State = null,
+            Commands = []
         };
     }
 


### PR DESCRIPTION
First pieces of the resource command support:

- Forked the FluentMenuButton component to make an AspireMenuButton component that had a few extra features (different item binding/commanding structure, ability to change the appearance of the button, ability to have only an icon of our choosing for the button). Already chatting with @vnbaaij about what to do long term
- Temporarily implemented commands in the local resource server. I won't merge until that is removed, but it'll make it easier for folks to test it out. Start/Stop commands always fail. Restart always succeeds. Start/Restart have confirmation message, Stop does not. Some resources (randomly) have no commands at all.
- If no commands are present on a particular resource, the button is still there, but its disabled
- If no commands are present on any resources, the column doesn't appear at all
- Toast component pops up for Success/Failure of the command. Failure has a View Logs link to take you to the console logs for the resource. Not 100% positive that's useful, but wanted to show it for discussion
- MessageBox component used for confirmation

Here's a quick recording of it in action:

![ResourceCommandsDark](https://github.com/dotnet/aspire/assets/9613109/c29de2e2-2023-4101-8915-df350867be35)

Some notes:
1. I had to hack around a glitch where the menu would appear offscreen very briefly, causing the horizontal scrollbar to appear. That's what the extra CSS for the grid does. This is only an issue when its the last column (or otherwise near the right edge of the screen)
2. I initially had no text in the column header for the commands. I didn't think it was necessary. But there's an odd rendering issue with the grid where the resize handle doesn't appear if there's no text. So I just made it say Commands
3. I have some special casing in the error handling for when ExecuteResourceCommand isn't implemented by the resource server. I'm not sure that's really necessary, but it seemed appropriate at this state where we are just starting to implement that (and indeed it is not implemented in the local server once I remove my change)
4. As mentioned above, I'll remove the changes to Hosting's DashboardService.cs and Partials.cs before this gets merged.
5. The toasts disappear after 7s (the default). We should consider whether that should be increased/decreased. We should also make sure it plays well with screen readers (if it doesn't, that should probably be fixed in the component long term).
6. We should consider if there needs to be keyboard shortcuts for the toasts.
7. I did not implement merging commands that exist on resource types into the ones that exist on a resource as part of this PR. At the moment, we don't really use the resource type object from the API in a way that made that straightforward. Since the first use case for these commands doesn't use it either, I think we can do that as a second step.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2572)