### PR TITLE
Testing: move DistributedApplicationBuilder into base test harness

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
@@ -16,7 +16,6 @@ namespace Aspire.Hosting.Testing;
 public sealed class DistributedApplicationTestingBuilder<TEntryPoint> : IDistributedApplicationBuilder where TEntryPoint : class
 {
     private readonly SuspendingDistributedApplicationFactory _factory;
-    private readonly DistributedApplicationBuilder _builder;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DistributedApplicationTestingBuilder{TEntryPoint}"/> class.
@@ -31,32 +30,31 @@ public sealed class DistributedApplicationTestingBuilder<TEntryPoint> : IDistrib
     public DistributedApplicationTestingBuilder(Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder)
     {
         _factory = new(configureBuilder);
-        _builder = _factory.DistributedApplicationBuilder;
     }
 
     /// <inheritdoc cref="IDistributedApplicationBuilder.Configuration" />
-    public ConfigurationManager Configuration => _builder.Configuration;
+    public ConfigurationManager Configuration => _factory.Builder.Configuration;
 
     /// <inheritdoc cref="IDistributedApplicationBuilder.Environment" />
-    public string AppHostDirectory => _builder.AppHostDirectory;
+    public string AppHostDirectory => _factory.Builder.AppHostDirectory;
 
     /// <inheritdoc cref="HostApplicationBuilder.Environment" />
-    public IHostEnvironment Environment => _builder.Environment;
+    public IHostEnvironment Environment => _factory.Builder.Environment;
 
     /// <inheritdoc cref="IDistributedApplicationBuilder.Services" />
-    public IServiceCollection Services => _builder.Services;
+    public IServiceCollection Services => _factory.Builder.Services;
 
     /// <inheritdoc cref="IDistributedApplicationBuilder.ExecutionContext" />
-    public DistributedApplicationExecutionContext ExecutionContext => _builder.ExecutionContext;
+    public DistributedApplicationExecutionContext ExecutionContext => _factory.Builder.ExecutionContext;
 
     /// <inheritdoc cref="IDistributedApplicationBuilder.Resources" />
-    public IResourceCollection Resources => _builder.Resources;
+    public IResourceCollection Resources => _factory.Builder.Resources;
 
     /// <inheritdoc cref="IDistributedApplicationBuilder.AddResource{T}(T)" />
-    public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource => _builder.AddResource(resource);
+    public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource => _factory.Builder.AddResource(resource);
 
     /// <inheritdoc cref="IDistributedApplicationBuilder.CreateResourceBuilder{T}(T)" />
-    public IResourceBuilder<T> CreateResourceBuilder<T>(T resource) where T : IResource => _builder.CreateResourceBuilder(resource);
+    public IResourceBuilder<T> CreateResourceBuilder<T>(T resource) where T : IResource => _factory.Builder.CreateResourceBuilder(resource);
 
     /// <inheritdoc cref="IDistributedApplicationBuilder.Build" />
     public DistributedApplication Build()
@@ -70,7 +68,8 @@ public sealed class DistributedApplicationTestingBuilder<TEntryPoint> : IDistrib
     {
         private readonly SemaphoreSlim _continueBuilding = new(0);
 
-        public new DistributedApplication DistributedApplication => base.DistributedApplication;
+        public new DistributedApplicationBuilder Builder => base.Builder;
+        public new DistributedApplication Application => base.Application;
 
         protected override void OnBuilderCreating(DistributedApplicationOptions applicationOptions, HostApplicationBuilderSettings hostOptions)
         {

--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingBuilder.cs
@@ -8,68 +8,35 @@ using Microsoft.Extensions.Hosting;
 namespace Aspire.Hosting.Testing;
 
 /// <summary>
-/// Harness for running a distributed application for testing.
+/// Methods for creating distributed application instances for testing purposes.
 /// </summary>
-/// <typeparam name="TEntryPoint">
-/// A type in the entry point assembly of the target Aspire AppHost. Typically, the Program class can be used.
-/// </typeparam>
-public sealed class DistributedApplicationTestingBuilder<TEntryPoint> : IDistributedApplicationBuilder where TEntryPoint : class
+public static class DistributedApplicationTestingBuilder
 {
-    private readonly SuspendingDistributedApplicationFactory _factory;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="DistributedApplicationTestingBuilder{TEntryPoint}"/> class.
+    /// Creates a new instance of <see cref="DistributedApplicationTestingBuilder"/>.
     /// </summary>
-    public DistributedApplicationTestingBuilder() : this((_, __) => { })
-    { }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DistributedApplicationTestingBuilder{TEntryPoint}"/> class.
-    /// </summary>
-    /// <param name="configureBuilder">The delegate used to configure the creation of the builder.</param>
-    public DistributedApplicationTestingBuilder(Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder)
+    /// <typeparam name="TEntryPoint">
+    /// A type in the entry point assembly of the target Aspire AppHost. Typically, the Program class can be used.
+    /// </typeparam>
+    /// <returns>
+    /// A new instance of <see cref="DistributedApplicationTestingBuilder"/>.
+    /// </returns>
+    public static async Task<IDistributedApplicationTestingBuilder> CreateAsync<TEntryPoint>(CancellationToken cancellationToken = default) where TEntryPoint : class
     {
-        _factory = new(configureBuilder);
+        var factory = new SuspendingDistributedApplicationFactory<TEntryPoint>((_, __) => { });
+        return await factory.CreateBuilderAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    /// <inheritdoc cref="IDistributedApplicationBuilder.Configuration" />
-    public ConfigurationManager Configuration => _factory.Builder.Configuration;
-
-    /// <inheritdoc cref="IDistributedApplicationBuilder.Environment" />
-    public string AppHostDirectory => _factory.Builder.AppHostDirectory;
-
-    /// <inheritdoc cref="HostApplicationBuilder.Environment" />
-    public IHostEnvironment Environment => _factory.Builder.Environment;
-
-    /// <inheritdoc cref="IDistributedApplicationBuilder.Services" />
-    public IServiceCollection Services => _factory.Builder.Services;
-
-    /// <inheritdoc cref="IDistributedApplicationBuilder.ExecutionContext" />
-    public DistributedApplicationExecutionContext ExecutionContext => _factory.Builder.ExecutionContext;
-
-    /// <inheritdoc cref="IDistributedApplicationBuilder.Resources" />
-    public IResourceCollection Resources => _factory.Builder.Resources;
-
-    /// <inheritdoc cref="IDistributedApplicationBuilder.AddResource{T}(T)" />
-    public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource => _factory.Builder.AddResource(resource);
-
-    /// <inheritdoc cref="IDistributedApplicationBuilder.CreateResourceBuilder{T}(T)" />
-    public IResourceBuilder<T> CreateResourceBuilder<T>(T resource) where T : IResource => _factory.Builder.CreateResourceBuilder(resource);
-
-    /// <inheritdoc cref="IDistributedApplicationBuilder.Build" />
-    public DistributedApplication Build()
-    {
-        _factory.Build();
-        return new DelegatedDistributedApplication(new DelegatedHost(_factory));
-    }
-
-    private sealed class SuspendingDistributedApplicationFactory(Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder)
-        : DistributedApplicationTestingHarness<TEntryPoint>
+    private sealed class SuspendingDistributedApplicationFactory<TEntryPoint>(Action<DistributedApplicationOptions, HostApplicationBuilderSettings> configureBuilder)
+        : DistributedApplicationFactory<TEntryPoint> where TEntryPoint : class
     {
         private readonly SemaphoreSlim _continueBuilding = new(0);
 
-        public new DistributedApplicationBuilder Builder => base.Builder;
-        public new DistributedApplication Application => base.Application;
+        public async Task<IDistributedApplicationTestingBuilder> CreateBuilderAsync(CancellationToken cancellationToken)
+        {
+            var innerBuilder = await ResolveBuilderAsync(cancellationToken).ConfigureAwait(false);
+            return new Builder(this, innerBuilder);
+        }
 
         protected override void OnBuilderCreating(DistributedApplicationOptions applicationOptions, HostApplicationBuilderSettings hostOptions)
         {
@@ -86,13 +53,14 @@ public sealed class DistributedApplicationTestingBuilder<TEntryPoint> : IDistrib
         {
             base.OnBuilding(applicationBuilder);
 
-            // Wait until the owner signals that building can continue by calling Build().
+            // Wait until the owner signals that building can continue by calling BuildAsync().
             _continueBuilding.Wait();
         }
 
-        public void Build()
+        public async Task<DistributedApplication> BuildAsync(CancellationToken cancellationToken)
         {
             _continueBuilding.Release();
+            return await ResolveApplicationAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public override async ValueTask DisposeAsync()
@@ -106,54 +74,135 @@ public sealed class DistributedApplicationTestingBuilder<TEntryPoint> : IDistrib
             _continueBuilding.Release();
             base.Dispose();
         }
+
+        private sealed class Builder(SuspendingDistributedApplicationFactory<TEntryPoint> factory, DistributedApplicationBuilder innerBuilder) : IDistributedApplicationTestingBuilder
+        {
+            public ConfigurationManager Configuration => innerBuilder.Configuration;
+
+            public string AppHostDirectory => innerBuilder.AppHostDirectory;
+
+            public IHostEnvironment Environment => innerBuilder.Environment;
+
+            public IServiceCollection Services => innerBuilder.Services;
+
+            public DistributedApplicationExecutionContext ExecutionContext => innerBuilder.ExecutionContext;
+
+            public IResourceCollection Resources => innerBuilder.Resources;
+
+            public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource => innerBuilder.AddResource(resource);
+
+            public async Task<DistributedApplication> BuildAsync(CancellationToken cancellationToken)
+            {
+                var innerApp = await factory.BuildAsync(cancellationToken).ConfigureAwait(false);
+                return new DelegatedDistributedApplication(new DelegatedHost(factory, innerApp));
+            }
+
+            public IResourceBuilder<T> CreateResourceBuilder<T>(T resource) where T : IResource => innerBuilder.CreateResourceBuilder(resource);
+        }
+
+        private sealed class DelegatedDistributedApplication(DelegatedHost host) : DistributedApplication(host)
+        {
+            private readonly DelegatedHost _host = host;
+
+            public override async Task RunAsync(CancellationToken cancellationToken)
+            {
+                // Avoid calling the base here, since it will execute the pre-start hooks
+                // before calling the corresponding host method, which also executes the same pre-start hooks.
+                await _host.RunAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            public override async Task StartAsync(CancellationToken cancellationToken)
+            {
+                // Avoid calling the base here, since it will execute the pre-start hooks
+                // before calling the corresponding host method, which also executes the same pre-start hooks.
+                await _host.StartAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            public override async Task StopAsync(CancellationToken cancellationToken)
+            {
+                await _host.StopAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private sealed class DelegatedHost(SuspendingDistributedApplicationFactory<TEntryPoint> appFactory, DistributedApplication innerApp) : IHost, IAsyncDisposable
+        {
+            public IServiceProvider Services => innerApp.Services;
+
+            public void Dispose()
+            {
+                appFactory.Dispose();
+            }
+
+            public async ValueTask DisposeAsync()
+            {
+                await appFactory.DisposeAsync().ConfigureAwait(false);
+            }
+
+            public async Task StartAsync(CancellationToken cancellationToken)
+            {
+                await appFactory.StartAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            public async Task StopAsync(CancellationToken cancellationToken)
+            {
+                await appFactory.DisposeAsync().ConfigureAwait(false);
+            }
+        }
     }
+}
 
-    private sealed class DelegatedDistributedApplication(DelegatedHost host) : DistributedApplication(host)
-    {
-        private readonly DelegatedHost _host = host;
+/// <summary>
+/// A builder for creating instances of <see cref="DistributedApplication"/> for testing purposes.
+/// </summary>
+public interface IDistributedApplicationTestingBuilder
+{
+    /// <inheritdoc cref="HostApplicationBuilder.Configuration" />
+    ConfigurationManager Configuration { get; }
 
-        public override async Task RunAsync(CancellationToken cancellationToken)
-        {
-            // Avoid calling the base here, since it will execute the pre-start hooks
-            // before calling the corresponding host method, which also executes the same pre-start hooks.
-            await _host.RunAsync(cancellationToken).ConfigureAwait(false);
-        }
+    /// <summary>
+    /// Directory of the project where the app host is located. Defaults to the content root if there's no project.
+    /// </summary>
+    string AppHostDirectory { get; }
 
-        public override async Task StartAsync(CancellationToken cancellationToken)
-        {
-            // Avoid calling the base here, since it will execute the pre-start hooks
-            // before calling the corresponding host method, which also executes the same pre-start hooks.
-            await _host.StartAsync(cancellationToken).ConfigureAwait(false);
-        }
+    /// <inheritdoc cref="HostApplicationBuilder.Environment" />
+    IHostEnvironment Environment { get; }
 
-        public override async Task StopAsync(CancellationToken cancellationToken)
-        {
-            await _host.StopAsync(cancellationToken).ConfigureAwait(false);
-        }
-    }
+    /// <inheritdoc cref="HostApplicationBuilder.Services" />
+    IServiceCollection Services { get; }
 
-    private sealed class DelegatedHost(SuspendingDistributedApplicationFactory appFactory) : IHost, IAsyncDisposable
-    {
-        public IServiceProvider Services => appFactory.Services;
+    /// <summary>
+    /// Execution context for this invocation of the AppHost.
+    /// </summary>
+    DistributedApplicationExecutionContext ExecutionContext { get; }
 
-        public void Dispose()
-        {
-            appFactory.Dispose();
-        }
+    /// <summary>
+    /// Gets the collection of resources for the distributed application.
+    /// </summary>
+    /// <remarks>
+    /// This can be mutated by adding more resources, which will update its current view.
+    /// </remarks>
+    IResourceCollection Resources { get; }
 
-        public async ValueTask DisposeAsync()
-        {
-            await appFactory.DisposeAsync().ConfigureAwait(false);
-        }
+    /// <summary>
+    /// Adds a resource of type <typeparamref name="T"/> to the distributed application.
+    /// </summary>
+    /// <typeparam name="T">The type of resource to add.</typeparam>
+    /// <param name="resource">The resource to add.</param>
+    /// <returns>A innerBuilder for configuring the added resource.</returns>
+    /// <exception cref="DistributedApplicationException">Thrown when a resource with the same name already exists.</exception>
+    IResourceBuilder<T> AddResource<T>(T resource) where T : IResource;
 
-        public async Task StartAsync(CancellationToken cancellationToken)
-        {
-            await appFactory.InitializeAsync(cancellationToken).ConfigureAwait(false);
-        }
+    /// <summary>
+    /// Creates a new resource innerBuilder based on an existing resource.
+    /// </summary>
+    /// <typeparam name="T">Type of resource.</typeparam>
+    /// <param name="resource">An existing resource.</param>
+    /// <returns>A resource innerBuilder.</returns>
+    IResourceBuilder<T> CreateResourceBuilder<T>(T resource) where T : IResource;
 
-        public async Task StopAsync(CancellationToken cancellationToken)
-        {
-            await appFactory.DisposeAsync().ConfigureAwait(false);
-        }
-    }
+    /// <summary>
+    /// Builds and returns a new <see cref="DistributedApplication"/> instance. This can only be called once.
+    /// </summary>
+    /// <returns>A new <see cref="DistributedApplication"/> instance.</returns>
+    Task<DistributedApplication> BuildAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingHarnessOfT.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingHarnessOfT.cs
@@ -188,8 +188,7 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
             return;
         }
 
-        Start();
-
+        StartEntryPoint();
         _builder = _builderTcs.Task.GetAwaiter().GetResult();
     }
 
@@ -201,13 +200,12 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
             return;
         }
 
-        Start();
-
+        StartEntryPoint();
         _app = _appTask.GetAwaiter().GetResult();
     }
 
     [MemberNotNull(nameof(_appTask))]
-    private void Start()
+    private void StartEntryPoint()
     {
         EnsureDepsFile();
 
@@ -238,18 +236,6 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
         }
     }
 
-    private void OnEntryPointExit(Exception? exception)
-    {
-        if (exception is not null)
-        {
-            _exitTcs.TrySetException(exception);
-        }
-        else
-        {
-            _exitTcs.TrySetResult();
-        }
-    }
-
     private async Task<DistributedApplication> ResolveApp(Func<string[], CancellationToken, Task<DistributedApplication>> factory)
     {
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
@@ -273,6 +259,18 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
             }
 
             return TimeSpan.FromMinutes(5);
+        }
+    }
+
+    private void OnEntryPointExit(Exception? exception)
+    {
+        if (exception is not null)
+        {
+            _exitTcs.TrySetException(exception);
+        }
+        else
+        {
+            _exitTcs.TrySetResult();
         }
     }
 

--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingHarnessOfT.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingHarnessOfT.cs
@@ -32,12 +32,12 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
     private IHostApplicationLifetime? _hostApplicationLifetime;
 
     /// <summary>
-    /// Gets the distributed application builder associated with this <see cref="DistributedApplicationTestingHarness{TEntryPoint}"/>.
+    /// Gets the distributed application builder associated with this instance.
     /// </summary>
     public DistributedApplicationBuilder DistributedApplicationBuilder { get { EnsureBuilder(); return _builder; } }
 
     /// <summary>
-    /// Gets the distributed application associated with this <see cref="DistributedApplicationTestingHarness{TEntryPoint}"/>.
+    /// Gets the distributed application associated with this instance.
     /// </summary>
     protected DistributedApplication DistributedApplication { get { EnsureApp(); return _app; } }
 
@@ -53,7 +53,7 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
     }
 
     /// <summary>
-    /// Gets the <see cref="IServiceProvider"/> created by the server associated with this <see cref="DistributedApplicationTestingHarness{TEntryPoint}"/>.
+    /// Gets the <see cref="IServiceProvider"/> created by the server associated with this instance.
     /// </summary>
     public virtual IServiceProvider Services
     {
@@ -65,7 +65,7 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
     }
 
     /// <summary>
-    /// Gets the <see cref="DistributedApplicationModel"/> associated with this <see cref="DistributedApplicationTestingHarness{TEntryPoint}"/>.
+    /// Gets the <see cref="DistributedApplicationModel"/> associated with this instance.
     /// </summary>
     public DistributedApplicationModel ApplicationModel
     {

--- a/src/Aspire.Hosting.Testing/DistributedApplicationTestingHarnessOfT.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationTestingHarnessOfT.cs
@@ -34,12 +34,12 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
     /// <summary>
     /// Gets the distributed application builder associated with this instance.
     /// </summary>
-    public DistributedApplicationBuilder DistributedApplicationBuilder { get { EnsureBuilder(); return _builder; } }
+    protected DistributedApplicationBuilder Builder { get { EnsureBuilder(); return _builder; } }
 
     /// <summary>
     /// Gets the distributed application associated with this instance.
     /// </summary>
-    protected DistributedApplication DistributedApplication { get { EnsureApp(); return _app; } }
+    protected DistributedApplication Application { get { EnsureApp(); return _app; } }
 
     /// <summary>
     /// Initializes the application.
@@ -86,7 +86,7 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
         EnsureApp();
         ThrowIfNotInitialized();
 
-        return DistributedApplication.CreateHttpClient(resourceName, endpointName);
+        return Application.CreateHttpClient(resourceName, endpointName);
     }
 
     /// <summary>
@@ -100,7 +100,7 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
         EnsureApp();
         ThrowIfNotInitialized();
 
-        return DistributedApplication.GetConnectionString(resourceName);
+        return Application.GetConnectionString(resourceName);
     }
 
     /// <summary>
@@ -116,7 +116,7 @@ public class DistributedApplicationTestingHarness<TEntryPoint> : IDisposable, IA
         EnsureApp();
         ThrowIfNotInitialized();
 
-        return DistributedApplication.GetEndpoint(resourceName, endpointName);
+        return Application.GetEndpoint(resourceName, endpointName);
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationFixtureOfT.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationFixtureOfT.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Aspire.Hosting.Testing.Tests;
 
-public sealed class DistributedApplicationFixture<TEntryPoint> : DistributedApplicationTestingHarness<TEntryPoint>, IAsyncLifetime where TEntryPoint : class
+public sealed class DistributedApplicationFixture<TEntryPoint> : DistributedApplicationFactory<TEntryPoint>, IAsyncLifetime where TEntryPoint : class
 {
     protected override void OnBuilderCreating(DistributedApplicationOptions applicationOptions, HostApplicationBuilderSettings hostOptions)
     {
@@ -20,7 +20,15 @@ public sealed class DistributedApplicationFixture<TEntryPoint> : DistributedAppl
         base.OnBuilding(applicationBuilder);
     }
 
-    public async Task InitializeAsync() => await base.InitializeAsync();
+    protected override void OnBuilt(DistributedApplication application)
+    {
+        Application = application;
+        base.OnBuilt(application);
+    }
+
+    public DistributedApplication Application { get; private set; } = null!;
+
+    public async Task InitializeAsync() => await StartAsync();
 
     async Task IAsyncLifetime.DisposeAsync() => await DisposeAsync();
 }

--- a/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationFixtureOfT.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationFixtureOfT.cs
@@ -1,10 +1,19 @@
 using Microsoft.Extensions.Hosting;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Aspire.Hosting.Testing.Tests;
 
 public sealed class DistributedApplicationFixture<TEntryPoint> : DistributedApplicationFactory<TEntryPoint>, IAsyncLifetime where TEntryPoint : class
 {
+    public DistributedApplicationFixture()
+    {
+        if (Environment.GetEnvironmentVariable("BUILD_BUILDID") != null)
+        {
+            throw new SkipException("These tests can only run in local environments.");
+        }
+    }
+
     protected override void OnBuilderCreating(DistributedApplicationOptions applicationOptions, HostApplicationBuilderSettings hostOptions)
     {
         base.OnBuilderCreating(applicationOptions, hostOptions);

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -33,8 +33,6 @@ public class TestingBuilderTests
     public async Task CanGetResources()
     {
         var appHost = new DistributedApplicationTestingBuilder<Program>();
-        appHost.Resources.Remove(appHost.Resources.Single(r => r.Name == "redis1"));
-
         await using var app = appHost.Build();
         await app.StartAsync();
 

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -11,14 +11,9 @@ using Xunit;
 
 namespace Aspire.Hosting.Testing.Tests;
 
-public class TestingFactoryTests : IClassFixture<DistributedApplicationFixture<Program>>
+public class TestingFactoryTests(DistributedApplicationFixture<Program> fixture) : IClassFixture<DistributedApplicationFixture<Program>>
 {
-    private readonly DistributedApplication _app;
-
-    public TestingFactoryTests(DistributedApplicationFixture<Program> fixture)
-    {
-        _app = fixture.Application;
-    }
+    private readonly DistributedApplication _app = fixture.Application;
 
     [LocalOnlyFact]
     public void HasEndPoints()

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Only run this test when not in CI. [LocalOnlyFact] is insufficient because the fixture is created and initialized unconditionally.
-#if !BUILD_BUILDID
-
 using System.Net.Http.Json;
 using Aspire.Hosting.Tests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,4 +48,3 @@ public class TestingFactoryTests(DistributedApplicationFixture<Program> fixture)
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
     }
 }
-#endif


### PR DESCRIPTION
This moves logic to get the app builder from `DistributedApplicationTestingBuilder` into the core `DistributedApplicationTestingHarness<TEntryPoint>` so that the lifecycle logic is a little more centralized and the control flow is a little clearer. More importantly, it fixes a deadlock introduced while trying make the tests run in CI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2575)