### PR TITLE
ThemeManager should not be singleton

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -103,7 +103,7 @@ public class DashboardWebApplication : IAsyncDisposable
 
         builder.Services.AddFluentUIComponents();
 
-        builder.Services.AddSingleton<ThemeManager>();
+        builder.Services.AddScoped<ThemeManager>();
         // ShortcutManager is scoped because we want shortcuts to apply one browser window.
         builder.Services.AddScoped<ShortcutManager>();
 


### PR DESCRIPTION
Addresses the immediate concern of #2561 so that theme changes don't impact all users of a particular instance of the Aspire Dashboard. More follow-up work will need to be done if we want to address the take-back mentioned in the issue. The workaround for now is just to refresh other tabs after making a theme change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2582)