### PR TITLE
Added Fix and tests for calling WithImage (#2580)

### DIFF
--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -133,8 +133,15 @@ public static class ContainerResourceBuilderExtensions
     /// <returns></returns>
     public static IResourceBuilder<T> WithImage<T>(this IResourceBuilder<T> builder, string image) where T : ContainerResource
     {
-        var containerImageAnnotation = builder.Resource.Annotations.OfType<ContainerImageAnnotation>().Single();
-        containerImageAnnotation.Image = image;
+        if (builder.Resource.Annotations.OfType<ContainerImageAnnotation>().LastOrDefault() is { } existingImageAnnotation)
+        {
+            existingImageAnnotation.Image = image;
+            return builder;
+        }
+
+        // if the annotation doesn't exist, create it with the given image and add it to the collection
+        var containerImageAnnotation = new ContainerImageAnnotation() { Image = image };
+        builder.Resource.Annotations.Add(containerImageAnnotation);
         return builder;
     }
 

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -134,21 +134,9 @@ public static class ContainerResourceBuilderExtensions
     /// <typeparam name="T">Type of container resource.</typeparam>
     /// <param name="builder">Builder for the container resource.</param>
     /// <param name="image">Image value.</param>
-    /// <returns></returns>
-    public static IResourceBuilder<T> WithImage<T>(this IResourceBuilder<T> builder, string image) where T : ContainerResource
-    {
-        return builder.WithImage<T>(image, "latest");
-    }
-
-    /// <summary>
-    /// Allows overriding the image on a container.
-    /// </summary>
-    /// <typeparam name="T">Type of container resource.</typeparam>
-    /// <param name="builder">Builder for the container resource.</param>
-    /// <param name="image">Image value.</param>
     /// <param name="tag">Tag value.</param>
     /// <returns></returns>
-    public static IResourceBuilder<T> WithImage<T>(this IResourceBuilder<T> builder, string image, string tag) where T : ContainerResource
+    public static IResourceBuilder<T> WithImage<T>(this IResourceBuilder<T> builder, string image, string tag = "latest") where T : ContainerResource
     {
         if (builder.Resource.Annotations.OfType<ContainerImageAnnotation>().LastOrDefault() is { } existingImageAnnotation)
         {

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -111,7 +111,7 @@ public static class ContainerResourceBuilderExtensions
             return builder;
         }
 
-        throw new InvalidOperationException("The resource does not contain any image annotation to be mutated");
+        throw new InvalidOperationException($"The resource '{builder.Resource.Name}' does not have a container image specified. Use WithImage to specify the container image and tag.");
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -158,7 +158,7 @@ public static class ContainerResourceBuilderExtensions
         }
 
         // if the annotation doesn't exist, create it with the given image and add it to the collection
-        var containerImageAnnotation = new ContainerImageAnnotation() { Image = image };
+        var containerImageAnnotation = new ContainerImageAnnotation() { Image = image, Tag = tag };
         builder.Resource.Annotations.Add(containerImageAnnotation);
         return builder;
     }

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -105,9 +105,13 @@ public static class ContainerResourceBuilderExtensions
     /// <returns></returns>
     public static IResourceBuilder<T> WithImageTag<T>(this IResourceBuilder<T> builder, string tag) where T : ContainerResource
     {
-        var containerImageAnnotation = builder.Resource.Annotations.OfType<ContainerImageAnnotation>().Single();
-        containerImageAnnotation.Tag = tag;
-        return builder;
+        if (builder.Resource.Annotations.OfType<ContainerImageAnnotation>().LastOrDefault() is { } existingImageAnnotation)
+        {
+            existingImageAnnotation.Tag = tag;
+            return builder;
+        }
+
+        throw new InvalidOperationException("The resource does not contain any image annotation to be mutated");
     }
 
     /// <summary>
@@ -129,13 +133,27 @@ public static class ContainerResourceBuilderExtensions
     /// </summary>
     /// <typeparam name="T">Type of container resource.</typeparam>
     /// <param name="builder">Builder for the container resource.</param>
-    /// <param name="image">Registry value.</param>
+    /// <param name="image">Image value.</param>
     /// <returns></returns>
     public static IResourceBuilder<T> WithImage<T>(this IResourceBuilder<T> builder, string image) where T : ContainerResource
+    {
+        return builder.WithImage<T>(image, "latest");
+    }
+
+    /// <summary>
+    /// Allows overriding the image on a container.
+    /// </summary>
+    /// <typeparam name="T">Type of container resource.</typeparam>
+    /// <param name="builder">Builder for the container resource.</param>
+    /// <param name="image">Image value.</param>
+    /// <param name="tag">Tag value.</param>
+    /// <returns></returns>
+    public static IResourceBuilder<T> WithImage<T>(this IResourceBuilder<T> builder, string image, string tag) where T : ContainerResource
     {
         if (builder.Resource.Annotations.OfType<ContainerImageAnnotation>().LastOrDefault() is { } existingImageAnnotation)
         {
             existingImageAnnotation.Image = image;
+            existingImageAnnotation.Tag = tag;
             return builder;
         }
 

--- a/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
@@ -16,6 +16,15 @@ public class ContainerResourceBuilderTests
     }
 
     [Fact]
+    public void WithImageMutatesImageNameAndTag()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var redis = builder.AddRedis("redis").WithImage("redis-stack", "1.0.0");
+        Assert.Equal("redis-stack", redis.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Image);
+        Assert.Equal("1.0.0", redis.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Tag);
+    }
+
+    [Fact]
     public void WithImageAddsAnnotationIfNotExistingAndMutatesImageName()
     {
         var builder = DistributedApplication.CreateBuilder();

--- a/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
@@ -45,7 +45,7 @@ public class ContainerResourceBuilderTests
 
         container.WithImage("new-image");
         Assert.Equal("new-image", container.Resource.Annotations.OfType<ContainerImageAnnotation>().Last().Image);
-        Assert.Equal("latest", container.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Tag);
+        Assert.Equal("latest", container.Resource.Annotations.OfType<ContainerImageAnnotation>().Last().Tag);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
@@ -16,6 +16,28 @@ public class ContainerResourceBuilderTests
     }
 
     [Fact]
+    public void WithImageAddsAnnotationIfNotExistingAndMutatesImageName()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var container = builder.AddContainer("app", "some-image");
+        container.Resource.Annotations.RemoveAt(0);
+
+        container.WithImage("new-image");
+        Assert.Equal("new-image", container.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Image);
+    }
+
+    [Fact]
+    public void WithImageMutatesImageNameOfLastAnnotation()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var container = builder.AddContainer("app", "some-image");
+        container.Resource.Annotations.Add(new ContainerImageAnnotation { Image = "another-image" } );
+
+        container.WithImage("new-image");
+        Assert.Equal("new-image", container.Resource.Annotations.OfType<ContainerImageAnnotation>().Last().Image);
+    }
+
+    [Fact]
     public void WithImageTagMutatesImageTag()
     {
         var builder = DistributedApplication.CreateBuilder();

--- a/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
@@ -33,6 +33,7 @@ public class ContainerResourceBuilderTests
 
         container.WithImage("new-image");
         Assert.Equal("new-image", container.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Image);
+        Assert.Equal("latest", container.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Tag);
     }
 
     [Fact]
@@ -44,6 +45,7 @@ public class ContainerResourceBuilderTests
 
         container.WithImage("new-image");
         Assert.Equal("new-image", container.Resource.Annotations.OfType<ContainerImageAnnotation>().Last().Image);
+        Assert.Equal("latest", container.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Tag);
     }
 
     [Fact]


### PR DESCRIPTION
When calling `WithImage`, we now first check if the annotation exist and mutate its image. if it doesn't we add the annotation with the given image.

Fixes #2580

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2588)