### PR TITLE
Support live references in the application model

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -162,9 +162,7 @@ public class AzureBicepResource(string name, string? templateFile = null, string
 
                 var value = input.Value switch
                 {
-                    IResourceBuilder<ParameterResource> p => p.Resource.ValueExpression,
-                    IResourceBuilder<IResourceWithConnectionString> p => p.Resource.ConnectionStringReferenceExpression,
-                    BicepOutputReference output => output.ValueExpression,
+                    IManifestExpressionProvider output => output.ValueExpression,
                     object obj => obj.ToString(),
                     null => ""
                 };
@@ -241,7 +239,7 @@ public readonly struct BicepTemplateFile(string path, bool deleteFileOnDispose) 
 /// </summary>
 /// <param name="name">The name of the secret output.</param>
 /// <param name="resource">The <see cref="AzureBicepResource"/>.</param>
-public class BicepSecretOutputReference(string name, AzureBicepResource resource)
+public class BicepSecretOutputReference(string name, AzureBicepResource resource) : IManifestExpressionProvider, IValueProvider
 {
     /// <summary>
     /// Name of the output.
@@ -293,7 +291,7 @@ public class BicepSecretOutputReference(string name, AzureBicepResource resource
 /// </summary>
 /// <param name="name">The name of the output</param>
 /// <param name="resource">The <see cref="AzureBicepResource"/>.</param>
-public class BicepOutputReference(string name, AzureBicepResource resource)
+public class BicepOutputReference(string name, AzureBicepResource resource) : IManifestExpressionProvider, IValueProvider
 {
     /// <summary>
     /// Name of the output.

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -85,7 +85,7 @@ public static class AzureConstructResourceExtensions
             throw new ArgumentException("Cannot bind Aspire parameter resource to this construct.", nameof(resource));
         }
 
-        construct.Resource.Parameters[parameterName] = parameterResourceBuilder;
+        construct.Resource.Parameters[parameterName] = parameterResourceBuilder.Resource;
 
         if (resource.Scope.GetParameters().Any(p => p.Name == parameterName))
         {

--- a/src/Aspire.Hosting.Azure/Extensions/AzureBicepResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureBicepResourceExtensions.cs
@@ -4,7 +4,6 @@
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
-using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
@@ -75,17 +74,9 @@ public static class AzureBicepResourceExtensions
     public static IResourceBuilder<T> WithEnvironment<T>(this IResourceBuilder<T> builder, string name, BicepOutputReference bicepOutputReference)
         where T : IResourceWithEnvironment
     {
-        return builder.WithEnvironment(async ctx =>
+        return builder.WithEnvironment(ctx =>
         {
-            if (ctx.ExecutionContext.IsPublishMode)
-            {
-                ctx.EnvironmentVariables[name] = bicepOutputReference.ValueExpression;
-                return;
-            }
-
-            ctx.Logger?.LogInformation("Getting bicep output {Name} from resource {ResourceName}", bicepOutputReference.Name, bicepOutputReference.Resource.Name);
-
-            ctx.EnvironmentVariables[name] = await bicepOutputReference.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false) ?? "";
+            ctx.EnvironmentVariables[name] = bicepOutputReference;
         });
     }
 
@@ -100,17 +91,9 @@ public static class AzureBicepResourceExtensions
     public static IResourceBuilder<T> WithEnvironment<T>(this IResourceBuilder<T> builder, string name, BicepSecretOutputReference bicepOutputReference)
         where T : IResourceWithEnvironment
     {
-        return builder.WithEnvironment(async ctx =>
+        return builder.WithEnvironment(ctx =>
         {
-            if (ctx.ExecutionContext.IsPublishMode)
-            {
-                ctx.EnvironmentVariables[name] = bicepOutputReference.ValueExpression;
-                return;
-            }
-
-            ctx.Logger?.LogInformation("Getting bicep secret output {Name} from resource {ResourceName}", bicepOutputReference.Name, bicepOutputReference.Resource.Name);
-
-            ctx.EnvironmentVariables[name] = await bicepOutputReference.GetValueAsync(ctx.CancellationToken).ConfigureAwait(false) ?? "";
+            ctx.EnvironmentVariables[name] = bicepOutputReference;
         });
     }
 
@@ -199,7 +182,7 @@ public static class AzureBicepResourceExtensions
     public static IResourceBuilder<T> WithParameter<T>(this IResourceBuilder<T> builder, string name, IResourceBuilder<ParameterResource> value)
         where T : AzureBicepResource
     {
-        builder.Resource.Parameters[name] = value;
+        builder.Resource.Parameters[name] = value.Resource;
         return builder;
     }
 
@@ -214,7 +197,7 @@ public static class AzureBicepResourceExtensions
     public static IResourceBuilder<T> WithParameter<T>(this IResourceBuilder<T> builder, string name, IResourceBuilder<IResourceWithConnectionString> value)
         where T : AzureBicepResource
     {
-        builder.Resource.Parameters[name] = value;
+        builder.Resource.Parameters[name] = value.Resource;
         return builder;
     }
 

--- a/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a reference to a connection string.
+/// </summary>
+public class ConnectionStringReference(IResourceWithConnectionString resource, bool optional) : IManifestExpressionProvider, IValueProvider
+{
+    /// <summary>
+    /// The resource that the connection string is referencing.
+    /// </summary>
+    public IResourceWithConnectionString Resource { get; } = resource;
+
+    /// <summary>
+    /// A flag indicating whether the connection string is optional.
+    /// </summary>
+    public bool Optional { get; } = optional;
+
+    string IManifestExpressionProvider.ValueExpression => Resource.ValueExpression;
+
+    async ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken)
+    {
+        var value = await Resource.GetValueAsync(cancellationToken).ConfigureAwait(false);
+
+        if (value is null && !Optional)
+        {
+            throw new DistributedApplicationException($"The connection string for the resource `{Resource.Name}` is not available.");
+        }
+
+        return value;
+    }
+}

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -27,7 +27,7 @@ public sealed class EndpointReference(IResourceWithEndpoints owner, string endpo
     ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => new(GetValue());
 
     /// <summary>
-    /// Gets the expression used in the manifest to reference the value of the endpoint.
+    /// Gets the specified property expression of the endpoint. Defaults to the URL if no property is specified.
     /// </summary>
     public string GetValueExpression(EndpointProperty property = EndpointProperty.Url)
     {
@@ -44,7 +44,7 @@ public sealed class EndpointReference(IResourceWithEndpoints owner, string endpo
     }
 
     /// <summary>
-    /// Gets the URI string for the endpoint reference.
+    /// Gets the specified property value of the endpoint. Defaults to the URL if no property is specified.
     /// </summary>
     public string GetValue(EndpointProperty property = EndpointProperty.Url)
     {
@@ -68,7 +68,7 @@ public sealed class EndpointReference(IResourceWithEndpoints owner, string endpo
     /// <summary>
     /// Gets the URI string for the endpoint reference.
     /// </summary>
-    [Obsolete("Use Value instead.")]
+    [Obsolete("Use GetValue instead.")]
     public string UriString
     {
         get

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackAnnotation.cs
@@ -32,7 +32,7 @@ public class EnvironmentCallbackAnnotation : IResourceAnnotation
     /// Initializes a new instance of the <see cref="EnvironmentCallbackAnnotation"/> class with the specified callback action.
     /// </summary>
     /// <param name="callback">The callback action to be executed.</param>
-    public EnvironmentCallbackAnnotation(Action<Dictionary<string, string>> callback)
+    public EnvironmentCallbackAnnotation(Action<Dictionary<string, object>> callback)
     {
         Callback = (c) =>
         {

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="executionContext">The execution context for this invocation of the AppHost.</param>
 /// <param name="environmentVariables">The environment variables associated with this execution.</param>
 /// <param name="cancellationToken">The cancellation token associated with this execution.</param>
-public class EnvironmentCallbackContext(DistributedApplicationExecutionContext executionContext, Dictionary<string, string>? environmentVariables = null, CancellationToken cancellationToken = default)
+public class EnvironmentCallbackContext(DistributedApplicationExecutionContext executionContext, Dictionary<string, object>? environmentVariables = null, CancellationToken cancellationToken = default)
 {
     /// <summary>
     /// Obsolete. Use ExecutionContext instead. Will be removed in next preview.
@@ -22,7 +22,7 @@ public class EnvironmentCallbackContext(DistributedApplicationExecutionContext e
     /// <summary>
     /// Gets the environment variables associated with the callback context.
     /// </summary>
-    public Dictionary<string, string> EnvironmentVariables { get; } = environmentVariables ?? new();
+    public Dictionary<string, object> EnvironmentVariables { get; } = environmentVariables ?? new();
 
     /// <summary>
     /// Gets the CancellationToken associated with the callback context.

--- a/src/Aspire.Hosting/ApplicationModel/IManifestExpressionProvider.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IManifestExpressionProvider.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// An interface that allows an object to express how it should be represented in a manifest.
+/// </summary>
+public interface IManifestExpressionProvider
+{
+    /// <summary>
+    /// Gets the expression that represents a value in manifest.
+    /// </summary>
+    string ValueExpression { get; }
+}

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
@@ -6,7 +6,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a resource that has a connection string associated with it.
 /// </summary>
-public interface IResourceWithConnectionString : IResource
+public interface IResourceWithConnectionString : IResource, IManifestExpressionProvider, IValueProvider
 {
     /// <summary>
     /// Gets the connection string associated with the resource.
@@ -20,6 +20,10 @@ public interface IResourceWithConnectionString : IResource
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string associated with the resource, when one is available.</returns>
     public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default) => new(GetConnectionString());
+
+    string IManifestExpressionProvider.ValueExpression => ConnectionStringReferenceExpression;
+
+    ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => GetConnectionStringAsync(cancellationToken);
 
     /// <summary>
     /// Describes the connection string format string used for this resource in the manifest.

--- a/src/Aspire.Hosting/ApplicationModel/IValueProvider.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IValueProvider.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// A interface that allows the value to be provided for an environment variable.
+/// </summary>
+public interface IValueProvider
+{
+    /// <summary>
+    /// Gets the value for use as an environment variable.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -6,7 +6,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a parameter resource.
 /// </summary>
-public sealed class ParameterResource : Resource
+public sealed class ParameterResource : Resource, IManifestExpressionProvider, IValueProvider
 {
     private readonly Func<string> _callback;
 
@@ -38,4 +38,6 @@ public sealed class ParameterResource : Resource
     /// Gets the expression used in the manifest to reference the value of the parameter.
     /// </summary>
     public string ValueExpression => $"{{{Name}.value}}";
+
+    ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => new(Value);
 }

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -5,7 +5,6 @@ using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Utils;
-using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
@@ -78,17 +77,7 @@ public static class ResourceBuilderExtensions
     {
         return builder.WithEnvironment(context =>
         {
-            if (context.ExecutionContext.IsPublishMode)
-            {
-                context.EnvironmentVariables[name] = endpointReference.ValueExpression;
-                return;
-            }
-
-            var replaceLocalhostWithContainerHost = builder.Resource is ContainerResource;
-
-            context.EnvironmentVariables[name] = replaceLocalhostWithContainerHost
-            ? HostNameResolver.ReplaceLocalhostWithContainerHost(endpointReference.Value, builder.ApplicationBuilder.Configuration)
-            : endpointReference.Value;
+            context.EnvironmentVariables[name] = endpointReference;
         });
     }
 
@@ -104,13 +93,7 @@ public static class ResourceBuilderExtensions
     {
         return builder.WithEnvironment(context =>
         {
-            if (context.ExecutionContext.IsPublishMode)
-            {
-                context.EnvironmentVariables[name] = parameter.Resource.ValueExpression;
-                return;
-            }
-
-            context.EnvironmentVariables[name] = parameter.Resource.Value;
+            context.EnvironmentVariables[name] = parameter.Resource;
         });
     }
 
@@ -219,37 +202,11 @@ public static class ResourceBuilderExtensions
         var resource = source.Resource;
         connectionName ??= resource.Name;
 
-        return builder.WithEnvironment(async context =>
+        return builder.WithEnvironment(context =>
         {
             var connectionStringName = resource.ConnectionStringEnvironmentVariable ?? $"{ConnectionStringEnvironmentName}{connectionName}";
 
-            if (context.ExecutionContext.IsPublishMode)
-            {
-                context.EnvironmentVariables[connectionStringName] = resource.ConnectionStringReferenceExpression;
-                return;
-            }
-
-            context.Logger?.LogInformation("Retrieving connection string for '{Name}'.", resource.Name);
-
-            var connectionString = await resource.GetConnectionStringAsync(context.CancellationToken).ConfigureAwait(false);
-
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                if (optional)
-                {
-                    // This is an optional connection string, so we can just return.
-                    return;
-                }
-
-                throw new DistributedApplicationException($"A connection string for '{resource.Name}' could not be retrieved.");
-            }
-
-            if (builder.Resource is ContainerResource)
-            {
-                connectionString = HostNameResolver.ReplaceLocalhostWithContainerHost(connectionString, builder.ApplicationBuilder.Configuration);
-            }
-
-            context.EnvironmentVariables[connectionStringName] = connectionString;
+            context.EnvironmentVariables[connectionStringName] = new ConnectionStringReference(resource, optional);
         });
     }
 

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -161,7 +161,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
     /// <param name="resource"></param>
     public async Task WriteEnvironmentVariablesAsync(IResource resource)
     {
-        var config = new Dictionary<string, string>();
+        var config = new Dictionary<string, object>();
 
         var envContext = new EnvironmentCallbackContext(ExecutionContext, config, CancellationToken);
 
@@ -175,7 +175,14 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
 
             foreach (var (key, value) in config)
             {
-                Writer.WriteString(key, value);
+                var valueString = value switch
+                {
+                    string stringValue => stringValue,
+                    IManifestExpressionProvider manifestExpression => manifestExpression.ValueExpression,
+                    _ => throw new DistributedApplicationException($"The value of the environment variable `{key}` is not supported.")
+                };
+
+                Writer.WriteString(key, valueString);
             }
 
             WriteServiceDiscoveryEnvironmentVariables(resource);

--- a/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Redis/RedisBuilderExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Redis;
@@ -24,7 +23,7 @@ public static class RedisBuilderExtensions
     {
         var redis = new RedisResource(name);
         return builder.AddResource(redis)
-                      .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, port: port, containerPort: 6379))
+                      .WithEndpoint(hostPort: port, containerPort: 6379, name: RedisResource.PrimaryEndpointName)
                       .WithAnnotation(new ContainerImageAnnotation { Image = "redis", Tag = "7.2.4" })
                       .PublishAsContainer();
     }

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -10,6 +10,11 @@ namespace Aspire.Hosting.ApplicationModel;
 public class RedisResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
     /// <summary>
+    /// Gets the primary endpoint for the Redis server.
+    /// </summary>
+    public EndpointReference PrimaryEndpoint => new(this, "tcp");
+
+    /// <summary>
     /// Gets the connection string expression for the Redis server for the manifest.
     /// </summary>
     public string? ConnectionStringExpression
@@ -21,7 +26,7 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
                 return connectionStringAnnotation.Resource.ConnectionStringExpression;
             }
 
-            return $"{{{Name}.bindings.tcp.host}}:{{{Name}.bindings.tcp.port}}";
+            return $"{PrimaryEndpoint.GetValueExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetValueExpression(EndpointProperty.Port)}";
         }
     }
 
@@ -51,13 +56,6 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
             return connectionStringAnnotation.Resource.GetConnectionString();
         }
 
-        if (!this.TryGetAnnotationsOfType<AllocatedEndpointAnnotation>(out var allocatedEndpoints))
-        {
-            throw new DistributedApplicationException("Redis resource does not have endpoint annotation.");
-        }
-
-        // We should only have one endpoint for Redis for local scenarios.
-        var endpoint = allocatedEndpoints.Single();
-        return endpoint.EndPointString;
+        return $"{PrimaryEndpoint.GetValue(EndpointProperty.Host)}:{PrimaryEndpoint.GetValue(EndpointProperty.Port)}";
     }
 }

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -9,10 +9,12 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 public class RedisResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
+    internal const string PrimaryEndpointName = "primary";
+
     /// <summary>
     /// Gets the primary endpoint for the Redis server.
     /// </summary>
-    public EndpointReference PrimaryEndpoint => new(this, "tcp");
+    public EndpointReference PrimaryEndpoint => new(this, PrimaryEndpointName);
 
     /// <summary>
     /// Gets the connection string expression for the Redis server for the manifest.

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 public class RedisResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
-    internal const string PrimaryEndpointName = "primary";
+    internal const string PrimaryEndpointName = "tcp";
 
     /// <summary>
     /// Gets the primary endpoint for the Redis server.

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.Tests.Azure;
 public class AzureBicepProvisionerTests
 {
     [Fact]
-    public void SetParametersTranslatesParametersToARMCompatibleJsonParameters()
+    public async Task SetParametersTranslatesParametersToARMCompatibleJsonParameters()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -20,14 +20,14 @@ public class AzureBicepProvisionerTests
                .WithParameter("name", "david");
 
         var parameters = new JsonObject();
-        BicepProvisioner.SetParameters(parameters, bicep0.Resource);
+        await BicepProvisioner.SetParametersAsync(parameters, bicep0.Resource);
 
         Assert.Single(parameters);
         Assert.Equal("david", parameters["name"]?["value"]?.ToString());
     }
 
     [Fact]
-    public void SetParametersTranslatesCompatibleParameterTypes()
+    public async Task SetParametersTranslatesCompatibleParameterTypes()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -45,7 +45,7 @@ public class AzureBicepProvisionerTests
                .WithParameter("param", param);
 
         var parameters = new JsonObject();
-        BicepProvisioner.SetParameters(parameters, bicep0.Resource);
+        await BicepProvisioner.SetParametersAsync(parameters, bicep0.Resource);
 
         Assert.Equal(6, parameters.Count);
         Assert.Equal("john", parameters["name"]?["value"]?.ToString());
@@ -57,7 +57,7 @@ public class AzureBicepProvisionerTests
     }
 
     [Fact]
-    public void ResourceWithTheSameBicepTemplateAndParametersHaveTheSameCheckSum()
+    public async Task ResourceWithTheSameBicepTemplateAndParametersHaveTheSameCheckSum()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -74,18 +74,18 @@ public class AzureBicepProvisionerTests
                        .WithParameter("jsonObj", new JsonObject { ["key"] = "value" });
 
         var parameters0 = new JsonObject();
-        BicepProvisioner.SetParameters(parameters0, bicep0.Resource);
+        await BicepProvisioner.SetParametersAsync(parameters0, bicep0.Resource);
         var checkSum0 = BicepProvisioner.GetChecksum(bicep0.Resource, parameters0);
 
         var parameters1 = new JsonObject();
-        BicepProvisioner.SetParameters(parameters1, bicep1.Resource);
+        await BicepProvisioner.SetParametersAsync(parameters1, bicep1.Resource);
         var checkSum1 = BicepProvisioner.GetChecksum(bicep1.Resource, parameters1);
 
         Assert.Equal(checkSum0, checkSum1);
     }
 
     [Fact]
-    public void ResourceWithSameTemplateButDifferentParametersHaveDifferentChecksums()
+    public async Task ResourceWithSameTemplateButDifferentParametersHaveDifferentChecksums()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -101,18 +101,18 @@ public class AzureBicepProvisionerTests
                        .WithParameter("jsonObj", new JsonObject { ["key"] = "value" });
 
         var parameters0 = new JsonObject();
-        BicepProvisioner.SetParameters(parameters0, bicep0.Resource);
+        await BicepProvisioner.SetParametersAsync(parameters0, bicep0.Resource);
         var checkSum0 = BicepProvisioner.GetChecksum(bicep0.Resource, parameters0);
 
         var parameters1 = new JsonObject();
-        BicepProvisioner.SetParameters(parameters1, bicep1.Resource);
+        await BicepProvisioner.SetParametersAsync(parameters1, bicep1.Resource);
         var checkSum1 = BicepProvisioner.GetChecksum(bicep1.Resource, parameters1);
 
         Assert.NotEqual(checkSum0, checkSum1);
     }
 
     [Fact]
-    public void GetCurrentChecksumSkipsKnownValuesForCheckSumCreation()
+    public async Task GetCurrentChecksumSkipsKnownValuesForCheckSumCreation()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -129,14 +129,14 @@ public class AzureBicepProvisionerTests
                        .WithParameter(AzureBicepResource.KnownParameters.PrincipalType, "type");
 
         var parameters0 = new JsonObject();
-        BicepProvisioner.SetParameters(parameters0, bicep0.Resource);
+        await BicepProvisioner.SetParametersAsync(parameters0, bicep0.Resource);
         var checkSum0 = BicepProvisioner.GetChecksum(bicep0.Resource, parameters0);
 
         // Save the old version of this resource's parameters to config
         var config = new ConfigurationManager();
         config["Parameters"] = parameters0.ToJsonString();
 
-        var checkSum1 = BicepProvisioner.GetCurrentChecksum(bicep1.Resource, config);
+        var checkSum1 = await BicepProvisioner.GetCurrentChecksumAsync(bicep1.Resource, config);
 
         Assert.Equal(checkSum0, checkSum1);
     }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Azure;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.Storage;
 using Azure.ResourceManager.Storage.Models;
@@ -170,17 +171,7 @@ public class AzureBicepResourceTests
         var serviceA = builder.AddProject<Projects.ServiceA>("serviceA")
             .WithReference(appInsights);
 
-        // Call environment variable callbacks.
-        var annotations = serviceA.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceA.Resource);
 
         Assert.True(config.ContainsKey("APPLICATIONINSIGHTS_CONNECTION_STRING"));
         Assert.Equal("myinstrumentationkey", config["APPLICATIONINSIGHTS_CONNECTION_STRING"]);

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -360,8 +360,8 @@ public class AzureBicepResourceTests
         Assert.Equal("Aspire.Hosting.Azure.Bicep.postgres.bicep", azurePostgres.Resource.TemplateResourceName);
         Assert.Equal("postgres", postgres.Resource.Name);
         Assert.Equal("postgres", azurePostgres.Resource.Parameters["serverName"]);
-        Assert.Same(usr, azurePostgres.Resource.Parameters["administratorLogin"]);
-        Assert.Same(pwd, azurePostgres.Resource.Parameters["administratorLoginPassword"]);
+        Assert.Same(usr.Resource, azurePostgres.Resource.Parameters["administratorLogin"]);
+        Assert.Same(pwd.Resource, azurePostgres.Resource.Parameters["administratorLoginPassword"]);
         Assert.True(azurePostgres.Resource.Parameters.ContainsKey(AzureBicepResource.KnownParameters.KeyVaultName));
         Assert.NotNull(databases);
         Assert.Equal(["dbName"], databases);
@@ -400,8 +400,8 @@ public class AzureBicepResourceTests
         Assert.Equal("Aspire.Hosting.Azure.Bicep.postgres.bicep", azurePostgres.Resource.TemplateResourceName);
         Assert.Equal("postgres", postgres.Resource.Name);
         Assert.Equal("postgres", azurePostgres.Resource.Parameters["serverName"]);
-        Assert.Same(usr, azurePostgres.Resource.Parameters["administratorLogin"]);
-        Assert.Same(pwd, azurePostgres.Resource.Parameters["administratorLoginPassword"]);
+        Assert.Same(usr.Resource, azurePostgres.Resource.Parameters["administratorLogin"]);
+        Assert.Same(pwd.Resource, azurePostgres.Resource.Parameters["administratorLoginPassword"]);
         Assert.True(azurePostgres.Resource.Parameters.ContainsKey(AzureBicepResource.KnownParameters.KeyVaultName));
         Assert.NotNull(databases);
         Assert.Equal(["db"], databases);

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Aspire.Hosting.Utils;
+using Aspire.Hosting.Tests.Utils;
 
 namespace Aspire.Hosting.Tests.MySql;
 
@@ -42,16 +43,7 @@ public class AddMySqlTests
         Assert.Equal("tcp", endpoint.Transport);
         Assert.Equal("tcp", endpoint.UriScheme);
 
-        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
 
         Assert.Collection(config,
             env =>
@@ -91,16 +83,7 @@ public class AddMySqlTests
         Assert.Equal("tcp", endpoint.Transport);
         Assert.Equal("tcp", endpoint.UriScheme);
 
-        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
 
         Assert.Collection(config,
             env =>
@@ -237,20 +220,11 @@ public class AddMySqlTests
 
         var myAdmin = builder.Resources.Single(r => r.Name.EndsWith("-phpmyadmin"));
 
-        var envAnnotations = myAdmin.Annotations.OfType<EnvironmentCallbackAnnotation>();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(myAdmin);
 
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-            await annotation.Callback(context);
-        }
-
-        Assert.Equal("host.docker.internal:5001", context.EnvironmentVariables["PMA_HOST"]);
-        Assert.NotNull(context.EnvironmentVariables["PMA_USER"]);
-        Assert.NotNull(context.EnvironmentVariables["PMA_PASSWORD"]);
+        Assert.Equal("host.docker.internal:5001", config["PMA_HOST"]);
+        Assert.NotNull(config["PMA_USER"]);
+        Assert.NotNull(config["PMA_PASSWORD"]);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -40,16 +41,7 @@ public class AddOracleDatabaseTests
         Assert.Equal("tcp", endpoint.Transport);
         Assert.Equal("tcp", endpoint.UriScheme);
 
-        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-           await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
 
         Assert.Collection(config,
             env =>
@@ -89,16 +81,7 @@ public class AddOracleDatabaseTests
         Assert.Equal("tcp", endpoint.Transport);
         Assert.Equal("tcp", endpoint.UriScheme);
 
-        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-           await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
 
         Assert.Collection(config,
             env =>
@@ -191,16 +174,7 @@ public class AddOracleDatabaseTests
         Assert.Equal("tcp", endpoint.Transport);
         Assert.Equal("tcp", endpoint.UriScheme);
 
-        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
 
         Assert.Collection(config,
             env =>

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using System.Text.Json;
 using Aspire.Hosting.Postgres;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -42,16 +43,7 @@ public class AddPostgresTests
         Assert.Equal("tcp", endpoint.Transport);
         Assert.Equal("tcp", endpoint.UriScheme);
 
-        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-           await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
 
         Assert.Collection(config,
             env =>
@@ -101,16 +93,7 @@ public class AddPostgresTests
         Assert.Equal("tcp", endpoint.Transport);
         Assert.Equal("tcp", endpoint.UriScheme);
 
-        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-           await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
 
         Assert.Collection(config,
             env =>
@@ -206,16 +189,7 @@ public class AddPostgresTests
         Assert.Equal("tcp", endpoint.Transport);
         Assert.Equal("tcp", endpoint.UriScheme);
 
-        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
 
         Assert.Collection(config,
             env =>

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Helpers;
+using Aspire.Hosting.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -28,16 +29,7 @@ public class ProjectResourceTests
         var serviceMetadata = Assert.Single(resource.Annotations.OfType<IProjectMetadata>());
         Assert.IsType<TestProject>(serviceMetadata);
 
-        var annotations = resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-           await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
 
         Assert.Collection(config,
             env =>

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Sockets;
 using Aspire.Hosting.Redis;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -148,18 +149,9 @@ public class AddRedisTests
 
         var commander = builder.Resources.Single(r => r.Name.EndsWith("-commander"));
 
-        var envAnnotations = commander.Annotations.OfType<EnvironmentCallbackAnnotation>();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(commander);
 
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-            await annotation.Callback(context);
-        }
-
-        Assert.Equal("myredis1:host.docker.internal:5001:0", context.EnvironmentVariables["REDIS_HOSTS"]);
+        Assert.Equal("myredis1:host.docker.internal:5001:0", config["REDIS_HOSTS"]);
     }
 
     [Fact]
@@ -180,17 +172,8 @@ public class AddRedisTests
 
         var commander = builder.Resources.Single(r => r.Name.EndsWith("-commander"));
 
-        var envAnnotations = commander.Annotations.OfType<EnvironmentCallbackAnnotation>();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(commander);
 
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-            await annotation.Callback(context);
-        }
-
-        Assert.Equal("myredis1:host.docker.internal:5001:0,myredis2:host.docker.internal:5002:0", context.EnvironmentVariables["REDIS_HOSTS"]);
+        Assert.Equal("myredis1:host.docker.internal:5001:0,myredis2:host.docker.internal:5002:0", config["REDIS_HOSTS"]);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -93,7 +93,7 @@ public class AddRedisTests
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
         var connectionString = connectionStringResource.GetConnectionString();
-        Assert.Equal("{myRedis.bindings.primary.host}:{myRedis.bindings.primary.port}", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
         Assert.StartsWith("localhost:2000", connectionString);
     }
 

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -80,7 +80,7 @@ public class AddRedisTests
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddRedis("myRedis")
             .WithAnnotation(
-            new AllocatedEndpointAnnotation("mybinding",
+            new AllocatedEndpointAnnotation(RedisResource.PrimaryEndpointName,
             ProtocolType.Tcp,
             "localhost",
             2000,
@@ -93,7 +93,7 @@ public class AddRedisTests
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
         var connectionString = connectionStringResource.GetConnectionString();
-        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("{myRedis.bindings.primary.host}:{myRedis.bindings.primary.port}", connectionStringResource.ConnectionStringExpression);
         Assert.StartsWith("localhost:2000", connectionString);
     }
 

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net.Sockets;
@@ -41,16 +42,7 @@ public class AddSqlServerTests
         Assert.Equal("mssql/server", containerAnnotation.Image);
         Assert.Equal("mcr.microsoft.com", containerAnnotation.Registry);
 
-        var envAnnotations = containerResource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in envAnnotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
 
         Assert.Collection(config,
             env =>

--- a/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Tests.Utils;
+
+public static class EnvironmentVariableEvaluator
+{
+    public static async ValueTask<Dictionary<string, string>> GetEnvironmentVariablesAsync(IResource resource,
+        DistributedApplicationOperation applicationOperation = DistributedApplicationOperation.Run)
+    {
+        var environmentVariables = new Dictionary<string, string>();
+
+        if (resource.TryGetEnvironmentVariables(out var callbacks))
+        {
+            var config = new Dictionary<string, object>();
+            var executionContext = new DistributedApplicationExecutionContext(applicationOperation);
+            var context = new EnvironmentCallbackContext(executionContext, config);
+
+            foreach (var callback in callbacks)
+            {
+                await callback.Callback(context);
+            }
+
+            foreach (var (key, expr) in config)
+            {
+                var value = (applicationOperation, expr) switch
+                {
+                    (_, string s) => s,
+                    (DistributedApplicationOperation.Run, IValueProvider provider) => await provider.GetValueAsync().ConfigureAwait(false),
+                    (DistributedApplicationOperation.Publish, IManifestExpressionProvider provider) => provider.ValueExpression,
+                    (_, null) => null,
+                    _ => throw new InvalidOperationException($"Unsupported expression type: {expr.GetType()}")
+                };
+
+                if (value is not null)
+                {
+                    environmentVariables[key] = value;
+                }
+            }
+        }
+
+        return environmentVariables;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
+using Aspire.Hosting.Tests.Utils;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -27,17 +28,7 @@ public class WithEnvironmentTests
 
         testProgram.Build();
 
-        // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("myName"));
         Assert.Equal(1, servicesKeysCount);
@@ -53,17 +44,7 @@ public class WithEnvironmentTests
 
         testProgram.Build();
 
-        // Call environment variable callbacks.
-        var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("myName"));
         Assert.Equal(1, servicesKeysCount);
@@ -82,16 +63,7 @@ public class WithEnvironmentTests
         environmentValue = "value2";
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("myName"));
         Assert.Equal(1, servicesKeysCount);
@@ -109,16 +81,7 @@ public class WithEnvironmentTests
 
         testProgram.Build();
 
-        var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource);
 
         Assert.Contains(config, kvp => kvp.Key == "MY_PARAMETER" && kvp.Value == "MY_PARAMETER_VALUE");
     }
@@ -133,16 +96,8 @@ public class WithEnvironmentTests
 
         testProgram.Build();
 
-        var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource,
+            DistributedApplicationOperation.Publish);
 
         Assert.Contains(config, kvp => kvp.Key == "MY_PARAMETER" && kvp.Value == "{parameter.value}");
     }
@@ -159,17 +114,7 @@ public class WithEnvironmentTests
 
         var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
 
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
-        {
-            foreach (var annotation in annotations)
-            {
-                await annotation.Callback(context);
-            }
-        });
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () => await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource));
 
         Assert.Equal("Parameter resource could not be used because configuration key `Parameters:parameter` is missing.", exception.Message);
     }
@@ -189,16 +134,7 @@ public class WithEnvironmentTests
         environmentValue = "value2";
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("myName"));
         Assert.Equal(1, servicesKeysCount);

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Sockets;
+using Aspire.Hosting.Tests.Utils;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -28,16 +29,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
         Assert.Equal(2, servicesKeysCount);
@@ -78,16 +70,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
         Assert.Equal(2, servicesKeysCount);
@@ -128,16 +111,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-           await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
         Assert.Equal(4, servicesKeysCount);
@@ -176,16 +150,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-           await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
         Assert.Equal(2, servicesKeysCount);
@@ -222,16 +187,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-           await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
         Assert.Equal(4, servicesKeysCount);
@@ -252,18 +208,9 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
         await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
         {
-            foreach (var annotation in annotations)
-            {
-                await annotation.Callback(context);
-            }
+            await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
         });
     }
 
@@ -277,17 +224,7 @@ public class WithReferenceTests
         testProgram.ServiceBBuilder.WithReference(resource, optional: true);
         testProgram.Build();
 
-        // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
         Assert.Equal(0, servicesKeysCount);
@@ -304,18 +241,9 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () =>
         {
-            foreach (var annotation in annotations)
-            {
-                await annotation.Callback(context);
-            }
+            var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
         });
 
         Assert.Equal("Connection string parameter resource could not be used because connection string `missingresource` is missing.", exception.Message);
@@ -333,16 +261,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         Assert.Equal("test connection string", config["ConnectionStrings__resource"]);
     }
@@ -358,16 +277,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource, DistributedApplicationOperation.Publish);
 
         Assert.Equal("{resource.connectionString}", config["ConnectionStrings__resource"]);
     }
@@ -383,16 +293,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource, DistributedApplicationOperation.Publish);
 
         Assert.Equal("{resource.connectionString}", config["MY_ENV"]);
     }
@@ -411,16 +312,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
         Assert.Equal(1, servicesKeysCount);
@@ -441,16 +333,7 @@ public class WithReferenceTests
         testProgram.Build();
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceBBuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("ConnectionStrings__"));
         Assert.Equal(1, servicesKeysCount);
@@ -481,16 +364,7 @@ public class WithReferenceTests
         testProgram.ServiceABuilder.WithReference("petstore", new Uri("https://petstore.swagger.io/"));
 
         // Call environment variable callbacks.
-        var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var config = new Dictionary<string, string>();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
-        var context = new EnvironmentCallbackContext(executionContext, config);
-
-        foreach (var annotation in annotations)
-        {
-            await annotation.Callback(context);
-        }
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
         Assert.Equal(1, servicesKeysCount);


### PR DESCRIPTION
- This change removes setting manifest expressions strings in publish mode (except inputs) and pushes object references into the model directly.
- This change also introduces `IManifestExpressionProvider` and `IValueProvider` (clashes with mvc) as way for external code to represent manifest and values without code taking a strong dependency on it. These are implemented on `ParameterResource`, `IResourceWithConnectionString`, `EndpointReference` and `ConnectionStringReference` in the core.
- Introduce `ConnectionStringReference` which stores the underlying resource and an option bool (preserving the syntax of the call itself).
- Added methods on `EndpointReference` to allow getting various parts of the URL
- `BicepOutputReference` and `BicepSecretOutputReference` also implement the new interfaces.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2594)