### PR TITLE
Propagate the state from parent to children for azure resources

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -68,27 +68,12 @@ internal sealed class AzureProvisioner(
             return;
         }
 
-        static IAzureResource? SelectParentAzureResource(IResource resource)
+        static IAzureResource? SelectParentAzureResource(IResource resource) => resource switch
         {
-            while (resource is not null)
-            {
-                if (resource is IAzureResource ar)
-                {
-                    return ar;
-                }
-
-                if (resource is IResourceWithParent rp)
-                {
-                    resource = rp.Parent;
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            return null;
-        }
+            IAzureResource ar => ar,
+            IResourceWithParent rp => SelectParentAzureResource(rp.Parent),
+            _ => null
+        };
 
         // parent -> children lookup
         var parentChildLookup = appModel.Resources.OfType<IResourceWithParent>()

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -54,32 +54,86 @@ internal sealed class AzureProvisioner(
         }
     }
 
-    public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
+    public async Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
         // TODO: Make this more general purpose
         if (executionContext.IsPublishMode)
         {
-            return Task.CompletedTask;
+            return;
         }
 
         var azureResources = appModel.Resources.Select(PromoteAzureResourceFromAnnotation).OfType<IAzureResource>().ToList();
         if (azureResources.Count == 0)
         {
-            return Task.CompletedTask;
+            return;
         }
 
+        // TODO: Handle multiple levels of nesting
+        // parent -> children lookup
+        var parentChildLookup = appModel.Resources.OfType<IResourceWithParent>()
+                                                  .Where(r => r.Parent is IAzureResource)
+                                                  .ToLookup(r => (IAzureResource)r.Parent);
+
+        // Sets the state of the resource and all of its children
+        async Task SetStateAsync(IAzureResource resource, string state)
+        {
+            await notificationService.PublishUpdateAsync(resource, s => s with
+            {
+                State = state
+            })
+            .ConfigureAwait(false);
+
+            foreach (var child in parentChildLookup[resource])
+            {
+                await notificationService.PublishUpdateAsync(child, s => s with
+                {
+                    State = state
+                })
+                .ConfigureAwait(false);
+            }
+        }
+
+        // After the resource is provisioned, set its state
+        async Task AfterProvisionAsync(IAzureResource resource)
+        {
+            try
+            {
+                await resource.ProvisioningTaskCompletionSource!.Task.ConfigureAwait(false);
+
+                await SetStateAsync(resource, "Running").ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                await SetStateAsync(resource, "FailedToStart").ConfigureAwait(false);
+            }
+        }
+
+        // Mark all resources as starting
         foreach (var r in azureResources)
         {
             r.ProvisioningTaskCompletionSource = new();
+
+            await SetStateAsync(r, "Starting").ConfigureAwait(false);
+
+            // After the resource is provisioned, set its state
+            _ = AfterProvisionAsync(r);
         }
 
         // This is fuly async so we can just fire and forget
-        _ = Task.Run(() => ProvisionAzureResources(configuration, environment, logger, azureResources, cancellationToken), cancellationToken);
-
-        return Task.CompletedTask;
+        _ = Task.Run(() => ProvisionAzureResources(
+            configuration,
+            environment,
+            logger,
+            azureResources,
+            cancellationToken), cancellationToken);
     }
 
-    private async Task ProvisionAzureResources(IConfiguration configuration, IHostEnvironment environment, ILogger<AzureProvisioner> logger, IList<IAzureResource> azureResources, CancellationToken cancellationToken)
+    private async Task ProvisionAzureResources(
+        IConfiguration configuration,
+        IHostEnvironment environment,
+        ILogger<AzureProvisioner> logger,
+        IList<IAzureResource> azureResources,
+        CancellationToken cancellationToken)
     {
         var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions()
         {
@@ -249,8 +303,6 @@ internal sealed class AzureProvisioner(
 
                 resourceLogger.LogWarning("No provisioner found for {resourceType} skipping.", resource.GetType().Name);
 
-                await notificationService.PublishUpdateAsync(resource, state => state with { State = "Running" }).ConfigureAwait(false);
-
                 continue;
             }
 
@@ -260,16 +312,12 @@ internal sealed class AzureProvisioner(
 
                 resourceLogger.LogInformation("Skipping {resourceName} because it is not configured to be provisioned.", resource.Name);
 
-                await notificationService.PublishUpdateAsync(resource, state => state with { State = "Running" }).ConfigureAwait(false);
-
                 continue;
             }
 
             if (await provisioner.ConfigureResourceAsync(configuration, resource, cancellationToken).ConfigureAwait(false))
             {
                 resource.ProvisioningTaskCompletionSource?.TrySetResult();
-
-                await notificationService.PublishUpdateAsync(resource, state => state with { State = "Running" }).ConfigureAwait(false);
 
                 resourceLogger.LogInformation("Using connection information stored in user secrets for {resourceName}.", resource.Name);
 
@@ -314,12 +362,6 @@ internal sealed class AzureProvisioner(
                         resourceLogger.LogError(ex, "Error provisioning {resourceName}.", resource.Name);
 
                         resource.ProvisioningTaskCompletionSource?.TrySetException(new InvalidOperationException($"Unable to resolve references from {resource.Name}"));
-
-                        await ns.PublishUpdateAsync(resource, state => state with
-                        {
-                            State = "FailedToStart"
-                        })
-                        .ConfigureAwait(false);
                     }
                 }
 
@@ -330,12 +372,6 @@ internal sealed class AzureProvisioner(
                 resourceLogger.LogError(ex, "Error provisioning {resourceName}.", resource.Name);
 
                 resource.ProvisioningTaskCompletionSource?.TrySetException(new InvalidOperationException($"Unable to resolve references from {resource.Name}"));
-
-                await notificationService.PublishUpdateAsync(resource, state => state with
-                {
-                    State = "FailedToStart"
-                })
-                .ConfigureAwait(false);
             }
         }
 
@@ -356,13 +392,11 @@ internal sealed class AzureProvisioner(
                 logger.LogInformation("Azure resource connection strings saved to user secrets.");
             }
         }
-        else
+
+        // Set the completion source for all resources
+        foreach (var resource in azureResources)
         {
-            // Set the completion source for all resources
-            foreach (var resource in azureResources)
-            {
-                resource.ProvisioningTaskCompletionSource?.TrySetResult();
-            }
+            resource.ProvisioningTaskCompletionSource?.TrySetResult();
         }
 
         // Do this in the background to avoid blocking startup

--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/AzureProvisioner.cs
@@ -68,10 +68,15 @@ internal sealed class AzureProvisioner(
             return;
         }
 
-        // TODO: Handle multiple levels of nesting
+        bool IsParentAzureResource(IResource resource)
+        {
+            return resource is IAzureResource ||
+                   resource is IResourceWithParent rp && IsParentAzureResource(rp.Parent);
+        }
+
         // parent -> children lookup
         var parentChildLookup = appModel.Resources.OfType<IResourceWithParent>()
-                                                  .Where(r => r.Parent is IAzureResource)
+                                                  .Where(IsParentAzureResource)
                                                   .ToLookup(r => (IAzureResource)r.Parent);
 
         // Sets the state of the resource and all of its children

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithParentOfT.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithParentOfT.cs
@@ -7,10 +7,23 @@ namespace Aspire.Hosting.ApplicationModel;
 /// Represents a resource that has a parent resource of type <typeparamref name="T"/>.
 /// </summary>
 /// <typeparam name="T">The type of the parent resource.</typeparam>
-public interface IResourceWithParent<out T> : IResource where T : IResource
+public interface IResourceWithParent<out T> : IResourceWithParent where T : IResource
 {
     /// <summary>
     /// Gets the parent resource of type <typeparamref name="T"/>.
     /// </summary>
-    T Parent { get; }
+    new T Parent { get; }
+
+    IResource IResourceWithParent.Parent => Parent;
+}
+
+/// <summary>
+/// Represents a resource that has a parent resource.
+/// </summary>
+public interface IResourceWithParent : IResource
+{
+    /// <summary>
+    /// Gets the parent resource.
+    /// </summary>
+    IResource Parent { get; }
 }


### PR DESCRIPTION
- Child resource states are currently independent of the parent resource. For azure resources specifically, we propagate that state downwards (at least one level), to avoid showing databases and other child resources as running before their parent is marked running.
- Added a non-generic `IResourceWithParent`, the generic one is quite useless 😄 (I could remove it)

Unsure if/how we should do this more generally as yet. In theory this is a problem for 

Contributes to https://github.com/dotnet/aspire/issues/2590


https://github.com/dotnet/aspire/assets/95136/0d3b1213-208e-4eba-8e79-43e704363332


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2597)