### PR TITLE
Fix SetParametersAsync not handling guids.

### DIFF
--- a/src/Aspire.Hosting.Azure.Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure.Provisioning/Provisioners/BicepProvisioner.cs
@@ -472,6 +472,7 @@ internal sealed class BicepProvisioner(ILogger<BicepProvisioner> logger,
                     IEnumerable<string> s => new JsonArray(s.Select(s => JsonValue.Create(s)).ToArray()),
                     int i => i,
                     bool b => b,
+                    Guid g => g.ToString(),
                     JsonNode node => node,
                     // TODO: Support this
                     AzureBicepResource bicepResource => throw new NotSupportedException("Referencing bicep resources is not supported"),


### PR DESCRIPTION
`SetParametersAsync(...)` was blowing up on the `principalId` guid parameter.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2601)