### PR TITLE
Encoding of all dashboard URL segments and query strings

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -1,6 +1,7 @@
 ﻿@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 @inject IStringLocalizer<ControlsStrings> Loc
 
 <div class="span-details-layout">
@@ -16,7 +17,7 @@
         <div>
             @((MarkupString)string.Format(ControlsStrings.SpanDetailsStartTime, DurationFormatter.FormatDuration(ViewModel.Span.StartTime - ViewModel.Span.Trace.FirstSpan.StartTime)))
         </div>
-        <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/structuredlogs?spanId={ViewModel.Span.SpanId}")">@Loc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
+        <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@DashboardUrls.StructuredLogsUrl(spanId: ViewModel.Span.SpanId)">@Loc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
         <FluentDivider slot="end" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <FluentSearch Placeholder="@Loc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Localization;
@@ -169,11 +170,11 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         {
             var url = args.Key.ToLower() switch
             {
-                "r" => "/",
-                "c" => "/consolelogs",
-                "s" => "/structuredlogs",
-                "t" => "/traces",
-                "m" => "/metrics",
+                "r" => DashboardUrls.ResourcesUrl(),
+                "c" => DashboardUrls.ConsoleLogsUrl(),
+                "s" => DashboardUrls.StructuredLogsUrl(),
+                "t" => DashboardUrls.TracesUrl(),
+                "m" => DashboardUrls.MetricsUrl(),
                 _ => null
             };
 

--- a/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/NavMenu.razor
@@ -1,5 +1,6 @@
 ﻿@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 @inject IStringLocalizer<Layout> Loc
 @inject IDashboardClient DashboardClient
 
@@ -7,29 +8,29 @@
     @if (DashboardClient.IsEnabled)
     {
         <FluentAppBarItem
-            Href="/"
+            Href="@DashboardUrls.ResourcesUrl()"
             Match="NavLinkMatch.All"
             Icon="ResourcesIcon()"
             SecondaryIcon="ResourcesIcon(secondary: true)"
             Text="@Loc[nameof(Layout.NavMenuResourcesTab)]" />
         <FluentAppBarItem
-            Href="/consolelogs"
+            Href="@DashboardUrls.ConsoleLogsUrl()"
             Icon="ConsoleLogsIcon()"
             SecondaryIcon="ConsoleLogsIcon(secondary: true)"
             Text="@Loc[nameof(Layout.NavMenuConsoleLogsTab)]" />
     }
     <FluentAppBarItem
-        Href="/structuredlogs"
+        Href="@DashboardUrls.StructuredLogsUrl()"
         Icon="StructuredLogsIcon()"
         SecondaryIcon="StructuredLogsIcon(secondary: true)"
         Text="@Loc[nameof(Layout.NavMenuStructuredLogsTab)]" />
     <FluentAppBarItem
-        Href="/traces"
+        Href="@DashboardUrls.TracesUrl()"
         Icon="TracesIcon()"
         SecondaryIcon="TracesIcon(secondary: true)"
         Text="@Loc[nameof(Layout.NavMenuTracesTab)]" />
     <FluentAppBarItem
-        Href="/metrics"
+        Href="@DashboardUrls.MetricsUrl()"
         Icon="MetricsIcon()"
         SecondaryIcon="MetricsIcon(secondary: true)"
         Text="@Loc[nameof(Layout.NavMenuMetricsTab)]" />

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -51,7 +51,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     // State
     public ConsoleLogsViewModel PageViewModel { get; set; } = null!;
 
-    public string BasePath => "consolelogs";
+    public string BasePath => DashboardUrls.ConsoleLogBasePath;
     public string SessionStorageKey => "ConsoleLogs_PageState";
 
     protected override async Task OnInitializedAsync()
@@ -360,14 +360,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         }
     }
 
-    public UrlState GetUrlFromSerializableViewModel(ConsoleLogsPageState serializable)
+    public string GetUrlFromSerializableViewModel(ConsoleLogsPageState serializable)
     {
-        if (serializable.SelectedResource is { } selectedOption)
-        {
-            return new UrlState($"{BasePath}/resource/{selectedOption}", null);
-        }
-
-        return new UrlState($"/{BasePath}", null);
+        return DashboardUrls.ConsoleLogsUrl(serializable.SelectedResource);
     }
 
     public ConsoleLogsPageState ConvertViewModelToSerializable()

--- a/src/Aspire.Dashboard/Components/Pages/IPageWithSessionAndUrlState.cs
+++ b/src/Aspire.Dashboard/Components/Pages/IPageWithSessionAndUrlState.cs
@@ -42,25 +42,12 @@ public interface IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel>
     /// Translates the <param name="serializable">serializable form of the view model</param> to a relative URL associated
     /// with that state
     /// </summary>
-    public UrlState GetUrlFromSerializableViewModel(TSerializableViewModel serializable);
+    public string GetUrlFromSerializableViewModel(TSerializableViewModel serializable);
 
     /// <summary>
     /// Maps <typeparamref name="TViewModel"/> to <typeparamref name="TSerializableViewModel"/>, which should contain simple types.
     /// </summary>
     public TSerializableViewModel ConvertViewModelToSerializable();
-}
-
-public sealed record UrlState(string Path, Dictionary<string, string?>? QueryParameters)
-{
-    public override string ToString()
-    {
-        if (QueryParameters is null || QueryParameters.Count == 0 || !QueryParameters.Any(kvp => kvp.Value is not null))
-        {
-            return Path;
-        }
-
-        return Path + "?" + string.Join('&', QueryParameters.Select(kvp => $"{kvp.Key}={kvp.Value}"));
-    }
 }
 
 public static class PageExtensions

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -6,6 +6,7 @@
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Otlp.Model
+@using Aspire.Dashboard.Utils
 @inject IStringLocalizer<Dashboard.Resources.Metrics> Loc
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
@@ -69,7 +70,7 @@
                             <FluentDataGrid Style="max-width:1100px;" Items="@PageViewModel.Instruments.Where(i => i.Parent == PageViewModel.SelectedMeter).OrderBy(i => i.Name).AsQueryable()" GridTemplateColumns="3fr 5fr" TGridItem="OtlpInstrument">
                                 <ChildContent>
                                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Metrics.MetricsInsturementNameGridNameColumnHeader)]">
-                                        <FluentAnchor Href="@($"/metrics/resource/{PageViewModel.SelectedApplication.Name}/meter/{context.Parent.MeterName}/instrument/{context.Name}")" Appearance="Appearance.Lightweight">
+                                        <FluentAnchor Href="@DashboardUrls.MetricsUrl(resource: PageViewModel.SelectedApplication.Name, meter: context.Parent.MeterName, instrument: context.Name)" Appearance="Appearance.Lightweight">
                                             @context.Name
                                         </FluentAnchor>
                                     </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -1,12 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -23,7 +23,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     private Subscription? _applicationsSubscription;
     private Subscription? _metricsSubscription;
 
-    public string BasePath => "metrics";
+    public string BasePath => DashboardUrls.MetricsBasePath;
     public string SessionStorageKey => "Metrics_PageState";
     public MetricsViewModel PageViewModel { get; set; } = null!;
 
@@ -31,9 +31,11 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     public string? ApplicationName { get; set; }
 
     [Parameter]
+    [SupplyParameterFromQuery(Name = "meter")]
     public string? MeterName { get; set; }
 
     [Parameter]
+    [SupplyParameterFromQuery(Name = "instrument")]
     public string? InstrumentName { get; set; }
 
     [Parameter]
@@ -204,37 +206,20 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
         return this.AfterViewModelChangedAsync();
     }
 
-    public UrlState GetUrlFromSerializableViewModel(MetricsPageState serializable)
+    public string GetUrlFromSerializableViewModel(MetricsPageState serializable)
     {
-        string path;
-        if (serializable.ApplicationName is not null && serializable.MeterName is not null)
-        {
-            path = serializable.InstrumentName is not null
-                ? $"/{BasePath}/resource/{serializable.ApplicationName}/meter/{serializable.MeterName}/instrument/{serializable.InstrumentName}"
-                : $"/{BasePath}/resource/{serializable.ApplicationName}/meter/{serializable.MeterName}";
-        }
-        else if (serializable.ApplicationName is not null)
-        {
-            path = $"/{BasePath}/resource/{serializable.ApplicationName}";
-        }
-        else
-        {
-            path = $"/{BasePath}";
-        }
+        var duration = PageViewModel.SelectedDuration.Id != s_defaultDuration
+            ? (int?)serializable.DurationMinutes
+            : null;
 
-        var queryParameters = new Dictionary<string, string?>();
+        var url = DashboardUrls.MetricsUrl(
+            resource: serializable.ApplicationName,
+            meter: serializable.MeterName,
+            instrument: serializable.InstrumentName,
+            duration: duration,
+            view: PageViewModel.SelectedViewKind?.ToString());
 
-        if (PageViewModel.SelectedDuration.Id != s_defaultDuration)
-        {
-            queryParameters.Add("duration", serializable.DurationMinutes.ToString(CultureInfo.InvariantCulture));
-        }
-
-        if (PageViewModel.SelectedViewKind is not null)
-        {
-            queryParameters.Add("view", PageViewModel.SelectedViewKind.ToString());
-        }
-
-        return new UrlState(path, queryParameters);
+        return url;
     }
 
     private async Task OnViewChangedAsync(MetricViewKind newView)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -73,7 +73,7 @@
                         <EndpointsColumnDisplay Resource="context" HasMultipleReplicas="HasMultipleReplicas(context)" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesLogsColumnHeader)]">
-                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/consolelogs/resource/{context.Name}")">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
+                        <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(resource: context.Name)">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesDetailsColumnHeader)]" Sortable="false">
                         <FluentButton Appearance="Appearance.Lightweight"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 
@@ -242,7 +243,7 @@ public partial class Resources : ComponentBase, IDisposable
                 Intent = ToastIntent.Error,
                 Title = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Resources.ResourceCommandFailed)], command.DisplayName),
                 PrimaryAction = Loc[nameof(Dashboard.Resources.Resources.ResourceCommandToastViewLogs)],
-                OnPrimaryAction = EventCallback.Factory.Create<ToastResult>(this, () => NavigationManager.NavigateTo($"/consolelogs/resource/{resource.Name}")),
+                OnPrimaryAction = EventCallback.Factory.Create<ToastResult>(this, () => NavigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: resource.Name))),
                 Content = new CommunicationToastContent()
                 {
                     Details = response.ErrorMessage

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -91,7 +91,7 @@
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
                                 @if (!string.IsNullOrEmpty(context.TraceId))
                                 {
-                                    <a href="@($"/traces/detail/{HttpUtility.UrlEncode(context.TraceId)}")" class="long-inner-content">
+                                    <a href="@DashboardUrls.TraceDetailUrl(context.TraceId)" class="long-inner-content">
                                         @OtlpHelpers.ToShortenedId(context.TraceId)
                                     </a>
                                 }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -7,6 +7,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -27,7 +28,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     private bool _applicationChanged;
     private CancellationTokenSource? _filterCts;
 
-    public string BasePath => "structuredlogs";
+    public string BasePath => DashboardUrls.StructuredLogsBasePath;
     public string SessionStorageKey => "StructuredLogs_PageState";
     public StructuredLogsPageViewModel PageViewModel { get; set; } = null!;
 
@@ -283,22 +284,16 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         _filterCts?.Dispose();
     }
 
-    public UrlState GetUrlFromSerializableViewModel(StructuredLogsPageState serializable)
+    public string GetUrlFromSerializableViewModel(StructuredLogsPageState serializable)
     {
-        var path = serializable.SelectedApplication is not null ? $"/structuredlogs/resource/{serializable.SelectedApplication}" : "/structuredlogs";
-        var queryParameters = new Dictionary<string, string?>();
+        var filters = (serializable.Filters.Count > 0) ? LogFilterFormatter.SerializeLogFiltersToString(serializable.Filters) : null;
 
-        if (serializable.LogLevelText is not null)
-        {
-            queryParameters.Add("level", serializable.LogLevelText);
-        }
+        var url = DashboardUrls.StructuredLogsUrl(
+            resource: serializable.SelectedApplication,
+            logLevel: serializable.LogLevelText,
+            filters: filters);
 
-        if (serializable.Filters.Count > 0)
-        {
-            queryParameters.Add("filters", LogFilterFormatter.SerializeLogFiltersToString(serializable.Filters));
-        }
-
-        return new UrlState(path, queryParameters);
+        return url;
     }
 
     public StructuredLogsPageState ConvertViewModelToSerializable()

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -37,7 +37,7 @@
             <div>
                 @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTotalSpansHeader)] <strong>@_trace.Spans.Count</strong>
             </div>
-            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@($"/structuredlogs?traceId={_trace.TraceId}")">@ControlStringsLoc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
+            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@DashboardUrls.StructuredLogsUrl(traceId: _trace.TraceId)">@ControlStringsLoc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
         </FluentToolbar>
 
         <SummaryDetailsView

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -94,7 +94,7 @@
                 </TemplateColumn>
 
                 <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.DetailsColumnHeader)]">
-                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@($"/traces/detail/{context.TraceId}")">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
+                    <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.TraceDetailUrl(context.TraceId)">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
                 </TemplateColumn>
             </ChildContent>
             <EmptyContent>

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -7,6 +7,7 @@ using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
@@ -108,7 +109,7 @@ public partial class Traces
 
     private Task HandleSelectedApplicationChangedAsync()
     {
-        NavigationManager.NavigateTo($"/traces/resource/{_selectedApplication.Name}");
+        NavigationManager.NavigateTo(DashboardUrls.TracesUrl(resource: _selectedApplication.Name));
         _applicationChanged = true;
 
         return Task.CompletedTask;

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components;
@@ -56,6 +57,6 @@ public partial class UnreadLogErrorsBadge
 
     private string GetResourceErrorStructuredLogsUrl()
     {
-        return $"/structuredlogs/resource/{_applicationName}?level=error";
+        return DashboardUrls.StructuredLogsUrl(resource: _applicationName, logLevel: "error");
     }
 }

--- a/src/Aspire.Dashboard/Utils/DashboardUrls.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUrls.cs
@@ -71,7 +71,8 @@ internal static class DashboardUrls
         }
         if (filters != null)
         {
-            url = QueryHelpers.AddQueryString(url, "filters", filters);
+            // Filters should already be escaped.
+            url += (!url.Contains('?')) ? $"?filters={filters}" : $"&filters={filters}";
         }
         if (traceId != null)
         {

--- a/src/Aspire.Dashboard/Utils/DashboardUrls.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUrls.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Web;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace Aspire.Dashboard.Utils;
+
+internal static class DashboardUrls
+{
+    public const string ConsoleLogBasePath = "consolelogs";
+    public const string MetricsBasePath = "metrics";
+    public const string StructuredLogsBasePath = "structuredlogs";
+    public const string TracesBasePath = "traces";
+
+    public static string ResourcesUrl()
+    {
+        return "/";
+    }
+
+    public static string ConsoleLogsUrl(string? resource = null)
+    {
+        var url = $"/{ConsoleLogBasePath}";
+        if (resource != null)
+        {
+            url += $"/resource/{HttpUtility.UrlEncode(resource)}";
+        }
+
+        return url;
+    }
+
+    public static string MetricsUrl(string? resource = null, string? meter = null, string? instrument = null, int? duration = null, string? view = null)
+    {
+        var url = $"/{MetricsBasePath}";
+        if (resource != null)
+        {
+            url += $"/resource/{HttpUtility.UrlEncode(resource)}";
+        }
+        if (meter is not null)
+        {
+            // Meter and instrument must be querystring parameters because it's valid for the name to contain forward slashes.
+            url = QueryHelpers.AddQueryString(url, "meter", meter);
+            if (instrument is not null)
+            {
+                url = QueryHelpers.AddQueryString(url, "instrument", instrument);
+            }
+        }
+        if (duration != null)
+        {
+            url = QueryHelpers.AddQueryString(url, "duration", duration.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        if (view != null)
+        {
+            url = QueryHelpers.AddQueryString(url, "view", view);
+        }
+
+        return url;
+    }
+
+    public static string StructuredLogsUrl(string? resource = null, string? logLevel = null, string? filters = null, string? traceId = null, string? spanId = null)
+    {
+        var url = $"/{StructuredLogsBasePath}";
+        if (resource != null)
+        {
+            url += $"/resource/{HttpUtility.UrlEncode(resource)}";
+        }
+        if (logLevel != null)
+        {
+            url = QueryHelpers.AddQueryString(url, "logLevel", logLevel);
+        }
+        if (filters != null)
+        {
+            url = QueryHelpers.AddQueryString(url, "filters", filters);
+        }
+        if (traceId != null)
+        {
+            url = QueryHelpers.AddQueryString(url, "traceId", traceId);
+        }
+        if (spanId != null)
+        {
+            url = QueryHelpers.AddQueryString(url, "spanId", spanId);
+        }
+
+        return url;
+    }
+
+    public static string TracesUrl(string? resource = null)
+    {
+        var url = $"/{TracesBasePath}";
+        if (resource != null)
+        {
+            url += $"/resource/{HttpUtility.UrlEncode(resource)}";
+        }
+
+        return url;
+    }
+
+    public static string TraceDetailUrl(string traceId)
+    {
+        return $"/{TracesBasePath}/detail/{HttpUtility.UrlEncode(traceId)}";
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Utils;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class DashboardUrlsTests
+{
+    [Fact]
+    public void ConsoleLogsUrl_HtmlValues_CorrectlyEscaped()
+    {
+        Assert.Equal("/consolelogs/resource/resource!%40%23", DashboardUrls.ConsoleLogsUrl(resource: "resource!@#"));
+    }
+
+    [Fact]
+    public void StructuredLogsUrl_HtmlValues_CorrectlyEscaped()
+    {
+        var url = DashboardUrls.StructuredLogsUrl(
+            resource: "resource!@#",
+            logLevel: "error",
+            filters: "test:contains:value",
+            traceId: "!@#",
+            spanId: "!@#");
+
+        Assert.Equal("/structuredlogs/resource/resource!%40%23?logLevel=error&filters=test:contains:value&traceId=!@%23&spanId=!@%23", url);
+    }
+
+    [Fact]
+    public void TracesUrl_HtmlValues_CorrectlyEscaped()
+    {
+        Assert.Equal("/traces/resource/resource!%40%23", DashboardUrls.TracesUrl(resource: "resource!@#"));
+    }
+
+    [Fact]
+    public void TraceDetailUrl_HtmlValues_CorrectlyEscaped()
+    {
+        Assert.Equal("/traces/detail/traceId!%40%23", DashboardUrls.TraceDetailUrl(traceId: "traceId!@#"));
+    }
+
+    [Fact]
+    public void MetricsUrl_HtmlValues_CorrectlyEscaped()
+    {
+        var url = DashboardUrls.MetricsUrl(
+            resource: "resource!@#",
+            meter: "meter!@#",
+            instrument: "meter!@#",
+            duration: 10,
+            view: "table");
+
+        Assert.Equal("/metrics/resource/resource!%40%23?meter=meter!@%23&instrument=meter!@%23&duration=10&view=table", url);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2598

Some external input was added to hrefs and navigation URLs without escaping. This could be used by an attacker to modify the URL in unexpected ways.

This PR:

* Adds `DashboardUrls` with strongly typed methods for building URLs. I updated all URLs I could find to use helper methods. Centralizes navigation to be safer and easier.
* Add built-in ASP.NET Core escaping where necessary:
  * Escapes data segments with `HttpUtility.UrlEncode`
  * Adds querystring with `QueryHelpers.AddQueryString`
* URL segments are very particular around what values they allow. For example, forward slash, even when encoded, causes issues. Changed meter name and instrument name to query string values because forward slash is allowed in those names.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2605)