### PR TITLE
Fix DashboardClient flaky test

### DIFF
--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -384,9 +384,9 @@ internal sealed class DashboardClient : IDashboardClient
 
             await _cts.CancelAsync().ConfigureAwait(false);
 
-            _channel?.Dispose();
-
             _cts.Dispose();
+
+            _channel?.Dispose();
 
             await TaskHelpers.WaitIgnoreCancelAsync(_connection, _logger, "Unexpected error from connection task.").ConfigureAwait(false);
         }

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -36,6 +36,7 @@ internal sealed class DashboardClient : IDashboardClient
 
     private readonly Dictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private readonly CancellationTokenSource _cts = new();
+    private readonly CancellationToken _clientCancellationToken;
     private readonly TaskCompletionSource _whenConnected = new();
     private readonly object _lock = new();
 
@@ -61,6 +62,9 @@ internal sealed class DashboardClient : IDashboardClient
     {
         _loggerFactory = loggerFactory;
         _configuration = configuration;
+
+        // Take a copy of the token and always use it to avoid race between disposal of CTS and usage of token.
+        _clientCancellationToken = _cts.Token;
 
         _logger = loggerFactory.CreateLogger<DashboardClient>();
 
@@ -142,7 +146,7 @@ internal sealed class DashboardClient : IDashboardClient
             return;
         }
 
-        _connection = Task.Run(() => ConnectAndWatchResourcesAsync(_cts.Token), _cts.Token);
+        _connection = Task.Run(() => ConnectAndWatchResourcesAsync(_clientCancellationToken), _clientCancellationToken);
 
         return;
 
@@ -316,8 +320,6 @@ internal sealed class DashboardClient : IDashboardClient
     {
         EnsureInitialized();
 
-        var clientCancellationToken = _cts.Token;
-
         lock (_lock)
         {
             // There are two types of channel in this class. This is not a gRPC channel.
@@ -336,7 +338,7 @@ internal sealed class DashboardClient : IDashboardClient
             {
                 try
                 {
-                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(clientCancellationToken, enumeratorCancellationToken);
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(_clientCancellationToken, enumeratorCancellationToken);
 
                     await foreach (var batch in channel.Reader.ReadAllAsync(cts.Token).ConfigureAwait(false))
                     {
@@ -355,7 +357,7 @@ internal sealed class DashboardClient : IDashboardClient
     {
         EnsureInitialized();
 
-        using var combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken);
+        using var combinedTokens = CancellationTokenSource.CreateLinkedTokenSource(_clientCancellationToken, cancellationToken);
 
         var call = _client!.WatchResourceConsoleLogs(
             new WatchResourceConsoleLogsRequest() { ResourceName = resourceName },
@@ -382,11 +384,11 @@ internal sealed class DashboardClient : IDashboardClient
 
             await _cts.CancelAsync().ConfigureAwait(false);
 
-            await TaskHelpers.WaitIgnoreCancelAsync(_connection, _logger, "Unexpected error from connection task.").ConfigureAwait(false);
-
-            // Dispose after the connection task has completed.
-            _cts.Dispose();
             _channel?.Dispose();
+
+            _cts.Dispose();
+
+            await TaskHelpers.WaitIgnoreCancelAsync(_connection, _logger, "Unexpected error from connection task.").ConfigureAwait(false);
         }
     }
 }

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -382,11 +382,11 @@ internal sealed class DashboardClient : IDashboardClient
 
             await _cts.CancelAsync().ConfigureAwait(false);
 
-            _cts.Dispose();
-
-            _channel?.Dispose();
-
             await TaskHelpers.WaitIgnoreCancelAsync(_connection, _logger, "Unexpected error from connection task.").ConfigureAwait(false);
+
+            // Dispose after the connection task has completed.
+            _cts.Dispose();
+            _channel?.Dispose();
         }
     }
 }


### PR DESCRIPTION
Dispose could happen after we've check for dispose but before getting the token from the CTS.

Fix by taking a copy of the token when the CTS is created.

Test error:

> System.ObjectDisposedException : The CancellationTokenSource has been disposed.
Stack trace
>   at System.Threading.CancellationTokenSource.get_Token()    at Aspire.Dashboard.Model.DashboardClient.<EnsureInitialized>b__23_0() in /_/src/Aspire.Dashboard/Model/DashboardClient.cs:line 145    at System.Threading.Tasks.Task`1.InnerInvoke()    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state) --- End of stack trace from previous location ---    at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)    at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread) --- End of stack trace from previous location ---    at Aspire.Dashboard.Utils.TaskHelpers.WaitIgnoreCancelCoreAsync(Task task, ILogger logger, String logMessage) in /_/src/Shared/TaskHelpers.cs:line 29    at Aspire.Dashboard.Model.DashboardClient.DisposeAsync() in /_/src/Aspire.Dashboard/Model/DashboardClient.cs:line 389    at Aspire.Dashboard.Tests.Model.DashboardClientTests.SubscribeResources_OnDispose_ChannelRemoved() in /_/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs:line 69 --- End of stack trace from previous location ---

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2608)