### PR TITLE
PublishAsAzurePostgresFlexibleServer shouldn't require a user and password

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -171,6 +171,8 @@ public class AzureBicepResource(string name, string? templateFile = null, string
             }
             context.Writer.WriteEndObject();
         }
+
+        context.WriteInputs(this);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure/Extensions/AzureBicepResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureBicepResourceExtensions.cs
@@ -209,6 +209,21 @@ public static class AzureBicepResourceExtensions
     /// <param name="name">The name of the input.</param>
     /// <param name="value">The value of the parameter.</param>
     /// <returns>An <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithParameter<T>(this IResourceBuilder<T> builder, string name, InputReference value)
+        where T : AzureBicepResource
+    {
+        builder.Resource.Parameters[name] = value;
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a parameter to the bicep template.
+    /// </summary>
+    /// <typeparam name="T">The <see cref="AzureBicepResource"/></typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="name">The name of the input.</param>
+    /// <param name="value">The value of the parameter.</param>
+    /// <returns>An <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<T> WithParameter<T>(this IResourceBuilder<T> builder, string name, BicepOutputReference value)
         where T : AzureBicepResource
     {

--- a/src/Aspire.Hosting.Azure/Extensions/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzurePostgresExtensions.cs
@@ -19,12 +19,15 @@ public static class AzurePostgresExtensions
     /// <param name="administratorLoginPassword">Parameter containing the administrator password for the server that will be provisioned in Azure.</param>
     /// <param name="callback">Callback to customize the Azure resources that will be provisioned in Azure.</param>
     /// <returns></returns>
-    public static IResourceBuilder<PostgresServerResource> PublishAsAzurePostgresFlexibleServer(this IResourceBuilder<PostgresServerResource> builder, IResourceBuilder<ParameterResource> administratorLogin, IResourceBuilder<ParameterResource> administratorLoginPassword, Action<IResourceBuilder<AzurePostgresResource>>? callback = null)
+    public static IResourceBuilder<PostgresServerResource> PublishAsAzurePostgresFlexibleServer(
+        this IResourceBuilder<PostgresServerResource> builder,
+        IResourceBuilder<ParameterResource>? administratorLogin = null,
+        IResourceBuilder<ParameterResource>? administratorLoginPassword = null,
+        Action<IResourceBuilder<AzurePostgresResource>>? callback = null)
     {
         var resource = new AzurePostgresResource(builder.Resource);
         var azurePostgres = builder.ApplicationBuilder.CreateResourceBuilder(resource).ConfigureDefaults();
-        azurePostgres.WithParameter("administratorLogin", administratorLogin)
-                     .WithParameter("administratorLoginPassword", administratorLoginPassword)
+        azurePostgres.WithLoginAndPassword(administratorLogin, administratorLoginPassword)
                      .WithParameter("databases", () => builder.Resource.Databases.Select(x => x.Value));
 
         if (callback != null)
@@ -43,12 +46,15 @@ public static class AzurePostgresExtensions
     /// <param name="administratorLoginPassword">Parameter containing the administrator password for the server that will be provisioned in Azure.</param>
     /// <param name="callback">Callback to customize the Azure resources that will be provisioned in Azure.</param>
     /// <returns></returns>
-    public static IResourceBuilder<PostgresServerResource> AsAzurePostgresFlexibleServer(this IResourceBuilder<PostgresServerResource> builder, IResourceBuilder<ParameterResource> administratorLogin, IResourceBuilder<ParameterResource> administratorLoginPassword, Action<IResourceBuilder<AzurePostgresResource>>? callback = null)
+    public static IResourceBuilder<PostgresServerResource> AsAzurePostgresFlexibleServer(
+        this IResourceBuilder<PostgresServerResource> builder,
+        IResourceBuilder<ParameterResource>? administratorLogin = null,
+        IResourceBuilder<ParameterResource>? administratorLoginPassword = null,
+        Action<IResourceBuilder<AzurePostgresResource>>? callback = null)
     {
         var resource = new AzurePostgresResource(builder.Resource);
         var azurePostgres = builder.ApplicationBuilder.CreateResourceBuilder(resource).ConfigureDefaults();
-        azurePostgres.WithParameter("administratorLogin", administratorLogin)
-                     .WithParameter("administratorLoginPassword", administratorLoginPassword)
+        azurePostgres.WithLoginAndPassword(administratorLogin, administratorLoginPassword)
                      .WithParameter("databases", () => builder.Resource.Databases.Select(x => x.Value));
 
         // Used to hold a reference to the azure surrogate for use with the provisioner.
@@ -75,5 +81,43 @@ public static class AzurePostgresExtensions
         return builder.WithManifestPublishingCallback(resource.WriteToManifest)
                       .WithParameter("serverName", resource.CreateBicepResourceName())
                       .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName);
+    }
+
+    private static IResourceBuilder<AzurePostgresResource> WithLoginAndPassword(
+        this IResourceBuilder<AzurePostgresResource> builder,
+        IResourceBuilder<ParameterResource>? administratorLogin,
+        IResourceBuilder<ParameterResource>? administratorLoginPassword)
+    {
+        if (administratorLogin is null)
+        {
+            // generate a username since a parameter was not provided
+            var usernameInput = new InputAnnotation("username")
+            {
+                Default = new GenerateInputDefault { MinLength = 10 }
+            };
+            builder.WithAnnotation(usernameInput);
+            builder.WithParameter("administratorLogin", new InputReference(builder.Resource, usernameInput));
+        }
+        else
+        {
+            builder.WithParameter("administratorLogin", administratorLogin);
+        }
+
+        if (administratorLoginPassword is null)
+        {
+            // generate a password since a parameter was not provided. Use the existing "password" input from the underlying PostgresServerResource
+            if (!(builder.Resource.Annotations.OfType<InputAnnotation>().SingleOrDefault(x => x.Name == "password") is { } passwordInput))
+            {
+                throw new DistributedApplicationException($"Could not find a 'password' InputAnnotation for resource '{builder.Resource.Name}'");
+            }
+
+            builder.WithParameter("administratorLoginPassword", new InputReference(builder.Resource, passwordInput));
+        }
+        else
+        {
+            builder.WithParameter("administratorLoginPassword", administratorLoginPassword);
+        }
+
+        return builder;
     }
 }

--- a/src/Aspire.Hosting.Azure/Extensions/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzurePostgresExtensions.cs
@@ -90,12 +90,13 @@ public static class AzurePostgresExtensions
     {
         if (administratorLogin is null)
         {
+            const string usernameInput = "username";
             // generate a username since a parameter was not provided
-            var usernameInput = new InputAnnotation("username")
+            builder.WithAnnotation(new InputAnnotation(usernameInput)
             {
                 Default = new GenerateInputDefault { MinLength = 10 }
-            };
-            builder.WithAnnotation(usernameInput);
+            });
+
             builder.WithParameter("administratorLogin", new InputReference(builder.Resource, usernameInput));
         }
         else
@@ -106,12 +107,7 @@ public static class AzurePostgresExtensions
         if (administratorLoginPassword is null)
         {
             // generate a password since a parameter was not provided. Use the existing "password" input from the underlying PostgresServerResource
-            if (!(builder.Resource.Annotations.OfType<InputAnnotation>().SingleOrDefault(x => x.Name == "password") is { } passwordInput))
-            {
-                throw new DistributedApplicationException($"Could not find a 'password' InputAnnotation for resource '{builder.Resource.Name}'");
-            }
-
-            builder.WithParameter("administratorLoginPassword", new InputReference(builder.Resource, passwordInput));
+            builder.WithParameter("administratorLoginPassword", new InputReference(builder.Resource, "password"));
         }
         else
         {

--- a/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -47,6 +48,19 @@ public sealed class InputAnnotation : IResourceAnnotation
     /// Represents how the default value of the input should be retrieved.
     /// </summary>
     public InputDefault? Default { get; set; }
+
+    /// <summary>
+    /// The value of the input.
+    /// </summary>
+    public string? GenerateDefaultValue()
+    {
+        if (Default is null)
+        {
+            throw new InvalidOperationException("The input does not have a default value.");
+        }
+
+        return Default.GenerateDefaultValue();
+    }
 }
 
 /// <summary>
@@ -59,6 +73,12 @@ public abstract class InputDefault
     /// </summary>
     /// <param name="context">The context for the manifest publishing operation.</param>
     public abstract void WriteToManifest(ManifestPublishingContext context);
+
+    /// <summary>
+    /// Generates a value for the input.
+    /// </summary>
+    /// <returns>The generated string value.</returns>
+    public abstract string GenerateDefaultValue();
 }
 
 /// <summary>
@@ -77,5 +97,12 @@ public sealed class GenerateInputDefault : InputDefault
         context.Writer.WriteStartObject("generate");
         context.Writer.WriteNumber("minLength", MinLength);
         context.Writer.WriteEndObject();
+    }
+
+    /// <inheritdoc/>
+    public override string GenerateDefaultValue()
+    {
+        // https://github.com/Azure/azure-dev/issues/3462 tracks adding more generation options
+        return PasswordGenerator.GenerateRandomLettersValue(MinLength);
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/InputReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputReference.cs
@@ -7,8 +7,8 @@ namespace Aspire.Hosting.ApplicationModel;
 /// Represents an input reference for a resource with inputs.
 /// </summary>
 /// <param name="owner">The resource with inputs that owns the input.</param>
-/// <param name="input">The <see cref="InputAnnotation"/>.</param>
-public sealed class InputReference(IResource owner, InputAnnotation input) : IManifestExpressionProvider
+/// <param name="inputName">The name of the input.</param>
+public sealed class InputReference(IResource owner, string inputName) : IManifestExpressionProvider
 {
     /// <summary>
     /// Gets the owner of the input.
@@ -16,17 +16,25 @@ public sealed class InputReference(IResource owner, InputAnnotation input) : IMa
     public IResource Owner { get; } = owner;
 
     /// <summary>
-    /// The instance of the input resource.
+    /// Gets the instance of the input annotation.
     /// </summary>
-    public InputAnnotation Input { get; } = input;
+    public InputAnnotation Input => GetInputAnnotation();
 
     /// <summary>
     /// Gets the name of the input associated with the input reference.
     /// </summary>
-    public string InputName => Input.Name;
+    public string InputName => inputName;
 
     /// <summary>
     /// Gets the expression used in the manifest to reference the value of the input.
     /// </summary>
     public string ValueExpression => $"{{{Owner.Name}.inputs.{InputName}}}";
+
+    private InputAnnotation GetInputAnnotation()
+    {
+        var input = Owner.Annotations.OfType<InputAnnotation>().SingleOrDefault(a => a.Name == InputName) ??
+            throw new InvalidOperationException($"The InputAnnotation `{InputName}` was not found for the resource `{Owner.Name}`.");
+
+        return input;
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/InputReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputReference.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents an input reference for a resource with inputs.
+/// </summary>
+/// <param name="owner">The resource with inputs that owns the input.</param>
+/// <param name="input">The <see cref="InputAnnotation"/>.</param>
+public sealed class InputReference(IResource owner, InputAnnotation input) : IManifestExpressionProvider
+{
+    /// <summary>
+    /// Gets the owner of the input.
+    /// </summary>
+    public IResource Owner { get; } = owner;
+
+    /// <summary>
+    /// The instance of the input resource.
+    /// </summary>
+    public InputAnnotation Input { get; } = input;
+
+    /// <summary>
+    /// Gets the name of the input associated with the input reference.
+    /// </summary>
+    public string InputName => Input.Name;
+
+    /// <summary>
+    /// Gets the expression used in the manifest to reference the value of the input.
+    /// </summary>
+    public string ValueExpression => $"{{{Owner.Name}.inputs.{InputName}}}";
+}

--- a/src/Aspire.Hosting/Utils/PasswordGenerator.cs
+++ b/src/Aspire.Hosting/Utils/PasswordGenerator.cs
@@ -54,15 +54,14 @@ internal static class PasswordGenerator
     /// <summary>
     /// Creates a random string of upper and lower case letters.
     /// </summary>
-    public static string GenerateRandomLettersValue(int minLength)
+    public static string GenerateRandomLettersValue(int length)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(minLength);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(minLength, 128);
+        ArgumentOutOfRangeException.ThrowIfNegative(length);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(length, 128);
 
-        Span<char> chars = stackalloc char[minLength];
+        Span<char> chars = stackalloc char[length];
 
         RandomNumberGenerator.GetItems(LettersChars, chars);
-        RandomNumberGenerator.Shuffle(chars);
 
         return new string(chars);
     }

--- a/src/Aspire.Hosting/Utils/PasswordGenerator.cs
+++ b/src/Aspire.Hosting/Utils/PasswordGenerator.cs
@@ -14,6 +14,7 @@ internal static class PasswordGenerator
 
     internal const string LowerCaseChars = "abcdefghjkmnpqrstuvwxyz"; // exclude i,l,o
     internal const string UpperCaseChars = "ABCDEFGHJKMNPQRSTUVWXYZ"; // exclude I,L,O
+    internal const string LettersChars = LowerCaseChars + UpperCaseChars;
     internal const string DigitChars = "0123456789";
     internal const string SpecialChars = "-_.{}~()*+!"; // exclude &<>=;,`'^%$#@/:[]
 
@@ -45,6 +46,22 @@ internal static class PasswordGenerator
         RandomNumberGenerator.GetItems(UpperCaseChars, chars.Slice(lowerCase, upperCase));
         RandomNumberGenerator.GetItems(DigitChars, chars.Slice(lowerCase + upperCase, digit));
         RandomNumberGenerator.GetItems(SpecialChars, chars.Slice(lowerCase + upperCase + digit, special));
+        RandomNumberGenerator.Shuffle(chars);
+
+        return new string(chars);
+    }
+
+    /// <summary>
+    /// Creates a random string of upper and lower case letters.
+    /// </summary>
+    public static string GenerateRandomLettersValue(int minLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(minLength);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(minLength, 128);
+
+        Span<char> chars = stackalloc char[minLength];
+
+        RandomNumberGenerator.GetItems(LettersChars, chars);
         RandomNumberGenerator.Shuffle(chars);
 
         return new string(chars);

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -360,6 +360,17 @@ public class AzureBicepResourceTests
                 "principalId": "",
                 "principalName": "",
                 "principalType": ""
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                }
               }
             }
             """;
@@ -458,8 +469,151 @@ public class AzureBicepResourceTests
 
         var manifest = await ManifestUtils.GetManifest(postgres.Resource);
 
-        Assert.Equal("azure.bicep.v0", manifest["type"]?.ToString());
-        Assert.Equal("{postgres.secretOutputs.connectionString}", manifest["connectionString"]?.ToString());
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v0",
+              "connectionString": "{postgres.secretOutputs.connectionString}",
+              "path": "aspire.hosting.azure.bicep.postgres.bicep",
+              "params": {
+                "serverName": "postgres",
+                "keyVaultName": "",
+                "administratorLogin": "{usr.value}",
+                "administratorLoginPassword": "{pwd.value}",
+                "databases": [
+                  "db"
+                ]
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
+    }
+
+    [Fact]
+    public async Task PublishAsAzurePostgresFlexibleServerNoUserPassParams()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var postgres = builder.AddPostgres("postgres1")
+            .PublishAsAzurePostgresFlexibleServer();
+
+        var manifest = await ManifestUtils.GetManifest(postgres.Resource);
+        var expectedManifest = """
+            {
+              "type": "azure.bicep.v0",
+              "connectionString": "{postgres1.secretOutputs.connectionString}",
+              "path": "aspire.hosting.azure.bicep.postgres.bicep",
+              "params": {
+                "serverName": "postgres1",
+                "keyVaultName": "",
+                "administratorLogin": "{postgres1.inputs.username}",
+                "administratorLoginPassword": "{postgres1.inputs.password}",
+                "databases": []
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                },
+                "username": {
+                  "type": "string",
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
+
+        var param = builder.AddParameter("param");
+
+        postgres = builder.AddPostgres("postgres2")
+            .PublishAsAzurePostgresFlexibleServer(administratorLogin: param);
+
+        manifest = await ManifestUtils.GetManifest(postgres.Resource);
+        expectedManifest = """
+            {
+              "type": "azure.bicep.v0",
+              "connectionString": "{postgres2.secretOutputs.connectionString}",
+              "path": "aspire.hosting.azure.bicep.postgres.bicep",
+              "params": {
+                "serverName": "postgres2",
+                "keyVaultName": "",
+                "administratorLogin": "{param.value}",
+                "administratorLoginPassword": "{postgres2.inputs.password}",
+                "databases": []
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
+
+        postgres = builder.AddPostgres("postgres3")
+            .PublishAsAzurePostgresFlexibleServer(administratorLoginPassword: param);
+
+        manifest = await ManifestUtils.GetManifest(postgres.Resource);
+        expectedManifest = """
+            {
+              "type": "azure.bicep.v0",
+              "connectionString": "{postgres3.secretOutputs.connectionString}",
+              "path": "aspire.hosting.azure.bicep.postgres.bicep",
+              "params": {
+                "serverName": "postgres3",
+                "keyVaultName": "",
+                "administratorLogin": "{postgres3.inputs.username}",
+                "administratorLoginPassword": "{param.value}",
+                "databases": []
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                },
+                "username": {
+                  "type": "string",
+                  "default": {
+                    "generate": {
+                      "minLength": 10
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
Allow for PublishAsAzurePostgresFlexibleServer and AsAzurePostgresFlexibleServer to default the user name and password if one isn't provided.

Fix #2389
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2627)