### PR TITLE
Azure Redis via CDK

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.2.0-alpha.20240227.2" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.0-alpha.20240222.2" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.8.0-alpha.20240222.2" />
-    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240304.2" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240305.3" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.2.0-alpha.20240227.2" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.0-alpha.20240222.2" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.8.0-alpha.20240222.2" />
-    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240304.1" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240304.2" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion)" />

--- a/playground/cdk/CdkSample.ApiService/CdkSample.ApiService.csproj
+++ b/playground/cdk/CdkSample.ApiService/CdkSample.ApiService.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\..\..\src\Components\Aspire.Azure.Security.KeyVault\Aspire.Azure.Security.KeyVault.csproj" />
     <ProjectReference Include="..\..\..\src\Components\Aspire.Azure.Storage.Blobs\Aspire.Azure.Storage.Blobs.csproj" />
     <ProjectReference Include="..\..\..\src\Components\Aspire.Microsoft.EntityFrameworkCore.SqlServer\Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj" />
+    <ProjectReference Include="..\..\..\src\Components\Aspire.StackExchange.Redis\Aspire.StackExchange.Redis.csproj" />
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/playground/cdk/CdkSample.ApiService/Program.cs
+++ b/playground/cdk/CdkSample.ApiService/Program.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Azure.Security.KeyVault.Secrets;
 using Azure.Storage.Blobs;
 using Microsoft.EntityFrameworkCore;
+using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -12,20 +14,42 @@ builder.AddServiceDefaults();
 builder.AddAzureBlobService("blobs");
 builder.AddSqlServerDbContext<SqlContext>("sqldb");
 builder.AddAzureKeyVaultSecrets("mykv");
+builder.AddRedis("cache");
 
 var app = builder.Build();
 
-app.MapGet("/", async (BlobServiceClient bsc, SqlContext context, SecretClient sc) =>
+app.MapGet("/", async (BlobServiceClient bsc, SqlContext context, SecretClient sc, IConnectionMultiplexer connection) =>
 {
     return new
     {
+        redisEntries = await TestRedisAsync(connection),
         secretChecked = await TestSecretAsync(sc),
         blobFiles = await TestBlobStorageAsync(bsc),
         sqlRows = await TestSqlServerAsync(context)
     };
 });
-
 app.Run();
+
+static async Task<IEnumerable<Entry>> TestRedisAsync(IConnectionMultiplexer connection)
+{
+    var database = connection.GetDatabase();
+
+    var entry = new Entry();
+
+    // Add an entry to the list on each request.
+    await database.ListRightPushAsync("entries", JsonSerializer.SerializeToUtf8Bytes(entry));
+
+    var entries = new List<Entry>();
+    var list = await database.ListRangeAsync("entries");
+
+    foreach (var item in list)
+    {
+        entries.Add(JsonSerializer.Deserialize<Entry>((string)item!)!);
+    }
+
+    return entries;
+
+}
 
 static async Task<bool> TestSecretAsync(SecretClient secretClient)
 {

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -12,8 +12,8 @@ var signaturesecret = builder.AddParameter("signaturesecret");
 
 var storage = builder.AddAzureConstructStorage("storage", (_, account) =>
 {
-    account.AssignParameter(sa => sa.Sku.Name, sku);
-    account.AssignParameter(sa => sa.Location, locationOverride);
+    account.AssignProperty(sa => sa.Sku.Name, sku);
+    account.AssignProperty(sa => sa.Location, locationOverride);
 });
 
 var blobs = storage.AddBlobs("blobs");
@@ -23,13 +23,16 @@ var sqldb = builder.AddSqlServer("sql").AsAzureSqlDatabaseConstruct().AddDatabas
 var keyvault = builder.AddAzureKeyVaultConstruct("mykv", (construct, keyVault) =>
 {
     var secret = new KeyVaultSecret(construct, name: "mysecret");
-    secret.AssignParameter(x => x.Properties.Value, signaturesecret);
+    secret.AssignProperty(x => x.Properties.Value, signaturesecret);
 });
+
+var cache = builder.AddRedis("cache").AsAzureRedisConstruct();
 
 builder.AddProject<Projects.CdkSample_ApiService>("api")
        .WithReference(blobs)
        .WithReference(sqldb)
-       .WithReference(keyvault);
+       .WithReference(keyvault)
+       .WithReference(cache);
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code

--- a/playground/cdk/CdkSample.AppHost/aspire-manifest.json
+++ b/playground/cdk/CdkSample.AppHost/aspire-manifest.json
@@ -64,6 +64,15 @@
         "signaturesecret": "{signaturesecret.value}"
       }
     },
+    "cache": {
+      "type": "azure.bicep.v0",
+      "connectionString": "{cache.secretOutputs.connectionString}",
+      "path": "cache.module.bicep",
+      "params": {
+        "principalId": "",
+        "keyVaultName": ""
+      }
+    },
     "api": {
       "type": "project.v0",
       "path": "../CdkSample.ApiService/CdkSample.ApiService.csproj",
@@ -72,7 +81,8 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "ConnectionStrings__blobs": "{blobs.connectionString}",
         "ConnectionStrings__sqldb": "{sqldb.connectionString}",
-        "ConnectionStrings__mykv": "{mykv.connectionString}"
+        "ConnectionStrings__mykv": "{mykv.connectionString}",
+        "ConnectionStrings__cache": "{cache.connectionString}"
       },
       "bindings": {
         "http": {

--- a/playground/cdk/CdkSample.AppHost/cache.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/cache.module.bicep
@@ -1,0 +1,77 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+@description('')
+param keyVaultName string
+
+@description('')
+param principalId string
+
+@description('')
+param principalType string
+
+
+resource redisCache_p9fE6TK3F 'Microsoft.Cache/Redis@2020-06-01' = {
+  name: toLower(take(concat('cache', uniqueString(resourceGroup().id)), 24))
+  location: location
+  properties: {
+    enableNonSslPort: false
+    minimumTlsVersion: '1.2'
+    sku: {
+      name: 'Basic'
+      family: 'C'
+      capacity: 1
+    }
+  }
+}
+
+resource keyVault_GLHqcGjrx 'Microsoft.KeyVault/vaults@2023-02-01' = {
+  name: keyVaultName
+  location: location
+  properties: {
+    tenantId: tenant().tenantId
+    sku: {
+      name: 'standard'
+      family: 'A'
+    }
+    enableRbacAuthorization: true
+  }
+}
+
+resource keyVaultSecret_00uTkXYQa 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
+  parent: keyVault_GLHqcGjrx
+  name: 'connectionString'
+  location: location
+  properties: {
+    value: '${redisCache_p9fE6TK3F.properties.hostName},ssl=true,password=${redisCache_p9fE6TK3F.listKeys(redisCache_p9fE6TK3F.apiVersion).primaryKey}'
+  }
+}
+
+resource keyVaultSecret_SoyN6fZ8F 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
+  parent: keyVault_GLHqcGjrx
+  name: 'keyVaultName'
+  location: location
+  properties: {
+    value: keyVaultName
+  }
+}
+
+resource keyVaultSecret_wGdvQ8DEM 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
+  parent: keyVault_GLHqcGjrx
+  name: 'principalId'
+  location: location
+  properties: {
+    value: principalId
+  }
+}
+
+resource keyVaultSecret_cmuFkn6iw 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
+  parent: keyVault_GLHqcGjrx
+  name: 'principalType'
+  location: location
+  properties: {
+    value: principalType
+  }
+}

--- a/playground/cdk/CdkSample.AppHost/cache.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/cache.module.bicep
@@ -1,17 +1,18 @@
 targetScope = 'resourceGroup'
 
 @description('')
-param location string = resourceGroup().location
+param principalId string
 
 @description('')
 param keyVaultName string
 
 @description('')
-param principalId string
+param location string = resourceGroup().location
 
-@description('')
-param principalType string
 
+resource keyVault_IeF8jZvXV 'Microsoft.KeyVault/vaults@2023-02-01' existing = {
+  name: keyVaultName
+}
 
 resource redisCache_p9fE6TK3F 'Microsoft.Cache/Redis@2020-06-01' = {
   name: toLower(take(concat('cache', uniqueString(resourceGroup().id)), 24))
@@ -27,51 +28,11 @@ resource redisCache_p9fE6TK3F 'Microsoft.Cache/Redis@2020-06-01' = {
   }
 }
 
-resource keyVault_GLHqcGjrx 'Microsoft.KeyVault/vaults@2023-02-01' = {
-  name: keyVaultName
-  location: location
-  properties: {
-    tenantId: tenant().tenantId
-    sku: {
-      name: 'standard'
-      family: 'A'
-    }
-    enableRbacAuthorization: true
-  }
-}
-
-resource keyVaultSecret_00uTkXYQa 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
-  parent: keyVault_GLHqcGjrx
+resource keyVaultSecret_Ddsc3HjrA 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
+  parent: keyVault_IeF8jZvXV
   name: 'connectionString'
   location: location
   properties: {
     value: '${redisCache_p9fE6TK3F.properties.hostName},ssl=true,password=${redisCache_p9fE6TK3F.listKeys(redisCache_p9fE6TK3F.apiVersion).primaryKey}'
-  }
-}
-
-resource keyVaultSecret_SoyN6fZ8F 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
-  parent: keyVault_GLHqcGjrx
-  name: 'keyVaultName'
-  location: location
-  properties: {
-    value: keyVaultName
-  }
-}
-
-resource keyVaultSecret_wGdvQ8DEM 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
-  parent: keyVault_GLHqcGjrx
-  name: 'principalId'
-  location: location
-  properties: {
-    value: principalId
-  }
-}
-
-resource keyVaultSecret_cmuFkn6iw 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
-  parent: keyVault_GLHqcGjrx
-  name: 'principalType'
-  location: location
-  properties: {
-    value: principalType
   }
 }

--- a/playground/cdk/CdkSample.AppHost/mykv.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/mykv.module.bicep
@@ -1,13 +1,13 @@
 targetScope = 'resourceGroup'
 
 @description('')
-param location string = resourceGroup().location
-
-@description('')
 param principalId string
 
 @description('')
 param principalType string
+
+@description('')
+param location string = resourceGroup().location
 
 @description('')
 param signaturesecret string

--- a/playground/cdk/CdkSample.AppHost/sql.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/sql.module.bicep
@@ -1,13 +1,13 @@
 targetScope = 'resourceGroup'
 
 @description('')
-param location string = resourceGroup().location
-
-@description('')
 param principalId string
 
 @description('')
 param principalName string
+
+@description('')
+param location string = resourceGroup().location
 
 
 resource sqlServer_l5O9GRsSn 'Microsoft.Sql/servers@2022-08-01-preview' = {

--- a/playground/cdk/CdkSample.AppHost/storage.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/storage.module.bicep
@@ -1,6 +1,12 @@
 targetScope = 'resourceGroup'
 
 @description('')
+param principalId string
+
+@description('')
+param principalType string
+
+@description('')
 param location string = resourceGroup().location
 
 @description('')
@@ -8,12 +14,6 @@ param storagesku string
 
 @description('')
 param locationOverride string
-
-@description('')
-param principalId string
-
-@description('')
-param principalType string
 
 
 resource storageAccount_65zdmu5tK 'Microsoft.Storage/storageAccounts@2022-09-01' = {

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -76,7 +76,7 @@ public static class AzureConstructResourceExtensions
     /// <param name="propertySelector">Property selection expression.</param>
     /// <param name="parameterResourceBuilder">Aspire parameter resource builder.</param>
     /// <param name="parameterName">The name of the parameter to be assigned.</param>
-    public static void AssignParameter<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, IResourceBuilder<ParameterResource> parameterResourceBuilder, string? parameterName = null) where T: notnull
+    public static void AssignProperty<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, IResourceBuilder<ParameterResource> parameterResourceBuilder, string? parameterName = null) where T: notnull
     {
         parameterName ??= parameterResourceBuilder.Resource.Name;
 
@@ -90,12 +90,12 @@ public static class AzureConstructResourceExtensions
         if (resource.Scope.GetParameters().Any(p => p.Name == parameterName))
         {
             var parameter = resource.Scope.GetParameters().Single(p => p.Name == parameterName);
-            resource.AssignParameter(propertySelector, parameter);
+            resource.AssignProperty(propertySelector, parameter.Name);
         }
         else
         {
             var parameter = new Parameter(parameterName, isSecure: parameterResourceBuilder.Resource.Secret);
-            resource.AssignParameter(propertySelector, parameter);
+            resource.AssignProperty(propertySelector, parameter);
         }
     }
 
@@ -107,7 +107,7 @@ public static class AzureConstructResourceExtensions
     /// <param name="propertySelector">Property selection expression.</param>
     /// <param name="parameterName">The name of the parameter to be assigned.</param>
     /// <param name="outputReference">Aspire parameter resource builder.</param>
-    public static void AssignParameter<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, BicepOutputReference outputReference, string? parameterName = null) where T : notnull
+    public static void AssignProperty<T>(this Resource<T> resource, Expression<Func<T, object?>> propertySelector, BicepOutputReference outputReference, string? parameterName = null) where T : notnull
     {
         parameterName ??= outputReference.Resource.Name;
 
@@ -121,12 +121,12 @@ public static class AzureConstructResourceExtensions
         if (resource.Scope.GetParameters().Any(p => p.Name == parameterName))
         {
             var parameter = resource.Scope.GetParameters().Single(p => p.Name == parameterName);
-            resource.AssignParameter(propertySelector, parameter);
+            resource.AssignProperty(propertySelector, parameter);
         }
         else
         {
             var parameter = new Parameter(parameterName);
-            resource.AssignParameter(propertySelector, parameter);
+            resource.AssignProperty(propertySelector, parameter);
         }
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -30,13 +30,22 @@ public class AzureConstructResource(string name, Action<ResourceModuleConstruct>
 
         var resourceModuleConstruct = new ResourceModuleConstruct(this, configuration);
 
+        ConfigureConstruct(resourceModuleConstruct);
+
+        var constructParameters = resourceModuleConstruct.GetParameters();
+        var distinctConstructParameters = constructParameters.DistinctBy(p => p.Name);
+        var distinctConstructParametersLookup = distinctConstructParameters.ToDictionary(p => p.Name);
+
         foreach (var aspireParameter in this.Parameters)
         {
+            if (distinctConstructParametersLookup.ContainsKey(aspireParameter.Key))
+            {
+                continue;
+            }
+
             var constructParameter = new Parameter(aspireParameter.Key);
             resourceModuleConstruct.AddParameter(constructParameter);
         }
-
-        ConfigureConstruct(resourceModuleConstruct);
 
         var generationPath = Directory.CreateTempSubdirectory("aspire").FullName;
         resourceModuleConstruct.Build(generationPath);

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -32,6 +32,11 @@ public class AzureConstructResource(string name, Action<ResourceModuleConstruct>
 
         ConfigureConstruct(resourceModuleConstruct);
 
+        // WARNING: GetParameters currently returns more than one instance of the same
+        //          parameter. Its the only API that gives us what we need (a list of
+        //          parameters. Here we find all the distinct parameters by name and
+        //          put them into a dictionary for quick lookup so we don't need to scan
+        //          through the parameter enumerable each time.
         var constructParameters = resourceModuleConstruct.GetParameters();
         var distinctConstructParameters = constructParameters.DistinctBy(p => p.Name);
         var distinctConstructParametersLookup = distinctConstructParameters.ToDictionary(p => p.Name);

--- a/src/Aspire.Hosting.Azure/AzureRedisResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureRedisResource.cs
@@ -50,3 +50,50 @@ public class AzureRedisResource(RedisResource innerResource) :
     /// <inheritdoc />
     public override ResourceAnnotationCollection Annotations => innerResource.Annotations;
 }
+
+/// <summary>
+/// Represents an Azure Redis resource.
+/// </summary>
+/// <param name="innerResource">The inner resource.</param>
+/// <param name="configureConstruct"></param>
+public class AzureRedisConstructResource(RedisResource innerResource, Action<ResourceModuleConstruct> configureConstruct) :
+    AzureConstructResource(innerResource.Name, configureConstruct),
+    IResourceWithConnectionString
+{
+    /// <summary>
+    /// Gets the "connectionString" output reference from the bicep template for the Azure Redis resource.
+    /// </summary>
+    public BicepSecretOutputReference ConnectionString => new("connectionString", this);
+
+    /// <summary>
+    /// Gets the connection string template for the manifest for the Azure Redis resource.
+    /// </summary>
+    public string ConnectionStringExpression => ConnectionString.ValueExpression;
+
+    /// <summary>
+    /// Gets the connection string for the Azure Redis resource.
+    /// </summary>
+    /// <returns>The connection string for the Azure Redis resource.</returns>
+    public string? GetConnectionString() => ConnectionString.Value;
+
+    /// <summary>
+    /// Gets the connection string for the Azure Redis resource.
+    /// </summary>
+    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>The connection string for the Azure Redis resource.</returns>
+    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    {
+        if (ProvisioningTaskCompletionSource is not null)
+        {
+            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return GetConnectionString();
+    }
+
+    /// <inheritdoc/>
+    public override string Name => innerResource.Name;
+
+    /// <inheritdoc />
+    public override ResourceAnnotationCollection Annotations => innerResource.Annotations;
+}

--- a/src/Aspire.Hosting.Azure/Extensions/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureKeyVaultResourceExtensions.cs
@@ -44,8 +44,8 @@ public static class AzureKeyVaultResourceExtensions
             keyVault.AddOutput(x => x.Properties.VaultUri, "vaultUri");
 
             var keyVaultAdministratorRoleAssignment = keyVault.AssignRole(RoleDefinition.KeyVaultAdministrator);
-            keyVaultAdministratorRoleAssignment.AssignParameter(x => x.PrincipalId, construct.PrincipalIdParameter);
-            keyVaultAdministratorRoleAssignment.AssignParameter(x => x.PrincipalType, construct.PrincipalTypeParameter);
+            keyVaultAdministratorRoleAssignment.AssignProperty(x => x.PrincipalId, construct.PrincipalIdParameter);
+            keyVaultAdministratorRoleAssignment.AssignProperty(x => x.PrincipalType, construct.PrincipalTypeParameter);
 
             if (configureResource != null)
             {

--- a/src/Aspire.Hosting.Azure/Extensions/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureRedisExtensions.cs
@@ -3,6 +3,9 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
+using Azure.Provisioning;
+using Azure.Provisioning.KeyVaults;
+using Azure.Provisioning.Redis;
 
 namespace Aspire.Hosting;
 
@@ -65,5 +68,111 @@ public static class AzureRedisExtensions
         return builder.WithParameter("redisCacheName", resource.CreateBicepResourceName())
                       .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName)
                       .WithManifestPublishingCallback(resource.WriteToManifest);
+    }
+
+    /// <summary>
+    /// Configures the resource to be published as Azure Cache for Redis when deployed via Azure Developer CLI.
+    /// </summary>
+    /// <param name="builder">The <see cref="IResourceBuilder{RedisResource}"/> builder.</param>
+    /// <param name="configureResource">Callback to configure Azure resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{RedisResource}"/> builder.</returns>
+    public static IResourceBuilder<RedisResource> PublishAsAzureRedisConstruct(this IResourceBuilder<RedisResource> builder, Action<ResourceModuleConstruct, RedisCache>? configureResource = null)
+    {
+        return builder.PublishAsAzureRedisConstruct(configureResource);
+    }
+
+    /// <summary>
+    /// Configures the resource to be published as Azure Cache for Redis when deployed via Azure Developer CLI.
+    /// </summary>
+    /// <param name="builder">The <see cref="IResourceBuilder{RedisResource}"/> builder.</param>
+    /// <param name="configureResource">Callback to configure Azure resource.</param>
+    /// <param name="useProvisioner"></param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{RedisResource}"/> builder.</returns>
+    internal static IResourceBuilder<RedisResource> PublishAsAzureRedisConstruct(this IResourceBuilder<RedisResource> builder, Action<ResourceModuleConstruct, RedisCache>? configureResource = null, bool useProvisioner = false)
+    {
+        var configureConstruct = (ResourceModuleConstruct construct) =>
+        {
+            var redisCache = new RedisCache(construct, name: builder.Resource.Name);
+
+            // EXPERIMENTAL: Create a keyvault using the same details as the existing one.
+            var vaultNameParameter = new Parameter("keyVaultName");
+            construct.AddParameter(vaultNameParameter);
+
+            var keyVault = new KeyVault(construct);
+            keyVault.AssignProperty(x => x.Name, "keyVaultName");
+
+            // HACK: Temporary comment out whilst integration with AZD is figured out.
+            //var role = keyVault.AssignRole(RoleDefinition.KeyVaultAdministrator);
+            //role.AssignProperty(x => x.PrincipalId, construct.PrincipalIdParameter);
+            //role.AssignProperty(x => x.PrincipalType, construct.PrincipalTypeParameter);
+
+            // HACK: Use the name {resourcename}.salt1 to ensure the Bicep construct name is unique.
+            var keyVaultSecret = new KeyVaultSecret(construct, $"{builder.Resource.Name}salt1");
+            keyVaultSecret.AssignProperty(x => x.Name, "'connectionString'");
+            keyVaultSecret.AssignProperty(
+                x => x.Properties.Value,
+                $$"""'${{{redisCache.Name}}.properties.hostName},ssl=true,password=${{{redisCache.Name}}.listKeys({{redisCache.Name}}.apiVersion).primaryKey}'"""
+                );
+
+            // HACK: Use the name {resourcename}.salt1 to ensure the Bicep construct name is unique.
+            var discardSecret = new KeyVaultSecret(construct, $"{builder.Resource.Name}salt2");
+            discardSecret.AssignProperty(x => x.Name, "'keyVaultName'");
+            discardSecret.AssignProperty(x => x.Properties.Value, vaultNameParameter); // HACK: Ensures parameter stays in Bicep!
+
+            // HACK: Use the name {resourcename}.salt1 to ensure the Bicep construct name is unique.
+            var discardPrincipalId = new KeyVaultSecret(construct, $"{builder.Resource.Name}salt3");
+            discardPrincipalId.AssignProperty(x => x.Name, "'principalId'");
+            discardPrincipalId.AssignProperty(x => x.Properties.Value, construct.PrincipalIdParameter); // HACK: Ensures parameter stays in Bicep!
+
+            // HACK: Use the name {resourcename}.salt1 to ensure the Bicep construct name is unique.
+            var discardPrincipalType = new KeyVaultSecret(construct, $"{builder.Resource.Name}salt4");
+            discardPrincipalType.AssignProperty(x => x.Name, "'principalType'");
+            discardPrincipalType.AssignProperty(x => x.Properties.Value, construct.PrincipalTypeParameter); // HACK: Ensures parameter stays in Bicep!
+
+            if (configureResource != null)
+            {
+                configureResource(construct, redisCache);
+            }
+        };
+
+        var resource = new AzureRedisConstructResource(builder.Resource, configureConstruct);
+        var resourceBuilder = builder.ApplicationBuilder.CreateResourceBuilder(resource)
+                                     .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)
+                                     .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName)
+                                     .WithManifestPublishingCallback(resource.WriteToManifest);
+
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
+            {
+                resourceBuilder.WithParameter(AzureBicepResource.KnownParameters.PrincipalType);
+            }
+        }
+
+        if (useProvisioner)
+        {
+            // Used to hold a reference to the azure surrogate for use with the provisioner.
+            builder.WithAnnotation(new AzureBicepResourceAnnotation(resource));
+            builder.WithConnectionStringRedirection(resource);
+
+            // Remove the container annotation so that DCP doesn't do anything with it.
+            if (builder.Resource.Annotations.OfType<ContainerImageAnnotation>().SingleOrDefault() is { } containerAnnotation)
+            {
+                builder.Resource.Annotations.Remove(containerAnnotation);
+            }
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures resource to use Azure for local development and when doing a deployment via the Azure Developer CLI.
+    /// </summary>
+    /// <param name="builder">The <see cref="IResourceBuilder{RedisResource}"/> builder.</param>
+    /// <param name="configureResource">Callback to configure Azure resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{RedisResource}"/> builder.</returns>
+    public static IResourceBuilder<RedisResource> AsAzureRedisConstruct(this IResourceBuilder<RedisResource> builder, Action<ResourceModuleConstruct, RedisCache>? configureResource = null)
+    {
+        return builder.PublishAsAzureRedisConstruct(configureResource, useProvisioner: true);
     }
 }

--- a/src/Aspire.Hosting.Azure/Extensions/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureSqlExtensions.cs
@@ -81,8 +81,8 @@ public static class AzureSqlExtensions
 
             sqlServer.AssignProperty(x => x.Administrators.AdministratorType, "'ActiveDirectory'");
             sqlServer.AssignProperty(x => x.Administrators.IsAzureADOnlyAuthenticationEnabled, "true");
-            sqlServer.AssignParameter(x => x.Administrators.Sid, construct.PrincipalIdParameter);
-            sqlServer.AssignParameter(x => x.Administrators.Login, construct.PrincipalNameParameter);
+            sqlServer.AssignProperty(x => x.Administrators.Sid, construct.PrincipalIdParameter);
+            sqlServer.AssignProperty(x => x.Administrators.Login, construct.PrincipalNameParameter);
             sqlServer.AssignProperty(x => x.Administrators.TenantId, "subscription().tenantId");
 
             var azureServicesFirewallRule = new SqlFirewallRule(construct, sqlServer, "AllowAllAzureIps");
@@ -93,7 +93,7 @@ public static class AzureSqlExtensions
             {
                 // When in run mode we inject the users identity and we need to specify
                 // the principalType.
-                sqlServer.AssignParameter(x => x.Administrators.PrincipalType, construct.PrincipalTypeParameter);
+                sqlServer.AssignProperty(x => x.Administrators.PrincipalType, construct.PrincipalTypeParameter);
 
                 var sqlFirewall = new SqlFirewallRule(construct);
                 sqlFirewall.AssignProperty(x => x.StartIPAddress, "'0.0.0.0'");

--- a/src/Aspire.Hosting.Azure/Extensions/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureStorageExtensions.cs
@@ -53,13 +53,13 @@ public static class AzureStorageExtensions
             var blobService = new BlobService(construct);
 
             var blobRole = storageAccount.AssignRole(RoleDefinition.StorageBlobDataContributor);
-            blobRole.AssignParameter(p => p.PrincipalType, construct.PrincipalTypeParameter);
+            blobRole.AssignProperty(p => p.PrincipalType, construct.PrincipalTypeParameter);
 
             var tableRole = storageAccount.AssignRole(RoleDefinition.StorageTableDataContributor);
-            tableRole.AssignParameter(p => p.PrincipalType, construct.PrincipalTypeParameter);
+            tableRole.AssignProperty(p => p.PrincipalType, construct.PrincipalTypeParameter);
 
             var queueRole = storageAccount.AssignRole(RoleDefinition.StorageQueueDataContributor);
-            queueRole.AssignParameter(p => p.PrincipalType, construct.PrincipalTypeParameter);
+            queueRole.AssignProperty(p => p.PrincipalType, construct.PrincipalTypeParameter);
 
             storageAccount.AddOutput(sa => sa.PrimaryEndpoints.BlobUri, "blobEndpoint");
             storageAccount.AddOutput(sa => sa.PrimaryEndpoints.QueueUri, "queueEndpoint");

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -211,7 +211,7 @@ public class AzureBicepResourceTests
                 kind: StorageKind.StorageV2,
                 sku: StorageSkuName.StandardLrs
                 );
-            storage.AssignParameter(sa => sa.Sku.Name, skuName);
+            storage.AssignProperty(sa => sa.Sku.Name, skuName);
             moduleConstruct = construct;
         });
 
@@ -249,7 +249,7 @@ public class AzureBicepResourceTests
                 kind: StorageKind.StorageV2,
                 sku: StorageSkuName.StandardLrs
                 );
-            storage.AssignParameter(sa => sa.Sku.Name, skuName, parameterName: "sku");
+            storage.AssignProperty(sa => sa.Sku.Name, skuName, parameterName: "sku");
             moduleConstruct = construct;
         });
 
@@ -569,7 +569,7 @@ public class AzureBicepResourceTests
         var storagesku = builder.AddParameter("storagesku");
         var storage = builder.AddAzureConstructStorage("storage", (_, sa) =>
         {
-            sa.AssignParameter(x => x.Sku.Name, storagesku);
+            sa.AssignProperty(x => x.Sku.Name, storagesku);
         });
 
         storage.Resource.Outputs["blobEndpoint"] = "https://myblob";


### PR DESCRIPTION
This PR introduces support for deploying Azure Redis via CDK. The usage is as follows:

```csharp
builder.AddRedis("cache").PublishAsAzureRedisConstruct();
builder.AddRedis("cache").AsAzureRedisConstruct();
```

This will produce the following manifest:

```json
{
  "resources": {
    "storagesku": {
      "type": "parameter.v0",
      "value": "{storagesku.inputs.value}",
      "inputs": {
        "value": {
          "type": "string"
        }
      }
    },
    "locationOverride": {
      "type": "parameter.v0",
      "value": "{locationOverride.inputs.value}",
      "inputs": {
        "value": {
          "type": "string"
        }
      }
    },
    "signaturesecret": {
      "type": "parameter.v0",
      "value": "{signaturesecret.inputs.value}",
      "inputs": {
        "value": {
          "type": "string"
        }
      }
    },
    "storage": {
      "type": "azure.bicep.v0",
      "path": "storage.module.bicep",
      "params": {
        "principalId": "",
        "principalType": "",
        "storagesku": "{storagesku.value}",
        "locationOverride": "{locationOverride.value}"
      }
    },
    "blobs": {
      "type": "value.v0",
      "connectionString": "{storage.outputs.blobEndpoint}"
    },
    "sql": {
      "type": "azure.bicep.v0",
      "connectionString": "Server=tcp:{sql.outputs.sqlServerFqdn},1433;Encrypt=True;Authentication=\u0022Active Directory Default\u0022",
      "path": "sql.module.bicep",
      "params": {
        "principalId": "",
        "principalName": ""
      }
    },
    "sqldb": {
      "type": "value.v0",
      "connectionString": "{sql.connectionString};Database=sqldb"
    },
    "mykv": {
      "type": "azure.bicep.v0",
      "connectionString": "{mykv.outputs.vaultUri}",
      "path": "mykv.module.bicep",
      "params": {
        "principalId": "",
        "principalType": "",
        "signaturesecret": "{signaturesecret.value}"
      }
    },
    "cache": {
      "type": "azure.bicep.v0",
      "connectionString": "{cache.secretOutputs.connectionString}",
      "path": "cache.module.bicep",
      "params": {
        "principalId": "",
        "keyVaultName": ""
      }
    },
    "api": {
      "type": "project.v0",
      "path": "../CdkSample.ApiService/CdkSample.ApiService.csproj",
      "env": {
        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
        "ConnectionStrings__blobs": "{blobs.connectionString}",
        "ConnectionStrings__sqldb": "{sqldb.connectionString}",
        "ConnectionStrings__mykv": "{mykv.connectionString}",
        "ConnectionStrings__cache": "{cache.connectionString}"
      },
      "bindings": {
        "http": {
          "scheme": "http",
          "protocol": "tcp",
          "transport": "http"
        },
        "https": {
          "scheme": "https",
          "protocol": "tcp",
          "transport": "http"
        }
      }
    }
  }
}
```

And the following Bicep (for the Redis module):

```bicep
targetScope = 'resourceGroup'

@description('')
param principalId string

@description('')
param keyVaultName string

@description('')
param location string = resourceGroup().location


resource keyVault_IeF8jZvXV 'Microsoft.KeyVault/vaults@2023-02-01' existing = {
  name: keyVaultName
}

resource redisCache_p9fE6TK3F 'Microsoft.Cache/Redis@2020-06-01' = {
  name: toLower(take(concat('cache', uniqueString(resourceGroup().id)), 24))
  location: location
  properties: {
    enableNonSslPort: false
    minimumTlsVersion: '1.2'
    sku: {
      name: 'Basic'
      family: 'C'
      capacity: 1
    }
  }
}

resource keyVaultSecret_Ddsc3HjrA 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
  parent: keyVault_IeF8jZvXV
  name: 'connectionString'
  location: location
  properties: {
    value: '${redisCache_p9fE6TK3F.properties.hostName},ssl=true,password=${redisCache_p9fE6TK3F.listKeys(redisCache_p9fE6TK3F.apiVersion).primaryKey}'
  }
}
```