### PR TITLE
Use InputReference in more places

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
@@ -52,7 +52,7 @@ public sealed class InputAnnotation : IResourceAnnotation
     /// <summary>
     /// The value of the input.
     /// </summary>
-    public string? GenerateDefaultValue()
+    public string GenerateDefaultValue()
     {
         if (Default is null)
         {

--- a/src/Aspire.Hosting/ApplicationModel/InputReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputReference.cs
@@ -25,9 +25,7 @@ public sealed class InputReference(IResource owner, string inputName) : IManifes
     /// </summary>
     public string InputName => inputName;
 
-    /// <summary>
-    /// Gets the expression used in the manifest to reference the value of the input.
-    /// </summary>
+    /// <inheritdoc/>
     public string ValueExpression => $"{{{Owner.Name}.inputs.{InputName}}}";
 
     private InputAnnotation GetInputAnnotation()

--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -9,6 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 public sealed class ParameterResource : Resource, IManifestExpressionProvider, IValueProvider
 {
     private readonly Func<string> _callback;
+    private InputReference? _valueInput;
 
     /// <summary>
     /// Initializes a new instance of <see cref="ParameterResource"/>.
@@ -33,6 +34,8 @@ public sealed class ParameterResource : Resource, IManifestExpressionProvider, I
     /// Gets a value indicating whether the parameter is secret.
     /// </summary>
     public bool Secret { get; }
+
+    internal InputReference ValueInput => _valueInput ??= new(this, "value");
 
     /// <summary>
     /// Gets the expression used in the manifest to reference the value of the parameter.

--- a/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
@@ -66,10 +66,10 @@ public static class ParameterResourceBuilderExtensions
 
         if (connectionString)
         {
-            context.Writer.WriteString("connectionString", $"{{{resource.Name}.value}}");
+            context.Writer.WriteString("connectionString", resource.ValueExpression);
         }
 
-        context.Writer.WriteString("value", $"{{{resource.Name}.inputs.value}}");
+        context.Writer.WriteString("value", resource.ValueInput.ValueExpression);
         context.WriteInputs(resource);
     }
 

--- a/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
@@ -34,14 +34,9 @@ public static class MySqlBuilderExtensions
                       .WithDefaultPassword()
                       .WithEnvironment(context =>
                       {
-                          if (context.ExecutionContext.IsPublishMode)
-                          {
-                              context.EnvironmentVariables.Add(PasswordEnvVarName, resource.PasswordInput.ValueExpression);
-                          }
-                          else
-                          {
-                              context.EnvironmentVariables.Add(PasswordEnvVarName, resource.Password);
-                          }
+                          context.EnvironmentVariables[PasswordEnvVarName] = context.ExecutionContext.IsPublishMode
+                              ? resource.PasswordInput
+                              : resource.Password;
                       })
                       .PublishAsContainer();
     }
@@ -88,7 +83,7 @@ public static class MySqlBuilderExtensions
                                   .WithHttpEndpoint(containerPort: 80, hostPort: hostPort, name: containerName)
                                   .WithBindMount(Path.GetTempFileName(), "/etc/phpmyadmin/config.user.inc.php")
                                   .ExcludeFromManifest();
-        
+
         return builder;
     }
 

--- a/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MySql/MySqlBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class MySqlBuilderExtensions
                       {
                           if (context.ExecutionContext.IsPublishMode)
                           {
-                              context.EnvironmentVariables.Add(PasswordEnvVarName, $"{{{resource.Name}.inputs.password}}");
+                              context.EnvironmentVariables.Add(PasswordEnvVarName, resource.PasswordInput.ValueExpression);
                           }
                           else
                           {

--- a/src/Aspire.Hosting/MySql/MySqlServerResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlServerResource.cs
@@ -15,11 +15,14 @@ public class MySqlServerResource(string name, string password) : ContainerResour
     internal static string PrimaryEndpointName => "tcp";
 
     private EndpointReference? _primaryEndpoint;
+    private InputReference? _passwordInput;
 
     /// <summary>
     /// Gets the primary endpoint for the MySQL server.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+
+    internal InputReference PasswordInput => _passwordInput ??= new(this, "password");
 
     /// <summary>
     /// Gets the MySQL server root password.
@@ -30,7 +33,7 @@ public class MySqlServerResource(string name, string password) : ContainerResour
     /// Gets the connection string expression for the MySQL server.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"Server={PrimaryEndpoint.GetExpression(EndpointProperty.Host)};Port={PrimaryEndpoint.GetExpression(EndpointProperty.Port)};User ID=root;Password={{{Name}.inputs.password}}";
+        $"Server={PrimaryEndpoint.GetExpression(EndpointProperty.Host)};Port={PrimaryEndpoint.GetExpression(EndpointProperty.Port)};User ID=root;Password={PasswordInput.ValueExpression}";
 
     /// <summary>
     /// Gets the connection string for the MySQL server.

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
@@ -34,7 +34,7 @@ public static class OracleDatabaseBuilderExtensions
                       {
                           if (context.ExecutionContext.IsPublishMode)
                           {
-                              context.EnvironmentVariables.Add(PasswordEnvVarName, $"{{{oracleDatabaseServer.Name}.inputs.password}}");
+                              context.EnvironmentVariables.Add(PasswordEnvVarName, oracleDatabaseServer.PasswordInput.ValueExpression);
                           }
                           else
                           {

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
@@ -32,14 +32,9 @@ public static class OracleDatabaseBuilderExtensions
                       .WithDefaultPassword()
                       .WithEnvironment(context =>
                       {
-                          if (context.ExecutionContext.IsPublishMode)
-                          {
-                              context.EnvironmentVariables.Add(PasswordEnvVarName, oracleDatabaseServer.PasswordInput.ValueExpression);
-                          }
-                          else
-                          {
-                              context.EnvironmentVariables.Add(PasswordEnvVarName, oracleDatabaseServer.Password);
-                          }
+                          context.EnvironmentVariables[PasswordEnvVarName] = context.ExecutionContext.IsPublishMode
+                              ? oracleDatabaseServer.PasswordInput
+                              : oracleDatabaseServer.Password;
                       })
                       .PublishAsContainer();
     }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
@@ -15,11 +15,14 @@ public class OracleDatabaseServerResource(string name, string password) : Contai
     internal const string PrimaryEndpointName = "tcp";
 
     private EndpointReference? _primaryEndpoint;
+    private InputReference? _passwordInput;
 
     /// <summary>
     /// Gets the primary endpoint for the Redis server.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+
+    internal InputReference PasswordInput => _passwordInput ??= new(this, "password");
 
     /// <summary>
     /// Gets the Oracle Database server password.
@@ -30,7 +33,7 @@ public class OracleDatabaseServerResource(string name, string password) : Contai
     /// Gets the connection string expression for the Oracle Database server.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"user id=system;password={{{Name}.inputs.password}};data source={PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)};";
+        $"user id=system;password={PasswordInput.ValueExpression};data source={PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)};";
 
     /// <summary>
     /// Gets the connection string for the Oracle Database server.

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -36,14 +36,9 @@ public static class PostgresBuilderExtensions
                       .WithEnvironment("POSTGRES_INITDB_ARGS", "--auth-host=scram-sha-256 --auth-local=scram-sha-256")
                       .WithEnvironment(context =>
                       {
-                          if (context.ExecutionContext.IsPublishMode)
-                          {
-                              context.EnvironmentVariables.Add(PasswordEnvVarName, postgresServer.PasswordInput.ValueExpression);
-                          }
-                          else
-                          {
-                              context.EnvironmentVariables.Add(PasswordEnvVarName, postgresServer.Password);
-                          }
+                          context.EnvironmentVariables[PasswordEnvVarName] = context.ExecutionContext.IsPublishMode
+                              ? postgresServer.PasswordInput
+                              : postgresServer.Password;
                       })
                       .PublishAsContainer();
     }

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -38,7 +38,7 @@ public static class PostgresBuilderExtensions
                       {
                           if (context.ExecutionContext.IsPublishMode)
                           {
-                              context.EnvironmentVariables.Add(PasswordEnvVarName, $"{{{postgresServer.Name}.inputs.password}}");
+                              context.EnvironmentVariables.Add(PasswordEnvVarName, postgresServer.PasswordInput.ValueExpression);
                           }
                           else
                           {

--- a/src/Aspire.Hosting/Postgres/PostgresServerResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresServerResource.cs
@@ -15,11 +15,14 @@ public class PostgresServerResource(string name, string password) : ContainerRes
     internal const string PrimaryEndpointName = "tcp";
 
     private EndpointReference? _primaryEndpoint;
+    private InputReference? _passwordInput;
 
     /// <summary>
     /// Gets the primary endpoint for the Redis server.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+
+    internal InputReference PasswordInput => _passwordInput ??= new(this, "password");
 
     /// <summary>
     /// Gets the PostgreSQL server password.
@@ -38,7 +41,7 @@ public class PostgresServerResource(string name, string password) : ContainerRes
                 return connectionStringAnnotation.Resource.ConnectionStringExpression;
             }
 
-            return $"Host={PrimaryEndpoint.GetExpression(EndpointProperty.Host)};Port={PrimaryEndpoint.GetExpression(EndpointProperty.Port)};Username=postgres;Password={{{Name}.inputs.password}}";
+            return $"Host={PrimaryEndpoint.GetExpression(EndpointProperty.Host)};Port={PrimaryEndpoint.GetExpression(EndpointProperty.Port)};Username=postgres;Password={PasswordInput.ValueExpression}";
         }
     }
 

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class RabbitMQBuilderExtensions
                        {
                            if (context.ExecutionContext.IsPublishMode)
                            {
-                               context.EnvironmentVariables.Add("RABBITMQ_DEFAULT_PASS", $"{{{rabbitMq.Name}.inputs.password}}");
+                               context.EnvironmentVariables.Add("RABBITMQ_DEFAULT_PASS", rabbitMq.PasswordInput.ValueExpression);
                            }
                            else
                            {

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -30,14 +30,9 @@ public static class RabbitMQBuilderExtensions
                        .WithEnvironment("RABBITMQ_DEFAULT_USER", "guest")
                        .WithEnvironment(context =>
                        {
-                           if (context.ExecutionContext.IsPublishMode)
-                           {
-                               context.EnvironmentVariables.Add("RABBITMQ_DEFAULT_PASS", rabbitMq.PasswordInput.ValueExpression);
-                           }
-                           else
-                           {
-                               context.EnvironmentVariables.Add("RABBITMQ_DEFAULT_PASS", rabbitMq.Password);
-                           }
+                           context.EnvironmentVariables["RABBITMQ_DEFAULT_PASS"] = context.ExecutionContext.IsPublishMode
+                               ? rabbitMq.PasswordInput
+                               : rabbitMq.Password;
                        })
                        .PublishAsContainer();
     }

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
@@ -13,11 +13,14 @@ public class RabbitMQServerResource(string name, string password) : ContainerRes
     internal const string PrimaryEndpointName = "tcp";
 
     private EndpointReference? _primaryEndpoint;
+    private InputReference? _passwordInput;
 
     /// <summary>
     /// Gets the primary endpoint for the Redis server.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+
+    internal InputReference PasswordInput => _passwordInput ??= new(this, "password");
 
     /// <summary>
     /// The RabbitMQ server password.
@@ -28,7 +31,7 @@ public class RabbitMQServerResource(string name, string password) : ContainerRes
     /// Gets the connection string expression for the RabbitMQ server for the manifest.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"amqp://guest:{{{Name}.inputs.password}}@{PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)}";
+        $"amqp://guest:{PasswordInput.ValueExpression}@{PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)}";
 
     /// <summary>
     /// Gets the connection string for the RabbitMQ server.

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class SqlServerBuilderExtensions
                       {
                           if (context.ExecutionContext.IsPublishMode)
                           {
-                              context.EnvironmentVariables.Add("MSSQL_SA_PASSWORD", $"{{{sqlServer.Name}.inputs.password}}");
+                              context.EnvironmentVariables.Add("MSSQL_SA_PASSWORD", sqlServer.PasswordInput.ValueExpression);
                           }
                           else
                           {

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -33,14 +33,9 @@ public static class SqlServerBuilderExtensions
                       .WithEnvironment("ACCEPT_EULA", "Y")
                       .WithEnvironment(context =>
                       {
-                          if (context.ExecutionContext.IsPublishMode)
-                          {
-                              context.EnvironmentVariables.Add("MSSQL_SA_PASSWORD", sqlServer.PasswordInput.ValueExpression);
-                          }
-                          else
-                          {
-                              context.EnvironmentVariables.Add("MSSQL_SA_PASSWORD", sqlServer.Password);
-                          }
+                          context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = context.ExecutionContext.IsPublishMode
+                              ? sqlServer.PasswordInput
+                              : sqlServer.Password;
                       })
                       .PublishAsContainer();
     }

--- a/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
@@ -15,11 +15,14 @@ public class SqlServerServerResource(string name, string password) : ContainerRe
     internal const string PrimaryEndpointName = "tcp";
 
     private EndpointReference? _primaryEndpoint;
+    private InputReference? _passwordInput;
 
     /// <summary>
     /// Gets the primary endpoint for the Redis server.
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+
+    internal InputReference PasswordInput => _passwordInput ??= new(this, "password");
 
     /// <summary>
     /// Gets the password for the SQL Server container resource.
@@ -38,7 +41,7 @@ public class SqlServerServerResource(string name, string password) : ContainerRe
                 return connectionStringAnnotation.Resource.ConnectionStringExpression;
             }
 
-            return $"Server={PrimaryEndpoint.GetExpression(EndpointProperty.Host)},{PrimaryEndpoint.GetExpression(EndpointProperty.Port)};User ID=sa;Password={{{Name}.inputs.password}};TrustServerCertificate=true";
+            return $"Server={PrimaryEndpoint.GetExpression(EndpointProperty.Host)},{PrimaryEndpoint.GetExpression(EndpointProperty.Port)};User ID=sa;Password={PasswordInput.ValueExpression};TrustServerCertificate=true";
         }
     }
 


### PR DESCRIPTION
Model the Password inputs on Containers and the Value input on Parameters as an InputReference and use their ValueExpressions instead of hard-coding the strings.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2642)