### PR TITLE
Rename level to logLevel

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -59,7 +59,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     public string? SpanId { get; set; }
 
     [Parameter]
-    [SupplyParameterFromQuery(Name = "level")]
+    [SupplyParameterFromQuery(Name = "logLevel")]
     public string? LogLevelText { get; set; }
 
     [Parameter]


### PR DESCRIPTION
Fixes #2650 

in #2605 the parameter `level` was changed to `logLevel`,  this makes us read the right parameter name on page load
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2654)