### PR TITLE
Removed kafka references in XML comments

### DIFF
--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -153,7 +153,7 @@ public static class ContainerResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Changes the Kafka resource to be published as a container in the manifest.
+    /// Changes the resource to be published as a container in the manifest.
     /// </summary>
     /// <param name="builder">Resource builder.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>

--- a/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
@@ -15,7 +15,7 @@ public static class MongoDBBuilderExtensions
     private const int DefaultContainerPort = 27017;
 
     /// <summary>
-    /// Adds a MongoDB resource to the application model. A container is used for local development.Adds a Kafka resource to the application. A container is used for local development.  This version the package defaults to the 7.0.5 tag of the mongo container image
+    /// Adds a MongoDB resource to the application model. A container is used for local development. This version the package defaults to the 7.0.5 tag of the mongo container image.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>


### PR DESCRIPTION
Found examples of kafka references in the xml comments that are probably not correct.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2655)