### PR TITLE
Using own PrimaryEndpointName

### DIFF
--- a/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseBuilderExtensions.cs
@@ -41,7 +41,7 @@ public static class OracleDatabaseBuilderExtensions
 
         var oracleDatabaseServer = new OracleDatabaseServerResource(name, password);
         return builder.AddResource(oracleDatabaseServer)
-                      .WithEndpoint(hostPort: port, containerPort: 1521, name: MySqlServerResource.PrimaryEndpointName)
+                      .WithEndpoint(hostPort: port, containerPort: 1521, name: OracleDatabaseServerResource.PrimaryEndpointName)
                       .WithAnnotation(new ContainerImageAnnotation { Image = "database/free", Tag = "23.3.0.0", Registry = "container-registry.oracle.com" })
                       .WithDefaultPassword()
                       .WithEnvironment(context =>

--- a/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresBuilderExtensions.cs
@@ -29,7 +29,7 @@ public static class PostgresBuilderExtensions
 
         var postgresServer = new PostgresServerResource(name, password);
         return builder.AddResource(postgresServer)
-                      .WithEndpoint(hostPort: port, containerPort: 5432, name: MySqlServerResource.PrimaryEndpointName) // Internal port is always 5432.
+                      .WithEndpoint(hostPort: port, containerPort: 5432, name: PostgresServerResource.PrimaryEndpointName) // Internal port is always 5432.
                       .WithAnnotation(new ContainerImageAnnotation { Image = "postgres", Tag = "16.2" })
                       .WithDefaultPassword()
                       .WithEnvironment("POSTGRES_HOST_AUTH_METHOD", "scram-sha-256")

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class RabbitMQBuilderExtensions
 
         var rabbitMq = new RabbitMQServerResource(name, password);
         return builder.AddResource(rabbitMq)
-                       .WithEndpoint(hostPort: port, containerPort: 5672, name: MySqlServerResource.PrimaryEndpointName)
+                       .WithEndpoint(hostPort: port, containerPort: 5672, name: RabbitMQServerResource.PrimaryEndpointName)
                        .WithAnnotation(new ContainerImageAnnotation { Image = "rabbitmq", Tag = "3" })
                        .WithDefaultPassword()
                        .WithEnvironment("RABBITMQ_DEFAULT_USER", "guest")

--- a/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class SqlServerBuilderExtensions
         var sqlServer = new SqlServerServerResource(name, password);
 
         return builder.AddResource(sqlServer)
-                      .WithEndpoint(hostPort: port, containerPort: 1433, name: MySqlServerResource.PrimaryEndpointName)
+                      .WithEndpoint(hostPort: port, containerPort: 1433, name: SqlServerServerResource.PrimaryEndpointName)
                       .WithAnnotation(new ContainerImageAnnotation { Registry = "mcr.microsoft.com", Image = "mssql/server", Tag = "2022-latest" })
                       .WithDefaultPassword()
                       .WithEnvironment("ACCEPT_EULA", "Y")


### PR DESCRIPTION
Some builder extensions reference `MySqlServerResource.PrimaryEndpointName` instead of their own.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2657)