### PR TITLE
Don't use backticks in exception messages

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
@@ -25,7 +25,7 @@ public class ConnectionStringReference(IResourceWithConnectionString resource, b
 
         if (value is null && !Optional)
         {
-            throw new DistributedApplicationException($"The connection string for the resource `{Resource.Name}` is not available.");
+            throw new DistributedApplicationException($"The connection string for the resource '{Resource.Name}' is not available.");
         }
 
         return value;

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -40,7 +40,7 @@ public sealed class EndpointReference(IResourceWithEndpoints owner, string endpo
             EndpointProperty.Host => "host",
             EndpointProperty.Port => "port",
             EndpointProperty.Scheme => "scheme",
-            _ => throw new InvalidOperationException($"The property `{property}` is not supported for the endpoint `{EndpointName}`.")
+            _ => throw new InvalidOperationException($"The property '{property}' is not supported for the endpoint '{EndpointName}'.")
         };
 
         return $"{{{Owner.Name}.bindings.{EndpointName}.{prop}}}";
@@ -69,7 +69,7 @@ public sealed class EndpointReference(IResourceWithEndpoints owner, string endpo
     private AllocatedEndpointAnnotation GetAllocatedEndpoint()
     {
         var allocatedEndpoint = Owner.Annotations.OfType<AllocatedEndpointAnnotation>().SingleOrDefault(a => a.Name == EndpointName) ??
-            throw new InvalidOperationException($"The endpoint `{EndpointName}` is not allocated for the resource `{Owner.Name}`.");
+            throw new InvalidOperationException($"The endpoint '{EndpointName}' is not allocated for the resource '{Owner.Name}'.");
 
         return allocatedEndpoint;
     }

--- a/src/Aspire.Hosting/ApplicationModel/InputReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputReference.cs
@@ -31,7 +31,7 @@ public sealed class InputReference(IResource owner, string inputName) : IManifes
     private InputAnnotation GetInputAnnotation()
     {
         var input = Owner.Annotations.OfType<InputAnnotation>().SingleOrDefault(a => a.Name == InputName) ??
-            throw new InvalidOperationException($"The InputAnnotation `{InputName}` was not found for the resource `{Owner.Name}`.");
+            throw new InvalidOperationException($"The InputAnnotation '{InputName}' was not found for the resource '{Owner.Name}'.");
 
         return input;
     }

--- a/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ParameterResourceBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class ParameterResourceBuilderExtensions
         return builder.AddParameter(name, () =>
         {
             var configurationKey = $"Parameters:{name}";
-            return builder.Configuration[configurationKey] ?? throw new DistributedApplicationException($"Parameter resource could not be used because configuration key `{configurationKey}` is missing.");
+            return builder.Configuration[configurationKey] ?? throw new DistributedApplicationException($"Parameter resource could not be used because configuration key '{configurationKey}' is missing.");
         }, secret: secret);
     }
 
@@ -85,7 +85,7 @@ public static class ParameterResourceBuilderExtensions
     {
         var parameterBuilder = builder.AddParameter(name, () =>
         {
-            return builder.Configuration.GetConnectionString(name) ?? throw new DistributedApplicationException($"Connection string parameter resource could not be used because connection string `{name}` is missing.");
+            return builder.Configuration.GetConnectionString(name) ?? throw new DistributedApplicationException($"Connection string parameter resource could not be used because connection string '{name}' is missing.");
         },
         secret: true,
         connectionString: true);

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -179,7 +179,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 {
                     string stringValue => stringValue,
                     IManifestExpressionProvider manifestExpression => manifestExpression.ValueExpression,
-                    _ => throw new DistributedApplicationException($"The value of the environment variable `{key}` is not supported.")
+                    _ => throw new DistributedApplicationException($"The value of the environment variable '{key}' is not supported.")
                 };
 
                 Writer.WriteString(key, valueString);

--- a/src/Components/Aspire.Confluent.Kafka/MetricsService.cs
+++ b/src/Components/Aspire.Confluent.Kafka/MetricsService.cs
@@ -77,6 +77,6 @@ internal sealed partial class MetricsService(MetricsChannel channel, ConfluentKa
         }
     }
 
-    [LoggerMessage(LogLevel.Warning, EventId = 1, Message = "Invalid statistics json payload received: `{json}`")]
+    [LoggerMessage(LogLevel.Warning, EventId = 1, Message = "Invalid statistics json payload received: '{json}'")]
     private static partial void LogDeserializationWarning(ILogger logger, string json);
 }

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -116,7 +116,7 @@ public class WithEnvironmentTests
 
         var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () => await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource));
 
-        Assert.Equal("Parameter resource could not be used because configuration key `Parameters:parameter` is missing.", exception.Message);
+        Assert.Equal("Parameter resource could not be used because configuration key 'Parameters:parameter' is missing.", exception.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -246,7 +246,7 @@ public class WithReferenceTests
             var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
         });
 
-        Assert.Equal("Connection string parameter resource could not be used because connection string `missingresource` is missing.", exception.Message);
+        Assert.Equal("Connection string parameter resource could not be used because connection string 'missingresource' is missing.", exception.Message);
     }
 
     [Fact]


### PR DESCRIPTION
We should be using single quotes instead.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2659)