### PR TITLE
Improve resource subscription performance and safety

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -112,6 +112,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                 await foreach (var changes in subscription.WithCancellation(_resourceSubscriptionCancellation.Token))
                 {
                     // TODO: This could be updated to be more efficent.
+                    // It should apply on the resource changes in a batch and then update the UI.
                     foreach (var (changeType, resource) in changes)
                     {
                         await OnResourceChanged(changeType, resource);

--- a/src/Aspire.Dashboard/Model/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/IDashboardClient.cs
@@ -56,7 +56,7 @@ public interface IDashboardClient : IAsyncDisposable
 
 public sealed record ResourceViewModelSubscription(
     ImmutableArray<ResourceViewModel> InitialState,
-    IAsyncEnumerable<ResourceViewModelChange> Subscription);
+    IAsyncEnumerable<IReadOnlyList<ResourceViewModelChange>> Subscription);
 
 public sealed record ResourceViewModelChange(
     ResourceViewModelChangeType ChangeType,

--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -151,7 +151,7 @@ public class ResourceLoggerService
 
                 try
                 {
-                    await foreach (var entry in channel.GetBatchesAsync(cancellationToken))
+                    await foreach (var entry in channel.GetBatchesAsync(cancellationToken: cancellationToken))
                     {
                         yield return entry;
                     }

--- a/src/Aspire.Hosting/Dashboard/DockerContainerLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/DockerContainerLogSource.cs
@@ -45,7 +45,7 @@ internal sealed class DockerContainerLogSource(string containerId) : IAsyncEnume
             // Don't forward cancellationToken here, because it's handled internally in WaitForExit
             _ = Task.Run(() => WaitForExit(tcs, ctr), CancellationToken.None);
 
-            await foreach (var batch in channel.GetBatchesAsync(cancellationToken))
+            await foreach (var batch in channel.GetBatchesAsync(cancellationToken: cancellationToken))
             {
                 yield return batch;
             }

--- a/src/Aspire.Hosting/Dashboard/FileLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/FileLogSource.cs
@@ -27,7 +27,7 @@ internal sealed partial class FileLogSource(string stdOutPath, string stdErrPath
         var stdOut = Task.Run(() => WatchFileAsync(stdOutPath, isError: false), cancellationToken);
         var stdErr = Task.Run(() => WatchFileAsync(stdErrPath, isError: true), cancellationToken);
 
-        await foreach (var batch in channel.GetBatchesAsync(cancellationToken))
+        await foreach (var batch in channel.GetBatchesAsync(cancellationToken: cancellationToken))
         {
             yield return batch;
         }

--- a/src/Aspire.Hosting/Dashboard/ResourceLogSource.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceLogSource.cs
@@ -47,7 +47,7 @@ internal sealed class ResourceLogSource<TResource>(
             TaskContinuationOptions.None,
             TaskScheduler.Default).ConfigureAwait(false);
 
-        await foreach (var batch in channel.GetBatchesAsync(cancellationToken))
+        await foreach (var batch in channel.GetBatchesAsync(cancellationToken: cancellationToken))
         {
             yield return batch;
         }

--- a/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourcePublisher.cs
@@ -49,7 +49,7 @@ internal sealed class ResourcePublisher(CancellationToken cancellationToken)
 
                 try
                 {
-                    await foreach (var batch in channel.GetBatchesAsync(linked.Token).ConfigureAwait(false))
+                    await foreach (var batch in channel.GetBatchesAsync(cancellationToken: linked.Token).ConfigureAwait(false))
                     {
                         yield return batch;
                     }

--- a/src/Shared/ChannelExtensions.cs
+++ b/src/Shared/ChannelExtensions.cs
@@ -19,19 +19,31 @@ internal static class ChannelExtensions
     /// </remarks>
     /// <typeparam name="T">The type of items in the channel and returned batch.</typeparam>
     /// <param name="channel">The channel to read values from.</param>
+    /// <param name="minReadInterval">The minimum read interval. The enumerable will wait this long before returning the next available result.</param>
     /// <param name="cancellationToken">A token that signals a loss of interest in the operation.</param>
     /// <returns></returns>
     public static async IAsyncEnumerable<IReadOnlyList<T>> GetBatchesAsync<T>(
         this Channel<T> channel,
-        [EnumeratorCancellation] CancellationToken cancellationToken)
+        TimeSpan? minReadInterval = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        DateTime? lastRead = null;
+
         while (!cancellationToken.IsCancellationRequested)
         {
             List<T>? batch = null;
-
             // Wait until there's something to read, or the channel closes.
             if (await channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
             {
+                if (minReadInterval != null && lastRead != null)
+                {
+                    var s = DateTime.UtcNow.Add(minReadInterval.Value) - lastRead.Value;
+                    if (s > TimeSpan.Zero)
+                    {
+                        await Task.Delay(s, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+
                 // Read everything in the channel into a batch.
                 while (!cancellationToken.IsCancellationRequested && channel.Reader.TryRead(out var log))
                 {
@@ -41,6 +53,7 @@ internal static class ChannelExtensions
 
                 if (!cancellationToken.IsCancellationRequested && batch is not null)
                 {
+                    lastRead = DateTime.UtcNow;
                     yield return batch;
                 }
             }

--- a/src/Shared/ChannelExtensions.cs
+++ b/src/Shared/ChannelExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using Aspire.Dashboard.Otlp.Storage;
 
 namespace Aspire;
 
@@ -37,7 +38,7 @@ internal static class ChannelExtensions
             {
                 if (minReadInterval != null && lastRead != null)
                 {
-                    var s = DateTime.UtcNow.Add(minReadInterval.Value) - lastRead.Value;
+                    var s = lastRead.Value.Add(minReadInterval.Value) - DateTime.UtcNow;
                     if (s > TimeSpan.Zero)
                     {
                         await Task.Delay(s, cancellationToken).ConfigureAwait(false);

--- a/tests/Aspire.Dashboard.Tests/ChannelExtensionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ChannelExtensionsTests.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Threading.Channels;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class ChannelExtensionsTests
+{
+    [Fact]
+    public async Task GetBatchesAsync_CancellationToken_Exits()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        var channel = Channel.CreateUnbounded<IReadOnlyList<string>>();
+
+        channel.Writer.TryWrite(["a", "b", "c"]);
+
+        // Act
+        IReadOnlyList<IReadOnlyList<string>>? readBatch = null;
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var batch in channel.GetBatchesAsync(cancellationToken: cts.Token))
+            {
+                readBatch = batch;
+                cts.Cancel();
+            }
+        });
+
+        // Assert
+        try
+        {
+            await readTask;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task GetBatchesAsync_WithCancellation_Exits()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        var channel = Channel.CreateUnbounded<IReadOnlyList<string>>();
+
+        channel.Writer.TryWrite(["a", "b", "c"]);
+
+        // Act
+        IReadOnlyList<IReadOnlyList<string>>? readBatch = null;
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var batch in channel.GetBatchesAsync().WithCancellation(cts.Token))
+            {
+                readBatch = batch;
+                cts.Cancel();
+            }
+        });
+
+        // Assert
+        try
+        {
+            await readTask;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    [Fact]
+    public async Task GetBatchesAsync_MinReadInterval_WaitForNextRead()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        var channel = Channel.CreateUnbounded<IReadOnlyList<string>>();
+        var resultChannel = Channel.CreateUnbounded<IReadOnlyList<IReadOnlyList<string>>>();
+        var minReadInterval = TimeSpan.FromMilliseconds(500);
+
+        channel.Writer.TryWrite(["a", "b", "c"]);
+
+        // Act
+        var readTask = Task.Run(async () =>
+        {
+            await foreach (var batch in channel.GetBatchesAsync(minReadInterval).WithCancellation(cts.Token))
+            {
+                resultChannel.Writer.TryWrite(batch);
+            }
+        });
+
+        // Assert
+        var stopwatch = Stopwatch.StartNew();
+        var read1 = await resultChannel.Reader.ReadAsync();
+        Assert.Equal(["a", "b", "c"], read1.Single());
+
+        channel.Writer.TryWrite(["d", "e", "f"]);
+
+        var read2 = await resultChannel.Reader.ReadAsync();
+        Assert.Equal(["d", "e", "f"], read2.Single());
+
+        var elapsed = stopwatch.Elapsed;
+        Assert.True(elapsed >= minReadInterval, $"Elapsed time {elapsed} should be greater than min read interval {minReadInterval}.");
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
 using Aspire.V1;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Configuration;
@@ -46,7 +47,7 @@ public sealed class DashboardClientTests
 
         await cts.CancelAsync();
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => readTask).ConfigureAwait(false);
+        await TaskHelpers.WaitIgnoreCancelAsync(readTask);
 
         Assert.Equal(0, instance.OutgoingResourceSubscriberCount);
     }
@@ -76,7 +77,7 @@ public sealed class DashboardClientTests
 
         Assert.Equal(0, instance.OutgoingResourceSubscriberCount);
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => readTask).ConfigureAwait(false);
+        await TaskHelpers.WaitIgnoreCancelAsync(readTask);
     }
 
     [Fact]


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/2496

The goal of these changes is to make the dashboard client update the UI at the interval it wants to (max 10 times a second) and not the interval that external data sources force upon it.

* Change resource update stream to always return a list of updates. This allows multiple changes to be applied to the UI before re-rendering. I made the underlying stream return a list rather than just rely on `GetBatchesAsync` because the first write to the channel will trigger to reader. There is no write then flush.
* Add minReadInterval to `GetBatchesAsync`. This puts a limit on how often data is returned. If the UI is updating frequently this will cause fewer, bigger updates. Prevent UI re-rendering too much.
* Change `DashboardClient.SubscribeConsoleLogs` to read from gRPC and write to a channel, then read from the channel in batches. Allows it to take advantage of improvement to `GetBatchesAsync`.

Telemetry subscriptions will be in a separate PR. Telemetry subscriptions are different in that they use callbacks instead of async streams. The idea will be the same, limit callbacks to a min interval, but the implementation will be different.