### PR TITLE
Limit opacity override to resource select controls

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -12,6 +12,7 @@
     <h1 class="page-header">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect @ref="_resourceSelectComponent"
+                      Class="resource-list"
                       Items="@_resources"
                       OptionValue="@(c => c.Id?.InstanceId)"
                       OptionDisabled="@(c => c.Id?.Type is Otlp.Model.OtlpApplicationType.ReplicaSet)"

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -16,6 +16,7 @@
     <h1 class="page-header">@Loc[nameof(Dashboard.Resources.Metrics.MetricsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect Items="@_applications"
+                      Class="resource-list"
                       OptionDisabled="@(c => c.Id?.Type is OtlpApplicationType.ReplicaSet)"
                       OptionValue="@(c => c.Id?.InstanceId)"
                       @bind-SelectedOption="PageViewModel.SelectedApplication"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -19,6 +19,7 @@
     <h1 class="page-header">@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect Items="@_applicationViewModels"
+                      Class="resource-list"
                       OptionValue="@(c => c.Id?.InstanceId)"
                       OptionDisabled="@(c => c.Id?.Type is OtlpApplicationType.ReplicaSet)"
                       @bind-SelectedOption="PageViewModel.SelectedApplication"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -18,6 +18,7 @@
     <h1 class="page-header">@Loc[nameof(Dashboard.Resources.Traces.TracesHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
         <FluentSelect Items="@_applicationViewModels"
+                      Class="resource-list"
                       OptionValue="@(c => c.Id?.InstanceId)"
                       OptionDisabled="@(c => c.Id?.Type is OtlpApplicationType.ReplicaSet)"
                       @bind-SelectedOption="_selectedApplication"

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -45,9 +45,6 @@ fluent-toolbar[orientation=horizontal] {
     --error-counter-badge-foreground-color: var(--neutral-fill-rest);
     --kbd-background-color: var(--neutral-layer-4);
 
-    /* overrides of default fluentui-blazor styling */
-    --disabled-opacity: 0.7 !important;
-
     --layout-toolbar-padding: calc(var(--design-unit) * 1.5px);
 }
 
@@ -66,13 +63,22 @@ fluent-toolbar[orientation=horizontal] {
 
     /* overrides of default fluentui-blazor styling */
     --error: #E10B11 !important;
-    --disabled-opacity: 0.85 !important;
 
     color-scheme: dark;
 }
 
 [data-theme="light"] {
     color-scheme: light;
+}
+
+fluent-select.resource-list {
+    /* overrides of default fluentui-blazor styling */
+    --disabled-opacity: 0.7;
+}
+
+[data-theme="dark"] fluent-select.resource-list {
+    /* overrides of default fluentui-blazor styling */
+    --disabled-opacity: 0.85;
 }
 
 h1 {


### PR DESCRIPTION
#2123 added an override to the `--disabled-opacity` css variable because of how the disabled replica set entries looked in the resource selects. Unfortunately it applied globally and caused things that should look disabled to not look disabled enough (see comment https://github.com/dotnet/aspire/pull/2572#pullrequestreview-1915908165).

This change adds a `resource-list` class to denote that a particular fluent-select is being used for the above purpose and modifies `app.css` to only change the `--disabled-opacity` variable for those particular elements (and their descendants). 

There's no change to the appearance of those elements:

![image](https://github.com/dotnet/aspire/assets/9613109/a6c38e23-575b-4687-a1e1-d1bd04f6045b)
![image](https://github.com/dotnet/aspire/assets/9613109/f9bfb4d6-c37d-4eae-ab0a-3e6bdc35a52e)

But now the difference between enabled/disabled menu button is more obvious (compare with screenshot in the PR comment above):

![image](https://github.com/dotnet/aspire/assets/9613109/3eabc196-ce7b-40e6-80a0-31a90ad786e3)
![image](https://github.com/dotnet/aspire/assets/9613109/e304d371-c599-4ae2-b424-5c2012432863)

It's possible that its still too subtle, or we want to do something else to set it off when its disabled, but I think this change is appropriate regardless to limit the global impact of the `--disabled-opacity` variable.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2670)