### PR TITLE
Improve telemetry subscription performance and safety

### DIFF
--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Threading.Channels;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
@@ -642,5 +644,68 @@ public class LogTests
                         Assert.Equal("0123456789012345", p.Value);
                     });
             });
+    }
+
+    [Fact]
+    public async Task Subscription_MultipleUpdates_MinExecuteIntervalApplied()
+    {
+        // Arrange
+        var minExecuteInterval = TimeSpan.FromMilliseconds(500);
+        var repository = CreateRepository(subscriptionMinExecuteInterval: minExecuteInterval);
+
+        var callCount = 0;
+        var resultChannel = Channel.CreateUnbounded<int>();
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var subscription = repository.OnNewLogs(applicationId: null, SubscriptionType.Read, () =>
+        {
+            ++callCount;
+            resultChannel.Writer.TryWrite(callCount);
+            return Task.CompletedTask;
+        });
+
+        // Act
+        var addContext = new AddContext();
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord() }
+                    }
+                }
+            }
+        });
+
+        // Assert
+        var stopwatch = Stopwatch.StartNew();
+        var read1 = await resultChannel.Reader.ReadAsync();
+        Assert.Equal(1, read1);
+
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord() }
+                    }
+                }
+            }
+        });
+
+        var read2 = await resultChannel.Reader.ReadAsync();
+        Assert.Equal(2, read2);
+
+        var elapsed = stopwatch.Elapsed;
+        Assert.True(elapsed >= minExecuteInterval, $"Elapsed time {elapsed} should be greater than min execute interval {minExecuteInterval} on read.");
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
@@ -192,7 +192,8 @@ internal static class TestHelpers
         int? metricsCountLimit = null,
         int? attributeCountLimit = null,
         int? attributeLengthLimit = null,
-        int? spanEventCountLimit = null)
+        int? spanEventCountLimit = null,
+        TimeSpan? subscriptionMinExecuteInterval = null)
     {
         var inMemorySettings = new Dictionary<string, string?>();
         if (metricsCountLimit != null)
@@ -216,7 +217,12 @@ internal static class TestHelpers
             .AddInMemoryCollection(inMemorySettings)
             .Build();
 
-        return new TelemetryRepository(configuration, NullLoggerFactory.Instance);
+        var repository = new TelemetryRepository(configuration, NullLoggerFactory.Instance);
+        if (subscriptionMinExecuteInterval != null)
+        {
+            repository._subscriptionMinExecuteInterval = subscriptionMinExecuteInterval.Value;
+        }
+        return repository;
     }
 
     public static ulong DateTimeToUnixNanoseconds(DateTime dateTime)


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/2496

Related to https://github.com/dotnet/aspire/pull/2665

* Executing telemetry callbacks now has a queue where you potentionally wait for the minimum execution interval to elapse. One call can be in the queue. Additional calls will be discarded.
* More logging
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2672)