### PR TITLE
Dashboard dropdown max visible items

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -4,8 +4,9 @@
               Items="Resources"
               OptionValue="@(c => c!.Id?.InstanceId)"
               OptionDisabled="@(c => c!.Id?.Type is Otlp.Model.OtlpApplicationType.ReplicaSet)"
-              @bind-SelectedOption="SelectedResource"
-              AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAResource)]"
+              SelectedOption="SelectedResource"
+              SelectedOptionChanged="SelectedResourceChanged"
+              AriaLabel="@AriaLabel"
               Height="@GetPopupHeight()">
     <OptionTemplate>
         <ResourceSelectOptionTemplate ViewModel="@context" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -1,0 +1,13 @@
+﻿@using Aspire.Dashboard.Resources
+
+<FluentSelect @ref="_resourceSelectComponent"
+              Items="Resources"
+              OptionValue="@(c => c!.Id?.InstanceId)"
+              OptionDisabled="@(c => c!.Id?.Type is Otlp.Model.OtlpApplicationType.ReplicaSet)"
+              @bind-SelectedOption="SelectedResource"
+              AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAResource)]"
+              Height="@GetPopupHeight()">
+    <OptionTemplate>
+        <ResourceSelectOptionTemplate ViewModel="@context" />
+    </OptionTemplate>
+</FluentSelect>

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -7,6 +7,7 @@
               SelectedOption="SelectedResource"
               SelectedOptionChanged="SelectedResourceChanged"
               AriaLabel="@AriaLabel"
+              Class="resource-list"
               Height="@GetPopupHeight()">
     <OptionTemplate>
         <ResourceSelectOptionTemplate ViewModel="@context" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -13,6 +13,7 @@ public partial class ResourceSelect
 {
     private const int ResourceOptionPixelHeight = 32;
     private const int MaxVisibleResourceOptions = 15;
+    private const int SelectPadding = 4; // 2px top + 2px bottom
 
     [Parameter]
     public IEnumerable<SelectViewModel<ResourceTypeDetails>> Resources { get; set; } = default!;
@@ -57,6 +58,6 @@ public partial class ResourceSelect
             return null;
         }
 
-        return $"{ResourceOptionPixelHeight * MaxVisibleResourceOptions}px";
+        return $"{(ResourceOptionPixelHeight * MaxVisibleResourceOptions) + SelectPadding}px";
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Resources;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace Aspire.Dashboard.Components.Controls;
+
+public partial class ResourceSelect
+{
+    private const int ResourceOptionPixelHeight = 32;
+    private const int MaxVisibleResourceOptions = 10;
+
+    [Parameter]
+    public IEnumerable<SelectViewModel<ResourceTypeDetails>> Resources { get; set; } = default!;
+
+    [Parameter]
+    public SelectViewModel<ResourceTypeDetails> SelectedResource { get; set; } = default!;
+
+    [Parameter]
+    public EventCallback<SelectViewModel<ResourceTypeDetails>> SelectedResourceChanged { get; set; }
+
+    [Inject]
+    private IStringLocalizer<ControlsStrings> ControlsStringsLoc { get; set; } = default!;
+
+    [Inject]
+    private IJSRuntime Js { get; set; } = default!;
+
+    private FluentSelect<SelectViewModel<ResourceTypeDetails>>? _resourceSelectComponent;
+
+    /// <summary>
+    /// Workaround for issue in fluent-select web component where the display value of the
+    /// selected item doesn't update automatically when the item changes.
+    /// </summary>
+    public ValueTask UpdateDisplayValueAsync()
+    {
+        if (Js is null || _resourceSelectComponent is null)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return Js.InvokeVoidAsync("updateSelectDisplayValue", _resourceSelectComponent.Element);
+    }
+
+    private string? GetPopupHeight()
+    {
+        if (Resources?.TryGetNonEnumeratedCount(out var count) is false or null)
+        {
+            return null;
+        }
+
+        if (count <= MaxVisibleResourceOptions)
+        {
+            return null;
+        }
+
+        return $"{ResourceOptionPixelHeight * MaxVisibleResourceOptions}px";
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -3,9 +3,7 @@
 
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
-using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.Localization;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
 
@@ -25,8 +23,8 @@ public partial class ResourceSelect
     [Parameter]
     public EventCallback<SelectViewModel<ResourceTypeDetails>> SelectedResourceChanged { get; set; }
 
-    [Inject]
-    private IStringLocalizer<ControlsStrings> ControlsStringsLoc { get; set; } = default!;
+    [Parameter]
+    public string? AriaLabel { get; set; }
 
     [Inject]
     private IJSRuntime Js { get; set; } = default!;

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -12,7 +12,7 @@ namespace Aspire.Dashboard.Components.Controls;
 public partial class ResourceSelect
 {
     private const int ResourceOptionPixelHeight = 32;
-    private const int MaxVisibleResourceOptions = 10;
+    private const int MaxVisibleResourceOptions = 15;
 
     [Parameter]
     public IEnumerable<SelectViewModel<ResourceTypeDetails>> Resources { get; set; } = default!;

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -27,7 +27,7 @@ public partial class ResourceSelect
     public string? AriaLabel { get; set; }
 
     [Inject]
-    private IJSRuntime Js { get; set; } = default!;
+    public required IJSRuntime JSRuntime { get; init; }
 
     private FluentSelect<SelectViewModel<ResourceTypeDetails>>? _resourceSelectComponent;
 
@@ -37,12 +37,12 @@ public partial class ResourceSelect
     /// </summary>
     public ValueTask UpdateDisplayValueAsync()
     {
-        if (Js is null || _resourceSelectComponent is null)
+        if (JSRuntime is null || _resourceSelectComponent is null)
         {
             return ValueTask.CompletedTask;
         }
 
-        return Js.InvokeVoidAsync("updateSelectDisplayValue", _resourceSelectComponent.Element);
+        return JSRuntime.InvokeVoidAsync("updateSelectDisplayValue", _resourceSelectComponent.Element);
     }
 
     private string? GetPopupHeight()

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -13,7 +13,7 @@ public partial class ResourceSelect
 {
     private const int ResourceOptionPixelHeight = 32;
     private const int MaxVisibleResourceOptions = 15;
-    private const int SelectPadding = 4; // 2px top + 2px bottom
+    private const int SelectPadding = 8; // 4px top + 4px bottom
 
     [Parameter]
     public IEnumerable<SelectViewModel<ResourceTypeDetails>> Resources { get; set; } = default!;

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -11,7 +11,11 @@
 <div class="resource-logs-layout">
     <h1 class="page-header">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <ResourceSelect @ref="_resourceSelectComponent" Resources="_resources" @bind-SelectedResource="PageViewModel.SelectedOption" @bind-SelectedResource:after="HandleSelectedOptionChangedAsync" />
+        <ResourceSelect @ref="_resourceSelectComponent"
+                        Resources="_resources"
+                        AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAResource)]"
+                        @bind-SelectedResource="PageViewModel.SelectedOption"
+                        @bind-SelectedResource:after="HandleSelectedOptionChangedAsync" />
         <FluentLabel Typo="Typography.Body" aria-live="polite" aria-label="@Loc[nameof(Dashboard.Resources.ConsoleLogs.LogStatusLabel)]">@PageViewModel.Status</FluentLabel>
     </FluentToolbar>
     <LogViewer @ref="_logViewer" />

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -11,18 +11,7 @@
 <div class="resource-logs-layout">
     <h1 class="page-header">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <FluentSelect @ref="_resourceSelectComponent"
-                      Class="resource-list"
-                      Items="@_resources"
-                      OptionValue="@(c => c.Id?.InstanceId)"
-                      OptionDisabled="@(c => c.Id?.Type is Otlp.Model.OtlpApplicationType.ReplicaSet)"
-                      @bind-SelectedOption="PageViewModel.SelectedOption"
-                      @bind-SelectedOption:after="HandleSelectedOptionChangedAsync"
-                      AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAResource)]">
-            <OptionTemplate>
-                 <ResourceSelectOptionTemplate ViewModel="@context" />
-            </OptionTemplate>
-        </FluentSelect>
+        <ResourceSelect @ref="_resourceSelectComponent" Resources="_resources" @bind-SelectedResource="PageViewModel.SelectedOption" @bind-SelectedResource:after="HandleSelectedOptionChangedAsync" />
         <FluentLabel Typo="Typography.Body" aria-live="polite" aria-label="@Loc[nameof(Dashboard.Resources.ConsoleLogs.LogStatusLabel)]">@PageViewModel.Status</FluentLabel>
     </FluentToolbar>
     <LogViewer @ref="_logViewer" />

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
@@ -11,8 +12,6 @@ using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
-using Microsoft.FluentUI.AspNetCore.Components;
-using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Pages;
 
@@ -20,9 +19,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 {
     [Inject]
     public required IDashboardClient DashboardClient { get; init; }
-
-    [Inject]
-    public required IJSRuntime JS { get; init; }
 
     [Inject]
     public required ProtectedSessionStorage SessionStorage { get; init; }
@@ -44,7 +40,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     private Task? _resourceSubscriptionTask;
 
     // UI
-    private FluentSelect<SelectViewModel<ResourceTypeDetails>>? _resourceSelectComponent;
+    private ResourceSelect? _resourceSelectComponent;
     private SelectViewModel<ResourceTypeDetails> _noSelection = null!;
     private LogViewer _logViewer = null!;
 
@@ -306,9 +302,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
         // Workaround for issue in fluent-select web component where the display value of the
         // selected item doesn't update automatically when the item changes
-        if (_resourceSelectComponent is not null && JS is not null)
+        if (_resourceSelectComponent is not null)
         {
-            await JS.InvokeVoidAsync("updateFluentSelectDisplayValue", _resourceSelectComponent.Element);
+            await _resourceSelectComponent.UpdateDisplayValueAsync();
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -15,17 +15,10 @@
 <div class="metrics-layout">
     <h1 class="page-header">@Loc[nameof(Dashboard.Resources.Metrics.MetricsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <FluentSelect Items="@_applications"
-                      Class="resource-list"
-                      OptionDisabled="@(c => c.Id?.Type is OtlpApplicationType.ReplicaSet)"
-                      OptionValue="@(c => c.Id?.InstanceId)"
-                      @bind-SelectedOption="PageViewModel.SelectedApplication"
-                      @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync"
-                      AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]">
-            <OptionTemplate>
-                <ResourceSelectOptionTemplate ViewModel="@context" />
-            </OptionTemplate>
-        </FluentSelect>
+        <ResourceSelect Resources="_applications"
+                        AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"
+                        @bind-SelectedResource="PageViewModel.SelectedApplication"
+                        @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync" />
         <FluentIcon slot="end" Icon="Icons.Regular.Size20.Clock" Style="margin-right:5px;" />
         <FluentSelect slot="end" TOption="SelectViewModel<TimeSpan>"
                       Items="@_durations"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -18,17 +18,10 @@
 <div class="logs-layout">
     <h1 class="page-header">@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <FluentSelect Items="@_applicationViewModels"
-                      Class="resource-list"
-                      OptionValue="@(c => c.Id?.InstanceId)"
-                      OptionDisabled="@(c => c.Id?.Type is OtlpApplicationType.ReplicaSet)"
-                      @bind-SelectedOption="PageViewModel.SelectedApplication"
-                      @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync"
-                      AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]">
-            <OptionTemplate>
-                <ResourceSelectOptionTemplate ViewModel="@context" />
-            </OptionTemplate>
-        </FluentSelect>
+        <ResourceSelect Resources="_applicationViewModels"
+                        AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"
+                        @bind-SelectedResource="PageViewModel.SelectedApplication"
+                        @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync" />
         <FluentSearch @bind-Value="PageViewModel.Filter"
                       @oninput="HandleFilter"
                       @bind-Value:after="HandleClear"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -17,17 +17,10 @@
 <div class="traces-layout">
     <h1 class="page-header">@Loc[nameof(Dashboard.Resources.Traces.TracesHeader)]</h1>
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <FluentSelect Items="@_applicationViewModels"
-                      Class="resource-list"
-                      OptionValue="@(c => c.Id?.InstanceId)"
-                      OptionDisabled="@(c => c.Id?.Type is OtlpApplicationType.ReplicaSet)"
-                      @bind-SelectedOption="_selectedApplication"
-                      @bind-SelectedOption:after="HandleSelectedApplicationChangedAsync"
-                      AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]">
-            <OptionTemplate>
-                <ResourceSelectOptionTemplate ViewModel="@context" />
-            </OptionTemplate>
-        </FluentSelect>
+        <ResourceSelect Resources="_applicationViewModels"
+                        AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"
+                        @bind-SelectedResource="_selectedApplication"
+                        @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync" />
         <FluentSearch @bind-Value="_filter"
                       @oninput="HandleFilter"
                       @bind-Value:after="HandleClear"


### PR DESCRIPTION
- Fixes #2566 
- Added new component `ResourceSelect`
- Resource and application dropdowns now have a scrollbar when more than `10` items.

## 9 or less items in the dropdown:
The popup scales to fit the items.
![4 items in the dropdown](https://github.com/dotnet/aspire/assets/17270481/f0311a2a-7836-40aa-89bd-d1f38a82578a)


## 10 items in the dropdown:
The popup has scaled to its maximum size, but will not show a scrollbar
![10 items in the dropdown](https://github.com/dotnet/aspire/assets/17270481/6bb17afb-dcd6-4802-ac5e-4f44a0a1b560)

## 11 or more items in the dropdown:
The popup has scaled to its maximum size and shows a scrollbar.
![11 items in the dropdown](https://github.com/dotnet/aspire/assets/17270481/00ba5b16-00b1-4eba-badc-08e7c87273fd)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2678)