### PR TITLE
Isolate the use of host.docker.internal

### DIFF
--- a/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
@@ -22,12 +22,13 @@ internal class PgAdminConfigWriterHook(IConfiguration configuration) : IDistribu
 
         using var stream = new FileStream(serverFileMount.Source!, FileMode.Create);
         using var writer = new Utf8JsonWriter(stream);
-        var serverIndex = 1;
 
         var containerHostName = HostNameResolver.ReplaceLocalhostWithContainerHost("localhost", configuration);
 
         writer.WriteStartObject();
         writer.WriteStartObject("Servers");
+
+        var serverIndex = 1;
 
         foreach (var postgresInstance in postgresInstances)
         {


### PR DESCRIPTION
- For podman support we need to use another host name (host.containers.internal). That's configurable using a setting AppHost:ContainerHostName. Remove the hardcoded use of docker.host.internal and instead read from configuration everywhere.

Fixes https://github.com/dotnet/aspire/issues/2639