### PR TITLE
Update bUnit to support .NET 9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -124,7 +124,7 @@
     <PackageVersion Include="Microsoft.Signed.Wix" Version="1.0.0-v3.14.0.5722" />
     <PackageVersion Include="Microsoft.DotNet.Build.Tasks.Installers" Version="8.0.0-beta.23564.4" />
     <!-- unit test dependencies -->
-    <PackageVersion Include="bUnit" Version="1.26.64" />
+    <PackageVersion Include="bUnit" Version="1.27.17" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="$(MicrosoftExtensionsDiagnosticsTestingPackageVersion)" />
     <PackageVersion Include="Testcontainers.RabbitMq" Version="3.7.0" />
     <!-- Pinned version for Component Governance - Remove when root dependencies are updated -->


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/2576

Tests can be reenabled in .NET 9 branch after updating this dependency.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2693)