### PR TITLE
Use EndpointReference instead of AllocatedEndpoints

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.Cosmos;
@@ -13,9 +12,12 @@ namespace Aspire.Hosting;
 /// </summary>
 public class AzureCosmosDBResource(string name) :
     AzureBicepResource(name, templateResourceName: "Aspire.Hosting.Azure.Bicep.cosmosdb.bicep"),
-    IResourceWithConnectionString
+    IResourceWithConnectionString,
+    IResourceWithEndpoints
 {
     internal List<string> Databases { get; } = [];
+
+    internal EndpointReference EmulatorEndpoint => new(this, "emulator");
 
     /// <summary>
     /// Gets the "connectionString" reference from the secret outputs of the Azure Cosmos DB resource.
@@ -55,18 +57,11 @@ public class AzureCosmosDBResource(string name) :
     {
         if (IsEmulator)
         {
-            return AzureCosmosDBEmulatorConnectionString.Create(GetEmulatorPort("emulator"));
+            return AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port);
         }
 
         return ConnectionString.Value;
     }
-
-    private int GetEmulatorPort(string endpointName) =>
-        Annotations
-            .OfType<AllocatedEndpointAnnotation>()
-            .FirstOrDefault(x => x.Name == endpointName)
-            ?.Port
-        ?? throw new DistributedApplicationException($"Azure Cosmos DB resource does not have endpoint annotation with name '{endpointName}'.");
 }
 
 /// <summary>
@@ -103,7 +98,7 @@ public static class AzureCosmosExtensions
     /// </remarks>
     public static IResourceBuilder<AzureCosmosDBResource> RunAsEmulator(this IResourceBuilder<AzureCosmosDBResource> builder, Action<IResourceBuilder<AzureCosmosDBEmulatorResource>>? configureContainer = null)
     {
-        builder.WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, name: "emulator", containerPort: 8081))
+        builder.WithEndpoint(name: "emulator", containerPort: 8081)
                .WithAnnotation(new ContainerImageAnnotation { Image = "mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator", Tag = "latest" });
 
         if (configureContainer != null)

--- a/src/Aspire.Hosting.Azure/Extensions/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureStorageExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning.Authorization;
@@ -87,9 +86,9 @@ public static class AzureStorageExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureStorageResource> RunAsEmulator(this IResourceBuilder<AzureStorageResource> builder, Action<IResourceBuilder<AzureStorageEmulatorResource>>? configureContainer = null)
     {
-        builder.WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, name: "blob", containerPort: 10000))
-               .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, name: "queue", containerPort: 10001))
-               .WithAnnotation(new EndpointAnnotation(ProtocolType.Tcp, name: "table", containerPort: 10002))
+        builder.WithEndpoint(name: "blob", containerPort: 10000)
+               .WithEndpoint(name: "queue", containerPort: 10001)
+               .WithEndpoint(name: "table", containerPort: 10002)
                .WithAnnotation(new ContainerImageAnnotation { Image = "mcr.microsoft.com/azure-storage/azurite", Tag = "3.29.0" });
 
         if (configureContainer != null)

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -183,12 +183,12 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                 new CommandLineArgsCallbackAnnotation(
                     updatedArgs =>
                     {
-                        AllocatedEndpointAnnotation? httpEndPoint = null;
-                        if (resource.TryGetAllocatedEndPoints(out var projectEndPoints))
+                        EndpointReference? httpEndPoint = null;
+                        if (resource is IResourceWithEndpoints resourceWithEndpoints)
                         {
-                            httpEndPoint = projectEndPoints.FirstOrDefault(endPoint => endPoint.Name == "http");
+                            httpEndPoint = resourceWithEndpoints.GetEndpoint("http");
 
-                            if (httpEndPoint is not null && sidecarOptions?.AppPort is null)
+                            if (httpEndPoint.IsAllocated && sidecarOptions?.AppPort is null)
                             {
                                 updatedArgs.AddRange(daprAppPortArg(httpEndPoint.Port)());
                             }
@@ -203,7 +203,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         }
                         if (sidecarOptions?.AppChannelAddress is null && httpEndPoint is not null)
                         {
-                            updatedArgs.AddRange(daprAppChannelAddressArg(httpEndPoint.Address)());
+                            updatedArgs.AddRange(daprAppChannelAddressArg(httpEndPoint.Host)());
                         }
                     }));
 

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReferenceAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReferenceAnnotation.cs
@@ -1,15 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 
 namespace Aspire.Hosting.ApplicationModel;
 
 [DebuggerDisplay(@"Type = {GetType().Name,nq}, Resource = {Resource.Name}, EndpointNames = {string.Join("", "", EndpointNames)}")]
-internal sealed class EndpointReferenceAnnotation(IResource resource) : IResourceAnnotation
+internal sealed class EndpointReferenceAnnotation(IResourceWithEndpoints resource) : IResourceAnnotation
 {
-    public IResource Resource { get; } = resource;
+    public IResourceWithEndpoints Resource { get; } = resource;
     public bool UseAllEndpoints { get; set; }
-    public Collection<string> EndpointNames { get; } = new();
+    public HashSet<string> EndpointNames { get; } = new(StringComparers.EndpointAnnotationName);
 }

--- a/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
@@ -93,7 +93,8 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the allocated endpoints for.</param>
     /// <param name="allocatedEndPoints">When this method returns, contains the allocated endpoints for the specified resource, if they exist; otherwise, <c>null</c>.</param>
     /// <returns><c>true</c> if the allocated endpoints were successfully retrieved; otherwise, <c>false</c>.</returns>
-    private static bool TryGetAllocatedEndPoints(this IResource resource, [NotNullWhen(true)] out IEnumerable<AllocatedEndpointAnnotation>? allocatedEndPoints)
+    [Obsolete("Use GetEndpoints instead.")]
+    public static bool TryGetAllocatedEndPoints(this IResource resource, [NotNullWhen(true)] out IEnumerable<AllocatedEndpointAnnotation>? allocatedEndPoints)
     {
         return TryGetAnnotationsOfType(resource, out allocatedEndPoints);
     }
@@ -105,7 +106,7 @@ public static class ResourceExtensions
     /// <returns></returns>
     public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource)
     {
-        if (TryGetAllocatedEndPoints(resource, out var endpoints))
+        if (TryGetAnnotationsOfType<AllocatedEndpointAnnotation>(resource, out var endpoints))
         {
             return endpoints.Select(e => new EndpointReference(resource, e));
         }

--- a/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
@@ -99,6 +99,21 @@ public static class ResourceExtensions
     }
 
     /// <summary>
+    /// Gets the endpoints for the specified resource.
+    /// </summary>
+    /// <param name="resource"></param>
+    /// <returns></returns>
+    public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource)
+    {
+        if (TryGetAllocatedEndPoints(resource, out var endpoints))
+        {
+            return endpoints.Select(e => new EndpointReference(resource, e));
+        }
+
+        return [];
+    }
+
+    /// <summary>
     /// Attempts to get the container image name from the given resource.
     /// </summary>
     /// <param name="resource">The resource to get the container image name from.</param>

--- a/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
@@ -93,7 +93,7 @@ public static class ResourceExtensions
     /// <param name="resource">The resource to get the allocated endpoints for.</param>
     /// <param name="allocatedEndPoints">When this method returns, contains the allocated endpoints for the specified resource, if they exist; otherwise, <c>null</c>.</param>
     /// <returns><c>true</c> if the allocated endpoints were successfully retrieved; otherwise, <c>false</c>.</returns>
-    public static bool TryGetAllocatedEndPoints(this IResource resource, [NotNullWhen(true)] out IEnumerable<AllocatedEndpointAnnotation>? allocatedEndPoints)
+    private static bool TryGetAllocatedEndPoints(this IResource resource, [NotNullWhen(true)] out IEnumerable<AllocatedEndpointAnnotation>? allocatedEndPoints)
     {
         return TryGetAnnotationsOfType(resource, out allocatedEndPoints);
     }

--- a/src/Aspire.Hosting/MySql/PhpMyAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting/MySql/PhpMyAdminConfigWriterHook.cs
@@ -29,9 +29,9 @@ internal class PhpMyAdminConfigWriterHook : IDistributedApplicationLifecycleHook
         if (mySqlInstances.Count() == 1)
         {
             var singleInstance = mySqlInstances.Single();
-            if (singleInstance.TryGetAllocatedEndPoints(out var allocatedEndPoints))
+            if (singleInstance.PrimaryEndpoint.IsAllocated)
             {
-                var endpoint = allocatedEndPoints.Where(ae => ae.Name == "tcp").Single();
+                var endpoint = singleInstance.PrimaryEndpoint;
                 myAdminResource.Annotations.Add(new EnvironmentCallbackAnnotation((EnvironmentCallbackContext context) =>
                 {
                     context.EnvironmentVariables.Add("PMA_HOST", $"host.docker.internal:{endpoint.Port}");
@@ -51,9 +51,9 @@ internal class PhpMyAdminConfigWriterHook : IDistributedApplicationLifecycleHook
             writer.WriteLine();
             foreach (var mySqlInstance in mySqlInstances)
             {
-                if (mySqlInstance.TryGetAllocatedEndPoints(out var allocatedEndpoints))
+                if (mySqlInstance.PrimaryEndpoint.IsAllocated)
                 {
-                    var endpoint = allocatedEndpoints.Where(ae => ae.Name == "tcp").Single();
+                    var endpoint = mySqlInstance.PrimaryEndpoint;
                     writer.WriteLine("$i++;");
                     writer.WriteLine($"$cfg['Servers'][$i]['host'] = 'host.docker.internal:{endpoint.Port}';");
                     writer.WriteLine($"$cfg['Servers'][$i]['verbose'] = '{mySqlInstance.Name}';");

--- a/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
@@ -28,9 +28,9 @@ internal class PgAdminConfigWriterHook : IDistributedApplicationLifecycleHook
 
         foreach (var postgresInstance in postgresInstances)
         {
-            if (postgresInstance.TryGetAllocatedEndPoints(out var allocatedEndpoints))
+            if (postgresInstance.PrimaryEndpoint.IsAllocated)
             {
-                var endpoint = allocatedEndpoints.Where(ae => ae.Name == "tcp").Single();
+                var endpoint = postgresInstance.PrimaryEndpoint;
 
                 writer.WriteStartObject($"{serverIndex}");
                 writer.WriteString("Name", postgresInstance.Name);

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -185,8 +185,6 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 Writer.WriteString(key, valueString);
             }
 
-            WriteServiceDiscoveryEnvironmentVariables(resource);
-
             WritePortBindingEnvironmentVariables(resource);
 
             Writer.WriteEndObject();
@@ -224,40 +222,6 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 Writer.WriteEndObject();
             }
             Writer.WriteEndObject();
-        }
-    }
-
-    /// <summary>
-    /// TODO: Doc Comments
-    /// </summary>
-    /// <param name="resource"></param>
-    public void WriteServiceDiscoveryEnvironmentVariables(IResource resource)
-    {
-        var endpointReferenceAnnotations = resource.Annotations.OfType<EndpointReferenceAnnotation>();
-
-        if (endpointReferenceAnnotations.Any())
-        {
-            foreach (var endpointReferenceAnnotation in endpointReferenceAnnotations)
-            {
-                var endpointNames = endpointReferenceAnnotation.UseAllEndpoints
-                    ? endpointReferenceAnnotation.Resource.Annotations.OfType<EndpointAnnotation>().Select(sb => sb.Name)
-                    : endpointReferenceAnnotation.EndpointNames;
-
-                var endpointAnnotationsGroupedByScheme = endpointReferenceAnnotation.Resource.Annotations
-                    .OfType<EndpointAnnotation>()
-                    .Where(sba => endpointNames.Contains(sba.Name, StringComparers.EndpointAnnotationName))
-                    .GroupBy(sba => sba.UriScheme);
-
-                var i = 0;
-                foreach (var endpointAnnotationGroupedByScheme in endpointAnnotationsGroupedByScheme)
-                {
-                    // HACK: For November we are only going to support a single endpoint annotation
-                    //       per URI scheme per service reference.
-                    var binding = endpointAnnotationGroupedByScheme.Single();
-
-                    Writer.WriteString($"services__{endpointReferenceAnnotation.Resource.Name}__{i++}", $"{{{endpointReferenceAnnotation.Resource.Name}.bindings.{binding.Name}.url}}");
-                }
-            }
         }
     }
 

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -185,6 +185,8 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 Writer.WriteString(key, valueString);
             }
 
+            WriteServiceDiscoveryEnvironmentVariables(resource);
+
             WritePortBindingEnvironmentVariables(resource);
 
             Writer.WriteEndObject();
@@ -222,6 +224,40 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 Writer.WriteEndObject();
             }
             Writer.WriteEndObject();
+        }
+    }
+
+    /// <summary>
+    /// TODO: Doc Comments
+    /// </summary>
+    /// <param name="resource"></param>
+    public void WriteServiceDiscoveryEnvironmentVariables(IResource resource)
+    {
+        var endpointReferenceAnnotations = resource.Annotations.OfType<EndpointReferenceAnnotation>();
+
+        if (endpointReferenceAnnotations.Any())
+        {
+            foreach (var endpointReferenceAnnotation in endpointReferenceAnnotations)
+            {
+                var endpointNames = endpointReferenceAnnotation.UseAllEndpoints
+                    ? endpointReferenceAnnotation.Resource.Annotations.OfType<EndpointAnnotation>().Select(sb => sb.Name)
+                    : endpointReferenceAnnotation.EndpointNames;
+
+                var endpointAnnotationsGroupedByScheme = endpointReferenceAnnotation.Resource.Annotations
+                    .OfType<EndpointAnnotation>()
+                    .Where(sba => endpointNames.Contains(sba.Name, StringComparers.EndpointAnnotationName))
+                    .GroupBy(sba => sba.UriScheme);
+
+                var i = 0;
+                foreach (var endpointAnnotationGroupedByScheme in endpointAnnotationsGroupedByScheme)
+                {
+                    // HACK: For November we are only going to support a single endpoint annotation
+                    //       per URI scheme per service reference.
+                    var binding = endpointAnnotationGroupedByScheme.Single();
+
+                    Writer.WriteString($"services__{endpointReferenceAnnotation.Resource.Name}__{i++}", $"{{{endpointReferenceAnnotation.Resource.Name}.bindings.{binding.Name}.url}}");
+                }
+            }
         }
     }
 

--- a/src/Aspire.Hosting/Seq/SeqBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Seq/SeqBuilderExtensions.cs
@@ -28,8 +28,8 @@ public static class SeqBuilderExtensions
     {
         var seqResource = new SeqResource(name);
         var resourceBuilder = builder.AddResource(seqResource)
-            .WithHttpEndpoint(hostPort: port, containerPort: 80)
-            .WithAnnotation(new ContainerImageAnnotation {Image = "datalust/seq"})
+            .WithHttpEndpoint(hostPort: port, containerPort: 80, name: SeqResource.PrimaryEndpointName)
+            .WithAnnotation(new ContainerImageAnnotation { Image = "datalust/seq" })
             .WithImageTag("2024.1")
             .WithEnvironment("ACCEPT_EULA", "Y");
 

--- a/src/Aspire.Hosting/Seq/SeqResource.cs
+++ b/src/Aspire.Hosting/Seq/SeqResource.cs
@@ -9,22 +9,26 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the Seq resource</param>
 public class SeqResource(string name) : ContainerResource(name), IResourceWithConnectionString
 {
+    internal const string PrimaryEndpointName = "http";
+
+    private EndpointReference? _primaryEndpoint;
+
+    /// <summary>
+    /// Gets the primary endpoint for the Seq server.
+    /// </summary>
+    public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
+
     /// <summary>
     /// Gets the Uri of the Seq endpoint
     /// </summary>
     public string? GetConnectionString()
     {
-        if (!this.TryGetAnnotationsOfType<AllocatedEndpointAnnotation>(out var seqEndpointAnnotations))
-        {
-            throw new DistributedApplicationException("Seq resource does not have endpoint annotation.");
-        }
-
-        return seqEndpointAnnotations.Single().UriString;
+        return PrimaryEndpoint.Url;
     }
 
     /// <summary>
     /// Gets the connection string expression for the Seq server for the manifest.
     /// </summary>
     public string? ConnectionStringExpression =>
-        $"{{{Name}.bindings.tcp.host}}:{{{Name}.bindings.tcp.port}}";
+        PrimaryEndpoint.GetExpression(EndpointProperty.Url);
 }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -147,10 +147,9 @@ public class DistributedApplicationTests
 
         foreach (var item in appModel.Resources)
         {
-            if ((item is ContainerResource || item is ProjectResource || item is ExecutableResource) && item.TryGetEndpoints(out _))
+            if (item is IResourceWithEndpoints resourceWithEndpoints)
             {
-                Assert.True(item.TryGetAllocatedEndPoints(out var endpoints));
-                Assert.NotEmpty(endpoints);
+                Assert.True(resourceWithEndpoints.GetEndpoints().All(e => e.IsAllocated));
             }
         }
     }

--- a/tests/Aspire.Hosting.Tests/Helpers/AllocatedEndpointAnnotationTestExtensions.cs
+++ b/tests/Aspire.Hosting.Tests/Helpers/AllocatedEndpointAnnotationTestExtensions.cs
@@ -18,8 +18,8 @@ public static class AllocatedEndpointAnnotationTestExtensions
     public static async Task<string> HttpGetStringAsync<T>(this IResourceBuilder<T> builder, HttpClient client, string bindingName, string path, CancellationToken cancellationToken)
         where T : IResourceWithEndpoints
     {
-        var allocatedEndpoint = builder.Resource.Annotations.OfType<AllocatedEndpointAnnotation>().Single(a => a.Name == bindingName);
-        var url = $"{allocatedEndpoint.UriString}{path}";
+        var endpoint = builder.Resource.GetEndpoint(bindingName);
+        var url = $"{endpoint.Url}{path}";
 
         var response = await client.GetStringAsync(url, cancellationToken);
         return response;

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -9,8 +9,10 @@ namespace Aspire.Hosting.Tests;
 
 public class WithReferenceTests
 {
-    [Fact]
-    public async Task ResourceWithSingleEndpointProducesSimplifiedEnvironmentVariables()
+    [Theory]
+    [InlineData("mybinding")]
+    [InlineData("MYbinding")]
+    public async Task ResourceWithSingleEndpointProducesSimplifiedEnvironmentVariables(string endpointName)
     {
         using var testProgram = CreateTestProgram();
 
@@ -25,7 +27,7 @@ public class WithReferenceTests
             ));
 
         // Get the service provider.
-        testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("mybinding"));
+        testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint(endpointName));
         testProgram.Build();
 
         // Call environment variable callbacks.


### PR DESCRIPTION
- This unifies most of the callers way of property looking up named endpoints and fixed case sensivity issues.
- Added a GetEndpoints method which returns all allocated endpoints on a resource.

Fixes #2521 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2700)