### PR TITLE
Fix error when navigating away from console logs

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -1,7 +1,6 @@
 ﻿@using Aspire.Dashboard.Resources
 
-<FluentSelect @ref="_resourceSelectComponent"
-              Items="Resources"
+<FluentSelect Items="Resources"
               OptionValue="@(c => c!.Id?.InstanceId)"
               OptionDisabled="@(c => c!.Id?.Type is Otlp.Model.OtlpApplicationType.ReplicaSet)"
               SelectedOption="SelectedResource"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -4,8 +4,6 @@
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Microsoft.AspNetCore.Components;
-using Microsoft.FluentUI.AspNetCore.Components;
-using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -26,25 +24,6 @@ public partial class ResourceSelect
 
     [Parameter]
     public string? AriaLabel { get; set; }
-
-    [Inject]
-    public required IJSRuntime JSRuntime { get; init; }
-
-    private FluentSelect<SelectViewModel<ResourceTypeDetails>>? _resourceSelectComponent;
-
-    /// <summary>
-    /// Workaround for issue in fluent-select web component where the display value of the
-    /// selected item doesn't update automatically when the item changes.
-    /// </summary>
-    public ValueTask UpdateDisplayValueAsync()
-    {
-        if (JSRuntime is null || _resourceSelectComponent is null)
-        {
-            return ValueTask.CompletedTask;
-        }
-
-        return JSRuntime.InvokeVoidAsync("updateSelectDisplayValue", _resourceSelectComponent.Element);
-    }
 
     private string? GetPopupHeight()
     {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -304,13 +304,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         }
 
         await InvokeAsync(StateHasChanged);
-
-        // Workaround for issue in fluent-select web component where the display value of the
-        // selected item doesn't update automatically when the item changes
-        if (_resourceSelectComponent is not null)
-        {
-            await _resourceSelectComponent.UpdateDisplayValueAsync();
-        }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
@@ -38,7 +38,7 @@ public sealed class Subscription : IDisposable
         var success = _lock.Wait(0, cancellationToken);
         if (!success)
         {
-            Logger.LogDebug("Subscription '{Name}' update already queued.", Name);
+            Logger.LogTrace("Subscription '{Name}' update already queued.", Name);
             return false;
         }
 
@@ -50,7 +50,7 @@ public sealed class Subscription : IDisposable
                 var s = lastExecute.Value.Add(_telemetryRepository._subscriptionMinExecuteInterval) - DateTime.UtcNow;
                 if (s > TimeSpan.Zero)
                 {
-                    Logger.LogDebug("Subscription '{Name}' minimum execute interval hit. Waiting {DelayInterval}.", Name, s);
+                    Logger.LogTrace("Subscription '{Name}' minimum execute interval hit. Waiting {DelayInterval}.", Name, s);
                     await Task.Delay(s, cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -89,7 +89,7 @@ public sealed class Subscription : IDisposable
                     ExecutionContext.Restore(_executionContext);
                 }
 
-                Logger.LogDebug("Subscription '{Name}' executing.", Name);
+                Logger.LogTrace("Subscription '{Name}' executing.", Name);
                 await _callback().ConfigureAwait(false);
                 _lastExecute = DateTime.UtcNow;
             }


### PR DESCRIPTION
I made a change to await the resource subscription task in dispose. The task sometimes throws an error from calling a JS method. As far as I can tell this JS method isn't needed.

PR removes the JS method and fixes the error.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2702)