### PR TITLE
Fix flaky min rate tests

### DIFF
--- a/tests/Aspire.Dashboard.Tests/ChannelExtensionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ChannelExtensionsTests.cs
@@ -96,7 +96,7 @@ public class ChannelExtensionsTests
         Assert.Equal(["d", "e", "f"], read2.Single());
 
         var elapsed = stopwatch.Elapsed;
-        Assert.True(elapsed >= minReadInterval, $"Elapsed time {elapsed} should be greater than min read interval {minReadInterval} on read.");
+        CustomAssert.AssertExceedsMinInterval(elapsed, minReadInterval);
 
         channel.Writer.Complete();
         await TaskHelpers.WaitIgnoreCancelAsync(readTask);

--- a/tests/Aspire.Dashboard.Tests/CustomAssert.cs
+++ b/tests/Aspire.Dashboard.Tests/CustomAssert.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public static class CustomAssert
+{
+    public static void AssertExceedsMinInterval(TimeSpan duration, TimeSpan minInterval)
+    {
+        // Timers are not precise, so we allow for a small margin of error.
+        Assert.True(duration >= minInterval.Subtract(TimeSpan.FromMilliseconds(20)), $"Elapsed time {duration} should be greater than min interval {minInterval}.");
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -706,6 +706,6 @@ public class LogTests
         Assert.Equal(2, read2);
 
         var elapsed = stopwatch.Elapsed;
-        Assert.True(elapsed >= minExecuteInterval, $"Elapsed time {elapsed} should be greater than min execute interval {minExecuteInterval} on read.");
+        CustomAssert.AssertExceedsMinInterval(elapsed, minExecuteInterval);
     }
 }


### PR DESCRIPTION
Fixes:

> Error message
> Elapsed time 00:00:00.4993570 should be greater than min read interval 00:00:00.5000000 on read.
> Expected: True
> Actual:   False
> 
> Stack trace
>    at Aspire.Dashboard.Tests.ChannelExtensionsTests.GetBatchesAsync_MinReadInterval_WaitForNextRead() in /_/tests/Aspire.Dashboard.Tests/ChannelExtensionsTests.cs:line 99
> --- End of stack trace from previous location ---
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2703)