### PR TITLE
Enable resources grid virtualization

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -55,7 +55,7 @@
             @{
                 var gridTemplateColumns = HasResourcesWithCommands ? "1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr 1fr" : "1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr";
             }
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading">
+            <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading">
                 <ChildContent>
                     <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" />
                     <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort">


### PR DESCRIPTION
Resources page is very slow when there is 1000 resources. Enabling virtualization will only render the visible resources, making the page much faster, while keeping smooth scrolling of all resources.

The downside is a fixed height needs to be introduced. The only variable height content is endpoints. If there are 3 or more endpoints then the height grows. We would need to change how these are displayed. Perhaps place them in an [overflow](https://www.fluentui-blazor.net/Overflow)?

1000 resources with virtualization:
![resource-virtualization](https://github.com/dotnet/aspire/assets/303201/197de1f4-ecbb-4283-83d6-61664b668ffa)

cc @davidfowl 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2706)