### PR TITLE
Revert the update to Pomelo.EntityFrameworkCore.MySql

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,7 +99,7 @@
     <PackageVersion Include="Polly" Version="8.3.0" />
     <PackageVersion Include="Polly.Core" Version="8.3.0" />
     <PackageVersion Include="Polly.Extensions" Version="8.3.0" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.1" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.27" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
@@ -307,9 +307,6 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
             resourcesToSkip.Add(nameof(TestResourceNames.cosmos));
         }
 
-        // ActiveIssue: https://github.com/dotnet/aspire/issues/2690
-        resourcesToSkip.Add(nameof(TestResourceNames.pomelo));
-
         if (BuildEnvironment.IsRunningOnCI)
         {
             resourcesToSkip.Add(nameof(TestResourceNames.cosmos));

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
@@ -24,8 +24,7 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
     [Theory]
     [InlineData(TestResourceNames.mongodb)]
     [InlineData(TestResourceNames.mysql)]
-    // ActiveIssue: https://github.com/dotnet/aspire/issues/2690
-    //[InlineData(TestResourceNames.pomelo)]
+    [InlineData(TestResourceNames.pomelo)]
     [InlineData(TestResourceNames.postgres)]
     [InlineData(TestResourceNames.rabbitmq)]
     [InlineData(TestResourceNames.redis)]


### PR DESCRIPTION
This breaks the integration test. We need to fix the component to work with the latest version.

Contributes to #2690

@bgrainger - any chance you can try the `8.0.1` version of Pomelo.EntityFrameworkCore.MySql and fix the underlying issue. The integration test is reporting the following error with the new version:

```
System.InvalidOperationException: The connection string of a connection used by Pomelo.EntityFrameworkCore.MySql must contain "AllowUserVariables=True;UseAffectedRows=False".
   at Pomelo.EntityFrameworkCore.MySql.Storage.Internal.MySqlConnectionStringOptionsValidator.ThrowException(Exception innerException)
   at Pomelo.EntityFrameworkCore.MySql.Storage.Internal.MySqlConnectionStringOptionsValidator.EnsureMandatoryOptions(DbDataSource dataSource)
   at Pomelo.EntityFrameworkCore.MySql.Storage.Internal.MySqlRelationalConnection..ctor(RelationalConnectionDependencies dependencies, IMySqlConnectionStringOptionsValidator mySqlConnectionStringOptionsValidator, DbDataSource dataSource)
   at Pomelo.EntityFrameworkCore.MySql.Storage.Internal.MySqlRelationalConnection..ctor(RelationalConnectionDependencies dependencies, IMySqlConnectionStringOptionsValidator mySqlConnectionStringOptionsValidator, IMySqlOptions mySqlSingletonOptions)
   at InvokeStub_MySqlRelationalConnection..ctor(Object, Span`1)
```

cc @lauxjpn
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2712)