### PR TITLE
Service Discovery: allow multiple schemes to be specified in request

### DIFF
--- a/playground/TestShop/ApiGateway/appsettings.json
+++ b/playground/TestShop/ApiGateway/appsettings.json
@@ -39,7 +39,7 @@
       "basket": {
         "Destinations": {
           "basket": {
-            "Address": "https://basketservice",
+            "Address": "http://basketservice",
             "Health": "http://basketservice/readiness"
           }
         }

--- a/playground/TestShop/AppHost/Program.cs
+++ b/playground/TestShop/AppHost/Program.cs
@@ -19,7 +19,7 @@ var basketService = builder.AddProject("basketservice", @"..\BasketService\Baske
 
 builder.AddProject<Projects.MyFrontend>("frontend")
        .WithReference(basketService)
-       .WithReference(catalogService.GetEndpoint("http"));
+       .WithReference(catalogService);
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor", launchProfileName: "OrderProcessor")
        .WithReference(messaging);

--- a/playground/TestShop/AppHost/aspire-manifest.json
+++ b/playground/TestShop/AppHost/aspire-manifest.json
@@ -123,9 +123,9 @@
       "env": {
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "services__basketservice__0": "{basketservice.bindings.http.url}",
-        "services__basketservice__1": "{basketservice.bindings.https.url}",
-        "services__catalogservice__0": "{catalogservice.bindings.http.url}"
+        "services__basketservice__http__0": "{basketservice.bindings.http.url}",
+        "services__basketservice__https__0": "{basketservice.bindings.https.url}",
+        "services__catalogservice__http__0": "{catalogservice.bindings.http.url}"
       },
       "bindings": {
         "http": {
@@ -155,10 +155,10 @@
       "env": {
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "services__basketservice__0": "{basketservice.bindings.http.url}",
-        "services__basketservice__1": "{basketservice.bindings.https.url}",
-        "services__catalogservice__0": "{catalogservice.bindings.http.url}",
-        "services__catalogservice__1": "{catalogservice.bindings.https.url}"
+        "services__basketservice__http__0": "{basketservice.bindings.http.url}",
+        "services__basketservice__https__0": "{basketservice.bindings.https.url}",
+        "services__catalogservice__http__0": "{catalogservice.bindings.http.url}",
+        "services__catalogservice__https__0": "{catalogservice.bindings.https.url}"
       },
       "bindings": {
         "http": {

--- a/playground/TestShop/AppHost/aspire-manifest.json
+++ b/playground/TestShop/AppHost/aspire-manifest.json
@@ -125,7 +125,8 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "services__basketservice__http__0": "{basketservice.bindings.http.url}",
         "services__basketservice__https__0": "{basketservice.bindings.https.url}",
-        "services__catalogservice__http__0": "{catalogservice.bindings.http.url}"
+        "services__catalogservice__http__0": "{catalogservice.bindings.http.url}",
+        "services__catalogservice__https__0": "{catalogservice.bindings.https.url}"
       },
       "bindings": {
         "http": {

--- a/playground/TestShop/MyFrontend/Program.cs
+++ b/playground/TestShop/MyFrontend/Program.cs
@@ -8,7 +8,7 @@ builder.AddServiceDefaults();
 
 builder.Services.AddHttpForwarderWithServiceDiscovery();
 
-builder.Services.AddHttpClient<CatalogServiceClient>(c => c.BaseAddress = new("http://catalogservice"));
+builder.Services.AddHttpClient<CatalogServiceClient>(c => c.BaseAddress = new("https+http://catalogservice"));
 
 builder.Services.AddSingleton<BasketServiceClient>()
                 .AddGrpcClient<Basket.BasketClient>(o => o.Address = new("http://basketservice"));

--- a/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
@@ -34,11 +34,6 @@ public class AllocatedEndpoint
     public EndpointAnnotation Endpoint { get; }
 
     /// <summary>
-    /// Friendly name for the endpoint.
-    /// </summary>
-    public string Name => Endpoint.Name;
-
-    /// <summary>
     /// The address of the endpoint
     /// </summary>
     public string Address { get; private set; }

--- a/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Net.Sockets;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -10,39 +9,34 @@ namespace Aspire.Hosting.ApplicationModel;
 /// Represents an endpoint allocated for a service instance.
 /// </summary>
 [DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, UriString = {UriString}, EndpointNameQualifiedUriString = {EndpointNameQualifiedUriString}")]
-public class AllocatedEndpointAnnotation : IResourceAnnotation
+public class AllocatedEndpoint
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="AllocatedEndpointAnnotation"/> class.
+    /// Initializes a new instance of the <see cref="AllocatedEndpoint"/> class.
     /// </summary>
-    /// <param name="name">The name of the endpoint.</param>
-    /// <param name="protocol">The protocol used by the endpoint.</param>
+    /// <param name="endpoint">The endpoint.</param>
     /// <param name="address">The IP address of the endpoint.</param>
     /// <param name="port">The port number of the endpoint.</param>
-    /// <param name="scheme">The URI scheme used by the endpoint.</param>
-    public AllocatedEndpointAnnotation(string name, ProtocolType protocol, string address, int port, string scheme)
+    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port)
     {
-        ArgumentNullException.ThrowIfNullOrEmpty(name);
-        ArgumentNullException.ThrowIfNullOrEmpty(scheme);
+        ArgumentNullException.ThrowIfNull(endpoint);
         ArgumentOutOfRangeException.ThrowIfLessThan(port, 1, nameof(port));
         ArgumentOutOfRangeException.ThrowIfGreaterThan(port, 65535, nameof(port));
 
-        Name = name;
-        Protocol = protocol;
+        Endpoint = endpoint;
         Address = address;
         Port = port;
-        UriScheme = scheme;
     }
+
+    /// <summary>
+    /// Gets the endpoint which this allocation is associated with.
+    /// </summary>
+    public EndpointAnnotation Endpoint { get; }
 
     /// <summary>
     /// Friendly name for the endpoint.
     /// </summary>
-    public string Name { get; private set; }
-
-    /// <summary>
-    /// The network protocol (TCP and UDP are supported).
-    /// </summary>
-    public ProtocolType Protocol { get; private set; }
+    public string Name => Endpoint.Name;
 
     /// <summary>
     /// The address of the endpoint
@@ -57,7 +51,7 @@ public class AllocatedEndpointAnnotation : IResourceAnnotation
     /// <summary>
     /// For URI-addressed services, contains the scheme part of the address.
     /// </summary>
-    public string UriScheme { get; private set; }
+    public string UriScheme => Endpoint.UriScheme;
 
     /// <summary>
     /// Endpoint in string representation formatted as <c>"Address:Port"</c>.

--- a/src/Aspire.Hosting/ApplicationModel/AllocatedEndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AllocatedEndpointAnnotation.cs
@@ -65,11 +65,6 @@ public class AllocatedEndpointAnnotation : IResourceAnnotation
     public string EndPointString => $"{Address}:{Port}";
 
     /// <summary>
-    /// URI in string representation specially formatted to be processed by service discovery without ambiguity.
-    /// </summary>
-    public string EndpointNameQualifiedUriString => $"{Name}://{EndPointString}";
-
-    /// <summary>
     /// URI in string representation.
     /// </summary>
     public string UriString => $"{UriScheme}://{EndPointString}";

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -104,4 +104,9 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// </summary>
     /// <remarks>Defaults to <c>true</c>.</remarks>
     public bool IsProxied { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the allocated endpoint.
+    /// </summary>
+    public AllocatedEndpoint? AllocatedEndpoint { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReferenceAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReferenceAnnotation.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 namespace Aspire.Hosting.ApplicationModel;
 
-[DebuggerDisplay(@"Type = {GetType().Name,nq}, Resource = {Resource.Name}, EndpointNames = {string.Join("", "", EndpointNames)}")]
+[DebuggerDisplay(@"Type = {GetType().Name,nq}, Resource = {Resource.Name}, EndpointNames = {UseAllEndpoints ? ""(All)"" : string.Join("", "", EndpointNames)}")]
 internal sealed class EndpointReferenceAnnotation(IResourceWithEndpoints resource) : IResourceAnnotation
 {
     public IResourceWithEndpoints Resource { get; } = resource;

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -309,15 +309,10 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                     throw new InvalidOperationException($"Service '{svc.Metadata.Name}' needs to specify a port for endpoint '{sp.EndpointAnnotation.Name}' since it isn't using a proxy.");
                 }
 
-                var a = new AllocatedEndpointAnnotation(
-                    sp.EndpointAnnotation.Name,
-                    PortProtocol.ToProtocolType(svc.Spec.Protocol),
+                sp.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(
+                    sp.EndpointAnnotation,
                     sp.EndpointAnnotation.IsProxied ? svc.AllocatedAddress! : "localhost",
-                    (int)svc.AllocatedPort!,
-                    sp.EndpointAnnotation.UriScheme
-                    );
-
-                appResource.ModelResource.Annotations.Add(a);
+                    (int)svc.AllocatedPort!);
             }
         }
     }

--- a/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
@@ -94,9 +94,18 @@ public static class ResourceExtensions
     /// <param name="allocatedEndPoints">When this method returns, contains the allocated endpoints for the specified resource, if they exist; otherwise, <c>null</c>.</param>
     /// <returns><c>true</c> if the allocated endpoints were successfully retrieved; otherwise, <c>false</c>.</returns>
     [Obsolete("Use GetEndpoints instead.")]
-    public static bool TryGetAllocatedEndPoints(this IResource resource, [NotNullWhen(true)] out IEnumerable<AllocatedEndpointAnnotation>? allocatedEndPoints)
+    public static bool TryGetAllocatedEndPoints(this IResource resource, [NotNullWhen(true)] out IEnumerable<AllocatedEndpoint>? allocatedEndPoints)
     {
-        return TryGetAnnotationsOfType(resource, out allocatedEndPoints);
+        if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
+        {
+            allocatedEndPoints = endpoints.Where(e => e.AllocatedEndpoint != null).Select(e => e.AllocatedEndpoint!);
+            return true;
+        }
+        else
+        {
+            allocatedEndPoints = null;
+            return false;
+        }
     }
 
     /// <summary>
@@ -106,7 +115,7 @@ public static class ResourceExtensions
     /// <returns></returns>
     public static IEnumerable<EndpointReference> GetEndpoints(this IResourceWithEndpoints resource)
     {
-        if (TryGetAnnotationsOfType<AllocatedEndpointAnnotation>(resource, out var endpoints))
+        if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
         {
             return endpoints.Select(e => new EndpointReference(resource, e));
         }

--- a/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceExtensions.cs
@@ -88,27 +88,6 @@ public static class ResourceExtensions
     }
 
     /// <summary>
-    /// Attempts to get the allocated endpoints for the specified resource.
-    /// </summary>
-    /// <param name="resource">The resource to get the allocated endpoints for.</param>
-    /// <param name="allocatedEndPoints">When this method returns, contains the allocated endpoints for the specified resource, if they exist; otherwise, <c>null</c>.</param>
-    /// <returns><c>true</c> if the allocated endpoints were successfully retrieved; otherwise, <c>false</c>.</returns>
-    [Obsolete("Use GetEndpoints instead.")]
-    public static bool TryGetAllocatedEndPoints(this IResource resource, [NotNullWhen(true)] out IEnumerable<AllocatedEndpoint>? allocatedEndPoints)
-    {
-        if (TryGetAnnotationsOfType<EndpointAnnotation>(resource, out var endpoints))
-        {
-            allocatedEndPoints = endpoints.Where(e => e.AllocatedEndpoint != null).Select(e => e.AllocatedEndpoint!);
-            return true;
-        }
-        else
-        {
-            allocatedEndPoints = null;
-            return false;
-        }
-    }
-
-    /// <summary>
     /// Gets the endpoints for the specified resource.
     /// </summary>
     /// <param name="resource"></param>

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -185,8 +185,6 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 Writer.WriteString(key, valueString);
             }
 
-            WriteServiceDiscoveryEnvironmentVariables(resource);
-
             WritePortBindingEnvironmentVariables(resource);
 
             Writer.WriteEndObject();
@@ -224,42 +222,6 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 Writer.WriteEndObject();
             }
             Writer.WriteEndObject();
-        }
-    }
-
-    /// <summary>
-    /// TODO: Doc Comments
-    /// </summary>
-    /// <param name="resource"></param>
-    public void WriteServiceDiscoveryEnvironmentVariables(IResource resource)
-    {
-        var endpointReferenceAnnotations = resource.Annotations.OfType<EndpointReferenceAnnotation>();
-
-        if (endpointReferenceAnnotations.Any())
-        {
-            foreach (var endpointReferenceAnnotation in endpointReferenceAnnotations)
-            {
-                var endpointNames = endpointReferenceAnnotation.UseAllEndpoints
-                    ? endpointReferenceAnnotation.Resource.Annotations.OfType<EndpointAnnotation>().Select(sb => sb.Name)
-                    : endpointReferenceAnnotation.EndpointNames;
-
-                var endpointAnnotationsGroupedByName = endpointReferenceAnnotation.Resource.Annotations
-                    .OfType<EndpointAnnotation>()
-                    .Where(sba => endpointNames.Contains(sba.Name, StringComparers.EndpointAnnotationName))
-                    .GroupBy(sba => sba.Name);
-
-                var serviceName = endpointReferenceAnnotation.Resource.Name;
-                foreach (var group in endpointAnnotationsGroupedByName)
-                {
-                    var i = 0;
-                    foreach (var endpointAnnotation in group)
-                    {
-                        Writer.WriteString(
-                            $"services__{serviceName}__{endpointAnnotation.Name}__{i++}",
-                            $"{{{serviceName}.bindings.{endpointAnnotation.Name}.url}}");
-                    }
-                }
-            }
         }
     }
 

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -243,19 +243,21 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                     ? endpointReferenceAnnotation.Resource.Annotations.OfType<EndpointAnnotation>().Select(sb => sb.Name)
                     : endpointReferenceAnnotation.EndpointNames;
 
-                var endpointAnnotationsGroupedByScheme = endpointReferenceAnnotation.Resource.Annotations
+                var endpointAnnotationsGroupedByName = endpointReferenceAnnotation.Resource.Annotations
                     .OfType<EndpointAnnotation>()
                     .Where(sba => endpointNames.Contains(sba.Name, StringComparers.EndpointAnnotationName))
-                    .GroupBy(sba => sba.UriScheme);
+                    .GroupBy(sba => sba.Name);
 
-                var i = 0;
-                foreach (var endpointAnnotationGroupedByScheme in endpointAnnotationsGroupedByScheme)
+                var serviceName = endpointReferenceAnnotation.Resource.Name;
+                foreach (var group in endpointAnnotationsGroupedByName)
                 {
-                    // HACK: For November we are only going to support a single endpoint annotation
-                    //       per URI scheme per service reference.
-                    var binding = endpointAnnotationGroupedByScheme.Single();
-
-                    Writer.WriteString($"services__{endpointReferenceAnnotation.Resource.Name}__{i++}", $"{{{endpointReferenceAnnotation.Resource.Name}.bindings.{binding.Name}.url}}");
+                    var i = 0;
+                    foreach (var endpointAnnotation in group)
+                    {
+                        Writer.WriteString(
+                            $"services__{serviceName}__{endpointAnnotation.Name}__{i++}",
+                            $"{{{serviceName}.bindings.{endpointAnnotation.Name}.url}}");
+                    }
                 }
             }
         }

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.ServiceDiscovery;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -27,6 +28,12 @@ public static class Extensions
             // Turn on service discovery by default
             http.UseServiceDiscovery();
         });
+
+        // Uncomment the following to restrict the allowed schemes for service discovery.
+        // builder.Services.Configure<ServiceDiscoveryOptions>(options =>
+        // {
+        //     options.AllowedSchemes = ["https"];
+        // });
 
         return builder;
     }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Microsoft.Extensions.ServiceDiscovery.Abstractions.csproj
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Microsoft.Extensions.ServiceDiscovery.Abstractions.csproj
@@ -6,6 +6,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <Description>Provides abstractions for service discovery. Interfaces defined in this package are implemented in Microsoft.Extensions.ServiceDiscovery and other service discovery packages.</Description>
     <PackageIconFullPath>$(DefaultDotnetIconFullPath)</PackageIconFullPath>
+    <RootNamespace>Microsoft.Extensions.ServiceDiscovery</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/UriEndPoint.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/UriEndPoint.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+
+namespace Microsoft.Extensions.ServiceDiscovery;
+
+/// <summary>
+/// An endpoint represented by a <see cref="System.Uri"/>.
+/// </summary>
+/// <param name="uri">The <see cref="System.Uri"/>.</param>
+public sealed class UriEndPoint(Uri uri) : EndPoint
+{
+    /// <summary>
+    /// Gets the <see cref="System.Uri"/> associated with this endpoint.
+    /// </summary>
+    public Uri Uri => uri;
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+    {
+        return obj is UriEndPoint other && Uri.Equals(other.Uri);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Uri.GetHashCode();
+
+    /// <inheritdoc/>
+    public override string? ToString() => uri.ToString();
+}

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsServiceEndPointResolverProvider.cs
@@ -9,24 +9,16 @@ using Microsoft.Extensions.ServiceDiscovery.Internal;
 
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
-/// <summary>
-/// Provides <see cref="IServiceEndPointProvider"/> instances which resolve endpoints from DNS.
-/// </summary>
-/// <remarks>
-/// Initializes a new <see cref="DnsServiceEndPointResolverProvider"/> instance.
-/// </remarks>
-/// <param name="options">The options.</param>
-/// <param name="logger">The logger.</param>
-/// <param name="timeProvider">The time provider.</param>
 internal sealed partial class DnsServiceEndPointResolverProvider(
     IOptionsMonitor<DnsServiceEndPointResolverOptions> options,
     ILogger<DnsServiceEndPointResolver> logger,
-    TimeProvider timeProvider) : IServiceEndPointResolverProvider
+    TimeProvider timeProvider,
+    ServiceNameParser parser) : IServiceEndPointResolverProvider
 {
     /// <inheritdoc/>
     public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointProvider? resolver)
     {
-        if (!ServiceNameParts.TryParse(serviceName, out var parts))
+        if (!parser.TryParse(serviceName, out var parts))
         {
             DnsServiceEndPointResolverBase.Log.ServiceNameIsNotUriOrDnsName(logger, serviceName);
             resolver = default;

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
@@ -10,21 +10,12 @@ using Microsoft.Extensions.ServiceDiscovery.Internal;
 
 namespace Microsoft.Extensions.ServiceDiscovery.Dns;
 
-/// <summary>
-/// Provides <see cref="IServiceEndPointProvider"/> instances which resolve endpoints from DNS using SRV queries.
-/// </summary>
-/// <remarks>
-/// Initializes a new <see cref="DnsSrvServiceEndPointResolverProvider"/> instance.
-/// </remarks>
-/// <param name="options">The options.</param>
-/// <param name="logger">The logger.</param>
-/// <param name="dnsClient">The DNS client.</param>
-/// <param name="timeProvider">The time provider.</param>
 internal sealed partial class DnsSrvServiceEndPointResolverProvider(
     IOptionsMonitor<DnsSrvServiceEndPointResolverOptions> options,
     ILogger<DnsSrvServiceEndPointResolver> logger,
     IDnsQuery dnsClient,
-    TimeProvider timeProvider) : IServiceEndPointResolverProvider
+    TimeProvider timeProvider,
+    ServiceNameParser parser) : IServiceEndPointResolverProvider
 {
     private static readonly string s_serviceAccountPath = Path.Combine($"{Path.DirectorySeparatorChar}var", "run", "secrets", "kubernetes.io", "serviceaccount");
     private static readonly string s_serviceAccountNamespacePath = Path.Combine($"{Path.DirectorySeparatorChar}var", "run", "secrets", "kubernetes.io", "serviceaccount", "namespace");
@@ -49,7 +40,7 @@ internal sealed partial class DnsSrvServiceEndPointResolverProvider(
             return false;
         }
 
-        if (!ServiceNameParts.TryParse(serviceName, out var parts))
+        if (!parser.TryParse(serviceName, out var parts))
         {
             DnsServiceEndPointResolverBase.Log.ServiceNameIsNotUriOrDnsName(logger, serviceName);
             resolver = default;

--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/Microsoft.Extensions.ServiceDiscovery.Dns.csproj
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/Microsoft.Extensions.ServiceDiscovery.Dns.csproj
@@ -9,10 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Microsoft.Extensions.ServiceDiscovery\Internal\ServiceNameParts.cs" Link="Internal\ServiceNameParts.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="DnsClient" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryForwarderHttpClientFactory.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryForwarderHttpClientFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 using Microsoft.Extensions.ServiceDiscovery.Http;
 using Yarp.ReverseProxy.Forwarder;
@@ -10,11 +11,12 @@ namespace Microsoft.Extensions.ServiceDiscovery.Yarp;
 internal sealed class ServiceDiscoveryForwarderHttpClientFactory(
     TimeProvider timeProvider,
     IServiceEndPointSelectorProvider selectorProvider,
-    ServiceEndPointResolverFactory factory) : ForwarderHttpClientFactory
+    ServiceEndPointResolverFactory factory,
+    IOptions<ServiceDiscoveryOptions> options) : ForwarderHttpClientFactory
 {
     protected override HttpMessageHandler WrapHandler(ForwarderHttpClientContext context, HttpMessageHandler handler)
     {
         var registry = new HttpServiceEndPointResolver(factory, selectorProvider, timeProvider);
-        return new ResolvingHttpDelegatingHandler(registry, handler);
+        return new ResolvingHttpDelegatingHandler(registry, options, handler);
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.Log.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolver.Log.cs
@@ -12,7 +12,7 @@ internal sealed partial class ConfigurationServiceEndPointResolver
 {
     private sealed partial class Log
     {
-        [LoggerMessage(1, LogLevel.Debug, "Skipping endpoint resolution for service '{ServiceName}': '{Reason}'.", EventName = "SkippedResolution")]  
+        [LoggerMessage(1, LogLevel.Debug, "Skipping endpoint resolution for service '{ServiceName}': '{Reason}'.", EventName = "SkippedResolution")]
         public static partial void SkippedResolution(ILogger logger, string serviceName, string reason);
 
         [LoggerMessage(2, LogLevel.Debug, "Matching endpoints using endpoint names for service '{ServiceName}' since endpoint names are specified in configuration.", EventName = "MatchingEndPointNames")]
@@ -38,11 +38,11 @@ internal sealed partial class ConfigurationServiceEndPointResolver
             }
         }
 
-        [LoggerMessage(4, LogLevel.Debug, "Using configuration from path '{Path}' to resolve endpoints for service '{ServiceName}'.", EventName = "UsingConfigurationPath")]
-        public static partial void UsingConfigurationPath(ILogger logger, string path, string serviceName);
+        [LoggerMessage(4, LogLevel.Debug, "Using configuration from path '{Path}' to resolve endpoint '{EndpointName}' for service '{ServiceName}'.", EventName = "UsingConfigurationPath")]
+        public static partial void UsingConfigurationPath(ILogger logger, string path, string endpointName, string serviceName);
 
-        [LoggerMessage(5, LogLevel.Debug, "No endpoints configured for service '{ServiceName}' from path '{Path}'.", EventName = "ConfigurationNotFound")]
-        internal static partial void ConfigurationNotFound(ILogger logger, string serviceName, string path);
+        [LoggerMessage(5, LogLevel.Debug, "No valid endpoint configuration was found for service '{ServiceName}' from path '{Path}'.", EventName = "ServiceConfigurationNotFound")]
+        internal static partial void ServiceConfigurationNotFound(ILogger logger, string serviceName, string path);
 
         [LoggerMessage(6, LogLevel.Debug, "Endpoints configured for service '{ServiceName}' from path '{Path}': {ConfiguredEndPoints}.", EventName = "ConfiguredEndPoints")]
         internal static partial void ConfiguredEndPoints(ILogger logger, string serviceName, string path, string configuredEndPoints);
@@ -67,5 +67,8 @@ internal sealed partial class ConfigurationServiceEndPointResolver
             var configuredEndPoints = endpointValues.ToString();
             ConfiguredEndPoints(logger, serviceName, path, configuredEndPoints);
         }
+
+        [LoggerMessage(7, LogLevel.Debug, "No valid endpoint configuration was found for endpoint '{EndpointName}' on service '{ServiceName}' from path '{Path}'.", EventName = "EndpointConfigurationNotFound")]
+        internal static partial void EndpointConfigurationNotFound(ILogger logger, string endpointName, string serviceName, string path);
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverOptions.cs
@@ -1,20 +1,40 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Options;
+
 namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 /// <summary>
 /// Options for <see cref="ConfigurationServiceEndPointResolver"/>.
 /// </summary>
-public class ConfigurationServiceEndPointResolverOptions
+public sealed class ConfigurationServiceEndPointResolverOptions
 {
     /// <summary>
     /// The name of the configuration section which contains service endpoints. Defaults to <c>"Services"</c>.
     /// </summary>
-    public string? SectionName { get; set; } = "Services";
+    public string SectionName { get; set; } = "Services";
 
     /// <summary>
     /// Gets or sets a delegate used to determine whether to apply host name metadata to each resolved endpoint. Defaults to <c>false</c>.
     /// </summary>
     public Func<ServiceEndPoint, bool> ApplyHostNameMetadata { get; set; } = _ => false;
+}
+
+internal sealed class ConfigurationServiceEndPointResolverOptionsValidator : IValidateOptions<ConfigurationServiceEndPointResolverOptions>
+{
+    public ValidateOptionsResult Validate(string? name, ConfigurationServiceEndPointResolverOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.SectionName))
+        {
+            return ValidateOptionsResult.Fail($"{nameof(options.SectionName)} must not be null or empty.");
+        }
+
+        if (options.ApplyHostNameMetadata is null)
+        {
+            return ValidateOptionsResult.Fail($"{nameof(options.ApplyHostNameMetadata)} must not be null.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Configuration/ConfigurationServiceEndPointResolverProvider.cs
@@ -5,28 +5,23 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.ServiceDiscovery.Internal;
 
 namespace Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 /// <summary>
 /// <see cref="IServiceEndPointResolverProvider"/> implementation that resolves services using <see cref="IConfiguration"/>.
 /// </summary>
-/// <param name="configuration">The configuration.</param>
-/// <param name="options">The options.</param>
-/// <param name="loggerFactory">The logger factory.</param>
-public class ConfigurationServiceEndPointResolverProvider(
+internal sealed class ConfigurationServiceEndPointResolverProvider(
     IConfiguration configuration,
     IOptions<ConfigurationServiceEndPointResolverOptions> options,
-    ILoggerFactory loggerFactory) : IServiceEndPointResolverProvider
+    ILogger<ConfigurationServiceEndPointResolver> logger,
+    ServiceNameParser parser) : IServiceEndPointResolverProvider
 {
-    private readonly IConfiguration _configuration = configuration;
-    private readonly IOptions<ConfigurationServiceEndPointResolverOptions> _options = options;
-    private readonly ILogger<ConfigurationServiceEndPointResolver> _logger = loggerFactory.CreateLogger<ConfigurationServiceEndPointResolver>();
-
     /// <inheritdoc/>
     public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointProvider? resolver)
     {
-        resolver = new ConfigurationServiceEndPointResolver(serviceName, _configuration, _logger, _options);
+        resolver = new ConfigurationServiceEndPointResolver(serviceName, configuration, logger, options, parser);
         return true;
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/HostingExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/HostingExtensions.cs
@@ -4,8 +4,10 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.ServiceDiscovery;
 using Microsoft.Extensions.ServiceDiscovery.Abstractions;
+using Microsoft.Extensions.ServiceDiscovery.Internal;
 using Microsoft.Extensions.ServiceDiscovery.PassThrough;
 
 namespace Microsoft.Extensions.Hosting;
@@ -36,6 +38,8 @@ public static class HostingExtensions
     {
         services.AddOptions();
         services.AddLogging();
+        services.TryAddSingleton<ServiceNameParser>();
+        services.TryAddTransient<IValidateOptions<ServiceDiscoveryOptions>, ServiceDiscoveryOptionsValidator>();
         services.TryAddSingleton<TimeProvider>(static sp => TimeProvider.System);
         services.TryAddSingleton<IServiceEndPointSelectorProvider, RoundRobinServiceEndPointSelectorProvider>();
         services.TryAddSingleton<ServiceEndPointResolverFactory>();
@@ -63,6 +67,7 @@ public static class HostingExtensions
     {
         services.AddServiceDiscoveryCore();
         services.AddSingleton<IServiceEndPointResolverProvider, ConfigurationServiceEndPointResolverProvider>();
+        services.AddTransient<IValidateOptions<ConfigurationServiceEndPointResolverOptions>, ConfigurationServiceEndPointResolverOptionsValidator>();
         if (configureOptions is not null)
         {
             services.Configure(configureOptions);

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpClientBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpClientBuilderExtensions.cs
@@ -31,7 +31,8 @@ public static class HttpClientBuilderExtensions
             var timeProvider = services.GetService<TimeProvider>() ?? TimeProvider.System;
             var resolverProvider = services.GetRequiredService<ServiceEndPointResolverFactory>();
             var registry = new HttpServiceEndPointResolver(resolverProvider, selectorProvider, timeProvider);
-            return new ResolvingHttpDelegatingHandler(registry);
+            var options = services.GetRequiredService<IOptions<ServiceDiscoveryOptions>>();
+            return new ResolvingHttpDelegatingHandler(registry, options);
         });
 
         // Configure the HttpClient to disable gRPC load balancing.
@@ -56,7 +57,8 @@ public static class HttpClientBuilderExtensions
             var selectorProvider = services.GetRequiredService<IServiceEndPointSelectorProvider>();
             var resolverProvider = services.GetRequiredService<ServiceEndPointResolverFactory>();
             var registry = new HttpServiceEndPointResolver(resolverProvider, selectorProvider, timeProvider);
-            return new ResolvingHttpDelegatingHandler(registry);
+            var options = services.GetRequiredService<IOptions<ServiceDiscoveryOptions>>();
+            return new ResolvingHttpDelegatingHandler(registry, options);
         });
 
         // Configure the HttpClient to disable gRPC load balancing.

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/ResolvingHttpDelegatingHandler.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/ResolvingHttpDelegatingHandler.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.ServiceDiscovery.Abstractions;
 
 namespace Microsoft.Extensions.ServiceDiscovery.Http;
@@ -13,24 +14,29 @@ namespace Microsoft.Extensions.ServiceDiscovery.Http;
 public class ResolvingHttpDelegatingHandler : DelegatingHandler
 {
     private readonly HttpServiceEndPointResolver _resolver;
+    private readonly ServiceDiscoveryOptions _options;
 
     /// <summary>
     /// Initializes a new <see cref="ResolvingHttpDelegatingHandler"/> instance.
     /// </summary>
     /// <param name="resolver">The endpoint resolver.</param>
-    public ResolvingHttpDelegatingHandler(HttpServiceEndPointResolver resolver)
+    /// <param name="options">The service discovery options.</param>
+    public ResolvingHttpDelegatingHandler(HttpServiceEndPointResolver resolver, IOptions<ServiceDiscoveryOptions> options)
     {
         _resolver = resolver;
+        _options = options.Value;
     }
 
     /// <summary>
     /// Initializes a new <see cref="ResolvingHttpDelegatingHandler"/> instance.
     /// </summary>
     /// <param name="resolver">The endpoint resolver.</param>
+    /// <param name="options">The service discovery options.</param>
     /// <param name="innerHandler">The inner handler.</param>
-    public ResolvingHttpDelegatingHandler(HttpServiceEndPointResolver resolver, HttpMessageHandler innerHandler) : base(innerHandler)
+    public ResolvingHttpDelegatingHandler(HttpServiceEndPointResolver resolver, IOptions<ServiceDiscoveryOptions> options, HttpMessageHandler innerHandler) : base(innerHandler)
     {
         _resolver = resolver;
+        _options = options.Value;
     }
 
     /// <inheritdoc/>
@@ -43,7 +49,7 @@ public class ResolvingHttpDelegatingHandler : DelegatingHandler
         if (originalUri?.Host is not null)
         {
             var result = await _resolver.GetEndpointAsync(request, cancellationToken).ConfigureAwait(false);
-            request.RequestUri = GetUriWithEndPoint(originalUri, result);
+            request.RequestUri = GetUriWithEndPoint(originalUri, result, _options);
             request.Headers.Host ??= result.Features.Get<IHostNameFeature>()?.HostName;
             epHealth = result.Features.Get<IEndPointHealthFeature>();
         }
@@ -64,37 +70,71 @@ public class ResolvingHttpDelegatingHandler : DelegatingHandler
         }
     }
 
-    internal static Uri GetUriWithEndPoint(Uri uri, ServiceEndPoint serviceEndPoint)
+    internal static Uri GetUriWithEndPoint(Uri uri, ServiceEndPoint serviceEndPoint, ServiceDiscoveryOptions options)
     {
         var endpoint = serviceEndPoint.EndPoint;
-
-        string host;
-        int port;
-        switch (endpoint)
+        UriBuilder result;
+        if (endpoint is UriEndPoint { Uri: { } ep })
         {
-            case IPEndPoint ip:
-                host = ip.Address.ToString();
-                port = ip.Port;
-                break;
-            case DnsEndPoint dns:
-                host = dns.Host;
-                port = dns.Port;
-                break;
-            default:
-                throw new InvalidOperationException($"Endpoints of type {endpoint.GetType()} are not supported");
+            result = new UriBuilder(uri)
+            {
+                Scheme = ep.Scheme,
+                Host = ep.Host,
+            };
+
+            if (ep.Port > 0)
+            {
+                result.Port = ep.Port;
+            }
+
+            if (ep.AbsolutePath.Length > 1)
+            {
+                result.Path = $"{ep.AbsolutePath.TrimEnd('/')}/{uri.AbsolutePath.TrimStart('/')}";
+            }
+        }
+        else
+        {
+            string host;
+            int port;
+            switch (endpoint)
+            {
+                case IPEndPoint ip:
+                    host = ip.Address.ToString();
+                    port = ip.Port;
+                    break;
+                case DnsEndPoint dns:
+                    host = dns.Host;
+                    port = dns.Port;
+                    break;
+                default:
+                    throw new InvalidOperationException($"Endpoints of type {endpoint.GetType()} are not supported");
+            }
+
+            result = new UriBuilder(uri)
+            {
+                Host = host,
+            };
+
+            // Default to the default port for the scheme.
+            if (port > 0)
+            {
+                result.Port = port;
+            }
+
+            if (uri.Scheme.IndexOf('+') > 0)
+            {
+                var scheme = uri.Scheme.Split('+')[0];
+                if (options.AllowedSchemes.Equals(ServiceDiscoveryOptions.AllSchemes) || options.AllowedSchemes.Contains(scheme, StringComparer.OrdinalIgnoreCase))
+                {
+                    result.Scheme = scheme;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"The scheme '{scheme}' is not allowed.");
+                }
+            }
         }
 
-        var builder = new UriBuilder(uri)
-        {
-            Host = host,
-        };
-
-        // Default to the default port for the scheme.
-        if (port > 0)
-        {
-            builder.Port = port;
-        }
-
-        return builder.Uri;
+        return result.Uri;
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceDiscoveryOptionsValidator.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceDiscoveryOptionsValidator.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Internal;
+
+internal sealed class ServiceDiscoveryOptionsValidator : IValidateOptions<ServiceDiscoveryOptions>
+{
+    public ValidateOptionsResult Validate(string? name, ServiceDiscoveryOptions options)
+    {
+        if (options.AllowedSchemes is null)
+        {
+            return ValidateOptionsResult.Fail("At least one allowed scheme must be specified.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}
+

--- a/src/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceNameParser.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceNameParser.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Internal;
+
+internal sealed class ServiceNameParser(IOptions<ServiceDiscoveryOptions> options)
+{
+    private readonly string[] _allowedSchemes = options.Value.AllowedSchemes;
+
+    public bool TryParse(string serviceName, [NotNullWhen(true)] out ServiceNameParts parts)
+    {
+        if (serviceName.IndexOf("://") < 0 && Uri.TryCreate($"fakescheme://{serviceName}", default, out var uri))
+        {
+            parts = Create(uri, hasScheme: false);
+            return true;
+        }
+
+        if (Uri.TryCreate(serviceName, default, out uri))
+        {
+            parts = Create(uri, hasScheme: true);
+            return true;
+        }
+
+        parts = default;
+        return false;
+
+        ServiceNameParts Create(Uri uri, bool hasScheme)
+        {
+            var uriHost = uri.Host;
+            var segmentSeparatorIndex = uriHost.IndexOf('.');
+            string host;
+            string? endPointName = null;
+            var port = uri.Port > 0 ? uri.Port : 0;
+            if (uriHost.StartsWith('_') && segmentSeparatorIndex > 1 && uriHost[^1] != '.')
+            {
+                endPointName = uriHost[1..segmentSeparatorIndex];
+
+                // Skip the endpoint name, including its prefix ('_') and suffix ('.').
+                host = uriHost[(segmentSeparatorIndex + 1)..];
+            }
+            else
+            {
+                host = uriHost;
+            }
+
+            // Allow multiple schemes to be separated by a '+', eg. "https+http://host:port".
+            var schemes = hasScheme ? ParseSchemes(uri.Scheme) : [];
+            return new(schemes, host, endPointName, port);
+        }
+    }
+
+    private string[] ParseSchemes(string scheme)
+    {
+        if (_allowedSchemes.Equals(ServiceDiscoveryOptions.AllSchemes))
+        {
+            return scheme.Split('+');
+        }
+
+        List<string> result = [];
+        foreach (var s in scheme.Split('+'))
+        {
+            foreach (var allowed in _allowedSchemes)
+            {
+                if (string.Equals(s, allowed, StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Add(s);
+                    break;
+                }
+            }
+        }
+
+        return result.ToArray();
+    }
+}
+

--- a/src/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceNameParts.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Internal/ServiceNameParts.cs
@@ -1,15 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-using System.Net;
-
 namespace Microsoft.Extensions.ServiceDiscovery.Internal;
 
 internal readonly struct ServiceNameParts : IEquatable<ServiceNameParts>
 {
-    public ServiceNameParts(string host, string? endPointName, int port) : this()
+    public ServiceNameParts(string[] schemePriority, string host, string? endPointName, int port) : this()
     {
+        Schemes = schemePriority;
         Host = host;
         EndPointName = endPointName;
         Port = port;
@@ -17,85 +15,13 @@ internal readonly struct ServiceNameParts : IEquatable<ServiceNameParts>
 
     public string? EndPointName { get; init; }
 
+    public string[] Schemes { get; init; }
+
     public string Host { get; init; }
 
     public int Port { get; init; }
 
     public override string? ToString() => EndPointName is not null ? $"EndPointName: {EndPointName}, Host: {Host}, Port: {Port}" : $"Host: {Host}, Port: {Port}";
-
-    public static bool TryParse(string serviceName, [NotNullWhen(true)] out ServiceNameParts parts)
-    {
-        if (serviceName.IndexOf("://") < 0 && Uri.TryCreate($"fakescheme://{serviceName}", default, out var uri))
-        {
-            parts = Create(uri, hasScheme: false);
-            return true;
-        }
-
-        if (Uri.TryCreate(serviceName, default, out uri))
-        {
-            parts = Create(uri, hasScheme: true);
-            return true;
-        }
-
-        parts = default;
-        return false;
-
-        static ServiceNameParts Create(Uri uri, bool hasScheme)
-        {
-            var uriHost = uri.Host;
-            var segmentSeparatorIndex = uriHost.IndexOf('.');
-            string host;
-            string? endPointName = null;
-            var port = uri.Port > 0 ? uri.Port : 0;
-            if (uriHost.StartsWith('_') && segmentSeparatorIndex > 1 && uriHost[^1] != '.')
-            {
-                endPointName = uriHost[1..segmentSeparatorIndex];
-
-                // Skip the endpoint name, including its prefix ('_') and suffix ('.').
-                host = uriHost[(segmentSeparatorIndex + 1)..];
-            }
-            else
-            {
-                host = uriHost;
-                if (hasScheme)
-                {
-                    endPointName = uri.Scheme;
-                }
-            }
-
-            return new(host, endPointName, port);
-        }
-    }
-
-    public static bool TryCreateEndPoint(ServiceNameParts parts, [NotNullWhen(true)] out EndPoint? endPoint)
-    {
-        if (IPAddress.TryParse(parts.Host, out var ip))
-        {
-            endPoint = new IPEndPoint(ip, parts.Port);
-        }
-        else if (!string.IsNullOrEmpty(parts.Host))
-        {
-            endPoint = new DnsEndPoint(parts.Host, parts.Port);
-        }
-        else
-        {
-            endPoint = null;
-            return false;
-        }
-
-        return true;
-    }
-
-    public static bool TryCreateEndPoint(string serviceName, [NotNullWhen(true)] out EndPoint? serviceEndPoint)
-    {
-        if (TryParse(serviceName, out var parts))
-        {
-            return TryCreateEndPoint(parts, out serviceEndPoint);
-        }
-
-        serviceEndPoint = null;
-        return false;
-    }
 
     public override bool Equals(object? obj) => obj is ServiceNameParts other && Equals(other);
 

--- a/src/Microsoft.Extensions.ServiceDiscovery/Microsoft.Extensions.ServiceDiscovery.csproj
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Microsoft.Extensions.ServiceDiscovery.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />
     <Compile Include="$(SharedDir)ValueStopwatch\*.cs" />
+    <InternalsVisibleTo Include="Microsoft.Extensions.ServiceDiscovery.Dns"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Extensions.ServiceDiscovery/PassThrough/PassThroughServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/PassThrough/PassThroughServiceEndPointResolverProvider.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.ServiceDiscovery.Abstractions;
-using Microsoft.Extensions.ServiceDiscovery.Internal;
 
 namespace Microsoft.Extensions.ServiceDiscovery.PassThrough;
 
@@ -17,13 +16,52 @@ internal sealed class PassThroughServiceEndPointResolverProvider(ILogger<PassThr
     /// <inheritdoc/>
     public bool TryCreateResolver(string serviceName, [NotNullWhen(true)] out IServiceEndPointProvider? resolver)
     {
-        if (!ServiceNameParts.TryCreateEndPoint(serviceName, out var endPoint))
+        if (!TryCreateEndPoint(serviceName, out var endPoint))
         {
             // Propagate the value through regardless, leaving it to the caller to interpret it.
             endPoint = new DnsEndPoint(serviceName, 0);
         }
 
         resolver = new PassThroughServiceEndPointResolver(logger, serviceName, endPoint);
+        return true;
+    }
+
+    private static bool TryCreateEndPoint(string serviceName, [NotNullWhen(true)] out EndPoint? serviceEndPoint)
+    {
+        if ((serviceName.Contains("://", StringComparison.Ordinal) || !Uri.TryCreate($"fakescheme://{serviceName}", default, out var uri)) && !Uri.TryCreate(serviceName, default, out uri))
+        {
+            serviceEndPoint = null;
+            return false;
+        }
+
+        var uriHost = uri.Host;
+        var segmentSeparatorIndex = uriHost.IndexOf('.');
+        string host;
+        if (uriHost.StartsWith('_') && segmentSeparatorIndex > 1 && uriHost[^1] != '.')
+        {
+            // Skip the endpoint name, including its prefix ('_') and suffix ('.').
+            host = uriHost[(segmentSeparatorIndex + 1)..];
+        }
+        else
+        {
+            host = uriHost;
+        }
+
+        var port = uri.Port > 0 ? uri.Port : 0;
+        if (IPAddress.TryParse(host, out var ip))
+        {
+            serviceEndPoint = new IPEndPoint(ip, port);
+        }
+        else if (!string.IsNullOrEmpty(host))
+        {
+            serviceEndPoint = new DnsEndPoint(host, port);
+        }
+        else
+        {
+            serviceEndPoint = null;
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryOptions.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Extensions.ServiceDiscovery;
+
+/// <summary>
+/// Options for configuring service discovery.
+/// </summary>
+public sealed class ServiceDiscoveryOptions
+{
+    /// <summary>
+    /// The value for <see cref="AllowedSchemes"/> which indicates that all schemes are allowed.
+    /// </summary>
+#pragma warning disable IDE0300 // Simplify collection initialization
+#pragma warning disable CA1825 // Avoid zero-length array allocations
+    public static readonly string[] AllSchemes = new string[0];
+#pragma warning restore CA1825 // Avoid zero-length array allocations
+#pragma warning restore IDE0300 // Simplify collection initialization
+
+    /// <summary>
+    /// Gets or sets the collection of allowed URI schemes for URIs resolved by the service discovery system when multiple schemes are specified, for example "https+http://_endpoint.service".
+    /// </summary>
+    /// <remarks>
+    /// When set to <see cref="AllSchemes"/>, all schemes are allowed.
+    /// Schemes are not case-sensitive.
+    /// </remarks>
+    public string[] AllowedSchemes { get; set; } = AllSchemes;
+}
+

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Sockets;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Tests.Utils;
@@ -278,7 +277,7 @@ public class AzureBicepResourceTests
         var builder = DistributedApplication.CreateBuilder();
 
         var redis = builder.AddRedis("cache")
-            .WithAnnotation(new AllocatedEndpointAnnotation("tcp", ProtocolType.Tcp, "localhost", 12455, "tcp"))
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 12455))
             .PublishAsAzureRedis();
 
         Assert.True(redis.Resource.IsContainer());
@@ -297,7 +296,7 @@ public class AzureBicepResourceTests
         var builder = DistributedApplication.CreateBuilder();
 
         var redis = builder.AddRedis("cache")
-            .WithAnnotation(new AllocatedEndpointAnnotation("tcp", ProtocolType.Tcp, "localhost", 12455, "tcp"))
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 12455))
             .PublishAsAzureRedisConstruct(useProvisioner: false); // Resolving abiguity due to InternalsVisibleTo
 
         Assert.True(redis.Resource.IsContainer());
@@ -520,9 +519,8 @@ public class AzureBicepResourceTests
 
         // Verify that when PublishAs variant is used, connection string acquisition
         // still uses the local endpoint.
-        var endpointAnnotation = new AllocatedEndpointAnnotation(PostgresServerResource.PrimaryEndpointName, System.Net.Sockets.ProtocolType.Tcp, "localhost", 1234, "tcp");
-        postgres.WithAnnotation(endpointAnnotation);
-        var expectedConnectionString = $"Host={endpointAnnotation.Address};Port={endpointAnnotation.Port};Username=postgres;Password={PasswordUtil.EscapePassword(postgres.Resource.Password)}";
+        postgres.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1234));
+        var expectedConnectionString = $"Host=localhost;Port=1234;Username=postgres;Password={PasswordUtil.EscapePassword(postgres.Resource.Password)}";
         Assert.Equal(expectedConnectionString, postgres.Resource.GetConnectionString());
 
         Assert.Equal("{postgres.secretOutputs.connectionString}", azurePostgres.Resource.ConnectionStringExpression);

--- a/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
@@ -47,13 +47,7 @@ public class AddKafkaTests
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
             .AddKafka("kafka")
-            .WithAnnotation(
-                new AllocatedEndpointAnnotation(KafkaServerResource.PrimaryEndpointName,
-                ProtocolType.Tcp,
-                "localhost",
-                27017,
-                "tcp"
-            ));
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 27017));
 
         using var app = appBuilder.Build();
 

--- a/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
@@ -80,13 +80,7 @@ public class AddMongoDBTests
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
             .AddMongoDB("mongodb")
-            .WithAnnotation(
-                new AllocatedEndpointAnnotation("tcp",
-                ProtocolType.Tcp,
-                "localhost",
-                27017,
-                "https"
-            ))
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 27017))
             .AddDatabase("mydatabase");
 
         using var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -98,13 +98,7 @@ public class AddMySqlTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddMySql("mysql")
-            .WithAnnotation(
-            new AllocatedEndpointAnnotation(MySqlServerResource.PrimaryEndpointName,
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ));
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         using var app = appBuilder.Build();
 
@@ -122,13 +116,7 @@ public class AddMySqlTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddMySql("mysql")
-            .WithAnnotation(
-            new AllocatedEndpointAnnotation(MySqlServerResource.PrimaryEndpointName,
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ))
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000))
             .AddDatabase("db");
 
         using var app = appBuilder.Build();
@@ -212,7 +200,7 @@ public class AddMySqlTests
         using var app = builder.Build();
 
         // Add fake allocated endpoints.
-        mysql.WithAnnotation(new AllocatedEndpointAnnotation(MySqlServerResource.PrimaryEndpointName, ProtocolType.Tcp, "host.docker.internal", 5001, "tcp"));
+        mysql.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "host.docker.internal", 5001));
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var hook = new PhpMyAdminConfigWriterHook();
@@ -248,8 +236,8 @@ public class AddMySqlTests
         var mysql2 = builder.AddMySql("mysql2").WithPhpMyAdmin(8081);
 
         // Add fake allocated endpoints.
-        mysql1.WithAnnotation(new AllocatedEndpointAnnotation(MySqlServerResource.PrimaryEndpointName, ProtocolType.Tcp, "host.docker.internal", 5001, "tcp"));
-        mysql2.WithAnnotation(new AllocatedEndpointAnnotation(MySqlServerResource.PrimaryEndpointName, ProtocolType.Tcp, "host.docker.internal", 5002, "tcp"));
+        mysql1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "host.docker.internal", 5001));
+        mysql2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "host.docker.internal", 5002));
 
         var myAdmin = builder.Resources.Single(r => r.Name.EndsWith("-phpmyadmin"));
         var volume = myAdmin.Annotations.OfType<ContainerMountAnnotation>().Single();

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -96,13 +96,7 @@ public class AddOracleTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddOracle("orcl")
-            .WithAnnotation(
-            new AllocatedEndpointAnnotation(OracleDatabaseServerResource.PrimaryEndpointName,
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ));
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         using var app = appBuilder.Build();
 
@@ -121,13 +115,7 @@ public class AddOracleTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddOracle("orcl")
-            .WithAnnotation(
-            new AllocatedEndpointAnnotation(OracleDatabaseServerResource.PrimaryEndpointName,
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ))
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000))
             .AddDatabase("db");
 
         using var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -118,13 +118,7 @@ public class AddPostgresTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         var postgres = appBuilder.AddPostgres("postgres")
-                                 .WithAnnotation(
-                                     new AllocatedEndpointAnnotation(PostgresServerResource.PrimaryEndpointName,
-                                      ProtocolType.Tcp,
-                                     "localhost",
-                                     2000,
-                                     "https"
-                                 ));
+                                 .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         var connectionString = postgres.Resource.GetConnectionString();
         Assert.Equal("Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres.inputs.password}", postgres.Resource.ConnectionStringExpression);
@@ -136,13 +130,7 @@ public class AddPostgresTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddPostgres("postgres")
-            .WithAnnotation(
-            new AllocatedEndpointAnnotation(PostgresServerResource.PrimaryEndpointName,
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ))
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000))
             .AddDatabase("db");
 
         using var app = appBuilder.Build();
@@ -292,8 +280,8 @@ public class AddPostgresTests
         var pg2 = builder.AddPostgres("mypostgres2").WithPgAdmin(8081);
 
         // Add fake allocated endpoints.
-        pg1.WithAnnotation(new AllocatedEndpointAnnotation("tcp", ProtocolType.Tcp, "host.docker.internal", 5001, "tcp"));
-        pg2.WithAnnotation(new AllocatedEndpointAnnotation("tcp", ProtocolType.Tcp, "host.docker.internal", 5002, "tcp"));
+        pg1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "host.docker.internal", 5001));
+        pg2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "host.docker.internal", 5002));
 
         var pgadmin = builder.Resources.Single(r => r.Name.EndsWith("-pgadmin"));
         var volume = pgadmin.Annotations.OfType<ContainerMountAnnotation>().Single();

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -48,13 +48,7 @@ public class AddRabbitMQTests
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
             .AddRabbitMQ("rabbit")
-            .WithAnnotation(
-                new AllocatedEndpointAnnotation(RabbitMQServerResource.PrimaryEndpointName,
-                ProtocolType.Tcp,
-                "localhost",
-                27011,
-                "tcp"
-            ));
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 27011));
 
         using var app = appBuilder.Build();
 

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -79,13 +79,7 @@ public class AddRedisTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddRedis("myRedis")
-            .WithAnnotation(
-            new AllocatedEndpointAnnotation(RedisResource.PrimaryEndpointName,
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "tcp"
-            ));
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         using var app = appBuilder.Build();
 
@@ -141,7 +135,7 @@ public class AddRedisTests
         using var app = builder.Build();
 
         // Add fake allocated endpoints.
-        redis.WithAnnotation(new AllocatedEndpointAnnotation("tcp", ProtocolType.Tcp, "host.docker.internal", 5001, "tcp"));
+        redis.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "host.docker.internal", 5001));
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var hook = new RedisCommanderConfigWriterHook();
@@ -163,8 +157,8 @@ public class AddRedisTests
         using var app = builder.Build();
 
         // Add fake allocated endpoints.
-        redis1.WithAnnotation(new AllocatedEndpointAnnotation("tcp", ProtocolType.Tcp, "host.docker.internal", 5001, "tcp"));
-        redis2.WithAnnotation(new AllocatedEndpointAnnotation("tcp", ProtocolType.Tcp, "host.docker.internal", 5002, "tcp"));
+        redis1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "host.docker.internal", 5001));
+        redis2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "host.docker.internal", 5002));
 
         var model = app.Services.GetRequiredService<DistributedApplicationModel>();
         var hook = new RedisCommanderConfigWriterHook();

--- a/tests/Aspire.Hosting.Tests/SlimTestProgramTests.cs
+++ b/tests/Aspire.Hosting.Tests/SlimTestProgramTests.cs
@@ -46,9 +46,8 @@ public class SlimTestProgramTests
         foreach (var projectBuilders in testProgram.ServiceProjectBuilders)
         {
             var endpoint = projectBuilders.Resource.Annotations.OfType<EndpointAnnotation>().Single();
-            var allocatedEndpoint = projectBuilders.Resource.Annotations.OfType<AllocatedEndpointAnnotation>().Single();
-
-            Assert.Equal(endpoint.Port, allocatedEndpoint.Port);
+            Assert.NotNull(endpoint.AllocatedEndpoint);
+            Assert.Equal(endpoint.Port, endpoint.AllocatedEndpoint.Port);
         }
     }
 
@@ -68,9 +67,8 @@ public class SlimTestProgramTests
         foreach (var projectBuilders in testProgram.ServiceProjectBuilders)
         {
             var endpoint = projectBuilders.Resource.Annotations.OfType<EndpointAnnotation>().Single();
-            var allocatedEndpoint = projectBuilders.Resource.Annotations.OfType<AllocatedEndpointAnnotation>().Single();
-
-            Assert.Equal(endpoint.Port, allocatedEndpoint.Port);
+            Assert.NotNull(endpoint.AllocatedEndpoint);
+            Assert.Equal(endpoint.Port, endpoint.AllocatedEndpoint.Port);
         }
     }
 }

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -64,13 +64,7 @@ public class AddSqlServerTests
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
             .AddSqlServer("sqlserver")
-            .WithAnnotation(
-                    new AllocatedEndpointAnnotation(SqlServerServerResource.PrimaryEndpointName,
-                    ProtocolType.Tcp,
-                    "localhost",
-                    1433,
-                    "tcp"
-             ));
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1433));
 
         using var app = appBuilder.Build();
 
@@ -90,13 +84,8 @@ public class AddSqlServerTests
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
             .AddSqlServer("sqlserver")
-            .WithAnnotation(
-                    new AllocatedEndpointAnnotation(SqlServerServerResource.PrimaryEndpointName,
-                    ProtocolType.Tcp,
-                    "localhost",
-                    1433,
-                    "tcp"
-             )).AddDatabase("mydb");
+            .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1433))
+            .AddDatabase("mydb");
 
         using var app = appBuilder.Build();
 

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Sockets;
 using Aspire.Hosting.Tests.Utils;
 using Xunit;
 
@@ -16,13 +15,9 @@ public class WithEnvironmentTests
 
         // Create a binding and its metching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 2000, "mybinding");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("mybinding",
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ));
+        testProgram.ServiceABuilder.WithEndpoint(
+            "mybinding",
+            e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         testProgram.ServiceBBuilder.WithEnvironment("myName", testProgram.ServiceABuilder.GetEndpoint("mybinding"));
 

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -16,7 +16,7 @@ public class WithReferenceTests
     {
         using var testProgram = CreateTestProgram();
 
-        // Create a binding and its metching annotation (simulating DCP behavior)
+        // Create a binding and its matching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 2000, "mybinding");
         testProgram.ServiceABuilder.WithAnnotation(
             new AllocatedEndpointAnnotation("mybinding",
@@ -34,9 +34,8 @@ public class WithReferenceTests
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
-        Assert.Equal(2, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__0" && kvp.Value == "mybinding://localhost:2000");
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__1" && kvp.Value == "https://localhost:2000");
+        Assert.Equal(1, servicesKeysCount);
+        Assert.Contains(config, kvp => kvp.Key == "services__servicea__mybinding__0" && kvp.Value == "https://localhost:2000");
     }
 
     [Fact]
@@ -76,8 +75,8 @@ public class WithReferenceTests
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
         Assert.Equal(2, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__0" && kvp.Value == "mybinding://localhost:2000");
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__1" && kvp.Value == "myconflictingbinding://localhost:3000");
+        Assert.Contains(config, kvp => kvp.Key == "services__servicea__mybinding__0" && kvp.Value == "https://localhost:2000");
+        Assert.Contains(config, kvp => kvp.Key == "services__servicea__myconflictingbinding__0" && kvp.Value == "https://localhost:3000");
     }
 
     [Fact]
@@ -116,11 +115,9 @@ public class WithReferenceTests
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
-        Assert.Equal(4, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__0" && kvp.Value == "mybinding://localhost:2000");
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__1" && kvp.Value == "https://localhost:2000");
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__2" && kvp.Value == "mynonconflictingbinding://localhost:3000");
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__3" && kvp.Value == "http://localhost:3000");
+        Assert.Equal(2, servicesKeysCount);
+        Assert.Contains(config, kvp => kvp.Key == "services__servicea__mybinding__0" && kvp.Value == "https://localhost:2000");
+        Assert.Contains(config, kvp => kvp.Key == "services__servicea__mynonconflictingbinding__0" && kvp.Value == "http://localhost:3000");
     }
 
     [Fact]
@@ -156,8 +153,8 @@ public class WithReferenceTests
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
         Assert.Equal(2, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__0" && kvp.Value == "mybinding://localhost:2000");
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__1" && kvp.Value == "mybinding2://localhost:3000");
+        Assert.Contains(config, kvp => kvp.Key == "services__servicea__mybinding__0" && kvp.Value == "https://localhost:2000");
+        Assert.Contains(config, kvp => kvp.Key == "services__servicea__mybinding2__0" && kvp.Value == "https://localhost:3000");
     }
 
     [Fact]
@@ -192,11 +189,9 @@ public class WithReferenceTests
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
 
         var servicesKeysCount = config.Keys.Count(k => k.StartsWith("services__"));
-        Assert.Equal(4, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__0" && kvp.Value == "mybinding://localhost:2000");
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__1" && kvp.Value == "https://localhost:2000");
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__2" && kvp.Value == "mybinding2://localhost:3000");
-        Assert.Contains(config, kvp => kvp.Key == "services__servicea__3" && kvp.Value == "http://localhost:3000");
+        Assert.Equal(2, servicesKeysCount);
+        Assert.Contains(config, kvp => kvp.Key == "services__servicea__mybinding__0" && kvp.Value == "https://localhost:2000");
+        Assert.Contains(config, kvp => kvp.Key == "services__servicea__mybinding2__0" && kvp.Value == "http://localhost:3000");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Net.Sockets;
 using Aspire.Hosting.Tests.Utils;
 using Xunit;
 
@@ -18,13 +17,7 @@ public class WithReferenceTests
 
         // Create a binding and its matching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 2000, "mybinding");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("mybinding",
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ));
+        testProgram.ServiceABuilder.WithEndpoint("mybinding", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         // Get the service provider.
         testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint(endpointName));
@@ -45,25 +38,12 @@ public class WithReferenceTests
 
         // Create a binding and its matching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 2000, "mybinding");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("mybinding",
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ));
+        testProgram.ServiceABuilder.WithEndpoint("mybinding", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         // Create a binding and its matching annotation (simulating DCP behavior) - HOWEVER
         // this binding conflicts with the earlier because they have the same scheme.
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 3000, "myconflictingbinding");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("myconflictingbinding",
-            ProtocolType.Tcp,
-            "localhost",
-            3000,
-            "https"
-            ));
-
+        testProgram.ServiceABuilder.WithEndpoint("myconflictingbinding", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 3000));
         testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("mybinding"));
         testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("myconflictingbinding"));
 
@@ -86,24 +66,12 @@ public class WithReferenceTests
 
         // Create a binding and its matching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 2000, "mybinding");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("mybinding",
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ));
+        testProgram.ServiceABuilder.WithEndpoint("mybinding", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         // Create a binding and its matching annotation (simulating DCP behavior) - not
         // conflicting because the scheme is different to the first binding.
         testProgram.ServiceABuilder.WithHttpEndpoint(1000, 3000, "mynonconflictingbinding");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("mynonconflictingbinding",
-            ProtocolType.Tcp,
-            "localhost",
-            3000,
-            "http"
-            ));
+        testProgram.ServiceABuilder.WithEndpoint("mynonconflictingbinding", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 3000));
 
         testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("mybinding"));
         testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder.GetEndpoint("mynonconflictingbinding"));
@@ -127,22 +95,10 @@ public class WithReferenceTests
 
         // Create a binding and its metching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 2000, "mybinding");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("mybinding",
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ));
+        testProgram.ServiceABuilder.WithEndpoint("mybinding", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 3000, "mybinding2");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("mybinding2",
-            ProtocolType.Tcp,
-            "localhost",
-            3000,
-            "https"
-            ));
+        testProgram.ServiceABuilder.WithEndpoint("mybinding2", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 3000));
 
         // Get the service provider.
         testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder);
@@ -164,22 +120,10 @@ public class WithReferenceTests
 
         // Create a binding and its metching annotation (simulating DCP behavior)
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 2000, "mybinding");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("mybinding",
-            ProtocolType.Tcp,
-            "localhost",
-            2000,
-            "https"
-            ));
+        testProgram.ServiceABuilder.WithEndpoint("mybinding", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
         testProgram.ServiceABuilder.WithHttpEndpoint(1000, 3000, "mybinding2");
-        testProgram.ServiceABuilder.WithAnnotation(
-            new AllocatedEndpointAnnotation("mybinding2",
-            ProtocolType.Tcp,
-            "localhost",
-            3000,
-            "http"
-            ));
+        testProgram.ServiceABuilder.WithEndpoint("mybinding2", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 3000));
 
         // Get the service provider.
         testProgram.ServiceBBuilder.WithReference(testProgram.ServiceABuilder);

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -100,7 +100,7 @@ public class WithReferenceTests
         testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 3000, "mybinding2");
         testProgram.ServiceABuilder.WithEndpoint("mybinding2", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 3000));
 
-        // The appsettings.json adds an "http" endpoint
+        // The launch profile adds an "http" endpoint
         testProgram.ServiceABuilder.WithEndpoint("http", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 4000));
 
         // Get the service provider.
@@ -129,7 +129,7 @@ public class WithReferenceTests
         testProgram.ServiceABuilder.WithHttpEndpoint(1000, 3000, "mybinding2");
         testProgram.ServiceABuilder.WithEndpoint("mybinding2", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 3000));
 
-        // The appsettings.json adds an "http" endpoint
+        // The launch profile adds an "http" endpoint
         testProgram.ServiceABuilder.WithEndpoint("http", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 4000));
 
         // Get the service provider.

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndPointResolverTests.cs
@@ -164,8 +164,8 @@ public class DnsSrvServiceEndPointResolverTests
         {
             InitialData = new Dictionary<string, string?>
             {
-                ["services:basket:0"] = "localhost:8080",
-                ["services:basket:1"] = "remotehost:9090",
+                ["services:basket:http:0"] = "localhost:8080",
+                ["services:basket:http:1"] = "remotehost:9090",
             }
         };
         var config = new ConfigurationBuilder().Add(configSource);

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ConfigurationServiceEndPointResolverTests.cs
@@ -22,7 +22,7 @@ public class ConfigurationServiceEndPointResolverTests
     {
         var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["services:basket"] = "localhost:8080",
+            ["services:basket:http"] = "localhost:8080",
         });
         var services = new ServiceCollection()
             .AddSingleton<IConfiguration>(config.Build())
@@ -53,14 +53,80 @@ public class ConfigurationServiceEndPointResolverTests
     }
 
     [Fact]
+    public async Task ResolveServiceEndPoint_Configuration_DisallowedScheme()
+    {
+        // Try to resolve an http endpoint when only https is allowed.
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["services:basket:foo:0"] = "http://localhost:8080",
+            ["services:basket:foo:1"] = "https://localhost",
+        });
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(config.Build())
+            .AddServiceDiscoveryCore()
+            .AddConfigurationServiceEndPointResolver()
+            .Configure<ServiceDiscoveryOptions>(o => o.AllowedSchemes = ["https"])
+            .BuildServiceProvider();
+        var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
+        ServiceEndPointWatcher resolver;
+
+        // Explicitly specifying http.
+        // We should get no endpoint back because http is not allowed by configuration.
+        await using ((resolver = resolverFactory.CreateResolver("http://_foo.basket")).ConfigureAwait(false))
+        {
+            Assert.NotNull(resolver);
+            var tcs = new TaskCompletionSource<ServiceEndPointResolverResult>();
+            resolver.OnEndPointsUpdated = tcs.SetResult;
+            resolver.Start();
+            var initialResult = await tcs.Task.ConfigureAwait(false);
+            Assert.NotNull(initialResult);
+            Assert.True(initialResult.ResolvedSuccessfully);
+            Assert.Equal(ResolutionStatus.Success, initialResult.Status);
+            Assert.Empty(initialResult.EndPoints);
+        }
+
+        // Specifying either https or http.
+        // The result should be that we only get the http endpoint back.
+        await using ((resolver = resolverFactory.CreateResolver("https+http://_foo.basket")).ConfigureAwait(false))
+        {
+            Assert.NotNull(resolver);
+            var tcs = new TaskCompletionSource<ServiceEndPointResolverResult>();
+            resolver.OnEndPointsUpdated = tcs.SetResult;
+            resolver.Start();
+            var initialResult = await tcs.Task.ConfigureAwait(false);
+            Assert.NotNull(initialResult);
+            Assert.True(initialResult.ResolvedSuccessfully);
+            Assert.Equal(ResolutionStatus.Success, initialResult.Status);
+            var ep = Assert.Single(initialResult.EndPoints);
+            Assert.Equal(new UriEndPoint(new Uri("https://localhost")), ep.EndPoint);
+        }
+
+        // Specifying either https or http, but in reverse.
+        // The result should be that we only get the http endpoint back.
+        await using ((resolver = resolverFactory.CreateResolver("http+https://_foo.basket")).ConfigureAwait(false))
+        {
+            Assert.NotNull(resolver);
+            var tcs = new TaskCompletionSource<ServiceEndPointResolverResult>();
+            resolver.OnEndPointsUpdated = tcs.SetResult;
+            resolver.Start();
+            var initialResult = await tcs.Task.ConfigureAwait(false);
+            Assert.NotNull(initialResult);
+            Assert.True(initialResult.ResolvedSuccessfully);
+            Assert.Equal(ResolutionStatus.Success, initialResult.Status);
+            var ep = Assert.Single(initialResult.EndPoints);
+            Assert.Equal(new UriEndPoint(new Uri("https://localhost")), ep.EndPoint);
+        }
+    }
+
+    [Fact]
     public async Task ResolveServiceEndPoint_Configuration_MultipleResults()
     {
         var configSource = new MemoryConfigurationSource
         {
             InitialData = new Dictionary<string, string?>
             {
-                ["services:basket:0"] = "http://localhost:8080",
-                ["services:basket:1"] = "http://remotehost:9090",
+                ["services:basket:http:0"] = "http://localhost:8080",
+                ["services:basket:http:1"] = "http://remotehost:9090",
             }
         };
         var config = new ConfigurationBuilder().Add(configSource);
@@ -82,8 +148,31 @@ public class ConfigurationServiceEndPointResolverTests
             Assert.True(initialResult.ResolvedSuccessfully);
             Assert.Equal(ResolutionStatus.Success, initialResult.Status);
             Assert.Equal(2, initialResult.EndPoints.Count);
-            Assert.Equal(new DnsEndPoint("localhost", 8080), initialResult.EndPoints[0].EndPoint);
-            Assert.Equal(new DnsEndPoint("remotehost", 9090), initialResult.EndPoints[1].EndPoint);
+            Assert.Equal(new UriEndPoint(new Uri("http://localhost:8080")), initialResult.EndPoints[0].EndPoint);
+            Assert.Equal(new UriEndPoint(new Uri("http://remotehost:9090")), initialResult.EndPoints[1].EndPoint);
+
+            Assert.All(initialResult.EndPoints, ep =>
+            {
+                var hostNameFeature = ep.Features.Get<IHostNameFeature>();
+                Assert.NotNull(hostNameFeature);
+                Assert.Equal("basket", hostNameFeature.HostName);
+            });
+        }
+
+        // Request either https or http. Since there are only http endpoints, we should get only http endpoints back.
+        await using ((resolver = resolverFactory.CreateResolver("https+http://basket")).ConfigureAwait(false))
+        {
+            Assert.NotNull(resolver);
+            var tcs = new TaskCompletionSource<ServiceEndPointResolverResult>();
+            resolver.OnEndPointsUpdated = tcs.SetResult;
+            resolver.Start();
+            var initialResult = await tcs.Task.ConfigureAwait(false);
+            Assert.NotNull(initialResult);
+            Assert.True(initialResult.ResolvedSuccessfully);
+            Assert.Equal(ResolutionStatus.Success, initialResult.Status);
+            Assert.Equal(2, initialResult.EndPoints.Count);
+            Assert.Equal(new UriEndPoint(new Uri("http://localhost:8080")), initialResult.EndPoints[0].EndPoint);
+            Assert.Equal(new UriEndPoint(new Uri("http://remotehost:9090")), initialResult.EndPoints[1].EndPoint);
 
             Assert.All(initialResult.EndPoints, ep =>
             {
@@ -101,10 +190,12 @@ public class ConfigurationServiceEndPointResolverTests
         {
             InitialData = new Dictionary<string, string?>
             {
-                ["services:basket:0"] = "http://localhost:8080",
-                ["services:basket:1"] = "http://remotehost:9090",
-                ["services:basket:2"] = "http://_grpc.localhost:2222",
-                ["services:basket:3"] = "grpc://remotehost:2222",
+                ["services:basket:http:0"] = "http://localhost:8080",
+                ["services:basket:https:1"] = "https://remotehost:9090",
+                ["services:basket:grpc:0"] = "localhost:2222",
+                ["services:basket:grpc:1"] = "127.0.0.1:3333",
+                ["services:basket:grpc:2"] = "http://remotehost:4444",
+                ["services:basket:grpc:3"] = "https://remotehost:5555",
             }
         };
         var config = new ConfigurationBuilder().Add(configSource);
@@ -125,9 +216,60 @@ public class ConfigurationServiceEndPointResolverTests
             Assert.NotNull(initialResult);
             Assert.True(initialResult.ResolvedSuccessfully);
             Assert.Equal(ResolutionStatus.Success, initialResult.Status);
-            Assert.Equal(2, initialResult.EndPoints.Count);
+            Assert.Equal(3, initialResult.EndPoints.Count);
             Assert.Equal(new DnsEndPoint("localhost", 2222), initialResult.EndPoints[0].EndPoint);
-            Assert.Equal(new DnsEndPoint("remotehost", 2222), initialResult.EndPoints[1].EndPoint);
+            Assert.Equal(new IPEndPoint(IPAddress.Loopback, 3333), initialResult.EndPoints[1].EndPoint);
+            Assert.Equal(new UriEndPoint(new Uri("http://remotehost:4444")), initialResult.EndPoints[2].EndPoint);
+
+            Assert.All(initialResult.EndPoints, ep =>
+            {
+                var hostNameFeature = ep.Features.Get<IHostNameFeature>();
+                Assert.Null(hostNameFeature);
+            });
+        }
+    }
+
+    [Fact]
+    public async Task ResolveServiceEndPoint_Configuration_MultipleProtocols_WithSpecificationByConsumer()
+    {
+        var configSource = new MemoryConfigurationSource
+        {
+            InitialData = new Dictionary<string, string?>
+            {
+                ["services:basket:default:0"] = "http://localhost:8080",
+                ["services:basket:default:1"] = "remotehost:9090",
+                ["services:basket:grpc:0"] = "localhost:2222",
+                ["services:basket:grpc:1"] = "127.0.0.1:3333",
+                ["services:basket:grpc:2"] = "http://remotehost:4444",
+                ["services:basket:grpc:3"] = "https://remotehost:5555",
+            }
+        };
+        var config = new ConfigurationBuilder().Add(configSource);
+        var services = new ServiceCollection()
+            .AddSingleton<IConfiguration>(config.Build())
+            .AddServiceDiscoveryCore()
+            .AddConfigurationServiceEndPointResolver()
+            .BuildServiceProvider();
+        var resolverFactory = services.GetRequiredService<ServiceEndPointResolverFactory>();
+        ServiceEndPointWatcher resolver;
+        await using ((resolver = resolverFactory.CreateResolver("https+http://_grpc.basket")).ConfigureAwait(false))
+        {
+            Assert.NotNull(resolver);
+            var tcs = new TaskCompletionSource<ServiceEndPointResolverResult>();
+            resolver.OnEndPointsUpdated = tcs.SetResult;
+            resolver.Start();
+            var initialResult = await tcs.Task.ConfigureAwait(false);
+            Assert.NotNull(initialResult);
+            Assert.True(initialResult.ResolvedSuccessfully);
+            Assert.Equal(ResolutionStatus.Success, initialResult.Status);
+            Assert.Equal(3, initialResult.EndPoints.Count);
+
+            // These must be treated as HTTPS by the HttpClient middleware, but that is not the responsibility of the resolver.
+            Assert.Equal(new DnsEndPoint("localhost", 2222), initialResult.EndPoints[0].EndPoint);
+            Assert.Equal(new IPEndPoint(IPAddress.Loopback, 3333), initialResult.EndPoints[1].EndPoint);
+
+            // We expect the HTTPS endpoint back but not the HTTP one.
+            Assert.Equal(new UriEndPoint(new Uri("https://remotehost:5555")), initialResult.EndPoints[2].EndPoint);
 
             Assert.All(initialResult.EndPoints, ep =>
             {

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/PassThroughServiceEndPointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/PassThroughServiceEndPointResolverTests.cs
@@ -49,7 +49,7 @@ public class PassThroughServiceEndPointResolverTests
         {
             InitialData = new Dictionary<string, string?>
             {
-                ["services:basket:0"] = "http://localhost:8080",
+                ["services:basket:http:0"] = "http://localhost:8080",
             }
         };
         var config = new ConfigurationBuilder().Add(configSource);
@@ -72,7 +72,7 @@ public class PassThroughServiceEndPointResolverTests
 
             // We expect the basket service to be resolved from Configuration, not the pass-through provider.
             Assert.Single(initialResult.EndPoints);
-            Assert.Equal(new DnsEndPoint("localhost", 8080), initialResult.EndPoints[0].EndPoint);
+            Assert.Equal(new UriEndPoint(new Uri("http://localhost:8080")), initialResult.EndPoints[0].EndPoint);
         }
     }
 
@@ -83,7 +83,7 @@ public class PassThroughServiceEndPointResolverTests
         {
             InitialData = new Dictionary<string, string?>
             {
-                ["services:basket:0"] = "http://localhost:8080",
+                ["services:basket:default:0"] = "http://localhost:8080",
             }
         };
         var config = new ConfigurationBuilder().Add(configSource);
@@ -118,7 +118,7 @@ public class PassThroughServiceEndPointResolverTests
         {
             InitialData = new Dictionary<string, string?>
             {
-                ["services:basket:0"] = "http://localhost:8080",
+                ["services:basket:default:0"] = "http://localhost:8080",
             }
         };
         var config = new ConfigurationBuilder().Add(configSource);

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -37,9 +37,9 @@ public class TestProgram : IDisposable
 
         var serviceAPath = Path.Combine(Projects.TestProject_AppHost.ProjectPath, @"..\TestProject.ServiceA\TestProject.ServiceA.csproj");
 
-        ServiceABuilder = AppBuilder.AddProject("servicea", serviceAPath);
-        ServiceBBuilder = AppBuilder.AddProject<Projects.ServiceB>("serviceb");
-        ServiceCBuilder = AppBuilder.AddProject<Projects.ServiceC>("servicec");
+        ServiceABuilder = AppBuilder.AddProject("servicea", serviceAPath, launchProfileName: "http");
+        ServiceBBuilder = AppBuilder.AddProject<Projects.ServiceB>("serviceb", launchProfileName: "http");
+        ServiceCBuilder = AppBuilder.AddProject<Projects.ServiceC>("servicec", launchProfileName: "http");
         WorkerABuilder = AppBuilder.AddProject<Projects.WorkerA>("workera");
 
         if (includeNodeApp)

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -158,7 +158,7 @@ public class TestProgram : IDisposable
     public void Dispose() => App?.Dispose();
 
     /// <summary>
-    /// Writes the allocated endpoints to the console in JSON format.
+    /// Writes the allocatedEndpoint endpoints to the console in JSON format.
     /// This allows for easier consumption by the external test process.
     /// </summary>
     private sealed class EndPointWriterHook : IDistributedApplicationLifecycleHook
@@ -174,11 +174,19 @@ public class TestProgram : IDisposable
                 var endpointsJsonArray = new JsonArray();
                 projectJson["Endpoints"] = endpointsJsonArray;
 
-                foreach (var endpoint in project.Annotations.OfType<AllocatedEndpointAnnotation>())
+                foreach (var endpoint in project.Annotations.OfType<EndpointAnnotation>())
                 {
-                    var endpointJsonObject = new JsonObject();
-                    endpointJsonObject["Name"] = endpoint.Name;
-                    endpointJsonObject["Uri"] = endpoint.UriString;
+                    var allocatedEndpoint = endpoint.AllocatedEndpoint;
+                    if (allocatedEndpoint is null)
+                    {
+                        continue;
+                    }
+
+                    var endpointJsonObject = new JsonObject
+                    {
+                        ["Name"] = endpoint.Name,
+                        ["Uri"] = allocatedEndpoint.UriString
+                    };
                     endpointsJsonArray.Add(endpointJsonObject);
                 }
             }


### PR DESCRIPTION
This PR adds support in Service Discovery for specifying multiple schemes during resolution, separated by a `+` character. This allows developers to enforce HTTPS in production while falling back to HTTP during development and testing.
For example, a user can allow both HTTPS and HTTP like so:

```csharp
builder.Services.AddHttpClient<CatalogServiceClient>(
  c => c.BaseAddress = new("https+http://catalogservice"));
```

The order of schemes is important: if endpoints are found matching the first scheme, no endpoints from subsequent schemes are allowed.

This PR also introduces configuration to specify an allow-list of acceptable schemes for service discovery:

For example, to allow only `https://`:
```csharp
builder.Services.Configure<ServiceDiscoveryOptions>(options =>
{
    options.AllowedSchemes = ["https"];
});
```
To allow `http://` or `https://`:
```csharp
builder.Services.Configure<ServiceDiscoveryOptions>(options =>
{
    options.AllowedSchemes = ["https", "http"];
});
```
To allow any scheme (the default):
```csharp
builder.Services.Configure<ServiceDiscoveryOptions>(options =>
{
    options.AllowedSchemes = ServiceDiscoveryOptions.AllSchemes;
});
```

This PR changes the format of Service Discovery configuration so that the endpoint name is included in the configuration path, if an endpoint name is set. If no endpoint name is specified, then the scheme is used (and again, schemes are checked in the specified order, with only the first present being selected). If no endpoint name or scheme is specified, `"default"` is used as the endpoint name.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2719)