### PR TITLE
Update Pomelo to v8.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,7 +99,7 @@
     <PackageVersion Include="Polly" Version="8.3.0" />
     <PackageVersion Include="Polly.Core" Version="8.3.0" />
     <PackageVersion Include="Polly.Extensions" Version="8.3.0" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.0-beta.2" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.1" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.27" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/tests/testproject/TestProject.IntegrationServiceA/Program.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Program.cs
@@ -15,7 +15,16 @@ if (!resourcesToSkip.Contains(TestResourceNames.sqlserver))
 }
 if (!resourcesToSkip.Contains(TestResourceNames.mysql))
 {
-    builder.AddMySqlDataSource("mysqldb");
+    builder.AddMySqlDataSource("mysqldb", settings =>
+    {
+        // add the connection string options required by Pomelo EF Core MySQL
+        var connectionStringBuilder = new MySqlConnector.MySqlConnectionStringBuilder(settings.ConnectionString!)
+        {
+            AllowUserVariables = true,
+            UseAffectedRows = false,
+        };
+        settings.ConnectionString = connectionStringBuilder.ConnectionString;
+    });
     if (!resourcesToSkip.Contains(TestResourceNames.pomelo))
     {
         builder.AddMySqlDbContext<PomeloDbContext>("mysqldb", settings => settings.ServerVersion = "8.2.0-mysql");


### PR DESCRIPTION
Fixes #2690

This reflects connection string validation changes from https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/pull/1819.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2721)