### PR TITLE
Fix reading launchSettings.json with extra semicolon

### DIFF
--- a/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ProjectResourceBuilderExtensions.cs
@@ -114,7 +114,7 @@ public static class ProjectResourceBuilderExtensions
                 return builder;
             }
 
-            var urlsFromApplicationUrl = launchProfile.ApplicationUrl?.Split(';') ?? [];
+            var urlsFromApplicationUrl = launchProfile.ApplicationUrl?.Split(';', StringSplitOptions.RemoveEmptyEntries) ?? [];
             foreach (var url in urlsFromApplicationUrl)
             {
                 var uri = new Uri(url);

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -112,7 +112,7 @@ public class ProjectResourceTests
     }
 
     [Fact]
-    public void WithLaunchProfile_TrailingSemiColon()
+    public void WithLaunchProfile_ApplicationUrlTrailingSemiColon_Ignore()
     {
         var appBuilder = CreateBuilder(operation: DistributedApplicationOperation.Run);
 

--- a/tests/testproject/TestProject.ServiceA/Properties/launchSettings.json
+++ b/tests/testproject/TestProject.ServiceA/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -22,7 +22,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:7123;http://localhost:5156",
+      "applicationUrl": "https://localhost:7123;http://localhost:5156;",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
Bug I noticed while playing around with Aspire:

```
"applicationUrl": "https://localhost:7123/;http://localhost:5156/;",
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2725)