### PR TITLE
Display resource endpoints in an overflow for consistent line height

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -61,7 +61,7 @@
             @($"+{overflow.ItemsOverflow.Count()}")
         </FluentButton>
     </MoreButtonTemplate>
-    <OverflowTemplate Context="overflow" style="display:flex">
+    <OverflowTemplate Context="overflow">
         @{
             var items = overflow.ItemsOverflow.ToList();
         }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -33,22 +33,60 @@
     }
 }
 
-<ul class="endpoint-list">
-    @foreach (var displayedEndpoint in displayedEndpoints)
-    {
-        <li>
-            @if (displayedEndpoint.Url != null)
-            {
-                <a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Text</a>
-            }
-            else
-            {
-                @displayedEndpoint.Text
-            }
-        </li>
-    }
-    @if (!string.IsNullOrEmpty(additionalMessage))
-    {
-        <li>@additionalMessage</li>
-    }
-</ul>
+<FluentOverflow>
+    <ChildContent>
+        @for (var i = 0; i < displayedEndpoints.Count; i++)
+        {
+            var displayedEndpoint = displayedEndpoints[i];
+            var isLast = i == displayedEndpoints.Count - 1;
+
+            <FluentOverflowItem Data="displayedEndpoint">
+                @if (displayedEndpoint.Url != null)
+                {
+                    <a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Text</a>
+                }
+                else
+                {
+                    @displayedEndpoint.Text
+                }
+                @if (!isLast)
+                {
+                    <span>,</span>
+                }
+            </FluentOverflowItem>
+        }
+    </ChildContent>
+    <MoreButtonTemplate Context="overflow">
+        <FluentBadge>
+            @($"+{overflow.ItemsOverflow.Count()}")
+        </FluentBadge>
+    </MoreButtonTemplate>
+    <OverflowTemplate Context="overflow">
+        @{
+            var items = overflow.ItemsOverflow.ToList();
+        }
+        <FluentTooltip UseTooltipService="false" Anchor="@overflow.IdMoreButton">
+            <div style="max-height:400px; overflow-x:hidden; overflow-y: auto; padding:5px 10px;">
+                @foreach (var item in items)
+                {
+                    var d = (DisplayedEndpoint)item.Data!;
+                    <div style="margin-top: 8px; margin-bottom: 8px;">
+                        @if (d.Url != null)
+                        {
+                            <a href="@d.Url" target="_blank">@d.Text</a>
+                        }
+                        else
+                        {
+                            @d.Text
+                        }
+                    </div>
+                }
+            </div>
+        </FluentTooltip>
+    </OverflowTemplate>
+</FluentOverflow>
+
+@if (!string.IsNullOrEmpty(additionalMessage))
+{
+    <div>@additionalMessage</div>
+}

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -33,7 +33,7 @@
     }
 }
 
-<FluentOverflow>
+<FluentOverflow Style="overflow-x: visible;">
     <ChildContent>
         @for (var i = 0; i < displayedEndpoints.Count; i++)
         {
@@ -57,7 +57,7 @@
         }
     </ChildContent>
     <MoreButtonTemplate Context="overflow">
-        <FluentBadge>
+        <FluentBadge Appearance="Appearance.Accent" Style="pointer-events: none; user-select: none;">
             @($"+{overflow.ItemsOverflow.Count()}")
         </FluentBadge>
     </MoreButtonTemplate>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -33,7 +33,7 @@
     }
 }
 
-<FluentOverflow Style="overflow-x: visible;">
+<FluentOverflow Class="endpoint-overflow">
     <ChildContent>
         @for (var i = 0; i < displayedEndpoints.Count; i++)
         {
@@ -57,32 +57,37 @@
         }
     </ChildContent>
     <MoreButtonTemplate Context="overflow">
-        <FluentBadge Appearance="Appearance.Accent" Style="pointer-events: none; user-select: none;">
+        <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
             @($"+{overflow.ItemsOverflow.Count()}")
-        </FluentBadge>
+        </FluentButton>
     </MoreButtonTemplate>
-    <OverflowTemplate Context="overflow">
+    <OverflowTemplate Context="overflow" style="display:flex">
         @{
             var items = overflow.ItemsOverflow.ToList();
         }
-        <FluentTooltip UseTooltipService="false" Anchor="@overflow.IdMoreButton">
-            <div style="max-height:400px; overflow-x:hidden; overflow-y: auto; padding:5px 10px;">
-                @foreach (var item in items)
-                {
-                    var d = (DisplayedEndpoint)item.Data!;
-                    <div style="margin-top: 8px; margin-bottom: 8px;">
-                        @if (d.Url != null)
-                        {
-                            <a href="@d.Url" target="_blank">@d.Text</a>
-                        }
-                        else
-                        {
-                            @d.Text
-                        }
-                    </div>
-                }
-            </div>
-        </FluentTooltip>
+        <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200">
+            <Header>
+                Endpoints
+            </Header>
+            <Body>
+                <div style="max-height:400px; overflow-x:hidden; overflow-y: auto; padding:5px 10px;">
+                    @foreach (var item in items)
+                    {
+                        var d = (DisplayedEndpoint)item.Data!;
+                        <div style="margin-bottom: 4px;">
+                            @if (d.Url != null)
+                            {
+                                <a href="@d.Url" target="_blank">@d.Text</a>
+                            }
+                            else
+                            {
+                                @d.Text
+                            }
+                        </div>
+                    }
+                </div>
+            </Body>
+        </FluentPopover>
     </OverflowTemplate>
 </FluentOverflow>
 

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
@@ -17,6 +17,8 @@ public partial class EndpointsColumnDisplay
     [Inject]
     public required ILogger<EndpointsColumnDisplay> Logger { get; init; }
 
+    private bool _popoverVisible;
+
     /// <summary>
     /// A resource has services and endpoints. These can overlap. This method attempts to return a single list without duplicates.
     /// </summary>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -378,3 +378,21 @@ fluent-switch.table-switch::part(label) {
 fluent-data-grid-cell.no-ellipsis {
     text-overflow: unset !important;
 }
+
+.endpoint-overflow {
+    overflow-x: visible !important;
+}
+
+.endpoint-overflow .fluent-overflow-more {
+    display: flex;
+}
+
+.endpoint-button {
+    height: unset;
+    font-size: 12px;
+    line-height: 16px;
+}
+
+.endpoint-button::part(control) {
+    padding: 1px 3px;
+}

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -389,10 +389,10 @@ fluent-data-grid-cell.no-ellipsis {
 
 .endpoint-button {
     height: unset;
-    font-size: 12px;
-    line-height: 16px;
+    font-size: var(--type-ramp-minus-1-font-size);
+    line-height: var(--type-ramp-minus-1-line-height);
 }
 
 .endpoint-button::part(control) {
-    padding: 1px 3px;
+    padding: calc(((var(--design-unit) * 0.5) - var(--stroke-width)) * 1px) calc((var(--design-unit) - var(--stroke-width)) * 1px);
 }


### PR DESCRIPTION
I created a resource with many endpoints in the stress enviornment. A resource with many endpoints vertically streches the grid.

Changing display to an overflow allows the grid to show as many as there are room for and then an indicator + hover of additional endpoints.

Before with 30 endpoints:
![image](https://github.com/dotnet/aspire/assets/303201/599b44cf-3102-441e-bac6-87385d58ad81)

After with overflow:
![update-endpoints-more](https://github.com/dotnet/aspire/assets/303201/11afdcdc-31c7-41f5-bea5-955b574172a0)

This change allows the resource grid to be virtualized. See https://github.com/dotnet/aspire/pull/2706
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2726)