### PR TITLE
Fix initial resource display status

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -28,7 +28,7 @@ else if (Resource is { State: ResourceStates.StartingState })
 {
     <FluentIcon Icon="Icons.Filled.Size16.Circle"
                 Color="Color.Info"
-    Class="severity-icon"/>
+                Class="severity-icon"/>
 }
 else if (Resource is { State: /* pending */ null })
 {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -24,11 +24,17 @@
                     Class="severity-icon"/>
     }
 }
-else if (Resource is { State: ResourceStates.StartingState or /* pending */ null })
+else if (Resource is { State: ResourceStates.StartingState })
 {
     <FluentIcon Icon="Icons.Filled.Size16.Circle"
                 Color="Color.Info"
-                Class="severity-icon"/>
+    Class="severity-icon"/>
+}
+else if (Resource is { State: /* pending */ null })
+{
+    /* Show nothing while waiting for
+       the resource to be assigned a state.
+    */
 }
 else
 {
@@ -37,7 +43,7 @@ else
                 Class="severity-icon"/>
 }
 
-@Resource.State.Humanize()
+@(Resource.State?.Humanize() ?? "Pending")
 <UnreadLogErrorsBadge UnviewedErrorCounts="UnviewedErrorCounts" Resource="@Resource" />
 
 @code {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -30,11 +30,11 @@ else if (Resource is { State: ResourceStates.StartingState })
                 Color="Color.Info"
                 Class="severity-icon"/>
 }
-else if (Resource is { State: /* pending */ null })
+else if (Resource is { State: /* unknown */ null })
 {
-    /* Show nothing while waiting for
-       the resource to be assigned a state.
-    */
+    <FluentIcon Icon="Icons.Filled.Size16.Circle"
+                Color="Color.Neutral"
+                Class="severity-icon" />
 }
 else
 {
@@ -43,7 +43,8 @@ else
                 Class="severity-icon"/>
 }
 
-@(Resource.State?.Humanize() ?? "Pending")
+@(Resource.State?.Humanize() ?? "Unknown")
+
 <UnreadLogErrorsBadge UnviewedErrorCounts="UnviewedErrorCounts" Resource="@Resource" />
 
 @code {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -24,7 +24,7 @@
                     Class="severity-icon"/>
     }
 }
-else if (Resource is { State: ResourceStates.StartingState or /* about to start */ null })
+else if (Resource is { State: ResourceStates.StartingState or /* pending */ null })
 {
     <FluentIcon Icon="Icons.Filled.Size16.Circle"
                 Color="Color.Info"

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -24,7 +24,7 @@
                     Class="severity-icon"/>
     }
 }
-else if (Resource is { State: ResourceStates.StartingState })
+else if (Resource is { State: ResourceStates.StartingState or /* about to start */ null })
 {
     <FluentIcon Icon="Icons.Filled.Size16.Circle"
                 Color="Color.Info"


### PR DESCRIPTION
Fixes #2557  
When no status:
- Show no status icon
- Show text `Pending`
![resources_pending](https://github.com/dotnet/aspire/assets/17270481/06f0a873-ddc2-439b-94ae-e15b490c50d6)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2727)