### PR TITLE
Ignore ANSI when parsing URLs in logs

### DIFF
--- a/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
@@ -8,7 +8,7 @@ namespace Aspire.Dashboard.ConsoleLogs;
 
 public class AnsiParser
 {
-    public const char EscapeChar = '\x1B';
+    private const char EscapeChar = '\x1B';
     private const int ResetCode = 0;
     private const int IncreasedIntensityCode = 1;
     private const int NormalIntensityCode = 22;
@@ -133,7 +133,7 @@ public class AnsiParser
         }
     }
 
-    public static bool IsControlSequence(ReadOnlySpan<char> span, int position, out int parameter)
+    private static bool IsControlSequence(ReadOnlySpan<char> span, int position, out int parameter)
     {
         // If we're at \x1B[ and the span is at least long enough for a single digit parameter
         if (span[position] == EscapeChar && span.Length >= position + 4 && span[position + 1] == '[')

--- a/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
@@ -8,7 +8,7 @@ namespace Aspire.Dashboard.ConsoleLogs;
 
 public class AnsiParser
 {
-    private const char EscapeChar = '\x1B';
+    public const char EscapeChar = '\x1B';
     private const int ResetCode = 0;
     private const int IncreasedIntensityCode = 1;
     private const int NormalIntensityCode = 22;
@@ -133,7 +133,7 @@ public class AnsiParser
         }
     }
 
-    private static bool IsControlSequence(ReadOnlySpan<char> span, int position, out int parameter)
+    public static bool IsControlSequence(ReadOnlySpan<char> span, int position, out int parameter)
     {
         // If we're at \x1B[ and the span is at least long enough for a single digit parameter
         if (span[position] == EscapeChar && span.Length >= position + 4 && span[position + 1] == '[')

--- a/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
@@ -65,7 +65,7 @@ public static partial class UrlParser
         if (TryRemoveXmlTagsFromMatch(text, match.Index, out var noXmlTags, out var removedCharacterCount))
         {
             var noXmlTagsMatch = s_urlRegEx.Match(noXmlTags);
-            nextCharIndex = noXmlTagsMatch.Index + noXmlTagsMatch.Length + removedCharacterCount;
+            nextCharIndex = match.Index + noXmlTagsMatch.Length + removedCharacterCount;
             return noXmlTagsMatch.Value;
         }
         else
@@ -95,7 +95,6 @@ public static partial class UrlParser
             var tagEnd = text.IndexOf('>', nextTagStart);
             if (tagEnd < 0)
             {
-                index = text.Length - 1;
                 break;
             }
 
@@ -106,6 +105,7 @@ public static partial class UrlParser
         }
 
         sb.Append(text[index..]);
+
         modifiedText = sb.ToString();
         return true;
     }

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
@@ -58,4 +58,24 @@ public class UrlParserTests
 
         Assert.False(result);
     }
+
+    [Theory]
+    [InlineData("https://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m", "<a target=\"_blank\" href=\"https://localhost:5173\">https://localhost:5173</a>")]
+    [InlineData("http://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m", "<a target=\"_blank\" href=\"http://localhost:5173\">http://localhost:5173</a>")]
+    public void TryParse_IgnoreAnsiSequenceInUrl(string input, string? expectedOutput)
+    {
+        var result = UrlParser.TryParse(input, out var modifiedText);
+
+        Assert.True(result);
+        Assert.Equal(expectedOutput, modifiedText);
+    }
+
+    [Theory]
+    [InlineData("\u001b[94mhttp://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m")]
+    public void TryParse_UnsupportedAnsiAtStartOfUrl(string input)
+    {
+        var result = UrlParser.TryParse(input, out _);
+
+        Assert.False(result);
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
@@ -60,16 +60,14 @@ public class UrlParserTests
     }
 
     [Theory]
-    [InlineData("https://localhost\x1B[30m:\x1B[30m5173\x1B[30m\x1B[0m", "<a target=\"_blank\" href=\"https://localhost:5173\">https://localhost:5173</a>")]
-    [InlineData("http://localhost\x1B[30m:\x1B[30m5173\x1B[30m\x1B[0m", "<a target=\"_blank\" href=\"http://localhost:5173\">http://localhost:5173</a>")]
-    [InlineData("\u001b[30mSome data\x1B[0m: http://localhost\x1B[30m:\x1B[30m5173\x1B[30m\x1B[0m", "<span class=\"ansi-fg-black\">Some data</span>: <a target=\"_blank\" href=\"http://localhost:5173\">http://localhost:5173</a>")]
-    [InlineData("\x1B[32m→\x1b[0m\tLocal: http://localhost\x1B[34m:\x1B[36m5173\x1B[34m/\x1B[0m", "<span class=\"ansi-fg-green\">→</span>\tLocal: <a target=\"_blank\" href=\"http://localhost:5173/\">http://localhost:5173/</a>")]
-    public void TryParse_IgnoreAnsiSequenceInUrl(string input, string? expectedOutput)
+    [InlineData("http://<span>b</span>ing.com", "<a target=\"_blank\" href=\"http://bing.com\">http://<span>b</span>ing.com</a>")]
+    [InlineData("ht<span>tp</span>://<span>b</span>ing.com", "<a target=\"_blank\" href=\"http://bing.com\">ht<span>tp</span>://<span>b</span>ing.com</a>")]
+    [InlineData("http://<span class=\"url-host\">bing.com</span>:81", "<a target=\"_blank\" href=\"http://bing.com:81\">http://<span class=\"url-host\">bing.com</span>:81</a>")]
+    public void TryParse_IgnoresHtmlWhenMatching(string input, string output)
     {
-        var inputAsHtml = AnsiParser.ConvertToHtml(input).ConvertedText;
-        var result = UrlParser.TryParse(inputAsHtml, out var modifiedText);
+        var result = UrlParser.TryParse(input, out var modifiedHtml);
 
         Assert.True(result);
-        Assert.Equal(expectedOutput, modifiedText);
+        Assert.Equal(output, modifiedHtml);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
@@ -60,9 +60,10 @@ public class UrlParserTests
     }
 
     [Theory]
-    [InlineData("https://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m", "<a target=\"_blank\" href=\"https://localhost:5173\">https://localhost:5173</a>")]
-    [InlineData("http://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m", "<a target=\"_blank\" href=\"http://localhost:5173\">http://localhost:5173</a>")]
-    [InlineData("\u001b[94mhttp://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m", "<a target=\"_blank\" href=\"http://localhost:5173\">http://localhost:5173</a>")]
+    [InlineData("https://localhost\x1B[30m:\x1B[30m5173\x1B[30m\x1B[0m", "<a target=\"_blank\" href=\"https://localhost:5173\">https://localhost:5173</a>")]
+    [InlineData("http://localhost\x1B[30m:\x1B[30m5173\x1B[30m\x1B[0m", "<a target=\"_blank\" href=\"http://localhost:5173\">http://localhost:5173</a>")]
+    [InlineData("\u001b[30mSome data\x1B[0m: http://localhost\x1B[30m:\x1B[30m5173\x1B[30m\x1B[0m", "<span class=\"ansi-fg-black\">Some data</span>: <a target=\"_blank\" href=\"http://localhost:5173\">http://localhost:5173</a>")]
+    [InlineData("\x1B[32m→\x1b[0m\tLocal: http://localhost\x1B[34m:\x1B[36m5173\x1B[34m/\x1B[0m", "<span class=\"ansi-fg-green\">→</span>\tLocal: <a target=\"_blank\" href=\"http://localhost:5173/\">http://localhost:5173/</a>")]
     public void TryParse_IgnoreAnsiSequenceInUrl(string input, string? expectedOutput)
     {
         var inputAsHtml = AnsiParser.ConvertToHtml(input).ConvertedText;

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
@@ -63,6 +63,10 @@ public class UrlParserTests
     [InlineData("http://<span>b</span>ing.com", "<a target=\"_blank\" href=\"http://bing.com\">http://<span>b</span>ing.com</a>")]
     [InlineData("ht<span>tp</span>://<span>b</span>ing.com", "<a target=\"_blank\" href=\"http://bing.com\">ht<span>tp</span>://<span>b</span>ing.com</a>")]
     [InlineData("http://<span class=\"url-host\">bing.com</span>:81", "<a target=\"_blank\" href=\"http://bing.com:81\">http://<span class=\"url-host\">bing.com</span>:81</a>")]
+
+    // Known limitations that must be fixed before merge
+    [InlineData("<span>http</span>://bing.com:81", "<a target=\"_blank\" href=\"http://bing.com:81\"><span>http</span>://bing.com:81</a>")]
+    [InlineData("http://bing.com:<span>81</span>", "<a target=\"_blank\" href=\"http://bing.com:81\">http://bing.com:<span>81</span></a>")]
     public void TryParse_IgnoresHtmlWhenMatching(string input, string output)
     {
         var result = UrlParser.TryParse(input, out var modifiedHtml);

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
@@ -62,20 +62,13 @@ public class UrlParserTests
     [Theory]
     [InlineData("https://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m", "<a target=\"_blank\" href=\"https://localhost:5173\">https://localhost:5173</a>")]
     [InlineData("http://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m", "<a target=\"_blank\" href=\"http://localhost:5173\">http://localhost:5173</a>")]
+    [InlineData("\u001b[94mhttp://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m", "<a target=\"_blank\" href=\"http://localhost:5173\">http://localhost:5173</a>")]
     public void TryParse_IgnoreAnsiSequenceInUrl(string input, string? expectedOutput)
     {
-        var result = UrlParser.TryParse(input, out var modifiedText);
+        var inputAsHtml = AnsiParser.ConvertToHtml(input).ConvertedText;
+        var result = UrlParser.TryParse(inputAsHtml, out var modifiedText);
 
         Assert.True(result);
         Assert.Equal(expectedOutput, modifiedText);
-    }
-
-    [Theory]
-    [InlineData("\u001b[94mhttp://localhost\x1B[94m:\x1B[96m5173\x1B[94m\x1B[0m")]
-    public void TryParse_UnsupportedAnsiAtStartOfUrl(string input)
-    {
-        var result = UrlParser.TryParse(input, out _);
-
-        Assert.False(result);
     }
 }


### PR DESCRIPTION
# Ignore ANSI sequences when parsing URLs for logs.

- Fixes #1105 

_Fancy graphics I just learned how to make_
```mermaid
flowchart LR
    start[Start]
    seek[Find URL]
    contains_xml{Does URL <br/>contain XML?}
    parse_url[Parse URL]
    remove_xml[Remove XML<br/> in/after match]
    
    start --> seek
    seek--> contains_xml
    parse_url --> |Continue| seek
    contains_xml --> |No| parse_url
    contains_xml --> |Yes| remove_xml
   remove_xml --> parse_url
```

If the URL does **not** contain XML, then the code behaves as before.  
If the URL **does** contain XML, the XML after the match is removed and the string is checked again for a URL match at the same index. 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2736)