### PR TITLE
Follow up from password rework

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
@@ -83,7 +83,7 @@ public sealed class InputAnnotation : IResourceAnnotation
         var passwordInput = new InputAnnotation("password", secret: true);
         passwordInput.Default = new GenerateInputDefault
         {
-            MinLength = 22, // enough to give 128 bits of entropy
+            MinLength = 22, // enough to give 128 bits of entropy when using the default 67 possible characters. See remarks in PasswordGenerator.Generate
             Lower = lower,
             Upper = upper,
             Numeric = numeric,

--- a/src/Aspire.Hosting/Utils/PasswordGenerator.cs
+++ b/src/Aspire.Hosting/Utils/PasswordGenerator.cs
@@ -86,7 +86,12 @@ internal static class PasswordGenerator
 
         RandomNumberGenerator.Shuffle(chars);
 
-        return new string(chars);
+        var result = new string(chars);
+
+        // clear the buffer so the password isn't in memory in multiple places
+        chars.Clear();
+
+        return result;
     }
 
     private static void CheckMinZeroWhenDisabled(

--- a/src/Aspire.Hosting/Utils/PasswordGenerator.cs
+++ b/src/Aspire.Hosting/Utils/PasswordGenerator.cs
@@ -21,12 +21,44 @@ internal static class PasswordGenerator
     /// <summary>
     /// Creates a cryptographically random string.
     /// </summary>
+    /// <remarks>
+    /// The recommended minimum bits of entropy for a generated password is 128 bits.
+    ///
+    /// The general calculation of bits of entropy is:
+    ///
+    /// log base 2 (numberPossibleOutputs)
+    ///
+    /// This generator uses 23 upper case, 23 lower case (excludes i,l,o,I,L,O to prevent confusion),
+    /// 10 numeric, and 11 special characters. So a total of 67 possible characters.
+    /// 
+    /// When all character sets are enabled, the number of possible outputs is (67 ^ length).
+    /// The minimum password length for 128 bits of entropy is 22 characters: log base 2 (67 ^ 22).
+    ///
+    /// When character sets are disabled, it lowers the number of possible outputs and thus the bits of entropy.
+    ///
+    /// Using minLower, minUpper, minNumeric, and minSpecial also lowers the number of possible outputs and thus the bits of entropy.
+    /// 
+    /// A generalized lower-bound formula for the number of possible outputs is to consider a string of the form:
+    ///
+    /// {nonRequiredCharacters}{requiredCharacters}
+    ///
+    /// let a = minLower, b = minUpper, c = minNumeric, d = minSpecial
+    /// let x = length - (a + b + c + d)
+    ///
+    /// nonRequiredPossibilities = 67^x
+    /// requiredPossibilities = 23^a * 23^b * 10^c * 11^d * (a + b + c + d)! / (a! * b! * c! * d!)
+    /// 
+    /// lower-bound of total possibilities = nonRequiredPossibilities * requiredPossibilities
+    ///
+    /// Putting it all together, the lower-bound bits of entropy calculation is:
+    ///
+    /// log base 2 [67^x * 23^a * 23^b * 10^c * 11^d * (a + b + c + d)! / (a! * b! * c! * d!)]
+    /// </remarks>
     public static string Generate(int minLength,
         bool lower, bool upper, bool numeric, bool special,
         int minLower, int minUpper, int minNumeric, int minSpecial)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(minLength);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(minLength, 128);
         ArgumentOutOfRangeException.ThrowIfNegative(minLower);
         ArgumentOutOfRangeException.ThrowIfNegative(minUpper);
         ArgumentOutOfRangeException.ThrowIfNegative(minNumeric);
@@ -36,10 +68,10 @@ internal static class PasswordGenerator
         CheckMinZeroWhenDisabled(numeric, minNumeric);
         CheckMinZeroWhenDisabled(special, minSpecial);
 
-        var requiredMinLength = minLower + minUpper + minNumeric + minSpecial;
+        var requiredMinLength = checked(minLower + minUpper + minNumeric + minSpecial);
         var length = Math.Max(minLength, requiredMinLength);
 
-        Span<char> chars = stackalloc char[length];
+        Span<char> chars = length <= 128 ? stackalloc char[length] : new char[length];
 
         // fill the required characters first
         var currentChars = chars;

--- a/tests/Aspire.Hosting.Tests/Utils/PasswordGeneratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/PasswordGeneratorTests.cs
@@ -12,7 +12,6 @@ public class PasswordGeneratorTests
     public void ThrowsArgumentOutOfRangeException()
     {
         Assert.Throws<ArgumentOutOfRangeException>(() => Generate(-1, true, true, true, true, 0, 0, 0, 0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => Generate(129, true, true, true, true, 0, 0, 0, 0));
 
         Assert.Throws<ArgumentOutOfRangeException>(() => Generate(10, true, true, true, true, -1, 0, 0, 0));
         Assert.Throws<ArgumentOutOfRangeException>(() => Generate(10, true, true, true, true, 0, -1, 0, 0));
@@ -30,6 +29,12 @@ public class PasswordGeneratorTests
         Assert.Throws<ArgumentException>(() => Generate(10, true, true, true, false, 0, 0, 0, 1));
 
         Assert.Throws<ArgumentException>(() => Generate(10, false, false, false, false, 0, 0, 0, 0));
+    }
+
+    [Fact]
+    public void ThrowsOverflowException()
+    {
+        Assert.Throws<OverflowException>(() => Generate(10, true, true, true, true, int.MaxValue, 1, 0, 0));
     }
 
     [Theory]
@@ -114,5 +119,15 @@ public class PasswordGeneratorTests
         var password = Generate(7, true, true, true, true, 2, 2, 2, 2);
 
         Assert.Equal(8, password.Length);
+    }
+
+    [Fact]
+    public void WorksWithLargeLengths()
+    {
+        var password = Generate(1025, true, true, true, true, 0, 0, 0, 0);
+        Assert.Equal(1025, password.Length);
+
+        password = Generate(10, true, true, true, true, 1024, 1024, 1024, 1025);
+        Assert.Equal(4097, password.Length);
     }
 }


### PR DESCRIPTION
1. Fix an issue when the sum of minLower, minUpper is greater than 128, which circumvents the stackalloc length check.
2. Allow any length of password, don't limit to 128.
3. Add comments describing password recommendations and entropy calculation
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2740)