### PR TITLE
Write details of container volumes to the publishing manifest

### DIFF
--- a/playground/TestShop/AppHost/Properties/launchSettings.json
+++ b/playground/TestShop/AppHost/Properties/launchSettings.json
@@ -14,14 +14,11 @@
     },
     "generate-manifest": {
       "commandName": "Project",
-      "launchBrowser": true,
       "dotnetRunMessages": true,
       "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
-      "applicationUrl": "http://localhost:15888",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031"
+        "DOTNET_ENVIRONMENT": "Development"
       }
     }
   },


### PR DESCRIPTION
Writes container volume details to the manifest. Both named and anonymous volumes are supported. Bind mounts are not written out as they're intended to mount files/directories directly from the container host machine file system into a container which isn't suitable for deployed environments.

This leaves open the possibility of modeling volumes as separate resources in the future to enable shared volumes between different containers but that's out of scope for now (aka #1521).

Related to #1676

AZD issue: Azure/azure-dev#3515
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2742)