### PR TITLE
[workload-testing] Update testing nuget, and remove some workarounds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -22,10 +22,6 @@
     <add key="azure-sdk-for-net-dev" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <!-- used for installing test workloads for resolving aspire workload manifest -->
-    <packageSource key="nuget-local">
-      <package pattern="*Aspire*" />
-    </packageSource>
     <packageSource key="dotnet9-transport">
       <package pattern="*WorkloadBuildTasks*" />
     </packageSource>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -73,9 +73,9 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.WorkloadTesting.Internal" Version="9.0.0-preview.3.24151.4">
+    <Dependency Name="Microsoft.NET.Runtime.WorkloadTesting.Internal" Version="9.0.0-preview.3.24158.8">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>50d6e5d5ffd05dd4034cffd222ea610baedcc326</Sha>
+      <Sha>54d318d6da76e409d4e865220d9923283d55a06d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.OpenApi" Version="8.0.2">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,6 +45,6 @@
     <MicrosoftEntityFrameworkCoreDesignPackageVersion>8.0.2</MicrosoftEntityFrameworkCoreDesignPackageVersion>
     <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>8.0.2</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
     <MicrosoftEntityFrameworkCoreToolsPackageVersion>8.0.2</MicrosoftEntityFrameworkCoreToolsPackageVersion>
-    <MicrosoftNETRuntimeWorkloadTestingInternalVersion>9.0.0-preview.3.24151.4</MicrosoftNETRuntimeWorkloadTestingInternalVersion>
+    <MicrosoftNETRuntimeWorkloadTestingInternalVersion>9.0.0-preview.3.24158.8</MicrosoftNETRuntimeWorkloadTestingInternalVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.NET.Sdk.Aspire/Microsoft.NET.Sdk.Aspire.csproj
+++ b/src/Microsoft.NET.Sdk.Aspire/Microsoft.NET.Sdk.Aspire.csproj
@@ -5,16 +5,6 @@
   <PropertyGroup>
     <PackageId>$(PackageId).Manifest-$(DotNetAspireManifestVersionBand)</PackageId>
     <Description>.NET Aspire workload manifest</Description>
-
-    <!--
-      the workload testing targets from dotnet/runtime install the manifest nuget with nuget-restore, which fails
-      for this manifest package because PackageType='dotnetplatform'.
-
-      As a temporary workaround, set `PackageType=''` but only for Linux/CI or local runs
-      Because the official workload packages are generated on windows, they will not be
-      affected by this workaround
-    -->
-    <PackageType Condition="'$(ContinuousIntegrationBuild)' != 'true' or ('$(OS)' != 'Windows_NT' and '$(ArchiveTests)' == 'true')" />
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
+++ b/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
@@ -23,7 +23,7 @@
     <Compile Include="..\Shared\WorkloadTesting\*.cs" Link="WorkloadTestingCommon" />
 
     <None Include="..\testproject\**\*" Link="testassets\testproject\%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="$(PatchedNuGetConfigPath)" Link="testassets\testproject\nuget.config" CopyToOutputDirectory="PreserveNewest" />
+    <None Condition="'$(InstallWorkloadForTesting)' == 'true'" Include="$(PatchedNuGetConfigPath)" Link="testassets\testproject\nuget.config" CopyToOutputDirectory="PreserveNewest" />
     <None Include="$(RepoRoot)Directory.Packages.props" Link="testassets\testproject\Directory.Packages.repo.props" CopyToOutputDirectory="PreserveNewest" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/tests/Shared/Aspire.Workload.Testing.targets
+++ b/tests/Shared/Aspire.Workload.Testing.targets
@@ -79,7 +79,11 @@
 
   <!-- For test projects -->
 
-  <Target Name="_PatchNuGetConfigForBuildingTestProject" AfterTargets="GetCopyToOutputDirectoryItems" Inputs="$(TemplateNuGetConfigPath)" Outputs="$(PatchedNuGetConfigPath)">
+  <Target Name="_PatchNuGetConfigForBuildingTestProject"
+          AfterTargets="GetCopyToOutputDirectoryItems"
+          Condition="'$(InstallWorkloadForTesting)' == 'true'"
+          Inputs="$(TemplateNuGetConfigPath)"
+          Outputs="$(PatchedNuGetConfigPath)">
     <!-- %BUILT_NUGETS_PATH% is set when building the testproject -->
     <PatchNuGetConfig TemplateNuGetConfigPath="$(RepoRoot)NuGet.config"
                       LocalNuGetsPath="%BUILT_NUGETS_PATH%"

--- a/tests/Shared/Aspire.Workload.Testing.targets
+++ b/tests/Shared/Aspire.Workload.Testing.targets
@@ -5,7 +5,6 @@
 
     <!-- this will cause the output for `dotnet workload install` to be visible to the user -->
     <WorkloadInstallCommandOutputImportance>High</WorkloadInstallCommandOutputImportance>
-
     <NuGetConfigPackageSourceMappingsForWorkloadTesting>*Aspire*</NuGetConfigPackageSourceMappingsForWorkloadTesting>
 
     <_ShippingPackagesDir>$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'packages', $(Configuration), 'Shipping'))</_ShippingPackagesDir>

--- a/tests/Shared/Aspire.Workload.Testing.targets
+++ b/tests/Shared/Aspire.Workload.Testing.targets
@@ -3,6 +3,11 @@
     <GetWorkloadInputsDependsOn>_GetWorkloadsToInstall;$(GetWorkloadInputsDependsOn)</GetWorkloadInputsDependsOn>
     <GetNuGetsToBuildForWorkloadTestingDependsOn>_GetNuGetsToBuild;$(GetNuGetsToBuildForWorkloadTestingDependsOn)</GetNuGetsToBuildForWorkloadTestingDependsOn>
 
+    <!-- this will cause the output for `dotnet workload install` to be visible to the user -->
+    <WorkloadInstallCommandOutputImportance>High</WorkloadInstallCommandOutputImportance>
+
+    <NuGetConfigPackageSourceMappingsForWorkloadTesting>*Aspire*</NuGetConfigPackageSourceMappingsForWorkloadTesting>
+
     <_ShippingPackagesDir>$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'packages', $(Configuration), 'Shipping'))</_ShippingPackagesDir>
 
     <_GlobalJsonContent>$([System.IO.File]::ReadAllText('$(RepoRoot)global.json'))</_GlobalJsonContent>
@@ -72,69 +77,14 @@
     </ItemGroup>
   </Target>
 
-  <UsingTask TaskName="PrepareNuGetConfigForWorkloadTesting"
-      TaskFactory="RoslynCodeTaskFactory"
-      AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <TemplateNuGetConfigPath ParameterType="System.String" Required="true" />
-      <OutputFile ParameterType="System.String" Required="true" />
-      <AddBuiltNuGetSource ParameterType="System.Boolean" Required="false" />
-      <AddPackageSourceMapping ParameterType="System.Boolean" Required="false" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Xml.Linq" />
-      <Using Namespace="System.Xml.XPath" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-          if (!File.Exists(TemplateNuGetConfigPath))
-          {
-            Log.LogError($"Could not find nuget config template at '{TemplateNuGetConfigPath}' .");
-            return false;
-          }
-
-          XDocument doc = XDocument.Load(TemplateNuGetConfigPath);
-          if (AddBuiltNuGetSource)
-          {
-            string xpath = "/configuration/packageSources";
-            XElement packageSources = doc.XPathSelectElement(xpath);
-            if (packageSources is null)
-            {
-              Log.LogError($"Could not find {xpath} in {TemplateNuGetConfigPath}");
-              return false;
-            }
-            packageSources.LastNode.AddAfterSelf(
-              new XElement("add",
-                new XAttribute("key", "nuget-local"),
-                new XAttribute("value", "%BUILT_NUGETS_PATH%")));
-          }
-
-          if (AddPackageSourceMapping)
-          {
-            string mappingXpath = "/configuration/packageSourceMapping";
-            XElement packageSourceMapping = doc.XPathSelectElement(mappingXpath);
-            if (packageSourceMapping is null)
-            {
-              // if mapping has been removed completely then the task needs an update!
-              throw new InvalidOperationException($"Expected to find {mappingXpath} in {TemplateNuGetConfigPath}");
-            }
-
-            packageSourceMapping.FirstNode.AddBeforeSelf(
-              new XElement("packageSource",
-                new XAttribute("key", "nuget-local"),
-                new XElement("package", new XAttribute("pattern", "*Aspire*"))));
-          }
-          doc.Save(OutputFile);
-          Log.LogMessage(MessageImportance.Low, $"Generated patched nuget.config at {OutputFile}");
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
   <!-- For test projects -->
 
-  <Target Name="_PatchNuGetConfig" AfterTargets="GetCopyToOutputDirectoryItems" Inputs="$(TemplateNuGetConfigPath)" Outputs="$(PatchedNuGetConfigPath)">
-    <PrepareNuGetConfigForWorkloadTesting TemplateNuGetConfigPath="$(RepoRoot)NuGet.config" OutputFile="$(PatchedNuGetConfigPath)" AddBuiltNuGetSource="true" />
+  <Target Name="_PatchNuGetConfigForBuildingTestProject" AfterTargets="GetCopyToOutputDirectoryItems" Inputs="$(TemplateNuGetConfigPath)" Outputs="$(PatchedNuGetConfigPath)">
+    <!-- %BUILT_NUGETS_PATH% is set when building the testproject -->
+    <PatchNuGetConfig TemplateNuGetConfigPath="$(RepoRoot)NuGet.config"
+                      LocalNuGetsPath="%BUILT_NUGETS_PATH%"
+                      NuGetConfigPackageSourceMappings="$(NuGetConfigPackageSourceMappingsForWorkloadTesting)"
+                      OutputPath="$(PatchedNuGetConfigPath)" />
   </Target>
 
   <Target Name="_AddPackageVersionsForUseWithHelix" BeforeTargets="ZipTestArchive">


### PR DESCRIPTION
Contributes to e2e follow up work - https://github.com/dotnet/aspire/issues/2687 .

`Update Microsoft.NET.Runtime.WorkloadTesting.Internal to 9.0.0-preview.3.24158.8`

```
[workload-testing] Remove the hacks, and use the update task

  1. remove package source mapping from `nuget.config` as it gets added at
     build time now
  2. Manifest packages are installed with a `PackageDownload` instead of a
     `PackageReference`, thus it can work with
     `PackageType='dotnetplatform'` packages.
  3. Generating a patched nuget.config for building test projects can be
     done using a new `PatchNuGetConfig` task, and thus we can remove the
     inline task.
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2748)