### PR TITLE
Represent expressions made up of multiple properties of other resources.

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
@@ -26,21 +26,8 @@ public class AzureAppConfigurationResource(string name) :
     /// <summary>
     /// Gets the connection string for the Azure App Configuration resource.
     /// </summary>
-    /// <returns>The connection string for the Azure App Configuration resource.</returns>
-    public string? GetConnectionString() => Endpoint.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure App Configuration resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure App Configuration resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
+        => Endpoint.GetValueAsync(cancellationToken);
 }

--- a/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
@@ -26,23 +26,10 @@ public class AzureApplicationInsightsResource(string name) :
     /// <summary>
     /// Gets the connection string for the Azure Application Insights resource.
     /// </summary>
-    /// <returns>The connection string for the Azure Application Insights resource.</returns>
-    public string? GetConnectionString() => ConnectionString.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Application Insights resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Application Insights resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+        => ConnectionString.GetValueAsync(cancellationToken);
 
     // UseAzureMonitor is looks for this specific environment variable name.
     string IResourceWithConnectionString.ConnectionStringEnvironmentVariable => "APPLICATIONINSIGHTS_CONNECTION_STRING";

--- a/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
@@ -28,12 +28,6 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
     /// <summary>
     /// Gets the connection string for the Azure Blob Storage resource.
     /// </summary>
-    /// <returns>The connection string for the Azure Blob Storage resource.</returns>
-    public string? GetConnectionString() => Parent.GetBlobConnectionString();
-
-    /// <summary>
-    /// Gets the connection string for the Azure Blob Storage resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Blob Storage resource.</returns>
     public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
@@ -43,7 +37,7 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
             await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        return GetConnectionString();
+        return Parent.GetBlobConnectionString();
     }
 
     /// <summary>
@@ -79,12 +73,6 @@ public class AzureBlobStorageConstructResource(string name, AzureStorageConstruc
     /// <summary>
     /// Gets the connection string for the Azure Blob Storage resource.
     /// </summary>
-    /// <returns>The connection string for the Azure Blob Storage resource.</returns>
-    public string? GetConnectionString() => Parent.GetBlobConnectionString();
-
-    /// <summary>
-    /// Gets the connection string for the Azure Blob Storage resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Blob Storage resource.</returns>
     public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
@@ -94,7 +82,7 @@ public class AzureBlobStorageConstructResource(string name, AzureStorageConstruc
             await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        return GetConnectionString();
+        return Parent.GetBlobConnectionString();
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
@@ -43,28 +43,14 @@ public class AzureCosmosDBResource(string name) :
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string to use for this database.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
-    }
-
-    /// <summary>
-    /// Gets the connection string to use for this database.
-    /// </summary>
-    /// <returns>The connection string to use for this database.</returns>
-    public string? GetConnectionString()
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
         if (IsEmulator)
         {
-            return AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port);
+            return new(AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port));
         }
 
-        return ConnectionString.Value;
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 }
 
@@ -100,28 +86,14 @@ public class AzureCosmosDBConstructResource(string name, Action<ResourceModuleCo
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string to use for this database.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
-    }
-
-    /// <summary>
-    /// Gets the connection string to use for this database.
-    /// </summary>
-    /// <returns>The connection string to use for this database.</returns>
-    public string? GetConnectionString()
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
         if (IsEmulator)
         {
-            return AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port);
+            return new(AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port));
         }
 
-        return ConnectionString.Value;
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 }
 

--- a/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
@@ -26,22 +26,11 @@ public class AzureKeyVaultResource(string name) :
     /// <summary>
     /// Gets the connection string for the Azure Key Vault resource.
     /// </summary>
-    /// <returns>The connection string for the Azure Key Vault resource.</returns>
-    public string? GetConnectionString() => VaultUri.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Key Vault resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Key Vault resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return new(GetConnectionString());
+        return VaultUri.GetValueAsync(cancellationToken);
     }
 }
 
@@ -65,21 +54,10 @@ public class AzureKeyVaultConstructResource(string name, Action<ResourceModuleCo
     /// <summary>
     /// Gets the connection string for the Azure Key Vault resource.
     /// </summary>
-    /// <returns>The connection string for the Azure Key Vault resource.</returns>
-    public string? GetConnectionString() => VaultUri.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Key Vault resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Key Vault resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return new(GetConnectionString());
+        return VaultUri.GetValueAsync(cancellationToken);
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureOpenAIResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureOpenAIResource.cs
@@ -28,7 +28,8 @@ public class AzureOpenAIResource(string name) :
     /// Gets the connection string for the resource.
     /// </summary>
     /// <returns>The connection string for the resource.</returns>
-    public string? GetConnectionString() => ConnectionString.Value;
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
+        => ConnectionString.GetValueAsync(cancellationToken);
 
     /// <summary>
     /// Gets the list of deployments of the Azure OpenAI resource.

--- a/src/Aspire.Hosting.Azure/AzurePostgresResource.cs
+++ b/src/Aspire.Hosting.Azure/AzurePostgresResource.cs
@@ -26,22 +26,11 @@ public class AzurePostgresResource(PostgresServerResource innerResource) :
     /// <summary>
     /// Gets the connection string for the Azure Postgres Flexible Server.
     /// </summary>
-    /// <returns>The connection string.</returns>
-    public string? GetConnectionString() => ConnectionString.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Postgres Flexible Server.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -73,22 +62,11 @@ public class AzurePostgresConstructResource(PostgresServerResource innerResource
     /// <summary>
     /// Gets the connection string for the Azure Postgres Flexible Server.
     /// </summary>
-    /// <returns>The connection string.</returns>
-    public string? GetConnectionString() => ConnectionString.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Postgres Flexible Server.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
@@ -28,12 +28,6 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
     /// <summary>
     /// Gets the connection string for the Azure Queue Storage resource.
     ///</summary>
-    ///<returns> The connection string for the Azure Queue Storage resource.</returns>
-    public string? GetConnectionString() => Parent.GetQueueConnectionString();
-
-    /// <summary>
-    /// Gets the connection string for the Azure Queue Storage resource.
-    ///</summary>
     ///<param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     ///<returns> The connection string for the Azure Queue Storage resource.</returns>
     public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
@@ -43,7 +37,7 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
             await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        return GetConnectionString();
+        return Parent.GetQueueConnectionString();
     }
 
     internal void WriteToManifest(ManifestPublishingContext context)
@@ -73,12 +67,6 @@ public class AzureQueueStorageConstructResource(string name, AzureStorageConstru
     public string ConnectionStringExpression => Parent.QueueEndpoint.ValueExpression;
 
     /// <summary>
-    /// Gets the connection string for the Azure Queue Storage resource.
-    ///</summary>
-    ///<returns> The connection string for the Azure Queue Storage resource.</returns>
-    public string? GetConnectionString() => Parent.GetQueueConnectionString();
-
-    /// <summary>
     /// Gets the connection string for the Azure Blob Storage resource.
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
@@ -90,7 +78,7 @@ public class AzureQueueStorageConstructResource(string name, AzureStorageConstru
             await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        return GetConnectionString();
+        return Parent.GetQueueConnectionString();
     }
 
     internal void WriteToManifest(ManifestPublishingContext context)

--- a/src/Aspire.Hosting.Azure/AzureRedisResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureRedisResource.cs
@@ -26,22 +26,11 @@ public class AzureRedisResource(RedisResource innerResource) :
     /// <summary>
     /// Gets the connection string for the Azure Redis resource.
     /// </summary>
-    /// <returns>The connection string for the Azure Redis resource.</returns>
-    public string? GetConnectionString() => ConnectionString.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Redis resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Redis resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -73,22 +62,11 @@ public class AzureRedisConstructResource(RedisResource innerResource, Action<Res
     /// <summary>
     /// Gets the connection string for the Azure Redis resource.
     /// </summary>
-    /// <returns>The connection string for the Azure Redis resource.</returns>
-    public string? GetConnectionString() => ConnectionString.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Redis resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Redis resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting.Azure/AzureSearchResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureSearchResource.cs
@@ -26,22 +26,11 @@ public class AzureSearchResource(string name) :
     /// <summary>
     /// Gets the connection string for the azure search resource.
     /// </summary>
-    /// <returns>The connection string for the resource.</returns>
-    public string? GetConnectionString() => ConnectionString.Value;
-
-    /// <summary>
-    /// Gets the connection string for the azure search resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 }
 

--- a/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
@@ -30,22 +30,11 @@ public class AzureServiceBusResource(string name) :
     /// <summary>
     /// Gets the connection string for the Azure Service Bus endpoint.
     /// </summary>
-    /// <returns>The connection string for the Azure Service Bus endpoint.</returns>
-    public string? GetConnectionString() => ServiceBusEndpoint.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Service Bus endpoint.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Service Bus endpoint.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ServiceBusEndpoint.GetValueAsync(cancellationToken);
     }
 }
 
@@ -74,21 +63,10 @@ public class AzureServiceBusConstructResource(string name, Action<ResourceModule
     /// <summary>
     /// Gets the connection string for the Azure Service Bus endpoint.
     /// </summary>
-    /// <returns>The connection string for the Azure Service Bus endpoint.</returns>
-    public string? GetConnectionString() => ServiceBusEndpoint.Value;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Service Bus endpoint.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Service Bus endpoint.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ServiceBusEndpoint.GetValueAsync(cancellationToken);
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureSignalRResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureSignalRResource.cs
@@ -18,29 +18,21 @@ public class AzureSignalRResource(string name) :
     /// </summary>
     public BicepOutputReference HostName => new("hostName", this);
 
+    private ReferenceExpression ConnectionString
+        => ReferenceExpression.Create($"Endpoint=https://{HostName};AuthType=azure");
+
     /// <summary>
     /// Gets the connection string template for the manifest for Azure SignalR.
     /// </summary>
-    public string ConnectionStringExpression => $"Endpoint=https://{HostName.ValueExpression};AuthType=azure";
-
-    /// <summary>
-    /// Gets the connection string for Azure SignalR.
-    /// </summary>
-    /// <returns>The connection string for Azure SignalR.</returns>
-    public string? GetConnectionString() => $"Endpoint=https://{HostName.Value};AuthType=azure";
+    public string ConnectionStringExpression => ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for Azure SignalR.
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for Azure SignalR.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureSqlServerResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureSqlServerResource.cs
@@ -18,34 +18,24 @@ public class AzureSqlServerResource(SqlServerServerResource innerResource) :
     /// </summary>
     public BicepOutputReference FullyQualifiedDomainName => new("sqlServerFqdn", this);
 
+    private ReferenceExpression ConnectionString =>
+        ReferenceExpression.Create(
+            $"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
+
     /// <summary>
     /// Gets the connection template for the manifest for the Azure SQL Server resource.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"Server=tcp:{FullyQualifiedDomainName.ValueExpression},1433;Encrypt=True;Authentication=\"Active Directory Default\"";
-
-    /// <summary>
-    /// Gets the connection string for the Azure SQL Server resource.
-    /// </summary>
-    /// <returns>The connection string for the Azure SQL Server resource.</returns>
-    public string? GetConnectionString()
-    {
-        return $"Server=tcp:{FullyQualifiedDomainName.Value},1433;Encrypt=True;Authentication=\"Active Directory Default\"";
-    }
+        ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure SQL Server resource.
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure SQL Server resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -67,34 +57,24 @@ public class AzureSqlServerConstructResource(SqlServerServerResource innerResour
     /// </summary>
     public BicepOutputReference FullyQualifiedDomainName => new("sqlServerFqdn", this);
 
+    private ReferenceExpression ConnectionString =>
+        ReferenceExpression.Create(
+            $"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
+
     /// <summary>
     /// Gets the connection template for the manifest for the Azure SQL Server resource.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"Server=tcp:{FullyQualifiedDomainName.ValueExpression},1433;Encrypt=True;Authentication=\"Active Directory Default\"";
-
-    /// <summary>
-    /// Gets the connection string for the Azure SQL Server resource.
-    /// </summary>
-    /// <returns>The connection string for the Azure SQL Server resource.</returns>
-    public string? GetConnectionString()
-    {
-        return $"Server=tcp:{FullyQualifiedDomainName.Value},1433;Encrypt=True;Authentication=\"Active Directory Default\"";
-    }
+        ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Azure SQL Server resource.
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure SQL Server resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
-        if (ProvisioningTaskCompletionSource is not null)
-        {
-            await ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return GetConnectionString();
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
@@ -28,12 +28,6 @@ public class AzureTableStorageResource(string name, AzureStorageResource storage
     /// <summary>
     /// Gets the connection string for the Azure Table Storage resource.
     /// </summary>
-    /// <returns>The connection string for the Azure Table Storage resource.</returns>
-    public string? GetConnectionString() => Parent.GetTableConnectionString();
-
-    /// <summary>
-    /// Gets the connection string for the Azure Table Storage resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the Azure Table Storage resource.</returns>
     public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
@@ -43,7 +37,7 @@ public class AzureTableStorageResource(string name, AzureStorageResource storage
             await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        return GetConnectionString();
+        return Parent.GetTableConnectionString();
     }
 
     internal void WriteToManifest(ManifestPublishingContext context)
@@ -73,12 +67,6 @@ public class AzureTableStorageConstructResource(string name, AzureStorageConstru
     public string ConnectionStringExpression => Parent.TableEndpoint.ValueExpression;
 
     /// <summary>
-    /// Gets the connection string for the Azure Table Storage resource.
-    /// </summary>
-    /// <returns>The connection string for the Azure Table Storage resource.</returns>
-    public string? GetConnectionString() => Parent.GetTableConnectionString();
-
-    /// <summary>
     /// Gets the connection string for the Azure Blob Storage resource.
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
@@ -90,7 +78,7 @@ public class AzureTableStorageConstructResource(string name, AzureStorageConstru
             await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        return GetConnectionString();
+        return Parent.GetTableConnectionString();
     }
 
     internal void WriteToManifest(ManifestPublishingContext context)

--- a/src/Aspire.Hosting.Testing/DistributedApplicationExtensions.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationExtensions.cs
@@ -32,9 +32,10 @@ public static class DistributedApplicationExtensions
     /// </summary>
     /// <param name="app">The application.</param>
     /// <param name="resourceName">The resource name.</param>
+    /// <param name="cancellationToken"> The cancellationToken to observe while waiting for the task to complete.</param>
     /// <returns>The connection string for the specified resource.</returns>
     /// <exception cref="ArgumentException">The resource was not found or does not expose a connection string.</exception>
-    public static string? GetConnectionString(this DistributedApplication app, string resourceName)
+    public static ValueTask<string?> GetConnectionStringAsync(this DistributedApplication app, string resourceName, CancellationToken cancellationToken = default)
     {
         var resource = GetResource(app, resourceName);
         if (resource is not IResourceWithConnectionString resourceWithConnectionString)
@@ -42,7 +43,7 @@ public static class DistributedApplicationExtensions
             throw new ArgumentException($"Resource '{resourceName}' does not expose a connection string.", nameof(resourceName));
         }
 
-        return resourceWithConnectionString.GetConnectionString();
+        return resourceWithConnectionString.GetConnectionStringAsync(cancellationToken);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactoryOfT.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactoryOfT.cs
@@ -72,9 +72,9 @@ public class DistributedApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     /// <param name="resourceName">The resource name.</param>
     /// <returns>The connection string for the specified resource.</returns>
     /// <exception cref="ArgumentException">The resource was not found or does not expose a connection string.</exception>
-    public string? GetConnectionString(string resourceName)
+    public ValueTask<string?> GetConnectionString(string resourceName)
     {
-        return GetStartedApplication().GetConnectionString(resourceName);
+        return GetStartedApplication().GetConnectionStringAsync(resourceName);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
@@ -16,8 +16,9 @@ public class AllocatedEndpoint
     /// </summary>
     /// <param name="endpoint">The endpoint.</param>
     /// <param name="address">The IP address of the endpoint.</param>
+    /// <param name="containerHostAddress">The address of the container host.</param>
     /// <param name="port">The port number of the endpoint.</param>
-    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port)
+    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port, string containerHostAddress = "host.docker.internal")
     {
         ArgumentNullException.ThrowIfNull(endpoint);
         ArgumentOutOfRangeException.ThrowIfLessThan(port, 1, nameof(port));
@@ -25,6 +26,7 @@ public class AllocatedEndpoint
 
         Endpoint = endpoint;
         Address = address;
+        ContainerHostAddress = containerHostAddress;
         Port = port;
     }
 
@@ -37,6 +39,11 @@ public class AllocatedEndpoint
     /// The address of the endpoint
     /// </summary>
     public string Address { get; private set; }
+
+    /// <summary>
+    /// The address of the container host.
+    /// </summary>
+    public string ContainerHostAddress { get; private set; }
 
     /// <summary>
     /// The port used by the endpoint

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
@@ -11,15 +11,9 @@ public interface IResourceWithConnectionString : IResource, IManifestExpressionP
     /// <summary>
     /// Gets the connection string associated with the resource.
     /// </summary>
-    /// <returns>The connection string associated with the resource, when one is available.</returns>
-    public string? GetConnectionString();
-
-    /// <summary>
-    /// Gets the connection string associated with the resource.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string associated with the resource, when one is available.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default) => new(GetConnectionString());
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default);
 
     string IManifestExpressionProvider.ValueExpression => ConnectionStringReferenceExpression;
 

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents an expression that might be made up of multiple resource properties. For example,
+/// a connection string might be made up of a host, port, and password from different endpoints.
+/// </summary>
+public class ReferenceExpression : IValueProvider, IManifestExpressionProvider
+{
+    private readonly string[] _manifestExpressions;
+
+    private ReferenceExpression(string format, IValueProvider[] valueProviders, string[] manifestExpressions)
+    {
+        Format = format;
+        ValueProviders = valueProviders;
+        _manifestExpressions = manifestExpressions;
+    }
+
+    /// <summary>
+    /// The format string for this expression.
+    /// </summary>
+    public string Format { get; }
+
+    /// <summary>
+    /// The manifest expressions for the parameters for the format string.
+    /// </summary>
+    public IReadOnlyList<string> ManifestExpressions => _manifestExpressions;
+
+    /// <summary>
+    /// The list of <see cref="IValueProvider"/> that will be used to resolve parameters for the format string.
+    /// </summary>
+    public IReadOnlyList<IValueProvider> ValueProviders { get; }
+
+    /// <summary>
+    /// The value expression for the format string.
+    /// </summary>
+    public string ValueExpression =>
+        string.Format(CultureInfo.InvariantCulture, Format, _manifestExpressions);
+
+    /// <summary>
+    /// Gets the value of the expression. The final string value after evaluating the format string and its parameters.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
+    {
+        var args = new object?[ValueProviders.Count];
+        for (var i = 0; i < ValueProviders.Count; i++)
+        {
+            args[i] = await ValueProviders[i].GetValueAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return string.Format(CultureInfo.InvariantCulture, Format, args);
+    }
+
+    internal static ReferenceExpression Create(string format, IValueProvider[] valueProviders, string[] manifestExpressions)
+    {
+        return new(format, valueProviders, manifestExpressions);
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ReferenceExpression"/> with the specified format and value providers.
+    /// </summary>
+    /// <param name="handler">The handler that contains the format and value providers.</param>
+    /// <returns>A new instance of <see cref="ReferenceExpression"/> with the specified format and value providers.</returns>
+    public static ReferenceExpression Create(in ExpressionInterpolatedStringHandler handler)
+    {
+        return handler.GetExpression();
+    }
+}
+
+/// <summary>
+/// Represents a handler for interpolated strings that contain expressions. Those expressions will either be literal strings or
+/// instances of types that implement both <see cref="IValueProvider"/> and <see cref="IManifestExpressionProvider"/>.
+/// </summary>
+/// <param name="literalLength">The length of the literal part of the interpolated string.</param>
+/// <param name="formattedCount">The number of formatted parts in the interpolated string.</param>
+[InterpolatedStringHandler]
+public ref struct ExpressionInterpolatedStringHandler(int literalLength, int formattedCount)
+{
+    private readonly StringBuilder _builder = new(literalLength * 2);
+    private readonly List<IValueProvider> _valueProviders = new(formattedCount);
+    private readonly List<string> _manifestExpressions = new(formattedCount);
+
+    /// <summary>
+    /// Appends a literal value to the expression.
+    /// </summary>
+    /// <param name="value"></param>
+    public readonly void AppendLiteral(string value)
+    {
+        _builder.Append(value);
+    }
+
+    /// <summary>
+    /// Appends a formatted value to the expression.
+    /// </summary>
+    /// <param name="value"></param>
+    public readonly void AppendFormatted(string value)
+    {
+        _builder.Append(value);
+    }
+
+    /// <summary>
+    /// Appends a formatted value to the expression. The value must implement <see cref="IValueProvider"/> and <see cref="IManifestExpressionProvider"/>.
+    /// </summary>
+    /// <param name="valueProvider"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    public void AppendFormatted<T>(T valueProvider) where T : IValueProvider, IManifestExpressionProvider
+    {
+        var index = _valueProviders.Count;
+        _builder.Append(CultureInfo.InvariantCulture, $"{{{index}}}");
+
+        _valueProviders.Add(valueProvider);
+        _manifestExpressions.Add(valueProvider.ValueExpression);
+    }
+
+    internal readonly ReferenceExpression GetExpression() =>
+        ReferenceExpression.Create(_builder.ToString(), [.. _valueProviders], [.. _manifestExpressions]);
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
@@ -9,9 +9,9 @@ internal sealed class ResourceWithConnectionStringSurrogate(IResource innerResou
 
     public ResourceAnnotationCollection Annotations => innerResource.Annotations;
 
-    public string? GetConnectionString()
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
     {
-        return callback();
+        return new(callback());
     }
 
     public string? ConnectionStringEnvironmentVariable => environmentVariableName;

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -290,8 +290,10 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         await Task.WhenAll(containersTask, executablesTask).ConfigureAwait(false);
     }
 
-    private static void AddAllocatedEndpointInfo(IEnumerable<AppResource> resources)
+    private void AddAllocatedEndpointInfo(IEnumerable<AppResource> resources)
     {
+        var containerHost = HostNameResolver.ReplaceLocalhostWithContainerHost("localhost", configuration);
+
         foreach (var appResource in resources)
         {
             foreach (var sp in appResource.ServicesProduced)
@@ -312,7 +314,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 sp.EndpointAnnotation.AllocatedEndpoint = new AllocatedEndpoint(
                     sp.EndpointAnnotation,
                     sp.EndpointAnnotation.IsProxied ? svc.AllocatedAddress! : "localhost",
-                    (int)svc.AllocatedPort!);
+                    (int)svc.AllocatedPort!,
+                    containerHostAddress: containerHost);
             }
         }
     }

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -33,6 +33,25 @@ public static class ResourceBuilderExtensions
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">The resource builder.</param>
     /// <param name="name">The name of the environment variable.</param>
+    /// <param name="value">The value of the environment variable.</param>
+    /// <returns>A resource configured with the specified environment variable.</returns>
+    public static IResourceBuilder<T> WithEnvironment<T>(this IResourceBuilder<T> builder, string name, in ExpressionInterpolatedStringHandler value)
+        where T : IResourceWithEnvironment
+    {
+        var expression = value.GetExpression();
+
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[name] = expression;
+        });
+    }
+
+    /// <summary>
+    /// Adds an environment variable to the resource.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="name">The name of the environment variable.</param>
     /// <param name="callback">A callback that allows for deferred execution of a specific environment variable. This runs after resources have been allocated by the orchestrator and allows access to other resources to resolve computed data, e.g. connection strings, ports.</param>
     /// <returns>A resource configured with the specified environment variable.</returns>
     public static IResourceBuilder<T> WithEnvironment<T>(this IResourceBuilder<T> builder, string name, Func<string> callback) where T : IResourceWithEnvironment
@@ -161,7 +180,7 @@ public static class ResourceBuilderExtensions
     /// The format of the environment variable will be "ConnectionStrings__{sourceResourceName}={connectionString}."
     /// <para>
     /// Each resource defines the format of the connection string value. The
-    /// underlying connection string value can be retrieved using <see cref="IResourceWithConnectionString.GetConnectionString"/>.
+    /// underlying connection string value can be retrieved using <see cref="IResourceWithConnectionString.GetConnectionStringAsync(CancellationToken)"/>.
     /// </para>
     /// <para>
     /// Connection strings are also resolved by the configuration system (appSettings.json in the AppHost project, or environment variables). If a connection string is not found on the resource, the configuration system will be queried for a connection string

--- a/src/Aspire.Hosting/Kafka/KafkaServerResource.cs
+++ b/src/Aspire.Hosting/Kafka/KafkaServerResource.cs
@@ -20,18 +20,20 @@ public class KafkaServerResource(string name) : ContainerResource(name), IResour
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
+    private ReferenceExpression ConnectionString =>
+        ReferenceExpression.Create(
+            $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
+
     /// <summary>
     /// Gets the connection string expression for Kafka broker for the manifest.
     /// </summary>
     public string ConnectionStringExpression =>
-       $"{PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)}";
+       ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for Kafka broker.
     /// </summary>
     /// <returns>A connection string for the Kafka in the form "host:port" to be passed as <see href="https://docs.confluent.io/platform/current/clients/confluent-kafka-dotnet/_site/api/Confluent.Kafka.ClientConfig.html#Confluent_Kafka_ClientConfig_BootstrapServers">BootstrapServers</see>.</returns>
-    public string? GetConnectionString()
-    {
-        return $"{PrimaryEndpoint.Host}:{PrimaryEndpoint.Port}";
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
+        ConnectionString.GetValueAsync(cancellationToken);
 }

--- a/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBBuilderExtensions.cs
@@ -75,7 +75,7 @@ public static class MongoDBBuilderExtensions
 
     private static void ConfigureMongoExpressContainer(EnvironmentCallbackContext context, MongoDBServerResource resource)
     {
-        context.EnvironmentVariables.Add("ME_CONFIG_MONGODB_URL", $"mongodb://host.docker.internal:{resource.PrimaryEndpoint.Port}/?directConnection=true");
+        context.EnvironmentVariables.Add("ME_CONFIG_MONGODB_URL", $"mongodb://{resource.PrimaryEndpoint.ContainerHost}:{resource.PrimaryEndpoint.Port}/?directConnection=true");
         context.EnvironmentVariables.Add("ME_CONFIG_BASICAUTH", "false");
     }
 }

--- a/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
@@ -28,9 +28,9 @@ public class MongoDBDatabaseResource(string name, string databaseName, MongoDBSe
     /// Gets the connection string for the MongoDB database.
     /// </summary>
     /// <returns>A connection string for the MongoDB database.</returns>
-    public string? GetConnectionString()
+    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
     {
-        if (Parent.GetConnectionString() is { } connectionString)
+        if (await Parent.GetConnectionStringAsync(cancellationToken).ConfigureAwait(false) is { } connectionString)
         {
             return connectionString.EndsWith('/') ?
                 $"{connectionString}{DatabaseName}" :

--- a/src/Aspire.Hosting/MongoDB/MongoDBServerResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBServerResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.MongoDB;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -20,23 +18,23 @@ public class MongoDBServerResource(string name) : ContainerResource(name), IReso
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
-    /// <summary>
-    /// Gets the connection string for the MongoDB server.
-    /// </summary>
-    public string ConnectionStringExpression =>
-        $"mongodb://{PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)}";
+    private ReferenceExpression ConnectionString =>
+        ReferenceExpression.Create(
+            $"mongodb://{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
 
     /// <summary>
     /// Gets the connection string for the MongoDB server.
     /// </summary>
+    public string ConnectionStringExpression =>
+        ConnectionString.ValueExpression;
+
+    /// <summary>
+    /// Gets the connection string for the MongoDB server.
+    /// </summary>
+    /// <param name="cancellationToken"> Cancellation token. </param>
     /// <returns>A connection string for the MongoDB server in the form "mongodb://host:port".</returns>
-    public string? GetConnectionString()
-    {
-        return new MongoDBConnectionStringBuilder()
-            .WithServer(PrimaryEndpoint.Host)
-            .WithPort(PrimaryEndpoint.Port)
-            .Build();
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
+        ConnectionString.GetValueAsync(cancellationToken);
 
     private readonly Dictionary<string, string> _databases = new Dictionary<string, string>(StringComparers.ResourceName);
 

--- a/src/Aspire.Hosting/MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlDatabaseResource.cs
@@ -28,9 +28,9 @@ public class MySqlDatabaseResource(string name, string databaseName, MySqlServer
     /// Gets the connection string for the MySQL database.
     /// </summary>
     /// <returns>A connection string for the MySQL database.</returns>
-    public string? GetConnectionString()
+    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
     {
-        if (Parent.GetConnectionString() is { } connectionString)
+        if (await Parent.GetConnectionStringAsync(cancellationToken).ConfigureAwait(false) is { } connectionString)
         {
             return $"{connectionString};Database={DatabaseName}";
         }

--- a/src/Aspire.Hosting/MySql/MySqlServerResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlServerResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Utils;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -37,20 +35,23 @@ public class MySqlServerResource : ContainerResource, IResourceWithConnectionStr
     /// </summary>
     public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
 
+    private ReferenceExpression ConnectionString =>
+        ReferenceExpression.Create(
+            $"Server={PrimaryEndpoint.Property(EndpointProperty.Host)};Port={PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=root;Password={PasswordInput}");
+
     /// <summary>
     /// Gets the connection string expression for the MySQL server.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"Server={PrimaryEndpoint.GetExpression(EndpointProperty.Host)};Port={PrimaryEndpoint.GetExpression(EndpointProperty.Port)};User ID=root;Password={PasswordInput.ValueExpression}";
+        ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the MySQL server.
     /// </summary>
-    /// <returns>A connection string for the MySQL server in the form "Server=host;Port=port;User ID=root;Password=password".</returns>
-    public string? GetConnectionString()
-    {
-        return $"Server={PrimaryEndpoint.Host};Port={PrimaryEndpoint.Port};User ID=root;Password=\"{PasswordUtil.EscapePassword(Password)}\"";
-    }
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
+        ConnectionString.GetValueAsync(cancellationToken);
 
     private readonly Dictionary<string, string> _databases = new Dictionary<string, string>(StringComparers.ResourceName);
 

--- a/src/Aspire.Hosting/MySql/PhpMyAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting/MySql/PhpMyAdminConfigWriterHook.cs
@@ -34,7 +34,7 @@ internal class PhpMyAdminConfigWriterHook : IDistributedApplicationLifecycleHook
                 var endpoint = singleInstance.PrimaryEndpoint;
                 myAdminResource.Annotations.Add(new EnvironmentCallbackAnnotation((EnvironmentCallbackContext context) =>
                 {
-                    context.EnvironmentVariables.Add("PMA_HOST", $"host.docker.internal:{endpoint.Port}");
+                    context.EnvironmentVariables.Add("PMA_HOST", $"{endpoint.ContainerHost}:{endpoint.Port}");
                     context.EnvironmentVariables.Add("PMA_USER", "root");
                     context.EnvironmentVariables.Add("PMA_PASSWORD", singleInstance.Password);
                 }));
@@ -55,7 +55,7 @@ internal class PhpMyAdminConfigWriterHook : IDistributedApplicationLifecycleHook
                 {
                     var endpoint = mySqlInstance.PrimaryEndpoint;
                     writer.WriteLine("$i++;");
-                    writer.WriteLine($"$cfg['Servers'][$i]['host'] = 'host.docker.internal:{endpoint.Port}';");
+                    writer.WriteLine($"$cfg['Servers'][$i]['host'] = '{endpoint.ContainerHost}:{endpoint.Port}';");
                     writer.WriteLine($"$cfg['Servers'][$i]['verbose'] = '{mySqlInstance.Name}';");
                     writer.WriteLine($"$cfg['Servers'][$i]['auth_type'] = 'cookie';");
                     writer.WriteLine($"$cfg['Servers'][$i]['user'] = 'root';");

--- a/src/Aspire.Hosting/Nats/NatsServerResource.cs
+++ b/src/Aspire.Hosting/Nats/NatsServerResource.cs
@@ -20,18 +20,21 @@ public class NatsServerResource(string name) : ContainerResource(name), IResourc
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
+    private ReferenceExpression ConnectionString =>
+        ReferenceExpression.Create(
+            $"{PrimaryNatsSchemeName}://{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
+
     /// <summary>
     /// Gets the connection string expression for the NATS server for the manifest.
     /// </summary>
-    public string? ConnectionStringExpression => $"{PrimaryNatsSchemeName}://{PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)}";
+    public string? ConnectionStringExpression =>
+        ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string (NATS_URL) for the NATS server.
     /// </summary>
+    /// <param name="cancellationToken">Cancellation token. </param>
     /// <returns>A connection string for the NATS server in the form "nats://host:port".</returns>
-
-    public string GetConnectionString()
-    {
-        return $"{PrimaryNatsSchemeName}://{PrimaryEndpoint.Host}:{PrimaryEndpoint.Port}";
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
+        ConnectionString.GetValueAsync(cancellationToken);
 }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
@@ -27,9 +27,9 @@ public class OracleDatabaseResource(string name, string databaseName, OracleData
     /// Gets the connection string for the Oracle Database.
     /// </summary>
     /// <returns>A connection string for the Oracle Database.</returns>
-    public string? GetConnectionString()
+    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
     {
-        if (Parent.GetConnectionString() is { } connectionString)
+        if (await Parent.GetConnectionStringAsync(cancellationToken).ConfigureAwait(false) is { } connectionString)
         {
             return $"{connectionString}/{DatabaseName}";
         }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Utils;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -37,20 +35,22 @@ public class OracleDatabaseServerResource : ContainerResource, IResourceWithConn
     /// </summary>
     public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
 
+    private ReferenceExpression ConnectionString =>
+        ReferenceExpression.Create(
+            $"user id=system;password={PasswordInput};data source={PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
+
     /// <summary>
     /// Gets the connection string expression for the Oracle Database server.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"user id=system;password={PasswordInput.ValueExpression};data source={PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)};";
+        ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the Oracle Database server.
     /// </summary>
     /// <returns>A connection string for the Oracle Database server in the form "user id=system;password=password;data source=host:port".</returns>
-    public string? GetConnectionString()
-    {
-        return $"user id=system;password={PasswordUtil.EscapePassword(Password)};data source={PrimaryEndpoint.Host}:{PrimaryEndpoint.Port}";
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
+        ConnectionString.GetValueAsync(cancellationToken);
 
     private readonly Dictionary<string, string> _databases = new(StringComparers.ResourceName);
 

--- a/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting/Postgres/PgAdminConfigWriterHook.cs
@@ -35,7 +35,7 @@ internal class PgAdminConfigWriterHook : IDistributedApplicationLifecycleHook
                 writer.WriteStartObject($"{serverIndex}");
                 writer.WriteString("Name", postgresInstance.Name);
                 writer.WriteString("Group", "Aspire instances");
-                writer.WriteString("Host", "host.docker.internal");
+                writer.WriteString("Host", endpoint.ContainerHost);
                 writer.WriteNumber("Port", endpoint.Port);
                 writer.WriteString("Username", "postgres");
                 writer.WriteString("SSLMode", "prefer");

--- a/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
@@ -26,22 +26,6 @@ public class PostgresDatabaseResource(string name, string databaseName, Postgres
     /// <summary>
     /// Gets the connection string for the Postgres database.
     /// </summary>
-    /// <returns>A connection string for the Postgres database.</returns>
-    public string? GetConnectionString()
-    {
-        if (Parent.GetConnectionString() is { } connectionString)
-        {
-            return $"{connectionString};Database={DatabaseName}";
-        }
-        else
-        {
-            throw new DistributedApplicationException("Parent resource connection string was null.");
-        }
-    }
-
-    /// <summary>
-    /// Gets the connection string for the Postgres database.
-    /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>A connection string for the Postgres database.</returns>
     public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
@@ -36,18 +36,20 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
     /// </summary>
     public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
 
+    private ReferenceExpression ConnectionString =>
+        ReferenceExpression.Create(
+            $"amqp://guest:{PasswordInput}@{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
+
     /// <summary>
     /// Gets the connection string expression for the RabbitMQ server for the manifest.
     /// </summary>
     public string ConnectionStringExpression =>
-        $"amqp://guest:{PasswordInput.ValueExpression}@{PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)}";
+        ConnectionString.ValueExpression;
 
     /// <summary>
     /// Gets the connection string for the RabbitMQ server.
     /// </summary>
     /// <returns>A connection string for the RabbitMQ server in the form "amqp://user:password@host:port".</returns>
-    public string? GetConnectionString()
-    {
-        return $"amqp://guest:{Password}@{PrimaryEndpoint.Host}:{PrimaryEndpoint.Port}";
-    }
+    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
+        await ConnectionString.GetValueAsync(cancellationToken).ConfigureAwait(false);
 }

--- a/src/Aspire.Hosting/Redis/RedisCommanderConfigWriterHook.cs
+++ b/src/Aspire.Hosting/Redis/RedisCommanderConfigWriterHook.cs
@@ -31,7 +31,7 @@ internal class RedisCommanderConfigWriterHook : IDistributedApplicationLifecycle
         {
             if (redisInstance.PrimaryEndpoint.IsAllocated)
             {
-                var hostString = $"{(hostsVariableBuilder.Length > 0 ? "," : string.Empty)}{redisInstance.Name}:host.docker.internal:{redisInstance.PrimaryEndpoint.Port}:0";
+                var hostString = $"{(hostsVariableBuilder.Length > 0 ? "," : string.Empty)}{redisInstance.Name}:{redisInstance.PrimaryEndpoint.ContainerHost}:{redisInstance.PrimaryEndpoint.Port}:0";
                 hostsVariableBuilder.Append(hostString);
             }
         }

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -18,6 +18,10 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
+    private ReferenceExpression ConnectionString =>
+        ReferenceExpression.Create(
+            $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
+
     /// <summary>
     /// Gets the connection string expression for the Redis server for the manifest.
     /// </summary>
@@ -30,7 +34,7 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
                 return connectionStringAnnotation.Resource.ConnectionStringExpression;
             }
 
-            return $"{PrimaryEndpoint.GetExpression(EndpointProperty.Host)}:{PrimaryEndpoint.GetExpression(EndpointProperty.Port)}";
+            return ConnectionString.ValueExpression;
         }
     }
 
@@ -46,20 +50,6 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
             return connectionStringAnnotation.Resource.GetConnectionStringAsync(cancellationToken);
         }
 
-        return new(GetConnectionString());
-    }
-
-    /// <summary>
-    /// Gets the connection string for the Redis server.
-    /// </summary>
-    /// <returns>A connection string for the redis server in the form "host:port".</returns>
-    public string? GetConnectionString()
-    {
-        if (this.TryGetLastAnnotation<ConnectionStringRedirectAnnotation>(out var connectionStringAnnotation))
-        {
-            return connectionStringAnnotation.Resource.GetConnectionString();
-        }
-
-        return $"{PrimaryEndpoint.Host}:{PrimaryEndpoint.Port}";
+        return ConnectionString.GetValueAsync(cancellationToken);
     }
 }

--- a/src/Aspire.Hosting/Seq/SeqResource.cs
+++ b/src/Aspire.Hosting/Seq/SeqResource.cs
@@ -18,17 +18,18 @@ public class SeqResource(string name) : ContainerResource(name), IResourceWithCo
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
+    private EndpointReferenceExpression ConnectionEndpoint =>
+        PrimaryEndpoint.Property(EndpointProperty.Url);
+
     /// <summary>
     /// Gets the Uri of the Seq endpoint
     /// </summary>
-    public string? GetConnectionString()
-    {
-        return PrimaryEndpoint.Url;
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
+        => ConnectionEndpoint.GetValueAsync(cancellationToken);
 
     /// <summary>
     /// Gets the connection string expression for the Seq server for the manifest.
     /// </summary>
     public string? ConnectionStringExpression =>
-        PrimaryEndpoint.GetExpression(EndpointProperty.Url);
+        ConnectionEndpoint.ValueExpression;
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
@@ -28,23 +28,6 @@ public class SqlServerDatabaseResource(string name, string databaseName, SqlServ
     /// </summary>
     /// <returns>The connection string for the database resource.</returns>
     /// <exception cref="DistributedApplicationException">Thrown when the parent resource connection string is null.</exception>
-    public string? GetConnectionString()
-    {
-        if (Parent.GetConnectionString() is { } connectionString)
-        {
-            return $"{connectionString};Database={DatabaseName}";
-        }
-        else
-        {
-            throw new DistributedApplicationException("Parent resource connection string was null.");
-        }
-    }
-
-    /// <summary>
-    /// Gets the connection string for the database resource.
-    /// </summary>
-    /// <returns>The connection string for the database resource.</returns>
-    /// <exception cref="DistributedApplicationException">Thrown when the parent resource connection string is null.</exception>
     public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
         if (await Parent.GetConnectionStringAsync(cancellationToken).ConfigureAwait(false) is { } connectionString)

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -24,7 +24,7 @@ public class TestingBuilderTests
         Assert.True(workerEndpoint.Host.Length > 0);
 
         // Get a connection string from a resource
-        var pgConnectionString = app.GetConnectionString("postgres1");
+        var pgConnectionString = await app.GetConnectionStringAsync("postgres1");
         Assert.NotNull(pgConnectionString);
         Assert.True(pgConnectionString.Length > 0);
     }

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -13,7 +13,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Program> fixture)
     private readonly DistributedApplication _app = fixture.Application;
 
     [LocalOnlyFact]
-    public void HasEndPoints()
+    public async void HasEndPoints()
     {
         // Get an endpoint from a resource
         var workerEndpoint = _app.GetEndpoint("myworker1", "myendpoint1");
@@ -21,7 +21,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Program> fixture)
         Assert.True(workerEndpoint.Host.Length > 0);
 
         // Get a connection string from a resource
-        var pgConnectionString = _app.GetConnectionString("postgres1");
+        var pgConnectionString = await _app.GetConnectionStringAsync("postgres1");
         Assert.NotNull(pgConnectionString);
         Assert.True(pgConnectionString.Length > 0);
     }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
@@ -145,6 +145,6 @@ public class AzureBicepProvisionerTests
         Resource(name),
         IResourceWithConnectionString
     {
-        public string? GetConnectionString() => connectionString;
+        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) => new(connectionString);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -102,7 +102,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AddAzureCosmosDb()
+    public async Task AddAzureCosmosDb()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -118,7 +118,7 @@ public class AzureBicepResourceTests
         Assert.Equal("cosmos", cosmos.Resource.Parameters["databaseAccountName"]);
         Assert.NotNull(databases);
         Assert.Equal(["mydatabase"], databases);
-        Assert.Equal("mycosmosconnectionstring", cosmos.Resource.GetConnectionString());
+        Assert.Equal("mycosmosconnectionstring", await cosmos.Resource.GetConnectionStringAsync());
         Assert.Equal("{cosmos.secretOutputs.connectionString}", cosmos.Resource.ConnectionStringExpression);
     }
 
@@ -157,11 +157,11 @@ public class AzureBicepResourceTests
             );
 
         Assert.Equal("cosmos", cosmos.Resource.Name);
-        Assert.Equal("mycosmosconnectionstring", cosmos.Resource.GetConnectionString());
+        Assert.Equal("mycosmosconnectionstring", await cosmos.Resource.GetConnectionStringAsync(default));
     }
 
     [Fact]
-    public void AddAppConfiguration()
+    public async Task AddAppConfiguration()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -172,7 +172,7 @@ public class AzureBicepResourceTests
         Assert.Equal("Aspire.Hosting.Azure.Bicep.appconfig.bicep", appConfig.Resource.TemplateResourceName);
         Assert.Equal("appConfig", appConfig.Resource.Name);
         Assert.Equal("appconfig", appConfig.Resource.Parameters["configName"]);
-        Assert.Equal("https://myendpoint", appConfig.Resource.GetConnectionString());
+        Assert.Equal("https://myendpoint", await appConfig.Resource.GetConnectionStringAsync(default));
         Assert.Equal("{appConfig.outputs.appConfigEndpoint}", appConfig.Resource.ConnectionStringExpression);
     }
 
@@ -189,7 +189,7 @@ public class AzureBicepResourceTests
         Assert.Equal("appInsights", appInsights.Resource.Name);
         Assert.Equal("appinsights", appInsights.Resource.Parameters["appInsightsName"]);
         Assert.True(appInsights.Resource.Parameters.ContainsKey(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId));
-        Assert.Equal("myinstrumentationkey", appInsights.Resource.GetConnectionString());
+        Assert.Equal("myinstrumentationkey", await appInsights.Resource.GetConnectionStringAsync(default));
         Assert.Equal("{appInsights.outputs.appInsightsConnectionString}", appInsights.Resource.ConnectionStringExpression);
 
         var appInsightsManifest = await ManifestUtils.GetManifest(appInsights.Resource);
@@ -321,7 +321,7 @@ public class AzureBicepResourceTests
 
         Assert.True(redis.Resource.IsContainer());
 
-        Assert.Equal("localhost:12455", redis.Resource.GetConnectionString());
+        Assert.Equal("localhost:12455", await redis.Resource.GetConnectionStringAsync());
 
         var manifest = await ManifestUtils.GetManifest(redis.Resource);
 
@@ -340,7 +340,7 @@ public class AzureBicepResourceTests
 
         Assert.True(redis.Resource.IsContainer());
 
-        Assert.Equal("localhost:12455", redis.Resource.GetConnectionString());
+        Assert.Equal("localhost:12455", await redis.Resource.GetConnectionStringAsync());
 
         var manifest = await ManifestUtils.GetManifest(redis.Resource);
         var expectedManifest = """
@@ -360,7 +360,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AddBicepKeyVault()
+    public async Task AddKeyVault()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -371,7 +371,7 @@ public class AzureBicepResourceTests
         Assert.Equal("Aspire.Hosting.Azure.Bicep.keyvault.bicep", keyVault.Resource.TemplateResourceName);
         Assert.Equal("keyVault", keyVault.Resource.Name);
         Assert.Equal("keyvault", keyVault.Resource.Parameters["vaultName"]);
-        Assert.Equal("https://myvault", keyVault.Resource.GetConnectionString());
+        Assert.Equal("https://myvault", await keyVault.Resource.GetConnectionStringAsync());
         Assert.Equal("{keyVault.outputs.vaultUri}", keyVault.Resource.ConnectionStringExpression);
     }
 
@@ -406,7 +406,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AsAzureSqlDatabase()
+    public async Task AsAzureSqlDatabase()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -429,7 +429,7 @@ public class AzureBicepResourceTests
         Assert.Equal("sql", azureSql.Resource.Parameters["serverName"]);
         Assert.NotNull(databases);
         Assert.Equal(["dbName"], databases);
-        Assert.Equal("Server=tcp:myserver,1433;Encrypt=True;Authentication=\"Active Directory Default\"", sql.Resource.GetConnectionString());
+        Assert.Equal("Server=tcp:myserver,1433;Encrypt=True;Authentication=\"Active Directory Default\"", await sql.Resource.GetConnectionStringAsync(default));
         Assert.Equal("Server=tcp:{sql.outputs.sqlServerFqdn},1433;Encrypt=True;Authentication=\"Active Directory Default\"", sql.Resource.ConnectionStringExpression);
     }
 
@@ -486,7 +486,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AsAzurePostgresFlexibleServer()
+    public async Task AsAzurePostgresFlexibleServer()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -521,7 +521,7 @@ public class AzureBicepResourceTests
 
         // Setup to verify that connection strings is acquired via resource connectionstring redirct.
         azurePostgres.Resource.SecretOutputs["connectionString"] = "myconnectionstring";
-        Assert.Equal("myconnectionstring", postgres.Resource.GetConnectionString());
+        Assert.Equal("myconnectionstring", await postgres.Resource.GetConnectionStringAsync(default));
 
         Assert.Equal("{postgres.secretOutputs.connectionString}", azurePostgres.Resource.ConnectionStringExpression);
     }
@@ -563,7 +563,7 @@ public class AzureBicepResourceTests
         // still uses the local endpoint.
         postgres.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1234));
         var expectedConnectionString = $"Host=localhost;Port=1234;Username=postgres;Password={PasswordUtil.EscapePassword(postgres.Resource.Password)}";
-        Assert.Equal(expectedConnectionString, postgres.Resource.GetConnectionString());
+        Assert.Equal(expectedConnectionString, await postgres.Resource.GetConnectionStringAsync(default));
 
         Assert.Equal("{postgres.secretOutputs.connectionString}", azurePostgres.Resource.ConnectionStringExpression);
 
@@ -721,7 +721,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AddAzureServiceBus()
+    public async Task AddAzureServiceBus()
     {
         var builder = DistributedApplication.CreateBuilder();
         var serviceBus = builder.AddAzureServiceBus("sb");
@@ -749,7 +749,7 @@ public class AzureBicepResourceTests
         Assert.Equal(["queue1", "queue2"], queues);
         Assert.NotNull(topics);
         Assert.Equal("""[{"name":"t1","subscriptions":["s1","s2"]},{"name":"t2","subscriptions":[]},{"name":"t3","subscriptions":["s3"]}]""", topics.ToJsonString());
-        Assert.Equal("mynamespaceEndpoint", serviceBus.Resource.GetConnectionString());
+        Assert.Equal("mynamespaceEndpoint", await serviceBus.Resource.GetConnectionStringAsync(default));
         Assert.Equal("{sb.outputs.serviceBusEndpoint}", serviceBus.Resource.ConnectionStringExpression);
     }
 
@@ -769,7 +769,7 @@ public class AzureBicepResourceTests
         serviceBus.Resource.Outputs["serviceBusEndpoint"] = "mynamespaceEndpoint";
 
         Assert.Equal("sb", serviceBus.Resource.Name);
-        Assert.Equal("mynamespaceEndpoint", serviceBus.Resource.GetConnectionString());
+        Assert.Equal("mynamespaceEndpoint", await serviceBus.Resource.GetConnectionStringAsync());
         Assert.Equal("{sb.outputs.serviceBusEndpoint}", serviceBus.Resource.ConnectionStringExpression);
 
         var manifest = await ManifestUtils.GetManifest(serviceBus.Resource);
@@ -806,9 +806,9 @@ public class AzureBicepResourceTests
         Assert.Equal("storage", storage.Resource.Name);
         Assert.Equal("storage", storage.Resource.Parameters["storageName"]);
 
-        Assert.Equal("https://myblob", blob.Resource.GetConnectionString());
-        Assert.Equal("https://myqueue", queue.Resource.GetConnectionString());
-        Assert.Equal("https://mytable", table.Resource.GetConnectionString());
+        Assert.Equal("https://myblob", await blob.Resource.GetConnectionStringAsync());
+        Assert.Equal("https://myqueue", await queue.Resource.GetConnectionStringAsync());
+        Assert.Equal("https://mytable", await table.Resource.GetConnectionStringAsync());
         Assert.Equal("{storage.outputs.blobEndpoint}", blob.Resource.ConnectionStringExpression);
         Assert.Equal("{storage.outputs.queueEndpoint}", queue.Resource.ConnectionStringExpression);
         Assert.Equal("{storage.outputs.tableEndpoint}", table.Resource.ConnectionStringExpression);
@@ -856,7 +856,7 @@ public class AzureBicepResourceTests
 
         // Check blob resource.
         var blob = storage.AddBlobs("blob");
-        Assert.Equal("https://myblob", blob.Resource.GetConnectionString());
+        Assert.Equal("https://myblob", await blob.Resource.GetConnectionStringAsync());
         var expectedBlobManifest = """
             {
               "type": "value.v0",
@@ -868,7 +868,7 @@ public class AzureBicepResourceTests
 
         // Check queue resource.
         var queue = storage.AddQueues("queue");
-        Assert.Equal("https://myqueue", queue.Resource.GetConnectionString());
+        Assert.Equal("https://myqueue", await queue.Resource.GetConnectionStringAsync());
         var expectedQueueManifest = """
             {
               "type": "value.v0",
@@ -880,7 +880,7 @@ public class AzureBicepResourceTests
 
         // Check table resource.
         var table = storage.AddTables("table");
-        Assert.Equal("https://mytable", table.Resource.GetConnectionString());
+        Assert.Equal("https://mytable", await table.Resource.GetConnectionStringAsync());
         var expectedTableManifest = """
             {
               "type": "value.v0",
@@ -892,7 +892,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AddAzureSearch()
+    public async Task AddAzureSearch()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -902,7 +902,7 @@ public class AzureBicepResourceTests
 
         Assert.Equal("Aspire.Hosting.Azure.Bicep.search.bicep", search.Resource.TemplateResourceName);
         Assert.Equal("search", search.Resource.Name);
-        Assert.Equal("mysearchconnectionstring", search.Resource.GetConnectionString());
+        Assert.Equal("mysearchconnectionstring", await search.Resource.GetConnectionStringAsync(default));
         Assert.Equal("{search.outputs.connectionString}", search.Resource.ConnectionStringExpression);
     }
 
@@ -932,7 +932,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public void AddAzureOpenAI()
+    public async Task AddAzureOpenAI()
     {
         var builder = DistributedApplication.CreateBuilder();
 
@@ -947,7 +947,7 @@ public class AzureBicepResourceTests
 
         Assert.Equal("Aspire.Hosting.Azure.Bicep.openai.bicep", openai.Resource.TemplateResourceName);
         Assert.Equal("openai", openai.Resource.Name);
-        Assert.Equal("myopenaiconnectionstring", openai.Resource.GetConnectionString());
+        Assert.Equal("myopenaiconnectionstring", await openai.Resource.GetConnectionStringAsync(default));
         Assert.Equal("{openai.outputs.connectionString}", openai.Resource.ConnectionStringExpression);
         Assert.NotNull(deployment);
         Assert.Equal("mymodel", deployment["name"]?.ToString());

--- a/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
@@ -42,7 +42,7 @@ public class AddKafkaTests
     }
 
     [Fact]
-    public void KafkaCreatesConnectionString()
+    public async Task KafkaCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
@@ -54,7 +54,7 @@ public class AddKafkaTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<KafkaServerResource>());
-        var connectionString = connectionStringResource.GetConnectionString();
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
 
         Assert.Equal("localhost:27017", connectionString);
         Assert.Equal("{kafka.bindings.tcp.host}:{kafka.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);

--- a/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
@@ -75,7 +75,7 @@ public class AddMongoDBTests
     }
 
     [Fact]
-    public void MongoDBCreatesConnectionString()
+    public async Task MongoDBCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
@@ -88,9 +88,9 @@ public class AddMongoDBTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<MongoDBDatabaseResource>());
-        var connectionString = connectionStringResource.GetConnectionString();
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
 
-        Assert.Equal("mongodb://localhost:27017/", connectionStringResource.Parent.GetConnectionString());
+        Assert.Equal("mongodb://localhost:27017", await connectionStringResource.Parent.GetConnectionStringAsync(default));
         Assert.Equal("mongodb://{mongodb.bindings.tcp.host}:{mongodb.bindings.tcp.port}", connectionStringResource.Parent.ConnectionStringExpression);
         Assert.Equal("mongodb://localhost:27017/mydatabase", connectionString);
         Assert.Equal("{mongodb.connectionString}/mydatabase", connectionStringResource.ConnectionStringExpression);

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -94,7 +94,7 @@ public class AddMySqlTests
     }
 
     [Fact]
-    public void MySqlCreatesConnectionString()
+    public async Task MySqlCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddMySql("mysql")
@@ -105,14 +105,14 @@ public class AddMySqlTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        var connectionString = connectionStringResource.GetConnectionString();
+        var connectionString = await connectionStringResource.GetConnectionStringAsync();
 
         Assert.Equal("Server={mysql.bindings.tcp.host};Port={mysql.bindings.tcp.port};User ID=root;Password={mysql.inputs.password}", connectionStringResource.ConnectionStringExpression);
         Assert.StartsWith("Server=localhost;Port=2000;User ID=root;Password=", connectionString);
     }
 
     [Fact]
-    public void MySqlCreatesConnectionStringWithDatabase()
+    public async Task MySqlCreatesConnectionStringWithDatabase()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddMySql("mysql")
@@ -124,9 +124,9 @@ public class AddMySqlTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var mySqlResource = Assert.Single(appModel.Resources.OfType<MySqlServerResource>());
-        var mySqlConnectionString = mySqlResource.GetConnectionString();
+        var mySqlConnectionString = await mySqlResource.GetConnectionStringAsync(default);
         var mySqlDatabaseResource = Assert.Single(appModel.Resources.OfType<MySqlDatabaseResource>());
-        var dbConnectionString = mySqlDatabaseResource.GetConnectionString();
+        var dbConnectionString = await mySqlDatabaseResource.GetConnectionStringAsync(default);
 
         Assert.Equal(mySqlConnectionString + ";Database=db", dbConnectionString);
         Assert.Equal("{mysql.connectionString};Database=db", mySqlDatabaseResource.ConnectionStringExpression);

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -92,7 +92,7 @@ public class AddOracleTests
     }
 
     [Fact]
-    public void OracleCreatesConnectionString()
+    public async Task OracleCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddOracle("orcl")
@@ -103,15 +103,15 @@ public class AddOracleTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        var connectionString = connectionStringResource.GetConnectionString();
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
 
-        Assert.Equal("user id=system;password={orcl.inputs.password};data source={orcl.bindings.tcp.host}:{orcl.bindings.tcp.port};", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("user id=system;password={orcl.inputs.password};data source={orcl.bindings.tcp.host}:{orcl.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
         Assert.StartsWith("user id=system;password=", connectionString);
         Assert.EndsWith(";data source=localhost:2000", connectionString);
     }
 
     [Fact]
-    public void OracleCreatesConnectionStringWithDatabase()
+    public async void OracleCreatesConnectionStringWithDatabase()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddOracle("orcl")
@@ -123,9 +123,9 @@ public class AddOracleTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var oracleResource = Assert.Single(appModel.Resources.OfType<OracleDatabaseServerResource>());
-        var oracleConnectionString = oracleResource.GetConnectionString();
+        var oracleConnectionString = oracleResource.GetConnectionStringAsync(default);
         var oracleDatabaseResource = Assert.Single(appModel.Resources.OfType<OracleDatabaseResource>());
-        var dbConnectionString = oracleDatabaseResource.GetConnectionString();
+        var dbConnectionString = await oracleDatabaseResource.GetConnectionStringAsync(default);
 
         Assert.Equal("{orcl.connectionString}/db", oracleDatabaseResource.ConnectionStringExpression);
         Assert.Equal(oracleConnectionString + "/db", dbConnectionString);
@@ -185,7 +185,7 @@ public class AddOracleTests
         var expectedManifest = """
             {
               "type": "container.v0",
-              "connectionString": "user id=system;password={oracle.inputs.password};data source={oracle.bindings.tcp.host}:{oracle.bindings.tcp.port};",
+              "connectionString": "user id=system;password={oracle.inputs.password};data source={oracle.bindings.tcp.host}:{oracle.bindings.tcp.port}",
               "image": "container-registry.oracle.com/database/free:23.3.0.0",
               "env": {
                 "ORACLE_PWD": "{oracle.inputs.password}"

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -114,19 +114,19 @@ public class AddPostgresTests
     }
 
     [Fact]
-    public void PostgresCreatesConnectionString()
+    public async Task PostgresCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         var postgres = appBuilder.AddPostgres("postgres")
                                  .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
-        var connectionString = postgres.Resource.GetConnectionString();
+        var connectionString = await postgres.Resource.GetConnectionStringAsync();
         Assert.Equal("Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres.inputs.password}", postgres.Resource.ConnectionStringExpression);
         Assert.Equal($"Host=localhost;Port=2000;Username=postgres;Password={PasswordUtil.EscapePassword(postgres.Resource.Password)}", connectionString);
     }
 
     [Fact]
-    public void PostgresCreatesConnectionStringWithDatabase()
+    public async Task PostgresCreatesConnectionStringWithDatabase()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddPostgres("postgres")
@@ -138,9 +138,9 @@ public class AddPostgresTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var postgresResource = Assert.Single(appModel.Resources.OfType<PostgresServerResource>());
-        var postgresConnectionString = postgresResource.GetConnectionString();
+        var postgresConnectionString = await postgresResource.GetConnectionStringAsync();
         var postgresDatabaseResource = Assert.Single(appModel.Resources.OfType<PostgresDatabaseResource>());
-        var dbConnectionString = postgresDatabaseResource.GetConnectionString();
+        var dbConnectionString = await postgresDatabaseResource.GetConnectionStringAsync(default);
 
         Assert.Equal("{postgres.connectionString};Database=db", postgresDatabaseResource.ConnectionStringExpression);
         Assert.Equal(postgresConnectionString + ";Database=db", dbConnectionString);

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -43,7 +43,7 @@ public class AddRabbitMQTests
     }
 
     [Fact]
-    public void RabbitMQCreatesConnectionString()
+    public async Task RabbitMQCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
@@ -55,7 +55,7 @@ public class AddRabbitMQTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<RabbitMQServerResource>());
-        var connectionString = connectionStringResource.GetConnectionString();
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
         var password = connectionStringResource.Password;
 
         Assert.Equal($"amqp://guest:{password}@localhost:27011", connectionString);

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -75,7 +75,7 @@ public class AddRedisTests
     }
 
     [Fact]
-    public void RedisCreatesConnectionString()
+    public async Task RedisCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddRedis("myRedis")
@@ -86,7 +86,7 @@ public class AddRedisTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
-        var connectionString = connectionStringResource.GetConnectionString();
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
         Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
         Assert.StartsWith("localhost:2000", connectionString);
     }

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -150,6 +150,6 @@ public class ResourceNotificationTests
         IResourceWithEnvironment,
         IResourceWithConnectionString
     {
-        public string? GetConnectionString() => "CustomConnectionString";
+        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) => new("CustomConnectionString");
     }
 }

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -59,7 +59,7 @@ public class AddSqlServerTests
     }
 
     [Fact]
-    public void SqlServerCreatesConnectionString()
+    public async Task SqlServerCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
@@ -71,7 +71,7 @@ public class AddSqlServerTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<SqlServerServerResource>());
-        var connectionString = connectionStringResource.GetConnectionString();
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
         var password = PasswordUtil.EscapePassword(connectionStringResource.Password);
 
         Assert.Equal($"Server=127.0.0.1,1433;User ID=sa;Password={password};TrustServerCertificate=true", connectionString);
@@ -79,7 +79,7 @@ public class AddSqlServerTests
     }
 
     [Fact]
-    public void SqlServerDatabaseCreatesConnectionString()
+    public async Task SqlServerDatabaseCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder
@@ -92,7 +92,7 @@ public class AddSqlServerTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<SqlServerDatabaseResource>());
-        var connectionString = connectionStringResource.GetConnectionString();
+        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
         var password = PasswordUtil.EscapePassword(connectionStringResource.Parent.Password);
 
         Assert.Equal($"Server=127.0.0.1,1433;User ID=sa;Password={password};TrustServerCertificate=true;Database=mydb", connectionString);

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -173,8 +173,6 @@ public class WithEnvironmentTests
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
-        // public string? ConnectionStringExpression => "{{connectionString}}";
-
         public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
         {
             return new(connectionString);

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -330,9 +330,9 @@ public class WithReferenceTests
 
         public ResourceAnnotationCollection Annotations => throw new NotImplementedException();
 
-        public string? GetConnectionString()
+        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
         {
-            return ConnectionString;
+            return new(ConnectionString);
         }
     }
 }


### PR DESCRIPTION
Introduce a `ReferenceExpression` which uses string interpolation to represent expressions that reference multiple resources. This removes duplication between the manifest and runtime model and allows introspection of the reference parameters.

- Removed synchronous `GetConnectionString`.
- Re-implement `GetConnectionStringAsync` to use ReferenceExpressions
- Centralize hard coding of host.docker.internal
- Added support for reference expressions in environment variables.

Contributes to https://github.com/dotnet/aspire/issues/2639
Fixes https://github.com/dotnet/aspire/issues/2428

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2759)