### PR TITLE
Azure Open AI provisioning via CDK.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.2.0-alpha.20240309.1" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.0-alpha.20240310.2" />
     <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.8.0-alpha.20240309.1" />
-    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240311.1" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240311.2" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,10 +22,10 @@
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.ResourceManager" Version="1.11.0-alpha.20240222.6" />
-    <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.2.0-alpha.20240227.2" />
-    <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.0-alpha.20240222.2" />
-    <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.8.0-alpha.20240222.2" />
-    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240308.1" />
+    <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.2.0-alpha.20240309.1" />
+    <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.0-alpha.20240310.2" />
+    <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.8.0-alpha.20240309.1" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20240311.1" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion)" />

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/OpenAIEndToEnd.AppHost.csproj
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/OpenAIEndToEnd.AppHost.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireHost>true</IsAspireHost>
-    <UserSecretsId>b757dbc4-6942-448f-9f26-d15de0f2e760</UserSecretsId>
+    <UserSecretsId>55ef4430-77f1-4dfa-9af3-e2e39d665e2a</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
@@ -5,8 +5,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureProvisioning();
 
-var openai = builder.AddAzureOpenAI("openai")
-    .WithDeployment(new("gpt-35-turbo", "gpt-35-turbo", "0613"));
+var openai = builder.AddAzureOpenAIConstruct("openai")
+                    .AddDeployment(new("gpt-35-turbo", "gpt-35-turbo", "0613"));
 
 builder.AddProject<Projects.OpenAIEndToEnd_WebStory>("webstory")
        .WithReference(openai);

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Properties/launchSettings.json
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Properties/launchSettings.json
@@ -11,6 +11,16 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16195"
       }
+    },
+    "generate-manifest": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/aspire-manifest.json
@@ -2,7 +2,7 @@
   "resources": {
     "openai": {
       "type": "azure.bicep.v0",
-      "connectionString": "{openai.secretOutputs.connectionString}",
+      "connectionString": "{openai.outputs.connectionString}",
       "path": "openai.module.bicep",
       "params": {
         "principalId": "",

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/aspire-manifest.json
@@ -6,8 +6,7 @@
       "path": "openai.module.bicep",
       "params": {
         "principalId": "",
-        "principalType": "",
-        "keyVaultName": ""
+        "principalType": ""
       }
     },
     "webstory": {

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/aspire-manifest.json
@@ -2,26 +2,12 @@
   "resources": {
     "openai": {
       "type": "azure.bicep.v0",
-      "connectionString": "{openai.outputs.connectionString}",
-      "path": "aspire.hosting.azure.bicep.openai.bicep",
+      "connectionString": "{openai.secretOutputs.connectionString}",
+      "path": "openai.module.bicep",
       "params": {
-        "name": "openai",
-        "deployments": [
-          {
-            "name": "gpt-35-turbo",
-            "sku": {
-              "name": "Standard",
-              "capacity": 1
-            },
-            "model": {
-              "format": "OpenAI",
-              "name": "gpt-35-turbo",
-              "version": "0613"
-            }
-          }
-        ],
         "principalId": "",
-        "principalType": ""
+        "principalType": "",
+        "keyVaultName": ""
       }
     },
     "webstory": {
@@ -30,6 +16,7 @@
       "env": {
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
+        "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
         "ConnectionStrings__openai": "{openai.connectionString}"
       },
       "bindings": {

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
@@ -13,10 +13,6 @@ param principalType string
 param keyVaultName string
 
 
-resource keyVault_IeF8jZvXV 'Microsoft.KeyVault/vaults@2023-02-01' existing = {
-  name: keyVaultName
-}
-
 resource cognitiveServicesAccount_DqMZSfXbZ 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: toLower(take(concat('openai', uniqueString(resourceGroup().id)), 24))
   location: location
@@ -25,6 +21,7 @@ resource cognitiveServicesAccount_DqMZSfXbZ 'Microsoft.CognitiveServices/account
     name: 'S0'
   }
   properties: {
+    customSubDomainName: toLower(take(concat('openai', uniqueString(resourceGroup().id)), 24))
     publicNetworkAccess: 'Enabled'
   }
 }
@@ -55,11 +52,4 @@ resource cognitiveServicesAccountDeployment_0OtUTY1oh 'Microsoft.CognitiveServic
   }
 }
 
-resource keyVaultSecret_Ddsc3HjrA 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
-  parent: keyVault_IeF8jZvXV
-  name: 'connectionString'
-  location: location
-  properties: {
-    value: 'Endpoint=${cognitiveServicesAccount_DqMZSfXbZ.properties.endpoint}'
-  }
-}
+output connectionString string = 'Endpoint=${cognitiveServicesAccount_DqMZSfXbZ.properties.endpoint}'

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
@@ -9,9 +9,6 @@ param principalId string
 @description('')
 param principalType string
 
-@description('')
-param keyVaultName string
-
 
 resource cognitiveServicesAccount_6g8jyEjX5 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: toLower(take(concat('openai', uniqueString(resourceGroup().id)), 24))

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
@@ -1,0 +1,65 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+@description('')
+param principalId string
+
+@description('')
+param principalType string
+
+@description('')
+param keyVaultName string
+
+
+resource keyVault_IeF8jZvXV 'Microsoft.KeyVault/vaults@2023-02-01' existing = {
+  name: keyVaultName
+}
+
+resource cognitiveServicesAccount_DqMZSfXbZ 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: toLower(take(concat('openai', uniqueString(resourceGroup().id)), 24))
+  location: location
+  kind: 'OpenAI'
+  sku: {
+    name: 'S0'
+  }
+  properties: {
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource roleAssignment_biQFQxikh 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: cognitiveServicesAccount_DqMZSfXbZ
+  name: guid(cognitiveServicesAccount_DqMZSfXbZ.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442'))
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442')
+    principalId: principalId
+    principalType: principalType
+  }
+}
+
+resource cognitiveServicesAccountDeployment_0OtUTY1oh 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01' = {
+  parent: cognitiveServicesAccount_DqMZSfXbZ
+  name: 'gpt-35-turbo'
+  sku: {
+    name: 'Standard'
+    capacity: 1
+  }
+  properties: {
+    model: {
+      name: 'gpt-35-turbo'
+      format: 'OpenAI'
+      version: '0613'
+    }
+  }
+}
+
+resource keyVaultSecret_Ddsc3HjrA 'Microsoft.KeyVault/vaults/secrets@2023-02-01' = {
+  parent: keyVault_IeF8jZvXV
+  name: 'connectionString'
+  location: location
+  properties: {
+    value: 'Endpoint=${cognitiveServicesAccount_DqMZSfXbZ.properties.endpoint}'
+  }
+}

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
@@ -13,7 +13,7 @@ param principalType string
 param keyVaultName string
 
 
-resource cognitiveServicesAccount_DqMZSfXbZ 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+resource cognitiveServicesAccount_6g8jyEjX5 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: toLower(take(concat('openai', uniqueString(resourceGroup().id)), 24))
   location: location
   kind: 'OpenAI'
@@ -26,9 +26,9 @@ resource cognitiveServicesAccount_DqMZSfXbZ 'Microsoft.CognitiveServices/account
   }
 }
 
-resource roleAssignment_biQFQxikh 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: cognitiveServicesAccount_DqMZSfXbZ
-  name: guid(cognitiveServicesAccount_DqMZSfXbZ.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442'))
+resource roleAssignment_X7ie0XqR2 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: cognitiveServicesAccount_6g8jyEjX5
+  name: guid(cognitiveServicesAccount_6g8jyEjX5.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442')
     principalId: principalId
@@ -36,8 +36,8 @@ resource roleAssignment_biQFQxikh 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource cognitiveServicesAccountDeployment_0OtUTY1oh 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01' = {
-  parent: cognitiveServicesAccount_DqMZSfXbZ
+resource cognitiveServicesAccountDeployment_f9rYX6SRK 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01' = {
+  parent: cognitiveServicesAccount_6g8jyEjX5
   name: 'gpt-35-turbo'
   sku: {
     name: 'Standard'
@@ -52,4 +52,4 @@ resource cognitiveServicesAccountDeployment_0OtUTY1oh 'Microsoft.CognitiveServic
   }
 }
 
-output connectionString string = 'Endpoint=${cognitiveServicesAccount_DqMZSfXbZ.properties.endpoint}'
+output connectionString string = 'Endpoint=${cognitiveServicesAccount_6g8jyEjX5.properties.endpoint}'

--- a/src/Aspire.Hosting.Azure/AzureOpenAIResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureOpenAIResource.cs
@@ -43,3 +43,44 @@ public class AzureOpenAIResource(string name) :
         _deployments.Add(deployment);
     }
 }
+
+/// <summary>
+/// Represents an Azure OpenAI resource.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="configureConstruct">Configures the underlying Azure resource using the CDK.</param>
+public class AzureOpenAIConstructResource(string name, Action<ResourceModuleConstruct> configureConstruct) :
+    AzureConstructResource(name, configureConstruct),
+    IResourceWithConnectionString
+{
+    private readonly List<AzureOpenAIDeployment> _deployments = [];
+
+    /// <summary>
+    /// Gets the "connectionString" output reference from the Azure OpenAI resource.
+    /// </summary>
+    public BicepSecretOutputReference ConnectionString => new("connectionString", this);
+
+    /// <summary>
+    /// Gets the connection string template for the manifest for the resource.
+    /// </summary>
+    public string ConnectionStringExpression => ConnectionString.ValueExpression;
+
+    /// <summary>
+    /// Gets the connection string for the resource.
+    /// </summary>
+    /// <returns>The connection string for the resource.</returns>
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
+        => ConnectionString.GetValueAsync(cancellationToken);
+
+    /// <summary>
+    /// Gets the list of deployments of the Azure OpenAI resource.
+    /// </summary>
+    public IReadOnlyList<AzureOpenAIDeployment> Deployments => _deployments;
+
+    internal void AddDeployment(AzureOpenAIDeployment deployment)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+
+        _deployments.Add(deployment);
+    }
+}

--- a/src/Aspire.Hosting.Azure/AzureOpenAIResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureOpenAIResource.cs
@@ -58,7 +58,7 @@ public class AzureOpenAIConstructResource(string name, Action<ResourceModuleCons
     /// <summary>
     /// Gets the "connectionString" output reference from the Azure OpenAI resource.
     /// </summary>
-    public BicepSecretOutputReference ConnectionString => new("connectionString", this);
+    public BicepOutputReference ConnectionString => new("connectionString", this);
 
     /// <summary>
     /// Gets the connection string template for the manifest for the resource.

--- a/src/Aspire.Hosting.Azure/Extensions/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureKeyVaultResourceExtensions.cs
@@ -41,7 +41,7 @@ public static class AzureKeyVaultResourceExtensions
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var keyVault = construct.AddKeyVault(name: construct.Resource.Name);
-            keyVault.AddOutput(x => x.Properties.VaultUri, "vaultUri");
+            keyVault.AddOutput("vaultUri", x => x.Properties.VaultUri);
 
             var keyVaultAdministratorRoleAssignment = keyVault.AssignRole(RoleDefinition.KeyVaultAdministrator);
             keyVaultAdministratorRoleAssignment.AssignProperty(x => x.PrincipalId, construct.PrincipalIdParameter);

--- a/src/Aspire.Hosting.Azure/Extensions/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureOpenAIExtensions.cs
@@ -78,7 +78,6 @@ public static class AzureOpenAIExtensions
         return builder.AddResource(resource)
                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)
                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalType)
-                      .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName)
                       .WithManifestPublishingCallback(resource.WriteToManifest);
     }
 

--- a/src/Aspire.Hosting.Azure/Extensions/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureOpenAIExtensions.cs
@@ -54,7 +54,7 @@ public static class AzureOpenAIExtensions
 
             var resource = (AzureOpenAIConstructResource)construct.Resource;
 
-            List<CognitiveServicesAccountDeployment> cdkDeployments = new List<CognitiveServicesAccountDeployment>();
+            var cdkDeployments = new List<CognitiveServicesAccountDeployment>();
             foreach (var deployment in resource.Deployments)
             {
                 var model = new CognitiveServicesAccountDeploymentModel();

--- a/src/Aspire.Hosting.Azure/Extensions/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureOpenAIExtensions.cs
@@ -4,6 +4,10 @@
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
+using Azure.Provisioning.Authorization;
+using Azure.Provisioning.CognitiveServices;
+using Azure.Provisioning.KeyVaults;
+using Azure.ResourceManager.CognitiveServices.Models;
 
 namespace Aspire.Hosting;
 
@@ -30,12 +34,86 @@ public static class AzureOpenAIExtensions
     }
 
     /// <summary>
+    /// Adds an Azure OpenAI resource to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
+    /// <param name="configureResource"></param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureOpenAIConstructResource> AddAzureOpenAIConstruct(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureOpenAIConstructResource>, ResourceModuleConstruct, CognitiveServicesAccount, IEnumerable<CognitiveServicesAccountDeployment>>? configureResource = null)
+    {
+        var configureConstruct = (ResourceModuleConstruct construct) =>
+        {
+            var cogServicesAccount = new CognitiveServicesAccount(construct, "OpenAI", name: name);
+
+            // HACK: This name should be an auto generated name based on input name and resource group.
+            //       https://github.com/Azure/azure-sdk-for-net/issues/42574
+            cogServicesAccount.AssignProperty(x => x.Name, $"toLower(take(concat('{name}', uniqueString(resourceGroup().id)), 24))");
+            cogServicesAccount.AssignProperty(x => x.Properties.CustomSubDomainName, $"toLower(take(concat('{name}', uniqueString(resourceGroup().id)), 24))");
+            cogServicesAccount.AssignProperty(x => x.Properties.PublicNetworkAccess, "'Enabled'");
+
+            var roleAssignment = cogServicesAccount.AssignRole(RoleDefinition.CognitiveServicesOpenAIContributor);
+            roleAssignment.AssignProperty(x => x.PrincipalId, construct.PrincipalIdParameter);
+            roleAssignment.AssignProperty(x => x.PrincipalType, construct.PrincipalTypeParameter);
+
+            var resource = (AzureOpenAIConstructResource)construct.Resource;
+
+            List<CognitiveServicesAccountDeployment> cdkDeployments = new List<CognitiveServicesAccountDeployment>();
+            foreach (var deployment in resource.Deployments)
+            {
+                var model = new CognitiveServicesAccountDeploymentModel();
+                model.Name = deployment.ModelName;
+                model.Version = deployment.ModelVersion;
+                model.Format = "OpenAI";
+
+                var cdkDeployment = new CognitiveServicesAccountDeployment(construct, model, parent: cogServicesAccount, name: deployment.Name);
+                cdkDeployment.AssignProperty(x => x.Sku.Name, $"'{deployment.SkuName}'");
+                cdkDeployment.AssignProperty(x => x.Sku.Capacity, $"{deployment.SkuCapacity}");
+            }
+
+            // HACK: We can't create an output that is an interpolated string so we are
+            //       storing the result in a keyvault secret so we can get it out in the
+            //       format that we want even though there is not anything on it that is
+            //       strictly a secret.
+            var keyVault = KeyVault.FromExisting(construct, "keyVaultName");
+            var connectionStringSecret = new KeyVaultSecret(construct, keyVault, "connectionString");
+            connectionStringSecret.AssignProperty(x => x.Properties.Value, $"'Endpoint=${{{cogServicesAccount.Name}.properties.endpoint}}'");
+
+            if (configureResource != null)
+            {
+                var resourceBuilder = builder.CreateResourceBuilder(resource);
+                configureResource(resourceBuilder, construct, cogServicesAccount, cdkDeployments);
+            }
+
+        };
+
+        var resource = new AzureOpenAIConstructResource(name, configureConstruct);
+        return builder.AddResource(resource)
+                      .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)
+                      .WithParameter(AzureBicepResource.KnownParameters.PrincipalType)
+                      .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName)
+                      .WithManifestPublishingCallback(resource.WriteToManifest);
+    }
+
+    /// <summary>
     /// Adds an Azure OpenAI Deployment resource to the application model. This resource requires an <see cref="AzureOpenAIResource"/> to be added to the application model.
     /// </summary>
     /// <param name="builder">The Azure OpenAI resource builder.</param>
     /// <param name="deployment">The deployment to add.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureOpenAIResource> WithDeployment(this IResourceBuilder<AzureOpenAIResource> builder, AzureOpenAIDeployment deployment)
+    {
+        builder.Resource.AddDeployment(deployment);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an Azure OpenAI Deployment resource to the application model. This resource requires an <see cref="AzureOpenAIResource"/> to be added to the application model.
+    /// </summary>
+    /// <param name="builder">The Azure OpenAI resource builder.</param>
+    /// <param name="deployment">The deployment to add.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureOpenAIConstructResource> AddDeployment(this IResourceBuilder<AzureOpenAIConstructResource> builder, AzureOpenAIDeployment deployment)
     {
         builder.Resource.AddDeployment(deployment);
         return builder;

--- a/src/Aspire.Hosting.Azure/Extensions/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureOpenAIExtensions.cs
@@ -44,10 +44,6 @@ public static class AzureOpenAIExtensions
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var cogServicesAccount = new CognitiveServicesAccount(construct, "OpenAI", name: name);
-
-            // HACK: This name should be an auto generated name based on input name and resource group.
-            //       https://github.com/Azure/azure-sdk-for-net/issues/42574
-            cogServicesAccount.AssignProperty(x => x.Name, $"toLower(take(concat('{name}', uniqueString(resourceGroup().id)), 24))");
             cogServicesAccount.AssignProperty(x => x.Properties.CustomSubDomainName, $"toLower(take(concat('{name}', uniqueString(resourceGroup().id)), 24))");
             cogServicesAccount.AssignProperty(x => x.Properties.PublicNetworkAccess, "'Enabled'");
             cogServicesAccount.AddOutput("connectionString", """'Endpoint=${{{0}}}'""", x => x.Properties.Endpoint);
@@ -76,7 +72,6 @@ public static class AzureOpenAIExtensions
                 var resourceBuilder = builder.CreateResourceBuilder(resource);
                 configureResource(resourceBuilder, construct, cogServicesAccount, cdkDeployments);
             }
-
         };
 
         var resource = new AzureOpenAIConstructResource(name, configureConstruct);

--- a/src/Aspire.Hosting.Azure/Extensions/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureServiceBusExtensions.cs
@@ -60,7 +60,7 @@ public static class AzureServiceBusExtensions
             var serviceBusDataOwnerRole = serviceBusNamespace.AssignRole(RoleDefinition.ServiceBusDataOwner);
             serviceBusDataOwnerRole.AssignProperty(p => p.PrincipalType, construct.PrincipalTypeParameter);
 
-            serviceBusNamespace.AddOutput(sa => sa.ServiceBusEndpoint, "serviceBusEndpoint");
+            serviceBusNamespace.AddOutput("serviceBusEndpoint", sa => sa.ServiceBusEndpoint);
 
             configureResource?.Invoke(construct, serviceBusNamespace);
 

--- a/src/Aspire.Hosting.Azure/Extensions/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureSqlExtensions.cs
@@ -108,7 +108,7 @@ public static class AzureSqlExtensions
                 sqlDatabases.Add(sqlDatabase);
             }
 
-            sqlServer.AddOutput(x => x.FullyQualifiedDomainName, "sqlServerFqdn");
+            sqlServer.AddOutput("sqlServerFqdn", x => x.FullyQualifiedDomainName);
 
             if (configureResource != null)
             {

--- a/src/Aspire.Hosting.Azure/Extensions/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureStorageExtensions.cs
@@ -60,9 +60,9 @@ public static class AzureStorageExtensions
             var queueRole = storageAccount.AssignRole(RoleDefinition.StorageQueueDataContributor);
             queueRole.AssignProperty(p => p.PrincipalType, construct.PrincipalTypeParameter);
 
-            storageAccount.AddOutput(sa => sa.PrimaryEndpoints.BlobUri, "blobEndpoint");
-            storageAccount.AddOutput(sa => sa.PrimaryEndpoints.QueueUri, "queueEndpoint");
-            storageAccount.AddOutput(sa => sa.PrimaryEndpoints.TableUri, "tableEndpoint");
+            storageAccount.AddOutput("blobEndpoint", sa => sa.PrimaryEndpoints.BlobUri);
+            storageAccount.AddOutput("queueEndpoint", sa => sa.PrimaryEndpoints.QueueUri);
+            storageAccount.AddOutput("tableEndpoint", sa => sa.PrimaryEndpoints.TableUri);
 
             if (configureResource != null)
             {

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -226,7 +226,7 @@ public class AzureBicepResourceTests
                 kind: StorageKind.StorageV2,
                 sku: StorageSkuName.StandardLrs
                 );
-            storage.AddOutput(sa => sa.Name, "storageAccountName");
+            storage.AddOutput("storageAccountName", sa => sa.Name);
         });
 
         var manifest = await ManifestUtils.GetManifest(construct1.Resource);


### PR DESCRIPTION
This PR introduces `AddAzureOpenAIConstruct`. The `WithDeployment(...)` extension method has been changed to `AddDeployment(...)` to be consistent with `AddDatabase` on database resource types (for the construct based resource only. When we converge APIs we'll need to add an obslete market to `WithDeployment`.