### PR TITLE
Rename AddKeyVaultSecrets to match other extension methods naming

### DIFF
--- a/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
@@ -109,7 +109,24 @@ public static class AspireKeyVaultExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureSecurityKeyVaultSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="SecretClientOptions"/>.</param>
     /// <param name="options">An optional <see cref="AzureKeyVaultConfigurationOptions"/> instance to configure the behavior of the configuration provider.</param>
+    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(AddAzureKeyVaultSecrets)} instead.")]
     public static void AddKeyVaultSecrets(
+        this IConfigurationManager configurationManager,
+        string connectionName,
+        Action<AzureSecurityKeyVaultSettings>? configureSettings = null,
+        Action<SecretClientOptions>? configureClientOptions = null,
+        AzureKeyVaultConfigurationOptions? options = null)
+        => AddAzureKeyVaultSecrets(configurationManager, connectionName, configureSettings, configureClientOptions, options);
+
+    /// <summary>
+    /// Adds the Azure KeyVault secrets to be configuration values in the <paramref name="configurationManager"/>.
+    /// </summary>
+    /// <param name="configurationManager">The <see cref="IConfigurationManager"/> to add the secrets to.</param>
+    /// <param name="connectionName">A name used to retrieve the connection string from the ConnectionStrings configuration section.</param>
+    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureSecurityKeyVaultSettings"/>. It's invoked after the settings are read from the configuration.</param>
+    /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="SecretClientOptions"/>.</param>
+    /// <param name="options">An optional <see cref="AzureKeyVaultConfigurationOptions"/> instance to configure the behavior of the configuration provider.</param>
+    public static void AddAzureKeyVaultSecrets(
         this IConfigurationManager configurationManager,
         string connectionName,
         Action<AzureSecurityKeyVaultSettings>? configureSettings = null,

--- a/src/Components/Aspire.Azure.Security.KeyVault/README.md
+++ b/src/Components/Aspire.Azure.Security.KeyVault/README.md
@@ -21,10 +21,10 @@ dotnet add package Aspire.Azure.Security.KeyVault
 
 ### Add secrets to configuration
 
-In the _Program.cs_ file of your project, call the `builder.Configuration.AddKeyVaultSecrets` extension method to add the secrets in the Azure Key Vault to the application's Configuration. The method takes a connection name parameter.
+In the _Program.cs_ file of your project, call the `builder.Configuration.AddAzureKeyVaultSecrets` extension method to add the secrets in the Azure Key Vault to the application's Configuration. The method takes a connection name parameter.
 
 ```csharp
-builder.Configuration.AddKeyVaultSecrets("secrets");
+builder.Configuration.AddAzureKeyVaultSecrets("secrets");
 ```
 
 You can then retrieve a secret through normal `IConfiguration` APIs. For example, to retrieve a secret from a Web API controller:

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/AspireKeyVaultExtensionsTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/AspireKeyVaultExtensionsTests.cs
@@ -81,7 +81,7 @@ public class AspireKeyVaultExtensionsTests
             new KeyValuePair<string, string?>("ConnectionStrings:secrets", ConformanceTests.VaultUri)
         ]);
 
-        builder.Configuration.AddKeyVaultSecrets("secrets", configureClientOptions: o =>
+        builder.Configuration.AddAzureKeyVaultSecrets("secrets", configureClientOptions: o =>
         {
             o.Transport = new MockTransport(
                 CreateResponse("""


### PR DESCRIPTION
The other extension methods were renamed to have "Azure" in them. This method should be named the same.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2786)