### PR TITLE
Fix build with VS

### DIFF
--- a/tests/Shared/Aspire.Workload.Testing.targets
+++ b/tests/Shared/Aspire.Workload.Testing.targets
@@ -82,8 +82,6 @@
     <ParameterGroup>
       <TemplateNuGetConfigPath ParameterType="System.String" Required="true" />
       <OutputFile ParameterType="System.String" Required="true" />
-      <AddBuiltNuGetSource ParameterType="System.Boolean" Required="false" />
-      <AddPackageSourceMapping ParameterType="System.Boolean" Required="false" />
     </ParameterGroup>
     <Task>
       <Using Namespace="System.IO" />
@@ -97,37 +95,40 @@
             return false;
           }
 
+          // This task adds a nuget packageSource pointing to the locally built nugets.
+          // And then adds a packageSourceMapping for that source to `*Aspire*` so the
+          // locally built nugets can be restored from there
+
+          // add packageSource
           XDocument doc = XDocument.Load(TemplateNuGetConfigPath);
-          if (AddBuiltNuGetSource)
+          string xpath = "/configuration/packageSources";
+          XElement packageSources = doc.XPathSelectElement(xpath);
+          if (packageSources is null)
           {
-            string xpath = "/configuration/packageSources";
-            XElement packageSources = doc.XPathSelectElement(xpath);
-            if (packageSources is null)
-            {
-              Log.LogError($"Could not find {xpath} in {TemplateNuGetConfigPath}");
-              return false;
-            }
-            packageSources.LastNode.AddAfterSelf(
-              new XElement("add",
-                new XAttribute("key", "nuget-local"),
-                new XAttribute("value", "%BUILT_NUGETS_PATH%")));
+            Log.LogError($"Could not find {xpath} in {TemplateNuGetConfigPath}");
+            return false;
           }
 
-          if (AddPackageSourceMapping)
-          {
-            string mappingXpath = "/configuration/packageSourceMapping";
-            XElement packageSourceMapping = doc.XPathSelectElement(mappingXpath);
-            if (packageSourceMapping is null)
-            {
-              // if mapping has been removed completely then the task needs an update!
-              throw new InvalidOperationException($"Expected to find {mappingXpath} in {TemplateNuGetConfigPath}");
-            }
+          // %BUILT_NUGETS_PATH% is set when building the testproject
+          packageSources.LastNode.AddAfterSelf(
+            new XElement("add",
+              new XAttribute("key", "nuget-local"),
+              new XAttribute("value", "%BUILT_NUGETS_PATH%")));
 
-            packageSourceMapping.FirstNode.AddBeforeSelf(
-              new XElement("packageSource",
-                new XAttribute("key", "nuget-local"),
-                new XElement("package", new XAttribute("pattern", "*Aspire*"))));
+          // add packageSourceMapping
+          string mappingXpath = "/configuration/packageSourceMapping";
+          XElement packageSourceMapping = doc.XPathSelectElement(mappingXpath);
+          if (packageSourceMapping is null)
+          {
+            // if mapping has been removed completely then the task needs an update!
+            throw new InvalidOperationException($"Expected to find {mappingXpath} in {TemplateNuGetConfigPath}");
           }
+
+          packageSourceMapping.FirstNode.AddBeforeSelf(
+            new XElement("packageSource",
+              new XAttribute("key", "nuget-local"),
+              new XElement("package", new XAttribute("pattern", "*Aspire*"))));
+
           doc.Save(OutputFile);
           Log.LogMessage(MessageImportance.Low, $"Generated patched nuget.config at {OutputFile}");
         ]]>

--- a/tests/Shared/Aspire.Workload.Testing.targets
+++ b/tests/Shared/Aspire.Workload.Testing.targets
@@ -139,7 +139,7 @@
   <!-- For test projects -->
 
   <Target Name="_PatchNuGetConfig" AfterTargets="GetCopyToOutputDirectoryItems" Inputs="$(TemplateNuGetConfigPath)" Outputs="$(PatchedNuGetConfigPath)">
-    <PrepareNuGetConfigForWorkloadTesting TemplateNuGetConfigPath="$(RepoRoot)NuGet.config" OutputFile="$(PatchedNuGetConfigPath)" AddBuiltNuGetSource="true" AddPackageSourceMapping="true" />
+    <PrepareNuGetConfigForWorkloadTesting TemplateNuGetConfigPath="$(RepoRoot)NuGet.config" OutputFile="$(PatchedNuGetConfigPath)" />
   </Target>
 
   <Target Name="_AddPackageVersionsForUseWithHelix" BeforeTargets="ZipTestArchive">

--- a/tests/Shared/Aspire.Workload.Testing.targets
+++ b/tests/Shared/Aspire.Workload.Testing.targets
@@ -76,18 +76,69 @@
     </ItemGroup>
   </Target>
 
+  <UsingTask TaskName="PrepareNuGetConfigForWorkloadTesting"
+      TaskFactory="RoslynCodeTaskFactory"
+      AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <TemplateNuGetConfigPath ParameterType="System.String" Required="true" />
+      <OutputFile ParameterType="System.String" Required="true" />
+      <AddBuiltNuGetSource ParameterType="System.Boolean" Required="false" />
+      <AddPackageSourceMapping ParameterType="System.Boolean" Required="false" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Xml.Linq" />
+      <Using Namespace="System.Xml.XPath" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+          if (!File.Exists(TemplateNuGetConfigPath))
+          {
+            Log.LogError($"Could not find nuget config template at '{TemplateNuGetConfigPath}' .");
+            return false;
+          }
+
+          XDocument doc = XDocument.Load(TemplateNuGetConfigPath);
+          if (AddBuiltNuGetSource)
+          {
+            string xpath = "/configuration/packageSources";
+            XElement packageSources = doc.XPathSelectElement(xpath);
+            if (packageSources is null)
+            {
+              Log.LogError($"Could not find {xpath} in {TemplateNuGetConfigPath}");
+              return false;
+            }
+            packageSources.LastNode.AddAfterSelf(
+              new XElement("add",
+                new XAttribute("key", "nuget-local"),
+                new XAttribute("value", "%BUILT_NUGETS_PATH%")));
+          }
+
+          if (AddPackageSourceMapping)
+          {
+            string mappingXpath = "/configuration/packageSourceMapping";
+            XElement packageSourceMapping = doc.XPathSelectElement(mappingXpath);
+            if (packageSourceMapping is null)
+            {
+              // if mapping has been removed completely then the task needs an update!
+              throw new InvalidOperationException($"Expected to find {mappingXpath} in {TemplateNuGetConfigPath}");
+            }
+
+            packageSourceMapping.FirstNode.AddBeforeSelf(
+              new XElement("packageSource",
+                new XAttribute("key", "nuget-local"),
+                new XElement("package", new XAttribute("pattern", "*Aspire*"))));
+          }
+          doc.Save(OutputFile);
+          Log.LogMessage(MessageImportance.Low, $"Generated patched nuget.config at {OutputFile}");
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
   <!-- For test projects -->
 
-  <Target Name="_PatchNuGetConfigForBuildingTestProject"
-          AfterTargets="GetCopyToOutputDirectoryItems"
-          Condition="'$(InstallWorkloadForTesting)' == 'true'"
-          Inputs="$(TemplateNuGetConfigPath)"
-          Outputs="$(PatchedNuGetConfigPath)">
-    <!-- %BUILT_NUGETS_PATH% is set when building the testproject -->
-    <PatchNuGetConfig TemplateNuGetConfigPath="$(RepoRoot)NuGet.config"
-                      LocalNuGetsPath="%BUILT_NUGETS_PATH%"
-                      NuGetConfigPackageSourceMappings="$(NuGetConfigPackageSourceMappingsForWorkloadTesting)"
-                      OutputPath="$(PatchedNuGetConfigPath)" />
+  <Target Name="_PatchNuGetConfig" AfterTargets="GetCopyToOutputDirectoryItems" Inputs="$(TemplateNuGetConfigPath)" Outputs="$(PatchedNuGetConfigPath)">
+    <PrepareNuGetConfigForWorkloadTesting TemplateNuGetConfigPath="$(RepoRoot)NuGet.config" OutputFile="$(PatchedNuGetConfigPath)" AddBuiltNuGetSource="true" AddPackageSourceMapping="true" />
   </Target>
 
   <Target Name="_AddPackageVersionsForUseWithHelix" BeforeTargets="ZipTestArchive">


### PR DESCRIPTION
[workload-testing] Use `PatchNuGetConfig` task only when actually needed - which is when running tests outside of repo
`net472` version of the task is needed for VS

The new task `PatchNuGetConfig` being used targets `net8.0`, and thus it fails in VS. The task is needed only when running tests outside-of-repo, so the condition is adjusted here.

Follow-up: ensure E2E tests can be run from VS too, outside-of-repo

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2792)