### PR TITLE
Bring environment and arguments to parity

### DIFF
--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -133,7 +133,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         PostOptionsArgs(Args(sidecarOptions?.Command)));
 
             var daprCliResourceName = $"{daprSidecar.Name}-cli";
-            var daprCli = new ExecutableResource(daprCliResourceName, fileName, appHostDirectory, daprCommandLine.Arguments.ToArray());
+            var daprCli = new ExecutableResource(daprCliResourceName, fileName, appHostDirectory);
 
             resource.Annotations.Add(
                 new EnvironmentCallbackAnnotation(
@@ -183,6 +183,8 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                 new CommandLineArgsCallbackAnnotation(
                     updatedArgs =>
                     {
+                        updatedArgs.AddRange(daprCommandLine.Arguments);
+
                         EndpointReference? httpEndPoint = null;
                         if (resource is IResourceWithEndpoints resourceWithEndpoints)
                         {

--- a/src/Aspire.Hosting/ApplicationModel/CommandLineArgsCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandLineArgsCallbackAnnotation.cs
@@ -21,7 +21,7 @@ public class CommandLineArgsCallbackAnnotation : IResourceAnnotation
     /// Initializes a new instance of the <see cref="CommandLineArgsCallbackAnnotation"/> class with the specified callback action.
     /// </summary>
     /// <param name="callback"> The callback action to be executed.</param>
-    public CommandLineArgsCallbackAnnotation(Action<IList<string>> callback)
+    public CommandLineArgsCallbackAnnotation(Action<IList<object>> callback)
     {
         Callback = (c) =>
         {
@@ -41,12 +41,12 @@ public class CommandLineArgsCallbackAnnotation : IResourceAnnotation
 /// </summary>
 /// <param name="args"> The list of command-line arguments.</param>
 /// <param name="cancellationToken"> The cancellation token associated with this execution.</param>
-public sealed class CommandLineArgsCallbackContext(IList<string> args, CancellationToken cancellationToken = default)
+public sealed class CommandLineArgsCallbackContext(IList<object> args, CancellationToken cancellationToken = default)
 {
     /// <summary>
     /// Gets the list of command-line arguments.
     /// </summary>
-    public IList<string> Args { get; } = args;
+    public IList<object> Args { get; } = args;
 
     /// <summary>
     /// Gets the cancellation token associated with the callback context.

--- a/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerResource.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="entrypoint">An optional container entrypoint.</param>
-public class ContainerResource(string name, string? entrypoint = null) : Resource(name), IResourceWithEnvironment, IResourceWithEndpoints
+public class ContainerResource(string name, string? entrypoint = null) : Resource(name), IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints
 {
     /// <summary>
     /// The container Entrypoint.

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -9,8 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="command">The command to execute.</param>
 /// <param name="workingDirectory">The working directory of the executable.</param>
-/// <param name="args">The arguments to pass to the executable.</param>
-public class ExecutableResource(string name, string command, string workingDirectory, string[]? args) : Resource(name), IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints
+public class ExecutableResource(string name, string command, string workingDirectory) : Resource(name), IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints
 {
     /// <summary>
     /// Gets the command associated with this executable resource.
@@ -21,9 +20,4 @@ public class ExecutableResource(string name, string command, string workingDirec
     /// Gets the working directory for the executable resource.
     /// </summary>
     public string WorkingDirectory { get; } = workingDirectory;
-    
-    /// <summary>
-    /// Gets the command line arguments passed to the executable resource.
-    /// </summary>
-    public string[]? Args { get; } = args;
 }

--- a/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExecutableResource.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="command">The command to execute.</param>
 /// <param name="workingDirectory">The working directory of the executable.</param>
 /// <param name="args">The arguments to pass to the executable.</param>
-public class ExecutableResource(string name, string command, string workingDirectory, string[]? args) : Resource(name), IResourceWithEnvironment, IResourceWithEndpoints
+public class ExecutableResource(string name, string command, string workingDirectory, string[]? args) : Resource(name), IResourceWithEnvironment, IResourceWithArgs, IResourceWithEndpoints
 {
     /// <summary>
     /// Gets the command associated with this executable resource.

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithArgs.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithArgs.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a resource that is associated with commandline arguments.
+/// </summary>
+public interface IResourceWithArgs : IResource
+{
+}

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -883,7 +883,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
             // The working directory is always relative to the app host project directory (if it exists).
             exe.Spec.WorkingDirectory = executable.WorkingDirectory;
-            exe.Spec.Args = executable.Args?.ToList();
             exe.Spec.ExecutionType = ExecutionType.Process;
             exe.Annotate(Executable.OtelServiceNameAnnotation, exe.Metadata.Name);
             exe.Annotate(Executable.ResourceNameAnnotation, executable.Name);

--- a/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ContainerResourceBuilderExtensions.cs
@@ -68,22 +68,6 @@ public static class ContainerResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds the arguments to be passed to a container resource when the container is started.
-    /// </summary>
-    /// <typeparam name="T">The resource type.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="args">The arguments to be passed to the container when it is started.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>    
-    public static IResourceBuilder<T> WithArgs<T>(this IResourceBuilder<T> builder, params string[] args) where T : ContainerResource
-    {
-        var annotation = new CommandLineArgsCallbackAnnotation(updatedArgs =>
-        {
-            updatedArgs.AddRange(args);
-        });
-        return builder.WithAnnotation(annotation);
-    }
-
-    /// <summary>
     /// Sets the Entrypoint for the container.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>

--- a/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
@@ -52,22 +52,6 @@ public static class ExecutableResourceBuilderExtensions
         return builder.WithManifestPublishingCallback(context => WriteExecutableAsDockerfileResourceAsync(context, builder.Resource));
     }
 
-    /// <summary>
-    /// Adds the arguments to be passed to an executable resource when the executable is started.
-    /// </summary>
-    /// <typeparam name="T">The resource type.</typeparam>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="args">The arguments to be passed to the executable when it is started.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> WithArgs<T>(this IResourceBuilder<T> builder, params string[] args) where T : ExecutableResource
-    {
-        var annotation = new CommandLineArgsCallbackAnnotation(updatedArgs =>
-        {
-            updatedArgs.AddRange(args);
-        });
-        return builder.WithAnnotation(annotation);
-    }
-
     private static async Task WriteExecutableAsDockerfileResourceAsync(ManifestPublishingContext context, ExecutableResource executable)
     {
         context.Writer.WriteString("type", "dockerfile.v0");

--- a/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
@@ -25,8 +25,15 @@ public static class ExecutableResourceBuilderExtensions
     {
         workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, workingDirectory));
 
-        var executable = new ExecutableResource(name, command, workingDirectory, args);
-        return builder.AddResource(executable);
+        var executable = new ExecutableResource(name, command, workingDirectory);
+        return builder.AddResource(executable)
+                      .WithArgs(context =>
+                      {
+                          if (args is not null)
+                          {
+                              context.Args.AddRange(args);
+                          }
+                      });
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ResourceBuilderExtensions.cs
@@ -116,6 +116,46 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Adds the arguments to be passed to a container resource when the container is started.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="args">The arguments to be passed to the container when it is started.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithArgs<T>(this IResourceBuilder<T> builder, params string[] args) where T : IResourceWithArgs
+    {
+        return builder.WithArgs(context => context.Args.AddRange(args));
+    }
+
+    /// <summary>
+    /// Adds a callback to be executed with a list of command-line arguments when a container resource is started.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="callback">A callback that allows for deferred execution for computing arguments. This runs after resources have been allocated by the orchestrator and allows access to other resources to resolve computed data, e.g. connection strings, ports.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithArgs<T>(this IResourceBuilder<T> builder, Action<CommandLineArgsCallbackContext> callback) where T : IResourceWithArgs
+    {
+        return builder.WithArgs(context =>
+        {
+            callback(context);
+            return Task.CompletedTask;
+        });
+    }
+
+    /// <summary>
+    /// Adds a callback to be executed with a list of command-line arguments when a container resource is started.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="callback">A callback that allows for deferred execution for computing arguments. This runs after resources have been allocated by the orchestrator and allows access to other resources to resolve computed data, e.g. connection strings, ports.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithArgs<T>(this IResourceBuilder<T> builder, Func<CommandLineArgsCallbackContext, Task> callback) where T : IResourceWithArgs
+    {
+        return builder.WithAnnotation(new CommandLineArgsCallbackAnnotation(callback));
+    }
+
+    /// <summary>
     /// Registers a callback which is invoked when manifest is generated for the app model.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>

--- a/src/Aspire.Hosting/Node/NodeAppResource.cs
+++ b/src/Aspire.Hosting/Node/NodeAppResource.cs
@@ -10,9 +10,8 @@ namespace Aspire.Hosting;
 /// <param name="name">The name of the resource.</param>
 /// <param name="command">The command to execute.</param>
 /// <param name="workingDirectory">The working directory to use for the command. If null, the working directory of the current process is used.</param>
-/// <param name="args">The arguments to pass to the command.</param>
-public class NodeAppResource(string name, string command, string workingDirectory, string[]? args)
-    : ExecutableResource(name, command, workingDirectory, args), IResourceWithServiceDiscovery
+public class NodeAppResource(string name, string command, string workingDirectory)
+    : ExecutableResource(name, command, workingDirectory), IResourceWithServiceDiscovery
 {
 
 }

--- a/src/Aspire.Hosting/Node/NodeExtensions.cs
+++ b/src/Aspire.Hosting/Node/NodeExtensions.cs
@@ -27,10 +27,11 @@ public static class NodeAppHostingExtension
         workingDirectory ??= Path.GetDirectoryName(scriptPath)!;
         workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, workingDirectory));
 
-        var resource = new NodeAppResource(name, "node", workingDirectory, effectiveArgs);
+        var resource = new NodeAppResource(name, "node", workingDirectory);
 
         return builder.AddResource(resource)
-                      .WithNodeDefaults();
+                      .WithNodeDefaults()
+                      .WithArgs(effectiveArgs);
     }
 
     /// <summary>
@@ -49,10 +50,11 @@ public static class NodeAppHostingExtension
             : ["run", scriptName];
 
         workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, workingDirectory));
-        var resource = new NodeAppResource(name, "npm", workingDirectory, allArgs);
+        var resource = new NodeAppResource(name, "npm", workingDirectory);
 
         return builder.AddResource(resource)
-                      .WithNodeDefaults();
+                      .WithNodeDefaults()
+                      .WithArgs(allArgs);
     }
 
     private static IResourceBuilder<NodeAppResource> WithNodeDefaults(this IResourceBuilder<NodeAppResource> builder) =>

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -140,28 +140,7 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
 
         context.Writer.WriteString("command", executable.Command);
 
-        var args = new List<string>(executable.Args ?? []);
-
-        if (executable.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argsCallback))
-        {
-            var commandLineArgsContext = new CommandLineArgsCallbackContext(args, context.CancellationToken);
-
-            foreach (var callback in argsCallback)
-            {
-                await callback.Callback(commandLineArgsContext).ConfigureAwait(false);
-            }
-        }
-
-        if (args.Count > 0)
-        {
-            context.Writer.WriteStartArray("args");
-
-            foreach (var arg in args)
-            {
-                context.Writer.WriteStringValue(arg);
-            }
-            context.Writer.WriteEndArray();
-        }
+        await context.WriteCommandLineArgumentsAsync(executable).ConfigureAwait(false);
 
         await context.WriteEnvironmentVariablesAsync(executable).ConfigureAwait(false);
         context.WriteBindings(executable);

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -82,28 +82,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
         }
 
         // Write args if they are present
-        if (container.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argsCallback))
-        {
-            var args = new List<string>();
-
-            var commandLineArgsContext = new CommandLineArgsCallbackContext(args, CancellationToken);
-
-            foreach (var callback in argsCallback)
-            {
-                await callback.Callback(commandLineArgsContext).ConfigureAwait(false);
-            }
-
-            if (args.Count > 0)
-            {
-                Writer.WriteStartArray("args");
-
-                foreach (var arg in args)
-                {
-                    Writer.WriteStringValue(arg);
-                }
-                Writer.WriteEndArray();
-            }
-        }
+        await WriteCommandLineArgumentsAsync(container).ConfigureAwait(false);
 
         // Write volume details
         if (container.TryGetAnnotationsOfType<ContainerMountAnnotation>(out var mounts))
@@ -223,6 +202,45 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
             WritePortBindingEnvironmentVariables(resource);
 
             Writer.WriteEndObject();
+        }
+    }
+
+    /// <summary>
+    /// TODO: Doc Comments
+    /// </summary>
+    /// <param name="resource"></param>
+    /// <returns></returns>
+    public async Task WriteCommandLineArgumentsAsync(IResource resource)
+    {
+        var args = new List<object>();
+
+        if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argsCallback))
+        {
+            var commandLineArgsContext = new CommandLineArgsCallbackContext(args, CancellationToken);
+
+            foreach (var callback in argsCallback)
+            {
+                await callback.Callback(commandLineArgsContext).ConfigureAwait(false);
+            }
+        }
+
+        if (args.Count > 0)
+        {
+            Writer.WriteStartArray("args");
+
+            foreach (var arg in args)
+            {
+                var valueString = arg switch
+                {
+                    string stringValue => stringValue,
+                    IManifestExpressionProvider manifestExpression => manifestExpression.ValueExpression,
+                    _ => throw new DistributedApplicationException($"The value of the argument '{arg}' is not supported.")
+                };
+
+                Writer.WriteStringValue(valueString);
+            }
+
+            Writer.WriteEndArray();
         }
     }
 

--- a/tests/Aspire.Hosting.Tests/ContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -44,5 +46,62 @@ public class ContainerResourceTests
         Assert.Equal("nightly", containerAnnotation.Tag);
         Assert.Equal("none", containerAnnotation.Image);
         Assert.Null(containerAnnotation.Registry);
+    }
+
+    [Fact]
+    public async Task AddContainerWithArgs()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var testResource = new TestResource("test", "connectionString");
+
+        var c1 = appBuilder.AddContainer("c1", "image2")
+            .WithEndpoint("ep", e =>
+            {
+                e.UriScheme = "http";
+                e.AllocatedEndpoint = new(e, "localhost", 1234);
+            });
+
+        var c2 = appBuilder.AddContainer("container", "none")
+             .WithArgs(context =>
+             {
+                 context.Args.Add("arg1");
+                 context.Args.Add(c1.GetEndpoint("ep"));
+                 context.Args.Add(testResource);
+             });
+
+        using var app = appBuilder.Build();
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(c2.Resource);
+
+        Assert.Collection(args,
+            arg => Assert.Equal("arg1", arg),
+            arg => Assert.Equal("http://localhost:1234", arg),
+            arg => Assert.Equal("connectionString", arg));
+
+        var manifest = await ManifestUtils.GetManifest(c2.Resource);
+
+        var expectedManifest =
+        """
+        {
+          "type": "container.v0",
+          "image": "none:latest",
+          "args": [
+            "arg1",
+            "{c1.bindings.ep.url}",
+            "{test.connectionString}"
+          ]
+        }
+        """;
+
+        Assert.Equal(expectedManifest, manifest.ToString());
+    }
+
+    private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
+    {
+        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+        {
+            return new(connectionString);
+        }
     }
 }

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class ExecutableResourceTests
+{
+    [Fact]
+    public async Task AddContainerWithArgs()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var testResource = new TestResource("test", "connectionString");
+
+        var exe1 = appBuilder.AddExecutable("e1", "ruby", ".", "app.rb")
+            .WithEndpoint("ep", e =>
+            {
+                e.UriScheme = "http";
+                e.AllocatedEndpoint = new(e, "localhost", 1234);
+            });
+
+        var exe2 = appBuilder.AddExecutable("e2", "python", ".", "app.py")
+             .WithArgs(context =>
+             {
+                 context.Args.Add("arg1");
+                 context.Args.Add(exe1.GetEndpoint("ep"));
+                 context.Args.Add(testResource);
+             });
+
+        using var app = appBuilder.Build();
+
+        var args = await ArgumentEvaluator.GetArgumentListAsync(exe2.Resource);
+
+        Assert.Collection(args,
+            arg => Assert.Equal("arg1", arg),
+            arg => Assert.Equal("http://localhost:1234", arg),
+            arg => Assert.Equal("connectionString", arg));
+
+        var manifest = await ManifestUtils.GetManifest(exe2.Resource);
+
+        var expectedManifest =
+        """
+        {
+          "type": "executable.v0",
+          "workingDirectory": "net8.0",
+          "command": "python",
+          "args": [
+            "arg1",
+            "{e1.bindings.ep.url}",
+            "{test.connectionString}"
+          ]
+        }
+        """;
+
+        Assert.Equal(expectedManifest, manifest.ToString());
+    }
+
+    private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
+    {
+        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
+        {
+            return new(connectionString);
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Tests;
 public class ExecutableResourceTests
 {
     [Fact]
-    public async Task AddContainerWithArgs()
+    public async Task AddExecutableWithArgs()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
 
@@ -36,6 +36,7 @@ public class ExecutableResourceTests
         var args = await ArgumentEvaluator.GetArgumentListAsync(exe2.Resource);
 
         Assert.Collection(args,
+            arg => Assert.Equal("app.py", arg),
             arg => Assert.Equal("arg1", arg),
             arg => Assert.Equal("http://localhost:1234", arg),
             arg => Assert.Equal("connectionString", arg));
@@ -49,6 +50,7 @@ public class ExecutableResourceTests
           "workingDirectory": "net8.0",
           "command": "python",
           "args": [
+            "app.py",
             "arg1",
             "{e1.bindings.ep.url}",
             "{test.connectionString}"

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -466,6 +466,7 @@ public class ManifestGenerationTests
 
         static void AssertNodeResource(string resourceName, JsonElement jsonElement, string expectedCommand, string[] expectedArgs)
         {
+            var s = jsonElement.ToString();
             Assert.Equal("executable.v0", jsonElement.GetProperty("type").GetString());
 
             var bindings = jsonElement.GetProperty("bindings");
@@ -480,8 +481,6 @@ public class ManifestGenerationTests
             var command = jsonElement.GetProperty("command");
             Assert.Equal(expectedCommand, command.GetString());
             Assert.Equal(expectedArgs, jsonElement.GetProperty("args").EnumerateArray().Select(e => e.GetString()).ToArray());
-
-            var args = jsonElement.GetProperty("args");
         }
 
         AssertNodeResource("nodeapp", nodeApp, "node", ["..\\foo\\app.js"]);

--- a/tests/Aspire.Hosting.Tests/Nats/AddNatsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Nats/AddNatsTests.cs
@@ -58,7 +58,7 @@ public class AddNatsTests
 
         var argsAnnotation = Assert.Single(containerResource.Annotations.OfType<CommandLineArgsCallbackAnnotation>());
         Assert.NotNull(argsAnnotation.Callback);
-        var args = new List<string>();
+        var args = new List<object>();
         argsAnnotation.Callback(new CommandLineArgsCallbackContext(args));
         Assert.Equal("-js -sd /data".Split(' '), args);
 

--- a/tests/Aspire.Hosting.Tests/Utils/ArgumentEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/ArgumentEvaluator.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Tests.Utils;
+
+internal sealed class ArgumentEvaluator
+{
+    public static async ValueTask<List<string>> GetArgumentListAsync(IResource resource)
+    {
+        var finalArgs = new List<string>();
+
+        if (resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var exeArgsCallbacks))
+        {
+            var args = new List<object>();
+            var commandLineContext = new CommandLineArgsCallbackContext(args, default);
+
+            foreach (var exeArgsCallback in exeArgsCallbacks)
+            {
+                await exeArgsCallback.Callback(commandLineContext).ConfigureAwait(false);
+            }
+
+            foreach (var arg in args)
+            {
+                var value = arg switch
+                {
+                    string s => s,
+                    IValueProvider valueProvider => await valueProvider.GetValueAsync().ConfigureAwait(false),
+                    null => null,
+                    _ => throw new InvalidOperationException($"Unexpected value for {arg}")
+                };
+
+                if (value is not null)
+                {
+                    finalArgs.Add(value);
+                }
+            }
+        }
+
+        return finalArgs;
+    }
+}


### PR DESCRIPTION
- Added `IResourceWithArgs`, and moved all of the WithArgs extension methods to it.
- Allow objects in command line arguments.
- Removed args array from ExecutableResource and use WithArgs
- Added tests
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2797)