### PR TITLE
Add loading indicator to resources page

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -54,7 +54,7 @@
             @{
                 var gridTemplateColumns = HasResourcesWithCommands ? "1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr 1fr" : "1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr";
             }
-            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass">
+            <FluentDataGrid Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading">
                 <ChildContent>
                     <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" />
                     <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -38,6 +38,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
     private string _filter = "";
     private bool _isTypeFilterVisible;
     private Task? _resourceSubscriptionTask;
+    private bool _isLoading = true;
 
     public Resources()
     {
@@ -129,6 +130,8 @@ public partial class Resources : ComponentBase, IAsyncDisposable
                 await InvokeAsync(StateHasChanged);
             }
         });
+
+        _isLoading = false;
 
         async Task SubscribeResourcesAsync()
         {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -111,8 +111,21 @@ h1 {
     overflow: auto;
 }
 
-fluent-data-grid .empty-content-cell {
-    height: 100px;
+fluent-data-grid .empty-content-cell,
+fluent-data-grid .loading-content-cell {
+    padding: calc(var(--design-unit) * 5px);
+    display: flex;
+    align-items: center;
+}
+
+/*
+    Default LoadingContent template has align-items set to start, so the
+    text doesn't line up with the spinner properly. It is set via inline style
+    so we need to use !important to override it.
+*/
+fluent-data-grid .loading-content-cell .stack-horizontal {
+    align-items: center !important;
+    column-gap: calc(var(--design-unit) * 2px) !important;
 }
 
 .custom-body-content {


### PR DESCRIPTION
Resolves #2568.

After some inspection, the pages using virtualized data that have static backing stores (Structured Logs, Traces, Metrics) make a call to get data before the page even loads (in the first SetParametersAsync call). So there's no reasonable window to have a loading indicator. So this PR just addresses the `/resources` page. If we find a good repro of a delay in one of the other pages, we can address it separately at that time.

The grid loads with Loading = true. Loading is set to false after the subscription is created and the first snapshot is loaded. If there's no data in that first snapshot, then we'll show the empty content template as before.

An example (w/ an artificial delay added to the call):
![ResourcesLoadingIndicator](https://github.com/dotnet/aspire/assets/9613109/465bba19-58c9-40f3-9bf0-e72b51d8bd97)

I also adjusted the empty content template styling as it looks like it regressed at some point (you can see the before in the examples in https://github.com/dotnet/aspire/pull/2556):
![image](https://github.com/dotnet/aspire/assets/9613109/81ddce07-0c23-4282-bb4a-ad0c4b527b22)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2806)