### PR TITLE
Improve performance of trace detail page with big traces

### DIFF
--- a/playground/Stress/Stress.ApiService/BigTraceCreator.cs
+++ b/playground/Stress/Stress.ApiService/BigTraceCreator.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Stress.ApiService;
+
+public class BigTraceCreator
+{
+    public const string ActivitySourceName = "BigTraceSpan";
+
+    private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
+
+    public async Task CreateBigTraceAsync()
+    {
+        var activityStack = new Stack<Activity>();
+
+        for (var i = 0; i < 10; i++)
+        {
+            var name = $"Span-{i}";
+            using var activity = s_activitySource.StartActivity(name, ActivityKind.Client);
+            if (activity == null)
+            {
+                continue;
+            }
+
+            await CreateChildActivityAsync(name);
+
+            await Task.Delay(Random.Shared.Next(10, 50));
+        }
+
+        while (activityStack.Count > 0)
+        {
+            activityStack.Pop().Stop();
+        }
+    }
+
+    private static async Task CreateChildActivityAsync(string parentName)
+    {
+        if (Random.Shared.NextDouble() > 0.05)
+        {
+            var name = parentName + "-0";
+            using var activity = s_activitySource.StartActivity(name, ActivityKind.Client);
+
+            await Task.Delay(Random.Shared.Next(10, 50));
+
+            await CreateChildActivityAsync(name);
+
+            await Task.Delay(Random.Shared.Next(10, 50));
+        }
+    }
+}

--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -1,14 +1,28 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Stress.ApiService;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddSource(BigTraceCreator.ActivitySourceName));
 
 var app = builder.Build();
 
 app.Lifetime.ApplicationStarted.Register(ConsoleStresser.Stress);
 
 app.MapGet("/", () => "Hello world");
+
+app.MapGet("/big-trace", async () =>
+{
+    var bigTraceCreator = new BigTraceCreator();
+
+    await bigTraceCreator.CreateBigTraceAsync();
+
+    return "Big trace created";
+});
 
 app.Run();

--- a/playground/Stress/Stress.TelemetryService/TelemetryStresser.cs
+++ b/playground/Stress/Stress.TelemetryService/TelemetryStresser.cs
@@ -26,9 +26,17 @@ public class TelemetryStresser(ILogger<TelemetryStresser> logger, IConfiguration
         {
             value += Random.Shared.Next(0, 10);
 
-            var request = new ExportMetricsServiceRequest
-            {
-                ResourceMetrics =
+            await ExportMetrics(logger, client, value, cancellationToken);
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+        }
+    }
+
+    private static async Task ExportMetrics(ILogger<TelemetryStresser> logger, MetricsService.MetricsServiceClient client, int value, CancellationToken cancellationToken)
+    {
+        var request = new ExportMetricsServiceRequest
+        {
+            ResourceMetrics =
                 {
                     new ResourceMetrics
                     {
@@ -49,14 +57,11 @@ public class TelemetryStresser(ILogger<TelemetryStresser> logger, IConfiguration
                         }
                     }
                 }
-            };
+        };
 
-            logger.LogDebug("Exporting metrics");
-            var response = await client.ExportAsync(request, cancellationToken: cancellationToken);
-            logger.LogDebug($"Export complete. Rejected count: {response.PartialSuccess?.RejectedDataPoints ?? 0}");
-
-            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
-        }
+        logger.LogDebug("Exporting metrics");
+        var response = await client.ExportAsync(request, cancellationToken: cancellationToken);
+        logger.LogDebug($"Export complete. Rejected count: {response.PartialSuccess?.RejectedDataPoints ?? 0}");
     }
 
     public static Resource CreateResource(string? name = null, string? instanceId = null)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -10,12 +10,12 @@
 
 <PageTitle><ApplicationName ResourceName="@nameof(Dashboard.Resources.TraceDetail.TraceDetailPageTitle)" Loc="@Loc" /></PageTitle>
 
-@if (_trace != null)
+@if (_trace is { } trace)
 {
     <div class="trace-detail-layout">
         <div class="trace-detail-header page-header">
-            <h1 style="display:inline-block">@GetResourceName(_trace.FirstSpan.Source): @_trace.FirstSpan.Name</h1>
-            <span class="trace-id">@OtlpHelpers.ToShortenedId(_trace.TraceId)</span>
+            <h1 style="display:inline-block">@GetResourceName(trace.FirstSpan.Source): @trace.FirstSpan.Name</h1>
+            <span class="trace-id">@OtlpHelpers.ToShortenedId(trace.TraceId)</span>
         </div>
         <FluentToolbar Orientation="Orientation.Horizontal">
             <div>
@@ -23,11 +23,11 @@
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
-                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailDurationHeader)] <strong>@DurationFormatter.FormatDuration(_trace.Duration)</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailDurationHeader)] <strong>@DurationFormatter.FormatDuration(trace.Duration)</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
-                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailResourcesHeader)] <strong>@_trace.Spans.GroupBy(s => s.Source).Count()</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailResourcesHeader)] <strong>@trace.Spans.GroupBy(s => s.Source).Count()</strong>
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
@@ -35,9 +35,9 @@
             </div>
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <div>
-                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTotalSpansHeader)] <strong>@_trace.Spans.Count</strong>
+                @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTotalSpansHeader)] <strong>@trace.Spans.Count</strong>
             </div>
-            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@DashboardUrls.StructuredLogsUrl(traceId: _trace.TraceId)">@ControlStringsLoc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
+            <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@DashboardUrls.StructuredLogsUrl(traceId: trace.TraceId)">@ControlStringsLoc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
         </FluentToolbar>
 
         <SummaryDetailsView
@@ -53,7 +53,7 @@
                 </div>
             </DetailsTitleTemplate>
             <Summary>
-                <FluentDataGrid Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="4fr 12fr 85px">
+                <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="4fr 12fr 85px">
                     <TemplateColumn Title="Name">
                         <div class="col-long-content" title="@context.GetTooltip()" @onclick="() => OnShowProperties(context)">
                             @{
@@ -139,15 +139,15 @@
                                 <span class="tick-label" style="grid-column: 1;">@DurationFormatter.FormatDuration(TimeSpan.Zero)</span>
 
                                 <div class="tick" style="grid-column: 2;"></div>
-                                <span class="tick-label" style="grid-column: 2;">@DurationFormatter.FormatDuration(_trace.Duration / 4)</span>
+                                <span class="tick-label" style="grid-column: 2;">@DurationFormatter.FormatDuration(trace.Duration / 4)</span>
 
                                 <div class="tick" style="grid-column: 3;"></div>
-                                <span class="tick-label" style="grid-column: 3;">@DurationFormatter.FormatDuration(_trace.Duration / 4 * 2)</span>
+                                <span class="tick-label" style="grid-column: 3;">@DurationFormatter.FormatDuration(trace.Duration / 4 * 2)</span>
 
                                 <div class="tick" style="grid-column: 4;"></div>
-                                <span class="tick-label" style="grid-column: 4;">@DurationFormatter.FormatDuration(_trace.Duration / 4 * 3)</span>
+                                <span class="tick-label" style="grid-column: 4;">@DurationFormatter.FormatDuration(trace.Duration / 4 * 3)</span>
 
-                                <span class="tick-label end-tick" style="grid-column: 4;">@DurationFormatter.FormatDuration(_trace.Duration)</span>
+                                <span class="tick-label end-tick" style="grid-column: 4;">@DurationFormatter.FormatDuration(trace.Duration)</span>
                                 <div class="tick" style="grid-column: 5;"></div>
                             </div>
                         </HeaderCellItemTemplate>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -50,10 +50,21 @@ public partial class TraceDetail : ComponentBase
         Debug.Assert(_spanWaterfallViewModels != null);
 
         var visibleSpanWaterfallViewModels = _spanWaterfallViewModels.Where(viewModel => !viewModel.IsHidden).ToList();
+
+        var page = visibleSpanWaterfallViewModels.AsEnumerable();
+        if (request.StartIndex > 0)
+        {
+            page = page.Skip(request.StartIndex);
+        }
+        if (request.Count != null)
+        {
+            page = page.Take(request.Count.Value);
+        }
+
         return ValueTask.FromResult(new GridItemsProviderResult<SpanWaterfallViewModel>
         {
-            Items = visibleSpanWaterfallViewModels,
-            TotalItemCount = _spanWaterfallViewModels.Count
+            Items = page.ToList(),
+            TotalItemCount = visibleSpanWaterfallViewModels.Count
         });
     }
 
@@ -180,15 +191,15 @@ public partial class TraceDetail : ComponentBase
         if (TraceId is not null)
         {
             _trace = TelemetryRepository.GetTrace(TraceId);
-            if (_trace != null)
+            if (_trace is { } trace)
             {
-                _spanWaterfallViewModels = CreateSpanWaterfallViewModels(_trace, new TraceDetailState(OutgoingPeerResolvers, _collapsedSpanIds));
+                _spanWaterfallViewModels = CreateSpanWaterfallViewModels(trace, new TraceDetailState(OutgoingPeerResolvers, _collapsedSpanIds));
                 _maxDepth = _spanWaterfallViewModels.Max(s => s.Depth);
 
-                if (_tracesSubscription is null || _tracesSubscription.ApplicationId != _trace.FirstSpan.Source.InstanceId)
+                if (_tracesSubscription is null || _tracesSubscription.ApplicationId != trace.FirstSpan.Source.InstanceId)
                 {
                     _tracesSubscription?.Dispose();
-                    _tracesSubscription = TelemetryRepository.OnNewTraces(_trace.FirstSpan.Source.InstanceId, SubscriptionType.Read, () => InvokeAsync(() =>
+                    _tracesSubscription = TelemetryRepository.OnNewTraces(trace.FirstSpan.Source.InstanceId, SubscriptionType.Read, () => InvokeAsync(() =>
                     {
                         UpdateDetailViewData();
                         StateHasChanged();


### PR DESCRIPTION
Traces can have an unlimited number of spans. The trace detail page struggles rendering more than a few hundred spans in the span graph.

Fortunately the smart and handsome developer of this page built the span graph in a FluentDataGrid. It's simple to enable virtualization. Only rendering the viewed data makes this page fast with thousands of spans.

Demo of big trace with virtualization:
![trace-detail-large-trace](https://github.com/dotnet/aspire/assets/303201/0697a120-4c7c-4c70-b6d3-37bea0bfe276)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2807)