### PR TITLE
Redirect test logs into a subfolder

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- Set RunSettingsFilePath property which is read by VSTest. -->
     <RunSettingsFilePath Condition="'$(RunSettingsFilePath)' == ''">$(RepositoryEngineeringDir).runsettings</RunSettingsFilePath>
+    <!-- Redirect test logs into a subfolder -->
+    <TestResultsLogDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsLogDir)', 'TestLogs'))</TestResultsLogDir>
     <!-- We don't want to use the workload for AppHost projects in this repo -->
     <SkipAspireWorkloadManifest>true</SkipAspireWorkloadManifest>
 


### PR DESCRIPTION
Redirect test logs to dedicated folders making it easier to view build artifacts. 
Documentation: https://github.com/dotnet/arcade/blob/main/Documentation/ArcadeSdk.md#testresultslogdir-string

![image](https://github.com/dotnet/aspire/assets/4403806/1575341f-a81e-48fb-90d1-c773d5daa512)

Example build: https://dev.azure.com/dnceng-public/public/_build/results?buildId=599186&view=artifacts&pathAsName=false&type=publishedArtifacts

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2808)