### PR TITLE
Replace HttpUtility.UrlEncode with Uri.EscapeDataString, use escaped form of + when joining multiple structured logs filters

### DIFF
--- a/src/Aspire.Dashboard/Utils/DashboardUrls.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUrls.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using System.Web;
 using Microsoft.AspNetCore.WebUtilities;
 
 namespace Aspire.Dashboard.Utils;
@@ -24,7 +23,7 @@ internal static class DashboardUrls
         var url = $"/{ConsoleLogBasePath}";
         if (resource != null)
         {
-            url += $"/resource/{HttpUtility.UrlEncode(resource)}";
+            url += $"/resource/{Uri.EscapeDataString(resource)}";
         }
 
         return url;
@@ -35,7 +34,7 @@ internal static class DashboardUrls
         var url = $"/{MetricsBasePath}";
         if (resource != null)
         {
-            url += $"/resource/{HttpUtility.UrlEncode(resource)}";
+            url += $"/resource/{Uri.EscapeDataString(resource)}";
         }
         if (meter is not null)
         {
@@ -63,7 +62,7 @@ internal static class DashboardUrls
         var url = $"/{StructuredLogsBasePath}";
         if (resource != null)
         {
-            url += $"/resource/{HttpUtility.UrlEncode(resource)}";
+            url += $"/resource/{Uri.EscapeDataString(resource)}";
         }
         if (logLevel != null)
         {
@@ -91,7 +90,7 @@ internal static class DashboardUrls
         var url = $"/{TracesBasePath}";
         if (resource != null)
         {
-            url += $"/resource/{HttpUtility.UrlEncode(resource)}";
+            url += $"/resource/{Uri.EscapeDataString(resource)}";
         }
 
         return url;
@@ -99,6 +98,6 @@ internal static class DashboardUrls
 
     public static string TraceDetailUrl(string traceId)
     {
-        return $"/{TracesBasePath}/detail/{HttpUtility.UrlEncode(traceId)}";
+        return $"/{TracesBasePath}/detail/{Uri.EscapeDataString(traceId)}";
     }
 }

--- a/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
@@ -39,16 +39,17 @@ public class DashboardUrlsTests
 
         Assert.Equal($"/structuredlogs/resource/resource{PlaceholderAllCharactersEncoded}?logLevel=error&filters=test:contains:value&traceId={PlaceholderAllButExclamationMarkEncoded}&spanId={PlaceholderAllButExclamationMarkEncoded}", singleFilterUrl);
 
-        var multipleFiltersUrl = DashboardUrls.StructuredLogsUrl(
+        var multipleFiltersIncludingSpacesUrl = DashboardUrls.StructuredLogsUrl(
             resource: $"resource{PlaceholderInput}",
             logLevel: "error",
             filters: LogFilterFormatter.SerializeLogFiltersToString([
                 new LogFilter { Condition = FilterCondition.Contains, Field = "test", Value = "value" },
+                new LogFilter { Condition = FilterCondition.GreaterThan, Field = "fieldWithSpacedValue", Value = "!! multiple words here !!" },
                 new LogFilter { Condition = FilterCondition.NotEqual, Field = "name", Value = "nameValue" },
             ]),
             traceId: PlaceholderInput,
             spanId: PlaceholderInput);
-        Assert.Equal($"/structuredlogs/resource/resource{PlaceholderAllCharactersEncoded}?logLevel=error&filters=test:contains:value%2Bname:!equals:nameValue&traceId={PlaceholderAllButExclamationMarkEncoded}&spanId={PlaceholderAllButExclamationMarkEncoded}", multipleFiltersUrl);
+        Assert.Equal($"/structuredlogs/resource/resource{PlaceholderAllCharactersEncoded}?logLevel=error&filters=test:contains:value%2BfieldWithSpacedValue:gt:%21%21%20multiple%20words%20here%20%21%21%2Bname:!equals:nameValue&traceId={PlaceholderAllButExclamationMarkEncoded}&spanId={PlaceholderAllButExclamationMarkEncoded}", multipleFiltersIncludingSpacesUrl);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardUrlsTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Extensions;
+using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Utils;
 using Xunit;
 
@@ -8,47 +10,69 @@ namespace Aspire.Dashboard.Tests;
 
 public class DashboardUrlsTests
 {
+    private const string PlaceholderInput = "!@#";
+
+    // There is a difference in behavior between Uri.EscapeDataString and QueryHelpers.AddQueryString
+    // with relation to ! and @ - they are encoded by the former, but not the latter.
+    // It is not required to encode either - some implementations do, and some do not. However, ASP.NET will decode
+    // both the encoded and unencoded characters to the same character, so it has no practical effect.
+    private const string PlaceholderAllCharactersEncoded = "%21%40%23";
+    private const string PlaceholderAllButExclamationMarkEncoded = "!@%23";
+
     [Fact]
     public void ConsoleLogsUrl_HtmlValues_CorrectlyEscaped()
     {
-        Assert.Equal("/consolelogs/resource/resource!%40%23", DashboardUrls.ConsoleLogsUrl(resource: "resource!@#"));
+        Assert.Equal($"/consolelogs/resource/resource{PlaceholderAllCharactersEncoded}", DashboardUrls.ConsoleLogsUrl(resource: $"resource{PlaceholderInput}"));
     }
 
     [Fact]
     public void StructuredLogsUrl_HtmlValues_CorrectlyEscaped()
     {
-        var url = DashboardUrls.StructuredLogsUrl(
-            resource: "resource!@#",
+        var singleFilterUrl = DashboardUrls.StructuredLogsUrl(
+            resource: $"resource{PlaceholderInput}",
             logLevel: "error",
-            filters: "test:contains:value",
-            traceId: "!@#",
-            spanId: "!@#");
+            filters: LogFilterFormatter.SerializeLogFiltersToString([
+                new LogFilter { Condition = FilterCondition.Contains, Field = "test", Value = "value" }
+            ]),
+            traceId: PlaceholderInput,
+            spanId: PlaceholderInput);
 
-        Assert.Equal("/structuredlogs/resource/resource!%40%23?logLevel=error&filters=test:contains:value&traceId=!@%23&spanId=!@%23", url);
+        Assert.Equal($"/structuredlogs/resource/resource{PlaceholderAllCharactersEncoded}?logLevel=error&filters=test:contains:value&traceId={PlaceholderAllButExclamationMarkEncoded}&spanId={PlaceholderAllButExclamationMarkEncoded}", singleFilterUrl);
+
+        var multipleFiltersUrl = DashboardUrls.StructuredLogsUrl(
+            resource: $"resource{PlaceholderInput}",
+            logLevel: "error",
+            filters: LogFilterFormatter.SerializeLogFiltersToString([
+                new LogFilter { Condition = FilterCondition.Contains, Field = "test", Value = "value" },
+                new LogFilter { Condition = FilterCondition.NotEqual, Field = "name", Value = "nameValue" },
+            ]),
+            traceId: PlaceholderInput,
+            spanId: PlaceholderInput);
+        Assert.Equal($"/structuredlogs/resource/resource{PlaceholderAllCharactersEncoded}?logLevel=error&filters=test:contains:value%2Bname:!equals:nameValue&traceId={PlaceholderAllButExclamationMarkEncoded}&spanId={PlaceholderAllButExclamationMarkEncoded}", multipleFiltersUrl);
     }
 
     [Fact]
     public void TracesUrl_HtmlValues_CorrectlyEscaped()
     {
-        Assert.Equal("/traces/resource/resource!%40%23", DashboardUrls.TracesUrl(resource: "resource!@#"));
+        Assert.Equal($"/traces/resource/resource{PlaceholderAllCharactersEncoded}", DashboardUrls.TracesUrl(resource: $"resource{PlaceholderInput}"));
     }
 
     [Fact]
     public void TraceDetailUrl_HtmlValues_CorrectlyEscaped()
     {
-        Assert.Equal("/traces/detail/traceId!%40%23", DashboardUrls.TraceDetailUrl(traceId: "traceId!@#"));
+        Assert.Equal($"/traces/detail/traceId{PlaceholderAllCharactersEncoded}", DashboardUrls.TraceDetailUrl(traceId: $"traceId{PlaceholderInput}"));
     }
 
     [Fact]
     public void MetricsUrl_HtmlValues_CorrectlyEscaped()
     {
         var url = DashboardUrls.MetricsUrl(
-            resource: "resource!@#",
-            meter: "meter!@#",
-            instrument: "meter!@#",
+            resource: $"resource{PlaceholderInput}",
+            meter: $"meter{PlaceholderInput}",
+            instrument: $"meter{PlaceholderInput}",
             duration: 10,
             view: "table");
 
-        Assert.Equal("/metrics/resource/resource!%40%23?meter=meter!@%23&instrument=meter!@%23&duration=10&view=table", url);
+        Assert.Equal($"/metrics/resource/resource{PlaceholderAllCharactersEncoded}?meter=meter{PlaceholderAllButExclamationMarkEncoded}&instrument=meter{PlaceholderAllButExclamationMarkEncoded}&duration=10&view=table", url);
     }
 }


### PR DESCRIPTION
`Uri.EscapeDataString` is more appropriate than `HttpUtility.UrlEncode` in our uses, as we are not using it to encode paths. 

This fixes #2762 as well, as a space is encoded by UrlEncode as a +, instead of %20. Since the separator between filters was +, multi-word filters were not working.

<img width="1423" alt="image" src="https://github.com/dotnet/aspire/assets/20359921/49df7f90-acd9-46c7-ae11-c5265d795e57">

The filters query parameter for the above now encodes to `filters=Message:contains:Application%20started%2BApplication:!contains:f`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2817)