### PR TITLE
Enable DATAS GC for the Dashboard

### DIFF
--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -4,7 +4,7 @@
     <!-- This list of runtimes needs to match the set of runtimes specified in eng/workloads/workloads.csproj -->
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <TargetFramework>$(NetCurrent)</TargetFramework>
-    <!-- Enable System.GC.DynamicAdaptationMode by default to get a GC that dynamically adapts to the application's memory use. -->
+    <!-- Enable System.GC.DynamicAdaptationMode to get a GC that dynamically adapts to the application's memory use. -->
     <GarbageCollectionAdaptationMode>1</GarbageCollectionAdaptationMode>
     <!--
       CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'

--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -3,10 +3,9 @@
   <PropertyGroup>
     <!-- This list of runtimes needs to match the set of runtimes specified in eng/workloads/workloads.csproj -->
     <RuntimeIdentifiers>win-x86;win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
-    <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCurrent)</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Enable System.GC.DynamicAdaptationMode by default to get a GC that dynamically adapts to the application's memory use. -->
+    <GarbageCollectionAdaptationMode>1</GarbageCollectionAdaptationMode>
     <!--
       CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
       CS8002: Referenced assembly does not have a strong name


### PR DESCRIPTION
In .NET 8, the .NET runtime team developed a new GC mode named "DATAS (Dynamic Adaptation To Application Sizes)". This is like Server GC, but it doesn't try to consume all the memory the machine is given. It tries to dynamically adapt to how much the app needs. You can read more about this in https://maoni0.medium.com/dynamically-adapting-to-application-sizes-2d72fcb6f1ea.

Enable this GC mode for the Dashboard in order to consume less memory.

Before and after memory consumption in Task Manager after using the TestShop app and pushing around in the Dashboard (yes I know this isn't a very scientific test).

### Before
![image](https://github.com/dotnet/aspire/assets/8291187/e40d21f0-6367-424b-8f38-13a133528623)

### After
![image](https://github.com/dotnet/aspire/assets/8291187/d4b97497-bd01-4f61-a670-5262aca9d4fd)

(ignore the VS memory consumption. That is unrelated)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2818)