### PR TITLE
Prevent menu button from overflowing bottom of page

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -17,7 +17,7 @@
         }
     </FluentButton>
 
-    <FluentMenu Anchor="@_buttonId" aria-labelledby="button" @bind-Open="@_visible">
+    <FluentMenu Anchor="@_buttonId" aria-labelledby="button" @bind-Open="@_visible" VerticalThreshold="200">
         @foreach (TItem command in Items)
         {
             <FluentMenuItem OnClick="() => HandleItemClicked(command)">@ItemText(command)</FluentMenuItem>


### PR DESCRIPTION
Fixes #2661 

When clicking the ... on the bottom couple rows, it'll now go up as expected:
![image](https://github.com/dotnet/aspire/assets/9613109/43aa13fb-f6f1-4241-bffc-c814becef263)

The 200 matches the default horizontal threshold.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2835)