### PR TITLE
Add missing variable

### DIFF
--- a/eng/pipelines/azure-pipelines-public.yml
+++ b/eng/pipelines/azure-pipelines-public.yml
@@ -38,6 +38,8 @@ variables:
     value: false
   - name: HelixApiAccessToken
     value: ''
+  - name: _InternalBuildArgs
+    value: ''
 
 resources:
   containers:


### PR DESCRIPTION
As observed in https://dev.azure.com/dnceng-public/public/_build/results?buildId=601195&view=logs&j=0bc77094-9fcd-5c38-f6e4-27d2ae131589&t=d0f091e0-7dba-547a-a9e4-e48ea7b20a3f&l=18:
```
_InternalBuildArgs : The term '_InternalBuildArgs' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:206
+ ... binlog -projects eng\workloads\workloads.csproj $(_InternalBuildArgs)
+                                                       ~~~~~~~~~~~~~~~~~~
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2836)