### PR TITLE
Add support for `docker build --build-args`

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/DockerBuildArg.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DockerBuildArg.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// </summary>
 /// <param name="name">The required name of the arg.</param>
 /// <param name="value">The optional value of the arg, when omitted the value is populated from the corresponding environment variable.</param>
-public sealed class DockerBuildArg(string name, string? value = null)
+public sealed class DockerBuildArg(string name, object? value = null)
 {
     /// <summary>
     /// Gets or initializes the name part of the <c>docker builder --build-arg &lt;NAME&gt;[=&lt;VALUE&gt;]</c>.
@@ -19,5 +19,5 @@ public sealed class DockerBuildArg(string name, string? value = null)
     /// <summary>
     /// Gets or initializes the value part of the <c>docker builder --build-arg &lt;NAME&gt;[=&lt;VALUE&gt;]</c>.
     /// </summary>
-    public string? Value { get; init; } = value;
+    public object? Value { get; init; } = value;
 }

--- a/src/Aspire.Hosting/ApplicationModel/DockerBuildArg.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DockerBuildArg.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a name/value pair, used to satisfy the <c>docker builder --build-arg &lt;NAME&gt;[=&lt;VALUE&gt;]</c> command switch.
+/// For more information, see <a href="https://docs.docker.com/reference/cli/docker/image/build/#build-arg"></a>.
+/// </summary>
+/// <param name="name">The required name of the arg.</param>
+/// <param name="value">The optional value of the arg, when omitted the value is populated from the corresponding environment variable.</param>
+public sealed class DockerBuildArg(string name, string? value = null)
+{
+    /// <summary>
+    /// Gets or initializes the name part of the <c>docker builder --build-arg &lt;NAME&gt;[=&lt;VALUE&gt;]</c>.
+    /// </summary>
+    public string Name { get; init; } = name ?? throw new ArgumentNullException(nameof(name));
+
+    /// <summary>
+    /// Gets or initializes the value part of the <c>docker builder --build-arg &lt;NAME&gt;[=&lt;VALUE&gt;]</c>.
+    /// </summary>
+    public string? Value { get; init; } = value;
+}

--- a/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/Extensions/ExecutableResourceBuilderExtensions.cs
@@ -50,30 +50,19 @@ public static class ExecutableResourceBuilderExtensions
 
     /// <summary>
     /// Adds annotation to <see cref="ExecutableResource" /> to support containerization during deployment.
+    /// The resulting container image is built, and when the optional <paramref name="buildArgs"/> are provided
+    /// they're used with <c>docker build --build-arg</c>.
     /// </summary>
     /// <typeparam name="T">Type of executable resource</typeparam>
     /// <param name="builder">Resource builder</param>
+    /// <param name="buildArgs">The optional build arguments, used with <c>docker build --build-args</c>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> PublishAsDockerFile<T>(this IResourceBuilder<T> builder) where T : ExecutableResource
-    {
-        return builder.WithManifestPublishingCallback(context => WriteExecutableAsDockerfileResourceAsync(context, builder.Resource));
-    }
-
-    /// <summary>
-    /// Adds annotation to <see cref="ExecutableResource" /> to support containerization during deployment.
-    /// The resulting container image is built with the given <paramref name="buildArgs"/> that are provided
-    /// during <c>docker build</c>, as <c>--build-arg</c>.
-    /// </summary>
-    /// <typeparam name="T">Type of executable resource</typeparam>
-    /// <param name="builder">Resource builder</param>
-    /// <param name="buildArgs"></param>
-    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<T> PublishAsDockerFile<T>(this IResourceBuilder<T> builder, DockerBuildArg[] buildArgs) where T : ExecutableResource
+    public static IResourceBuilder<T> PublishAsDockerFile<T>(this IResourceBuilder<T> builder, IEnumerable<DockerBuildArg>? buildArgs = null) where T : ExecutableResource
     {
         return builder.WithManifestPublishingCallback(context => WriteExecutableAsDockerfileResourceAsync(context, builder.Resource, buildArgs));
     }
 
-    private static async Task WriteExecutableAsDockerfileResourceAsync(ManifestPublishingContext context, ExecutableResource executable, DockerBuildArg[]? buildArgs = null)
+    private static async Task WriteExecutableAsDockerfileResourceAsync(ManifestPublishingContext context, ExecutableResource executable, IEnumerable<DockerBuildArg>? buildArgs = null)
     {
         context.Writer.WriteString("type", "dockerfile.v0");
 
@@ -84,7 +73,7 @@ public static class ExecutableResourceBuilderExtensions
         var manifestFileRelativePathToContextDirectory = context.GetManifestRelativePath(executable.WorkingDirectory);
         context.Writer.WriteString("context", manifestFileRelativePathToContextDirectory);
 
-        if (buildArgs is { Length: > 0 })
+        if (buildArgs is not null)
         {
             context.WriteDockerBuildArgs(buildArgs);
         }

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -269,6 +269,35 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
         }
     }
 
+    internal void WriteDockerBuildArgs(DockerBuildArg[] buildArgs)
+    {
+        if (buildArgs is { Length: > 0 })
+        {
+            Writer.WriteStartObject("buildArgs");
+
+            for (var i = 0; i < buildArgs.Length; i++)
+            {
+                var buildArg = buildArgs[i];
+
+                var value = buildArg.Value;
+                if (string.IsNullOrEmpty(value))
+                {
+                    value = Environment.GetEnvironmentVariable(buildArg.Name);
+                }
+
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new DistributedApplicationException(
+                        $"No value was given for {buildArg.Name} in the Dockerfile build args or as an environment variable.");
+                }
+
+                Writer.WriteString(buildArg.Name, buildArg.Value);
+            }
+
+            Writer.WriteEndObject();
+        }
+    }
+
     internal void WriteManifestMetadata(IResource resource)
     {
         if (!resource.TryGetAnnotationsOfType<ManifestMetadataAnnotation>(out var metadataAnnotations))

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -271,8 +271,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
 
     internal void WriteDockerBuildArgs(IEnumerable<DockerBuildArg>? buildArgs)
     {
-        var args = buildArgs?.ToArray();
-        if (args is { Length: > 0 })
+        if (buildArgs?.ToArray() is { Length: > 0 } args)
         {
             Writer.WriteStartObject("buildArgs");
 
@@ -284,7 +283,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 {
                     string stringValue => stringValue,
                     IManifestExpressionProvider manifestExpression => manifestExpression.ValueExpression,
-                    null => null,
+                    null => null, // null means let docker build pull from env var.
                     _ => buildArg.Value.ToString()
                 };
 

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -271,7 +271,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
 
     internal void WriteDockerBuildArgs(IEnumerable<DockerBuildArg>? buildArgs)
     {
-        var args = buildArgs?.ToArray() ?? [];
+        var args = buildArgs?.ToArray();
         if (args is { Length: > 0 })
         {
             Writer.WriteStartObject("buildArgs");

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -284,10 +284,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 {
                     string stringValue => stringValue,
                     IManifestExpressionProvider manifestExpression => manifestExpression.ValueExpression,
-
-                    _ => Environment.GetEnvironmentVariable(buildArg.Name) ??
-                        throw new DistributedApplicationException(
-                            $"No value was given for {buildArg.Name} in the Dockerfile build args or as an environment variable.")
+                    _ => null
                 };
 
                 Writer.WriteString(buildArg.Name, valueString);

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -284,7 +284,8 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 {
                     string stringValue => stringValue,
                     IManifestExpressionProvider manifestExpression => manifestExpression.ValueExpression,
-                    _ => null
+                    null => null,
+                    _ => buildArg.Value.ToString()
                 };
 
                 Writer.WriteString(buildArg.Name, valueString);

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -115,46 +115,6 @@ public class ManifestGenerationTests
     }
 
     [Fact]
-    public void EnsureExecutablesWithDockerfileAndBuildArgsProduceDockerfilev0Manifest()
-    {
-        using var program = CreateTestProgramJsonDocumentManifestPublisher(includeNodeApp: true);
-        program.NodeAppBuilder!.WithHttpsEndpoint(containerPort: 3000, env: "HTTPS_PORT")
-            .PublishAsDockerFile(buildArgs: [
-                new DockerBuildArg("HTTP_PROXY", "http://10.20.30.2:1234"),
-                new DockerBuildArg("FTP_PROXY", "http://40.50.60.5:456")
-            ]);
-
-        // Build AppHost so that publisher can be resolved.
-        program.Build();
-        var publisher = program.GetManifestPublisher();
-
-        program.Run();
-
-        var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
-
-        // NPM app should still be executable.v0
-        var npmapp = resources.GetProperty("npmapp");
-        Assert.Equal("executable.v0", npmapp.GetProperty("type").GetString());
-        Assert.DoesNotContain("\\", npmapp.GetProperty("workingDirectory").GetString());
-
-        // Node app should now be dockerfile.v0
-        var nodeapp = resources.GetProperty("nodeapp");
-        Assert.Equal("dockerfile.v0", nodeapp.GetProperty("type").GetString());
-        Assert.True(nodeapp.TryGetProperty("path", out _));
-        Assert.True(nodeapp.TryGetProperty("context", out _));
-        Assert.True(nodeapp.TryGetProperty("env", out var env));
-        Assert.True(nodeapp.TryGetProperty("bindings", out var bindings));
-
-        var buildArgs = nodeapp.GetProperty("buildArgs");
-        Assert.Equal("http://10.20.30.2:1234", buildArgs.GetProperty("HTTP_PROXY").GetString());
-        Assert.Equal("http://40.50.60.5:456", buildArgs.GetProperty("FTP_PROXY").GetString());
-
-        Assert.Equal(3000, bindings.GetProperty("https").GetProperty("containerPort").GetInt32());
-        Assert.Equal("https", bindings.GetProperty("https").GetProperty("scheme").GetString());
-        Assert.Equal("{nodeapp.bindings.https.port}", env.GetProperty("HTTPS_PORT").GetString());
-    }
-
-    [Fact]
     public void ExcludeLaunchProfileOmitsBindings()
     {
         var appBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions

--- a/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
@@ -7,7 +7,8 @@ using System.Text.Json;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
-public class PublishAsConnnectionStringTests
+
+public class PublishAsConnectionStringTests
 {
     [Fact]
     public async Task PublishAsConnectionStringConfiguresManifestAsParameter()

--- a/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
@@ -19,9 +19,23 @@ public class PublishAsConnectionStringTests
 
         var manifest = await ManifestUtils.GetManifest(redis.Resource);
 
-        Assert.NotNull(manifest);
-        Assert.Equal("parameter.v0", manifest?["type"]?.ToString());
-        Assert.Equal("{redis.value}", manifest?["connectionString"]?.ToString());
-        Assert.Equal("{redis.inputs.value}", manifest?["value"]?.ToString());
+        var expected =
+            """
+            {
+              "type": "parameter.v0",
+              "connectionString": "{redis.value}",
+              "value": "{redis.inputs.value}",
+              "inputs": {
+                "value": {
+                  "type": "string",
+                  "secret": true
+                }
+              }
+            }
+            """;
+
+        var actual = manifest.ToString();
+
+        Assert.Equal(expected, actual, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
     }
 }

--- a/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
@@ -1,10 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
-using System.Text.Json.Nodes;
-using System.Text.Json;
 using Xunit;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting.Tests;
 
@@ -17,28 +15,13 @@ public class PublishAsConnectionStringTests
 
         var redis = builder.AddRedis("redis").PublishAsConnectionString();
 
-        Assert.True(redis.Resource.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var annotation));
+        Assert.True(redis.Resource.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out _));
 
-        var manifest = await GetManifest(annotation.Callback!);
+        var manifest = await ManifestUtils.GetManifest(redis.Resource);
 
         Assert.NotNull(manifest);
         Assert.Equal("parameter.v0", manifest?["type"]?.ToString());
         Assert.Equal("{redis.value}", manifest?["connectionString"]?.ToString());
         Assert.Equal("{redis.inputs.value}", manifest?["value"]?.ToString());
-    }
-
-    private static async Task<JsonNode> GetManifest(Func<ManifestPublishingContext, Task> writeManifest)
-    {
-        using var ms = new MemoryStream();
-        var writer = new Utf8JsonWriter(ms);
-        writer.WriteStartObject();
-        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
-        await writeManifest(new ManifestPublishingContext(executionContext, Environment.CurrentDirectory, writer)).ConfigureAwait(false);
-        writer.WriteEndObject();
-        writer.Flush();
-        ms.Position = 0;
-        var obj = JsonNode.Parse(ms);
-        Assert.NotNull(obj);
-        return obj;
     }
 }

--- a/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Publishing;
+using System.Text.Json.Nodes;
+using System.Text.Json;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class PublishAsDockerfileTests
+{
+    [Fact]
+    public async Task PublishAsDockerFileConfiguresManifestWithoutBuildArgs()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var redis = builder.AddNpmApp("frontend", "../NodeFrontend", "watch")
+            .PublishAsDockerFile();
+
+        Assert.True(redis.Resource.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var annotation));
+
+        var manifest = await GetManifestAsync(annotation.Callback!);
+
+        Assert.NotNull(manifest);
+        Assert.Equal("dockerfile.v0", manifest?["type"]?.ToString());
+        Assert.Equal("NodeFrontend/Dockerfile", manifest?["path"]?.ToString());
+        Assert.Equal("NodeFrontend", manifest?["context"]?.ToString());
+        Assert.Equal("development", manifest?["env"]?["NODE_ENV"]?.ToString());
+    }
+
+    [Fact]
+    public async Task PublishAsDockerFileConfiguresManifestWithBuildArgs()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var redis = builder.AddNpmApp("frontend", "../NodeFrontend", "watch")
+            .PublishAsDockerFile(buildArgs: [
+                new DockerBuildArg("SOME_ARG", "TEST")
+            ]);
+
+        Assert.True(redis.Resource.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var annotation));
+
+        var manifest = await GetManifestAsync(annotation.Callback!);
+
+        Assert.NotNull(manifest);
+        Assert.Equal("dockerfile.v0", manifest?["type"]?.ToString());
+        Assert.Equal("NodeFrontend/Dockerfile", manifest?["path"]?.ToString());
+        Assert.Equal("NodeFrontend", manifest?["context"]?.ToString());
+        Assert.Equal("development", manifest?["env"]?["NODE_ENV"]?.ToString());
+        Assert.Equal("TEST", manifest?["buildArgs"]?["SOME_ARG"]?.ToString());
+    }
+
+    [Fact]
+    public async Task PublishAsDockerFileThrowsWhenBuildArgHasNoEnvVarValue()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var redis = builder.AddNpmApp("frontend", "../NodeFrontend", "watch")
+            .PublishAsDockerFile(buildArgs: [
+                new DockerBuildArg("THIS_SHOULD_THROW_AS_THERE_IS_NO_ENV_VAR_VALUE")
+            ]);
+
+        Assert.True(redis.Resource.TryGetLastAnnotation<ManifestPublishingCallbackAnnotation>(out var annotation));
+
+        await Assert.ThrowsAsync<DistributedApplicationException>(async () => await GetManifestAsync(annotation.Callback!));
+    }
+
+    private static async Task<JsonNode> GetManifestAsync(Func<ManifestPublishingContext, Task> writeManifest)
+    {
+        using var ms = new MemoryStream();
+        var writer = new Utf8JsonWriter(ms);
+        writer.WriteStartObject();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        await writeManifest(new ManifestPublishingContext(executionContext, Environment.CurrentDirectory, writer)).ConfigureAwait(false);
+        writer.WriteEndObject();
+        writer.Flush();
+        ms.Position = 0;
+        var obj = JsonNode.Parse(ms);
+        Assert.NotNull(obj);
+        return obj;
+    }
+}


### PR DESCRIPTION
Add support for `docker build --build-args` from the `PublishAsDockerFile` API.

- Fixes #2441.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2851)