### PR TITLE
Append text node instead of using innerHTML in metrics table

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.js
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.js
@@ -1,4 +1,4 @@
-﻿/*
+/*
  Announces row text of the specified indices to screen readers using an offscreen div
  */
 export function announceDataGridRows(dataGridContainerId, indices) {
@@ -21,7 +21,8 @@ export function announceDataGridRows(dataGridContainerId, indices) {
         const rowText = getRowText(dataGridContainerId, index);
         if (rowText) {
             const newItem = document.createElement("li");
-            newItem.innerHTML = rowText;
+            const textNode = document.createTextNode(rowText);
+            newItem.appendChild(textNode);
             list.appendChild(newItem);
         }
     });


### PR DESCRIPTION
innerHTML has the possibility of XSS. Explicitly creating and appending a text node is safer.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2876)