### PR TITLE
Use ReferenceExpression as the connection string representation

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureAppConfigurationResource.cs
@@ -21,15 +21,8 @@ public class AzureAppConfigurationResource(string name) :
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure App Configuration resource.
     /// </summary>
-    public string ConnectionStringExpression => Endpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure App Configuration resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure App Configuration resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-        => Endpoint.GetValueAsync(cancellationToken);
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{Endpoint}");
 }
 
 /// <summary>
@@ -49,13 +42,6 @@ public class AzureAppConfigurationConstructResource(string name, Action<Resource
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure App Configuration resource.
     /// </summary>
-    public string ConnectionStringExpression => Endpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure App Configuration resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure App Configuration resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-        => Endpoint.GetValueAsync(cancellationToken);
+    public ReferenceExpression ConnectionStringExpression =>
+       ReferenceExpression.Create($"{Endpoint}");
 }

--- a/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
@@ -24,14 +24,6 @@ public class AzureApplicationInsightsResource(string name) :
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create($"{ConnectionString}");
 
-    /// <summary>
-    /// Gets the connection string for the Azure Application Insights resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Application Insights resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-        => ConnectionString.GetValueAsync(cancellationToken);
-
     // UseAzureMonitor is looks for this specific environment variable name.
     string IResourceWithConnectionString.ConnectionStringEnvironmentVariable => "APPLICATIONINSIGHTS_CONNECTION_STRING";
 }

--- a/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureApplicationInsightsResource.cs
@@ -21,7 +21,8 @@ public class AzureApplicationInsightsResource(string name) :
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Application Insights resource.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ConnectionString}");
 
     /// <summary>
     /// Gets the connection string for the Azure Application Insights resource.

--- a/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
@@ -23,22 +23,8 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Blob Storage resource.
     /// </summary>
-    public string ConnectionStringExpression => Parent.BlobEndpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Blob Storage resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Blob Storage resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (Parent.ProvisioningTaskCompletionSource is not null)
-        {
-            await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return Parent.GetBlobConnectionString();
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+       ReferenceExpression.Create($"{Parent.BlobEndpoint}");
 
     /// <summary>
     /// Called by manifest publisher to write manifest resource.
@@ -68,22 +54,8 @@ public class AzureBlobStorageConstructResource(string name, AzureStorageConstruc
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Blob Storage resource.
     /// </summary>
-    public string ConnectionStringExpression => Parent.BlobEndpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Blob Storage resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Blob Storage resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (Parent.ProvisioningTaskCompletionSource is not null)
-        {
-            await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return Parent.GetBlobConnectionString();
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        Parent.GetBlobConnectionString();
 
     /// <summary>
     /// Called by manifest publisher to write manifest resource.

--- a/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
@@ -36,22 +36,10 @@ public class AzureCosmosDBResource(string name) :
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Cosmos DB resource.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string to use for this database.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string to use for this database.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (IsEmulator)
-        {
-            return new(AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port));
-        }
-
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        IsEmulator
+        ? ReferenceExpression.Create($"{AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port)}")
+        : ReferenceExpression.Create($"{ConnectionString}");
 }
 
 /// <summary>
@@ -79,22 +67,10 @@ public class AzureCosmosDBConstructResource(string name, Action<ResourceModuleCo
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Cosmos DB resource.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string to use for this database.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string to use for this database.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (IsEmulator)
-        {
-            return new(AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port));
-        }
-
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        IsEmulator
+        ? ReferenceExpression.Create($"{AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port)}")
+        : ReferenceExpression.Create($"{ConnectionString}");
 }
 
 /// <summary>

--- a/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureKeyVaultResource.cs
@@ -21,17 +21,8 @@ public class AzureKeyVaultResource(string name) :
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Key Vault resource.
     /// </summary>
-    public string ConnectionStringExpression => VaultUri.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Key Vault resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Key Vault resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return VaultUri.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{VaultUri}");
 }
 
 /// <summary>
@@ -49,15 +40,6 @@ public class AzureKeyVaultConstructResource(string name, Action<ResourceModuleCo
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Key Vault resource.
     /// </summary>
-    public string ConnectionStringExpression => VaultUri.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Key Vault resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Key Vault resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return VaultUri.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{VaultUri}");
 }

--- a/src/Aspire.Hosting.Azure/AzureOpenAIResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureOpenAIResource.cs
@@ -22,14 +22,8 @@ public class AzureOpenAIResource(string name) :
     /// <summary>
     /// Gets the connection string template for the manifest for the resource.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the resource.
-    /// </summary>
-    /// <returns>The connection string for the resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-        => ConnectionString.GetValueAsync(cancellationToken);
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ConnectionString}");
 
     /// <summary>
     /// Gets the list of deployments of the Azure OpenAI resource.
@@ -63,14 +57,8 @@ public class AzureOpenAIConstructResource(string name, Action<ResourceModuleCons
     /// <summary>
     /// Gets the connection string template for the manifest for the resource.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the resource.
-    /// </summary>
-    /// <returns>The connection string for the resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-        => ConnectionString.GetValueAsync(cancellationToken);
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ConnectionString}");
 
     /// <summary>
     /// Gets the list of deployments of the Azure OpenAI resource.

--- a/src/Aspire.Hosting.Azure/AzurePostgresResource.cs
+++ b/src/Aspire.Hosting.Azure/AzurePostgresResource.cs
@@ -21,17 +21,8 @@ public class AzurePostgresResource(PostgresServerResource innerResource) :
     /// <summary>
     /// Gets the connection template for the manifest for the Azure Postgres Flexible Server.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Postgres Flexible Server.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ConnectionString}");
 
     /// <inheritdoc/>
     public override string Name => innerResource.Name;
@@ -57,17 +48,8 @@ public class AzurePostgresConstructResource(PostgresServerResource innerResource
     /// <summary>
     /// Gets the connection template for the manifest for the Azure Postgres Flexible Server.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Postgres Flexible Server.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ConnectionString}");
 
     /// <inheritdoc/>
     public override string Name => innerResource.Name;

--- a/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
@@ -23,22 +23,8 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Queue Storage resource.
     /// </summary>
-    public string ConnectionStringExpression => Parent.QueueEndpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Queue Storage resource.
-    ///</summary>
-    ///<param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    ///<returns> The connection string for the Azure Queue Storage resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (Parent.ProvisioningTaskCompletionSource is not null)
-        {
-            await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return Parent.GetQueueConnectionString();
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        Parent.GetQueueConnectionString();
 
     internal void WriteToManifest(ManifestPublishingContext context)
     {
@@ -64,22 +50,8 @@ public class AzureQueueStorageConstructResource(string name, AzureStorageConstru
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Queue Storage resource.
     /// </summary>
-    public string ConnectionStringExpression => Parent.QueueEndpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Blob Storage resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Blob Storage resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (Parent.ProvisioningTaskCompletionSource is not null)
-        {
-            await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return Parent.GetQueueConnectionString();
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        Parent.GetQueueConnectionString();
 
     internal void WriteToManifest(ManifestPublishingContext context)
     {

--- a/src/Aspire.Hosting.Azure/AzureRedisResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureRedisResource.cs
@@ -21,17 +21,8 @@ public class AzureRedisResource(RedisResource innerResource) :
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Redis resource.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Redis resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Redis resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ConnectionString}");
 
     /// <inheritdoc/>
     public override string Name => innerResource.Name;
@@ -57,17 +48,8 @@ public class AzureRedisConstructResource(RedisResource innerResource, Action<Res
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Redis resource.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Redis resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Redis resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ConnectionString}");
 
     /// <inheritdoc/>
     public override string Name => innerResource.Name;

--- a/src/Aspire.Hosting.Azure/AzureSearchResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureSearchResource.cs
@@ -24,17 +24,8 @@ public class AzureSearchResource(string name) :
     /// <summary>
     /// Gets the connection string template for the manifest for the resource.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the azure search resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ConnectionString}");
 }
 
 /// <summary>
@@ -57,16 +48,6 @@ public class AzureSearchConstructResource(string name, Action<ResourceModuleCons
     /// <summary>
     /// Gets the connection string template for the manifest for the resource.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure AI Search resource.
-    /// </summary>
-    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the resource.</returns>
-    /// <remarks>
-    /// This connection string will assume you're deploying to public Azure.
-    /// </remarks>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default) =>
-        await ConnectionString.GetValueAsync(cancellationToken).ConfigureAwait(false);
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ConnectionString}");
 }

--- a/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureServiceBusResource.cs
@@ -25,17 +25,8 @@ public class AzureServiceBusResource(string name) :
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Service Bus endpoint.
     /// </summary>
-    public string ConnectionStringExpression => ServiceBusEndpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Service Bus endpoint.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Service Bus endpoint.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ServiceBusEndpoint.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ServiceBusEndpoint}");
 }
 
 /// <summary>
@@ -58,15 +49,6 @@ public class AzureServiceBusConstructResource(string name, Action<ResourceModule
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Service Bus endpoint.
     /// </summary>
-    public string ConnectionStringExpression => ServiceBusEndpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Service Bus endpoint.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Service Bus endpoint.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ServiceBusEndpoint.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{ServiceBusEndpoint}");
 }

--- a/src/Aspire.Hosting.Azure/AzureSignalRResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureSignalRResource.cs
@@ -18,23 +18,11 @@ public class AzureSignalRResource(string name) :
     /// </summary>
     public BicepOutputReference HostName => new("hostName", this);
 
-    private ReferenceExpression ConnectionString
-        => ReferenceExpression.Create($"Endpoint=https://{HostName};AuthType=azure");
-
     /// <summary>
     /// Gets the connection string template for the manifest for Azure SignalR.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for Azure SignalR.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for Azure SignalR.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"Endpoint=https://{HostName};AuthType=azure");
 }
 
 /// <summary>
@@ -51,21 +39,9 @@ public class AzureSignalRConstructResource(string name, Action<ResourceModuleCon
     /// </summary>
     public BicepOutputReference HostName => new("hostName", this);
 
-    private ReferenceExpression ConnectionString
-        => ReferenceExpression.Create($"Endpoint=https://{HostName};AuthType=azure");
-
     /// <summary>
     /// Gets the connection string template for the manifest for Azure SignalR.
     /// </summary>
-    public string ConnectionStringExpression => ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for Azure SignalR.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for Azure SignalR.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"Endpoint=https://{HostName};AuthType=azure");
 }

--- a/src/Aspire.Hosting.Azure/AzureSqlServerResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureSqlServerResource.cs
@@ -18,25 +18,12 @@ public class AzureSqlServerResource(SqlServerServerResource innerResource) :
     /// </summary>
     public BicepOutputReference FullyQualifiedDomainName => new("sqlServerFqdn", this);
 
-    private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
-            $"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
-
     /// <summary>
     /// Gets the connection template for the manifest for the Azure SQL Server resource.
     /// </summary>
-    public string ConnectionStringExpression =>
-        ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure SQL Server resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure SQL Server resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create(
+            $"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
 
     /// <inheritdoc/>
     public override string Name => innerResource.Name;
@@ -57,25 +44,12 @@ public class AzureSqlServerConstructResource(SqlServerServerResource innerResour
     /// </summary>
     public BicepOutputReference FullyQualifiedDomainName => new("sqlServerFqdn", this);
 
-    private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
-            $"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
-
     /// <summary>
     /// Gets the connection template for the manifest for the Azure SQL Server resource.
     /// </summary>
-    public string ConnectionStringExpression =>
-        ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure SQL Server resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure SQL Server resource.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        return ConnectionString.GetValueAsync(cancellationToken);
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create(
+            $"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
 
     /// <inheritdoc/>
     public override string Name => innerResource.Name;

--- a/src/Aspire.Hosting.Azure/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureStorageResource.cs
@@ -40,29 +40,17 @@ public class AzureStorageConstructResource(string name, Action<ResourceModuleCon
     /// </summary>
     public bool IsEmulator => this.IsContainer();
 
-    internal string? GetTableConnectionString() => IsEmulator
-        ? AzureStorageEmulatorConnectionString.Create(tablePort: EmulatorTableEndpoint.Port)
-        : TableEndpoint.Value;
+    internal ReferenceExpression GetTableConnectionString() => IsEmulator
+        ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(tablePort: EmulatorTableEndpoint.Port)}")
+        : ReferenceExpression.Create($"{TableEndpoint}");
 
-    internal async ValueTask<string?> GetTableConnectionStringAsync(CancellationToken cancellationToken = default) => IsEmulator
-        ? AzureStorageEmulatorConnectionString.Create(tablePort: EmulatorTableEndpoint.Port)
-        : await TableEndpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
+    internal ReferenceExpression GetQueueConnectionString() => IsEmulator
+        ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(queuePort: EmulatorQueueEndpoint.Port)}")
+        : ReferenceExpression.Create($"{QueueEndpoint}");
 
-    internal string? GetQueueConnectionString() => IsEmulator
-        ? AzureStorageEmulatorConnectionString.Create(queuePort: EmulatorQueueEndpoint.Port)
-        : QueueEndpoint.Value;
-
-    internal async ValueTask<string?> GetQueueConnectionStringAsync(CancellationToken cancellationToken = default) => IsEmulator
-        ? AzureStorageEmulatorConnectionString.Create(queuePort: EmulatorQueueEndpoint.Port)
-        : await QueueEndpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
-
-    internal string? GetBlobConnectionString() => IsEmulator
-        ? AzureStorageEmulatorConnectionString.Create(blobPort: EmulatorBlobEndpoint.Port)
-        : BlobEndpoint.Value;
-
-    internal async ValueTask<string?> GetBlobConnectionStringAsync(CancellationToken cancellationToken = default) => IsEmulator
-        ? AzureStorageEmulatorConnectionString.Create(blobPort: EmulatorBlobEndpoint.Port)
-        : await BlobEndpoint.GetValueAsync(cancellationToken).ConfigureAwait(false);
+    internal ReferenceExpression GetBlobConnectionString() => IsEmulator
+        ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(blobPort: EmulatorBlobEndpoint.Port)}")
+        : ReferenceExpression.Create($"{BlobEndpoint}");
 }
 
 /// <summary>
@@ -98,17 +86,17 @@ public class AzureStorageResource(string name) :
     /// </summary>
     public bool IsEmulator => this.IsContainer();
 
-    internal string? GetTableConnectionString() => IsEmulator
-        ? AzureStorageEmulatorConnectionString.Create(tablePort: EmulatorTableEndpoint.Port)
-        : TableEndpoint.Value;
+    internal ReferenceExpression GetTableConnectionString() => IsEmulator
+        ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(tablePort: EmulatorTableEndpoint.Port)}")
+        : ReferenceExpression.Create($"{TableEndpoint}");
 
-    internal string? GetQueueConnectionString() => IsEmulator
-        ? AzureStorageEmulatorConnectionString.Create(queuePort: EmulatorQueueEndpoint.Port)
-        : QueueEndpoint.Value;
+    internal ReferenceExpression GetQueueConnectionString() => IsEmulator
+        ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(queuePort: EmulatorQueueEndpoint.Port)}")
+        : ReferenceExpression.Create($"{QueueEndpoint}");
 
-    internal string? GetBlobConnectionString() => IsEmulator
-        ? AzureStorageEmulatorConnectionString.Create(blobPort: EmulatorBlobEndpoint.Port)
-        : BlobEndpoint.Value;
+    internal ReferenceExpression GetBlobConnectionString() => IsEmulator
+        ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(blobPort: EmulatorBlobEndpoint.Port)}")
+        : ReferenceExpression.Create($"{BlobEndpoint}");
 }
 
 file static class AzureStorageEmulatorConnectionString

--- a/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
@@ -23,22 +23,8 @@ public class AzureTableStorageResource(string name, AzureStorageResource storage
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Table Storage resource.
     /// </summary>
-    public string ConnectionStringExpression => Parent.TableEndpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Table Storage resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Table Storage resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (Parent.ProvisioningTaskCompletionSource is not null)
-        {
-            await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return Parent.GetTableConnectionString();
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        Parent.GetTableConnectionString();
 
     internal void WriteToManifest(ManifestPublishingContext context)
     {
@@ -64,22 +50,8 @@ public class AzureTableStorageConstructResource(string name, AzureStorageConstru
     /// <summary>
     /// Gets the connection string template for the manifest for the Azure Table Storage resource.
     /// </summary>
-    public string ConnectionStringExpression => Parent.TableEndpoint.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for the Azure Blob Storage resource.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>The connection string for the Azure Blob Storage resource.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (Parent.ProvisioningTaskCompletionSource is not null)
-        {
-            await Parent.ProvisioningTaskCompletionSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        return Parent.GetTableConnectionString();
-    }
+    public ReferenceExpression ConnectionStringExpression =>
+        Parent.GetTableConnectionString();
 
     internal void WriteToManifest(ManifestPublishingContext context)
     {

--- a/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ConnectionStringReference.cs
@@ -23,7 +23,7 @@ public class ConnectionStringReference(IResourceWithConnectionString resource, b
     {
         var value = await Resource.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
-        if (value is null && !Optional)
+        if (string.IsNullOrEmpty(value) && !Optional)
         {
             throw new DistributedApplicationException($"The connection string for the resource '{Resource.Name}' is not available.");
         }

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
@@ -13,7 +13,8 @@ public interface IResourceWithConnectionString : IResource, IManifestExpressionP
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>The connection string associated with the resource, when one is available.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default);
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default) =>
+        ConnectionStringExpression.GetValueAsync(cancellationToken);
 
     string IManifestExpressionProvider.ValueExpression => ConnectionStringReferenceExpression;
 
@@ -22,7 +23,7 @@ public interface IResourceWithConnectionString : IResource, IManifestExpressionP
     /// <summary>
     /// Describes the connection string format string used for this resource in the manifest.
     /// </summary>
-    public string? ConnectionStringExpression => null;
+    public ReferenceExpression ConnectionStringExpression { get; }
 
     /// <summary>
     /// The expression used in the manifest to reference the connection string.

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
@@ -16,7 +16,7 @@ public interface IResourceWithConnectionString : IResource, IManifestExpressionP
     public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default) =>
         ConnectionStringExpression.GetValueAsync(cancellationToken);
 
-    string IManifestExpressionProvider.ValueExpression => ConnectionStringReferenceExpression;
+    string IManifestExpressionProvider.ValueExpression => $"{{{Name}.connectionString}}";
 
     ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => GetConnectionStringAsync(cancellationToken);
 
@@ -24,11 +24,6 @@ public interface IResourceWithConnectionString : IResource, IManifestExpressionP
     /// Describes the connection string format string used for this resource in the manifest.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression { get; }
-
-    /// <summary>
-    /// The expression used in the manifest to reference the connection string.
-    /// </summary>
-    public string ConnectionStringReferenceExpression => $"{{{Name}.connectionString}}";
 
     /// <summary>
     /// The environment variable name to use for the connection string.

--- a/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
+++ b/src/Aspire.Hosting/ApplicationModel/IResourceWithConnectionString.cs
@@ -21,7 +21,7 @@ public interface IResourceWithConnectionString : IResource, IManifestExpressionP
     ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => GetConnectionStringAsync(cancellationToken);
 
     /// <summary>
-    /// Describes the connection string format string used for this resource in the manifest.
+    /// Describes the connection string format string used for this resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression { get; }
 

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -53,6 +53,11 @@ public class ReferenceExpression : IValueProvider, IManifestExpressionProvider
     /// <returns></returns>
     public async ValueTask<string?> GetValueAsync(CancellationToken cancellationToken)
     {
+        if (Format.Length == 0)
+        {
+            return null;
+        }
+
         var args = new object?[ValueProviders.Count];
         for (var i = 0; i < ValueProviders.Count; i++)
         {
@@ -104,7 +109,7 @@ public ref struct ExpressionInterpolatedStringHandler(int literalLength, int for
     /// Appends a formatted value to the expression.
     /// </summary>
     /// <param name="value"></param>
-    public readonly void AppendFormatted(string value)
+    public readonly void AppendFormatted(string? value)
     {
         _builder.Append(value);
     }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
@@ -9,13 +9,8 @@ internal sealed class ResourceWithConnectionStringSurrogate(IResource innerResou
 
     public ResourceAnnotationCollection Annotations => innerResource.Annotations;
 
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-    {
-        return new(callback());
-    }
-
     public string? ConnectionStringEnvironmentVariable => environmentVariableName;
 
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"");
+        ReferenceExpression.Create($"{callback()}");
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
@@ -15,4 +15,7 @@ internal sealed class ResourceWithConnectionStringSurrogate(IResource innerResou
     }
 
     public string? ConnectionStringEnvironmentVariable => environmentVariableName;
+
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"");
 }

--- a/src/Aspire.Hosting/Kafka/KafkaServerResource.cs
+++ b/src/Aspire.Hosting/Kafka/KafkaServerResource.cs
@@ -20,20 +20,10 @@ public class KafkaServerResource(string name) : ContainerResource(name), IResour
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
-    private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
-            $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
-
     /// <summary>
     /// Gets the connection string expression for Kafka broker for the manifest.
     /// </summary>
-    public string ConnectionStringExpression =>
-       ConnectionString.ValueExpression;
-
-    /// <summary>
-    /// Gets the connection string for Kafka broker.
-    /// </summary>
-    /// <returns>A connection string for the Kafka in the form "host:port" to be passed as <see href="https://docs.confluent.io/platform/current/clients/confluent-kafka-dotnet/_site/api/Confluent.Kafka.ClientConfig.html#Confluent_Kafka_ClientConfig_BootstrapServers">BootstrapServers</see>.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
-        ConnectionString.GetValueAsync(cancellationToken);
+    public ReferenceExpression ConnectionStringExpression =>
+       ReferenceExpression.Create(
+            $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
 }

--- a/src/Aspire.Hosting/Kafka/KafkaServerResource.cs
+++ b/src/Aspire.Hosting/Kafka/KafkaServerResource.cs
@@ -21,7 +21,7 @@ public class KafkaServerResource(string name) : ContainerResource(name), IResour
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
     /// <summary>
-    /// Gets the connection string expression for Kafka broker for the manifest.
+    /// Gets the connection string expression for the Kafka broker.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
        ReferenceExpression.Create(

--- a/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
@@ -25,13 +25,6 @@ public class MongoDBDatabaseResource(string name, string databaseName, MongoDBSe
     public MongoDBServerResource Parent => parent;
 
     /// <summary>
-    /// Gets the connection string for the MongoDB database.
-    /// </summary>
-    /// <returns>A connection string for the MongoDB database.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
-        ConnectionStringExpression.GetValueAsync(cancellationToken);
-
-    /// <summary>
     /// Gets the database name.
     /// </summary>
     public string DatabaseName { get; } = databaseName;

--- a/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBDatabaseResource.cs
@@ -16,8 +16,8 @@ public class MongoDBDatabaseResource(string name, string databaseName, MongoDBSe
     /// <summary>
     /// Gets the connection string expression for the MongoDB database.
     /// </summary>
-    public string ConnectionStringExpression
-        => $"{{{Parent.Name}.connectionString}}/{DatabaseName}";
+    public ReferenceExpression ConnectionStringExpression
+        => ReferenceExpression.Create($"{Parent}/{DatabaseName}");
 
     /// <summary>
     /// Gets the parent MongoDB container resource.
@@ -28,17 +28,8 @@ public class MongoDBDatabaseResource(string name, string databaseName, MongoDBSe
     /// Gets the connection string for the MongoDB database.
     /// </summary>
     /// <returns>A connection string for the MongoDB database.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-    {
-        if (await Parent.GetConnectionStringAsync(cancellationToken).ConfigureAwait(false) is { } connectionString)
-        {
-            return connectionString.EndsWith('/') ?
-                $"{connectionString}{DatabaseName}" :
-                $"{connectionString}/{DatabaseName}";
-        }
-
-        throw new DistributedApplicationException("Parent resource connection string was null.");
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
+        ConnectionStringExpression.GetValueAsync(cancellationToken);
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting/MongoDB/MongoDBServerResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBServerResource.cs
@@ -18,23 +18,12 @@ public class MongoDBServerResource(string name) : ContainerResource(name), IReso
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
-    private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
-            $"mongodb://{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
-
     /// <summary>
     /// Gets the connection string for the MongoDB server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ConnectionString;
-
-    /// <summary>
-    /// Gets the connection string for the MongoDB server.
-    /// </summary>
-    /// <param name="cancellationToken"> Cancellation token. </param>
-    /// <returns>A connection string for the MongoDB server in the form "mongodb://host:port".</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
-        ConnectionString.GetValueAsync(cancellationToken);
+        ReferenceExpression.Create(
+            $"mongodb://{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
 
     private readonly Dictionary<string, string> _databases = new Dictionary<string, string>(StringComparers.ResourceName);
 

--- a/src/Aspire.Hosting/MongoDB/MongoDBServerResource.cs
+++ b/src/Aspire.Hosting/MongoDB/MongoDBServerResource.cs
@@ -25,8 +25,8 @@ public class MongoDBServerResource(string name) : ContainerResource(name), IReso
     /// <summary>
     /// Gets the connection string for the MongoDB server.
     /// </summary>
-    public string ConnectionStringExpression =>
-        ConnectionString.ValueExpression;
+    public ReferenceExpression ConnectionStringExpression =>
+        ConnectionString;
 
     /// <summary>
     /// Gets the connection string for the MongoDB server.

--- a/src/Aspire.Hosting/MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlDatabaseResource.cs
@@ -21,24 +21,16 @@ public class MySqlDatabaseResource(string name, string databaseName, MySqlServer
     /// <summary>
     /// Gets the connection string expression for the MySQL database.
     /// </summary>
-    public string ConnectionStringExpression =>
-        $"{{{Parent.Name}.connectionString}};Database={DatabaseName}";
+    public ReferenceExpression ConnectionStringExpression =>
+       ReferenceExpression.Create(
+           $"{Parent};Database={DatabaseName}");
 
     /// <summary>
     /// Gets the connection string for the MySQL database.
     /// </summary>
     /// <returns>A connection string for the MySQL database.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-    {
-        if (await Parent.GetConnectionStringAsync(cancellationToken).ConfigureAwait(false) is { } connectionString)
-        {
-            return $"{connectionString};Database={DatabaseName}";
-        }
-        else
-        {
-            throw new DistributedApplicationException("Parent resource connection string was null.");
-        }
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
+        ConnectionStringExpression.GetValueAsync(cancellationToken);
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting/MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlDatabaseResource.cs
@@ -22,15 +22,7 @@ public class MySqlDatabaseResource(string name, string databaseName, MySqlServer
     /// Gets the connection string expression for the MySQL database.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create(
-           $"{Parent};Database={DatabaseName}");
-
-    /// <summary>
-    /// Gets the connection string for the MySQL database.
-    /// </summary>
-    /// <returns>A connection string for the MySQL database.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
-        ConnectionStringExpression.GetValueAsync(cancellationToken);
+       ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting/MySql/MySqlServerResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlServerResource.cs
@@ -35,23 +35,12 @@ public class MySqlServerResource : ContainerResource, IResourceWithConnectionStr
     /// </summary>
     public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
 
-    private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
-            $"Server={PrimaryEndpoint.Property(EndpointProperty.Host)};Port={PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=root;Password={PasswordInput}");
-
     /// <summary>
     /// Gets the connection string expression for the MySQL server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ConnectionString;
-
-    /// <summary>
-    /// Gets the connection string for the MySQL server.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
-        ConnectionString.GetValueAsync(cancellationToken);
+        ReferenceExpression.Create(
+            $"Server={PrimaryEndpoint.Property(EndpointProperty.Host)};Port={PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=root;Password={PasswordInput}");
 
     private readonly Dictionary<string, string> _databases = new Dictionary<string, string>(StringComparers.ResourceName);
 

--- a/src/Aspire.Hosting/MySql/MySqlServerResource.cs
+++ b/src/Aspire.Hosting/MySql/MySqlServerResource.cs
@@ -42,8 +42,8 @@ public class MySqlServerResource : ContainerResource, IResourceWithConnectionStr
     /// <summary>
     /// Gets the connection string expression for the MySQL server.
     /// </summary>
-    public string ConnectionStringExpression =>
-        ConnectionString.ValueExpression;
+    public ReferenceExpression ConnectionStringExpression =>
+        ConnectionString;
 
     /// <summary>
     /// Gets the connection string for the MySQL server.

--- a/src/Aspire.Hosting/Nats/NatsServerResource.cs
+++ b/src/Aspire.Hosting/Nats/NatsServerResource.cs
@@ -27,8 +27,8 @@ public class NatsServerResource(string name) : ContainerResource(name), IResourc
     /// <summary>
     /// Gets the connection string expression for the NATS server for the manifest.
     /// </summary>
-    public string? ConnectionStringExpression =>
-        ConnectionString.ValueExpression;
+    public ReferenceExpression ConnectionStringExpression =>
+        ConnectionString;
 
     /// <summary>
     /// Gets the connection string (NATS_URL) for the NATS server.

--- a/src/Aspire.Hosting/Nats/NatsServerResource.cs
+++ b/src/Aspire.Hosting/Nats/NatsServerResource.cs
@@ -21,7 +21,7 @@ public class NatsServerResource(string name) : ContainerResource(name), IResourc
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
     /// <summary>
-    /// Gets the connection string expression for the NATS server for the manifest.
+    /// Gets the connection string expression for the NATS server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create(

--- a/src/Aspire.Hosting/Nats/NatsServerResource.cs
+++ b/src/Aspire.Hosting/Nats/NatsServerResource.cs
@@ -20,21 +20,10 @@ public class NatsServerResource(string name) : ContainerResource(name), IResourc
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
-    private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
-            $"{PrimaryNatsSchemeName}://{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
-
     /// <summary>
     /// Gets the connection string expression for the NATS server for the manifest.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ConnectionString;
-
-    /// <summary>
-    /// Gets the connection string (NATS_URL) for the NATS server.
-    /// </summary>
-    /// <param name="cancellationToken">Cancellation token. </param>
-    /// <returns>A connection string for the NATS server in the form "nats://host:port".</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
-        ConnectionString.GetValueAsync(cancellationToken);
+        ReferenceExpression.Create(
+            $"{PrimaryNatsSchemeName}://{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
 }

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
@@ -21,7 +21,8 @@ public class OracleDatabaseResource(string name, string databaseName, OracleData
     /// <summary>
     /// Gets the connection string expression for the Oracle Database.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Parent.Name}.connectionString}}/{DatabaseName}";
+    public ReferenceExpression ConnectionStringExpression =>
+       ReferenceExpression.Create($"{Parent}/{DatabaseName}");
 
     /// <summary>
     /// Gets the connection string for the Oracle Database.

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseResource.cs
@@ -25,22 +25,6 @@ public class OracleDatabaseResource(string name, string databaseName, OracleData
        ReferenceExpression.Create($"{Parent}/{DatabaseName}");
 
     /// <summary>
-    /// Gets the connection string for the Oracle Database.
-    /// </summary>
-    /// <returns>A connection string for the Oracle Database.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-    {
-        if (await Parent.GetConnectionStringAsync(cancellationToken).ConfigureAwait(false) is { } connectionString)
-        {
-            return $"{connectionString}/{DatabaseName}";
-        }
-        else
-        {
-            throw new DistributedApplicationException("Parent resource connection string was null.");
-        }
-    }
-
-    /// <summary>
     /// Gets the database name.
     /// </summary>
     public string DatabaseName { get; } = databaseName;

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
@@ -42,8 +42,8 @@ public class OracleDatabaseServerResource : ContainerResource, IResourceWithConn
     /// <summary>
     /// Gets the connection string expression for the Oracle Database server.
     /// </summary>
-    public string ConnectionStringExpression =>
-        ConnectionString.ValueExpression;
+    public ReferenceExpression ConnectionStringExpression =>
+        ConnectionString;
 
     /// <summary>
     /// Gets the connection string for the Oracle Database server.

--- a/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting/Oracle/OracleDatabaseServerResource.cs
@@ -45,13 +45,6 @@ public class OracleDatabaseServerResource : ContainerResource, IResourceWithConn
     public ReferenceExpression ConnectionStringExpression =>
         ConnectionString;
 
-    /// <summary>
-    /// Gets the connection string for the Oracle Database server.
-    /// </summary>
-    /// <returns>A connection string for the Oracle Database server in the form "user id=system;password=password;data source=host:port".</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
-        ConnectionString.GetValueAsync(cancellationToken);
-
     private readonly Dictionary<string, string> _databases = new(StringComparers.ResourceName);
 
     /// <summary>

--- a/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
@@ -21,24 +21,16 @@ public class PostgresDatabaseResource(string name, string databaseName, Postgres
     /// <summary>
     /// Gets the connection string expression for the Postgres database for the manifest.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Parent.Name}.connectionString}};Database={DatabaseName}";
+    public ReferenceExpression ConnectionStringExpression =>
+       ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
 
     /// <summary>
     /// Gets the connection string for the Postgres database.
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>A connection string for the Postgres database.</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (await Parent.GetConnectionStringAsync(cancellationToken).ConfigureAwait(false) is { } connectionString)
-        {
-            return $"{connectionString};Database={DatabaseName}";
-        }
-        else
-        {
-            throw new DistributedApplicationException("Parent resource connection string was null.");
-        }
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default) =>
+        ConnectionStringExpression.GetValueAsync(cancellationToken);
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
@@ -19,7 +19,7 @@ public class PostgresDatabaseResource(string name, string databaseName, Postgres
     public PostgresServerResource Parent { get; } = postgresParentResource;
 
     /// <summary>
-    /// Gets the connection string expression for the Postgres database for the manifest.
+    /// Gets the connection string expression for the Postgres database.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
        ReferenceExpression.Create($"{Parent};Database={DatabaseName}");

--- a/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresDatabaseResource.cs
@@ -25,14 +25,6 @@ public class PostgresDatabaseResource(string name, string databaseName, Postgres
        ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
 
     /// <summary>
-    /// Gets the connection string for the Postgres database.
-    /// </summary>
-    /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>A connection string for the Postgres database.</returns>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default) =>
-        ConnectionStringExpression.GetValueAsync(cancellationToken);
-
-    /// <summary>
     /// Gets the database name.
     /// </summary>
     public string DatabaseName { get; } = databaseName;

--- a/src/Aspire.Hosting/Postgres/PostgresServerResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresServerResource.cs
@@ -42,7 +42,7 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
     /// <summary>
     /// Gets the connection string expression for the PostgreSQL server for the manifest.
     /// </summary>
-    public string? ConnectionStringExpression
+    public ReferenceExpression ConnectionStringExpression
     {
         get
         {
@@ -51,7 +51,7 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
                 return connectionStringAnnotation.Resource.ConnectionStringExpression;
             }
 
-            return ConnectionString.ValueExpression;
+            return ConnectionString;
         }
     }
 
@@ -67,7 +67,7 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
             return connectionStringAnnotation.Resource.GetConnectionStringAsync(cancellationToken);
         }
 
-        return ConnectionString.GetValueAsync(cancellationToken);
+        return ConnectionStringExpression.GetValueAsync(cancellationToken);
     }
 
     private readonly Dictionary<string, string> _databases = new Dictionary<string, string>(StringComparers.ResourceName);

--- a/src/Aspire.Hosting/Postgres/PostgresServerResource.cs
+++ b/src/Aspire.Hosting/Postgres/PostgresServerResource.cs
@@ -40,7 +40,7 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
             $"Host={PrimaryEndpoint.Property(EndpointProperty.Host)};Port={PrimaryEndpoint.Property(EndpointProperty.Port)};Username=postgres;Password={PasswordInput}");
 
     /// <summary>
-    /// Gets the connection string expression for the PostgreSQL server for the manifest.
+    /// Gets the connection string expression for the PostgreSQL server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression
     {

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -101,9 +101,9 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
     public void WriteConnectionString(IResource resource)
     {
         if (resource is IResourceWithConnectionString resourceWithConnectionString &&
-            resourceWithConnectionString.ConnectionStringExpression is string connectionString)
+            resourceWithConnectionString.ConnectionStringExpression is { } connectionString)
         {
-            Writer.WriteString("connectionString", connectionString);
+            Writer.WriteString("connectionString", connectionString.ValueExpression);
         }
     }
 

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
@@ -37,7 +37,7 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
     public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
 
     /// <summary>
-    /// Gets the connection string expression for the RabbitMQ server for the manifest.
+    /// Gets the connection string expression for the RabbitMQ server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create(

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
@@ -43,8 +43,8 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
     /// <summary>
     /// Gets the connection string expression for the RabbitMQ server for the manifest.
     /// </summary>
-    public string ConnectionStringExpression =>
-        ConnectionString.ValueExpression;
+    public ReferenceExpression ConnectionStringExpression =>
+        ConnectionString;
 
     /// <summary>
     /// Gets the connection string for the RabbitMQ server.

--- a/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting/RabbitMQ/RabbitMQServerResource.cs
@@ -36,20 +36,10 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
     /// </summary>
     public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
 
-    private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
-            $"amqp://guest:{PasswordInput}@{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
-
     /// <summary>
     /// Gets the connection string expression for the RabbitMQ server for the manifest.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ConnectionString;
-
-    /// <summary>
-    /// Gets the connection string for the RabbitMQ server.
-    /// </summary>
-    /// <returns>A connection string for the RabbitMQ server in the form "amqp://user:password@host:port".</returns>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) =>
-        await ConnectionString.GetValueAsync(cancellationToken).ConfigureAwait(false);
+        ReferenceExpression.Create(
+            $"amqp://guest:{PasswordInput}@{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
 }

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -23,7 +23,7 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
             $"{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
 
     /// <summary>
-    /// Gets the connection string expression for the Redis server for the manifest.
+    /// Gets the connection string expression for the Redis server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression
     {

--- a/src/Aspire.Hosting/Redis/RedisResource.cs
+++ b/src/Aspire.Hosting/Redis/RedisResource.cs
@@ -25,7 +25,7 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
     /// <summary>
     /// Gets the connection string expression for the Redis server for the manifest.
     /// </summary>
-    public string? ConnectionStringExpression
+    public ReferenceExpression ConnectionStringExpression
     {
         get
         {
@@ -34,7 +34,7 @@ public class RedisResource(string name) : ContainerResource(name), IResourceWith
                 return connectionStringAnnotation.Resource.ConnectionStringExpression;
             }
 
-            return ConnectionString.ValueExpression;
+            return ConnectionString;
         }
     }
 

--- a/src/Aspire.Hosting/Seq/SeqResource.cs
+++ b/src/Aspire.Hosting/Seq/SeqResource.cs
@@ -19,7 +19,7 @@ public class SeqResource(string name) : ContainerResource(name), IResourceWithCo
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
     /// <summary>
-    /// Gets the connection string expression for the Seq server for the manifest.
+    /// Gets the connection string expression for the Seq server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create($"{PrimaryEndpoint.Property(EndpointProperty.Url)}");

--- a/src/Aspire.Hosting/Seq/SeqResource.cs
+++ b/src/Aspire.Hosting/Seq/SeqResource.cs
@@ -18,18 +18,9 @@ public class SeqResource(string name) : ContainerResource(name), IResourceWithCo
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
-    private ReferenceExpression ConnectionEndpoint =>
-        ReferenceExpression.Create($"{PrimaryEndpoint.Property(EndpointProperty.Url)}");
-
-    /// <summary>
-    /// Gets the Uri of the Seq endpoint
-    /// </summary>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-        => ConnectionEndpoint.GetValueAsync(cancellationToken);
-
     /// <summary>
     /// Gets the connection string expression for the Seq server for the manifest.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ConnectionEndpoint;
+        ReferenceExpression.Create($"{PrimaryEndpoint.Property(EndpointProperty.Url)}");
 }

--- a/src/Aspire.Hosting/Seq/SeqResource.cs
+++ b/src/Aspire.Hosting/Seq/SeqResource.cs
@@ -18,8 +18,8 @@ public class SeqResource(string name) : ContainerResource(name), IResourceWithCo
     /// </summary>
     public EndpointReference PrimaryEndpoint => _primaryEndpoint ??= new(this, PrimaryEndpointName);
 
-    private EndpointReferenceExpression ConnectionEndpoint =>
-        PrimaryEndpoint.Property(EndpointProperty.Url);
+    private ReferenceExpression ConnectionEndpoint =>
+        ReferenceExpression.Create($"{PrimaryEndpoint.Property(EndpointProperty.Url)}");
 
     /// <summary>
     /// Gets the Uri of the Seq endpoint
@@ -30,6 +30,6 @@ public class SeqResource(string name) : ContainerResource(name), IResourceWithCo
     /// <summary>
     /// Gets the connection string expression for the Seq server for the manifest.
     /// </summary>
-    public string? ConnectionStringExpression =>
-        ConnectionEndpoint.ValueExpression;
+    public ReferenceExpression ConnectionStringExpression =>
+        ConnectionEndpoint;
 }

--- a/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
@@ -25,14 +25,6 @@ public class SqlServerDatabaseResource(string name, string databaseName, SqlServ
         ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
 
     /// <summary>
-    /// Gets the connection string for the database resource.
-    /// </summary>
-    /// <returns>The connection string for the database resource.</returns>
-    /// <exception cref="DistributedApplicationException">Thrown when the parent resource connection string is null.</exception>
-    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default) =>
-        ConnectionStringExpression.GetValueAsync(cancellationToken);
-
-    /// <summary>
     /// Gets the database name.
     /// </summary>
     public string DatabaseName { get; } = databaseName;

--- a/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
@@ -21,24 +21,16 @@ public class SqlServerDatabaseResource(string name, string databaseName, SqlServ
     /// <summary>
     /// Gets the connection string expression for the SQL Server database for use in the manifest.
     /// </summary>
-    public string ConnectionStringExpression => $"{{{Parent.Name}.connectionString}};Database={DatabaseName}";
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
 
     /// <summary>
     /// Gets the connection string for the database resource.
     /// </summary>
     /// <returns>The connection string for the database resource.</returns>
     /// <exception cref="DistributedApplicationException">Thrown when the parent resource connection string is null.</exception>
-    public async ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-    {
-        if (await Parent.GetConnectionStringAsync(cancellationToken).ConfigureAwait(false) is { } connectionString)
-        {
-            return $"{connectionString};Database={DatabaseName}";
-        }
-        else
-        {
-            throw new DistributedApplicationException("Parent resource connection string was null.");
-        }
-    }
+    public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default) =>
+        ConnectionStringExpression.GetValueAsync(cancellationToken);
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerDatabaseResource.cs
@@ -19,7 +19,7 @@ public class SqlServerDatabaseResource(string name, string databaseName, SqlServ
     public SqlServerServerResource Parent { get; } = parent;
 
     /// <summary>
-    /// Gets the connection string expression for the SQL Server database for use in the manifest.
+    /// Gets the connection string expression for the SQL Server database.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create($"{Parent};Database={DatabaseName}");

--- a/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
@@ -43,7 +43,7 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
     /// <summary>
     /// Gets the connection string expression for the SQL Server for the manifest.
     /// </summary>
-    public string? ConnectionStringExpression
+    public ReferenceExpression ConnectionStringExpression
     {
         get
         {
@@ -52,7 +52,7 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
                 return connectionStringAnnotation.Resource.ConnectionStringExpression;
             }
 
-            return ConnectionString.ValueExpression;
+            return ConnectionString;
         }
     }
 

--- a/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting/SqlServer/SqlServerServerResource.cs
@@ -41,7 +41,7 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
             $"Server={PrimaryEndpoint.Property(EndpointProperty.IPV4Host)},{PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=sa;Password={PasswordInput};TrustServerCertificate=true");
 
     /// <summary>
-    /// Gets the connection string expression for the SQL Server for the manifest.
+    /// Gets the connection string expression for the SQL Server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression
     {

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
@@ -145,8 +145,7 @@ public class AzureBicepProvisionerTests
         Resource(name),
         IResourceWithConnectionString
     {
-        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
-
-        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) => new(connectionString);
+        public ReferenceExpression ConnectionStringExpression =>
+           ReferenceExpression.Create($"{connectionString}");
     }
 }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
@@ -145,6 +145,8 @@ public class AzureBicepProvisionerTests
         Resource(name),
         IResourceWithConnectionString
     {
+        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
+
         public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) => new(connectionString);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -128,14 +128,15 @@ public class AzureBicepResourceTests
         cosmos.Resource.SecretOutputs["connectionString"] = "mycosmosconnectionstring";
 
         var databases = cosmos.Resource.Parameters["databases"] as IEnumerable<string>;
+        var connectionStringResource = (IResourceWithConnectionString)cosmos.Resource;
 
         Assert.Equal("Aspire.Hosting.Azure.Bicep.cosmosdb.bicep", cosmos.Resource.TemplateResourceName);
         Assert.Equal("cosmos", cosmos.Resource.Name);
         Assert.Equal("cosmos", cosmos.Resource.Parameters["databaseAccountName"]);
         Assert.NotNull(databases);
         Assert.Equal(["mydatabase"], databases);
-        Assert.Equal("mycosmosconnectionstring", await cosmos.Resource.GetConnectionStringAsync());
-        Assert.Equal("{cosmos.secretOutputs.connectionString}", cosmos.Resource.ConnectionStringExpression);
+        Assert.Equal("mycosmosconnectionstring", await connectionStringResource.GetConnectionStringAsync());
+        Assert.Equal("{cosmos.secretOutputs.connectionString}", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -151,6 +152,8 @@ public class AzureBicepResourceTests
         cosmos.AddDatabase("mydatabase");
 
         cosmos.Resource.SecretOutputs["connectionString"] = "mycosmosconnectionstring";
+
+        var connectionStringResource = (IResourceWithConnectionString)cosmos.Resource;
 
         var manifest = await ManifestUtils.GetManifest(cosmos.Resource);
         var expectedManifest = """
@@ -173,7 +176,7 @@ public class AzureBicepResourceTests
             );
 
         Assert.Equal("cosmos", cosmos.Resource.Name);
-        Assert.Equal("mycosmosconnectionstring", await cosmos.Resource.GetConnectionStringAsync(default));
+        Assert.Equal("mycosmosconnectionstring", await connectionStringResource.GetConnectionStringAsync());
     }
 
     [Fact]
@@ -185,11 +188,13 @@ public class AzureBicepResourceTests
 
         appConfig.Resource.Outputs["appConfigEndpoint"] = "https://myendpoint";
 
+        var connectionStringResource = (IResourceWithConnectionString)appConfig.Resource;
+
         Assert.Equal("Aspire.Hosting.Azure.Bicep.appconfig.bicep", appConfig.Resource.TemplateResourceName);
         Assert.Equal("appConfig", appConfig.Resource.Name);
         Assert.Equal("appconfig", appConfig.Resource.Parameters["configName"]);
-        Assert.Equal("https://myendpoint", await appConfig.Resource.GetConnectionStringAsync(default));
-        Assert.Equal("{appConfig.outputs.appConfigEndpoint}", appConfig.Resource.ConnectionStringExpression);
+        Assert.Equal("https://myendpoint", await connectionStringResource.GetConnectionStringAsync());
+        Assert.Equal("{appConfig.outputs.appConfigEndpoint}", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -198,8 +203,12 @@ public class AzureBicepResourceTests
         var builder = DistributedApplication.CreateBuilder();
 
         var appConfig = builder.AddAzureAppConfigurationConstruct("appConfig");
+
         appConfig.Resource.Outputs["appConfigEndpoint"] = "https://myendpoint";
-        Assert.Equal("https://myendpoint", await appConfig.Resource.GetConnectionStringAsync(default));
+
+        var connectionStringResource = (IResourceWithConnectionString)appConfig.Resource;
+
+        Assert.Equal("https://myendpoint", await connectionStringResource.GetConnectionStringAsync());
 
         var expectedManifest = """
             {
@@ -231,7 +240,7 @@ public class AzureBicepResourceTests
         Assert.Equal("appinsights", appInsights.Resource.Parameters["appInsightsName"]);
         Assert.True(appInsights.Resource.Parameters.ContainsKey(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId));
         Assert.Equal("myinstrumentationkey", await appInsights.Resource.GetConnectionStringAsync(default));
-        Assert.Equal("{appInsights.outputs.appInsightsConnectionString}", appInsights.Resource.ConnectionStringExpression);
+        Assert.Equal("{appInsights.outputs.appInsightsConnectionString}", appInsights.Resource.ConnectionStringExpression.ValueExpression);
 
         var appInsightsManifest = await ManifestUtils.GetManifest(appInsights.Resource);
         Assert.Equal("{appInsights.outputs.appInsightsConnectionString}", appInsightsManifest["connectionString"]?.ToString());
@@ -409,11 +418,13 @@ public class AzureBicepResourceTests
 
         keyVault.Resource.Outputs["vaultUri"] = "https://myvault";
 
+        var connectionStringResource = (IResourceWithConnectionString)keyVault.Resource;
+
         Assert.Equal("Aspire.Hosting.Azure.Bicep.keyvault.bicep", keyVault.Resource.TemplateResourceName);
         Assert.Equal("keyVault", keyVault.Resource.Name);
         Assert.Equal("keyvault", keyVault.Resource.Parameters["vaultName"]);
-        Assert.Equal("https://myvault", await keyVault.Resource.GetConnectionStringAsync());
-        Assert.Equal("{keyVault.outputs.vaultUri}", keyVault.Resource.ConnectionStringExpression);
+        Assert.Equal("https://myvault", await connectionStringResource.GetConnectionStringAsync());
+        Assert.Equal("{keyVault.outputs.vaultUri}", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -494,7 +505,7 @@ public class AzureBicepResourceTests
         Assert.NotNull(databases);
         Assert.Equal(["dbName"], databases);
         Assert.Equal("Server=tcp:myserver,1433;Encrypt=True;Authentication=\"Active Directory Default\"", await sql.Resource.GetConnectionStringAsync(default));
-        Assert.Equal("Server=tcp:{sql.outputs.sqlServerFqdn},1433;Encrypt=True;Authentication=\"Active Directory Default\"", sql.Resource.ConnectionStringExpression);
+        Assert.Equal("Server=tcp:{sql.outputs.sqlServerFqdn},1433;Encrypt=True;Authentication=\"Active Directory Default\"", sql.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -587,7 +598,7 @@ public class AzureBicepResourceTests
         azurePostgres.Resource.SecretOutputs["connectionString"] = "myconnectionstring";
         Assert.Equal("myconnectionstring", await postgres.Resource.GetConnectionStringAsync(default));
 
-        Assert.Equal("{postgres.secretOutputs.connectionString}", azurePostgres.Resource.ConnectionStringExpression);
+        Assert.Equal("{postgres.secretOutputs.connectionString}", azurePostgres.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -629,7 +640,7 @@ public class AzureBicepResourceTests
         var expectedConnectionString = $"Host=localhost;Port=1234;Username=postgres;Password={postgres.Resource.Password}";
         Assert.Equal(expectedConnectionString, await postgres.Resource.GetConnectionStringAsync(default));
 
-        Assert.Equal("{postgres.secretOutputs.connectionString}", azurePostgres.Resource.ConnectionStringExpression);
+        Assert.Equal("{postgres.secretOutputs.connectionString}", azurePostgres.Resource.ConnectionStringExpression.ValueExpression);
 
         var manifest = await ManifestUtils.GetManifest(postgres.Resource);
 
@@ -799,6 +810,8 @@ public class AzureBicepResourceTests
 
         serviceBus.Resource.Outputs["serviceBusEndpoint"] = "mynamespaceEndpoint";
 
+        var connectionStringResource = (IResourceWithConnectionString)serviceBus.Resource;
+
         var queuesCallback = serviceBus.Resource.Parameters["queues"] as Func<object?>;
         var topicsCallback = serviceBus.Resource.Parameters["topics"] as Func<object?>;
         Assert.NotNull(queuesCallback);
@@ -813,8 +826,8 @@ public class AzureBicepResourceTests
         Assert.Equal(["queue1", "queue2"], queues);
         Assert.NotNull(topics);
         Assert.Equal("""[{"name":"t1","subscriptions":["s1","s2"]},{"name":"t2","subscriptions":[]},{"name":"t3","subscriptions":["s3"]}]""", topics.ToJsonString());
-        Assert.Equal("mynamespaceEndpoint", await serviceBus.Resource.GetConnectionStringAsync(default));
-        Assert.Equal("{sb.outputs.serviceBusEndpoint}", serviceBus.Resource.ConnectionStringExpression);
+        Assert.Equal("mynamespaceEndpoint", await connectionStringResource.GetConnectionStringAsync());
+        Assert.Equal("{sb.outputs.serviceBusEndpoint}", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -832,9 +845,11 @@ public class AzureBicepResourceTests
 
         serviceBus.Resource.Outputs["serviceBusEndpoint"] = "mynamespaceEndpoint";
 
+        var connectionStringResource = (IResourceWithConnectionString)serviceBus.Resource;
+
         Assert.Equal("sb", serviceBus.Resource.Name);
-        Assert.Equal("mynamespaceEndpoint", await serviceBus.Resource.GetConnectionStringAsync());
-        Assert.Equal("{sb.outputs.serviceBusEndpoint}", serviceBus.Resource.ConnectionStringExpression);
+        Assert.Equal("mynamespaceEndpoint", await connectionStringResource.GetConnectionStringAsync());
+        Assert.Equal("{sb.outputs.serviceBusEndpoint}", connectionStringResource.ConnectionStringExpression.ValueExpression);
 
         var manifest = await ManifestUtils.GetManifest(serviceBus.Resource);
         var expected = """
@@ -866,16 +881,20 @@ public class AzureBicepResourceTests
         var queue = storage.AddQueues("queue");
         var table = storage.AddTables("table");
 
+        var connectionStringBlobResource = (IResourceWithConnectionString)blob.Resource;
+        var connectionStringQueueResource = (IResourceWithConnectionString)queue.Resource;
+        var connectionStringTableResource = (IResourceWithConnectionString)table.Resource;
+
         Assert.Equal("Aspire.Hosting.Azure.Bicep.storage.bicep", storage.Resource.TemplateResourceName);
         Assert.Equal("storage", storage.Resource.Name);
         Assert.Equal("storage", storage.Resource.Parameters["storageName"]);
 
-        Assert.Equal("https://myblob", await blob.Resource.GetConnectionStringAsync());
-        Assert.Equal("https://myqueue", await queue.Resource.GetConnectionStringAsync());
-        Assert.Equal("https://mytable", await table.Resource.GetConnectionStringAsync());
-        Assert.Equal("{storage.outputs.blobEndpoint}", blob.Resource.ConnectionStringExpression);
-        Assert.Equal("{storage.outputs.queueEndpoint}", queue.Resource.ConnectionStringExpression);
-        Assert.Equal("{storage.outputs.tableEndpoint}", table.Resource.ConnectionStringExpression);
+        Assert.Equal("https://myblob", await connectionStringBlobResource.GetConnectionStringAsync());
+        Assert.Equal("https://myqueue", await connectionStringQueueResource.GetConnectionStringAsync());
+        Assert.Equal("https://mytable", await connectionStringTableResource.GetConnectionStringAsync());
+        Assert.Equal("{storage.outputs.blobEndpoint}", connectionStringBlobResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{storage.outputs.queueEndpoint}", connectionStringQueueResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{storage.outputs.tableEndpoint}", connectionStringTableResource.ConnectionStringExpression.ValueExpression);
 
         var blobManifest = await ManifestUtils.GetManifest(blob.Resource);
         Assert.Equal("{storage.outputs.blobEndpoint}", blobManifest["connectionString"]?.ToString());
@@ -920,7 +939,10 @@ public class AzureBicepResourceTests
 
         // Check blob resource.
         var blob = storage.AddBlobs("blob");
-        Assert.Equal("https://myblob", await blob.Resource.GetConnectionStringAsync());
+
+        var connectionStringBlobResource = (IResourceWithConnectionString)blob.Resource;
+
+        Assert.Equal("https://myblob", await connectionStringBlobResource.GetConnectionStringAsync());
         var expectedBlobManifest = """
             {
               "type": "value.v0",
@@ -932,7 +954,10 @@ public class AzureBicepResourceTests
 
         // Check queue resource.
         var queue = storage.AddQueues("queue");
-        Assert.Equal("https://myqueue", await queue.Resource.GetConnectionStringAsync());
+
+        var connectionStringQueueResource = (IResourceWithConnectionString)queue.Resource;
+
+        Assert.Equal("https://myqueue", await connectionStringQueueResource.GetConnectionStringAsync());
         var expectedQueueManifest = """
             {
               "type": "value.v0",
@@ -944,7 +969,10 @@ public class AzureBicepResourceTests
 
         // Check table resource.
         var table = storage.AddTables("table");
-        Assert.Equal("https://mytable", await table.Resource.GetConnectionStringAsync());
+
+        var connectionStringTableResource = (IResourceWithConnectionString)table.Resource;
+
+        Assert.Equal("https://mytable", await connectionStringTableResource.GetConnectionStringAsync());
         var expectedTableManifest = """
             {
               "type": "value.v0",
@@ -964,10 +992,12 @@ public class AzureBicepResourceTests
 
         search.Resource.Outputs["connectionString"] = "mysearchconnectionstring";
 
+        var connectionStringResource = (IResourceWithConnectionString)search.Resource;
+
         Assert.Equal("Aspire.Hosting.Azure.Bicep.search.bicep", search.Resource.TemplateResourceName);
         Assert.Equal("search", search.Resource.Name);
-        Assert.Equal("mysearchconnectionstring", await search.Resource.GetConnectionStringAsync(default));
-        Assert.Equal("{search.outputs.connectionString}", search.Resource.ConnectionStringExpression);
+        Assert.Equal("mysearchconnectionstring", await connectionStringResource.GetConnectionStringAsync());
+        Assert.Equal("{search.outputs.connectionString}", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -984,10 +1014,12 @@ public class AzureBicepResourceTests
         const string fakeConnectionString = "mysearchconnectionstring";
         search.Resource.Outputs["connectionString"] = fakeConnectionString;
 
+        var connectionStringResource = (IResourceWithConnectionString)search.Resource;
+
         // Validate the resource
         Assert.Equal("search", search.Resource.Name);
-        Assert.Equal("{search.outputs.connectionString}", search.Resource.ConnectionStringExpression);
-        Assert.Equal(fakeConnectionString, await search.Resource.GetConnectionStringAsync());
+        Assert.Equal("{search.outputs.connectionString}", connectionStringResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal(fakeConnectionString, await connectionStringResource.GetConnectionStringAsync());
 
         // Validate the manifest
         var expectedManifest =
@@ -1042,14 +1074,16 @@ public class AzureBicepResourceTests
 
         openai.Resource.Outputs["connectionString"] = "myopenaiconnectionstring";
 
+        var connectionStringResource = (IResourceWithConnectionString)openai.Resource;
+
         var callback = openai.Resource.Parameters["deployments"] as Func<object?>;
         var deployments = callback?.Invoke() as JsonArray;
         var deployment = deployments?.FirstOrDefault();
 
         Assert.Equal("Aspire.Hosting.Azure.Bicep.openai.bicep", openai.Resource.TemplateResourceName);
         Assert.Equal("openai", openai.Resource.Name);
-        Assert.Equal("myopenaiconnectionstring", await openai.Resource.GetConnectionStringAsync(default));
-        Assert.Equal("{openai.outputs.connectionString}", openai.Resource.ConnectionStringExpression);
+        Assert.Equal("myopenaiconnectionstring", await connectionStringResource.GetConnectionStringAsync(default));
+        Assert.Equal("{openai.outputs.connectionString}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.NotNull(deployment);
         Assert.Equal("mymodel", deployment["name"]?.ToString());
         Assert.Equal("Basic", deployment["sku"]?["name"]?.ToString());

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -235,11 +235,13 @@ public class AzureBicepResourceTests
 
         appInsights.Resource.Outputs["appInsightsConnectionString"] = "myinstrumentationkey";
 
+        var connectionStringResource = (IResourceWithConnectionString)appInsights.Resource;
+
         Assert.Equal("Aspire.Hosting.Azure.Bicep.appinsights.bicep", appInsights.Resource.TemplateResourceName);
         Assert.Equal("appInsights", appInsights.Resource.Name);
         Assert.Equal("appinsights", appInsights.Resource.Parameters["appInsightsName"]);
         Assert.True(appInsights.Resource.Parameters.ContainsKey(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId));
-        Assert.Equal("myinstrumentationkey", await appInsights.Resource.GetConnectionStringAsync(default));
+        Assert.Equal("myinstrumentationkey", await connectionStringResource.GetConnectionStringAsync());
         Assert.Equal("{appInsights.outputs.appInsightsConnectionString}", appInsights.Resource.ConnectionStringExpression.ValueExpression);
 
         var appInsightsManifest = await ManifestUtils.GetManifest(appInsights.Resource);

--- a/tests/Aspire.Hosting.Tests/ContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceTests.cs
@@ -99,11 +99,7 @@ public class ContainerResourceTests
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
-        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
-
-        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-        {
-            return new(connectionString);
-        }
+        public ReferenceExpression ConnectionStringExpression =>
+            ReferenceExpression.Create($"{connectionString}");
     }
 }

--- a/tests/Aspire.Hosting.Tests/ContainerResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceTests.cs
@@ -99,6 +99,8 @@ public class ContainerResourceTests
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
+        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
+
         public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
         {
             return new(connectionString);

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -63,6 +63,8 @@ public class ExecutableResourceTests
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
+        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
+
         public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
         {
             return new(connectionString);

--- a/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExecutableResourceTests.cs
@@ -63,11 +63,7 @@ public class ExecutableResourceTests
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
-        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
-
-        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-        {
-            return new(connectionString);
-        }
+        public ReferenceExpression ConnectionStringExpression =>
+            ReferenceExpression.Create($"{connectionString}");
     }
 }

--- a/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
@@ -50,11 +50,11 @@ public class AddKafkaTests
 
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        var connectionStringResource = Assert.Single(appModel.Resources.OfType<KafkaServerResource>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var connectionStringResource = Assert.Single(appModel.Resources.OfType<KafkaServerResource>()) as IResourceWithConnectionString;
+        var connectionString = await connectionStringResource.GetConnectionStringAsync();
 
         Assert.Equal("localhost:27017", connectionString);
-        Assert.Equal("{kafka.bindings.tcp.host}:{kafka.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("{kafka.bindings.tcp.host}:{kafka.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
@@ -81,13 +81,16 @@ public class AddMongoDBTests
 
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        var connectionStringResource = Assert.Single(appModel.Resources.OfType<MongoDBDatabaseResource>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
+        var dbResource = Assert.Single(appModel.Resources.OfType<MongoDBDatabaseResource>());
+        var serverResource = dbResource.Parent as IResourceWithConnectionString;
+        var connectionStringResource = dbResource as IResourceWithConnectionString;
+        Assert.NotNull(connectionStringResource);
+        var connectionString = await connectionStringResource.GetConnectionStringAsync();
 
-        Assert.Equal("mongodb://localhost:27017", await connectionStringResource.Parent.GetConnectionStringAsync(default));
-        Assert.Equal("mongodb://{mongodb.bindings.tcp.host}:{mongodb.bindings.tcp.port}", connectionStringResource.Parent.ConnectionStringExpression);
+        Assert.Equal("mongodb://localhost:27017", await serverResource.GetConnectionStringAsync());
+        Assert.Equal("mongodb://{mongodb.bindings.tcp.host}:{mongodb.bindings.tcp.port}", serverResource.ConnectionStringExpression.ValueExpression);
         Assert.Equal("mongodb://localhost:27017/mydatabase", connectionString);
-        Assert.Equal("{mongodb.connectionString}/mydatabase", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("{mongodb.connectionString}/mydatabase", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -181,8 +184,8 @@ public class AddMongoDBTests
         Assert.Equal("customers1", db1.Resource.DatabaseName);
         Assert.Equal("customers2", db2.Resource.DatabaseName);
 
-        Assert.Equal("{mongo1.connectionString}/customers1", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{mongo1.connectionString}/customers2", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{mongo1.connectionString}/customers1", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{mongo1.connectionString}/customers2", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -199,7 +202,7 @@ public class AddMongoDBTests
         Assert.Equal("imports", db1.Resource.DatabaseName);
         Assert.Equal("imports", db2.Resource.DatabaseName);
 
-        Assert.Equal("{mongo1.connectionString}/imports", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{mongo2.connectionString}/imports", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{mongo1.connectionString}/imports", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{mongo2.connectionString}/imports", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 }

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -101,7 +101,7 @@ public class AddMySqlTests
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
         var connectionString = await connectionStringResource.GetConnectionStringAsync();
 
-        Assert.Equal("Server={mysql.bindings.tcp.host};Port={mysql.bindings.tcp.port};User ID=root;Password={mysql.inputs.password}", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("Server={mysql.bindings.tcp.host};Port={mysql.bindings.tcp.port};User ID=root;Password={mysql.inputs.password}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith("Server=localhost;Port=2000;User ID=root;Password=", connectionString);
     }
 
@@ -123,7 +123,7 @@ public class AddMySqlTests
         var dbConnectionString = await mySqlDatabaseResource.GetConnectionStringAsync(default);
 
         Assert.Equal(mySqlConnectionString + ";Database=db", dbConnectionString);
-        Assert.Equal("{mysql.connectionString};Database=db", mySqlDatabaseResource.ConnectionStringExpression);
+        Assert.Equal("{mysql.connectionString};Database=db", mySqlDatabaseResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -293,8 +293,8 @@ public class AddMySqlTests
         Assert.Equal("customers1", db1.Resource.DatabaseName);
         Assert.Equal("customers2", db2.Resource.DatabaseName);
 
-        Assert.Equal("{mysql1.connectionString};Database=customers1", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{mysql1.connectionString};Database=customers2", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{mysql1.connectionString};Database=customers1", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{mysql1.connectionString};Database=customers2", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -311,7 +311,7 @@ public class AddMySqlTests
         Assert.Equal("imports", db1.Resource.DatabaseName);
         Assert.Equal("imports", db2.Resource.DatabaseName);
 
-        Assert.Equal("{mysql1.connectionString};Database=imports", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{mysql2.connectionString};Database=imports", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{mysql1.connectionString};Database=imports", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{mysql2.connectionString};Database=imports", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 }

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -118,9 +118,11 @@ public class AddMySqlTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var mySqlResource = Assert.Single(appModel.Resources.OfType<MySqlServerResource>());
-        var mySqlConnectionString = await mySqlResource.GetConnectionStringAsync(default);
+        var mySqlConnectionStringResource = (IResourceWithConnectionString)mySqlResource;
+        var mySqlConnectionString = await mySqlConnectionStringResource.GetConnectionStringAsync();
         var mySqlDatabaseResource = Assert.Single(appModel.Resources.OfType<MySqlDatabaseResource>());
-        var dbConnectionString = await mySqlDatabaseResource.GetConnectionStringAsync(default);
+        var mySqlDatabaseConnectionStringResource = (IResourceWithConnectionString)mySqlDatabaseResource;
+        var dbConnectionString = await mySqlDatabaseConnectionStringResource.GetConnectionStringAsync();
 
         Assert.Equal(mySqlConnectionString + ";Database=db", dbConnectionString);
         Assert.Equal("{mysql.connectionString};Database=db", mySqlDatabaseResource.ConnectionStringExpression.ValueExpression);

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -124,9 +124,9 @@ public class AddOracleTests
         var oracleConnectionString = oracleConnectionStringResource.GetConnectionStringAsync();
         var oracleDatabaseResource = Assert.Single(appModel.Resources.OfType<OracleDatabaseResource>());
         var oracleDatabaseConnectionStringResource = (IResourceWithConnectionString)oracleDatabaseResource;
-        var dbConnectionString = await oracleConnectionStringResource.GetConnectionStringAsync();
+        var dbConnectionString = await oracleDatabaseConnectionStringResource.GetConnectionStringAsync();
 
-        Assert.Equal("{orcl.connectionString}/db", oracleDatabaseResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{orcl.connectionString}/db", oracleDatabaseConnectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.Equal(oracleConnectionString + "/db", dbConnectionString);
     }
 

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -120,9 +120,11 @@ public class AddOracleTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var oracleResource = Assert.Single(appModel.Resources.OfType<OracleDatabaseServerResource>());
-        var oracleConnectionString = oracleResource.GetConnectionStringAsync(default);
+        var oracleConnectionStringResource = (IResourceWithConnectionString)oracleResource;
+        var oracleConnectionString = oracleConnectionStringResource.GetConnectionStringAsync();
         var oracleDatabaseResource = Assert.Single(appModel.Resources.OfType<OracleDatabaseResource>());
-        var dbConnectionString = await oracleDatabaseResource.GetConnectionStringAsync(default);
+        var oracleDatabaseConnectionStringResource = (IResourceWithConnectionString)oracleDatabaseResource;
+        var dbConnectionString = await oracleConnectionStringResource.GetConnectionStringAsync();
 
         Assert.Equal("{orcl.connectionString}/db", oracleDatabaseResource.ConnectionStringExpression.ValueExpression);
         Assert.Equal(oracleConnectionString + "/db", dbConnectionString);

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -102,7 +102,7 @@ public class AddOracleTests
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
         var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
 
-        Assert.Equal("user id=system;password={orcl.inputs.password};data source={orcl.bindings.tcp.host}:{orcl.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("user id=system;password={orcl.inputs.password};data source={orcl.bindings.tcp.host}:{orcl.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith("user id=system;password=", connectionString);
         Assert.EndsWith(";data source=localhost:2000", connectionString);
     }
@@ -124,7 +124,7 @@ public class AddOracleTests
         var oracleDatabaseResource = Assert.Single(appModel.Resources.OfType<OracleDatabaseResource>());
         var dbConnectionString = await oracleDatabaseResource.GetConnectionStringAsync(default);
 
-        Assert.Equal("{orcl.connectionString}/db", oracleDatabaseResource.ConnectionStringExpression);
+        Assert.Equal("{orcl.connectionString}/db", oracleDatabaseResource.ConnectionStringExpression.ValueExpression);
         Assert.Equal(oracleConnectionString + "/db", dbConnectionString);
     }
 
@@ -255,8 +255,8 @@ public class AddOracleTests
         Assert.Equal("customers1", db1.Resource.DatabaseName);
         Assert.Equal("customers2", db2.Resource.DatabaseName);
 
-        Assert.Equal("{oracle1.connectionString}/customers1", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{oracle1.connectionString}/customers2", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{oracle1.connectionString}/customers1", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{oracle1.connectionString}/customers2", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -273,7 +273,7 @@ public class AddOracleTests
         Assert.Equal("imports", db1.Resource.DatabaseName);
         Assert.Equal("imports", db2.Resource.DatabaseName);
 
-        Assert.Equal("{oracle1.connectionString}/imports", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{oracle2.connectionString}/imports", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{oracle1.connectionString}/imports", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{oracle2.connectionString}/imports", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -114,8 +114,10 @@ public class AddPostgresTests
         var postgres = appBuilder.AddPostgres("postgres")
                                  .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
 
-        var connectionString = await postgres.Resource.GetConnectionStringAsync();
-        Assert.Equal("Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres.inputs.password}", postgres.Resource.ConnectionStringExpression);
+        var connectionStringResource = postgres.Resource as IResourceWithConnectionString;
+
+        var connectionString = await connectionStringResource.GetConnectionStringAsync();
+        Assert.Equal("Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres.inputs.password}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.Equal($"Host=localhost;Port=2000;Username=postgres;Password={postgres.Resource.Password}", connectionString);
     }
 
@@ -136,7 +138,7 @@ public class AddPostgresTests
         var postgresDatabaseResource = Assert.Single(appModel.Resources.OfType<PostgresDatabaseResource>());
         var dbConnectionString = await postgresDatabaseResource.GetConnectionStringAsync(default);
 
-        Assert.Equal("{postgres.connectionString};Database=db", postgresDatabaseResource.ConnectionStringExpression);
+        Assert.Equal("{postgres.connectionString};Database=db", postgresDatabaseResource.ConnectionStringExpression.ValueExpression);
         Assert.Equal(postgresConnectionString + ";Database=db", dbConnectionString);
     }
 
@@ -345,8 +347,8 @@ public class AddPostgresTests
         Assert.Equal("customers1", db1.Resource.DatabaseName);
         Assert.Equal("customers2", db2.Resource.DatabaseName);
 
-        Assert.Equal("{postgres1.connectionString};Database=customers1", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{postgres1.connectionString};Database=customers2", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{postgres1.connectionString};Database=customers1", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{postgres1.connectionString};Database=customers2", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -363,7 +365,7 @@ public class AddPostgresTests
         Assert.Equal("imports", db1.Resource.DatabaseName);
         Assert.Equal("imports", db2.Resource.DatabaseName);
 
-        Assert.Equal("{postgres1.connectionString};Database=imports", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{postgres2.connectionString};Database=imports", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{postgres1.connectionString};Database=imports", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{postgres2.connectionString};Database=imports", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 }

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -136,7 +136,8 @@ public class AddPostgresTests
         var postgresResource = Assert.Single(appModel.Resources.OfType<PostgresServerResource>());
         var postgresConnectionString = await postgresResource.GetConnectionStringAsync();
         var postgresDatabaseResource = Assert.Single(appModel.Resources.OfType<PostgresDatabaseResource>());
-        var dbConnectionString = await postgresDatabaseResource.GetConnectionStringAsync(default);
+        var postgresDatabaseConnectionStringResource = (IResourceWithConnectionString)postgresDatabaseResource;
+        var dbConnectionString = await postgresDatabaseConnectionStringResource.GetConnectionStringAsync();
 
         Assert.Equal("{postgres.connectionString};Database=db", postgresDatabaseResource.ConnectionStringExpression.ValueExpression);
         Assert.Equal(postgresConnectionString + ";Database=db", dbConnectionString);

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -51,12 +51,13 @@ public class AddRabbitMQTests
 
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        var connectionStringResource = Assert.Single(appModel.Resources.OfType<RabbitMQServerResource>());
+        var rabbitMqResource = Assert.Single(appModel.Resources.OfType<RabbitMQServerResource>());
+        var connectionStringResource = rabbitMqResource as IResourceWithConnectionString;
         var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
-        var password = connectionStringResource.Password;
+        var password = rabbitMqResource.Password;
 
         Assert.Equal($"amqp://guest:{password}@localhost:27011", connectionString);
-        Assert.Equal("amqp://guest:{rabbit.inputs.password}@{rabbit.bindings.tcp.host}:{rabbit.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("amqp://guest:{rabbit.inputs.password}@{rabbit.bindings.tcp.host}:{rabbit.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -81,7 +81,7 @@ public class AddRedisTests
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<IResourceWithConnectionString>());
         var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
-        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("{myRedis.bindings.tcp.host}:{myRedis.bindings.tcp.port}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.StartsWith("localhost:2000", connectionString);
     }
 

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -151,8 +151,7 @@ public class ResourceNotificationTests
         IResourceWithEnvironment,
         IResourceWithConnectionString
     {
-        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
-
-        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) => new("CustomConnectionString");
+        public ReferenceExpression ConnectionStringExpression =>
+            ReferenceExpression.Create($"CustomConnectionString");
     }
 }

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -151,6 +151,8 @@ public class ResourceNotificationTests
         IResourceWithEnvironment,
         IResourceWithConnectionString
     {
+        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
+
         public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken) => new("CustomConnectionString");
     }
 }

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -72,7 +72,7 @@ public class AddSqlServerTests
         var password = connectionStringResource.Password;
 
         Assert.Equal($"Server=127.0.0.1,1433;User ID=sa;Password={password};TrustServerCertificate=true", connectionString);
-        Assert.Equal("Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver.inputs.password};TrustServerCertificate=true", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver.inputs.password};TrustServerCertificate=true", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class AddSqlServerTests
         var password = connectionStringResource.Parent.Password;
 
         Assert.Equal($"Server=127.0.0.1,1433;User ID=sa;Password={password};TrustServerCertificate=true;Database=mydb", connectionString);
-        Assert.Equal("{sqlserver.connectionString};Database=mydb", connectionStringResource.ConnectionStringExpression);
+        Assert.Equal("{sqlserver.connectionString};Database=mydb", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -186,8 +186,8 @@ public class AddSqlServerTests
         Assert.Equal("customers1", db1.Resource.DatabaseName);
         Assert.Equal("customers2", db2.Resource.DatabaseName);
 
-        Assert.Equal("{sqlserver1.connectionString};Database=customers1", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{sqlserver1.connectionString};Database=customers2", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{sqlserver1.connectionString};Database=customers1", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{sqlserver1.connectionString};Database=customers2", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -204,7 +204,7 @@ public class AddSqlServerTests
         Assert.Equal("imports", db1.Resource.DatabaseName);
         Assert.Equal("imports", db2.Resource.DatabaseName);
 
-        Assert.Equal("{sqlserver1.connectionString};Database=imports", db1.Resource.ConnectionStringExpression);
-        Assert.Equal("{sqlserver2.connectionString};Database=imports", db2.Resource.ConnectionStringExpression);
+        Assert.Equal("{sqlserver1.connectionString};Database=imports", db1.Resource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("{sqlserver2.connectionString};Database=imports", db2.Resource.ConnectionStringExpression.ValueExpression);
     }
 }

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -88,9 +88,10 @@ public class AddSqlServerTests
 
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        var connectionStringResource = Assert.Single(appModel.Resources.OfType<SqlServerDatabaseResource>());
-        var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
-        var password = connectionStringResource.Parent.Password;
+        var sqlResource = Assert.Single(appModel.Resources.OfType<SqlServerDatabaseResource>());
+        var connectionStringResource = (IResourceWithConnectionString)sqlResource;
+        var connectionString = await connectionStringResource.GetConnectionStringAsync();
+        var password = sqlResource.Parent.Password;
 
         Assert.Equal($"Server=127.0.0.1,1433;User ID=sa;Password={password};TrustServerCertificate=true;Database=mydb", connectionString);
         Assert.Equal("{sqlserver.connectionString};Database=mydb", connectionStringResource.ConnectionStringExpression.ValueExpression);

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -173,6 +173,8 @@ public class WithEnvironmentTests
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
+        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
+
         public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
         {
             return new(connectionString);

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -173,12 +173,8 @@ public class WithEnvironmentTests
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
-        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
-
-        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
-        {
-            return new(connectionString);
-        }
+        public ReferenceExpression ConnectionStringExpression =>
+            ReferenceExpression.Create($"{connectionString}");
     }
 
     private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithReferenceTests>(args);

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -327,6 +327,6 @@ public class WithReferenceTests
         public string? ConnectionString { get; set; }
 
         public ReferenceExpression ConnectionStringExpression =>
-            ReferenceExpression.Create($"{ConnectionString ?? throw new InvalidOperationException("ConnectionString is not set.")}");
+            ReferenceExpression.Create($"{ConnectionString ?? ""}");
     }
 }

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -322,13 +322,11 @@ public class WithReferenceTests
 
     private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithReferenceTests>(args);
 
-    private sealed class TestResource(string name) : IResourceWithConnectionString
+    private sealed class TestResource(string name) : Resource(name), IResourceWithConnectionString
     {
-        public string Name => name;
-
         public string? ConnectionString { get; set; }
 
-        public ResourceAnnotationCollection Annotations => throw new NotImplementedException();
+        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
 
         public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
         {

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -327,6 +327,6 @@ public class WithReferenceTests
         public string? ConnectionString { get; set; }
 
         public ReferenceExpression ConnectionStringExpression =>
-            ReferenceExpression.Create($"{ConnectionString ?? ""}");
+            ReferenceExpression.Create($"{ConnectionString}");
     }
 }

--- a/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithReferenceTests.cs
@@ -326,11 +326,7 @@ public class WithReferenceTests
     {
         public string? ConnectionString { get; set; }
 
-        public ReferenceExpression ConnectionStringExpression => throw new NotImplementedException();
-
-        public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken)
-        {
-            return new(ConnectionString);
-        }
+        public ReferenceExpression ConnectionStringExpression =>
+            ReferenceExpression.Create($"{ConnectionString ?? throw new InvalidOperationException("ConnectionString is not set.")}");
     }
 }


### PR DESCRIPTION
- Swap over resources to use ReferenceExpression for connection strings
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2879)