### PR TITLE
Add messaging icon to tracing

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -110,6 +110,10 @@
                                                 {
                                                     icon = new Icons.Filled.Size16.Database();
                                                 }
+                                                else if (context.Span.Attributes.HasKey("messaging.system"))
+                                                {
+                                                    icon = new Icons.Filled.Size16.Mail();
+                                                }
                                                 else
                                                 {
                                                     // Everything else.


### PR DESCRIPTION
* Add an icon for messaging spans
* Make rabbitmq output server tags so its spans have an uninstrumented peer

![image](https://github.com/dotnet/aspire/assets/303201/38b05d7d-179c-49ee-bab6-98ddbdd164fe)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2880)