### PR TITLE
remove height property from trace view grid (breaks safari)

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -45,7 +45,6 @@
     border: 0;
     border-radius: 0;
     vertical-align: middle;
-    height: 100%;
 }
 
 ::deep .trace-view-grid fluent-data-grid-cell[grid-column="2"] fluent-divider {


### PR DESCRIPTION
Fixes #2272 

I do not know why the cell height property completely broke safari, but removing it fixes the display.

Before:

https://github.com/dotnet/aspire/assets/20359921/66f53caa-6a9f-42ef-ba91-07cd63ed22a8


After:

https://github.com/dotnet/aspire/assets/20359921/0fe0ae9c-549e-4fc1-9bc1-5147d1cb181d


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2894)