### PR TITLE
Improve caching of culture format strings

### DIFF
--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -11,36 +11,36 @@ namespace Aspire.Dashboard.Utils;
 
 internal static partial class FormatHelpers
 {
+    // There are an unbound number of CultureInfo instances so we don't want to use it as the key.
+    // Someone could have also customized their culture so we don't want to use the name as the key.
+    // This struct contains required information from the culture that is used in cached format strings.
+    private record struct CultureDetailsKey(string LongTimePattern, string ShortDatePattern, string NumberDecimalSeparator);
     private sealed record MillisecondFormatStrings(string LongTimePattern, string ShortDateLongTimePattern);
-
-    // Use culture name as key. Culture name isn't case sensitive.
-    private static readonly ConcurrentDictionary<string, MillisecondFormatStrings> s_formatStrings = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<CultureDetailsKey, MillisecondFormatStrings> s_formatStrings = new();
 
     [GeneratedRegex("(:ss|:s)")]
     private static partial Regex MatchSecondsInTimeFormatPattern();
 
     private static MillisecondFormatStrings GetMillisecondFormatStrings(CultureInfo cultureInfo)
     {
-        // The culture name is used as the key for the cache. The name is used to avoid unbounded growth from custom CultureInfo instances.
-        // Note that the culture name must match to a cached readonly instance of CultureInfo.
-        // If the passed in culture info has customizations then they won't be used. The cached CultureInfo with a name is the source of truth.
-        return s_formatStrings.GetOrAdd(cultureInfo.Name, static name =>
+        var key = new CultureDetailsKey(cultureInfo.DateTimeFormat.LongTimePattern, cultureInfo.DateTimeFormat.ShortDatePattern, cultureInfo.NumberFormat.NumberDecimalSeparator);
+
+        return s_formatStrings.GetOrAdd(key, static k =>
         {
-            var c = CultureInfo.GetCultureInfo(name);
-            var longTimePatternWithMilliseconds = GetLongTimePatternWithMillisecondsCore(c);
-            return new MillisecondFormatStrings(longTimePatternWithMilliseconds, c.DateTimeFormat.ShortDatePattern + " " + longTimePatternWithMilliseconds);
+            var longTimePatternWithMilliseconds = GetLongTimePatternWithMillisecondsCore(k);
+            return new MillisecondFormatStrings(longTimePatternWithMilliseconds, k.ShortDatePattern + " " + longTimePatternWithMilliseconds);
         });
 
-        static string GetLongTimePatternWithMillisecondsCore(CultureInfo cultureInfo)
+        static string GetLongTimePatternWithMillisecondsCore(CultureDetailsKey cultureInfo)
         {
             // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
 
             // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
-            var longTimePattern = cultureInfo.DateTimeFormat.LongTimePattern;
+            var longTimePattern = cultureInfo.LongTimePattern;
 
             // Create a format similar to .fff but based on the current culture.
             // Intentionally use fff here instead of FFF so output has a consistent length.
-            var millisecondFormat = $"'{cultureInfo.NumberFormat.NumberDecimalSeparator}'fff";
+            var millisecondFormat = $"'{cultureInfo.NumberDecimalSeparator}'fff";
 
             // Append millisecond pattern to current culture's long time pattern.
             return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1{millisecondFormat}");

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -14,7 +14,7 @@ internal static partial class FormatHelpers
     // There are an unbound number of CultureInfo instances so we don't want to use it as the key.
     // Someone could have also customized their culture so we don't want to use the name as the key.
     // This struct contains required information from the culture that is used in cached format strings.
-    private record struct CultureDetailsKey(string LongTimePattern, string ShortDatePattern, string NumberDecimalSeparator);
+    private readonly record struct CultureDetailsKey(string LongTimePattern, string ShortDatePattern, string NumberDecimalSeparator);
     private sealed record MillisecondFormatStrings(string LongTimePattern, string ShortDateLongTimePattern);
     private static readonly ConcurrentDictionary<CultureDetailsKey, MillisecondFormatStrings> s_formatStrings = new();
 
@@ -31,16 +31,16 @@ internal static partial class FormatHelpers
             return new MillisecondFormatStrings(longTimePatternWithMilliseconds, k.ShortDatePattern + " " + longTimePatternWithMilliseconds);
         });
 
-        static string GetLongTimePatternWithMillisecondsCore(CultureDetailsKey cultureInfo)
+        static string GetLongTimePatternWithMillisecondsCore(CultureDetailsKey key)
         {
             // From https://learn.microsoft.com/dotnet/standard/base-types/how-to-display-milliseconds-in-date-and-time-values
 
             // Gets the long time pattern, which is something like "h:mm:ss tt" (en-US), "H:mm:ss" (ja-JP), "HH:mm:ss" (fr-FR).
-            var longTimePattern = cultureInfo.LongTimePattern;
+            var longTimePattern = key.LongTimePattern;
 
             // Create a format similar to .fff but based on the current culture.
             // Intentionally use fff here instead of FFF so output has a consistent length.
-            var millisecondFormat = $"'{cultureInfo.NumberDecimalSeparator}'fff";
+            var millisecondFormat = $"'{key.NumberDecimalSeparator}'fff";
 
             // Append millisecond pattern to current culture's long time pattern.
             return MatchSecondsInTimeFormatPattern().Replace(longTimePattern, $"$1{millisecondFormat}");


### PR DESCRIPTION
Previously cached culture info used the culture name as the key. To avoid the possibility of the current culture settings not matching the registered culture with the same name, caching now uses a composite key of required information.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2909)