### PR TITLE
Clear selection on filter changes

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -41,9 +41,10 @@
             </Body>
         </FluentPopover>
         <FluentSearch Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
-                        Immediate="true"
-                        @bind-Value="_filter"
-                        slot="end" />
+                      Immediate="true"
+                      @bind-Value="_filter"
+                      slot="end"
+                      @bind-Value:after="HandleSearchFilterChanged" />
     </FluentToolbar>
     <SummaryDetailsView DetailsTitle="@(SelectedResource != null ? $"{SelectedResource.ResourceType}: {GetResourceName(SelectedResource)}" : null)"
                         ShowDetails="@(SelectedResource is not null)"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -57,6 +57,13 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         {
             _visibleResourceTypes.TryRemove(resourceType, out _);
         }
+
+        ClearSelectedResource();
+    }
+
+    private void HandleSearchFilterChanged()
+    {
+        ClearSelectedResource();
     }
 
     private bool? AreAllTypesVisible

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -149,6 +149,8 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     {
         _applicationChanged = true;
 
+        ClearSelectedLogEntry();
+
         return this.AfterViewModelChangedAsync();
     }
 
@@ -220,6 +222,8 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
             {
                 ViewModel.AddFilter(filter);
             }
+
+            ClearSelectedLogEntry();
         }
 
         return this.AfterViewModelChangedAsync();
@@ -230,6 +234,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         if (args.Value is string newFilter)
         {
             PageViewModel.Filter = newFilter;
+            ClearSelectedLogEntry();
             _filterCts?.Cancel();
 
             // Debouncing logic. Apply the filter after a delay.
@@ -247,6 +252,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     {
         _filterCts?.Cancel();
         ViewModel.FilterText = string.Empty;
+        ClearSelectedLogEntry();
         StateHasChanged();
     }
 


### PR DESCRIPTION
Resolves #2776 by clearing the selection on Resources and Structured Logs when any of the filters change.

For now I did _not_ try to retain the selection on either page if the selected item would still be visible after the filter. That was easy enough on Resources that always has a small non-paged dataset. But not as simple on Structured Logs where the filtered data set might still be extremely large (see https://github.com/dotnet/aspire/issues/2776#issuecomment-1996649043). For consistency between the pages, I just cleared on both. 

We can complete this PR as-is and see if feedback says we should try to maintain selection, or we can decide to do more. But I figured I'd start with this.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2913)