### PR TITLE
Fix storage emulator connection string for blobs

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
@@ -24,7 +24,7 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
     /// Gets the connection string template for the manifest for the Azure Blob Storage resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create($"{Parent.BlobEndpoint}");
+       Parent.GetBlobConnectionString();
 
     /// <summary>
     /// Called by manifest publisher to write manifest resource.

--- a/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureCosmosDBResource.cs
@@ -160,7 +160,7 @@ public static class AzureCosmosExtensions
     }
 }
 
-file static class AzureCosmosDBEmulatorConnectionString
+internal static class AzureCosmosDBEmulatorConnectionString
 {
     public static string Create(int port) => $"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint=https://127.0.0.1:{port};DisableServerCertificateValidation=True;";
 }

--- a/src/Aspire.Hosting.Azure/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureStorageResource.cs
@@ -53,7 +53,7 @@ public class AzureStorageResource(string name, Action<ResourceModuleConstruct> c
         : ReferenceExpression.Create($"{BlobEndpoint}");
 }
 
-file static class AzureStorageEmulatorConnectionString
+internal static class AzureStorageEmulatorConnectionString
 {
     // Use defaults from https://learn.microsoft.com/azure/storage/common/storage-configure-connection-string#connect-to-the-emulator-account-using-the-shortcut
     private const string ConnectionStringHeader = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;";


### PR DESCRIPTION
- This broke after the CDK merge. We were missing test coverage.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2921)