### PR TITLE
Start watching for resource changes before we create any resources.

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -109,6 +109,9 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
             await PublishResourcesWithInitialStateAsync().ConfigureAwait(false);
 
+            // Watch for changes to the resource state.
+            WatchResourceChanges(cancellationToken);
+
             await CreateServicesAsync(cancellationToken).ConfigureAwait(false);
 
             await CreateContainersAndExecutablesAsync(cancellationToken).ConfigureAwait(false);
@@ -117,9 +120,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             {
                 await lifecycleHook.AfterResourcesCreatedAsync(_model, cancellationToken).ConfigureAwait(false);
             }
-
-            // Watch for changes to the resource state.
-            WatchResourceChanges(cancellationToken);
         }
         finally
         {


### PR DESCRIPTION
- Creating resources is fully async and can take a long time, we want to be able to get updates from resources that have already been creating even if we're waiting for others. Start watching for resource changes from DCP immediately.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2925)