### PR TITLE
Don't overwrite configured location

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -316,7 +316,6 @@ internal sealed class AzureProvisioner(
         {
             var response = await resourceGroups.GetAsync(resourceGroupName, cancellationToken).ConfigureAwait(false);
             resourceGroup = response.Value;
-            location = resourceGroup.Data.Location;
 
             logger.LogInformation("Using existing resource group {rgName}.", resourceGroup.Data.Name);
         }


### PR DESCRIPTION
If the location is changed, but the resource group already exists, we end up overwriting the configured location
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2943)