### PR TITLE
Make HostNameResolver internal

### DIFF
--- a/src/Aspire.Hosting/Utils/HostNameResolver.cs
+++ b/src/Aspire.Hosting/Utils/HostNameResolver.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.Utils;
 /// <summary>
 /// Helpers to resolve host names when running in a containers.
 /// </summary>
-public class HostNameResolver
+internal class HostNameResolver
 {
     /// <summary>
     /// Resolves the "localhost" with the container host name.


### PR DESCRIPTION
- We should be resolving the container host internally and exposing it on endpoint references
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2944)