### PR TITLE
Make malformed user secrets more obvious.

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -171,10 +171,11 @@ internal sealed class AzureProvisioner(
         {
             try
             {
-                var userSecrets = await provisioningContextLazy.Value.ConfigureAwait(false);
+                var provisioningContext = await provisioningContextLazy.Value.ConfigureAwait(false);
+
                 // Ensure directory exists before attempting to create secrets file
                 Directory.CreateDirectory(Path.GetDirectoryName(userSecretsPath)!);
-                await File.WriteAllTextAsync(userSecretsPath, userSecrets.ToString(), cancellationToken).ConfigureAwait(false);
+                await File.WriteAllTextAsync(userSecretsPath, provisioningContext.UserSecrets.ToString(), cancellationToken).ConfigureAwait(false);
 
                 logger.LogInformation("Azure resource connection strings saved to user secrets.");
             }


### PR DESCRIPTION
Fixes #2939 

Now when failure occurs we'll get an error message for each impacted Azure resource as well as an error message right up front in the console log. The resources will also be in a failed state to make it obvious that folks need to dig in.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2953)