### PR TITLE
Add consumer and consumer messaging icons to traces UI

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -57,13 +57,13 @@
                     <TemplateColumn Title="Name">
                         <div class="col-long-content" title="@context.GetTooltip()" @onclick="() => OnShowProperties(context)">
                             @{
-                                var isServerKind = context.Span.Kind == OtlpSpanKind.Server;
+                                var isServerOrConsumer = context.Span.Kind == OtlpSpanKind.Server || context.Span.Kind == OtlpSpanKind.Consumer;
                                 // Indent the span name based on the depth of the span.
                                 var marginLeft = (context.Depth - 1) * 15;
 
                                 // We want to have consistent margin for both client and server spans.
                                 string spanNameContainerStyle;
-                                if (!isServerKind)
+                                if (!isServerOrConsumer)
                                 {
                                     // Client span has 19px extra content:
                                     // - 5px extra margin-left
@@ -73,7 +73,7 @@
                                 }
                                 else
                                 {
-                                    // Server span has 19px extra content:
+                                    // Span with icon has 19px extra content:
                                     // - 16px icon
                                     // - 3px padding-left
                                     spanNameContainerStyle = string.Empty;
@@ -88,12 +88,12 @@
                                     }
                                 </span>
                                 <span class="span-name-container" style="@spanNameContainerStyle">
-                                    @if (isServerKind)
+                                    @if (isServerOrConsumer)
                                     {
-                                        <FluentIcon Class="server-request-icon"
+                                        <FluentIcon Class="span-kind-icon"
                                                     Color="Color.Custom"
                                                     CustomColor="@ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))"
-                                                    Icon="Icons.Filled.Size16.Server" />
+                                                    Value="@GetSpanIcon(context.Span)" />
                                     }
 
                                     @if (context.IsError)

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -57,6 +57,26 @@ public partial class TraceDetail : ComponentBase
         });
     }
 
+    private static Icon GetSpanIcon(OtlpSpan span)
+    {
+        switch (span.Kind)
+        {
+            case OtlpSpanKind.Server:
+                return new Icons.Filled.Size16.Server();
+            case OtlpSpanKind.Consumer:
+                if (span.Attributes.HasKey("messaging.system"))
+                {
+                    return new Icons.Filled.Size16.Mailbox();
+                }
+                else
+                {
+                    return new Icons.Filled.Size16.ContentSettings();
+                }
+            default:
+                throw new InvalidOperationException($"Unsupported span kind when resolving icon: {span.Kind}");
+        }
+    }
+
     private static List<SpanWaterfallViewModel> CreateSpanWaterfallViewModels(OtlpTrace trace, TraceDetailState state)
     {
         var orderedSpans = new List<SpanWaterfallViewModel>();

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -133,7 +133,7 @@
     padding-left: 0.25rem;
 }
 
-::deep .server-request-icon {
+::deep .span-kind-icon {
     margin-right: 3px;
     vertical-align: text-bottom;
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/1725

Consumer span types have their own icon. This extends what is already done for servers.

Consumer span type + `messaging.system` has a custom icon of a mailbox.

![image](https://github.com/dotnet/aspire/assets/303201/e4e378f8-c49d-4e77-81dc-4a58fc1e8778)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2969)