### PR TITLE
Fix TimeProvider error by registering separate type as scoped

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
@@ -34,7 +34,7 @@ public abstract class ChartBase : ComponentBase
     public required IInstrumentUnitResolver InstrumentUnitResolver { get; init; }
 
     [Inject]
-    public required TimeProvider TimeProvider { get; init; }
+    public required BrowserTimeProvider TimeProvider { get; init; }
 
     [Parameter, EditorRequired]
     public required InstrumentViewModel InstrumentViewModel { get; set; }

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -19,7 +19,7 @@ public sealed partial class LogViewer
     private IJSObjectReference? _jsModule;
 
     [Inject]
-    public required TimeProvider TimeProvider { get; init; }
+    public required BrowserTimeProvider TimeProvider { get; init; }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -26,7 +26,7 @@ public partial class ResourceDetails
     public required ILogger<ResourceDetails> Logger { get; init; }
 
     [Inject]
-    public required TimeProvider TimeProvider { get; init; }
+    public required BrowserTimeProvider TimeProvider { get; init; }
 
     private bool IsSpecOnlyToggleDisabled => !Resource.Environment.All(i => !i.FromSpec) && !GetResourceValues().Any(v => v.KnownProperty == null);
 
@@ -144,7 +144,7 @@ public partial class ResourceDetails
         }
     }
 
-    private static string GetDisplayedValue(TimeProvider timeProvider, SummaryValue summaryValue)
+    private static string GetDisplayedValue(BrowserTimeProvider timeProvider, SummaryValue summaryValue)
     {
         string value;
         if (summaryValue.Value.HasStringValue)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -29,7 +29,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
     [Inject]
     public required IToastService ToastService { get; init; }
     [Inject]
-    public required TimeProvider TimeProvider { get; init; }
+    public required BrowserTimeProvider TimeProvider { get; init; }
 
     private ResourceViewModel? SelectedResource { get; set; }
 

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -51,7 +51,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     public required NavigationManager NavigationManager { get; set; }
 
     [Inject]
-    public required TimeProvider TimeProvider { get; set; }
+    public required BrowserTimeProvider TimeProvider { get; set; }
 
     [Parameter]
     [SupplyParameterFromQuery]

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -31,7 +31,7 @@ public partial class TraceDetail : ComponentBase
     public required IEnumerable<IOutgoingPeerResolver> OutgoingPeerResolvers { get; set; }
 
     [Inject]
-    public required TimeProvider TimeProvider { get; set; }
+    public required BrowserTimeProvider TimeProvider { get; set; }
 
     protected override void OnInitialized()
     {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -41,7 +41,7 @@ public partial class Traces
     public required IDialogService DialogService { get; set; }
 
     [Inject]
-    public required TimeProvider TimeProvider { get; set; }
+    public required BrowserTimeProvider TimeProvider { get; set; }
 
     private string GetNameTooltip(OtlpTrace trace)
     {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
@@ -11,7 +11,7 @@
 
 @code {
     [Inject]
-    public required TimeProvider TimeProvider { get; init; }
+    public required BrowserTimeProvider TimeProvider { get; set; }
 
     [Parameter, EditorRequired]
     public required ResourceViewModel Resource { get; set; }

--- a/src/Aspire.Dashboard/ConsoleLogs/LogParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogParser.cs
@@ -6,7 +6,7 @@ using Aspire.Dashboard.Model;
 
 namespace Aspire.Dashboard.ConsoleLogs;
 
-internal sealed partial class LogParser(TimeProvider timeProvider, bool convertTimestampsFromUtc)
+internal sealed partial class LogParser(BrowserTimeProvider timeProvider, bool convertTimestampsFromUtc)
 {
     private string? _parentTimestamp;
     private Guid? _parentId;

--- a/src/Aspire.Dashboard/ConsoleLogs/TimestampParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/TimestampParser.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Aspire.Dashboard.Extensions;
+using Aspire.Dashboard.Model;
 
 namespace Aspire.Dashboard.ConsoleLogs;
 
@@ -11,7 +12,7 @@ public static partial class TimestampParser
 {
     private static readonly Regex s_rfc3339RegEx = GenerateRfc3339RegEx();
 
-    public static bool TryColorizeTimestamp(TimeProvider timeProvider, string text, bool convertTimestampsFromUtc, out TimestampParserResult result)
+    public static bool TryColorizeTimestamp(BrowserTimeProvider timeProvider, string text, bool convertTimestampsFromUtc, out TimestampParserResult result)
     {
         var match = s_rfc3339RegEx.Match(text);
 
@@ -32,7 +33,7 @@ public static partial class TimestampParser
         return false;
     }
 
-    private static string ConvertTimestampFromUtc(TimeProvider timeProvider, ReadOnlySpan<char> timestamp)
+    private static string ConvertTimestampFromUtc(BrowserTimeProvider timeProvider, ReadOnlySpan<char> timestamp)
     {
         if (DateTimeOffset.TryParse(timestamp, out var dateTimeUtc))
         {

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -99,8 +99,7 @@ public class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddSingleton<IInstrumentUnitResolver, DefaultInstrumentUnitResolver>();
 
         // Time zone is set by the browser.
-        builder.Services.AddScoped<TimeProvider>(s => s.GetRequiredService<BrowserTimeProvider>());
-        builder.Services.AddScoped<BrowserTimeProvider>(s => new BrowserTimeProvider(s.GetRequiredService<ILoggerFactory>()));
+        builder.Services.AddScoped<BrowserTimeProvider>();
 
         builder.Services.AddLocalization();
 

--- a/src/Aspire.Dashboard/Extensions/TimeProviderExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/TimeProviderExtensions.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Model;
+
 namespace Aspire.Dashboard.Extensions;
 
 internal static class TimeProviderExtensions
 {
-    public static DateTime ToLocal(this TimeProvider timeProvider, DateTimeOffset utcDateTimeOffset)
+    public static DateTime ToLocal(this BrowserTimeProvider timeProvider, DateTimeOffset utcDateTimeOffset)
     {
         var dateTime = TimeZoneInfo.ConvertTimeFromUtc(utcDateTimeOffset.UtcDateTime, timeProvider.LocalTimeZone);
         dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Local);
@@ -13,12 +15,12 @@ internal static class TimeProviderExtensions
         return dateTime;
     }
 
-    public static DateTimeOffset ToLocalDateTimeOffset(this TimeProvider timeProvider, DateTimeOffset utcDateTimeOffset)
+    public static DateTimeOffset ToLocalDateTimeOffset(this BrowserTimeProvider timeProvider, DateTimeOffset utcDateTimeOffset)
     {
         return TimeZoneInfo.ConvertTime(utcDateTimeOffset, timeProvider.LocalTimeZone);
     }
 
-    public static DateTime ToLocal(this TimeProvider timeProvider, DateTime dateTime)
+    public static DateTime ToLocal(this BrowserTimeProvider timeProvider, DateTime dateTime)
     {
         if (dateTime.Kind == DateTimeKind.Local)
         {

--- a/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
+++ b/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
@@ -6,10 +6,11 @@ namespace Aspire.Dashboard.Model;
 /// <summary>
 /// This time provider is used to provide the time zone information from the browser to the server.
 /// It is a different type because we want to log setting the timezone, and we want a distinct type
-/// to register with DI. This time provider must be scoped to the user's session. And the built-in
-/// TimeProvider registration must be singleton for the system (used by auth).
+/// to register with DI:
+/// - BrowserTimeProvider must be scoped to the user's session.
+/// - The built-in TimeProvider registration must be singleton for the system time (used by auth).
 /// </summary>
-public sealed class BrowserTimeProvider : TimeProvider
+public class BrowserTimeProvider : TimeProvider
 {
     private readonly ILogger _logger;
     private TimeZoneInfo? _browserLocalTimeZone;

--- a/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
+++ b/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
@@ -3,6 +3,12 @@
 
 namespace Aspire.Dashboard.Model;
 
+/// <summary>
+/// This time provider is used to provide the time zone information from the browser to the server.
+/// It is a different type because we want to log setting the timezone, and we want a distinct type
+/// to register with DI. This time provider must be scoped to the user's session. And the built-in
+/// TimeProvider registration must be singleton for the system (used by auth).
+/// </summary>
 public sealed class BrowserTimeProvider : TimeProvider
 {
     private readonly ILogger _logger;

--- a/src/Aspire.Dashboard/Utils/FormatHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/FormatHelpers.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using Aspire.Dashboard.Extensions;
+using Aspire.Dashboard.Model;
 
 namespace Aspire.Dashboard.Utils;
 
@@ -50,7 +51,7 @@ internal static partial class FormatHelpers
 
     private static string GetShortDateLongTimePatternWithMilliseconds(CultureInfo cultureInfo) => GetMillisecondFormatStrings(cultureInfo).ShortDateLongTimePattern;
 
-    public static string FormatTime(TimeProvider timeProvider, DateTime value, bool includeMilliseconds = false, CultureInfo? cultureInfo = null)
+    public static string FormatTime(BrowserTimeProvider timeProvider, DateTime value, bool includeMilliseconds = false, CultureInfo? cultureInfo = null)
     {
         cultureInfo ??= CultureInfo.CurrentCulture;
         var local = timeProvider.ToLocal(value);
@@ -61,7 +62,7 @@ internal static partial class FormatHelpers
             : local.ToString("T", cultureInfo);
     }
 
-    public static string FormatDateTime(TimeProvider timeProvider, DateTime value, bool includeMilliseconds = false, CultureInfo? cultureInfo = null)
+    public static string FormatDateTime(BrowserTimeProvider timeProvider, DateTime value, bool includeMilliseconds = false, CultureInfo? cultureInfo = null)
     {
         cultureInfo ??= CultureInfo.CurrentCulture;
         var local = timeProvider.ToLocal(value);
@@ -72,7 +73,7 @@ internal static partial class FormatHelpers
             : local.ToString("G", cultureInfo);
     }
 
-    public static string FormatTimeWithOptionalDate(TimeProvider timeProvider, DateTime value, bool includeMilliseconds = false, CultureInfo? cultureInfo = null)
+    public static string FormatTimeWithOptionalDate(BrowserTimeProvider timeProvider, DateTime value, bool includeMilliseconds = false, CultureInfo? cultureInfo = null)
     {
         var local = timeProvider.ToLocal(value);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -7,6 +7,7 @@ using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Aspire.Dashboard.Otlp.Storage;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using Xunit;
@@ -24,7 +25,7 @@ public class PlotlyChartTests : TestContext
         // Arrange
         Services.AddLocalization();
         Services.AddSingleton<IInstrumentUnitResolver, TestInstrumentUnitResolver>();
-        Services.AddSingleton<TimeProvider, TestTimeProvider>();
+        Services.AddSingleton<BrowserTimeProvider, TestTimeProvider>();
 
         var model = new InstrumentViewModel();
 
@@ -48,7 +49,7 @@ public class PlotlyChartTests : TestContext
 
         Services.AddLocalization();
         Services.AddSingleton<IInstrumentUnitResolver, TestInstrumentUnitResolver>();
-        Services.AddSingleton<TimeProvider, TestTimeProvider>();
+        Services.AddSingleton<BrowserTimeProvider, TestTimeProvider>();
 
         var options = new TelemetryOptions();
         var instrument = new OtlpInstrument
@@ -106,9 +107,13 @@ public class PlotlyChartTests : TestContext
         }
     }
 
-    private sealed class TestTimeProvider : TimeProvider
+    private sealed class TestTimeProvider : BrowserTimeProvider
     {
         private TimeZoneInfo? _localTimeZone;
+
+        public TestTimeProvider() : base(NullLoggerFactory.Instance)
+        {
+        }
 
         public override DateTimeOffset GetUtcNow()
         {

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/TimestampParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/TimestampParserTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.ConsoleLogs;
+using Aspire.Dashboard.Model;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.ConsoleLogsTests;
@@ -14,7 +16,7 @@ public class TimestampParserTests
     [InlineData("This is some text without any timestamp")]
     public void TryColorizeTimestamp_DoesNotStartWithTimestamp_ReturnsFalse(string input)
     {
-        var result = TimestampParser.TryColorizeTimestamp(TimeProvider.System, input, convertTimestampsFromUtc: false, out var _);
+        var result = TimestampParser.TryColorizeTimestamp(CreateTimeProvider(), input, convertTimestampsFromUtc: false, out var _);
 
         Assert.False(result);
     }
@@ -26,7 +28,7 @@ public class TimestampParserTests
     [InlineData("With some text before it 2023-10-10T15:05:30.123456789Z", false, null, null)]
     public void TryColorizeTimestamp_ReturnsCorrectResult(string input, bool expectedResult, string? expectedOutput, string? expectedTimestamp)
     {
-        var result = TimestampParser.TryColorizeTimestamp(TimeProvider.System, input, convertTimestampsFromUtc: false, out var parseResult);
+        var result = TimestampParser.TryColorizeTimestamp(CreateTimeProvider(), input, convertTimestampsFromUtc: false, out var parseResult);
 
         Assert.Equal(expectedResult, result);
         Assert.Equal(expectedOutput, parseResult.ModifiedText);
@@ -49,8 +51,13 @@ public class TimestampParserTests
     [InlineData("2023-10-10T15:05:30.123456789")]
     public void TryColorizeTimestamp_SupportedTimestampFormats(string input)
     {
-        var result = TimestampParser.TryColorizeTimestamp(TimeProvider.System, input, convertTimestampsFromUtc: false, out var _);
+        var result = TimestampParser.TryColorizeTimestamp(CreateTimeProvider(), input, convertTimestampsFromUtc: false, out var _);
 
         Assert.True(result);
+    }
+
+    private static BrowserTimeProvider CreateTimeProvider()
+    {
+        return new BrowserTimeProvider(NullLoggerFactory.Instance);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/FormatHelpersTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests;
@@ -39,7 +41,7 @@ public class FormatHelpersTests
     public void FormatDateTime_WithMilliseconds_InvariantCulture(string expected, bool includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(TimeProvider.System, date, includeMilliseconds, cultureInfo: CultureInfo.InvariantCulture));
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.InvariantCulture));
     }
 
     [Theory]
@@ -50,7 +52,7 @@ public class FormatHelpersTests
     public void FormatDateTime_WithMilliseconds_GermanCulture(string expected, bool includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(TimeProvider.System, date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("de-DE")));
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("de-DE")));
     }
 
     [Theory]
@@ -61,7 +63,7 @@ public class FormatHelpersTests
     public void FormatDateTime_WithMilliseconds_NewZealandCulture(string expected, bool includeMilliseconds, string value)
     {
         var date = GetLocalDateTime(value);
-        Assert.Equal(expected, FormatHelpers.FormatDateTime(TimeProvider.System, date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ")));
+        Assert.Equal(expected, FormatHelpers.FormatDateTime(CreateTimeProvider(), date, includeMilliseconds, cultureInfo: CultureInfo.GetCultureInfo("en-NZ")));
     }
 
     private static DateTime GetLocalDateTime(string value)
@@ -70,5 +72,10 @@ public class FormatHelpersTests
         Assert.Equal(DateTimeKind.Utc, date.Kind);
         date = DateTime.SpecifyKind(date, DateTimeKind.Local);
         return date;
+    }
+
+    private static BrowserTimeProvider CreateTimeProvider()
+    {
+        return new BrowserTimeProvider(NullLoggerFactory.Instance);
     }
 }


### PR DESCRIPTION
The dashboard auth change and the dashboard time zone change conflict with each other and error. TimeProvider is registered as scoped and auth wants a singleton (i.e. the system time).

This PR fixes the problem by making the browser time provider a separate DI registration than the standard TimeProvider registration.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/2994)