### PR TITLE
Implement Custom 404 Page

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/NotFound.razor
+++ b/src/Aspire.Dashboard/Components/Pages/NotFound.razor
@@ -1,0 +1,10 @@
+﻿@page "/error/404"
+@inject IStringLocalizer<Dashboard.Resources.Routes> Loc
+
+<PageTitle>@Loc[nameof(Dashboard.Resources.Routes.NotFoundPageTitle)]</PageTitle>
+
+<div class="error-stack">
+    <div class="error-code">404</div>
+    <div class="error-description">@Loc[nameof(Dashboard.Resources.Routes.NotFoundDescription)]</div>
+    <div>@Loc[nameof(Dashboard.Resources.Routes.NotFoundDetails)]</div>
+</div>

--- a/src/Aspire.Dashboard/Components/Pages/NotFound.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/NotFound.razor.css
@@ -1,0 +1,17 @@
+.error-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: calc(var(--design-unit) * 10px);
+}
+
+.error-code {
+    --error-code-font-size: 90px;
+    font-size: var(--error-code-font-size);
+    line-height: var(--error-code-font-size);
+}
+
+.error-description {
+    font-size: var(--type-ramp-plus-6-font-size);
+    line-height: var(--type-ramp-plus-6-line-height);
+}

--- a/src/Aspire.Dashboard/Components/Routes.razor
+++ b/src/Aspire.Dashboard/Components/Routes.razor
@@ -5,9 +5,9 @@
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)" />
     </Found>
     <NotFound>
-        <PageTitle>@Loc[nameof(Resources.Routes.RoutesPageTitle)]</PageTitle>
+        <PageTitle>@Loc[nameof(Resources.Routes.NotFoundPageTitle)]</PageTitle>
         <LayoutView Layout="@typeof(Layout.MainLayout)">
-            <p role="alert">@Loc[nameof(Resources.Routes.RoutesNotFoundDescription)]</p>
+            <Aspire.Dashboard.Components.Pages.NotFound />
         </LayoutView>
     </NotFound>
 </Router>

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -171,6 +171,8 @@ public class DashboardWebApplication : IAsyncDisposable
             //_app.UseHsts();
         }
 
+        _app.UseStatusCodePagesWithReExecute("/error/{0}");
+
         if (isAllHttps)
         {
             _app.UseHttpsRedirection();

--- a/src/Aspire.Dashboard/Otlp/Grpc/OtlpLogsService.cs
+++ b/src/Aspire.Dashboard/Otlp/Grpc/OtlpLogsService.cs
@@ -6,11 +6,13 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Grpc.Core;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 
 namespace Aspire.Dashboard.Otlp.Grpc;
 
 [Authorize(Policy = OtlpAuthorization.PolicyName)]
+[SkipStatusCodePages]
 public class OtlpLogsService : LogsService.LogsServiceBase
 {
     private readonly ILogger<OtlpLogsService> _logger;

--- a/src/Aspire.Dashboard/Otlp/Grpc/OtlpMetricsService.cs
+++ b/src/Aspire.Dashboard/Otlp/Grpc/OtlpMetricsService.cs
@@ -6,11 +6,13 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Grpc.Core;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using OpenTelemetry.Proto.Collector.Metrics.V1;
 
 namespace Aspire.Dashboard.Otlp.Grpc;
 
 [Authorize(Policy = OtlpAuthorization.PolicyName)]
+[SkipStatusCodePages]
 public class OtlpMetricsService : MetricsService.MetricsServiceBase
 {
     private readonly ILogger<OtlpMetricsService> _logger;

--- a/src/Aspire.Dashboard/Otlp/Grpc/OtlpTraceService.cs
+++ b/src/Aspire.Dashboard/Otlp/Grpc/OtlpTraceService.cs
@@ -6,11 +6,13 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Grpc.Core;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using OpenTelemetry.Proto.Collector.Trace.V1;
 
 namespace Aspire.Dashboard.Otlp.Grpc;
 
 [Authorize(Policy = OtlpAuthorization.PolicyName)]
+[SkipStatusCodePages]
 public class OtlpTraceService : TraceService.TraceServiceBase
 {
     private readonly ILogger<OtlpTraceService> _logger;

--- a/src/Aspire.Dashboard/Resources/Routes.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Routes.Designer.cs
@@ -61,20 +61,29 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sorry, there&apos;s nothing at this address..
+        ///   Looks up a localized string similar to Not found.
         /// </summary>
-        public static string RoutesNotFoundDescription {
+        public static string NotFoundDescription {
             get {
-                return ResourceManager.GetString("RoutesNotFoundDescription", resourceCulture);
+                return ResourceManager.GetString("NotFoundDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The page you requested could not be found.
+        /// </summary>
+        public static string NotFoundDetails {
+            get {
+                return ResourceManager.GetString("NotFoundDetails", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Not found.
         /// </summary>
-        public static string RoutesPageTitle {
+        public static string NotFoundPageTitle {
             get {
-                return ResourceManager.GetString("RoutesPageTitle", resourceCulture);
+                return ResourceManager.GetString("NotFoundPageTitle", resourceCulture);
             }
         }
     }

--- a/src/Aspire.Dashboard/Resources/Routes.resx
+++ b/src/Aspire.Dashboard/Resources/Routes.resx
@@ -1,27 +1,129 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:element name="root" msdata:IsDataSet="true">
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
     </xsd:element>
   </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-    <value>1.3</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="RoutesPageTitle" xml:space="preserve">
+  <data name="NotFoundPageTitle" xml:space="preserve">
     <value>Not found</value>
   </data>
-  <data name="RoutesNotFoundDescription" xml:space="preserve">
-    <value>Sorry, there's nothing at this address.</value>
+  <data name="NotFoundDescription" xml:space="preserve">
+    <value>Not found</value>
+  </data>
+  <data name="NotFoundDetails" xml:space="preserve">
+    <value>The page you requested could not be found</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.cs.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">Omlouváme se, ale na této adrese nic není.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">Nenalezeno</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.de.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">An dieser Adresse befindet sich leider nichts.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">Nicht gefunden</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.es.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">Lo sentimos, no hay nada en esta dirección.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">No encontrado</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.fr.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">Désolé... Cette adresse est vide.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">Introuvable</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.it.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">Questo indirizzo non contiene nulla.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">Non trovata</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.ja.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">このアドレスには何もありません。</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">見つかりません</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.ko.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">죄송하지만 이 주소에는 아무것도 없습니다.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">찾을 수 없음</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.pl.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">Niestety, pod tym adresem nic nie ma.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">Nie znaleziono</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.pt-BR.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">Não há nada neste endereço.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">Não encontrado</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.ru.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">По адресу ничего не найдено.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">Не найдено</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.tr.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">Ne yazık ki bu adreste içerik yok.</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">Bulunamadı</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.zh-Hans.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">抱歉，此地址中没有任何内容。</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">未找到</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.zh-Hant.xlf
@@ -2,14 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Routes.resx">
     <body>
-      <trans-unit id="RoutesNotFoundDescription">
-        <source>Sorry, there's nothing at this address.</source>
-        <target state="translated">很抱歉，此位址沒有任何內容。</target>
+      <trans-unit id="NotFoundDescription">
+        <source>Not found</source>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoutesPageTitle">
+      <trans-unit id="NotFoundDetails">
+        <source>The page you requested could not be found</source>
+        <target state="new">The page you requested could not be found</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotFoundPageTitle">
         <source>Not found</source>
-        <target state="translated">找不到</target>
+        <target state="new">Not found</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Resolves #2599

The implementation here is more complex than it seems like it should be. 

Blazor WASM uses the `NotFound` parameter of the `Router` component. But we're not using WASM and the [docs](https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-8.0) say:

>This section only applies to Blazor WebAssembly apps. [ ] Blazor Web Apps typically process bad URL requests by either displaying the browser's built-in 404 UI or returning a custom 404 page from the ASP.NET Core server via ASP.NET Core middleware (for example, [UseStatusCodePagesWithRedirects](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/error-handling?view=aspnetcore-8.0#usestatuscodepageswithredirects) / [API documentation](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.statuscodepagesextensions.usestatuscodepageswithredirects)).

`UseStatusCodePagesWithRedirects` works as expected, but it is a bad user experience. The URL of the page is changed to e.g. `/error/404` and so you lose the context of what you were trying to get to. It's better if the URL in the browser shows the page that really returned the 404.

`UseStatusCodePagesWithReExecute` is a better user experience. But the way it works in Blazor w/ interactivity is confusing.

The route specified in the call to `UseStatusCodePagesWithReExecute` has to exist. If it does not, you'll get the browser's 404 page. But when it does exist, it is not what the user ends up seeing. The user ends up seeing what's in the `Router` component's `NotFound` parameter (including whatever the default is if that parameter is not specified).

This issue seems relevant: https://github.com/dotnet/aspnetcore/issues/51203 and [this comment](https://github.com/dotnet/aspnetcore/issues/51203#issuecomment-1992085307) matches my experience exactly.

To work around all this I have a new blazor component with a page attribute that handles the route specified in `UseStatusCodePagesWithReExecute` and then I re-use that component directly from within the `NotFound` parameter. 

This all works... just it feels wrong.

![image](https://github.com/dotnet/aspire/assets/9613109/648c860a-ee83-4a6c-8b2d-313496ca7dba)
![image](https://github.com/dotnet/aspire/assets/9613109/7b3a1ee9-4500-4a14-817a-b019dbbd2c3d)

Note that the focus here is mostly about just making sure that we have a custom 404 page at all - not spending too much time on the content. We have a pending work item with the design folks that may lead to something better in the future, but that is likely post-GA.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3011)