### PR TITLE
[tests] Use helix's retry mechanism for flaky tests

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -3,8 +3,8 @@
   "defaultOnFailure": "fail",
   "localRerunCount": 1,
   "retryOnRules": [
-    { "testAssembly": { "wildcard": "Aspire.EndToEnd.*" }, "failureMessage": { "regex": "App run failed" } },
-    { "testAssembly": { "wildcard": "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.*" } },
-    { "testAssembly": { "wildcard": "Aspire.Microsoft.EntityFrameworkCore.SqlServer.*" } }
+    { "testAssembly": { "regex": "Aspire.EndToEnd.*" }, "failureMessage": { "regex": "App run failed" } },
+    { "testAssembly": { "regex": "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.*" } },
+    { "testAssembly": { "regex": "Aspire.Microsoft.EntityFrameworkCore.SqlServer.*" } }
   ]
 }

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "defaultOnFailure": "fail",
+  "localRerunCount": 1,
+  "retryOnRules": [
+    { "testAssembly": { "wildcard": "Aspire.EndToEnd.*" }, "failureMessage": { "regex": "App run failed" } },
+    { "testAssembly": { "wildcard": "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.*" } },
+    { "testAssembly": { "wildcard": "Aspire.Microsoft.EntityFrameworkCore.SqlServer.*" } }
+  ]
+}


### PR DESCRIPTION
In particular:
`Aspire.EndToEnd.Tests`: https://github.com/dotnet/aspire/issues/2850

`Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests`, and
`Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests` get aborted with
timeout:

`Aborting test run: test run timeout of 600000 milliseconds exceeded.`

Related: https://github.com/dotnet/arcade/tree/main/src/Microsoft.DotNet.Helix/Sdk#test-retry

cc @eerhardt @joperezr @davidfowl 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3018)