### PR TITLE
Clean up Aspire.Hosting.AppHost after refactoring

### DIFF
--- a/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
+++ b/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
@@ -4,16 +4,11 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageTags>aspire hosting</PackageTags>
-    <Description>APIs for the .NET Aspire application model.</Description>
+    <Description>Core library and MSBuild logic for .NET Aspire AppHost projects.</Description>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="**/*.props;**/*.targets" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
-    <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
   </ItemGroup>
 
   <ItemGroup>
@@ -23,10 +18,6 @@
   <!-- Download DCP orchestrator components for local development -->
   <ItemGroup>
     <PackageDownload Include="Microsoft.DeveloperControlPlane.$(BuildOs)-$(BuildArch)" Version="[$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)]" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <InternalsVisibleTo Include="Aspire.Hosting.Tests" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -4,11 +4,9 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsAspireHost>true</IsAspireHost>
     <!--
-      CS0436: The type 'type' conflicts with the imported type 'type2'. StringComparers exists in both Aspire.Hosting and Aspire.Hosting.AppHost.
-      CS8002: Referenced assembly does not have a strong name. MongoDB.Driver package is unsigned
+      CS8002: Referenced assembly does not have a strong name. MongoDB.Driver package is unsigned, we ignore that warning on purpose
     -->
-    <!-- MongoDB.Driver package is unsigned, we ignore that warning on purpose  -->
-    <NoWarn>$(NoWarn);CS0436;CS8002</NoWarn>
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,7 +27,6 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
 
-    <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
   </ItemGroup>
 

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -8,6 +8,9 @@ namespace Aspire.Hosting.Tests;
 
 public class WithEndpointTests
 {
+    // copied from /src/Shared/StringComparers.cs to avoid ambiguous reference since StringComparers exists internally in multiple Hosting assemblies.
+    private static StringComparison EndpointAnnotationName => StringComparison.OrdinalIgnoreCase;
+
     [Fact]
     public void WithEndpointInvokesCallback()
     {
@@ -19,7 +22,7 @@ public class WithEndpointTests
         });
 
         var endpoint = testProgram.ServiceABuilder.Resource.Annotations.OfType<EndpointAnnotation>()
-            .Where(e => string.Equals(e.Name, "mybinding", StringComparisons.EndpointAnnotationName)).Single();
+            .Where(e => string.Equals(e.Name, "mybinding", EndpointAnnotationName)).Single();
         Assert.Equal(2000, endpoint.Port);
     }
 
@@ -37,7 +40,7 @@ public class WithEndpointTests
 
         Assert.False(executed);
         Assert.True(testProgram.ServiceABuilder.Resource.TryGetAnnotationsOfType<EndpointAnnotation>(out var annotations));
-        Assert.DoesNotContain(annotations, e => string.Equals(e.Name, "mybinding", StringComparisons.EndpointAnnotationName));
+        Assert.DoesNotContain(annotations, e => string.Equals(e.Name, "mybinding", EndpointAnnotationName));
     }
 
     [Fact]


### PR DESCRIPTION
- Remove unused Utils and IVT to the tests
- Fix the tests to workaround multiple assemblies having a StringComparers internally with IVT to the tests
- Update the package description
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3019)