### PR TITLE
Make username and password defaults consistent

### DIFF
--- a/playground/AWS/AWS.AppHost/aspire-manifest.json
+++ b/playground/AWS/AWS.AppHost/aspire-manifest.json
@@ -6,7 +6,7 @@
       "template-path": "app-resources.template",
       "references": [
         {
-          "TargetResource": "Frontend"
+          "target-resource": "Frontend"
         }
       ]
     },
@@ -16,7 +16,8 @@
       "env": {
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-        "ChatTopicArnEnv": "{AspireSampleDevResources.aws.cloudformation.output.ChatTopicArn}"
+        "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
+        "ChatTopicArnEnv": "{AspireSampleDevResources.output.ChatTopicArn}"
       },
       "bindings": {
         "http": {

--- a/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/aspire-manifest.json
@@ -7,6 +7,7 @@
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_USER": "postgres",
         "POSTGRES_PASSWORD": "{pg1.inputs.password}"
       },
       "bindings": {
@@ -40,6 +41,7 @@
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_USER": "postgres",
         "POSTGRES_PASSWORD": "{pg2.inputs.password}"
       },
       "bindings": {
@@ -73,6 +75,7 @@
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_USER": "postgres",
         "POSTGRES_PASSWORD": "{pg3.inputs.password}"
       },
       "bindings": {
@@ -110,6 +113,7 @@
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_USER": "postgres",
         "POSTGRES_PASSWORD": "{pg4.inputs.password}"
       },
       "bindings": {
@@ -143,6 +147,7 @@
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_USER": "postgres",
         "POSTGRES_PASSWORD": "{pg5.inputs.password}"
       },
       "bindings": {
@@ -176,6 +181,7 @@
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_USER": "postgres",
         "POSTGRES_PASSWORD": "{pg6.inputs.password}"
       },
       "bindings": {

--- a/playground/TestShop/AppHost/aspire-manifest.json
+++ b/playground/TestShop/AppHost/aspire-manifest.json
@@ -7,6 +7,7 @@
       "env": {
         "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
         "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
+        "POSTGRES_USER": "postgres",
         "POSTGRES_PASSWORD": "{postgres.inputs.password}"
       },
       "bindings": {

--- a/playground/bicep/BicepSample.AppHost/aspire-manifest.json
+++ b/playground/bicep/BicepSample.AppHost/aspire-manifest.json
@@ -119,17 +119,6 @@
         "keyVaultName": "",
         "administratorLogin": "{administratorLogin.value}",
         "administratorLoginPassword": "{administratorLoginPassword.value}"
-      },
-      "inputs": {
-        "password": {
-          "type": "string",
-          "secret": true,
-          "default": {
-            "generate": {
-              "minLength": 22
-            }
-          }
-        }
       }
     },
     "db2": {

--- a/playground/cdk/CdkSample.AppHost/aspire-manifest.json
+++ b/playground/cdk/CdkSample.AppHost/aspire-manifest.json
@@ -123,17 +123,6 @@
         "keyVaultName": "",
         "administratorLogin": "{pgsqlAdministratorLogin.value}",
         "administratorLoginPassword": "{pgsqlAdministratorLoginPassword.value}"
-      },
-      "inputs": {
-        "password": {
-          "type": "string",
-          "secret": true,
-          "default": {
-            "generate": {
-              "minLength": 22
-            }
-          }
-        }
       }
     },
     "pgsqldb": {

--- a/playground/orleans/OrleansAppHost/aspire-manifest.json
+++ b/playground/orleans/OrleansAppHost/aspire-manifest.json
@@ -29,7 +29,7 @@
         "Orleans__GrainStorage__Default__ProviderType": "AzureBlobStorage",
         "Orleans__GrainStorage__Default__ServiceKey": "grainstate",
         "ConnectionStrings__grainstate": "{grainstate.connectionString}",
-        "Orleans__ClusterId": "a29722a0d08c43d783b9d3eb9bdcaece",
+        "Orleans__ClusterId": "9caf4a85cf8248189d71c1c8bd133b09",
         "Orleans__EnableDistributedTracing": "true",
         "Orleans__Endpoints__SiloPort": "{silo.bindings.orleans-silo.port}",
         "Orleans__Endpoints__GatewayPort": "{silo.bindings.orleans-gateway.port}"

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -19,18 +19,18 @@ public static class MySqlBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
+    /// <param name="password">The parameter used to provide the root password for the MySQL resource. If <see langword="null"/> a random password will be generated.</param>
     /// <param name="port">The host port for MySQL.</param>
-    /// <param name="password">The password for the MySQL root user. Defaults to a random password.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<MySqlServerResource> AddMySql(this IDistributedApplicationBuilder builder, string name, int? port = null, string? password = null)
+    public static IResourceBuilder<MySqlServerResource> AddMySql(this IDistributedApplicationBuilder builder, string name, IResourceBuilder<ParameterResource>? password = null, int? port = null)
     {
-        var resource = new MySqlServerResource(name, password);
+        var resource = new MySqlServerResource(name, password?.Resource);
         return builder.AddResource(resource)
                       .WithEndpoint(hostPort: port, containerPort: 3306, name: MySqlServerResource.PrimaryEndpointName) // Internal port is always 3306.
                       .WithImage("mysql", "8.3.0")
                       .WithEnvironment(context =>
                       {
-                          context.EnvironmentVariables[PasswordEnvVarName] = resource.PasswordInput;
+                          context.EnvironmentVariables[PasswordEnvVarName] = resource.PasswordReference;
                       });
     }
 
@@ -89,7 +89,7 @@ public static class MySqlBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<MySqlServerResource> WithDataVolume(this IResourceBuilder<MySqlServerResource> builder, string? name = null, bool isReadOnly = false)
         => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/lib/mysql", isReadOnly);
- 
+
     /// <summary>
     /// Adds a bind mount for the data folder to a MySql container resource.
     /// </summary>

--- a/src/Aspire.Hosting.MySql/MySqlServerResource.cs
+++ b/src/Aspire.Hosting.MySql/MySqlServerResource.cs
@@ -18,11 +18,13 @@ public class MySqlServerResource : ContainerResource, IResourceWithConnectionStr
     public MySqlServerResource(string name, ParameterResource? password) : base(name)
     {
         PrimaryEndpoint = new(this, PrimaryEndpointName);
-        PasswordInput = new(this, "password");
-
         PasswordParameter = password;
 
-        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput());
+        if (PasswordParameter is null)
+        {
+            Annotations.Add(InputAnnotation.CreateDefaultPasswordInput());
+            PasswordInput = new(this, "password");
+        }
     }
 
     /// <summary>
@@ -30,7 +32,7 @@ public class MySqlServerResource : ContainerResource, IResourceWithConnectionStr
     /// </summary>
     public EndpointReference PrimaryEndpoint { get; }
 
-    private InputReference PasswordInput { get; }
+    private InputReference? PasswordInput { get; }
 
     /// <summary>
     /// Gets the parameter that contains the MySQL server password.
@@ -40,12 +42,12 @@ public class MySqlServerResource : ContainerResource, IResourceWithConnectionStr
     internal ReferenceExpression PasswordReference =>
         PasswordParameter is not null ?
             ReferenceExpression.Create($"{PasswordParameter}") :
-            ReferenceExpression.Create($"{PasswordInput}");
+            ReferenceExpression.Create($"{PasswordInput!}"); // either PasswordParameter or PasswordInput is non-null
 
     /// <summary>
     /// Gets the MySQL server root password.
     /// </summary>
-    internal string Password => PasswordParameter?.Value ?? PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
+    internal string Password => PasswordParameter?.Value ?? PasswordInput!.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
 
     /// <summary>
     /// Gets the connection string expression for the MySQL server.

--- a/src/Aspire.Hosting.MySql/MySqlServerResource.cs
+++ b/src/Aspire.Hosting.MySql/MySqlServerResource.cs
@@ -14,13 +14,15 @@ public class MySqlServerResource : ContainerResource, IResourceWithConnectionStr
     /// Initializes a new instance of the <see cref="MySqlServerResource"/> class.
     /// </summary>
     /// <param name="name">The name of the resource.</param>
-    /// <param name="password">The MySQL server root password, or <see langword="null"/> to generate a random password.</param>
-    public MySqlServerResource(string name, string? password = null) : base(name)
+    /// <param name="password">A parameter that contains the MySQL server password, or <see langword="null"/> to generate a random password.</param>
+    public MySqlServerResource(string name, ParameterResource? password) : base(name)
     {
         PrimaryEndpoint = new(this, PrimaryEndpointName);
         PasswordInput = new(this, "password");
 
-        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(password));
+        PasswordParameter = password;
+
+        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput());
     }
 
     /// <summary>
@@ -28,19 +30,29 @@ public class MySqlServerResource : ContainerResource, IResourceWithConnectionStr
     /// </summary>
     public EndpointReference PrimaryEndpoint { get; }
 
-    internal InputReference PasswordInput { get; }
+    private InputReference PasswordInput { get; }
+
+    /// <summary>
+    /// Gets the parameter that contains the MySQL server password.
+    /// </summary>
+    public ParameterResource? PasswordParameter { get; }
+
+    internal ReferenceExpression PasswordReference =>
+        PasswordParameter is not null ?
+            ReferenceExpression.Create($"{PasswordParameter}") :
+            ReferenceExpression.Create($"{PasswordInput}");
 
     /// <summary>
     /// Gets the MySQL server root password.
     /// </summary>
-    public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
+    internal string Password => PasswordParameter?.Value ?? PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
 
     /// <summary>
     /// Gets the connection string expression for the MySQL server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create(
-            $"Server={PrimaryEndpoint.Property(EndpointProperty.Host)};Port={PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=root;Password={PasswordInput}");
+            $"Server={PrimaryEndpoint.Property(EndpointProperty.Host)};Port={PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=root;Password={PasswordReference}");
 
     private readonly Dictionary<string, string> _databases = new Dictionary<string, string>(StringComparers.ResourceName);
 

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseServerResource.cs
@@ -14,13 +14,15 @@ public class OracleDatabaseServerResource : ContainerResource, IResourceWithConn
     /// Initializes a new instance of the <see cref="OracleDatabaseServerResource"/> class.
     /// </summary>
     /// <param name="name">The name of the resource.</param>
-    /// <param name="password">The Oracle Database server password, or <see langword="null"/> to generate a random password.</param>
-    public OracleDatabaseServerResource(string name, string? password = null) : base(name)
+    /// <param name="password">A parameter that contains the Oracle Database server password, or <see langword="null"/> to generate a random password.</param>
+    public OracleDatabaseServerResource(string name, ParameterResource? password) : base(name)
     {
         PrimaryEndpoint = new(this, PrimaryEndpointName);
         PasswordInput = new(this, "password");
 
-        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(password));
+        PasswordParameter = password;
+
+        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput());
     }
 
     /// <summary>
@@ -28,22 +30,24 @@ public class OracleDatabaseServerResource : ContainerResource, IResourceWithConn
     /// </summary>
     public EndpointReference PrimaryEndpoint { get; }
 
-    internal InputReference PasswordInput { get; }
+    private InputReference PasswordInput { get; }
 
     /// <summary>
-    /// Gets the Oracle Database server password.
+    /// Gets the parameter that contains the Oracle Database server password.
     /// </summary>
-    public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
+    public ParameterResource? PasswordParameter { get; }
 
-    private ReferenceExpression ConnectionString =>
-        ReferenceExpression.Create(
-            $"user id=system;password={PasswordInput};data source={PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
+    internal ReferenceExpression PasswordReference =>
+        PasswordParameter is not null ?
+            ReferenceExpression.Create($"{PasswordParameter}") :
+            ReferenceExpression.Create($"{PasswordInput}");
 
     /// <summary>
     /// Gets the connection string expression for the Oracle Database server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ConnectionString;
+        ReferenceExpression.Create(
+            $"user id=system;password={PasswordReference};data source={PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
 
     private readonly Dictionary<string, string> _databases = new(StringComparers.ResourceName);
 

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseServerResource.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseServerResource.cs
@@ -18,11 +18,13 @@ public class OracleDatabaseServerResource : ContainerResource, IResourceWithConn
     public OracleDatabaseServerResource(string name, ParameterResource? password) : base(name)
     {
         PrimaryEndpoint = new(this, PrimaryEndpointName);
-        PasswordInput = new(this, "password");
-
         PasswordParameter = password;
 
-        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput());
+        if (PasswordParameter is null)
+        {
+            Annotations.Add(InputAnnotation.CreateDefaultPasswordInput());
+            PasswordInput = new(this, "password");
+        }
     }
 
     /// <summary>
@@ -30,7 +32,7 @@ public class OracleDatabaseServerResource : ContainerResource, IResourceWithConn
     /// </summary>
     public EndpointReference PrimaryEndpoint { get; }
 
-    private InputReference PasswordInput { get; }
+    private InputReference? PasswordInput { get; }
 
     /// <summary>
     /// Gets the parameter that contains the Oracle Database server password.
@@ -40,7 +42,7 @@ public class OracleDatabaseServerResource : ContainerResource, IResourceWithConn
     internal ReferenceExpression PasswordReference =>
         PasswordParameter is not null ?
             ReferenceExpression.Create($"{PasswordParameter}") :
-            ReferenceExpression.Create($"{PasswordInput}");
+            ReferenceExpression.Create($"{PasswordInput!}"); // either PasswordParameter or PasswordInput is non-null
 
     /// <summary>
     /// Gets the connection string expression for the Oracle Database server.

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -15,18 +15,24 @@ public static class RabbitMQBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
+    /// <param name="userName">The parameter used to provide the user name for the RabbitMQ resource. If <see langword="null"/> a default value will be used.</param>
+    /// <param name="password">The parameter used to provide the password for the RabbitMQ resource. If <see langword="null"/> a random password will be generated.</param>
     /// <param name="port">The host port that the underlying container is bound to when running locally.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<RabbitMQServerResource> AddRabbitMQ(this IDistributedApplicationBuilder builder, string name, int? port = null)
+    public static IResourceBuilder<RabbitMQServerResource> AddRabbitMQ(this IDistributedApplicationBuilder builder,
+        string name,
+        IResourceBuilder<ParameterResource>? userName = null,
+        IResourceBuilder<ParameterResource>? password = null,
+        int? port = null)
     {
-        var rabbitMq = new RabbitMQServerResource(name);
+        var rabbitMq = new RabbitMQServerResource(name, userName?.Resource, password?.Resource);
         return builder.AddResource(rabbitMq)
                       .WithEndpoint(hostPort: port, containerPort: 5672, name: RabbitMQServerResource.PrimaryEndpointName)
                       .WithImage("rabbitmq", "3")
-                      .WithEnvironment("RABBITMQ_DEFAULT_USER", "guest")
                       .WithEnvironment(context =>
                       {
-                          context.EnvironmentVariables["RABBITMQ_DEFAULT_PASS"] = rabbitMq.PasswordInput;
+                          context.EnvironmentVariables["RABBITMQ_DEFAULT_USER"] = rabbitMq.UserNameReference;
+                          context.EnvironmentVariables["RABBITMQ_DEFAULT_PASS"] = rabbitMq.PasswordReference;
                       });
     }
 

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
@@ -20,13 +20,15 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
     public RabbitMQServerResource(string name, ParameterResource? userName, ParameterResource? password) : base(name)
     {
         PrimaryEndpoint = new(this, PrimaryEndpointName);
-        PasswordInput = new(this, "password");
-
         UserNameParameter = userName;
         PasswordParameter = password;
 
-        // don't use special characters in the password, since it goes into a URI
-        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(special: false));
+        if (PasswordParameter is null)
+        {
+            // don't use special characters in the password, since it goes into a URI
+            Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(special: false));
+            PasswordInput = new(this, "password");
+        }
     }
 
     /// <summary>
@@ -44,7 +46,7 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
             ReferenceExpression.Create($"{UserNameParameter}") :
             ReferenceExpression.Create($"{DefaultUserName}");
 
-    private InputReference PasswordInput { get; }
+    private InputReference? PasswordInput { get; }
 
     /// <summary>
     /// Gets the parameter that contains the PostgreSQL server password.
@@ -54,7 +56,7 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
     internal ReferenceExpression PasswordReference =>
         PasswordParameter is not null ?
             ReferenceExpression.Create($"{PasswordParameter}") :
-            ReferenceExpression.Create($"{PasswordInput}");
+            ReferenceExpression.Create($"{PasswordInput!}"); // either PasswordParameter or PasswordInput is non-null
 
     /// <summary>
     /// Gets the connection string expression for the RabbitMQ server.

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
@@ -9,19 +9,24 @@ namespace Aspire.Hosting.ApplicationModel;
 public class RabbitMQServerResource : ContainerResource, IResourceWithConnectionString, IResourceWithEnvironment
 {
     internal const string PrimaryEndpointName = "tcp";
+    private const string DefaultUserName = "guest";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RabbitMQServerResource"/> class.
     /// </summary>
     /// <param name="name">The name of the resource.</param>
-    /// <param name="password">The RabbitMQ server password, or <see langword="null"/> to generate a random password.</param>
-    public RabbitMQServerResource(string name, string? password = null) : base(name)
+    /// <param name="userName">A parameter that contains the RabbitMQ server user name, or <see langword="null"/> to use a default value.</param>
+    /// <param name="password">A parameter that contains the RabbitMQ server password, or <see langword="null"/> to generate a random password.</param>
+    public RabbitMQServerResource(string name, ParameterResource? userName, ParameterResource? password) : base(name)
     {
         PrimaryEndpoint = new(this, PrimaryEndpointName);
         PasswordInput = new(this, "password");
 
+        UserNameParameter = userName;
+        PasswordParameter = password;
+
         // don't use special characters in the password, since it goes into a URI
-        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(password, special: false));
+        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(special: false));
     }
 
     /// <summary>
@@ -29,17 +34,32 @@ public class RabbitMQServerResource : ContainerResource, IResourceWithConnection
     /// </summary>
     public EndpointReference PrimaryEndpoint { get; }
 
-    internal InputReference PasswordInput { get; }
+    /// <summary>
+    /// Gets the parameter that contains the RabbitMQ server user name.
+    /// </summary>
+    public ParameterResource? UserNameParameter { get; }
+
+    internal ReferenceExpression UserNameReference =>
+        UserNameParameter is not null ?
+            ReferenceExpression.Create($"{UserNameParameter}") :
+            ReferenceExpression.Create($"{DefaultUserName}");
+
+    private InputReference PasswordInput { get; }
 
     /// <summary>
-    /// Gets the RabbitMQ server password.
+    /// Gets the parameter that contains the PostgreSQL server password.
     /// </summary>
-    public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
+    public ParameterResource? PasswordParameter { get; }
+
+    internal ReferenceExpression PasswordReference =>
+        PasswordParameter is not null ?
+            ReferenceExpression.Create($"{PasswordParameter}") :
+            ReferenceExpression.Create($"{PasswordInput}");
 
     /// <summary>
     /// Gets the connection string expression for the RabbitMQ server.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create(
-            $"amqp://guest:{PasswordInput}@{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
+            $"amqp://{UserNameReference}:{PasswordReference}@{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)}");
 }

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -15,12 +15,12 @@ public static class SqlServerBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
-    /// <param name="password">The password of the SQL Server. By default, this will be randomly generated.</param>
+    /// <param name="password">The parameter used to provide the administrator password for the SQL Server resource. If <see langword="null"/> a random password will be generated.</param>
     /// <param name="port">The host port for the SQL Server.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<SqlServerServerResource> AddSqlServer(this IDistributedApplicationBuilder builder, string name, string? password = null, int? port = null)
+    public static IResourceBuilder<SqlServerServerResource> AddSqlServer(this IDistributedApplicationBuilder builder, string name, IResourceBuilder<ParameterResource>? password = null, int? port = null)
     {
-        var sqlServer = new SqlServerServerResource(name, password);
+        var sqlServer = new SqlServerServerResource(name, password?.Resource);
 
         return builder.AddResource(sqlServer)
                       .WithEndpoint(hostPort: port, containerPort: 1433, name: SqlServerServerResource.PrimaryEndpointName)
@@ -29,7 +29,7 @@ public static class SqlServerBuilderExtensions
                       .WithEnvironment("ACCEPT_EULA", "Y")
                       .WithEnvironment(context =>
                       {
-                          context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = sqlServer.PasswordInput;
+                          context.EnvironmentVariables["MSSQL_SA_PASSWORD"] = sqlServer.PasswordReference;
                       });
     }
 

--- a/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
@@ -18,12 +18,14 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
     public SqlServerServerResource(string name, ParameterResource? password) : base(name)
     {
         PrimaryEndpoint = new(this, PrimaryEndpointName);
-        PasswordInput = new(this, "password");
-
         PasswordParameter = password;
 
-        // The password must be at least 8 characters long and contain characters from three of the following four sets: Uppercase letters, Lowercase letters, Base 10 digits, and Symbols
-        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(minLower: 1, minUpper: 1, minNumeric: 1));
+        if (PasswordParameter is null)
+        {
+            // The password must be at least 8 characters long and contain characters from three of the following four sets: Uppercase letters, Lowercase letters, Base 10 digits, and Symbols
+            Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(minLower: 1, minUpper: 1, minNumeric: 1));
+            PasswordInput = new(this, "password");
+        }
     }
 
     /// <summary>
@@ -31,7 +33,7 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
     /// </summary>
     public EndpointReference PrimaryEndpoint { get; }
 
-    private InputReference PasswordInput { get; }
+    private InputReference? PasswordInput { get; }
 
     /// <summary>
     /// Gets the parameter that contains the PostgreSQL server password.
@@ -41,7 +43,7 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
     internal ReferenceExpression PasswordReference =>
         PasswordParameter is not null ?
             ReferenceExpression.Create($"{PasswordParameter}") :
-            ReferenceExpression.Create($"{PasswordInput}");
+            ReferenceExpression.Create($"{PasswordInput!}"); // either PasswordParameter or PasswordInput is non-null
 
     private ReferenceExpression ConnectionString =>
         ReferenceExpression.Create(

--- a/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
@@ -14,14 +14,16 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
     /// Initializes a new instance of the <see cref="SqlServerServerResource"/> class.
     /// </summary>
     /// <param name="name">The name of the resource.</param>
-    /// <param name="password">The SQL Sever password, or <see langword="null"/> to generate a random password.</param>
-    public SqlServerServerResource(string name, string? password = null) : base(name)
+    /// <param name="password">A parameter that contains the SQL Sever password, or <see langword="null"/> to generate a random password.</param>
+    public SqlServerServerResource(string name, ParameterResource? password) : base(name)
     {
         PrimaryEndpoint = new(this, PrimaryEndpointName);
         PasswordInput = new(this, "password");
 
+        PasswordParameter = password;
+
         // The password must be at least 8 characters long and contain characters from three of the following four sets: Uppercase letters, Lowercase letters, Base 10 digits, and Symbols
-        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(password, minLower: 1, minUpper: 1, minNumeric: 1));
+        Annotations.Add(InputAnnotation.CreateDefaultPasswordInput(minLower: 1, minUpper: 1, minNumeric: 1));
     }
 
     /// <summary>
@@ -29,16 +31,21 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
     /// </summary>
     public EndpointReference PrimaryEndpoint { get; }
 
-    internal InputReference PasswordInput { get; }
+    private InputReference PasswordInput { get; }
 
     /// <summary>
-    /// Gets the password for the SQL Server container resource.
+    /// Gets the parameter that contains the PostgreSQL server password.
     /// </summary>
-    public string Password => PasswordInput.Input.Value ?? throw new InvalidOperationException("Password cannot be null.");
+    public ParameterResource? PasswordParameter { get; }
+
+    internal ReferenceExpression PasswordReference =>
+        PasswordParameter is not null ?
+            ReferenceExpression.Create($"{PasswordParameter}") :
+            ReferenceExpression.Create($"{PasswordInput}");
 
     private ReferenceExpression ConnectionString =>
         ReferenceExpression.Create(
-            $"Server={PrimaryEndpoint.Property(EndpointProperty.IPV4Host)},{PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=sa;Password={PasswordInput};TrustServerCertificate=true");
+            $"Server={PrimaryEndpoint.Property(EndpointProperty.IPV4Host)},{PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=sa;Password={PasswordReference};TrustServerCertificate=true");
 
     /// <summary>
     /// Gets the connection string expression for the SQL Server.

--- a/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/InputAnnotation.cs
@@ -84,7 +84,6 @@ public sealed class InputAnnotation : IResourceAnnotation
     /// <summary>
     /// Creates a default password input annotation that generates a random password.
     /// </summary>
-    /// <param name="password">The hard-coded value of the password to use.</param> // TODO this should be removed with https://github.com/dotnet/aspire/issues/2403
     /// <param name="lower"><see langword="true" /> if lowercase alphabet characters should be included; otherwise, <see langword="false" />.</param>
     /// <param name="upper"><see langword="true" /> if uppercase alphabet characters should be included; otherwise, <see langword="false" />.</param>
     /// <param name="numeric"><see langword="true" /> if numeric characters should be included; otherwise, <see langword="false" />.</param>
@@ -94,7 +93,7 @@ public sealed class InputAnnotation : IResourceAnnotation
     /// <param name="minNumeric">The minimum number of numeric characters in the result.</param>
     /// <param name="minSpecial">The minimum number of special characters in the result.</param>
     /// <returns>The created <see cref="InputAnnotation"/> for generating a random password.</returns>
-    public static InputAnnotation CreateDefaultPasswordInput(string? password = null,
+    public static InputAnnotation CreateDefaultPasswordInput(
         bool lower = true, bool upper = true, bool numeric = true, bool special = true,
         int minLower = 0, int minUpper = 0, int minNumeric = 0, int minSpecial = 0)
     {
@@ -111,11 +110,6 @@ public sealed class InputAnnotation : IResourceAnnotation
             MinNumeric = minNumeric,
             MinSpecial = minSpecial
         };
-
-        if (password is not null)
-        {
-            passwordInput.SetValueGetter(() => password);
-        }
 
         return passwordInput;
     }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -914,17 +914,6 @@ public class AzureBicepResourceTests
                 "administratorLogin": "{usr.value}",
                 "administratorLoginPassword": "{pwd.value}",
                 "principalType": ""
-              },
-              "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22
-                    }
-                  }
-                }
               }
             }
             """;
@@ -1056,17 +1045,6 @@ public class AzureBicepResourceTests
                 "administratorLogin": "{usr.value}",
                 "administratorLoginPassword": "{pwd.value}",
                 "principalType": ""
-              },
-              "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22
-                    }
-                  }
-                }
               }
             }
             """;
@@ -1169,15 +1147,6 @@ public class AzureBicepResourceTests
                 "principalType": ""
               },
               "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22
-                    }
-                  }
-                },
                 "username": {
                   "type": "string",
                   "default": {

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -205,17 +205,6 @@ public class AddMySqlTests
                   "transport": "tcp",
                   "containerPort": 3306
                 }
-              },
-              "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22
-                    }
-                  }
-                }
               }
             }
             """;

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -54,7 +54,10 @@ public class AddMySqlTests
     public async Task AddMySqlAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.AddMySql("mysql", 1234, "pass");
+        appBuilder.Configuration["Parameters:pass"] = "pass";
+
+        var pass = appBuilder.AddParameter("pass");
+        appBuilder.AddMySql("mysql", pass, 1234);
 
         using var app = appBuilder.Build();
 
@@ -176,6 +179,47 @@ public class AddMySqlTests
             }
             """;
         Assert.Equal(expectedManifest, dbManifest.ToString());
+    }
+
+    [Fact]
+    public async Task VerifyManifestWithPasswordParameter()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var pass = appBuilder.AddParameter("pass");
+
+        var mysql = appBuilder.AddMySql("mysql", pass);
+        var serverManifest = await ManifestUtils.GetManifest(mysql.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "container.v0",
+              "connectionString": "Server={mysql.bindings.tcp.host};Port={mysql.bindings.tcp.port};User ID=root;Password={pass.value}",
+              "image": "mysql:8.3.0",
+              "env": {
+                "MYSQL_ROOT_PASSWORD": "{pass.value}"
+              },
+              "bindings": {
+                "tcp": {
+                  "scheme": "tcp",
+                  "protocol": "tcp",
+                  "transport": "tcp",
+                  "containerPort": 3306
+                }
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 22
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, serverManifest.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -245,17 +245,6 @@ public class AddOracleTests
                   "transport": "tcp",
                   "containerPort": 1521
                 }
-              },
-              "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22
-                    }
-                  }
-                }
               }
             }
             """;

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -52,7 +52,10 @@ public class AddOracleTests
     public async Task AddOracleAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.AddOracle("orcl", 1234, "pass");
+        appBuilder.Configuration["Parameters:pass"] = "pass";
+
+        var pass = appBuilder.AddParameter("pass");
+        appBuilder.AddOracle("orcl", pass, 1234);
 
         using var app = appBuilder.Build();
 
@@ -60,9 +63,6 @@ public class AddOracleTests
 
         var containerResource = Assert.Single(appModel.GetContainerResources());
         Assert.Equal("orcl", containerResource.Name);
-
-        var manifestPublishing = Assert.Single(containerResource.Annotations.OfType<ManifestPublishingCallbackAnnotation>());
-        Assert.NotNull(manifestPublishing.Callback);
 
         var containerAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerImageAnnotation>());
         Assert.Equal("23.3.0.0", containerAnnotation.Tag);
@@ -134,7 +134,10 @@ public class AddOracleTests
     public async Task AddDatabaseToOracleDatabaseAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.AddOracle("oracle", 1234, "pass").AddDatabase("db");
+        appBuilder.Configuration["Parameters:pass"] = "pass";
+
+        var pass = appBuilder.AddParameter("pass");
+        appBuilder.AddOracle("oracle", pass, 1234).AddDatabase("db");
 
         using var app = appBuilder.Build();
 
@@ -143,9 +146,6 @@ public class AddOracleTests
 
         var containerResource = Assert.Single(containerResources);
         Assert.Equal("oracle", containerResource.Name);
-
-        var manifestPublishing = Assert.Single(containerResource.Annotations.OfType<ManifestPublishingCallbackAnnotation>());
-        Assert.NotNull(manifestPublishing.Callback);
 
         var containerAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerImageAnnotation>());
         Assert.Equal("23.3.0.0", containerAnnotation.Tag);
@@ -219,6 +219,47 @@ public class AddOracleTests
             }
             """;
         Assert.Equal(expectedManifest, dbManifest.ToString());
+    }
+
+    [Fact]
+    public async Task VerifyManifestWithPasswordParameter()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        var pass = appBuilder.AddParameter("pass");
+
+        var oracleServer = appBuilder.AddOracle("oracle", pass);
+        var serverManifest = await ManifestUtils.GetManifest(oracleServer.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "container.v0",
+              "connectionString": "user id=system;password={pass.value};data source={oracle.bindings.tcp.host}:{oracle.bindings.tcp.port}",
+              "image": "container-registry.oracle.com/database/free:23.3.0.0",
+              "env": {
+                "ORACLE_PWD": "{pass.value}"
+              },
+              "bindings": {
+                "tcp": {
+                  "scheme": "tcp",
+                  "protocol": "tcp",
+                  "transport": "tcp",
+                  "containerPort": 1521
+                }
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 22
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, serverManifest.ToString());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -294,17 +294,6 @@ public class AddPostgresTests
                   "transport": "tcp",
                   "containerPort": 5432
                 }
-              },
-              "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22
-                    }
-                  }
-                }
               }
             }
             """;
@@ -367,17 +356,6 @@ public class AddPostgresTests
                   "protocol": "tcp",
                   "transport": "tcp",
                   "containerPort": 5432
-                }
-              },
-              "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22
-                    }
-                  }
                 }
               }
             }

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -131,18 +131,6 @@ public class AddRabbitMQTests
                   "transport": "tcp",
                   "containerPort": 5672
                 }
-              },
-              "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22,
-                      "special": false
-                    }
-                  }
-                }
               }
             }
             """;
@@ -202,18 +190,6 @@ public class AddRabbitMQTests
                   "protocol": "tcp",
                   "transport": "tcp",
                   "containerPort": 5672
-                }
-              },
-              "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22,
-                      "special": false
-                    }
-                  }
                 }
               }
             }

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -181,20 +181,6 @@ public class AddSqlServerTests
                   "transport": "tcp",
                   "containerPort": 1433
                 }
-              },
-              "inputs": {
-                "password": {
-                  "type": "string",
-                  "secret": true,
-                  "default": {
-                    "generate": {
-                      "minLength": 22,
-                      "minLower": 1,
-                      "minUpper": 1,
-                      "minNumeric": 1
-                    }
-                  }
-                }
               }
             }
             """;

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -59,8 +59,11 @@ public class AddSqlServerTests
     public async Task SqlServerCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.Configuration["Parameters:pass"] = "pass1";
+
+        var pass = appBuilder.AddParameter("pass");
         appBuilder
-            .AddSqlServer("sqlserver")
+            .AddSqlServer("sqlserver", pass)
             .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1433));
 
         using var app = appBuilder.Build();
@@ -69,18 +72,20 @@ public class AddSqlServerTests
 
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<SqlServerServerResource>());
         var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
-        var password = connectionStringResource.Password;
 
-        Assert.Equal($"Server=127.0.0.1,1433;User ID=sa;Password={password};TrustServerCertificate=true", connectionString);
-        Assert.Equal("Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver.inputs.password};TrustServerCertificate=true", connectionStringResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("Server=127.0.0.1,1433;User ID=sa;Password=pass1;TrustServerCertificate=true", connectionString);
+        Assert.Equal("Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
     public async Task SqlServerDatabaseCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.Configuration["Parameters:pass"] = "pass2";
+
+        var pass = appBuilder.AddParameter("pass");
         appBuilder
-            .AddSqlServer("sqlserver")
+            .AddSqlServer("sqlserver", pass)
             .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1433))
             .AddDatabase("mydb");
 
@@ -91,9 +96,8 @@ public class AddSqlServerTests
         var sqlResource = Assert.Single(appModel.Resources.OfType<SqlServerDatabaseResource>());
         var connectionStringResource = (IResourceWithConnectionString)sqlResource;
         var connectionString = await connectionStringResource.GetConnectionStringAsync();
-        var password = sqlResource.Parent.Password;
 
-        Assert.Equal($"Server=127.0.0.1,1433;User ID=sa;Password={password};TrustServerCertificate=true;Database=mydb", connectionString);
+        Assert.Equal("Server=127.0.0.1,1433;User ID=sa;Password=pass2;TrustServerCertificate=true;Database=mydb", connectionString);
         Assert.Equal("{sqlserver.connectionString};Database=mydb", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
@@ -149,6 +153,52 @@ public class AddSqlServerTests
             }
             """;
         Assert.Equal(expectedManifest, dbManifest.ToString());
+    }
+
+    [Fact]
+    public async Task VerifyManifestWithPasswordParameter()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        var pass = appBuilder.AddParameter("pass");
+
+        var sqlServer = appBuilder.AddSqlServer("sqlserver", pass);
+        var serverManifest = await ManifestUtils.GetManifest(sqlServer.Resource);
+
+        var expectedManifest = """
+            {
+              "type": "container.v0",
+              "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true",
+              "image": "mcr.microsoft.com/mssql/server:2022-latest",
+              "env": {
+                "ACCEPT_EULA": "Y",
+                "MSSQL_SA_PASSWORD": "{pass.value}"
+              },
+              "bindings": {
+                "tcp": {
+                  "scheme": "tcp",
+                  "protocol": "tcp",
+                  "transport": "tcp",
+                  "containerPort": 1433
+                }
+              },
+              "inputs": {
+                "password": {
+                  "type": "string",
+                  "secret": true,
+                  "default": {
+                    "generate": {
+                      "minLength": 22,
+                      "minLower": 1,
+                      "minUpper": 1,
+                      "minNumeric": 1
+                    }
+                  }
+                }
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, serverManifest.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
* Support RabbitMQ username and password from Parameter
* Support MySql password from Parameter
* Support Oracle password from Parameter
* Support SQL Server password from Parameter

Fix #2403
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3023)