### PR TITLE
Support new IDE protocol in app model

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationEntryPointInvoker.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationEntryPointInvoker.cs
@@ -97,10 +97,6 @@ internal sealed class DistributedApplicationEntryPointInvoker
                     // build to throw
                     _appTcs.TrySetException(new InvalidOperationException($"The entry point exited without building a {nameof(DistributedApplication)}."));
                 }
-                catch (TargetInvocationException tie) when (tie.InnerException?.GetType().Name == "HostAbortedException")
-                {
-                    // The host was stopped by our own logic
-                }
                 catch (TargetInvocationException tie)
                 {
                     exception = tie.InnerException ?? tie;

--- a/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
@@ -20,6 +19,9 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
 
     private readonly DistributedApplicationModel _applicationModel;
     private readonly DcpOptions _dcpOptions;
+    private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
+    private DcpInfo? _dcpInfo;
+    private bool _checkDone;
 
     public DcpDependencyCheck(
         DistributedApplicationModel applicationModel,
@@ -29,79 +31,96 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
         _dcpOptions = dcpOptions.Value;
     }
 
-    public async Task EnsureDcpDependenciesAsync(CancellationToken cancellationToken = default)
+    public async Task<DcpInfo?> GetDcpInfoAsync(CancellationToken cancellationToken = default)
     {
-        var dcpPath = _dcpOptions.CliPath;
-        var containerRuntime = _dcpOptions.ContainerRuntime;
-
-        if (!File.Exists(dcpPath))
-        {
-            throw new FileNotFoundException($"The Aspire orchestration component is not installed at \"{dcpPath}\". The application cannot be run without it.", dcpPath);
-        }
-
-        IAsyncDisposable? processDisposable = null;
-        Task<ProcessResult> task;
-
+        await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var outputStringBuilder = new StringBuilder();
-
-            var arguments = "info";
-            if (!string.IsNullOrEmpty(containerRuntime))
+            if (_checkDone)
             {
-                arguments += $" --container-runtime {containerRuntime}";
+                return _dcpInfo;
+            }
+            _checkDone = true;
+
+            var dcpPath = _dcpOptions.CliPath;
+            var containerRuntime = _dcpOptions.ContainerRuntime;
+
+            if (!File.Exists(dcpPath))
+            {
+                throw new FileNotFoundException($"The Aspire orchestration component is not installed at \"{dcpPath}\". The application cannot be run without it.", dcpPath);
             }
 
-            // Run `dcp version`
-            var processSpec = new ProcessSpec(dcpPath)
-            {
-                Arguments = arguments,
-                OnOutputData = s => outputStringBuilder.Append(s),
-            };
+            IAsyncDisposable? processDisposable = null;
+            Task<ProcessResult> task;
 
-            (task, processDisposable) = ProcessUtil.Run(processSpec);
-
-            // Disable timeout if DependencyCheckTimeout is set to zero or a negative value
-            if (_dcpOptions.DependencyCheckTimeout > 0)
+            try
             {
-                await task.WaitAsync(TimeSpan.FromSeconds(_dcpOptions.DependencyCheckTimeout), cancellationToken).ConfigureAwait(false);
+                var outputStringBuilder = new StringBuilder();
+
+                var arguments = "info";
+                if (!string.IsNullOrEmpty(containerRuntime))
+                {
+                    arguments += $" --container-runtime {containerRuntime}";
+                }
+
+                // Run `dcp version`
+                var processSpec = new ProcessSpec(dcpPath)
+                {
+                    Arguments = arguments,
+                    OnOutputData = s => outputStringBuilder.Append(s),
+                };
+
+                (task, processDisposable) = ProcessUtil.Run(processSpec);
+
+                // Disable timeout if DependencyCheckTimeout is set to zero or a negative value
+                if (_dcpOptions.DependencyCheckTimeout > 0)
+                {
+                    await task.WaitAsync(TimeSpan.FromSeconds(_dcpOptions.DependencyCheckTimeout), cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                // Parse the output as JSON
+                var output = outputStringBuilder.ToString();
+                if (output == string.Empty)
+                {
+                    return null; // Best effort
+                }
+
+                var dcpInfo = JsonSerializer.Deserialize<DcpInfo>(output);
+                if (dcpInfo == null)
+                {
+                    return null; // Best effort
+                }
+
+                EnsureDcpVersion(dcpInfo);
+                EnsureDcpContainerRuntime(dcpInfo);
+                _dcpInfo = dcpInfo;
+                return dcpInfo;
             }
-            else
+            catch (Exception ex) when (ex is not DistributedApplicationException)
             {
-                await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                Console.Error.WriteLine(string.Format(
+                    CultureInfo.InvariantCulture,
+                    Resources.DcpDependencyCheckFailedMessage,
+                    ex.ToString()
+                ));
+                Environment.Exit((int)DcpVersionCheckFailures.DcpVersionFailed);
+                return null; // Make compiler happy
             }
-
-            // Parse the output as JSON
-            var output = outputStringBuilder.ToString();
-            if (output == string.Empty)
+            finally
             {
-                return; // Best effort
+                if (processDisposable != null)
+                {
+                    await processDisposable.DisposeAsync().ConfigureAwait(false);
+                }
             }
-
-            var dcpInfo = JsonSerializer.Deserialize<DcpInfo>(output);
-            if (dcpInfo == null)
-            {
-                return; // Best effort
-            }
-
-            EnsureDcpVersion(dcpInfo);
-            EnsureDcpContainerRuntime(dcpInfo);
-        }
-        catch (Exception ex) when (ex is not DistributedApplicationException)
-        {
-            Console.Error.WriteLine(string.Format(
-                CultureInfo.InvariantCulture,
-                Resources.DcpDependencyCheckFailedMessage,
-                ex.ToString()
-            ));
-            Environment.Exit((int)DcpVersionCheckFailures.DcpVersionFailed);
         }
         finally
         {
-            if (processDisposable != null)
-            {
-                await processDisposable.DisposeAsync().ConfigureAwait(false);
-            }
+            this._lock.Release();
         }
     }
 
@@ -111,13 +130,14 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
 
         try
         {
-            var dcpVersionString = dcpInfo.Version;
+            var dcpVersionString = dcpInfo.VersionString;
 
             if (dcpVersionString == null
                 || dcpVersionString == string.Empty
                 || dcpVersionString == "dev")
             {
                 // If empty, null, or a dev version, pass
+                dcpInfo.Version = DcpVersion.Dev;
                 return;
             }
 
@@ -135,6 +155,8 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
                     ));
                     Environment.Exit((int)DcpVersionCheckFailures.DcpVersionIncompatible);
                 }
+
+                dcpInfo.Version = dcpVersion;
             }
         }
         finally
@@ -193,29 +215,5 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
         {
             AspireEventSource.Instance?.ContainerRuntimeHealthCheckStop();
         }
-    }
-
-    public sealed class DcpInfo
-    {
-        [JsonPropertyName("version")]
-        public string? Version { get; set; }
-
-        [JsonPropertyName("containers")]
-        public DcpContainersInfo? Containers { get; set; }
-    }
-
-    public sealed class DcpContainersInfo
-    {
-        [JsonPropertyName("runtime")]
-        public string? Runtime { get; set; }
-
-        [JsonPropertyName("installed")]
-        public bool Installed { get; set; } = false;
-
-        [JsonPropertyName("running")]
-        public bool Running { get; set; } = false;
-
-        [JsonPropertyName("error")]
-        public string? Error { get; set; }
     }
 }

--- a/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
@@ -102,13 +102,11 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
             }
             catch (Exception ex) when (ex is not DistributedApplicationException)
             {
-                Console.Error.WriteLine(string.Format(
+                throw new DistributedApplicationException(string.Format(
                     CultureInfo.InvariantCulture,
                     Resources.DcpDependencyCheckFailedMessage,
                     ex.ToString()
                 ));
-                Environment.Exit((int)DcpVersionCheckFailures.DcpVersionFailed);
-                return null; // Make compiler happy
             }
             finally
             {
@@ -120,7 +118,7 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
         }
         finally
         {
-            this._lock.Release();
+            _lock.Release();
         }
     }
 
@@ -149,11 +147,10 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
             {
                 if (dcpVersion < DcpVersion.MinimumVersionInclusive)
                 {
-                    Console.Error.WriteLine(string.Format(
+                    throw new DistributedApplicationException(string.Format(
                         CultureInfo.InvariantCulture,
                         Resources.DcpVersionCheckTooLowMessage
                     ));
-                    Environment.Exit((int)DcpVersionCheckFailures.DcpVersionIncompatible);
                 }
 
                 dcpInfo.Version = dcpVersion;
@@ -190,23 +187,21 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
 
             if (!installed)
             {
-                Console.Error.WriteLine(string.Format(
+                throw new DistributedApplicationException(string.Format(
                     CultureInfo.InvariantCulture,
                     Resources.ContainerRuntimePrerequisiteMissingExceptionMessage,
                     containerRuntime,
                     error
                 ));
-                Environment.Exit((int)ContainerRuntimeHealthCheckFailures.PrerequisiteMissing);
             }
             else if (!running)
             {
-                Console.Error.WriteLine(string.Format(
+                throw new DistributedApplicationException(string.Format(
                     CultureInfo.InvariantCulture,
                     Resources.ContainerRuntimeUnhealthyExceptionMessage,
                     containerRuntime,
                     error
                 ));
-                Environment.Exit((int)ContainerRuntimeHealthCheckFailures.Unhealthy);
             }
 
             // If we get to here all is good!

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -63,7 +63,8 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
             return;
         }
 
-        await _dependencyCheckService.EnsureDcpDependenciesAsync(cancellationToken).ConfigureAwait(false);
+        // Ensure DCP is installed and has all required dependencies
+        _ = await _dependencyCheckService.GetDcpInfoAsync(cancellationToken).ConfigureAwait(false);
 
         EnsureDcpHostRunning();
         await _appExecutor.RunApplicationAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Dcp/DcpVersion.cs
+++ b/src/Aspire.Hosting/Dcp/DcpVersion.cs
@@ -6,4 +6,10 @@ namespace Aspire.Hosting.Dcp;
 internal static class DcpVersion
 {
     public static Version MinimumVersionInclusive = new Version(0, 1, 55);
+    public static Version MinimumVersionIdeProtocolV1 = new Version(0, 1, 59);
+
+    /// <summary>
+    /// Development build version proxy, considered always "current" and supporting latest features. 
+    /// </summary>
+    public static Version Dev = new Version(1000, 0, 0);
 }

--- a/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
+++ b/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
@@ -1,9 +1,38 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
+
 namespace Aspire.Hosting.Dcp;
 
 internal interface IDcpDependencyCheckService
 {
-    Task EnsureDcpDependenciesAsync(CancellationToken cancellationToken = default);
+    Task<DcpInfo?> GetDcpInfoAsync(CancellationToken cancellationToken = default);
+}
+
+internal sealed class DcpInfo
+{
+    [JsonPropertyName("version")]
+    public string? VersionString { get; set; }
+
+    [JsonPropertyName("containers")]
+    public DcpContainersInfo? Containers { get; set; }
+
+    [JsonIgnore]
+    public Version? Version { get; set; }
+}
+
+internal sealed class DcpContainersInfo
+{
+    [JsonPropertyName("runtime")]
+    public string? Runtime { get; set; }
+
+    [JsonPropertyName("installed")]
+    public bool Installed { get; set; } = false;
+
+    [JsonPropertyName("running")]
+    public bool Running { get; set; } = false;
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
 }

--- a/src/Aspire.Hosting/Dcp/Model/Executable.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Executable.cs
@@ -3,6 +3,7 @@
 
 namespace Aspire.Hosting.Dcp.Model;
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using k8s.Models;
 
@@ -112,9 +113,11 @@ internal static class ExecutableState
 
 internal sealed class Executable : CustomResource<ExecutableSpec, ExecutableStatus>
 {
-    public const string CSharpProjectPathAnnotation = "csharp-project-path";
-    public const string CSharpLaunchProfileAnnotation = "csharp-launch-profile";
-    public const string CSharpDisableLaunchProfileAnnotation = "csharp-disable-launch-profile";
+    [Obsolete] public const string CSharpProjectPathAnnotation = "csharp-project-path";
+    [Obsolete] public const string CSharpLaunchProfileAnnotation = "csharp-launch-profile";
+    [Obsolete] public const string CSharpDisableLaunchProfileAnnotation = "csharp-disable-launch-profile";
+
+    public const string LaunchConfigurationsAnnotation = "executable.usvc-dev.developer.microsoft.com/launch-configurations";
     public const string OtelServiceNameAnnotation = "otel-service-name";
     public const string ResourceNameAnnotation = "resource-name";
 
@@ -139,4 +142,52 @@ internal sealed class Executable : CustomResource<ExecutableSpec, ExecutableStat
         this.Status?.State == ExecutableState.Running
         || this.Status?.State == ExecutableState.Finished
         || this.Status?.State == ExecutableState.Terminated;
+
+    public void SetProjectLaunchConfiguration(ProjectLaunchConfiguration launchConfiguration)
+    {
+        // In Aspire v1 only one launch configuration, of type "project", is supported.
+        // Further, there can be only one instance of project launch configuration per Executable.
+
+        this.Annotate(LaunchConfigurationsAnnotation, string.Empty); // Clear existing annotation, if any. 
+        this.AnnotateAsObjectList(LaunchConfigurationsAnnotation, launchConfiguration);
+    }
+
+    public bool TryGetProjectLaunchConfiguration([NotNullWhen(true)] out ProjectLaunchConfiguration? launchConfiguration)
+    {
+        launchConfiguration = null;
+        if (this.TryGetAnnotationAsObjectList(LaunchConfigurationsAnnotation, out List<ProjectLaunchConfiguration>? launchConfigurations))
+        {
+            // See above regarding how many launch configurations are currently supported.
+            launchConfiguration = launchConfigurations?.FirstOrDefault();
+        }
+
+        return launchConfiguration is not null;
+    }
 }
+
+internal static class ProjectLaunchMode
+{
+    public const string Debug = "Debug";
+    public const string NoDebug = "NoDebug";
+}
+
+internal sealed class ProjectLaunchConfiguration
+{
+    [JsonPropertyName("type")]
+#pragma warning disable CA1822 // We want this member to be non-static, as it is used in serialization.
+    public string Type => "project";
+#pragma warning restore CA1822
+
+    [JsonPropertyName("mode")]
+    public string Mode { get; set; } = System.Diagnostics.Debugger.IsAttached ? ProjectLaunchMode.Debug : ProjectLaunchMode.NoDebug;
+
+    [JsonPropertyName("project_path")]
+    public string ProjectPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("launch_profile")]
+    public string LaunchProfile { get; set; } = string.Empty;
+
+    [JsonPropertyName("disable_launch_profile")]
+    public bool DisableLaunchProfile { get; set; } = false;
+}
+

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -3,6 +3,7 @@
 
 namespace Aspire.Hosting.Dcp.Model;
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -45,12 +46,48 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
         AnnotateAsObjectList<TValue>(Metadata.Annotations, annotationName, value);
     }
 
+    public bool TryGetAnnotationAsObjectList<TValue>(string annotationName, [NotNullWhen(true)] out List<TValue>? list)
+    {
+        list = null;
+
+        if (Metadata.Annotations is null)
+        {
+            return false;
+        }
+
+        string? annotationValue;
+        bool found = Metadata.Annotations.TryGetValue(annotationName, out annotationValue);
+        if (!found || string.IsNullOrWhiteSpace(annotationValue))
+        {
+            return false;
+        }
+
+        try
+        {
+            list = JsonSerializer.Deserialize<List<TValue>>(annotationValue);
+        }
+        catch
+        {
+            return false;
+        }
+
+        return list is not null;
+    }
+
     internal static void AnnotateAsObjectList<TValue>(IDictionary<string, string> annotations, string annotationName, TValue value)
     {
         List<TValue> values;
-        if (annotations.TryGetValue(annotationName, out var annotationVal))
+        if (annotations.TryGetValue(annotationName, out var annotationVal) && !string.IsNullOrWhiteSpace(annotationVal))
         {
-            values = JsonSerializer.Deserialize<List<TValue>>(annotationVal) ?? new();
+            try
+            {
+                values = JsonSerializer.Deserialize<List<TValue>>(annotationVal) ?? new();
+            }
+            catch
+            {
+                values = new();
+            }
+
             if (!values.Contains(value))
             {
                 values.Add(value);
@@ -58,8 +95,7 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
         }
         else
         {
-            values = new();
-            values.Add(value);
+            values = [value];
         }
 
         var newAnnotationVal = JsonSerializer.Serialize(values);

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -9,37 +9,6 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting;
 
-internal enum ContainerRuntimeHealthCheckFailures : int
-{
-    /// <summary>
-    /// Represents the error code for when the check for a valid container runtime timed out.
-    /// </summary>
-    Unresponsive = 125,
-
-    /// <summary>
-    /// Represents the error code for when the container runtime is installed, but isn't healthy.
-    /// </summary>
-    Unhealthy = 126,
-
-    /// <summary>
-    /// Represents the exit code indicating that a prerequisite for running the application are missing.
-    /// </summary>
-    PrerequisiteMissing = 127
-}
-
-internal enum DcpVersionCheckFailures : int
-{
-    /// <summary>
-    /// Represents the exit code indicating that the version of DCP is too low or too high.
-    /// </summary>
-    DcpVersionIncompatible = 128,
-
-    /// <summary>
-    /// Represents the exit code indicating that the DCP version check failed.
-    /// </summary>
-    DcpVersionFailed = 129,
-}
-
 /// <summary>
 /// Represents a distributed application that implements the <see cref="IHost"/> and <see cref="IAsyncDisposable"/> interfaces.
 /// </summary>

--- a/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
@@ -73,7 +73,8 @@ public class ApplicationExecutorTests
             new MockDashboardEndpointProvider(),
             new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run),
             new ResourceNotificationService(new NullLogger<ResourceNotificationService>()),
-            new ResourceLoggerService()
+            new ResourceLoggerService(),
+            new TestDcpDependencyCheckService()
             );
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/TestDcpDependencyCheckService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestDcpDependencyCheckService.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dcp;
+
+namespace Aspire.Hosting.Tests.Dcp;
+internal sealed class TestDcpDependencyCheckService : IDcpDependencyCheckService
+{
+    public Task<DcpInfo?> GetDcpInfoAsync(CancellationToken cancellationToken = default)
+    {
+        var dcpInfo = new DcpInfo
+        {
+            VersionString = DcpVersion.Dev.ToString(),
+            Version = DcpVersion.Dev,
+            Containers = new DcpContainersInfo
+            {
+                Runtime = "docker",
+                Installed = true,
+                Running = true
+            }
+        };
+        return Task.FromResult((DcpInfo?)dcpInfo);
+    }
+}


### PR DESCRIPTION
Because it was decided that we should support the old version of the protocol for one preview release, the code inside `ApplicationExecutor` must do different things depending on the version of DCP it is talking to. As a result, I refactored a bit the DCP version/dependency check. Adding @ReubenBond who I was told is doing some work in this area right now.

Fixes #2928

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3026)