### PR TITLE
Use API key auth for OTLP in local development

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -759,11 +759,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             {
                 Name = "ASPNETCORE_ENVIRONMENT",
                 Value = aspnetcoreEnvironment
-            },
-            new()
-            {
-                Name = "DOTNET_DASHBOARD_OTLP_AUTH_MODE",
-                Value = "ApiKey" // Matches value in OtlpAuthMode enum.
             }
         ];
 

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Net.Sockets;
 using System.Text.Json;
-using System.Xml.Linq;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -764,11 +764,18 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
         if (configuration["AppHost:OtlpApiKey"] is { } otlpApiKey)
         {
-            dashboardExecutableSpec.Env.Add(new()
-            {
-                Name = "DOTNET_DASHBOARD_OTLP_API_KEY",
-                Value = otlpApiKey
-            });
+            dashboardExecutableSpec.Env.AddRange([
+                new()
+                {
+                    Name = "DOTNET_DASHBOARD_OTLP_API_KEY",
+                    Value = otlpApiKey
+                },
+                new()
+                {
+                    Name = "DOTNET_DASHBOARD_OTLP_AUTH_MODE",
+                    Value = "ApiKey" // Matches value in OtlpAuthMode enum.
+                }
+            ]);
         }
 
         var dashboardExecutable = new Executable(dashboardExecutableSpec)

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -679,6 +679,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 throw new DistributedApplicationException("Failed to configure dashboard resource because DOTNET_DASHBOARD_OTLP_ENDPOINT_URL environment variable was not set.");
             }
 
+            if (configuration["AppHost:OtlpApiKey"] is not { } otlpApiKey)
+            {
+                throw new DistributedApplicationException("Couldn't find OTLP API key for the app host.");
+            }
+
             // Grab the resource service URL. We need to inject this into the resource.
 
             var grpcEndpointUrl = await _dashboardEndpointProvider.GetResourceServiceUriAsync(context.CancellationToken).ConfigureAwait(false);
@@ -687,7 +692,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             context.EnvironmentVariables["DOTNET_RESOURCE_SERVICE_ENDPOINT_URL"] = grpcEndpointUrl;
             context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_ENDPOINT_URL"] = otlpEndpointUrl;
             context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_AUTH_MODE"] = "ApiKey"; // Matches value in OtlpAuthMode enum.
-            context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_API_KEY"] = "abc123"; // TODO: Replace with actual API key]
+            context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_API_KEY"] = otlpApiKey;
         }));
     }
 
@@ -764,7 +769,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             new()
             {
                 Name = "DOTNET_DASHBOARD_OTLP_API_KEY",
-                Value = "abc123" // TODO: Replace with actual API key
+                Value = configuration["AppHost:OtlpApiKey"]
             }
         ];
 

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Net.Sockets;
 using System.Text.Json;
+using System.Xml.Linq;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
@@ -686,6 +687,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             context.EnvironmentVariables["ASPNETCORE_URLS"] = appHostApplicationUrl;
             context.EnvironmentVariables["DOTNET_RESOURCE_SERVICE_ENDPOINT_URL"] = grpcEndpointUrl;
             context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_ENDPOINT_URL"] = otlpEndpointUrl;
+            context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_AUTH_MODE"] = "ApiKey"; // Matches value in OtlpAuthMode enum.
+            context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_API_KEY"] = "abc123"; // TODO: Replace with actual API key]
         }));
     }
 
@@ -753,6 +756,16 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             {
                 Name = "ASPNETCORE_ENVIRONMENT",
                 Value = aspnetcoreEnvironment
+            },
+            new()
+            {
+                Name = "DOTNET_DASHBOARD_OTLP_AUTH_MODE",
+                Value = "ApiKey" // Matches value in OtlpAuthMode enum.
+            },
+            new()
+            {
+                Name = "DOTNET_DASHBOARD_OTLP_API_KEY",
+                Value = "abc123" // TODO: Replace with actual API key
             }
         ];
 

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -80,9 +80,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             ["AppHost:Directory"] = AppHostDirectory
         };
 
-        if (_innerBuilder.Configuration[DisableOtlpApiKeyAuthKey] is { } configValue &&
-            bool.TryParse(configValue, out var disableAuth) &&
-            disableAuth)
+        if (!IsOtlpApiKeyAuthDisabled(_innerBuilder.Configuration))
         {
             // Set a random API key for the OTLP exporter.
             // Passed to apps as a standard OTEL attribute to include in OTLP requests and the dashboard to validate.
@@ -128,6 +126,13 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         _innerBuilder.Services.AddSingleton<DistributedApplicationExecutionContext>(ExecutionContext);
         LogBuilderConstructed(this);
+    }
+
+    private static bool IsOtlpApiKeyAuthDisabled(IConfiguration configuration)
+    {
+        return configuration[DisableOtlpApiKeyAuthKey] is { } configValue &&
+            bool.TryParse(configValue, out var disableAuth) &&
+            disableAuth;
     }
 
     private void ConfigurePublishingOptions(DistributedApplicationOptions options)

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -72,10 +72,13 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         AppHostDirectory = options.ProjectDirectory ?? _innerBuilder.Environment.ContentRootPath;
 
-        // Make the app host directory available to the application via configuration
         _innerBuilder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["AppHost:Directory"] = AppHostDirectory
+            // Make the app host directory available to the application via configuration
+            ["AppHost:Directory"] = AppHostDirectory,
+            // Set a random API key for the OTLP exporter.
+            // Passed to apps as a standard OTEL attribute to include in OTLP requests and the dashboard to validate.
+            ["AppHost:OtlpApiKey"] = Guid.NewGuid().ToString()
         });
 
         // Core things

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -36,6 +36,8 @@ public static class OtlpConfigurationExtensions
             }
 
             var url = configuration[DashboardOtlpUrlVariableName] ?? DashboardOtlpUrlDefaultValue;
+            var apiKey = configuration["AppHost:OtlpApiKey"];
+
             context.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = resource is ContainerResource
                 ? HostNameResolver.ReplaceLocalhostWithContainerHost(url, configuration)
                 : url;
@@ -43,7 +45,7 @@ public static class OtlpConfigurationExtensions
             // Set the service name and instance id to the resource name and UID. Values are injected by DCP.
             context.EnvironmentVariables["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id={{- .Name -}}";
             context.EnvironmentVariables["OTEL_SERVICE_NAME"] = "{{- index .Annotations \"otel-service-name\" -}}";
-            context.EnvironmentVariables["OTEL_EXPORTER_OTLP_HEADERS"] = "x-otlp-api-key=abc123";
+            context.EnvironmentVariables["OTEL_EXPORTER_OTLP_HEADERS"] = $"x-otlp-api-key={apiKey}";
 
             // Set a small batch schedule delay in development.
             // This reduces the delay that OTLP exporter waits to sends telemetry and makes the dashboard telemetry pages responsive.

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -36,7 +36,6 @@ public static class OtlpConfigurationExtensions
             }
 
             var url = configuration[DashboardOtlpUrlVariableName] ?? DashboardOtlpUrlDefaultValue;
-            var apiKey = configuration["AppHost:OtlpApiKey"];
 
             context.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = resource is ContainerResource
                 ? HostNameResolver.ReplaceLocalhostWithContainerHost(url, configuration)
@@ -45,7 +44,11 @@ public static class OtlpConfigurationExtensions
             // Set the service name and instance id to the resource name and UID. Values are injected by DCP.
             context.EnvironmentVariables["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id={{- .Name -}}";
             context.EnvironmentVariables["OTEL_SERVICE_NAME"] = "{{- index .Annotations \"otel-service-name\" -}}";
-            context.EnvironmentVariables["OTEL_EXPORTER_OTLP_HEADERS"] = $"x-otlp-api-key={apiKey}";
+
+            if (configuration["AppHost:OtlpApiKey"] is { } otlpApiKey)
+            {
+                context.EnvironmentVariables["OTEL_EXPORTER_OTLP_HEADERS"] = $"x-otlp-api-key={otlpApiKey}";
+            }
 
             // Set a small batch schedule delay in development.
             // This reduces the delay that OTLP exporter waits to sends telemetry and makes the dashboard telemetry pages responsive.

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -36,7 +36,6 @@ public static class OtlpConfigurationExtensions
             }
 
             var url = configuration[DashboardOtlpUrlVariableName] ?? DashboardOtlpUrlDefaultValue;
-
             context.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = resource is ContainerResource
                 ? HostNameResolver.ReplaceLocalhostWithContainerHost(url, configuration)
                 : url;

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -43,6 +43,7 @@ public static class OtlpConfigurationExtensions
             // Set the service name and instance id to the resource name and UID. Values are injected by DCP.
             context.EnvironmentVariables["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id={{- .Name -}}";
             context.EnvironmentVariables["OTEL_SERVICE_NAME"] = "{{- index .Annotations \"otel-service-name\" -}}";
+            context.EnvironmentVariables["OTEL_EXPORTER_OTLP_HEADERS"] = "x-otlp-api-key=abc123";
 
             // Set a small batch schedule delay in development.
             // This reduces the delay that OTLP exporter waits to sends telemetry and makes the dashboard telemetry pages responsive.

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -60,6 +60,13 @@ public class ProjectResourceTests
             },
             env =>
             {
+                Assert.Equal("OTEL_EXPORTER_OTLP_HEADERS", env.Key);
+                var parts = env.Value.Split('=');
+                Assert.Equal("x-otlp-api-key", parts[0]);
+                Assert.True(Guid.TryParse(parts[1], out _));
+            },
+            env =>
+            {
                 Assert.Equal("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION", env.Key);
                 Assert.Equal("true", env.Value);
             },

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -5,6 +5,7 @@ using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Helpers;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -80,6 +81,34 @@ public class ProjectResourceTests
                 Assert.Equal("LOGGING__CONSOLE__FORMATTEROPTIONS__TIMESTAMPFORMAT", env.Key);
                 Assert.Equal("yyyy-MM-ddTHH:mm:ss.fffffff ", env.Value);
             });
+    }
+
+    [Theory]
+    [InlineData("true", false)]
+    [InlineData("1", false)]
+    [InlineData("false", true)]
+    [InlineData("0", true)]
+    [InlineData(null, true)]
+    public async Task AddProjectAddsEnvironmentVariablesAndServiceMetadata_OtlpAuthDisabledSetting(string? value, bool hasHeader)
+    {
+        var appBuilder = CreateBuilder();
+        appBuilder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["DOTNET_DISABLE_OTLP_API_KEY_AUTH"] = value
+        });
+
+        appBuilder.AddProject<TestProject>("projectName", launchProfileName: null);
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var projectResources = appModel.GetProjectResources();
+
+        var resource = Assert.Single(projectResources);
+        Assert.Equal("projectName", resource.Name);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
+
+        Assert.Equal(hasHeader, config.ContainsKey("OTEL_EXPORTER_OTLP_HEADERS"));
     }
 
     [Fact]


### PR DESCRIPTION
Previous PR added API key auth to OTLP endpoint. There is the opportunity to secure the local dev environment by using API key auth and having the host co-ordinate the dashboard and user apps.

This PR:
* Generates a random API key each time the app host is run.
* Passes environment variables to dashboard to enable API key auth, and the expected API key.
* Passes environment variables to ups to add API key header to OTLP requests.
* Can be disabled by passing `DOTNET_DISABLE_OTLP_API_KEY_AUTH=true` setting to apphost.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3031)