### PR TITLE
Always require OTLP auth mode config when starting dashboard

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -22,6 +22,7 @@ namespace Aspire.Dashboard;
 
 public class DashboardWebApplication : IAsyncDisposable
 {
+    internal const string DashboardInsecureAllowAnonymousVariableName = "DOTNET_DASHBOARD_INSECURE_ALLOW_ANONYMOUS";
     internal const string DashboardOtlpAuthModeVariableName = "DOTNET_DASHBOARD_OTLP_AUTH_MODE";
     internal const string DashboardOtlpApiKeyVariableName = "DOTNET_DASHBOARD_OTLP_API_KEY";
     internal const string DashboardOtlpUrlVariableName = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL";
@@ -390,21 +391,19 @@ public class DashboardWebApplication : IAsyncDisposable
             throw new InvalidOperationException($"At least one URL for Aspire dashboard browser endpoint with {DashboardOtlpUrlDefaultValue} is required.");
         }
 
-        OtlpAuthMode otlpAuthMode;
+        var allowAnonymous = configuration.GetBool(DashboardInsecureAllowAnonymousVariableName) ?? false;
+        var otlpAuthMode = configuration.GetEnum<OtlpAuthMode>(DashboardOtlpAuthModeVariableName);
         string? otlpApiKey = null;
-
-        if (configuration[DashboardOtlpAuthModeVariableName] is not { } v)
-        {
-            throw new InvalidOperationException($"Configuration of OTLP endpoint authentication with {DashboardOtlpAuthModeVariableName} is required. Possible values: {string.Join(", ", typeof(OtlpAuthMode).GetEnumNames())}");
-        }
-
-        if (!Enum.TryParse(v, ignoreCase: true, out otlpAuthMode))
-        {
-            throw new InvalidOperationException($"Unknown {nameof(OtlpAuthMode)} value: {v}");
-        }
 
         switch (otlpAuthMode)
         {
+            case null:
+                if (!allowAnonymous)
+                {
+                    throw new InvalidOperationException($"Configuration of OTLP endpoint authentication is required. Either specify {DashboardInsecureAllowAnonymousVariableName} with a value of true, or specify {DashboardOtlpAuthModeVariableName}. Possible values: {string.Join(", ", typeof(OtlpAuthMode).GetEnumNames())}");
+                }
+                otlpAuthMode = OtlpAuthMode.None;
+                break;
             case OtlpAuthMode.None:
                 break;
             case OtlpAuthMode.ApiKey:
@@ -428,7 +427,7 @@ public class DashboardWebApplication : IAsyncDisposable
         {
             BrowserUris = browserUris,
             OtlpUri = otlpUris[0],
-            OtlpAuthMode = otlpAuthMode,
+            OtlpAuthMode = otlpAuthMode.Value,
             OtlpApiKey = otlpApiKey
         };
     }

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -393,37 +393,35 @@ public class DashboardWebApplication : IAsyncDisposable
         OtlpAuthMode otlpAuthMode;
         string? otlpApiKey = null;
 
-        if (configuration[DashboardOtlpAuthModeVariableName] is { } v)
-        {
-            if (!Enum.TryParse(v, ignoreCase: true, out otlpAuthMode))
-            {
-                throw new InvalidOperationException($"Unknown {nameof(OtlpAuthMode)} value: {v}");
-            }
-
-            switch (otlpAuthMode)
-            {
-                case OtlpAuthMode.None:
-                    break;
-                case OtlpAuthMode.ApiKey:
-                    otlpApiKey = configuration[DashboardOtlpApiKeyVariableName];
-                    if (string.IsNullOrEmpty(otlpApiKey))
-                    {
-                        throw new InvalidOperationException($"{DashboardOtlpAuthModeVariableName} value of {nameof(OtlpAuthMode.ApiKey)} requires an API key from {DashboardOtlpApiKeyVariableName}.");
-                    }
-                    break;
-                case OtlpAuthMode.ClientCertificate:
-                    if (!IsHttps(otlpUris[0]))
-                    {
-                        throw new InvalidOperationException($"{DashboardOtlpAuthModeVariableName} value of {nameof(OtlpAuthMode.ClientCertificate)} requires a HTTPS OTLP endpoint.");
-                    }
-                    break;
-                default:
-                    throw new InvalidOperationException($"Unexpected auth mode value: {otlpAuthMode}");
-            }
-        }
-        else
+        if (configuration[DashboardOtlpAuthModeVariableName] is not { } v)
         {
             throw new InvalidOperationException($"Configuration of OTLP endpoint authentication with {DashboardOtlpAuthModeVariableName} is required. Possible values: {string.Join(", ", typeof(OtlpAuthMode).GetEnumNames())}");
+        }
+
+        if (!Enum.TryParse(v, ignoreCase: true, out otlpAuthMode))
+        {
+            throw new InvalidOperationException($"Unknown {nameof(OtlpAuthMode)} value: {v}");
+        }
+
+        switch (otlpAuthMode)
+        {
+            case OtlpAuthMode.None:
+                break;
+            case OtlpAuthMode.ApiKey:
+                otlpApiKey = configuration[DashboardOtlpApiKeyVariableName];
+                if (string.IsNullOrEmpty(otlpApiKey))
+                {
+                    throw new InvalidOperationException($"{DashboardOtlpAuthModeVariableName} value of {nameof(OtlpAuthMode.ApiKey)} requires an API key from {DashboardOtlpApiKeyVariableName}.");
+                }
+                break;
+            case OtlpAuthMode.ClientCertificate:
+                if (!IsHttps(otlpUris[0]))
+                {
+                    throw new InvalidOperationException($"{DashboardOtlpAuthModeVariableName} value of {nameof(OtlpAuthMode.ClientCertificate)} requires a HTTPS OTLP endpoint.");
+                }
+                break;
+            default:
+                throw new InvalidOperationException($"Unexpected auth mode value: {otlpAuthMode}");
         }
 
         return new DashboardStartupConfiguration

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -418,12 +418,12 @@ public class DashboardWebApplication : IAsyncDisposable
                     }
                     break;
                 default:
-                    break;
+                    throw new InvalidOperationException($"Unexpected auth mode value: {otlpAuthMode}");
             }
         }
         else
         {
-            otlpAuthMode = OtlpAuthMode.None;
+            throw new InvalidOperationException($"Configuration of OTLP endpoint authentication with {DashboardOtlpAuthModeVariableName} is required. Possible values: {string.Join(", ", typeof(OtlpAuthMode).GetEnumNames())}");
         }
 
         return new DashboardStartupConfiguration

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -739,6 +739,10 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_AUTH_MODE"] = "ApiKey"; // Matches value in OtlpAuthMode enum.
                 context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_API_KEY"] = otlpApiKey;
             }
+            else
+            {
+                context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_AUTH_MODE"] = "None"; // Matches value in OtlpAuthMode enum.
+            }
         }));
     }
 
@@ -821,6 +825,16 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 {
                     Name = "DOTNET_DASHBOARD_OTLP_AUTH_MODE",
                     Value = "ApiKey" // Matches value in OtlpAuthMode enum.
+                }
+            ]);
+        }
+        else
+        {
+            dashboardExecutableSpec.Env.AddRange([
+                new()
+                {
+                    Name = "DOTNET_DASHBOARD_OTLP_AUTH_MODE",
+                    Value = "None" // Matches value in OtlpAuthMode enum.
                 }
             ]);
         }

--- a/src/Shared/IConfigurationExtensions.cs
+++ b/src/Shared/IConfigurationExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Configuration;
 
 namespace Aspire;
 

--- a/src/Shared/IConfigurationExtensions.cs
+++ b/src/Shared/IConfigurationExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Configuration;
 
 namespace Aspire;
 
@@ -116,6 +115,38 @@ internal static class IConfigurationExtensions
         catch (Exception ex)
         {
             throw new InvalidOperationException($"Error parsing URIs from configuration value '{key}'.", ex);
+        }
+    }
+
+    public static TEnum? GetEnum<TEnum>(this IConfiguration configuration, string key, TEnum? defaultValue = null) where TEnum : struct, Enum
+    {
+        try
+        {
+            var value = configuration[key];
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return defaultValue switch
+                {
+                    not null => defaultValue,
+                    null => null
+                };
+            }
+            else
+            {
+                if (Enum.TryParse<TEnum>(value, ignoreCase: true, out var e))
+                {
+                    return e;
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Unknown {nameof(TEnum)} value: {value}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Error parsing {nameof(TEnum)} from configuration value '{key}'.", ex);
         }
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography.X509Certificates;
+using Aspire.Dashboard.Authentication;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Net.Client.Configuration;
@@ -27,7 +28,8 @@ public static class IntegrationTestHelpers
         var initialData = new Dictionary<string, string?>
         {
             [DashboardWebApplication.DashboardUrlVariableName] = "http://127.0.0.1:0",
-            [DashboardWebApplication.DashboardOtlpUrlVariableName] = "http://127.0.0.1:0"
+            [DashboardWebApplication.DashboardOtlpUrlVariableName] = "http://127.0.0.1:0",
+            [DashboardWebApplication.DashboardOtlpAuthModeVariableName] = nameof(OtlpAuthMode.None)
         };
         additionalConfiguration?.Invoke(initialData);
 

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -138,6 +138,23 @@ public class StartupTests
     }
 
     [Fact]
+    public async Task Configuration_NoOtlpAuthMode_Error()
+    {
+        // Arrange & Act
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper,
+                additionalConfiguration: data =>
+                {
+                    data.Remove(DashboardWebApplication.DashboardOtlpAuthModeVariableName);
+                });
+        });
+
+        // Assert
+        Assert.Equal("Configuration of OTLP endpoint authentication with DOTNET_DASHBOARD_OTLP_AUTH_MODE is required. Possible values: None, ApiKey, ClientCertificate", ex.Message);
+    }
+
+    [Fact]
     public async Task LogOutput_DynamicPort_PortResolvedInLogs()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -151,7 +151,26 @@ public class StartupTests
         });
 
         // Assert
-        Assert.Equal("Configuration of OTLP endpoint authentication with DOTNET_DASHBOARD_OTLP_AUTH_MODE is required. Possible values: None, ApiKey, ClientCertificate", ex.Message);
+        Assert.Equal("Configuration of OTLP endpoint authentication is required. Either specify DOTNET_DASHBOARD_INSECURE_ALLOW_ANONYMOUS with a value of true, or specify DOTNET_DASHBOARD_OTLP_AUTH_MODE. Possible values: None, ApiKey, ClientCertificate", ex.Message);
+    }
+
+    [Fact]
+    public async Task Configuration_AllowAnonymous_NoError()
+    {
+        // Arrange
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper,
+            additionalConfiguration: data =>
+            {
+                data.Remove(DashboardWebApplication.DashboardOtlpAuthModeVariableName);
+                data[DashboardWebApplication.DashboardInsecureAllowAnonymousVariableName] = bool.TrueString;
+            });
+
+        // Act
+        await app.StartAsync();
+
+        // Assert
+        AssertDynamicIPEndpoint(app.BrowserEndPointAccessor);
+        AssertDynamicIPEndpoint(app.OtlpServiceEndPointAccessor);
     }
 
     [Fact]


### PR DESCRIPTION
Require OTLP auth mode when starting the dashboard so users must make an explicit decision to have no auth.

@davidfowl FYI, this was review feedback.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3036)