### PR TITLE
Support configuring dashboard with one endpoint for browser and OTLP

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -209,24 +209,34 @@ public class DashboardWebApplication : IAsyncDisposable
     // possible from the caller. e.g., using environment variables to configure each endpoint's TLS certificate.
     private void ConfigureKestrelEndpoints(WebApplicationBuilder builder, DashboardStartupConfiguration dashboardStartupConfig)
     {
-        // Translate high-level config settings such as DOTNET_DASHBOARD_OTLP_ENDPOINT_URL and ASPNETCORE_URLS
-        // to Kestrel's schema for loading endpoints from configuration.
-        var browserEndpointNames = new List<string>(capacity: dashboardStartupConfig.BrowserUris.Length);
+        var singleEndpoint = dashboardStartupConfig.BrowserUris.Length == 1 && dashboardStartupConfig.BrowserUris[0] == dashboardStartupConfig.OtlpUri;
+
         var initialValues = new Dictionary<string, string?>();
-        AddEndpointConfiguration(initialValues, "Otlp", dashboardStartupConfig.OtlpUri.OriginalString, HttpProtocols.Http2, requiredClientCertificate: dashboardStartupConfig.OtlpAuthMode == OtlpAuthMode.ClientCertificate);
-        if (dashboardStartupConfig.BrowserUris.Length == 1)
+        var browserEndpointNames = new List<string>(capacity: dashboardStartupConfig.BrowserUris.Length);
+
+        if (!singleEndpoint)
         {
-            browserEndpointNames.Add("Browser");
-            AddEndpointConfiguration(initialValues, "Browser", dashboardStartupConfig.BrowserUris[0].OriginalString);
+            // Translate high-level config settings such as DOTNET_DASHBOARD_OTLP_ENDPOINT_URL and ASPNETCORE_URLS
+            // to Kestrel's schema for loading endpoints from configuration.
+            AddEndpointConfiguration(initialValues, "Otlp", dashboardStartupConfig.OtlpUri.OriginalString, HttpProtocols.Http2, requiredClientCertificate: dashboardStartupConfig.OtlpAuthMode == OtlpAuthMode.ClientCertificate);
+            if (dashboardStartupConfig.BrowserUris.Length == 1)
+            {
+                browserEndpointNames.Add("Browser");
+                AddEndpointConfiguration(initialValues, "Browser", dashboardStartupConfig.BrowserUris[0].OriginalString);
+            }
+            else
+            {
+                for (var i = 0; i < dashboardStartupConfig.BrowserUris.Length; i++)
+                {
+                    var name = $"Browser{i}";
+                    browserEndpointNames.Add(name);
+                    AddEndpointConfiguration(initialValues, name, dashboardStartupConfig.BrowserUris[i].OriginalString);
+                }
+            }
         }
         else
         {
-            for (var i = 0; i < dashboardStartupConfig.BrowserUris.Length; i++)
-            {
-                var name = $"Browser{i}";
-                browserEndpointNames.Add(name);
-                AddEndpointConfiguration(initialValues, name, dashboardStartupConfig.BrowserUris[i].OriginalString);
-            }
+            AddEndpointConfiguration(initialValues, "Otlp", dashboardStartupConfig.OtlpUri.OriginalString, HttpProtocols.Http2, requiredClientCertificate: dashboardStartupConfig.OtlpAuthMode == OtlpAuthMode.ClientCertificate);
         }
 
         static void AddEndpointConfiguration(Dictionary<string, string?> values, string endpointName, string url, HttpProtocols? protocols = null, bool requiredClientCertificate = false)
@@ -250,8 +260,10 @@ public class DashboardWebApplication : IAsyncDisposable
         // with extra settings. e.g., UseOtlpConnection for the OTLP endpoint.
         builder.WebHost.ConfigureKestrel((context, serverOptions) =>
         {
-            var kestrelSection = context.Configuration.GetSection("Kestrel");
+            var logger = serverOptions.ApplicationServices.GetRequiredService<ILogger<DashboardWebApplication>>();
+            logger.LogDebug("Configuring Kestrel endpoints.");
 
+            var kestrelSection = context.Configuration.GetSection("Kestrel");
             var configurationLoader = serverOptions.Configure(kestrelSection);
 
             foreach (var browserEndpointName in browserEndpointNames)
@@ -267,6 +279,12 @@ public class DashboardWebApplication : IAsyncDisposable
             configurationLoader.Endpoint("Otlp", endpointConfiguration =>
             {
                 _otlpServiceEndPointAccessor = CreateEndPointAccessor(endpointConfiguration.ListenOptions, endpointConfiguration.IsHttps);
+                if (singleEndpoint)
+                {
+                    logger.LogDebug("Browser and OTLP accessible on a single endpoint.");
+                    _browserEndPointAccessor = _otlpServiceEndPointAccessor;
+                }
+
                 endpointConfiguration.ListenOptions.UseOtlpConnection();
 
                 if (endpointConfiguration.HttpsOptions.ClientCertificateMode == ClientCertificateMode.RequireCertificate)

--- a/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Net.NetworkInformation;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Dashboard.Tests.Integration;
+
+public static class ServerRetryHelper
+{
+    private const int RetryCount = 20;
+
+    /// <summary>
+    /// Retry a func. Useful when a test needs an explicit port and you want to avoid port conflicts.
+    /// </summary>
+    public static async Task BindPortsWithRetry(Func<int, Task> retryFunc, ILogger logger)
+    {
+        var retryCount = 0;
+
+        // Add a random number to starting port to reduce chance of conflicts because of multiple tests using this retry.
+        var nextPortAttempt = 30000 + Random.Shared.Next(10000);
+
+        while (true)
+        {
+            // Find a port that's available for TCP and UDP. Start with the given port search upwards from there.
+            var port = GetAvailablePort(nextPortAttempt, logger);
+
+            try
+            {
+                await retryFunc(port);
+                break;
+            }
+            catch (Exception ex)
+            {
+                retryCount++;
+                nextPortAttempt = port + Random.Shared.Next(100);
+
+                if (retryCount >= RetryCount)
+                {
+                    throw;
+                }
+                else
+                {
+                    logger.LogError(ex, "Error running test {retryCount}. Retrying.", retryCount);
+                }
+            }
+        }
+    }
+
+    private static int GetAvailablePort(int startingPort, ILogger logger)
+    {
+        logger.LogInformation("Searching for free port starting at {startingPort}.", startingPort);
+
+        var unavailableEndpoints = new List<IPEndPoint>();
+
+        var properties = IPGlobalProperties.GetIPGlobalProperties();
+
+        // Ignore active connections
+        AddEndpoints(startingPort, unavailableEndpoints, properties.GetActiveTcpConnections().Select(c => c.LocalEndPoint));
+
+        // Ignore active tcp listners
+        AddEndpoints(startingPort, unavailableEndpoints, properties.GetActiveTcpListeners());
+
+        // Ignore active UDP listeners
+        AddEndpoints(startingPort, unavailableEndpoints, properties.GetActiveUdpListeners());
+
+        logger.LogInformation("Found {count} unavailable endpoints.", unavailableEndpoints.Count);
+
+        for (var i = startingPort; i < ushort.MaxValue; i++)
+        {
+            var match = unavailableEndpoints.FirstOrDefault(ep => ep.Port == i);
+            if (match == null)
+            {
+                logger.LogInformation("Port {i} free.", i);
+                return i;
+            }
+            else
+            {
+                logger.LogInformation("Port {i} in use. End point: {match}", i, match);
+            }
+        }
+
+        throw new InvalidOperationException($"Couldn't find a free port after {startingPort}.");
+
+        static void AddEndpoints(int startingPort, List<IPEndPoint> endpoints, IEnumerable<IPEndPoint> activeEndpoints)
+        {
+            foreach (IPEndPoint endpoint in activeEndpoints)
+            {
+                if (endpoint.Port >= startingPort)
+                {
+                    endpoints.Add(endpoint);
+                }
+            }
+        }
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ServerRetryHelper.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Dashboard.Tests.Integration;
 
+// Copied from https://github.com/dotnet/aspnetcore/blob/1b2e5286b089fa1cab90ba8692c2df7ca6f9c077/src/Servers/Kestrel/shared/test/ServerRetryHelper.cs
 public static class ServerRetryHelper
 {
     private const int RetryCount = 20;

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -80,23 +80,6 @@ public class StartupTests
     }
 
     [Fact]
-    public async Task Configuration_NoOtlpAuthMode_Error()
-    {
-        // Arrange & Act
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-        {
-            await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper,
-                additionalConfiguration: data =>
-                {
-                    data.Remove(DashboardWebApplication.DashboardOtlpAuthModeVariableName);
-                });
-        });
-
-        // Assert
-        Assert.Equal("Configuration of OTLP endpoint authentication with DOTNET_DASHBOARD_OTLP_AUTH_MODE is required. Possible values: None, ApiKey, ClientCertificate", ex.Message);
-    }
-
-    [Fact]
     public async Task LogOutput_DynamicPort_PortResolvedInLogs()
     {
         // Arrange


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2756

If the dashboard was started with the same port for OTLP and browser endpoints, two endpoints were started and the dashboard fails because of a port conflict.

This PR changes the dashboard:
* Check if configured endpoints are the same, and if they are then only one endpoint is started. This allows the dashboard to be hosted in a single port environment such as Windows Azure App Service - https://github.com/Azure/app-service-linux-docs/blob/master/HowTo/gRPC/Windows/README.md
* Checks single endpoint for HTTPS. If it isn't secured with HTTPS, then a warning is logged that browser access is only possible via a proxy that terminates TSL.

TODO: Update dashboard readme.