### PR TITLE
Point to Kubernetes C# client logic from IsInKubernetesCluster()

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/DnsSrvServiceEndPointResolverProvider.cs
@@ -122,6 +122,8 @@ internal sealed partial class DnsSrvServiceEndPointResolverProvider(
 
     private static bool IsInKubernetesCluster()
     {
+        // This logic is based on the Kubernetes C# client logic found here:
+        // https://github.com/kubernetes-client/csharp/blob/52c3c00d4c55b28bdb491a219f4967823a83df2d/src/KubernetesClient/KubernetesClientConfiguration.InCluster.cs#L21
         var host = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST");
         var port = Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_PORT");
         if (string.IsNullOrEmpty(host) || string.IsNullOrEmpty(port))


### PR DESCRIPTION
This PR adds a comment to point readers to the C# Kubernetes client logic which `IsInKubernetesCluster()` is derived from.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3049)