### PR TITLE
Removing untriaged label automation

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -1,6 +1,6 @@
 id: labelManagement.issueOpened
 name: New Issues
-description: Adds untriaged label to new issues
+description: Adds CodeFlow link to new PRs
 owner:
 resource: repository
 disabled: false
@@ -8,14 +8,6 @@ where:
 configuration:
   resourceManagementConfiguration:
     eventResponderTasks:
-      - description: Add untriaged to new issues
-        if:
-          - payloadType: Issues
-          - isAction:
-              action: Opened
-        then:
-          - addLabel:
-              label: untriaged
       - description: Add CodeFlow link to new PRs
         if:
           - payloadType: Pull_Request


### PR DESCRIPTION
As discussed in our workitem triaging meeting, `untriaged` label isn't really useful as we consider an issue "untriaged" whenever it doesn't have a milestone. Given that definition and to remove the redudant label, this PR is removing the automation that always adds the label to new issues.

After this goes in, I will delete the label.

cc: @DamianEdwards 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3053)