### PR TITLE
Optionally retrieve the container host from dcp info once that's available upstream

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -92,7 +92,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
     private readonly ConcurrentDictionary<IResource, bool> _hiddenResources = new();
     private DcpInfo? _dcpInfo;
 
-    private string DefaultContainerHostName => configuration["AppHost:ContainerHostname"] ?? _dcpInfo?.Containers?.HostName ?? "host.docker.internal";
+    private string DefaultContainerHostName => configuration["AppHost:ContainerHostname"] ?? _dcpInfo?.Containers?.ContainerHostName ?? "host.docker.internal";
 
     public async Task RunApplicationAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -92,7 +92,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
     private readonly ConcurrentDictionary<IResource, bool> _hiddenResources = new();
     private DcpInfo? _dcpInfo;
 
-    private string DefaultContainerHostName => configuration["AppHost:ContainerHostname"] ?? _dcpInfo?.Containers?.ContainerHostName ?? "host.docker.internal";
+    private string DefaultContainerHostName => configuration["AppHost:ContainerHostname"] ?? _dcpInfo?.Containers?.HostName ?? "host.docker.internal";
 
     public async Task RunApplicationAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
+++ b/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
@@ -38,4 +38,11 @@ internal sealed class DcpContainersInfo
 
     [JsonPropertyName("hostName")]
     public string? HostName { get; set; }
+
+    internal string ContainerHostName =>
+        HostName ?? Runtime switch
+        {
+            "podman" => "host.containers.internal",
+            _ => "host.docker.internal",
+        };
 }

--- a/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
+++ b/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
@@ -36,10 +36,6 @@ internal sealed class DcpContainersInfo
     [JsonPropertyName("error")]
     public string? Error { get; set; }
 
-    internal string ContainerHostName =>
-        Runtime switch
-        {
-            "podman" => "host.containers.internal",
-            _ => "host.docker.internal",
-        };
+    [JsonPropertyName("hostName")]
+    public string? HostName { get; set; }
 }


### PR DESCRIPTION
This adds support for DCP info passing back the host once that's available upstream (while keeping the existing fallbacks that were added).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3054)