### PR TITLE
Fix SQL Server container mount helper methods

### DIFF
--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -29,17 +29,17 @@ public static class KafkaBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a named volume for the data folder to a KafkaServer container resource.
+    /// Adds a named volume for the data folder to a Kafka container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name. </param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<KafkaServerResource> WithDataVolume(this IResourceBuilder<KafkaServerResource> builder, string? name = null, bool isReadOnly = false)
         => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/lib/kafka/data", isReadOnly);
 
     /// <summary>
-    /// Adds a bind mount for the data folder to a KafkaServer container resource.
+    /// Adds a bind mount for the data folder to a Kafka container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -73,17 +73,17 @@ public static class MongoDBBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a named volume for the data folder to a MongoDb container resource.
+    /// Adds a named volume for the data folder to a MongoDB container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name. </param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<MongoDBServerResource> WithDataVolume(this IResourceBuilder<MongoDBServerResource> builder, string? name = null, bool isReadOnly = false)
         => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/data/db", isReadOnly);
 
     /// <summary>
-    /// Adds a bind mount for the data folder to a MongoDb container resource.
+    /// Adds a bind mount for the data folder to a MongoDB container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>
@@ -93,7 +93,7 @@ public static class MongoDBBuilderExtensions
         => builder.WithBindMount(source, "/data/db", isReadOnly);
 
     /// <summary>
-    /// Adds a bind mount for the init folder to a MongoDb container resource.
+    /// Adds a bind mount for the init folder to a MongoDB container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -84,7 +84,7 @@ public static class MySqlBuilderExtensions
     /// Adds a named volume for the data folder to a MySql container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name. </param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<MySqlServerResource> WithDataVolume(this IResourceBuilder<MySqlServerResource> builder, string? name = null, bool isReadOnly = false)

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -67,16 +67,16 @@ public static class OracleDatabaseBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a named volume for the data folder to a OracleDatabaseServer container resource.
+    /// Adds a named volume for the data folder to a Oracle Database server container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name. </param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<OracleDatabaseServerResource> WithDataVolume(this IResourceBuilder<OracleDatabaseServerResource> builder, string? name = null)
         => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/opt/oracle/oradata", true);
 
     /// <summary>
-    /// Adds a bind mount for the data folder to a OracleDatabaseServer container resource.
+    /// Adds a bind mount for the data folder to a Oracle Database server container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>
@@ -85,7 +85,7 @@ public static class OracleDatabaseBuilderExtensions
         => builder.WithBindMount(source, "/opt/oracle/oradata", false);
 
     /// <summary>
-    /// Adds a bind mount for the init folder to a OracleDatabaseServer container resource.
+    /// Adds a bind mount for the init folder to a Oracle Database server container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>
@@ -95,7 +95,7 @@ public static class OracleDatabaseBuilderExtensions
         => builder.WithBindMount(source, "/opt/oracle/scripts/startup", isReadOnly);
 
     /// <summary>
-    /// Adds a bind mount for the database setup folder to a OracleDatabaseServer container resource.
+    /// Adds a bind mount for the database setup folder to a Oracle Database server container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -102,7 +102,7 @@ public static class PostgresBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a named volume for the data folder to a Postgres container resource.
+    /// Adds a named volume for the data folder to a PostgreSQL container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
@@ -112,7 +112,7 @@ public static class PostgresBuilderExtensions
         => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/lib/postgresql/data", isReadOnly);
 
     /// <summary>
-    /// Adds a bind mount for the data folder to a Postgres container resource.
+    /// Adds a bind mount for the data folder to a PostgreSQL container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>
@@ -122,7 +122,7 @@ public static class PostgresBuilderExtensions
         => builder.WithBindMount(source, "/var/lib/postgresql/data", isReadOnly);
 
     /// <summary>
-    /// Adds a bind mount for the init folder to a Postgres container resource.
+    /// Adds a bind mount for the init folder to a PostgreSQL container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -34,7 +34,7 @@ public static class RabbitMQBuilderExtensions
     /// Adds a named volume for the data folder to a RabbitMQ container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name. </param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<RabbitMQServerResource> WithDataVolume(this IResourceBuilder<RabbitMQServerResource> builder, string? name = null, bool isReadOnly = false)

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -66,7 +66,7 @@ public static class RedisBuilderExtensions
     /// </code>
     /// </remarks>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name. </param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
     /// <param name="isReadOnly">
     /// A flag that indicates if this is a read-only volume. Setting this to <c>true</c> will disable Redis persistence.<br/>
     /// Defaults to <c>false</c>.

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -52,42 +52,22 @@ public static class SqlServerBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a named volume for the log folder to a SqlServer resource.
+    /// Adds a named volume for the data folder to a SQL Server resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name. </param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<SqlServerServerResource> WithDataVolume(this IResourceBuilder<SqlServerServerResource> builder, string? name = null, bool isReadOnly = false)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/opt/mssql/data", isReadOnly);
+        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/opt/mssql", isReadOnly);
 
     /// <summary>
-    /// Adds a bind mount for the log folder to a SqlServer resource.
+    /// Adds a bind mount for the data folder to a SQL Server resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only mount.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<SqlServerServerResource> WithDataBindMount(this IResourceBuilder<SqlServerServerResource> builder, string source, bool isReadOnly = false)
-        => builder.WithBindMount(source, "/var/opt/mssql/data", isReadOnly);
-
-    /// <summary>
-    /// Adds a named volume for the log folder to a SqlServer container resource.
-    /// </summary>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name. </param>
-    /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<SqlServerServerResource> WithLogsVolume(this IResourceBuilder<SqlServerServerResource> builder, string? name = null, bool isReadOnly = false)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-logs", "/var/opt/mssql/log", isReadOnly);
-
-    /// <summary>
-    /// Adds a bind mount for the log folder to a SqlServer container resource.
-    /// </summary>
-    /// <param name="builder">The resource builder.</param>
-    /// <param name="source">The source directory on the host to mount into the container.</param>
-    /// <param name="isReadOnly">A flag that indicates if this is a read-only mount.</param>
-    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<SqlServerServerResource> WithLogsBindMount(this IResourceBuilder<SqlServerServerResource> builder, string source, bool isReadOnly = false)
-        => builder.WithBindMount(source, "/var/opt/mssql/log", isReadOnly);
+        => builder.WithBindMount(source, "/var/opt/mssql", isReadOnly);
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -116,7 +116,7 @@ public class ResourceLoggerService
         /// <summary>
         /// Watch for changes to the log stream for a resource.
         /// </summary>
-        /// <returns> The log stream for the resource. </returns>
+        /// <returns>The log stream for the resource.</returns>
         public IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>> WatchAsync()
         {
             lock (_backlog)

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -139,7 +139,7 @@ public class ResourceNotificationService(ILogger<ResourceNotificationService> lo
 /// <summary>
 /// Represents a change in the state of a resource.
 /// </summary>
-/// <param name="resource">The resource associated with the event. </param>
+/// <param name="resource">The resource associated with the event.</param>
 /// <param name="resourceId">The unique id of the resource.</param>
 /// <param name="snapshot">The snapshot of the resource state.</param>
 public class ResourceEvent(IResource resource, string resourceId, CustomResourceSnapshot snapshot)


### PR DESCRIPTION
This removes the `WithLogsBindMount` and `WithLogsVolume` methods for the SQL Server resource in favor of just the `WithDataBindMount` and `WithDataVolume` methods pointing to `/var/opt/mssql`. The [SQL Server docs on this](https://learn.microsoft.com/sql/linux/sql-server-linux-docker-container-configure?view=sql-server-ver16&pivots=cs1-bash#persist) are a bit confusing as the examples show mounting to sub directories but the actual text says to mount to `/var/opt/mssql` and in my testing locally trying to mount a new volume directly to `/var/opt/mssql/data` or `/var/opt/mssql/logs` fails with permissions errors.
 
I cleaned up naming of resources and some extra whitespace in other doc comments too.

Fixes #3056

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3057)