### PR TITLE
Fix resource outgoing peer resolver not raising change event for initial snapshot

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -28,10 +28,15 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
         {
             var (snapshot, subscription) = await resourceService.SubscribeResourcesAsync(_watchContainersTokenSource.Token).ConfigureAwait(false);
 
-            foreach (var resource in snapshot)
+            if (snapshot.Length > 0)
             {
-                var added = _resourceByName.TryAdd(resource.Name, resource);
-                Debug.Assert(added, "Should not receive duplicate resources in initial snapshot data.");
+                foreach (var resource in snapshot)
+                {
+                    var added = _resourceByName.TryAdd(resource.Name, resource);
+                    Debug.Assert(added, "Should not receive duplicate resources in initial snapshot data.");
+                }
+
+                await RaisePeerChangesAsync().ConfigureAwait(false);
             }
 
             await foreach (var changes in subscription.WithCancellation(_watchContainersTokenSource.Token))

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Frozen;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Aspire.Dashboard.Model;
 using Google.Protobuf.WellKnownTypes;
 using Xunit;
@@ -129,8 +131,64 @@ public class ResourceOutgoingPeerResolverTests
         Assert.Equal("test", value);
     }
 
+    [Fact]
+    public async Task OnPeerChanges_DataUpdates_EventRaised()
+    {
+        // Arrange
+        var tcs = new TaskCompletionSource<ResourceViewModelSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sourceChannel = Channel.CreateUnbounded<ResourceViewModelChange>();
+        var resultChannel = Channel.CreateUnbounded<int>();
+        var dashboardClient = new MockDashboardClient(tcs.Task);
+        var resolver = new ResourceOutgoingPeerResolver(dashboardClient);
+        var changeCount = 1;
+        resolver.OnPeerChanges(async () =>
+        {
+            await resultChannel.Writer.WriteAsync(changeCount++);
+        });
+
+        var readValue = 0;
+        Assert.False(resultChannel.Reader.TryRead(out readValue));
+
+        // Act 1
+        tcs.SetResult(new ResourceViewModelSubscription(
+            [CreateResource("test")],
+            GetChanges()));
+
+        // Assert 1
+        readValue = await resultChannel.Reader.ReadAsync();
+        Assert.Equal(1, readValue);
+
+        // Act 2
+        await sourceChannel.Writer.WriteAsync(new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, CreateResource("test2")));
+
+        // Assert 2
+        readValue = await resultChannel.Reader.ReadAsync();
+        Assert.Equal(2, readValue);
+
+        await resolver.DisposeAsync();
+
+        async IAsyncEnumerable<IReadOnlyList<ResourceViewModelChange>> GetChanges([EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await foreach (var item in sourceChannel.Reader.ReadAllAsync(cancellationToken))
+            {
+                yield return [item];
+            }
+        }
+    }
+
     private static bool TryResolvePeerName(IDictionary<string, ResourceViewModel> resources, KeyValuePair<string, string>[] attributes, out string? peerName)
     {
         return ResourceOutgoingPeerResolver.TryResolvePeerNameCore(resources, attributes, out peerName);
+    }
+
+    private sealed class MockDashboardClient(Task<ResourceViewModelSubscription> subscribeResult) : IDashboardClient
+    {
+        public bool IsEnabled => true;
+        public Task WhenConnected => Task.CompletedTask;
+        public string ApplicationName => "<marquee>An HTML title!</marquee>";
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken) => subscribeResult;
     }
 }

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -185,7 +185,7 @@ public class ResourceOutgoingPeerResolverTests
     {
         public bool IsEnabled => true;
         public Task WhenConnected => Task.CompletedTask;
-        public string ApplicationName => "<marquee>An HTML title!</marquee>";
+        public string ApplicationName => "ApplicationName";
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken) => throw new NotImplementedException();
         public IAsyncEnumerable<IReadOnlyList<(string Content, bool IsErrorMessage)>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();


### PR DESCRIPTION
I noticed that refreshing the trace detail page wouldn't show resolved resource names. Resolver needs to raise change event for initial snapshot.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3064)