### PR TITLE
Write connection strings as values

### DIFF
--- a/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBlobStorageResource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting.Azure;
 
@@ -25,14 +24,4 @@ public class AzureBlobStorageResource(string name, AzureStorageResource storage)
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
        Parent.GetBlobConnectionString();
-
-    /// <summary>
-    /// Called by manifest publisher to write manifest resource.
-    /// </summary>
-    /// <param name="context">The context for the manifest publishing operation.</param>
-    internal void WriteToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "value.v0");
-        context.WriteConnectionString(this);
-    }
 }

--- a/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureQueueStorageResource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting.Azure;
 
@@ -25,10 +24,4 @@ public class AzureQueueStorageResource(string name, AzureStorageResource storage
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         Parent.GetQueueConnectionString();
-
-    internal void WriteToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "value.v0");
-        context.WriteConnectionString(this);
-    }
 }

--- a/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureTableStorageResource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting.Azure;
 
@@ -25,10 +24,4 @@ public class AzureTableStorageResource(string name, AzureStorageResource storage
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         Parent.GetTableConnectionString();
-
-    internal void WriteToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "value.v0");
-        context.WriteConnectionString(this);
-    }
 }

--- a/src/Aspire.Hosting.Azure/Extensions/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure/Extensions/AzureStorageExtensions.cs
@@ -200,8 +200,7 @@ public static class AzureStorageExtensions
     {
         var resource = new AzureBlobStorageResource(name, builder.Resource);
 
-        return builder.ApplicationBuilder.AddResource(resource)
-            .WithManifestPublishingCallback(resource.WriteToManifest);
+        return builder.ApplicationBuilder.AddResource(resource);
     }
 
     /// <summary>
@@ -214,8 +213,7 @@ public static class AzureStorageExtensions
     {
         var resource = new AzureTableStorageResource(name, builder.Resource);
 
-        return builder.ApplicationBuilder.AddResource(resource)
-            .WithManifestPublishingCallback(resource.WriteToManifest);
+        return builder.ApplicationBuilder.AddResource(resource);
     }
 
     /// <summary>
@@ -228,7 +226,6 @@ public static class AzureStorageExtensions
     {
         var resource = new AzureQueueStorageResource(name, builder.Resource);
 
-        return builder.ApplicationBuilder.AddResource(resource)
-            .WithManifestPublishingCallback(resource.WriteToManifest);
+        return builder.ApplicationBuilder.AddResource(resource);
     }
 }

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -47,8 +47,7 @@ public static class MongoDBBuilderExtensions
         var mongoDBDatabase = new MongoDBDatabaseResource(name, databaseName, builder.Resource);
 
         return builder.ApplicationBuilder
-            .AddResource(mongoDBDatabase)
-            .WithManifestPublishingCallback(mongoDBDatabase.WriteMongoDBDatabaseToManifest);
+            .AddResource(mongoDBDatabase);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.MongoDB/MongoDBDatabaseResource.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBDatabaseResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -28,10 +26,4 @@ public class MongoDBDatabaseResource(string name, string databaseName, MongoDBSe
     /// Gets the database name.
     /// </summary>
     public string DatabaseName { get; } = databaseName;
-
-    internal void WriteMongoDBDatabaseToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "value.v0");
-        context.WriteConnectionString(this);
-    }
 }

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -48,8 +48,7 @@ public static class MySqlBuilderExtensions
 
         builder.Resource.AddDatabase(name, databaseName);
         var mySqlDatabase = new MySqlDatabaseResource(name, databaseName, builder.Resource);
-        return builder.ApplicationBuilder.AddResource(mySqlDatabase)
-                                         .WithManifestPublishingCallback(mySqlDatabase.WriteToManifest);
+        return builder.ApplicationBuilder.AddResource(mySqlDatabase);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -28,10 +26,4 @@ public class MySqlDatabaseResource(string name, string databaseName, MySqlServer
     /// Gets the database name.
     /// </summary>
     public string DatabaseName { get; } = databaseName;
-
-    internal void WriteToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "value.v0");
-        context.WriteConnectionString(this);
-    }
 }

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -62,8 +62,7 @@ public static class OracleDatabaseBuilderExtensions
 
         builder.Resource.AddDatabase(name, databaseName);
         var oracleDatabase = new OracleDatabaseResource(name, databaseName, builder.Resource);
-        return builder.ApplicationBuilder.AddResource(oracleDatabase)
-                                         .WithManifestPublishingCallback(oracleDatabase.WriteToManifest);
+        return builder.ApplicationBuilder.AddResource(oracleDatabase);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -28,10 +26,4 @@ public class OracleDatabaseResource(string name, string databaseName, OracleData
     /// Gets the database name.
     /// </summary>
     public string DatabaseName { get; } = databaseName;
-
-    internal void WriteToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "value.v0");
-        context.WriteConnectionString(this);
-    }
 }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -57,8 +57,7 @@ public static class PostgresBuilderExtensions
 
         builder.Resource.AddDatabase(name, databaseName);
         var postgresDatabase = new PostgresDatabaseResource(name, databaseName, builder.Resource);
-        return builder.ApplicationBuilder.AddResource(postgresDatabase)
-                                         .WithManifestPublishingCallback(postgresDatabase.WriteToManifest);
+        return builder.ApplicationBuilder.AddResource(postgresDatabase);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -28,10 +26,4 @@ public class PostgresDatabaseResource(string name, string databaseName, Postgres
     /// Gets the database name.
     /// </summary>
     public string DatabaseName { get; } = databaseName;
-
-    internal void WriteToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "value.v0");
-        context.WriteConnectionString(this);
-    }
 }

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -47,8 +47,7 @@ public static class SqlServerBuilderExtensions
 
         builder.Resource.AddDatabase(name, databaseName);
         var sqlServerDatabase = new SqlServerDatabaseResource(name, databaseName, builder.Resource);
-        return builder.ApplicationBuilder.AddResource(sqlServerDatabase)
-                                         .WithManifestPublishingCallback(sqlServerDatabase.WriteToManifest);
+        return builder.ApplicationBuilder.AddResource(sqlServerDatabase);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerDatabaseResource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Hosting.Publishing;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -28,10 +26,4 @@ public class SqlServerDatabaseResource(string name, string databaseName, SqlServ
     /// Gets the database name.
     /// </summary>
     public string DatabaseName { get; } = databaseName;
-
-    internal void WriteToManifest(ManifestPublishingContext context)
-    {
-        context.Writer.WriteString("type", "value.v0");
-        context.WriteConnectionString(this);
-    }
 }

--- a/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublisher.cs
@@ -90,6 +90,10 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
         {
             await WriteResourceObjectAsync(executable, () => WriteExecutableAsync(executable, context)).ConfigureAwait(false);
         }
+        else if (resource is IResourceWithConnectionString resourceWithConnectionString)
+        {
+            await WriteResourceObjectAsync(resource, () => WriteConnectionStringAsync(resourceWithConnectionString, context)).ConfigureAwait(false);
+        }
         else
         {
             await WriteResourceObjectAsync(resource, () => WriteErrorAsync(context)).ConfigureAwait(false);
@@ -107,6 +111,15 @@ internal class ManifestPublisher(ILogger<ManifestPublisher> logger,
     private static Task WriteErrorAsync(ManifestPublishingContext context)
     {
         context.Writer.WriteString("error", "This resource does not support generation in the manifest.");
+        return Task.CompletedTask;
+    }
+
+    private static Task WriteConnectionStringAsync(IResourceWithConnectionString resource, ManifestPublishingContext context)
+    {
+        // Write connection strings as value.v0
+        context.Writer.WriteString("type", "value.v0");
+        context.WriteConnectionString(resource);
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
- Remove custom manifest writing and writes any `IResourceWithConnectionString` as a `value.v0`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3067)