### PR TITLE
Use application name in implicit volume names

### DIFF
--- a/Aspire.sln
+++ b/Aspire.sln
@@ -407,6 +407,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspire.Hosting.Azure.Sql", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspire.Hosting.Azure.Storage", "src\Aspire.Hosting.Azure.Storage\Aspire.Hosting.Azure.Storage.csproj", "{89E9F2B8-662C-4FFA-8F69-360680362653}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.Tests.SharedShim", "tests\Aspire.Hosting.Tests.SharedShim\Aspire.Hosting.Tests.SharedShim.csproj", "{74644A4D-8F61-4314-B6E8-5CE3802CD6C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1073,6 +1075,10 @@ Global
 		{89E9F2B8-662C-4FFA-8F69-360680362653}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{89E9F2B8-662C-4FFA-8F69-360680362653}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{89E9F2B8-662C-4FFA-8F69-360680362653}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74644A4D-8F61-4314-B6E8-5CE3802CD6C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74644A4D-8F61-4314-B6E8-5CE3802CD6C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74644A4D-8F61-4314-B6E8-5CE3802CD6C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74644A4D-8F61-4314-B6E8-5CE3802CD6C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1269,6 +1275,7 @@ Global
 		{CB7CAE39-F041-4B20-A0C4-D6F44920A647} = {77CFE74A-32EE-400C-8930-5025E8555256}
 		{9FF853BD-FA56-4DA5-A50A-9867F2FAB1F0} = {77CFE74A-32EE-400C-8930-5025E8555256}
 		{89E9F2B8-662C-4FFA-8F69-360680362653} = {77CFE74A-32EE-400C-8930-5025E8555256}
+		{74644A4D-8F61-4314-B6E8-5CE3802CD6C2} = {4981B3A5-4AFD-4191-BF7D-8692D9783D60}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6DCEDFEC-988E-4CB3-B45B-191EB5086E0C}

--- a/eng/testing/xunit.runner.json
+++ b/eng/testing/xunit.runner.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "longRunningTestSeconds": 120,
-  "parallelizeAssembly": false
+  "longRunningTestSeconds": 120
 }

--- a/eng/testing/xunit.runner.json
+++ b/eng/testing/xunit.runner.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "longRunningTestSeconds": 120
+  "longRunningTestSeconds": 120,
+  "parallelizeAssembly": false
 }

--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
+using Aspire.Hosting.Utils;
 using Azure.Provisioning.Authorization;
 using Azure.Provisioning.Storage;
 using Azure.ResourceManager.Storage.Models;
@@ -142,11 +143,11 @@ public static class AzureStorageExtensions
     /// Adds a named volume for the data folder to an Azure Storage emulator resource.
     /// </summary>
     /// <param name="builder">The builder for the <see cref="AzureStorageEmulatorResource"/>.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>A builder for the <see cref="AzureStorageEmulatorResource"/>.</returns>
     public static IResourceBuilder<AzureStorageEmulatorResource> WithDataVolume(this IResourceBuilder<AzureStorageEmulatorResource> builder, string? name = null, bool isReadOnly = false)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/data", isReadOnly);
+        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/data", isReadOnly);
 
     /// <summary>
     /// Modifies the host port that the storage emulator listens on for blob requests.

--- a/src/Aspire.Hosting.Kafka/Aspire.Hosting.Kafka.csproj
+++ b/src/Aspire.Hosting.Kafka/Aspire.Hosting.Kafka.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -32,11 +33,11 @@ public static class KafkaBuilderExtensions
     /// Adds a named volume for the data folder to a Kafka container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<KafkaServerResource> WithDataVolume(this IResourceBuilder<KafkaServerResource> builder, string? name = null, bool isReadOnly = false)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/lib/kafka/data", isReadOnly);
+        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/var/lib/kafka/data", isReadOnly);
 
     /// <summary>
     /// Adds a bind mount for the data folder to a Kafka container resource.

--- a/src/Aspire.Hosting.MongoDB/Aspire.Hosting.MongoDB.csproj
+++ b/src/Aspire.Hosting.MongoDB/Aspire.Hosting.MongoDB.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.MongoDB;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -75,11 +76,11 @@ public static class MongoDBBuilderExtensions
     /// Adds a named volume for the data folder to a MongoDB container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<MongoDBServerResource> WithDataVolume(this IResourceBuilder<MongoDBServerResource> builder, string? name = null, bool isReadOnly = false)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/data/db", isReadOnly);
+        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/data/db", isReadOnly);
 
     /// <summary>
     /// Adds a bind mount for the data folder to a MongoDB container resource.

--- a/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
+++ b/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.MySql;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -83,11 +84,11 @@ public static class MySqlBuilderExtensions
     /// Adds a named volume for the data folder to a MySql container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<MySqlServerResource> WithDataVolume(this IResourceBuilder<MySqlServerResource> builder, string? name = null, bool isReadOnly = false)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/lib/mysql", isReadOnly);
+        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/var/lib/mysql", isReadOnly);
 
     /// <summary>
     /// Adds a bind mount for the data folder to a MySql container resource.

--- a/src/Aspire.Hosting.Oracle/Aspire.Hosting.Oracle.csproj
+++ b/src/Aspire.Hosting.Oracle/Aspire.Hosting.Oracle.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -69,10 +70,10 @@ public static class OracleDatabaseBuilderExtensions
     /// Adds a named volume for the data folder to a Oracle Database server container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<OracleDatabaseServerResource> WithDataVolume(this IResourceBuilder<OracleDatabaseServerResource> builder, string? name = null)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/opt/oracle/oradata", true);
+        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/opt/oracle/oradata", true);
 
     /// <summary>
     /// Adds a bind mount for the data folder to a Oracle Database server container resource.

--- a/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Postgres;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -104,11 +105,11 @@ public static class PostgresBuilderExtensions
     /// Adds a named volume for the data folder to a PostgreSQL container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<PostgresServerResource> WithDataVolume(this IResourceBuilder<PostgresServerResource> builder, string? name = null, bool isReadOnly = false)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/lib/postgresql/data", isReadOnly);
+        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/var/lib/postgresql/data", isReadOnly);
 
     /// <summary>
     /// Adds a bind mount for the data folder to a PostgreSQL container resource.

--- a/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
+++ b/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -40,11 +41,11 @@ public static class RabbitMQBuilderExtensions
     /// Adds a named volume for the data folder to a RabbitMQ container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<RabbitMQServerResource> WithDataVolume(this IResourceBuilder<RabbitMQServerResource> builder, string? name = null, bool isReadOnly = false)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/lib/rabbitmq", isReadOnly);
+        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/var/lib/rabbitmq", isReadOnly);
 
     /// <summary>
     /// Adds a bind mount for the data folder to a RabbitMQ container resource.

--- a/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
+++ b/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
 

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Redis;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -66,7 +67,7 @@ public static class RedisBuilderExtensions
     /// </code>
     /// </remarks>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">
     /// A flag that indicates if this is a read-only volume. Setting this to <c>true</c> will disable Redis persistence.<br/>
     /// Defaults to <c>false</c>.
@@ -74,7 +75,7 @@ public static class RedisBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<RedisResource> WithDataVolume(this IResourceBuilder<RedisResource> builder, string? name = null, bool isReadOnly = false)
     {
-        builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/data", isReadOnly);
+        builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/data", isReadOnly);
         if (!isReadOnly)
         {
             builder.WithPersistence();

--- a/src/Aspire.Hosting.SqlServer/Aspire.Hosting.SqlServer.csproj
+++ b/src/Aspire.Hosting.SqlServer/Aspire.Hosting.SqlServer.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
 
 namespace Aspire.Hosting;
 
@@ -54,11 +55,11 @@ public static class SqlServerBuilderExtensions
     /// Adds a named volume for the data folder to a SQL Server resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the resource name.</param>
+    /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <param name="isReadOnly">A flag that indicates if this is a read-only volume.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<SqlServerServerResource> WithDataVolume(this IResourceBuilder<SqlServerServerResource> builder, string? name = null, bool isReadOnly = false)
-        => builder.WithVolume(name ?? $"{builder.Resource.Name}-data", "/var/opt/mssql", isReadOnly);
+        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/var/opt/mssql", isReadOnly);
 
     /// <summary>
     /// Adds a bind mount for the data folder to a SQL Server resource.

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -21,6 +21,7 @@
     <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
     <Compile Include="$(SharedDir)TaskHelpers.cs" Link="Utils\TaskHelpers.cs" />
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/Utils/StringUtils.cs
+++ b/src/Aspire.Hosting/Utils/StringUtils.cs
@@ -21,5 +21,4 @@ internal static class StringUtils
             return false;
         }
     }
-
 }

--- a/src/Shared/VolumeNameGenerator.cs
+++ b/src/Shared/VolumeNameGenerator.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Utils;
+
+internal static class VolumeNameGenerator
+{
+    /// <summary>
+    /// Creates a volume name with the form <c>$"{applicationName}-{resourceName}-{suffix}</c>, e.g. <c>"myapplication-postgres-data"</c>.
+    /// </summary>
+    /// <remarks>
+    /// If the application name contains chars that are invalid for a volume name, the prefix <c>"volume-"</c> will be used instead.
+    /// </remarks>
+    public static string CreateVolumeName<T>(IResourceBuilder<T> builder, string suffix) where T : IResource
+    {
+        if (!HasOnlyValidChars(suffix))
+        {
+            throw new ArgumentException($"The suffix '{suffix}' contains invalid characters. Only [a-zA-Z0-9_.-] are allowed.", nameof(suffix));
+        }
+
+        // Create volume name like "myapplication-postgres-data"
+        var applicationName = builder.ApplicationBuilder.Environment.ApplicationName;
+        var resourceName = builder.Resource.Name;
+        return $"{(HasOnlyValidChars(applicationName) ? applicationName : "volume")}-{resourceName}-{suffix}";
+    }
+
+    private static bool HasOnlyValidChars(string name)
+    {
+        // According to the error message from docker CLI, volume names must be of form "[a-zA-Z0-9][a-zA-Z0-9_.-]"
+        var nameSpan = name.AsSpan();
+
+        for (var i = 0; i < nameSpan.Length; i++)
+        {
+            var c = nameSpan[i];
+
+            if (i == 0 && !(Char.IsAsciiLetter(c) || Char.IsNumber(c)))
+            {
+                // First char must be a letter or number
+                return false;
+            }
+            else if (!(Char.IsAsciiLetter(c) || Char.IsNumber(c) || c == '_' || c == '.' || c == '-'))
+            {
+                // Subsequent chars must be a letter, number, underscore, period, or hyphen
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Aspire.Azure.AI.OpenAI.Tests/AspireAzureAIOpenAIExtensionsTests.cs
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/AspireAzureAIOpenAIExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspireAzureAIOpenAIExtensionsTests
             builder.AddAzureOpenAIClient("openai");
         }
 
-        using using var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<OpenAIClient>("openai") :
             host.Services.GetRequiredService<OpenAIClient>();
@@ -58,7 +58,7 @@ public class AspireAzureAIOpenAIExtensionsTests
             builder.AddAzureOpenAIClient("openai", settings => { settings.Endpoint = uri; settings.Key = key; });
         }
 
-        using using var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<OpenAIClient>("openai") :
             host.Services.GetRequiredService<OpenAIClient>();
@@ -80,7 +80,7 @@ public class AspireAzureAIOpenAIExtensionsTests
 
         builder.AddAzureOpenAIClient("openai");
 
-        using using var host = builder.Build();
+        using var host = builder.Build();
         var client = host.Services.GetRequiredService<OpenAIClient>();
 
         Assert.NotNull(client);

--- a/tests/Aspire.Azure.AI.OpenAI.Tests/AspireAzureAIOpenAIExtensionsTests.cs
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/AspireAzureAIOpenAIExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspireAzureAIOpenAIExtensionsTests
             builder.AddAzureOpenAIClient("openai");
         }
 
-        var host = builder.Build();
+        using using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<OpenAIClient>("openai") :
             host.Services.GetRequiredService<OpenAIClient>();
@@ -58,7 +58,7 @@ public class AspireAzureAIOpenAIExtensionsTests
             builder.AddAzureOpenAIClient("openai", settings => { settings.Endpoint = uri; settings.Key = key; });
         }
 
-        var host = builder.Build();
+        using using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<OpenAIClient>("openai") :
             host.Services.GetRequiredService<OpenAIClient>();
@@ -80,7 +80,7 @@ public class AspireAzureAIOpenAIExtensionsTests
 
         builder.AddAzureOpenAIClient("openai");
 
-        var host = builder.Build();
+        using using var host = builder.Build();
         var client = host.Services.GetRequiredService<OpenAIClient>();
 
         Assert.NotNull(client);

--- a/tests/Aspire.Azure.Data.Tables.Tests/AspireTablesExtensionsTests.cs
+++ b/tests/Aspire.Azure.Data.Tables.Tests/AspireTablesExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspireTablesExtensionsTests
             builder.AddAzureTableClient("tables");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<TableServiceClient>("tables") :
             host.Services.GetRequiredService<TableServiceClient>();
@@ -59,7 +59,7 @@ public class AspireTablesExtensionsTests
             builder.AddAzureTableClient("tables", settings => settings.ConnectionString = ConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<TableServiceClient>("tables") :
             host.Services.GetRequiredService<TableServiceClient>();
@@ -89,7 +89,7 @@ public class AspireTablesExtensionsTests
             builder.AddAzureTableClient("tables");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<TableServiceClient>("tables") :
             host.Services.GetRequiredService<TableServiceClient>();
@@ -117,7 +117,7 @@ public class AspireTablesExtensionsTests
             builder.AddAzureTableClient("tables");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<TableServiceClient>("tables") :
             host.Services.GetRequiredService<TableServiceClient>();

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AspireServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AspireServiceBusExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspireServiceBusExtensionsTests
             builder.AddAzureServiceBusClient("sb");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<ServiceBusClient>("sb") :
             host.Services.GetRequiredService<ServiceBusClient>();
@@ -59,7 +59,7 @@ public class AspireServiceBusExtensionsTests
             builder.AddAzureServiceBusClient("sb", settings => settings.ConnectionString = ConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<ServiceBusClient>("sb") :
             host.Services.GetRequiredService<ServiceBusClient>();
@@ -89,7 +89,7 @@ public class AspireServiceBusExtensionsTests
             builder.AddAzureServiceBusClient("sb");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<ServiceBusClient>("sb") :
             host.Services.GetRequiredService<ServiceBusClient>();
@@ -117,7 +117,7 @@ public class AspireServiceBusExtensionsTests
             builder.AddAzureServiceBusClient("sb");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<ServiceBusClient>("sb") :
             host.Services.GetRequiredService<ServiceBusClient>();

--- a/tests/Aspire.Azure.Search.Documents.Tests/AspireAzureSearchExtensionsTests.cs
+++ b/tests/Aspire.Azure.Search.Documents.Tests/AspireAzureSearchExtensionsTests.cs
@@ -33,7 +33,7 @@ public class AspireAzureSearchExtensionsTests
             builder.AddAzureSearchClient("search");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<SearchIndexClient>("search") :
             host.Services.GetRequiredService<SearchIndexClient>();
@@ -60,7 +60,7 @@ public class AspireAzureSearchExtensionsTests
             builder.AddAzureSearchClient("search", settings => { settings.Endpoint = searchEndpoint; settings.Key = key; });
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<SearchIndexClient>("search") :
             host.Services.GetRequiredService<SearchIndexClient>();

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/AspireKeyVaultExtensionsTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/AspireKeyVaultExtensionsTests.cs
@@ -35,7 +35,7 @@ public class AspireKeyVaultExtensionsTests
             builder.AddAzureKeyVaultClient("secrets", settings => settings.VaultUri = vaultUri);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<SecretClient>("secrets") :
             host.Services.GetRequiredService<SecretClient>();
@@ -65,7 +65,7 @@ public class AspireKeyVaultExtensionsTests
             builder.AddAzureKeyVaultClient("secrets");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<SecretClient>("secrets") :
             host.Services.GetRequiredService<SecretClient>();

--- a/tests/Aspire.Azure.Storage.Blobs.Tests/AspireBlobStorageExtensionsTests.cs
+++ b/tests/Aspire.Azure.Storage.Blobs.Tests/AspireBlobStorageExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspireBlobStorageExtensionsTests
             builder.AddAzureBlobClient("blob");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<BlobServiceClient>("blob") :
             host.Services.GetRequiredService<BlobServiceClient>();
@@ -59,7 +59,7 @@ public class AspireBlobStorageExtensionsTests
             builder.AddAzureBlobClient("blob", settings => settings.ConnectionString = ConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<BlobServiceClient>("blob") :
             host.Services.GetRequiredService<BlobServiceClient>();
@@ -89,7 +89,7 @@ public class AspireBlobStorageExtensionsTests
             builder.AddAzureBlobClient("blob");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<BlobServiceClient>("blob") :
             host.Services.GetRequiredService<BlobServiceClient>();
@@ -117,7 +117,7 @@ public class AspireBlobStorageExtensionsTests
             builder.AddAzureBlobClient("blob");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<BlobServiceClient>("blob") :
             host.Services.GetRequiredService<BlobServiceClient>();

--- a/tests/Aspire.Azure.Storage.Queues.Tests/AspireQueueStorageExtensionsTests.cs
+++ b/tests/Aspire.Azure.Storage.Queues.Tests/AspireQueueStorageExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspireQueueStorageExtensionsTests
             builder.AddAzureQueueClient("queue");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<QueueServiceClient>("queue") :
             host.Services.GetRequiredService<QueueServiceClient>();
@@ -59,7 +59,7 @@ public class AspireQueueStorageExtensionsTests
             builder.AddAzureQueueClient("queue", settings => settings.ConnectionString = ConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<QueueServiceClient>("queue") :
             host.Services.GetRequiredService<QueueServiceClient>();
@@ -89,7 +89,7 @@ public class AspireQueueStorageExtensionsTests
             builder.AddAzureQueueClient("queue");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<QueueServiceClient>("queue") :
             host.Services.GetRequiredService<QueueServiceClient>();
@@ -117,7 +117,7 @@ public class AspireQueueStorageExtensionsTests
             builder.AddAzureQueueClient("queue");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var client = useKeyed ?
             host.Services.GetRequiredKeyedService<QueueServiceClient>("queue") :
             host.Services.GetRequiredService<QueueServiceClient>();

--- a/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
@@ -359,7 +359,7 @@ public abstract class ConformanceTests<TService, TOptions>
         string? key = useKey ? "key" : null;
         RegisterComponent(builder, key: key);
 
-        using var host = builder.Build();
+        using using var host = builder.Build();
 
         Assert.Throws<InvalidOperationException>(() =>
             key is null

--- a/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Components.Common.Tests/ConformanceTests.cs
@@ -359,7 +359,7 @@ public abstract class ConformanceTests<TService, TOptions>
         string? key = useKey ? "key" : null;
         RegisterComponent(builder, key: key);
 
-        using using var host = builder.Build();
+        using var host = builder.Build();
 
         Assert.Throws<InvalidOperationException>(() =>
             key is null

--- a/tests/Aspire.Confluent.Kafka.Tests/ConsumerConfigurationTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/ConsumerConfigurationTests.cs
@@ -34,7 +34,7 @@ public class ConsumerConfigurationTests
             builder.AddKafkaConsumer<string, string>("messaging");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connectionFactory = useKeyed
             ? host.Services.GetRequiredKeyedService(ReflectionHelpers.ConsumerConnectionFactoryStringKeyStringValueType.Value!, "messaging")
             : host.Services.GetRequiredService(ReflectionHelpers.ConsumerConnectionFactoryStringKeyStringValueType.Value!);
@@ -67,7 +67,7 @@ public class ConsumerConfigurationTests
             builder.AddKafkaConsumer<string, string>("messaging", configureSettings: SetConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connectionFactory = useKeyed
             ? host.Services.GetRequiredKeyedService(ReflectionHelpers.ConsumerConnectionFactoryStringKeyStringValueType.Value!, "messaging")
             : host.Services.GetRequiredService(ReflectionHelpers.ConsumerConnectionFactoryStringKeyStringValueType.Value!);
@@ -100,7 +100,7 @@ public class ConsumerConfigurationTests
             builder.AddKafkaConsumer<string, string>("messaging");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connectionFactory = useKeyed
             ? host.Services.GetRequiredKeyedService(ReflectionHelpers.ConsumerConnectionFactoryStringKeyStringValueType.Value!, "messaging")
             : host.Services.GetRequiredService(ReflectionHelpers.ConsumerConnectionFactoryStringKeyStringValueType.Value!);
@@ -143,7 +143,7 @@ public class ConsumerConfigurationTests
 
         builder.AddKafkaConsumer<string, string>("messaging");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connectionFactory = host.Services.GetRequiredService(ReflectionHelpers.ConsumerConnectionFactoryStringKeyStringValueType.Value!);
 
         ConsumerConfig config = GetConsumerConfig(connectionFactory)!;

--- a/tests/Aspire.Confluent.Kafka.Tests/ProducerConfigurationTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/ProducerConfigurationTests.cs
@@ -31,7 +31,7 @@ public class ProducerConfigurationTests
             builder.AddKafkaProducer<string, string>("messaging");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connectionFactory = useKeyed ?
             host.Services.GetRequiredKeyedService(ReflectionHelpers.ProducerConnectionFactoryStringKeyStringValueType.Value!, "messaging") :
             host.Services.GetRequiredService(ReflectionHelpers.ProducerConnectionFactoryStringKeyStringValueType.Value!);
@@ -61,7 +61,7 @@ public class ProducerConfigurationTests
             builder.AddKafkaProducer<string, string>("messaging", configureSettings: SetConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connectionFactory = useKeyed ?
             host.Services.GetRequiredKeyedService(ReflectionHelpers.ProducerConnectionFactoryStringKeyStringValueType.Value!, "messaging") :
             host.Services.GetRequiredService(ReflectionHelpers.ProducerConnectionFactoryStringKeyStringValueType.Value!);
@@ -93,7 +93,7 @@ public class ProducerConfigurationTests
             builder.AddKafkaProducer<string, string>("messaging");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connectionFactory = useKeyed ?
             host.Services.GetRequiredKeyedService(ReflectionHelpers.ProducerConnectionFactoryStringKeyStringValueType.Value!, "messaging") :
             host.Services.GetRequiredService(ReflectionHelpers.ProducerConnectionFactoryStringKeyStringValueType.Value!);
@@ -135,7 +135,7 @@ public class ProducerConfigurationTests
 
         builder.AddKafkaProducer<string, string>("messaging");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connectionFactory = host.Services.GetRequiredService(ReflectionHelpers.ProducerConnectionFactoryStringKeyStringValueType.Value!);
 
         ProducerConfig config = GetProducerConfig(connectionFactory)!;

--- a/tests/Aspire.Hosting.Tests.SharedShim/Aspire.Hosting.Tests.SharedShim.csproj
+++ b/tests/Aspire.Hosting.Tests.SharedShim/Aspire.Hosting.Tests.SharedShim.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Aspire.Hosting/Aspire.Hosting.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Hosting.Tests.SharedShim/Aspire.Hosting.Tests.SharedShim.csproj
+++ b/tests/Aspire.Hosting.Tests.SharedShim/Aspire.Hosting.Tests.SharedShim.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -7,6 +7,8 @@
       CS8002: Referenced assembly does not have a strong name. MongoDB.Driver package is unsigned, we ignore that warning on purpose
     -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
+
+    <XunitRunnerJson>xunit.runner.json</XunitRunnerJson>
   </PropertyGroup>
 
   <ItemGroup>
@@ -40,6 +42,14 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
 
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="D:\src\GitHub\dotnet\aspire\eng\testing\xunit.runner.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Remove="D:\src\GitHub\dotnet\aspire\eng\testing\xunit.runner.json" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.Nats\Aspire.Hosting.Nats.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.PostgreSQL\Aspire.Hosting.PostgreSQL.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\testproject\TestProject.AppHost\TestProject.AppHost.csproj" IsAspireProjectResource="false" />
-
+    <ProjectReference Include="..\Aspire.Hosting.Tests.SharedShim\Aspire.Hosting.Tests.SharedShim.csproj" IsAspireProjectResource="false" Aliases="AspireHostingShared" />
     <ProjectReference Include="..\..\src\Components\Aspire.Microsoft.Data.SqlClient\Aspire.Microsoft.Data.SqlClient.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Components\Aspire.MongoDB.Driver\Aspire.MongoDB.Driver.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Components\Aspire.MySqlConnector\Aspire.MySqlConnector.csproj" IsAspireProjectResource="false" />

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -7,8 +7,6 @@
       CS8002: Referenced assembly does not have a strong name. MongoDB.Driver package is unsigned, we ignore that warning on purpose
     -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>
-
-    <XunitRunnerJson>xunit.runner.json</XunitRunnerJson>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,14 +40,6 @@
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
 
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="D:\src\GitHub\dotnet\aspire\eng\testing\xunit.runner.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Remove="D:\src\GitHub\dotnet\aspire\eng\testing\xunit.runner.json" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
@@ -79,7 +79,7 @@ public class AzureResourceExtensionsTests
         });
 
         var volumeAnnotation = storage.Resource.Annotations.OfType<ContainerMountAnnotation>().Single();
-        Assert.Equal("storage-data", volumeAnnotation.Source);
+        Assert.Equal("testhost-storage-data", volumeAnnotation.Source);
         Assert.Equal("/data", volumeAnnotation.Target);
         Assert.Equal(ContainerMountType.Volume, volumeAnnotation.Type);
         Assert.Equal(isReadOnly ?? false, volumeAnnotation.IsReadOnly);

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -641,7 +641,7 @@ public class DistributedApplicationTests
         var servicea = builder.AddProject<Projects.ServiceA>("servicea")
             .WithReference(redis);
 
-        var app = builder.Build();
+        using var app = builder.Build();
         await app.StartAsync();
 
         var s = app.Services.GetRequiredService<IKubernetesService>();
@@ -669,7 +669,7 @@ public class DistributedApplicationTests
             endpoint.IsProxied = false;
         });
 
-        var app = builder.Build();
+        using var app = builder.Build();
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync());
         Assert.Equal("Service 'redis' needs to specify a port for endpoint 'tcp' since it isn't using a proxy.", ex.Message);
@@ -684,7 +684,7 @@ public class DistributedApplicationTests
         builder.AddRedis("redis");
         builder.Services.TryAddLifecycleHook<KubernetesTestLifecycleHook>();
 
-        var app = builder.Build();
+        using var app = builder.Build();
 
         var s = app.Services.GetRequiredService<IKubernetesService>();
         var lifecycles = app.Services.GetServices<IDistributedApplicationLifecycleHook>();

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -124,7 +124,7 @@ public class ManifestGenerationTests
 
         appBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, JsonDocumentManifestPublisher>("manifest");
 
-        var program = appBuilder.Build();
+        using var program = appBuilder.Build();
         var publisher = program.Services.GetManifestPublisher();
 
         program.Run();

--- a/tests/Aspire.Hosting.Tests/Nats/AddNatsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Nats/AddNatsTests.cs
@@ -45,7 +45,7 @@ public class AddNatsTests
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddNats("nats", 1234).WithJetStream(srcMountPath: "/tmp/dev-data");
 
-        var app = appBuilder.Build();
+        using var app = appBuilder.Build();
 
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -188,7 +188,7 @@ public class AddRedisTests
 
         var volumeAnnotation = redis.Resource.Annotations.OfType<ContainerMountAnnotation>().Single();
 
-        Assert.Equal("myRedis-data", volumeAnnotation.Source);
+        Assert.Equal("testhost-myRedis-data", volumeAnnotation.Source);
         Assert.Equal("/data", volumeAnnotation.Target);
         Assert.Equal(ContainerMountType.Volume, volumeAnnotation.Type);
         Assert.Equal(isReadOnly ?? false, volumeAnnotation.IsReadOnly);

--- a/tests/Aspire.Hosting.Tests/Utils/VolumeNameGeneratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/VolumeNameGeneratorTests.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+extern alias AspireHostingShared;
+
+using static AspireHostingShared::Aspire.Hosting.Utils.VolumeNameGenerator;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Utils;
+
+public class VolumeNameGeneratorTests
+{
+    [Theory]
+    [InlineData("ACustomButValidAppName")]
+    [InlineData("0123ThisIsValidToo")]
+    [InlineData("This_Is_Valid_Too")]
+    [InlineData("This.Is.Valid.Too")]
+    [InlineData("This-Is-Valid-Too")]
+    [InlineData("This_Is.Valid-Too")]
+    [InlineData("This_0Is.1Valid-2Too")]
+    [InlineData("This_---.....---___Is_Valid_Too")]
+    public void UsesApplicationNameAsPrefixIfCharsAreValid(string applicationName)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.Environment.ApplicationName = applicationName;
+        var resource = builder.AddResource(new TestResource("myresource"));
+
+        var volumeName = CreateVolumeName(resource, "data");
+
+        Assert.Equal($"{builder.Environment.ApplicationName}-{resource.Resource.Name}-data", volumeName);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidNameParts))]
+    public void UsesVolumeAsPrefixIfApplicationNameCharsAreInvalid(string applicationName)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        builder.Environment.ApplicationName = applicationName;
+        var resource = builder.AddResource(new TestResource("myresource"));
+
+        var volumeName = CreateVolumeName(resource, "data");
+
+        Assert.Equal($"volume-{resource.Resource.Name}-data", volumeName);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidNameParts))]
+    public void ThrowsWhenSuffixContainsInvalidChars(string suffix)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var resource = builder.AddResource(new TestResource("myresource"));
+
+        Assert.Throws<ArgumentException>(nameof(suffix), () => CreateVolumeName(resource, suffix));
+    }
+
+    public static object[][] InvalidNameParts => [
+        ["This/is/invalid"],
+        [@"This\is\invalid"],
+        ["_ThisIsInvalidToo"],
+        [".ThisIsInvalidToo"],
+        ["-ThisIsInvalidToo"],
+        ["This&IsInvalidToo"]
+    ];
+
+    private sealed class TestResource(string name) : IResource
+    {
+        public string Name { get; } = name;
+
+        public ResourceAnnotationCollection Annotations { get; } = [];
+    }
+}

--- a/tests/Aspire.Hosting.Tests/xunit.runner.json
+++ b/tests/Aspire.Hosting.Tests/xunit.runner.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "longRunningTestSeconds": 120,
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false
+}

--- a/tests/Aspire.Hosting.Tests/xunit.runner.json
+++ b/tests/Aspire.Hosting.Tests/xunit.runner.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "longRunningTestSeconds": 120,
-  "parallelizeAssembly": false,
-  "parallelizeTestCollections": false
-}

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/AspireSqlServerSqlClientExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/AspireSqlServerSqlClientExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspireSqlServerSqlClientExtensionsTests
             builder.AddSqlServerClient("sqlconnection");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<SqlConnection>("sqlconnection") :
             host.Services.GetRequiredService<SqlConnection>();
@@ -60,7 +60,7 @@ public class AspireSqlServerSqlClientExtensionsTests
             builder.AddSqlServerClient("sqlconnection", SetConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<SqlConnection>("sqlconnection") :
             host.Services.GetRequiredService<SqlConnection>();
@@ -92,7 +92,7 @@ public class AspireSqlServerSqlClientExtensionsTests
             builder.AddSqlServerClient("sqlconnection");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var dataSource = useKeyed ?
             host.Services.GetRequiredKeyedService<SqlConnection>("sqlconnection") :
             host.Services.GetRequiredService<SqlConnection>();

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspireAzureEfCoreCosmosDBExtensionsTests
             });
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -66,7 +66,7 @@ public class AspireAzureEfCoreCosmosDBExtensionsTests
         builder.AddCosmosDbContext<TestDbContext>("cosmos", "test");
         builder.AddCosmosDbContext<TestDbContext2>("cosmos2", "test2");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
         var context2 = host.Services.GetRequiredService<TestDbContext2>();
 

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/EnrichCosmosDbTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/EnrichCosmosDbTests.cs
@@ -62,7 +62,7 @@ public class EnrichCosmosDbTests : ConformanceTests
 
         builder.EnrichCosmosDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -91,7 +91,7 @@ public class EnrichCosmosDbTests : ConformanceTests
 
         builder.EnrichCosmosDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }
@@ -112,7 +112,7 @@ public class EnrichCosmosDbTests : ConformanceTests
         Assert.NotNull(optionsDescriptor);
         Assert.Equal(ServiceLifetime.Singleton, optionsDescriptor.Lifetime);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
@@ -27,7 +27,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
 
         builder.AddSqlServerDbContext<TestDbContext>("sqlconnection");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         Assert.Equal(ConnectionString, context.Database.GetDbConnection().ConnectionString);
@@ -43,7 +43,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
 
         builder.AddSqlServerDbContext<TestDbContext>("sqlconnection", settings => settings.ConnectionString = ConnectionString);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         var actualConnectionString = context.Database.GetDbConnection().ConnectionString;
@@ -63,7 +63,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
 
         builder.AddSqlServerDbContext<TestDbContext>("sqlconnection");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         var actualConnectionString = context.Database.GetDbConnection().ConnectionString;
@@ -90,7 +90,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
             });
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -134,7 +134,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
             });
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -172,7 +172,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
         builder.AddSqlServerDbContext<TestDbContext>("sqlconnection");
         builder.AddSqlServerDbContext<TestDbContext2>("sqlconnection2");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
         var context2 = host.Services.GetRequiredService<TestDbContext2>();
 

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/EnrichSqlServerTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/EnrichSqlServerTests.cs
@@ -64,7 +64,7 @@ public class EnrichSqlServerTests : ConformanceTests
 
         builder.EnrichSqlServerDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -99,7 +99,7 @@ public class EnrichSqlServerTests : ConformanceTests
 
         builder.EnrichSqlServerDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -142,7 +142,7 @@ public class EnrichSqlServerTests : ConformanceTests
         Assert.NotNull(optionsDescriptor);
         Assert.Same(oldOptionsDescriptor, optionsDescriptor);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -180,7 +180,7 @@ public class EnrichSqlServerTests : ConformanceTests
 
         builder.EnrichSqlServerDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -209,7 +209,7 @@ public class EnrichSqlServerTests : ConformanceTests
 
         builder.EnrichSqlServerDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }
@@ -230,7 +230,7 @@ public class EnrichSqlServerTests : ConformanceTests
         Assert.NotNull(optionsDescriptor);
         Assert.Equal(ServiceLifetime.Singleton, optionsDescriptor.Lifetime);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }

--- a/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
@@ -33,7 +33,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
 
         builder.AddMongoDBClient(DefaultConnectionName);
 
-        var host = builder.Build();
+        using var host = builder.Build();
 
         var mongoClient = host.Services.GetRequiredService<IMongoClient>();
 
@@ -66,7 +66,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
 
         builder.AddKeyedMongoDBClient(key);
 
-        var host = builder.Build();
+        using var host = builder.Build();
 
         var mongoClient = host.Services.GetRequiredKeyedService<IMongoClient>(key);
 
@@ -99,7 +99,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
             settings.HealthCheckTimeout = 1;
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
 
         var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
@@ -120,7 +120,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
             settings.HealthChecks = false;
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
 
         var healthCheckService = host.Services.GetService<HealthCheckService>();
 
@@ -141,7 +141,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
             settings.HealthCheckTimeout = 1;
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
 
         var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
@@ -162,7 +162,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
             settings.HealthChecks = false;
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
 
         var healthCheckService = host.Services.GetService<HealthCheckService>();
 

--- a/tests/Aspire.MySqlConnector.Tests/AspireMySqlConnectorExtensionsTests.cs
+++ b/tests/Aspire.MySqlConnector.Tests/AspireMySqlConnectorExtensionsTests.cs
@@ -40,7 +40,7 @@ public class AspireMySqlConnectorExtensionsTests : IClassFixture<MySqlContainerF
             builder.AddMySqlDataSource("mysql");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var dataSource = useKeyed ?
             host.Services.GetRequiredKeyedService<MySqlDataSource>("mysql") :
             host.Services.GetRequiredService<MySqlDataSource>();
@@ -68,7 +68,7 @@ public class AspireMySqlConnectorExtensionsTests : IClassFixture<MySqlContainerF
             builder.AddMySqlDataSource("mysql", SetConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var dataSource = useKeyed ?
             host.Services.GetRequiredKeyedService<MySqlDataSource>("mysql") :
             host.Services.GetRequiredService<MySqlDataSource>();
@@ -100,7 +100,7 @@ public class AspireMySqlConnectorExtensionsTests : IClassFixture<MySqlContainerF
             builder.AddMySqlDataSource("mysql");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var dataSource = useKeyed ?
             host.Services.GetRequiredKeyedService<MySqlDataSource>("mysql") :
             host.Services.GetRequiredService<MySqlDataSource>();

--- a/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspireNatsClientExtensionsTests
             builder.AddNatsClient("nats");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<INatsConnection>("nats") :
             host.Services.GetRequiredService<INatsConnection>();
@@ -60,7 +60,7 @@ public class AspireNatsClientExtensionsTests
             builder.AddNatsClient("nats", SetConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<INatsConnection>("nats") :
             host.Services.GetRequiredService<INatsConnection>();
@@ -92,7 +92,7 @@ public class AspireNatsClientExtensionsTests
             builder.AddNatsClient("nats");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<INatsConnection>("nats") :
             host.Services.GetRequiredService<INatsConnection>();

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/AspireEFPostgreSqlExtensionsTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/AspireEFPostgreSqlExtensionsTests.cs
@@ -35,7 +35,7 @@ public class AspireEFPostgreSqlExtensionsTests
 
         builder.AddNpgsqlDbContext<TestDbContext>("npgsql", configureDbContextOptions: ConfigureDbContextOptionsBuilderForTesting);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         Assert.Equal(ConnectionString, context.Database.GetDbConnection().ConnectionString);
@@ -53,7 +53,7 @@ public class AspireEFPostgreSqlExtensionsTests
             settings => settings.ConnectionString = ConnectionString,
             configureDbContextOptions: ConfigureDbContextOptionsBuilderForTesting);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         var actualConnectionString = context.Database.GetDbConnection().ConnectionString;
@@ -73,7 +73,7 @@ public class AspireEFPostgreSqlExtensionsTests
 
         builder.AddNpgsqlDbContext<TestDbContext>("npgsql", configureDbContextOptions: ConfigureDbContextOptionsBuilderForTesting);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         var actualConnectionString = context.Database.GetDbConnection().ConnectionString;
@@ -100,7 +100,7 @@ public class AspireEFPostgreSqlExtensionsTests
             });
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -142,7 +142,7 @@ public class AspireEFPostgreSqlExtensionsTests
             });
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -180,7 +180,7 @@ public class AspireEFPostgreSqlExtensionsTests
         builder.AddNpgsqlDbContext<TestDbContext>("npgsql");
         builder.AddNpgsqlDbContext<TestDbContext2>("npgsql2");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
         var context2 = host.Services.GetRequiredService<TestDbContext2>();
 

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/EnrichNpgsqlTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/EnrichNpgsqlTests.cs
@@ -71,7 +71,7 @@ public class EnrichNpgsqlTests : ConformanceTests
 
         builder.EnrichNpgsqlDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -107,7 +107,7 @@ public class EnrichNpgsqlTests : ConformanceTests
 
         builder.EnrichNpgsqlDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -151,7 +151,7 @@ public class EnrichNpgsqlTests : ConformanceTests
         Assert.NotNull(optionsDescriptor);
         Assert.Same(oldOptionsDescriptor, optionsDescriptor);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -190,7 +190,7 @@ public class EnrichNpgsqlTests : ConformanceTests
 
         builder.EnrichNpgsqlDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -220,7 +220,7 @@ public class EnrichNpgsqlTests : ConformanceTests
 
         builder.EnrichNpgsqlDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }
@@ -242,7 +242,7 @@ public class EnrichNpgsqlTests : ConformanceTests
         Assert.NotNull(optionsDescriptor);
         Assert.Equal(ServiceLifetime.Singleton, optionsDescriptor.Lifetime);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }

--- a/tests/Aspire.Npgsql.Tests/AspirePostgreSqlNpgsqlExtensionsTests.cs
+++ b/tests/Aspire.Npgsql.Tests/AspirePostgreSqlNpgsqlExtensionsTests.cs
@@ -32,7 +32,7 @@ public class AspirePostgreSqlNpgsqlExtensionsTests
             builder.AddNpgsqlDataSource("npgsql");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var dataSource = useKeyed ?
             host.Services.GetRequiredKeyedService<NpgsqlDataSource>("npgsql") :
             host.Services.GetRequiredService<NpgsqlDataSource>();
@@ -60,7 +60,7 @@ public class AspirePostgreSqlNpgsqlExtensionsTests
             builder.AddNpgsqlDataSource("npgsql", SetConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var dataSource = useKeyed ?
             host.Services.GetRequiredKeyedService<NpgsqlDataSource>("npgsql") :
             host.Services.GetRequiredService<NpgsqlDataSource>();
@@ -92,7 +92,7 @@ public class AspirePostgreSqlNpgsqlExtensionsTests
             builder.AddNpgsqlDataSource("npgsql");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var dataSource = useKeyed ?
             host.Services.GetRequiredKeyedService<NpgsqlDataSource>("npgsql") :
             host.Services.GetRequiredService<NpgsqlDataSource>();
@@ -124,7 +124,7 @@ public class AspirePostgreSqlNpgsqlExtensionsTests
             builder.AddNpgsqlDataSource("npgsql", configureDataSourceBuilder: configureDataSourceBuilder);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var dataSource = useKeyed ?
             host.Services.GetRequiredKeyedService<NpgsqlDataSource>("npgsql") :
             host.Services.GetRequiredService<NpgsqlDataSource>();

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/AspireOracleEFCoreDatabaseExtensionsTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/AspireOracleEFCoreDatabaseExtensionsTests.cs
@@ -28,7 +28,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
 
         builder.AddOracleDatabaseDbContext<TestDbContext>("orclconnection");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         Assert.Equal(ConnectionString, context.Database.GetDbConnection().ConnectionString);
@@ -44,7 +44,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
 
         builder.AddOracleDatabaseDbContext<TestDbContext>("orclconnection", settings => settings.ConnectionString = ConnectionString);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         var actualConnectionString = context.Database.GetDbConnection().ConnectionString;
@@ -64,7 +64,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
 
         builder.AddOracleDatabaseDbContext<TestDbContext>("orclconnection");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         var actualConnectionString = context.Database.GetDbConnection().ConnectionString;
@@ -91,7 +91,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
             });
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -135,7 +135,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
             });
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -173,7 +173,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
         builder.AddOracleDatabaseDbContext<TestDbContext>("orclconnection");
         builder.AddOracleDatabaseDbContext<TestDbContext2>("orclconnection2");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
         var context2 = host.Services.GetRequiredService<TestDbContext2>();
 

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/EnrichOracleDatabaseTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/EnrichOracleDatabaseTests.cs
@@ -65,7 +65,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
 
         builder.EnrichOracleDatabaseDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -100,7 +100,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
 
         builder.EnrichOracleDatabaseDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -143,7 +143,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
         Assert.NotNull(optionsDescriptor);
         Assert.Same(oldOptionsDescriptor, optionsDescriptor);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -181,7 +181,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
 
         builder.EnrichOracleDatabaseDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -210,7 +210,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
 
         builder.EnrichOracleDatabaseDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }
@@ -231,7 +231,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
         Assert.NotNull(optionsDescriptor);
         Assert.Equal(ServiceLifetime.Singleton, optionsDescriptor.Lifetime);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
@@ -40,7 +40,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
 
         builder.AddMySqlDbContext<TestDbContext>("mysql");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         var actualConnectionString = context.Database.GetDbConnection().ConnectionString;
@@ -59,7 +59,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
 
         builder.AddMySqlDbContext<TestDbContext>("mysql", settings => settings.ConnectionString = ConnectionString);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         var actualConnectionString = context.Database.GetDbConnection().ConnectionString;
@@ -81,7 +81,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
 
         builder.AddMySqlDbContext<TestDbContext>("mysql");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
         var actualConnectionString = context.Database.GetDbConnection().ConnectionString;
@@ -109,7 +109,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
             });
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -152,7 +152,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
             });
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/EnrichMySqlTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/EnrichMySqlTests.cs
@@ -83,7 +83,7 @@ public class EnrichMySqlTests : ConformanceTests
 
         builder.EnrichMySqlDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -118,7 +118,7 @@ public class EnrichMySqlTests : ConformanceTests
 
         builder.EnrichMySqlDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -161,7 +161,7 @@ public class EnrichMySqlTests : ConformanceTests
         Assert.NotNull(optionsDescriptor);
         Assert.Same(oldOptionsDescriptor, optionsDescriptor);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -199,7 +199,7 @@ public class EnrichMySqlTests : ConformanceTests
 
         builder.EnrichMySqlDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -228,7 +228,7 @@ public class EnrichMySqlTests : ConformanceTests
 
         builder.EnrichMySqlDbContext<TestDbContext>();
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }
@@ -249,7 +249,7 @@ public class EnrichMySqlTests : ConformanceTests
         Assert.NotNull(optionsDescriptor);
         Assert.Equal(ServiceLifetime.Singleton, optionsDescriptor.Lifetime);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<ITestDbContext>() as TestDbContext;
         Assert.NotNull(context);
     }

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQExtensionsTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQExtensionsTests.cs
@@ -41,7 +41,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
             builder.AddRabbitMQClient("messaging");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<IConnection>("messaging") :
             host.Services.GetRequiredService<IConnection>();
@@ -71,7 +71,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
             builder.AddRabbitMQClient("messaging", SetConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<IConnection>("messaging") :
             host.Services.GetRequiredService<IConnection>();
@@ -103,7 +103,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
             builder.AddRabbitMQClient("messaging");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<IConnection>("messaging") :
             host.Services.GetRequiredService<IConnection>();
@@ -148,7 +148,7 @@ public class AspireRabbitMQExtensionsTests : IClassFixture<RabbitMQContainerFixt
 
         builder.AddRabbitMQClient("messaging");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connectionFactory = (ConnectionFactory)host.Services.GetRequiredService<IConnectionFactory>();
 
         Assert.Equal(SslProtocols.Tls12, connectionFactory.AmqpUriSslProtocols);

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -53,6 +53,7 @@ public class AspireRabbitMQLoggingTests
         using var connection = host.Services.GetRequiredService<IConnection>();
 
         await rabbitMqContainer.StopAsync();
+        await rabbitMqContainer.DisposeAsync();
 
         await tsc.Task.WaitAsync(TimeSpan.FromMinutes(1));
 

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -49,7 +49,7 @@ public class AspireRabbitMQLoggingTests
 
         builder.Services.AddSingleton<ILoggerProvider>(sp => new LoggerProvider(logger));
 
-        using using var host = builder.Build();
+        using var host = builder.Build();
         using var connection = host.Services.GetRequiredService<IConnection>();
 
         await rabbitMqContainer.StopAsync();
@@ -72,7 +72,7 @@ public class AspireRabbitMQLoggingTests
         var logger = new TestLogger();
         builder.Services.AddSingleton<ILoggerProvider>(sp => new LoggerProvider(logger));
 
-        using using var host = builder.Build();
+        using var host = builder.Build();
         host.Services.GetRequiredService<RabbitMQEventSourceLogForwarder>().Start();
 
         var message = "This is an informational message.";
@@ -101,7 +101,7 @@ public class AspireRabbitMQLoggingTests
         var logger = new TestLogger();
         builder.Services.AddSingleton<ILoggerProvider>(sp => new LoggerProvider(logger));
 
-        using using var host = builder.Build();
+        using var host = builder.Build();
         host.Services.GetRequiredService<RabbitMQEventSourceLogForwarder>().Start();
 
         var exceptionMessage = "Test exception";

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -49,7 +49,7 @@ public class AspireRabbitMQLoggingTests
 
         builder.Services.AddSingleton<ILoggerProvider>(sp => new LoggerProvider(logger));
 
-        using var host = builder.Build();
+        using using var host = builder.Build();
         using var connection = host.Services.GetRequiredService<IConnection>();
 
         await rabbitMqContainer.StopAsync();
@@ -72,7 +72,7 @@ public class AspireRabbitMQLoggingTests
         var logger = new TestLogger();
         builder.Services.AddSingleton<ILoggerProvider>(sp => new LoggerProvider(logger));
 
-        using var host = builder.Build();
+        using using var host = builder.Build();
         host.Services.GetRequiredService<RabbitMQEventSourceLogForwarder>().Start();
 
         var message = "This is an informational message.";
@@ -101,7 +101,7 @@ public class AspireRabbitMQLoggingTests
         var logger = new TestLogger();
         builder.Services.AddSingleton<ILoggerProvider>(sp => new LoggerProvider(logger));
 
-        using var host = builder.Build();
+        using using var host = builder.Build();
         host.Services.GetRequiredService<RabbitMQEventSourceLogForwarder>().Start();
 
         var exceptionMessage = "Test exception";

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/AspireRedisDistributedCacheExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/AspireRedisDistributedCacheExtensionsTests.cs
@@ -18,7 +18,7 @@ public class AspireRedisDistributedCacheExtensionsTests
 
         builder.AddRedisDistributedCache("redis");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var cache = host.Services.GetRequiredService<IDistributedCache>();
 
         Assert.IsAssignableFrom<RedisCache>(cache);

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
@@ -53,7 +53,7 @@ public class DistributedCacheConformanceTests : ConformanceTests
             // set the FlushInterval to to zero so the Activity gets created immediately
             builder.Services.Configure<StackExchangeRedisInstrumentationOptions>(options => options.FlushInterval = TimeSpan.Zero);
 
-            using using var host = builder.Build();
+            using var host = builder.Build();
             // We start the host to make it build TracerProvider.
             // If we don't, nothing gets reported!
             host.Start();

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
@@ -53,7 +53,7 @@ public class DistributedCacheConformanceTests : ConformanceTests
             // set the FlushInterval to to zero so the Activity gets created immediately
             builder.Services.Configure<StackExchangeRedisInstrumentationOptions>(options => options.FlushInterval = TimeSpan.Zero);
 
-            using var host = builder.Build();
+            using using var host = builder.Build();
             // We start the host to make it build TracerProvider.
             // If we don't, nothing gets reported!
             host.Start();

--- a/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/AspireRedisOutputCacheExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/AspireRedisOutputCacheExtensionsTests.cs
@@ -17,7 +17,7 @@ public class AspireRedisOutputCacheExtensionsTests
 
         builder.AddRedisOutputCache("redis");
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var cacheStore = host.Services.GetRequiredService<IOutputCacheStore>();
 
         // note the RedisOutputCacheStore is internal

--- a/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
@@ -53,7 +53,7 @@ public class OutputCacheConformanceTests : ConformanceTests
             // set the FlushInterval to to zero so the Activity gets created immediately
             builder.Services.Configure<StackExchangeRedisInstrumentationOptions>(options => options.FlushInterval = TimeSpan.Zero);
 
-            using var host = builder.Build();
+            using using var host = builder.Build();
             // We start the host to make it build TracerProvider.
             // If we don't, nothing gets reported!
             host.Start();

--- a/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
@@ -53,7 +53,7 @@ public class OutputCacheConformanceTests : ConformanceTests
             // set the FlushInterval to to zero so the Activity gets created immediately
             builder.Services.Configure<StackExchangeRedisInstrumentationOptions>(options => options.FlushInterval = TimeSpan.Zero);
 
-            using using var host = builder.Build();
+            using var host = builder.Build();
             // We start the host to make it build TracerProvider.
             // If we don't, nothing gets reported!
             host.Start();

--- a/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
@@ -44,7 +44,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
             options.User = "aspire-test-user";
         });
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = host.Services.GetRequiredService<IConnectionMultiplexer>();
 
         Assert.Contains("aspire-test-user", connection.Configuration);
@@ -69,7 +69,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
             builder.AddRedisClient("myredis");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<IConnectionMultiplexer>("myredis") :
             host.Services.GetRequiredService<IConnectionMultiplexer>();
@@ -97,7 +97,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
             builder.AddRedisClient("redis", SetConnectionString);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<IConnectionMultiplexer>("redis") :
             host.Services.GetRequiredService<IConnectionMultiplexer>();
@@ -129,7 +129,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
             builder.AddRedisClient("redis");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var connection = useKeyed ?
             host.Services.GetRequiredKeyedService<IConnectionMultiplexer>("redis") :
             host.Services.GetRequiredService<IConnectionMultiplexer>();
@@ -185,7 +185,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
             builder.AddRedisClient("redis");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var options = useKeyed ?
             host.Services.GetRequiredService<IOptionsMonitor<ConfigurationOptions>>().Get("redis") :
             host.Services.GetRequiredService<IOptions<ConfigurationOptions>>().Value;
@@ -215,7 +215,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
             builder.AddRedisOutputCache("redis");
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
 
         // Note that IDistributedCache and OutputCacheStore don't support keyed services - so only the Redis ConnectionMultiplexer is keyed.
 
@@ -244,7 +244,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
             settings.ConnectionString = "localhost";
             settings.Tracing = true;
         });
-        var host = builder.Build();
+        using var host = builder.Build();
 
         //This will add the instrumentations.
         var tracerProvider = host.Services.GetRequiredService<TracerProvider>();
@@ -271,7 +271,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
             builder.Services.Configure<StackExchangeRedisInstrumentationOptions>(options => options.FlushInterval = TimeSpan.Zero);
 
             builder.AddKeyedRedisClient("redis");
-            using var host = builder.Build();
+            using using var host = builder.Build();
 
             // We start the host to make it build TracerProvider.
             // If we don't, nothing gets reported!

--- a/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
@@ -271,7 +271,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
             builder.Services.Configure<StackExchangeRedisInstrumentationOptions>(options => options.FlushInterval = TimeSpan.Zero);
 
             builder.AddKeyedRedisClient("redis");
-            using using var host = builder.Build();
+            using var host = builder.Build();
 
             // We start the host to make it build TracerProvider.
             // If we don't, nothing gets reported!

--- a/tests/testproject/TestProject.WorkerA/Program.cs
+++ b/tests/testproject/TestProject.WorkerA/Program.cs
@@ -6,5 +6,5 @@ using TestProject.WorkerA;
 var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddHostedService<Worker>();
 
-var host = builder.Build();
+using var host = builder.Build();
 host.Run();


### PR DESCRIPTION
Implicit volume names are now in the form `$"{applicationName}-{resourceName}-{suffix}"`, unless the application name contains invalid chars for a volume name, in which case it's `$"volume-{resourceName}-{suffix}"`.

Fixes #3058
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3080)