### PR TITLE
Fix bug with deployments not being poulated.

### DIFF
--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
@@ -5,11 +5,16 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureProvisioning();
 
-var openai = builder.AddAzureOpenAI("openai")
-                    .AddDeployment(new("gpt-35-turbo", "gpt-35-turbo", "0613"));
+#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+var openai = builder.AddAzureOpenAI("openai", (_, _, _, deployments) => {
+    var deployment = deployments.Single();
+    deployment.AddOutput("modelName", x => x.Name);
+}).AddDeployment(new("gpt-35-turbo", "gpt-35-turbo", "0613"));
+#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 builder.AddProject<Projects.OpenAIEndToEnd_WebStory>("webstory")
-       .WithReference(openai);
+       .WithReference(openai)
+       .WithEnvironment("OpenAI__DeploymentName", openai.GetOutput("modelName"));
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
@@ -5,16 +5,14 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureProvisioning();
 
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-var openai = builder.AddAzureOpenAI("openai", (_, _, _, deployments) => {
-    var deployment = deployments.Single();
-    deployment.AddOutput("modelName", x => x.Name);
-}).AddDeployment(new("gpt-35-turbo", "gpt-35-turbo", "0613"));
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+var deploymentAndModelName = "gpt-35-turbo";
+var openai = builder.AddAzureOpenAI("openai").AddDeployment(
+    new(deploymentAndModelName, deploymentAndModelName, "0613")
+    );
 
 builder.AddProject<Projects.OpenAIEndToEnd_WebStory>("webstory")
        .WithReference(openai)
-       .WithEnvironment("OpenAI__DeploymentName", openai.GetOutput("modelName"));
+       .WithEnvironment("OpenAI__DeploymentName", deploymentAndModelName);
 
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/aspire-manifest.json
@@ -16,7 +16,8 @@
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
         "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
         "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
-        "ConnectionStrings__openai": "{openai.connectionString}"
+        "ConnectionStrings__openai": "{openai.connectionString}",
+        "OpenAI__DeploymentName": "{openai.outputs.modelName}"
       },
       "bindings": {
         "http": {

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
@@ -50,3 +50,4 @@ resource cognitiveServicesAccountDeployment_f9rYX6SRK 'Microsoft.CognitiveServic
 }
 
 output connectionString string = 'Endpoint=${cognitiveServicesAccount_6g8jyEjX5.properties.endpoint}'
+output modelName string = cognitiveServicesAccountDeployment_f9rYX6SRK.name

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.WebStory/Components/Pages/Home.razor
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.WebStory/Components/Pages/Home.razor
@@ -2,28 +2,37 @@
 @using Azure.AI.OpenAI
 @inject OpenAIClient aiClient
 @inject ILogger<Home> logger
+@inject IConfiguration configuration
 
     <div class="storybox" style="margin: 25%">
-        @foreach (var message in chatCompletionOptions.Messages.OfType<ChatRequestAssistantMessage>())
+        @if (chatCompletionOptions != null)
         {
-            <p style="font-size: 3em;">@message.Content</p>
+            foreach (var message in chatCompletionOptions.Messages.OfType<ChatRequestAssistantMessage>())
+            {
+                <p style="font-size: 3em;">@message.Content</p>
+            }
         }
 
         <button @onclick="GenerateNextParagraph" autofocus>Generate</button>
     </div>
 
 @code {
-    private ChatCompletionsOptions chatCompletionOptions = new ChatCompletionsOptions()
-    {
-        DeploymentName = "gpt-35-turbo",
-        Messages =
-        {
-            new ChatRequestSystemMessage("Pick a random topic and write a sentence of a fictional story about it.")
-        }
-    };
+    private ChatCompletionsOptions? chatCompletionOptions = null;
 
     private async Task GenerateNextParagraph()
     {
+        if (chatCompletionOptions == null)
+        {
+            chatCompletionOptions = new ChatCompletionsOptions()
+            {
+                DeploymentName = configuration["OpenAI:DeploymentName"] ?? throw new ApplicationException(),
+                Messages =
+                {
+                    new ChatRequestSystemMessage("Pick a random topic and write a sentence of a fictional story about it.")
+                }
+            };
+        }
+
         if (chatCompletionOptions.Messages.Count > 1)
         {
             chatCompletionOptions.Messages.Add(

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -62,6 +62,7 @@ public static class AzureOpenAIExtensions
                 var cdkDeployment = new CognitiveServicesAccountDeployment(construct, model, parent: cogServicesAccount, name: deployment.Name);
                 cdkDeployment.AssignProperty(x => x.Sku.Name, $"'{deployment.SkuName}'");
                 cdkDeployment.AssignProperty(x => x.Sku.Capacity, $"{deployment.SkuCapacity}");
+                cdkDeployments.Add(cdkDeployment);
             }
 
             var resourceBuilder = builder.CreateResourceBuilder(resource);

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
+using Azure.Provisioning.CognitiveServices;
 using Azure.Provisioning.CosmosDB;
 using Azure.Provisioning.Storage;
 using Azure.ResourceManager.Storage.Models;
@@ -1598,10 +1599,18 @@ public class AzureBicepResourceTests
     {
         var builder = DistributedApplication.CreateBuilder();
 
-        var openai = builder.AddAzureOpenAI("openai")
-            .AddDeployment(new("mymodel", "gpt-35-turbo", "0613", "Basic", 4));
+        IEnumerable<CognitiveServicesAccountDeployment>? aiDeployments = null;
+        var openai = builder.AddAzureOpenAI("openai", (_, _, _, deployments) =>
+        {
+            aiDeployments = deployments;
+        }).AddDeployment(new("mymodel", "gpt-35-turbo", "0613", "Basic", 4));
 
         var manifest = await ManifestUtils.GetManifestWithBicep(openai.Resource);
+
+        Assert.NotNull(aiDeployments);
+        Assert.Collection(
+            aiDeployments,
+            deployment => Assert.Equal("mymodel", deployment.Properties.Name));
 
         var expectedManifest = """
             {


### PR DESCRIPTION
Fix a bug discovered when looking at this issue: #3089

I wasn't adding the deployment to the list of deployments that were passed into the callback. Will need to check other resources for this bug as well but wanted this one fixed ASAP.

Also modified the playground code to show an example of how you can leverage the fact that the Open AI resource is a Bicep resource to pipe out the model name so it only has to be specified once.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3092)