### PR TITLE
Dispose DistributedApplication instances in tests.

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -270,4 +270,10 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     {
         diagnosticSource.Write(name, value);
     }
+
+    // Internal for builder clean up in tests.
+    internal void Cleanup()
+    {
+        _innerBuilder.Configuration.Dispose();
+    }
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -270,10 +270,4 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     {
         diagnosticSource.Write(name, value);
     }
-
-    // Internal for builder clean up in tests.
-    internal void Cleanup()
-    {
-        _innerBuilder.Configuration.Dispose();
-    }
 }

--- a/tests/Aspire.Hosting.Tests/AWS/AWSCloudFormationResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/AWS/AWSCloudFormationResourceTests.cs
@@ -12,7 +12,8 @@ public class AWSCloudFormationResourceTests
     [Fact]
     public void AddAWSCloudFormationStackResourceTest()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var awsSdkConfig = builder.AddAWSSDKConfig()
                                 .WithRegion(RegionEndpoint.USWest2)
@@ -31,7 +32,8 @@ public class AWSCloudFormationResourceTests
     [Fact]
     public void AddAWSCloudFormationTemplateResourceTest()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var awsSdkConfig = builder.AddAWSSDKConfig()
                                 .WithRegion(RegionEndpoint.USWest2)
@@ -58,7 +60,8 @@ public class AWSCloudFormationResourceTests
     [Fact]
     public async Task ManifestAWSCloudFormationStackResourceTest()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var resourceBuilder = builder.AddAWSCloudFormationStack("ExistingStack");
 
@@ -87,7 +90,8 @@ public class AWSCloudFormationResourceTests
     [Fact]
     public async Task ManifestAWSCloudFormationTemplateResourceTest()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var resourceBuilder = builder.AddAWSCloudFormationTemplate("NewStack", "cf.template");
 

--- a/tests/Aspire.Hosting.Tests/AWS/StackOutputReferenceTests.cs
+++ b/tests/Aspire.Hosting.Tests/AWS/StackOutputReferenceTests.cs
@@ -3,6 +3,7 @@
 
 using Amazon.CloudFormation.Model;
 using Aspire.Hosting.AWS.CloudFormation;
+using Aspire.Hosting.Utils;
 using Xunit;
 
 namespace Aspire.Hosting.Tests.AWS;
@@ -11,7 +12,8 @@ public class StackOutputReferenceTests
     [Fact]
     public async Task GetValueAsyncTest()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var resourceBuilder = builder.AddAWSCloudFormationTemplate("NewStack", "cf.template");
 
@@ -39,7 +41,8 @@ public class StackOutputReferenceTests
     [Fact]
     public void ValueExpressionTest()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var resourceBuilder = builder.AddAWSCloudFormationTemplate("NewStack", "cf.template");
 
@@ -58,7 +61,8 @@ public class StackOutputReferenceTests
     [Fact]
     public void InvalidOutputKey()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var resourceBuilder = builder.AddAWSCloudFormationTemplate("NewStack", "cf.template");
 

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepProvisionerTests.cs
@@ -4,6 +4,7 @@
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Azure.Provisioning;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -14,7 +15,8 @@ public class AzureBicepProvisionerTests
     [Fact]
     public async Task SetParametersTranslatesParametersToARMCompatibleJsonParameters()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
                .WithParameter("name", "david");
@@ -29,7 +31,8 @@ public class AzureBicepProvisionerTests
     [Fact]
     public async Task SetParametersTranslatesCompatibleParameterTypes()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var connectionStringResource = builder.CreateResourceBuilder(
             new ResourceWithConnectionString("A", "connection string"));
@@ -59,7 +62,8 @@ public class AzureBicepProvisionerTests
     [Fact]
     public async Task ResourceWithTheSameBicepTemplateAndParametersHaveTheSameCheckSum()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
                        .WithParameter("name", "david")
@@ -94,7 +98,8 @@ public class AzureBicepProvisionerTests
     {
         var ex = Assert.Throws<ArgumentException>(() =>
         {
-            var builder = DistributedApplication.CreateBuilder();
+            using var container = BuilderContainer.Create();
+            var builder = container.Builder;
             builder.AddAzureConstruct("construct", _ => { })
                    .WithParameter(bicepParameterName);
         });
@@ -111,7 +116,8 @@ public class AzureBicepProvisionerTests
     [InlineData("Alpha1_A")]
     public void WithParameterAllowsParameterNamesWhichAreValidBicepIdentifiers(string bicepParameterName)
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         builder.AddAzureConstruct("construct", _ => { })
                 .WithParameter(bicepParameterName);
     }
@@ -119,7 +125,8 @@ public class AzureBicepProvisionerTests
     [Fact]
     public async Task ResourceWithSameTemplateButDifferentParametersHaveDifferentChecksums()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
                        .WithParameter("name", "david")
@@ -146,7 +153,8 @@ public class AzureBicepProvisionerTests
     [Fact]
     public async Task GetCurrentChecksumSkipsKnownValuesForCheckSumCreation()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var bicep0 = builder.AddBicepTemplateString("bicep0", "param name string")
                        .WithParameter("name", "david")

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -19,7 +19,8 @@ public class AzureBicepResourceTests
     [Fact]
     public void AddBicepResource()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var bicepResource = builder.AddBicepTemplateString("mytemplate", "content")
                                    .WithParameter("param1", "value1")
@@ -33,7 +34,8 @@ public class AzureBicepResourceTests
     [Fact]
     public void GetOutputReturnsOutputValue()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var bicepResource = builder.AddBicepTemplateString("templ", "content");
 
@@ -45,7 +47,8 @@ public class AzureBicepResourceTests
     [Fact]
     public void GetSecretOutputReturnsSecretOutputValue()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var bicepResource = builder.AddBicepTemplateString("templ", "content");
 
@@ -57,7 +60,8 @@ public class AzureBicepResourceTests
     [Fact]
     public void GetOutputValueThrowsIfNoOutput()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var bicepResource = builder.AddBicepTemplateString("templ", "content");
 
@@ -67,7 +71,8 @@ public class AzureBicepResourceTests
     [Fact]
     public void GetSecretOutputValueThrowsIfNoOutput()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var bicepResource = builder.AddBicepTemplateString("templ", "content");
 
@@ -77,7 +82,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AssertManifestLayout()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var param = builder.AddParameter("p1");
 
@@ -121,7 +127,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureCosmosDBEmulator()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var cosmos = builder.AddAzureCosmosDB("cosmos").RunAsEmulator(e =>
         {
@@ -139,7 +146,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureCosmosDB()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         IEnumerable<CosmosDBSqlDatabase>? callbackDatabases = null;
         var cosmos = builder.AddAzureCosmosDB("cosmos", (resource, construct, account, databases) =>
@@ -237,7 +245,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureAppConfiguration()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var appConfig = builder.AddAzureAppConfiguration("appConfig");
         appConfig.Resource.Outputs["appConfigEndpoint"] = "https://myendpoint";
@@ -307,7 +316,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddApplicationInsights()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var appInsights = builder.AddAzureApplicationInsights("appInsights");
 
@@ -377,7 +387,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddLogAnalyticsWorkspace()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var logAnalyticsWorkspace = builder.AddAzureLogAnalyticsWorkspace("logAnalyticsWorkspace");
 
@@ -432,7 +443,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task WithReferenceAppInsightsSetsEnvironmentVariable()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var appInsights = builder.AddAzureApplicationInsights("ai");
 
@@ -450,7 +462,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureConstructGenertesCorrectManifestEntry()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         var construct1 = builder.AddAzureConstruct("construct1", (construct) =>
         {
             var storage = construct.AddStorageAccount(
@@ -468,7 +481,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AssignParameterPopulatesParametersEverywhere()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         builder.Configuration["Parameters:skuName"] = "Standard_ZRS";
 
         var skuName = builder.AddParameter("skuName");
@@ -506,7 +520,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AssignParameterWithSpecifiedNamePopulatesParametersEverywhere()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         builder.Configuration["Parameters:skuName"] = "Standard_ZRS";
 
         var skuName = builder.AddParameter("skuName");
@@ -544,7 +559,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task PublishAsRedisPublishesRedisAsAzureRedisConstruct()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var redis = builder.AddRedis("cache")
             .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 12455))
@@ -623,7 +639,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddKeyVault()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var mykv = builder.AddAzureKeyVault("mykv");
 
@@ -690,7 +707,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureSignalR()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var signalr = builder.AddAzureSignalR("signalr");
 
@@ -767,7 +785,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async void AsAzureSqlDatabase()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var sql = builder.AddSqlServer("sql").AsAzureSqlDatabase((azureSqlBuilder, _, _, _) =>
         {
@@ -880,7 +899,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AsAzurePostgresFlexibleServer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         builder.Configuration["Parameters:usr"] = "user";
         builder.Configuration["Parameters:pwd"] = "password";
@@ -1015,7 +1035,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task PublishAsAzurePostgresFlexibleServer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         builder.Configuration["Parameters:usr"] = "user";
         builder.Configuration["Parameters:pwd"] = "password";
@@ -1054,7 +1075,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task PublishAsAzurePostgresFlexibleServerNoUserPassParams()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var postgres = builder.AddPostgres("postgres1")
             .PublishAsAzurePostgresFlexibleServer(); // Because of InternalsVisibleTo
@@ -1166,7 +1188,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureServiceBus()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         var serviceBus = builder.AddAzureServiceBus("sb");
 
         serviceBus
@@ -1287,7 +1310,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureStorageEmulator()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var storage = builder.AddAzureStorage("storage").RunAsEmulator(e =>
         {
@@ -1318,7 +1342,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureStorage()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var storagesku = builder.AddParameter("storagesku");
         var storage = builder.AddAzureStorage("storage", (_, _, sa) =>
@@ -1473,7 +1498,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureSearch()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         // Add search and parameterize the SKU
         var sku = builder.AddParameter("searchSku");
@@ -1571,7 +1597,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task PublishAsConnectionString()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var ai = builder.AddAzureApplicationInsights("ai").PublishAsConnectionString();
         var serviceBus = builder.AddAzureServiceBus("servicebus").PublishAsConnectionString();
@@ -1596,7 +1623,8 @@ public class AzureBicepResourceTests
     [Fact]
     public async Task AddAzureOpenAI()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var openai = builder.AddAzureOpenAI("openai")
             .AddDeployment(new("mymodel", "gpt-35-turbo", "0613", "Basic", 4));

--- a/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Utils;
 using Xunit;
 
 namespace Aspire.Hosting.Tests.Azure;
@@ -13,7 +14,8 @@ public class AzureResourceExtensionsTests
     [InlineData(false)]
     public void AzureStorageUseEmulatorCallbackWithWithDataBindMountResultsInBindMountAnnotationWithDefaultPath(bool? isReadOnly)
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         var storage = builder.AddAzureStorage("storage").RunAsEmulator(configureContainer: builder =>
         {
             if (isReadOnly.HasValue)
@@ -39,7 +41,8 @@ public class AzureResourceExtensionsTests
     [InlineData(false)]
     public void AzureStorageUseEmulatorCallbackWithWithDataBindMountResultsInBindMountAnnotation(bool? isReadOnly)
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         var storage = builder.AddAzureStorage("storage").RunAsEmulator(configureContainer: builder =>
         {
             if (isReadOnly.HasValue)
@@ -65,7 +68,8 @@ public class AzureResourceExtensionsTests
     [InlineData(false)]
     public void AzureStorageUseEmulatorCallbackWithWithDataVolumeResultsInVolumeAnnotationWithDefaultName(bool? isReadOnly)
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         var storage = builder.AddAzureStorage("storage").RunAsEmulator(configureContainer: builder =>
         {
             if (isReadOnly.HasValue)
@@ -91,7 +95,8 @@ public class AzureResourceExtensionsTests
     [InlineData(false)]
     public void AzureStorageUseEmulatorCallbackWithWithDataVolumeResultsInVolumeAnnotation(bool? isReadOnly)
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         var storage = builder.AddAzureStorage("storage").RunAsEmulator(configureContainer: builder =>
         {
             if (isReadOnly.HasValue)
@@ -135,7 +140,8 @@ public class AzureResourceExtensionsTests
     [InlineData(9007)]
     public void AddAzureCosmosDBWithEmulatorGetsExpectedPort(int? port = null)
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var cosmos = builder.AddAzureCosmosDB("cosmos");
 
@@ -156,7 +162,8 @@ public class AzureResourceExtensionsTests
     [InlineData("1.0.7")]
     public void AddAzureCosmosDBWithEmulatorGetsExpectedImageTag(string imageTag)
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var cosmos = builder.AddAzureCosmosDB("cosmos");
 

--- a/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureResourceExtensionsTests.cs
@@ -119,7 +119,8 @@ public class AzureResourceExtensionsTests
     [Fact]
     public void AzureStorageUserEmulatorUseBlobQueueTablePortMethodsMutateEndpoints()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var storage = builder.AddAzureStorage("storage").RunAsEmulator(configureContainer: builder =>
         {
             builder.UseBlobPort(9001);

--- a/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Redis;
+using Aspire.Hosting.Utils;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -11,7 +12,8 @@ public class ContainerResourceBuilderTests
     [Fact]
     public void WithImageMutatesImageName()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var redis = builder.AddRedis("redis").WithImage("redis-stack");
         Assert.Equal("redis-stack", redis.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Image);
     }
@@ -28,7 +30,8 @@ public class ContainerResourceBuilderTests
     [Fact]
     public void WithImageAddsAnnotationIfNotExistingAndMutatesImageName()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var container = builder.AddContainer("app", "some-image");
         container.Resource.Annotations.RemoveAt(0);
 
@@ -40,7 +43,8 @@ public class ContainerResourceBuilderTests
     [Fact]
     public void WithImageMutatesImageNameOfLastAnnotation()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var container = builder.AddContainer("app", "some-image");
         container.Resource.Annotations.Add(new ContainerImageAnnotation { Image = "another-image" });
 
@@ -52,7 +56,8 @@ public class ContainerResourceBuilderTests
     [Fact]
     public void WithImageTagMutatesImageTag()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var redis = builder.AddRedis(RedisContainerImageTags.Image).WithImageTag(RedisContainerImageTags.Tag);
         Assert.Equal(RedisContainerImageTags.Tag, redis.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Tag);
     }
@@ -60,7 +65,8 @@ public class ContainerResourceBuilderTests
     [Fact]
     public void WithImageRegistryMutatesImageRegistry()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var redis = builder.AddRedis("redis").WithImageRegistry("myregistry.azurecr.io");
         Assert.Equal("myregistry.azurecr.io", redis.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Registry);
     }
@@ -68,7 +74,8 @@ public class ContainerResourceBuilderTests
     [Fact]
     public void WithImageSHA256MutatesImageSHA256()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var redis = builder.AddRedis("redis").WithImageSHA256("42b5c726e719639fcc1e9dbc13dd843f567dcd37911d0e1abb9f47f2cc1c95cd");
         Assert.Equal("42b5c726e719639fcc1e9dbc13dd843f567dcd37911d0e1abb9f47f2cc1c95cd", redis.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().SHA256);
     }
@@ -76,7 +83,8 @@ public class ContainerResourceBuilderTests
     [Fact]
     public void WithImageTagThrowsIfNoImageAnnotation()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var container = builder.AddResource(new TestContainerResource("testcontainer"));
 
         var exception = Assert.Throws<InvalidOperationException>(() => container.WithImageTag(RedisContainerImageTags.Tag));
@@ -86,7 +94,8 @@ public class ContainerResourceBuilderTests
     [Fact]
     public void WithImageRegistryThrowsIfNoImageAnnotation()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var container = builder.AddResource(new TestContainerResource("testcontainer"));
 
         var exception = Assert.Throws<InvalidOperationException>(() => container.WithImageRegistry("myregistry.azurecr.io"));
@@ -96,7 +105,8 @@ public class ContainerResourceBuilderTests
     [Fact]
     public void WithImageSHA256ThrowsIfNoImageAnnotation()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         var container = builder.AddResource(new TestContainerResource("testcontainer"));
 
         var exception = Assert.Throws<InvalidOperationException>(() => container.WithImageSHA256("42b5c726e719639fcc1e9dbc13dd843f567dcd37911d0e1abb9f47f2cc1c95cd"));

--- a/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/ContainerResourceBuilderTests.cs
@@ -25,6 +25,7 @@ public class ContainerResourceBuilderTests
         var redis = builder.AddRedis("redis").WithImage("redis-stack", "1.0.0");
         Assert.Equal("redis-stack", redis.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Image);
         Assert.Equal("1.0.0", redis.Resource.Annotations.OfType<ContainerImageAnnotation>().Single().Tag);
+        using var _ = builder.Build();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
@@ -19,6 +19,7 @@ public class DistributedApplicationBuilderTests
     {
         var builder = DistributedApplication.CreateBuilder(args);
         Assert.Equal(operation, builder.ExecutionContext.Operation);
+        using var _ = builder.Build();
     }
 
     [Fact]
@@ -97,6 +98,8 @@ public class DistributedApplicationBuilderTests
 
         var ex = Assert.Throws<DistributedApplicationException>(() => appBuilder.AddResource(new ContainerResource("Test")));
         Assert.Equal("Cannot add resource of type 'Aspire.Hosting.ApplicationModel.ContainerResource' with name 'Test' because resource of type 'Aspire.Hosting.ApplicationModel.ContainerResource' with that name already exists. Resource names are case-insensitive.", ex.Message);
+
+        using var _ = appBuilder.Build();
     }
 
     [Fact]
@@ -108,6 +111,8 @@ public class DistributedApplicationBuilderTests
 
         var ex = Assert.Throws<DistributedApplicationException>(() => appBuilder.AddResource(new ContainerResource("TEST")));
         Assert.Equal("Cannot add resource of type 'Aspire.Hosting.ApplicationModel.ContainerResource' with name 'TEST' because resource of type 'Aspire.Hosting.ApplicationModel.ContainerResource' with that name already exists. Resource names are case-insensitive.", ex.Message);
+
+        using var _ = appBuilder.Build();
     }
 
     [Fact]
@@ -120,6 +125,8 @@ public class DistributedApplicationBuilderTests
 
         var ex = Assert.Throws<DistributedApplicationException>(appBuilder.Build);
         Assert.Equal("Multiple resources with the name 'Test'. Resource names are case-insensitive.", ex.Message);
+
+        using var _ = appBuilder.Build();
     }
 
     [Fact]
@@ -132,6 +139,8 @@ public class DistributedApplicationBuilderTests
 
         var ex = Assert.Throws<DistributedApplicationException>(appBuilder.Build);
         Assert.Equal("Multiple resources with the name 'Test'. Resource names are case-insensitive.", ex.Message);
+
+        using var _ = appBuilder.Build();
     }
 
     private sealed class TestResource : IResource

--- a/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Kafka/AddKafkaTests.cs
@@ -60,7 +60,9 @@ public class AddKafkaTests
     [Fact]
     public async Task VerifyManifest()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var appBuilder = container.Builder;
+
         var kafka = appBuilder.AddKafka("kafka");
 
         var manifest = await ManifestUtils.GetManifest(kafka.Resource);

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -622,6 +622,7 @@ public class ManifestGenerationTests
 
         var manifest = await ManifestUtils.GetManifest(container.Resource);
         Assert.Equal(expectedManifest, manifest.ToString());
+        using var _ = appBuilder.Build();
     }
     private static TestProgram CreateTestProgramJsonDocumentManifestPublisher(bool includeNodeApp = false)
     {

--- a/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
@@ -97,7 +97,8 @@ public class AddMongoDBTests
     [Fact]
     public void WithMongoExpressAddsContainer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         builder.AddMongoDB("mongo")
             .WithMongoExpress();
 
@@ -109,7 +110,8 @@ public class AddMongoDBTests
     [InlineData("host.containers.internal")]
     public async Task WithMongoExpressUsesContainerHost(string containerHost)
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         builder.AddMongoDB("mongo")
             .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 3000, containerHost))
             .WithMongoExpress();
@@ -134,7 +136,8 @@ public class AddMongoDBTests
     [Fact]
     public void WithMongoExpressOnMultipleResources()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         builder.AddMongoDB("mongo").WithMongoExpress();
         builder.AddMongoDB("mongo2").WithMongoExpress();
 
@@ -180,7 +183,8 @@ public class AddMongoDBTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNames()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db = builder.AddMongoDB("mongo1");
         db.AddDatabase("db");
@@ -191,7 +195,8 @@ public class AddMongoDBTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNamesDifferentParents()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         builder.AddMongoDB("mongo1")
             .AddDatabase("db");
@@ -203,7 +208,8 @@ public class AddMongoDBTests
     [Fact]
     public void CanAddDatabasesWithDifferentNamesOnSingleServer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var mongo1 = builder.AddMongoDB("mongo1");
 
@@ -220,7 +226,8 @@ public class AddMongoDBTests
     [Fact]
     public void CanAddDatabasesWithTheSameNameOnMultipleServers()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db1 = builder.AddMongoDB("mongo1")
             .AddDatabase("db1", "imports");

--- a/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
@@ -178,6 +178,8 @@ public class AddMongoDBTests
             }
             """;
         Assert.Equal(expectedManifest, dbManifest.ToString());
+
+        using var _ = appBuilder.Build();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -134,7 +134,8 @@ public class AddMySqlTests
     [Fact]
     public async Task VerifyManifest()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var appBuilder = container.Builder;
         var mysql = appBuilder.AddMySql("mysql");
         var db = mysql.AddDatabase("db");
 
@@ -184,7 +185,8 @@ public class AddMySqlTests
     [Fact]
     public async Task VerifyManifestWithPasswordParameter()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var appBuilder = container.Builder;
         var pass = appBuilder.AddParameter("pass");
 
         var mysql = appBuilder.AddMySql("mysql", pass);
@@ -214,7 +216,8 @@ public class AddMySqlTests
     [Fact]
     public void WithMySqlTwiceEndsUpWithOneAdminContainer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         builder.AddMySql("mySql").WithPhpMyAdmin();
         builder.AddMySql("mySql2").WithPhpMyAdmin();
 
@@ -249,7 +252,8 @@ public class AddMySqlTests
     [Fact]
     public void WithPhpMyAdminAddsContainer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         builder.AddMySql("mySql").WithPhpMyAdmin();
 
         var container = builder.Resources.Single(r => r.Name == "mySql-phpmyadmin");
@@ -296,7 +300,8 @@ public class AddMySqlTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNames()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db = builder.AddMySql("mysql1");
         db.AddDatabase("db");
@@ -307,7 +312,8 @@ public class AddMySqlTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNamesDifferentParents()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         builder.AddMySql("mysql1")
             .AddDatabase("db");
@@ -319,7 +325,8 @@ public class AddMySqlTests
     [Fact]
     public void CanAddDatabasesWithDifferentNamesOnSingleServer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var mysql1 = builder.AddMySql("mysql1");
 
@@ -339,7 +346,8 @@ public class AddMySqlTests
     [Fact]
     public void CanAddDatabasesWithTheSameNameOnMultipleServers()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db1 = builder.AddMySql("mysql1")
             .AddDatabase("db1", "imports");

--- a/tests/Aspire.Hosting.Tests/Nats/AddNatsTests.cs
+++ b/tests/Aspire.Hosting.Tests/Nats/AddNatsTests.cs
@@ -82,7 +82,8 @@ public class AddNatsTests
     [Fact]
     public void WithNatsContainerOnMultipleResources()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         builder.AddNats("nats1");
         builder.AddNats("nats2");
 
@@ -92,8 +93,9 @@ public class AddNatsTests
     [Fact]
     public async Task VerifyManifest()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var nats = appBuilder.AddNats("nats");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var nats = builder.AddNats("nats");
 
         var manifest = await ManifestUtils.GetManifest(nats.Resource);
 

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -174,8 +174,9 @@ public class AddOracleTests
     [Fact]
     public async Task VerifyManifest()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var oracleServer = appBuilder.AddOracle("oracle");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var oracleServer = builder.AddOracle("oracle");
         var db = oracleServer.AddDatabase("db");
 
         var serverManifest = await ManifestUtils.GetManifest(oracleServer.Resource);
@@ -224,10 +225,11 @@ public class AddOracleTests
     [Fact]
     public async Task VerifyManifestWithPasswordParameter()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var pass = appBuilder.AddParameter("pass");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var pass = builder.AddParameter("pass");
 
-        var oracleServer = appBuilder.AddOracle("oracle", pass);
+        var oracleServer = builder.AddOracle("oracle", pass);
         var serverManifest = await ManifestUtils.GetManifest(oracleServer.Resource);
 
         var expectedManifest = """
@@ -254,7 +256,8 @@ public class AddOracleTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNames()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db = builder.AddOracle("oracle1");
         db.AddDatabase("db");
@@ -265,7 +268,8 @@ public class AddOracleTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNamesDifferentParents()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         builder.AddOracle("oracle1")
             .AddDatabase("db");
@@ -277,7 +281,8 @@ public class AddOracleTests
     [Fact]
     public void CanAddDatabasesWithDifferentNamesOnSingleServer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var oracle1 = builder.AddOracle("oracle1");
 
@@ -294,7 +299,8 @@ public class AddOracleTests
     [Fact]
     public void CanAddDatabasesWithTheSameNameOnMultipleServers()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db1 = builder.AddOracle("oracle1")
             .AddDatabase("db1", "imports");

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -132,6 +132,8 @@ public class AddPostgresTests
         var connectionString = await connectionStringResource.GetConnectionStringAsync();
         Assert.Equal("Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres.inputs.password}", connectionStringResource.ConnectionStringExpression.ValueExpression);
         Assert.Equal($"Host=localhost;Port=2000;Username=postgres;Password={postgres.Resource.Password}", connectionString);
+
+        using var _ = appBuilder.Build();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -215,8 +215,9 @@ public class AddPostgresTests
     [Fact]
     public async Task VerifyManifest()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var pgServer = appBuilder.AddPostgres("pg");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var pgServer = builder.AddPostgres("pg");
         var db = pgServer.AddDatabase("db");
 
         var serverManifest = await ManifestUtils.GetManifest(pgServer.Resource);
@@ -268,12 +269,13 @@ public class AddPostgresTests
     [Fact]
     public async Task VerifyManifestWithParameters()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
-        var userNameParameter = appBuilder.AddParameter("user");
-        var passwordParameter = appBuilder.AddParameter("pass");
+        var userNameParameter = builder.AddParameter("user");
+        var passwordParameter = builder.AddParameter("pass");
 
-        var pgServer = appBuilder.AddPostgres("pg", userNameParameter, passwordParameter);
+        var pgServer = builder.AddPostgres("pg", userNameParameter, passwordParameter);
         var serverManifest = await ManifestUtils.GetManifest(pgServer.Resource);
 
         var expectedManifest = """
@@ -299,7 +301,7 @@ public class AddPostgresTests
             """;
         Assert.Equal(expectedManifest, serverManifest.ToString());
 
-        pgServer = appBuilder.AddPostgres("pg2", userNameParameter);
+        pgServer = builder.AddPostgres("pg2", userNameParameter);
         serverManifest = await ManifestUtils.GetManifest(pgServer.Resource);
 
         expectedManifest = """
@@ -336,7 +338,7 @@ public class AddPostgresTests
             """;
         Assert.Equal(expectedManifest, serverManifest.ToString());
 
-        pgServer = appBuilder.AddPostgres("pg3", password: passwordParameter);
+        pgServer = builder.AddPostgres("pg3", password: passwordParameter);
         serverManifest = await ManifestUtils.GetManifest(pgServer.Resource);
 
         expectedManifest = """
@@ -366,7 +368,8 @@ public class AddPostgresTests
     [Fact]
     public void WithPgAdminAddsContainer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builderContainer = BuilderContainer.Create();
+        var builder = builderContainer.Builder;
         builder.AddPostgres("mypostgres").WithPgAdmin(8081);
 
         var container = builder.Resources.Single(r => r.Name == "mypostgres-pgadmin");
@@ -379,7 +382,8 @@ public class AddPostgresTests
     [Fact]
     public void WithPostgresTwiceEndsUpWithOneContainer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
         builder.AddPostgres("mypostgres1").WithPgAdmin(8081);
         builder.AddPostgres("mypostgres2").WithPgAdmin(8081);
 
@@ -437,7 +441,8 @@ public class AddPostgresTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNames()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db = builder.AddPostgres("postgres1");
         db.AddDatabase("db");
@@ -448,7 +453,8 @@ public class AddPostgresTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNamesDifferentParents()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         builder.AddPostgres("postgres1")
             .AddDatabase("db");
@@ -460,7 +466,8 @@ public class AddPostgresTests
     [Fact]
     public void CanAddDatabasesWithDifferentNamesOnSingleServer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var postgres1 = builder.AddPostgres("postgres1");
 
@@ -477,7 +484,8 @@ public class AddPostgresTests
     [Fact]
     public void CanAddDatabasesWithTheSameNameOnMultipleServers()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db1 = builder.AddPostgres("postgres1")
             .AddDatabase("db1", "imports");

--- a/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsConnectionStringTests.cs
@@ -37,5 +37,6 @@ public class PublishAsConnectionStringTests
         var actual = manifest.ToString();
 
         Assert.Equal(expected, actual, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        using var _ = appBuilder.Build();
     }
 }

--- a/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Tests/PublishAsDockerfileTests.cs
@@ -35,6 +35,7 @@ public class PublishAsDockerfileTests
         var actual = manifest.ToString();
 
         Assert.Equal(expected, actual, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        using var _ = builder.Build();
     }
 
     [Fact]
@@ -77,6 +78,7 @@ public class PublishAsDockerfileTests
         var actual = manifest.ToString();
 
         Assert.Equal(expected, actual, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        using var _ = builder.Build();
     }
 
     [Fact]
@@ -111,5 +113,6 @@ public class PublishAsDockerfileTests
         var actual = manifest.ToString();
 
         Assert.Equal(expected, actual, ignoreLineEndingDifferences: true, ignoreWhiteSpaceDifferences: true);
+        using var _ = builder.Build();
     }
 }

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -65,8 +65,9 @@ public class AddRabbitMQTests
     [Fact]
     public async Task VerifyManifest()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var rabbit = appBuilder.AddRabbitMQ("rabbit");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var rabbit = builder.AddRabbitMQ("rabbit");
 
         var manifest = await ManifestUtils.GetManifest(rabbit.Resource);
 
@@ -107,12 +108,13 @@ public class AddRabbitMQTests
     [Fact]
     public async Task VerifyManifestWithParameters()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
-        var userNameParameter = appBuilder.AddParameter("user");
-        var passwordParameter = appBuilder.AddParameter("pass");
+        var userNameParameter = builder.AddParameter("user");
+        var passwordParameter = builder.AddParameter("pass");
 
-        var rabbit = appBuilder.AddRabbitMQ("rabbit", userNameParameter, passwordParameter);
+        var rabbit = builder.AddRabbitMQ("rabbit", userNameParameter, passwordParameter);
         var manifest = await ManifestUtils.GetManifest(rabbit.Resource);
 
         var expectedManifest = """
@@ -136,7 +138,7 @@ public class AddRabbitMQTests
             """;
         Assert.Equal(expectedManifest, manifest.ToString());
 
-        rabbit = appBuilder.AddRabbitMQ("rabbit2", userNameParameter);
+        rabbit = builder.AddRabbitMQ("rabbit2", userNameParameter);
         manifest = await ManifestUtils.GetManifest(rabbit.Resource);
 
         expectedManifest = """
@@ -172,7 +174,7 @@ public class AddRabbitMQTests
             """;
         Assert.Equal(expectedManifest, manifest.ToString());
 
-        rabbit = appBuilder.AddRabbitMQ("rabbit3", password: passwordParameter);
+        rabbit = builder.AddRabbitMQ("rabbit3", password: passwordParameter);
         manifest = await ManifestUtils.GetManifest(rabbit.Resource);
 
         expectedManifest = """

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -88,8 +88,9 @@ public class AddRedisTests
     [Fact]
     public async Task VerifyManifest()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var redis = appBuilder.AddRedis("redis");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var redis = builder.AddRedis("redis");
 
         var manifest = await ManifestUtils.GetManifest(redis.Resource);
 
@@ -175,8 +176,9 @@ public class AddRedisTests
     [InlineData(false)]
     public void WithDataVolumeAddsVolumeAnnotation(bool? isReadOnly)
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var redis = appBuilder.AddRedis("myRedis");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var redis = builder.AddRedis("myRedis");
         if (isReadOnly.HasValue)
         {
             redis.WithDataVolume(isReadOnly: isReadOnly.Value);
@@ -200,8 +202,9 @@ public class AddRedisTests
     [InlineData(false)]
     public void WithDataBindMountAddsMountAnnotation(bool? isReadOnly)
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var redis = appBuilder.AddRedis("myRedis");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var redis = builder.AddRedis("myRedis");
         if (isReadOnly.HasValue)
         {
             redis.WithDataBindMount("mydata", isReadOnly: isReadOnly.Value);
@@ -222,8 +225,9 @@ public class AddRedisTests
     [Fact]
     public void WithDataVolumeAddsPersistenceAnnotation()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var redis = appBuilder.AddRedis("myRedis")
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var redis = builder.AddRedis("myRedis")
                               .WithDataVolume();
 
         var persistenceAnnotation = redis.Resource.Annotations.OfType<RedisPersistenceCommandLineArgsCallbackAnnotation>().Single();
@@ -235,9 +239,10 @@ public class AddRedisTests
     [Fact]
     public void WithDataVolumeDoesNotAddPersistenceAnnotationIfIsReadOnly()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var redis = appBuilder.AddRedis("myRedis")
-                              .WithDataVolume(isReadOnly: true);
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var redis = builder.AddRedis("myRedis")
+                           .WithDataVolume(isReadOnly: true);
 
         var persistenceAnnotation = redis.Resource.Annotations.OfType<RedisPersistenceCommandLineArgsCallbackAnnotation>().SingleOrDefault();
 
@@ -247,9 +252,10 @@ public class AddRedisTests
     [Fact]
     public void WithDataBindMountAddsPersistenceAnnotation()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var redis = appBuilder.AddRedis("myRedis")
-                              .WithDataBindMount("myredisdata");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var redis = builder.AddRedis("myRedis")
+                           .WithDataBindMount("myredisdata");
 
         var persistenceAnnotation = redis.Resource.Annotations.OfType<RedisPersistenceCommandLineArgsCallbackAnnotation>().Single();
 
@@ -260,9 +266,10 @@ public class AddRedisTests
     [Fact]
     public void WithDataBindMountDoesNotAddPersistenceAnnotationIfIsReadOnly()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var redis = appBuilder.AddRedis("myRedis")
-                              .WithDataBindMount("myredisdata", isReadOnly: true);
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var redis = builder.AddRedis("myRedis")
+                           .WithDataBindMount("myredisdata", isReadOnly: true);
 
         var persistenceAnnotation = redis.Resource.Annotations.OfType<RedisPersistenceCommandLineArgsCallbackAnnotation>().SingleOrDefault();
 
@@ -272,10 +279,11 @@ public class AddRedisTests
     [Fact]
     public void WithPersistenceReplacesPreviousAnnotationInstances()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var redis = appBuilder.AddRedis("myRedis")
-                              .WithDataVolume()
-                              .WithPersistence(TimeSpan.FromSeconds(10), 2);
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var redis = builder.AddRedis("myRedis")
+                           .WithDataVolume()
+                           .WithPersistence(TimeSpan.FromSeconds(10), 2);
 
         var persistenceAnnotation = redis.Resource.Annotations.OfType<RedisPersistenceCommandLineArgsCallbackAnnotation>().Single();
 
@@ -286,9 +294,10 @@ public class AddRedisTests
     [Fact]
     public void WithPersistenceAddsCommandLineArgsAnnotation()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var redis = appBuilder.AddRedis("myRedis")
-                              .WithPersistence(TimeSpan.FromSeconds(60));
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var redis = builder.AddRedis("myRedis")
+                           .WithPersistence(TimeSpan.FromSeconds(60));
 
         Assert.True(redis.Resource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argsAnnotations));
         Assert.NotNull(argsAnnotations.SingleOrDefault());

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -120,6 +120,7 @@ public class AddRedisTests
         builder.AddRedis("myredis2").WithRedisCommander();
 
         Assert.Single(builder.Resources.OfType<RedisCommanderResource>());
+        using var _ = builder.Build();
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceExtensionsTests.cs
@@ -14,6 +14,7 @@ public class ResourceExtensionsTests
 
         Assert.True(container.Resource.TryGetContainerImageName(out var imageName));
         Assert.Equal("grafana/grafana@sha256:1adbcc2df3866ff5ec1d836e9d2220c904c7f98901b918d3cc5e1118ab1af991", imageName);
+        using var _ = builder.Build();
     }
 
     [Fact]
@@ -24,5 +25,6 @@ public class ResourceExtensionsTests
 
         Assert.True(container.Resource.TryGetContainerImageName(out var imageName));
         Assert.Equal("grafana/grafana:10.3.1", imageName);
+        using var _ = builder.Build();
     }
 }

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -35,6 +35,7 @@ public class ResourceNotificationTests
             Assert.Equal("A", c.Key);
             Assert.Equal("B", c.Value);
         });
+        using var _ = builder.Build();
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -104,8 +104,9 @@ public class AddSqlServerTests
     [Fact]
     public async Task VerifyManifest()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
-        var sqlServer = appBuilder.AddSqlServer("sqlserver");
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
+        var sqlServer = builder.AddSqlServer("sqlserver");
         var db = sqlServer.AddDatabase("db");
 
         var serverManifest = await ManifestUtils.GetManifest(sqlServer.Resource);
@@ -158,11 +159,12 @@ public class AddSqlServerTests
     [Fact]
     public async Task VerifyManifestWithPasswordParameter()
     {
-        var appBuilder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = builder.AddParameter("pass");
 
-        var sqlServer = appBuilder.AddSqlServer("sqlserver", pass);
+        var sqlServer = builder.AddSqlServer("sqlserver", pass);
         var serverManifest = await ManifestUtils.GetManifest(sqlServer.Resource);
 
         var expectedManifest = """
@@ -190,7 +192,8 @@ public class AddSqlServerTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNames()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db = builder.AddSqlServer("sqlserver1");
         db.AddDatabase("db");
@@ -201,7 +204,8 @@ public class AddSqlServerTests
     [Fact]
     public void ThrowsWithIdenticalChildResourceNamesDifferentParents()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         builder.AddSqlServer("sqlserver1")
             .AddDatabase("db");
@@ -213,7 +217,8 @@ public class AddSqlServerTests
     [Fact]
     public void CanAddDatabasesWithDifferentNamesOnSingleServer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var sqlserver1 = builder.AddSqlServer("sqlserver1");
 
@@ -230,7 +235,8 @@ public class AddSqlServerTests
     [Fact]
     public void CanAddDatabasesWithTheSameNameOnMultipleServers()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var container = BuilderContainer.Create();
+        var builder = container.Builder;
 
         var db1 = builder.AddSqlServer("sqlserver1")
             .AddDatabase("db1", "imports");

--- a/tests/Aspire.Hosting.Tests/Utils/BuilderContainer.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/BuilderContainer.cs
@@ -16,7 +16,14 @@ public sealed class BuilderContainer : IDisposable
 
     public void Dispose()
     {
-        ((DistributedApplicationBuilder)Builder).Cleanup();
+        try
+        {
+            Builder.Build().Dispose();
+        }
+        catch
+        {
+            // Ignore errors.
+        }
     }
 }
 

--- a/tests/Aspire.Hosting.Tests/Utils/BuilderContainer.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/BuilderContainer.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Utils;
+
+public sealed class BuilderContainer : IDisposable
+{
+    public IDistributedApplicationBuilder Builder { get; }
+
+    public static BuilderContainer Create() => new BuilderContainer(DistributedApplication.CreateBuilder());
+
+    private BuilderContainer(IDistributedApplicationBuilder builder)
+    {
+        Builder = builder;
+    }
+
+    public void Dispose()
+    {
+        ((DistributedApplicationBuilder)Builder).Cleanup();
+    }
+}
+

--- a/tests/Aspire.Hosting.Tests/Utils/VolumeNameGeneratorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/VolumeNameGeneratorTests.cs
@@ -28,6 +28,7 @@ public class VolumeNameGeneratorTests
         var volumeName = CreateVolumeName(resource, "data");
 
         Assert.Equal($"{builder.Environment.ApplicationName}-{resource.Resource.Name}-data", volumeName);
+        using var _ = builder.Build();
     }
 
     [Theory]
@@ -41,6 +42,7 @@ public class VolumeNameGeneratorTests
         var volumeName = CreateVolumeName(resource, "data");
 
         Assert.Equal($"volume-{resource.Resource.Name}-data", volumeName);
+        using var _ = builder.Build();
     }
 
     [Theory]
@@ -51,6 +53,7 @@ public class VolumeNameGeneratorTests
         var resource = builder.AddResource(new TestResource("myresource"));
 
         Assert.Throws<ArgumentException>(nameof(suffix), () => CreateVolumeName(resource, suffix));
+        using var _ = builder.Build();
     }
 
     public static object[][] InvalidNameParts => [

--- a/tests/Aspire.Hosting.Tests/Utils/WithAnnotationTests.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/WithAnnotationTests.cs
@@ -19,6 +19,7 @@ public class WithAnnotationTests
 
         Assert.Equal(2, dummyAnnotations.Count());
         Assert.NotEqual(dummyAnnotations.First(), dummyAnnotations.Last());
+        using var _ = builder.Build();
     }
 
     [Fact]
@@ -33,6 +34,7 @@ public class WithAnnotationTests
 
         Assert.Equal(2, dummyAnnotations.Count());
         Assert.NotEqual(dummyAnnotations.First(), dummyAnnotations.Last());
+        using var _ = builder.Build();
     }
 
     [Fact]
@@ -48,6 +50,7 @@ public class WithAnnotationTests
         var secondAnnotation = redis.Resource.Annotations.OfType<DummyAnnotation>().Single();
 
         Assert.NotEqual(firstAnnotation, secondAnnotation);
+        using var _ = builder.Build();
     }
 }
 

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -138,6 +138,7 @@ public class WithEndpointTests
         });
 
         Assert.Equal("The endpoint \"ep\" has no associated container host name.", ex.Message);
+        using var _ = builder.Build();
     }
 
     private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithEndpointTests>(args);

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -169,6 +169,7 @@ public class WithEnvironmentTests
         Assert.Equal("{container1.bindings.primary.url}/foo", manifestConfig["URL"]);
         Assert.Equal("{container1.bindings.primary.port}", manifestConfig["PORT"]);
         Assert.Equal("{test.connectionString};name=1", manifestConfig["HOST"]);
+        using var _ = builder.Build();
     }
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/AspireAzureEfCoreCosmosDBExtensionsTests.cs
@@ -69,7 +69,7 @@ public class AspireAzureEfCoreCosmosDBExtensionsTests
                 configureDbContextOptions: optionsBuilder => optionsBuilder.UseCosmos(ConnectionString, "databaseName"),
                 configureSettings: useSettings ? settings => settings.RequestTimeout = TimeSpan.FromSeconds(608) : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -109,7 +109,7 @@ public class AspireAzureEfCoreCosmosDBExtensionsTests
                 },
                 configureSettings: useSettings ? settings => settings.RequestTimeout = TimeSpan.FromSeconds(300) : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
@@ -175,7 +175,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
                 configureDbContextOptions: optionsBuilder => optionsBuilder.UseSqlServer(),
                 configureSettings: useSettings ? settings => settings.CommandTimeout = 608 : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -210,7 +210,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
                     optionsBuilder.UseSqlServer(builder => builder.CommandTimeout(123)),
                 configureSettings: useSettings ? settings => settings.CommandTimeout = 300 : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.

--- a/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.Common.Tests;
@@ -135,7 +135,7 @@ public class AspireNatsClientExtensionsTests : IClassFixture<NatsContainerFixtur
             builder.AddNatsClient(DefaultConnectionName);
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
 
         var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
 
@@ -168,7 +168,7 @@ public class AspireNatsClientExtensionsTests : IClassFixture<NatsContainerFixtur
             });
         }
 
-        var host = builder.Build();
+        using var host = builder.Build();
 
         var healthCheckService = host.Services.GetService<HealthCheckService>();
 

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/AspireEFPostgreSqlExtensionsTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/AspireEFPostgreSqlExtensionsTests.cs
@@ -183,7 +183,7 @@ public class AspireEFPostgreSqlExtensionsTests
             configureDbContextOptions: optionsBuilder => optionsBuilder.UseNpgsql(),
             configureSettings: useSettings ? settings => settings.CommandTimeout = 123 : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -217,7 +217,7 @@ public class AspireEFPostgreSqlExtensionsTests
             configureDbContextOptions: optionsBuilder => optionsBuilder.UseNpgsql(builder => builder.CommandTimeout(123)),
             configureSettings: useSettings ? settings => settings.CommandTimeout = 300 : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/AspireOracleEFCoreDatabaseExtensionsTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/AspireOracleEFCoreDatabaseExtensionsTests.cs
@@ -176,7 +176,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
                 configureDbContextOptions: optionsBuilder => optionsBuilder.UseOracle(),
                 configureSettings: useSettings ? settings => settings.CommandTimeout = 608 : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -211,7 +211,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
                     optionsBuilder.UseOracle(builder => builder.CommandTimeout(123)),
                 configureSettings: useSettings ? settings => settings.CommandTimeout = 300 : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
@@ -195,7 +195,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
             optionsBuilder.UseMySql(new MySqlServerVersion(new Version(8, 2, 0))),
             configureSettings: useSettings ? settings => settings.CommandTimeout = 123 : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.
@@ -233,7 +233,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
             }),
             configureSettings: useSettings ? settings => settings.CommandTimeout = 300 : null);
 
-        var host = builder.Build();
+        using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
 
 #pragma warning disable EF1001 // Internal EF Core API usage.


### PR DESCRIPTION
I went low tech and appended `using var _ = builder.Build()` to tests. Generally it makes sense to do this as the end of the test once you are sure all other assertions that might depend on state prior to lifecycle hooks running.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3096)