### PR TITLE
Change how resources expose urls to the dashboard

### DIFF
--- a/playground/CustomResources/CustomResources.AppHost/TestResource.cs
+++ b/playground/CustomResources/CustomResources.AppHost/TestResource.cs
@@ -17,8 +17,8 @@ static class TestResourceExtensions
                           ResourceType = "Test Resource",
                           State = "Starting",
                           Properties = [
-                              ("P1", "P2"),
-                              (CustomResourceKnownProperties.Source, "Custom")
+                              new("P1", "P2"),
+                              new(CustomResourceKnownProperties.Source, "Custom")
                           ]
                       })
                       .ExcludeFromManifest();
@@ -47,7 +47,7 @@ internal sealed class TestResourceLifecycleHook(ResourceNotificationService noti
 
                 await notificationService.PublishUpdateAsync(resource, state => state with
                 {
-                    Properties = [.. state.Properties, ("Interval", seconds.ToString(CultureInfo.InvariantCulture))]
+                    Properties = [.. state.Properties, new("Interval", seconds.ToString(CultureInfo.InvariantCulture))]
                 });
 
                 using var timer = new PeriodicTimer(TimeSpan.FromSeconds(seconds));

--- a/playground/Stress/Stress.AppHost/TestResource.cs
+++ b/playground/Stress/Stress.AppHost/TestResource.cs
@@ -17,8 +17,8 @@ static class TestResourceExtensions
                           ResourceType = "Test Resource",
                           State = "Starting",
                           Properties = [
-                              ("P1", "P2"),
-                              (CustomResourceKnownProperties.Source, "Custom")
+                              new("P1", "P2"),
+                              new(CustomResourceKnownProperties.Source, "Custom")
                           ]
                       })
                       .ExcludeFromManifest();
@@ -47,7 +47,7 @@ internal sealed class TestResourceLifecycleHook(ResourceNotificationService noti
 
                 await notificationService.PublishUpdateAsync(resource, state => state with
                 {
-                    Properties = [.. state.Properties, ("Interval", seconds.ToString(CultureInfo.InvariantCulture))]
+                    Properties = [.. state.Properties, new("Interval", seconds.ToString(CultureInfo.InvariantCulture))]
                 });
 
                 using var timer = new PeriodicTimer(TimeSpan.FromSeconds(seconds));

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -104,7 +104,7 @@ public partial class ResourceDetails
 
     private IEnumerable<DisplayedEndpoint> GetEndpoints()
     {
-        return ResourceEndpointHelpers.GetEndpoints(Logger, Resource, includeInteralUrls: true);
+        return ResourceEndpointHelpers.GetEndpoints(Resource, includeInteralUrls: true);
     }
 
     private IEnumerable<SummaryValue> GetResourceValues()

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -104,7 +104,7 @@ public partial class ResourceDetails
 
     private IEnumerable<DisplayedEndpoint> GetEndpoints()
     {
-        return ResourceEndpointHelpers.GetEndpoints(Logger, Resource, excludeServices: false, includeEndpointUrl: true);
+        return ResourceEndpointHelpers.GetEndpoints(Logger, Resource, includeInteralUrls: true);
     }
 
     private IEnumerable<SummaryValue> GetResourceValues()

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -6,24 +6,11 @@
 @{
     List<DisplayedEndpoint> displayedEndpoints;
     string? additionalMessage = null;
-    if (Resource.Urls.Length == 0 && (Resource.State == ResourceStates.FinishedState || !Resource.ExpectUrls))
+    if (Resource.Urls.Length == 0)
     {
-        if (!Resource.ExpectUrls)
-        {
-            // If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None
-            additionalMessage = Loc[nameof(Columns.EndpointsColumnDisplayNone)];
-            displayedEndpoints = [];
-        }
-        else
-        {
-            displayedEndpoints = GetEndpoints(Resource);
-        }
-    }
-    else if (Resource.Urls.Length == 0 && (Resource.State != ResourceStates.FinishedState && Resource.ExpectUrls))
-    {
-        // If we're expecting more endpoints, say Starting..., unless the app isn't running anymore.
-        displayedEndpoints = GetEndpoints(Resource);
-        additionalMessage = Loc[nameof(Columns.EndpointsColumnDisplayPlaceholder)];
+        // If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None
+        additionalMessage = Loc[nameof(Columns.EndpointsColumnDisplayNone)];
+        displayedEndpoints = [];
     }
     else
     {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -6,9 +6,9 @@
 @{
     List<DisplayedEndpoint> displayedEndpoints;
     string? additionalMessage = null;
-    if (Resource.Endpoints.Length == 0 && (Resource.State == ResourceStates.FinishedState || Resource.ExpectedEndpointsCount == 0))
+    if (Resource.Urls.Length == 0 && (Resource.State == ResourceStates.FinishedState || Resource.ExpectUrls is false))
     {
-        if (Resource.Services.Length == 0)
+        if (Resource.ExpectUrls is false)
         {
             // If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None
             additionalMessage = Loc[nameof(Columns.EndpointsColumnDisplayNone)];
@@ -19,12 +19,10 @@
             displayedEndpoints = GetEndpoints(Resource);
         }
     }
-    else if (Resource.State != ResourceStates.FinishedState
-        && (Resource.ExpectedEndpointsCount is null || Resource.ExpectedEndpointsCount > Resource.Endpoints.Length))
+    else if (Resource.State != ResourceStates.FinishedState && Resource.ExpectUrls is false)
     {
         // If we're expecting more endpoints, say Starting..., unless the app isn't running anymore.
-        // Don't include service only endpoints in the list until finished loading endpoints.
-        displayedEndpoints = GetEndpoints(Resource, excludeServices: true);
+        displayedEndpoints = GetEndpoints(Resource);
         additionalMessage = Loc[nameof(Columns.EndpointsColumnDisplayPlaceholder)];
     }
     else

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -6,9 +6,9 @@
 @{
     List<DisplayedEndpoint> displayedEndpoints;
     string? additionalMessage = null;
-    if (Resource.Urls.Length == 0 && (Resource.State == ResourceStates.FinishedState || Resource.ExpectUrls is false))
+    if (Resource.Urls.Length == 0 && (Resource.State == ResourceStates.FinishedState || !Resource.ExpectUrls))
     {
-        if (Resource.ExpectUrls is false)
+        if (!Resource.ExpectUrls)
         {
             // If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None
             additionalMessage = Loc[nameof(Columns.EndpointsColumnDisplayNone)];
@@ -19,7 +19,7 @@
             displayedEndpoints = GetEndpoints(Resource);
         }
     }
-    else if (Resource.State != ResourceStates.FinishedState && Resource.ExpectUrls is false)
+    else if (Resource.Urls.Length == 0 && (Resource.State != ResourceStates.FinishedState && Resource.ExpectUrls))
     {
         // If we're expecting more endpoints, say Starting..., unless the app isn't running anymore.
         displayedEndpoints = GetEndpoints(Resource);

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
@@ -22,8 +22,8 @@ public partial class EndpointsColumnDisplay
     /// <summary>
     /// A resource has services and endpoints. These can overlap. This method attempts to return a single list without duplicates.
     /// </summary>
-    private List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool includeInteralUrls = false)
+    private static List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource)
     {
-        return ResourceEndpointHelpers.GetEndpoints(Logger, resource, includeInteralUrls);
+        return ResourceEndpointHelpers.GetEndpoints(resource, includeInteralUrls: false);
     }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
@@ -22,8 +22,8 @@ public partial class EndpointsColumnDisplay
     /// <summary>
     /// A resource has services and endpoints. These can overlap. This method attempts to return a single list without duplicates.
     /// </summary>
-    private List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool excludeServices = false)
+    private List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool includeInteralUrls = false)
     {
-        return ResourceEndpointHelpers.GetEndpoints(Logger, resource, excludeServices, includeEndpointUrl: false);
+        return ResourceEndpointHelpers.GetEndpoints(Logger, resource, includeInteralUrls);
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
@@ -10,26 +10,21 @@ internal static class ResourceEndpointHelpers
     /// <summary>
     /// A resource has services and endpoints. These can overlap. This method attempts to return a single list without duplicates.
     /// </summary>
-    public static List<DisplayedEndpoint> GetEndpoints(ILogger logger, ResourceViewModel resource, bool includeInteralUrls = false)
+    public static List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource, bool includeInteralUrls = false)
     {
         var endpoints = new List<DisplayedEndpoint>(resource.Urls.Length);
 
         foreach (var url in resource.Urls)
         {
-            if (!Uri.TryCreate(url.Url, UriKind.Absolute, out var uri))
-            {
-                // REVIEW: We should probably do this when creating the view model (once)
-                logger.LogWarning("Couldn't parse '{Url}' to a URI for resource {ResourceName}.", url.Url, resource.Name);
-            }
-            else if ((includeInteralUrls && url.IsInternal) || !url.IsInternal)
+            if ((includeInteralUrls && url.IsInternal) || !url.IsInternal)
             {
                 endpoints.Add(new DisplayedEndpoint
                 {
                     Name = url.Name,
-                    Text = url.Url,
-                    Address = uri.Host,
-                    Port = uri.Port,
-                    Url = uri.Scheme is "http" or "https" ? url.Url : null
+                    Text = url.Url.OriginalString,
+                    Address = url.Url.Host,
+                    Port = url.Url.Port,
+                    Url = url.Url.Scheme is "http" or "https" ? url.Url.OriginalString : null
                 });
             }
         }

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -96,9 +96,13 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
         {
             foreach (var (resourceName, resource) in resources)
             {
-                foreach (var service in resource.Services)
+                foreach (var service in resource.Urls)
                 {
-                    if (string.Equals(service.AddressAndPort, value, StringComparison.OrdinalIgnoreCase))
+                    var uri = new Uri(service.Url);
+
+                    var hostAndPort = uri.GetComponents(UriComponents.Host | UriComponents.Port, UriFormat.UriEscaped);
+
+                    if (string.Equals(hostAndPort, value, StringComparison.OrdinalIgnoreCase))
                     {
                         name = resource.Name;
                         return true;

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -98,9 +98,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
             {
                 foreach (var service in resource.Urls)
                 {
-                    var uri = new Uri(service.Url);
-
-                    var hostAndPort = uri.GetComponents(UriComponents.Host | UriComponents.Port, UriFormat.UriEscaped);
+                    var hostAndPort = service.Url.GetComponents(UriComponents.Host | UriComponents.Port, UriFormat.UriEscaped);
 
                     if (string.Equals(hostAndPort, value, StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -19,9 +19,8 @@ public sealed class ResourceViewModel
     public required string? State { get; init; }
     public required DateTime? CreationTimeStamp { get; init; }
     public required ImmutableArray<EnvironmentVariableViewModel> Environment { get; init; }
-    public required ImmutableArray<EndpointViewModel> Endpoints { get; init; }
-    public required ImmutableArray<ResourceServiceViewModel> Services { get; init; }
-    public required int? ExpectedEndpointsCount { get; init; }
+    public required ImmutableArray<UrlViewModel> Urls { get; init; }
+    public required bool ExpectUrls { get; init; }
     public required FrozenDictionary<string, Value> Properties { get; init; }
     public required ImmutableArray<CommandViewModel> Commands { get; init; }
 
@@ -92,37 +91,20 @@ public sealed class EnvironmentVariableViewModel
     }
 }
 
-public sealed class EndpointViewModel
-{
-    public string EndpointUrl { get; }
-    public string ProxyUrl { get; }
-
-    public EndpointViewModel(string endpointUrl, string proxyUrl)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(endpointUrl);
-        ArgumentException.ThrowIfNullOrWhiteSpace(proxyUrl);
-
-        EndpointUrl = endpointUrl;
-        ProxyUrl = proxyUrl;
-    }
-}
-
-public sealed class ResourceServiceViewModel
+public sealed class UrlViewModel
 {
     public string Name { get; }
-    public string? AllocatedAddress { get; }
-    public int? AllocatedPort { get; }
+    public string Url { get; }
+    public bool IsInternal { get; }
 
-    public string AddressAndPort { get; }
-
-    public ResourceServiceViewModel(string name, string? allocatedAddress, int? allocatedPort)
+    public UrlViewModel(string name, string url, bool isInternal)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(url);
 
         Name = name;
-        AllocatedAddress = allocatedAddress;
-        AllocatedPort = allocatedPort;
-        AddressAndPort = $"{allocatedAddress}:{allocatedPort}";
+        Url = url;
+        IsInternal = isInternal;
     }
 }
 

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -20,7 +20,6 @@ public sealed class ResourceViewModel
     public required DateTime? CreationTimeStamp { get; init; }
     public required ImmutableArray<EnvironmentVariableViewModel> Environment { get; init; }
     public required ImmutableArray<UrlViewModel> Urls { get; init; }
-    public required bool ExpectUrls { get; init; }
     public required FrozenDictionary<string, Value> Properties { get; init; }
     public required ImmutableArray<CommandViewModel> Commands { get; init; }
 
@@ -94,13 +93,13 @@ public sealed class EnvironmentVariableViewModel
 public sealed class UrlViewModel
 {
     public string Name { get; }
-    public string Url { get; }
+    public Uri Url { get; }
     public bool IsInternal { get; }
 
-    public UrlViewModel(string name, string url, bool isInternal)
+    public UrlViewModel(string name, Uri url, bool isInternal)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
-        ArgumentException.ThrowIfNullOrWhiteSpace(url);
+        ArgumentNullException.ThrowIfNull(url);
 
         Name = name;
         Url = url;

--- a/src/Aspire.Dashboard/Protos/Partials.cs
+++ b/src/Aspire.Dashboard/Protos/Partials.cs
@@ -25,7 +25,6 @@ partial class Resource
             Properties = Properties.ToFrozenDictionary(property => ValidateNotNull(property.Name), property => ValidateNotNull(property.Value), StringComparers.ResourcePropertyName),
             Environment = GetEnvironment(),
             Urls = GetUrls(),
-            ExpectUrls = ExpectUrls,
             State = HasState ? State : null,
             Commands = GetCommands()
         };
@@ -39,9 +38,12 @@ partial class Resource
 
         ImmutableArray<UrlViewModel> GetUrls()
         {
-            return Urls
-                .Select(e => new UrlViewModel(e.Name, e.FullUrl, e.IsInternal))
-                .ToImmutableArray();
+            // Filter out bad urls
+            return (from u in Urls
+                    let parsedUri = Uri.TryCreate(u.FullUrl, UriKind.Absolute, out var uri) ? uri : null
+                    where parsedUri != null
+                    select new UrlViewModel(u.Name, parsedUri, u.IsInternal))
+                    .ToImmutableArray();
         }
 
         ImmutableArray<CommandViewModel> GetCommands()

--- a/src/Aspire.Dashboard/Protos/Partials.cs
+++ b/src/Aspire.Dashboard/Protos/Partials.cs
@@ -23,20 +23,12 @@ partial class Resource
             Uid = ValidateNotNull(Uid),
             CreationTimeStamp = ValidateNotNull(CreatedAt).ToDateTime(),
             Properties = Properties.ToFrozenDictionary(property => ValidateNotNull(property.Name), property => ValidateNotNull(property.Value), StringComparers.ResourcePropertyName),
-            Endpoints = GetEndpoints(),
             Environment = GetEnvironment(),
-            ExpectedEndpointsCount = ExpectedEndpointsCount,
-            Services = GetServices(),
+            Urls = GetUrls(),
+            ExpectUrls = ExpectUrls,
             State = HasState ? State : null,
             Commands = GetCommands()
         };
-
-        ImmutableArray<ResourceServiceViewModel> GetServices()
-        {
-            return Services
-                .Select(s => new ResourceServiceViewModel(s.Name, s.AllocatedAddress, s.AllocatedPort))
-                .ToImmutableArray();
-        }
 
         ImmutableArray<EnvironmentVariableViewModel> GetEnvironment()
         {
@@ -45,10 +37,10 @@ partial class Resource
                 .ToImmutableArray();
         }
 
-        ImmutableArray<EndpointViewModel> GetEndpoints()
+        ImmutableArray<UrlViewModel> GetUrls()
         {
-            return Endpoints
-                .Select(e => new EndpointViewModel(e.EndpointUrl, e.ProxyUrl))
+            return Urls
+                .Select(e => new UrlViewModel(e.Name, e.FullUrl, e.IsInternal))
                 .ToImmutableArray();
         }
 

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -81,21 +81,19 @@ internal sealed class AzureProvisioner(
                                                   .ToLookup(x => x.Root, x => x.Child);
 
         // Sets the state of the resource and all of its children
-        async Task SetStateAsync(IAzureResource resource, string state)
-        {
-            await notificationService.PublishUpdateAsync(resource, s => s with
+        Task SetStateAsync(IAzureResource resource, string state) =>
+            UpdateStateAsync(resource, s => s with
             {
                 State = state
-            })
-            .ConfigureAwait(false);
+            });
+
+        async Task UpdateStateAsync(IAzureResource resource, Func<CustomResourceSnapshot, CustomResourceSnapshot> stateFactory)
+        {
+            await notificationService.PublishUpdateAsync(resource, stateFactory).ConfigureAwait(false);
 
             foreach (var child in parentChildLookup[resource])
             {
-                await notificationService.PublishUpdateAsync(child, s => s with
-                {
-                    State = state
-                })
-                .ConfigureAwait(false);
+                await notificationService.PublishUpdateAsync(child, stateFactory).ConfigureAwait(false);
             }
         }
 
@@ -119,7 +117,12 @@ internal sealed class AzureProvisioner(
         {
             r.ProvisioningTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            await SetStateAsync(r, "Starting").ConfigureAwait(false);
+            await UpdateStateAsync(r, s => s with
+            {
+                State = "Starting",
+                ExpectUrls = true // Portal url
+            })
+            .ConfigureAwait(false);
 
             // After the resource is provisioned, set its state
             _ = AfterProvisionAsync(r);

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -117,12 +117,7 @@ internal sealed class AzureProvisioner(
         {
             r.ProvisioningTaskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            await UpdateStateAsync(r, s => s with
-            {
-                State = "Starting",
-                ExpectUrls = true // Portal url
-            })
-            .ConfigureAwait(false);
+            await SetStateAsync(r, "Starting").ConfigureAwait(false);
 
             // After the resource is provisioned, set its state
             _ = AfterProvisionAsync(r);

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -74,13 +74,13 @@ internal sealed class BicepProvisioner(
             resource.SecretOutputs[item.Key] = item.Value;
         }
 
-        var portalUrls = new List<(string, string)>();
+        var portalUrls = new List<(string, string, bool)>();
 
         if (section["Id"] is string deploymentId &&
             ResourceIdentifier.TryParse(deploymentId, out var id) &&
             id is not null)
         {
-            portalUrls.Add(("deployment", GetDeploymentUrl(id)));
+            portalUrls.Add(("deployment", GetDeploymentUrl(id), false));
         }
 
         await notificationService.PublishUpdateAsync(resource, state =>
@@ -222,7 +222,7 @@ internal sealed class BicepProvisioner(
         {
             return state with
             {
-                Urls = [.. state.Urls, ("deployment", url)],
+                Urls = [.. state.Urls, ("deployment", url, false)],
             };
         })
         .ConfigureAwait(false);

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -74,24 +74,24 @@ internal sealed class BicepProvisioner(
             resource.SecretOutputs[item.Key] = item.Value;
         }
 
-        var portalUrls = new List<(string, string, bool)>();
+        var portalUrls = new List<UrlSnapshot>();
 
         if (section["Id"] is string deploymentId &&
             ResourceIdentifier.TryParse(deploymentId, out var id) &&
             id is not null)
         {
-            portalUrls.Add(("deployment", GetDeploymentUrl(id), false));
+            portalUrls.Add(new(Name: "deployment", Url: GetDeploymentUrl(id), IsInternal: false));
         }
 
         await notificationService.PublishUpdateAsync(resource, state =>
         {
-            ImmutableArray<(string, object?)> props = [
+            ImmutableArray<ResourcePropertySnapshot> props = [
                 .. state.Properties,
-                    ("azure.subscription.id", configuration["Azure:SubscriptionId"]),
-                    // ("azure.resource.group", configuration["Azure:ResourceGroup"]!),
-                    ("azure.tenant.domain", configuration["Azure:Tenant"]),
-                    ("azure.location", configuration["Azure:Location"]),
-                    (CustomResourceKnownProperties.Source, section["Id"])
+                    new("azure.subscription.id", configuration["Azure:SubscriptionId"]),
+                    // new("azure.resource.group", configuration["Azure:ResourceGroup"]!),
+                    new("azure.tenant.domain", configuration["Azure:Tenant"]),
+                    new("azure.location", configuration["Azure:Location"]),
+                    new(CustomResourceKnownProperties.Source, section["Id"])
             ];
 
             return state with
@@ -112,10 +112,10 @@ internal sealed class BicepProvisioner(
             ResourceType = resource.GetType().Name,
             State = "Starting",
             Properties = [
-                ("azure.subscription.id", context.Subscription.Id.Name),
-                ("azure.resource.group", context.ResourceGroup.Id.Name),
-                ("azure.tenant.domain", context.Tenant.Data.DefaultDomain),
-                ("azure.location", context.Location.ToString()),
+                new("azure.subscription.id", context.Subscription.Id.Name),
+                new("azure.resource.group", context.ResourceGroup.Id.Name),
+                new("azure.tenant.domain", context.Tenant.Data.DefaultDomain),
+                new("azure.location", context.Location.ToString()),
             ]
         }).ConfigureAwait(false);
 
@@ -222,7 +222,7 @@ internal sealed class BicepProvisioner(
         {
             return state with
             {
-                Urls = [.. state.Urls, ("deployment", url, false)],
+                Urls = [.. state.Urls, new(Name: "deployment", Url: url, IsInternal: false)],
             };
         })
         .ConfigureAwait(false);
@@ -308,9 +308,9 @@ internal sealed class BicepProvisioner(
 
         await notificationService.PublishUpdateAsync(resource, state =>
         {
-            ImmutableArray<(string, object?)> properties = [
+            ImmutableArray<ResourcePropertySnapshot> properties = [
                 .. state.Properties,
-                (CustomResourceKnownProperties.Source, deployment.Id.Name)
+                new(CustomResourceKnownProperties.Source, deployment.Id.Name)
             ];
 
             return state with

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -18,7 +18,7 @@ public sealed record CustomResourceSnapshot
     /// <summary>
     /// The properties that should show up in the dashboard for this resource.
     /// </summary>
-    public required ImmutableArray<(string Key, object? Value)> Properties { get; init; }
+    public required ImmutableArray<ResourcePropertySnapshot> Properties { get; init; }
 
     /// <summary>
     /// The creation timestamp of the resource.
@@ -38,11 +38,34 @@ public sealed record CustomResourceSnapshot
     /// <summary>
     /// The environment variables that should show up in the dashboard for this resource.
     /// </summary>
-    public ImmutableArray<(string Name, string Value, bool IsFromSpec)> EnvironmentVariables { get; init; } = [];
+    public ImmutableArray<EnvironmentVariableSnapshot> EnvironmentVariables { get; init; } = [];
 
     /// <summary>
     /// The URLs that should show up in the dashboard for this resource.
     /// </summary>
-    public ImmutableArray<(string Name, string Url, bool IsInternal)> Urls { get; init; } = [];
+    public ImmutableArray<UrlSnapshot> Urls { get; init; } = [];
 
 }
+
+/// <summary>
+/// A snapshot of an environment variable.
+/// </summary>
+/// <param name="Name">The name of the environment variable.</param>
+/// <param name="Value">The value of the environment variable.</param>
+/// <param name="IsFromSpec">Determines if this environment variable was defined in the resource explicitly or computed (for e.g. inherited from the process hierarchy).</param>
+public sealed record EnvironmentVariableSnapshot(string Name, string? Value, bool IsFromSpec);
+
+/// <summary>
+/// A snapshot of the url.
+/// </summary>
+/// <param name="Name">Name of the url.</param>
+/// <param name="Url">The full uri.</param>
+/// <param name="IsInternal">Determines if this url is internal.</param>
+public sealed record UrlSnapshot(string Name, string Url, bool IsInternal);
+
+/// <summary>
+/// A snapshot of the resource property.
+/// </summary>
+/// <param name="Name">The name of the property.</param>
+/// <param name="Value">The value of the property.</param>
+public sealed record ResourcePropertySnapshot(string Name, object? Value);

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -45,4 +45,10 @@ public sealed record CustomResourceSnapshot
     /// </summary>
     public ImmutableArray<(string Name, string Url, bool IsInternal)> Urls { get; init; } = [];
 
+    /// <summary>
+    /// Gets or sets a value that indicates if this resource will have urls in the future. If Urls
+    /// is non-empty, this will be true.
+    /// </summary>
+    public bool ExpectUrls { get; set; }
+
 }

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -45,10 +45,4 @@ public sealed record CustomResourceSnapshot
     /// </summary>
     public ImmutableArray<(string Name, string Url, bool IsInternal)> Urls { get; init; } = [];
 
-    /// <summary>
-    /// Gets or sets a value that indicates if this resource will have urls in the future. If Urls
-    /// is non-empty, this will be true.
-    /// </summary>
-    public bool ExpectUrls { get; set; }
-
 }

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -43,15 +43,6 @@ public sealed record CustomResourceSnapshot
     /// <summary>
     /// The URLs that should show up in the dashboard for this resource.
     /// </summary>
-    public ImmutableArray<(string Name, string Url)> Urls { get; init; } = [];
+    public ImmutableArray<(string Name, string Url, bool IsInternal)> Urls { get; init; } = [];
 
-    /// <summary>
-    /// The services that should show up in the dashboard for this resource.
-    /// </summary>
-    public ImmutableArray<(string Name, string? AllocatedAddress, int? AllocatedPort)> Services { get; init; } = [];
-
-    /// <summary>
-    /// The endpoints that should show up in the dashboard for this resource.
-    /// </summary>
-    public ImmutableArray<(string EndpointUrl, string ProxyUrl)> Endpoints { get; init; } = [];
 }

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -14,6 +14,9 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     private EndpointAnnotation? _endpointAnnotation;
     private bool? _isAllocated;
 
+    // TODO: Expose this
+    internal EndpointAnnotation EndpointAnnotation => GetEndpointAnnotation() ?? throw new InvalidOperationException($"The endpoint `{EndpointName}` is not defined for the resource `{Resource.Name}`.");
+
     /// <summary>
     /// Gets the resource owner of the endpoint reference.
     /// </summary>
@@ -93,11 +96,10 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
         GetAllocatedEndpoint()
         ?? throw new InvalidOperationException($"The endpoint `{EndpointName}` is not allocated for the resource `{Resource.Name}`.");
 
-    private AllocatedEndpoint? GetAllocatedEndpoint()
-    {
-        var endpoint = _endpointAnnotation ??= Resource.Annotations.OfType<EndpointAnnotation>().SingleOrDefault(a => StringComparers.EndpointAnnotationName.Equals(a.Name, EndpointName));
-        return endpoint?.AllocatedEndpoint;
-    }
+    private EndpointAnnotation? GetEndpointAnnotation() =>
+        _endpointAnnotation ??= Resource.Annotations.OfType<EndpointAnnotation>().SingleOrDefault(a => StringComparers.EndpointAnnotationName.Equals(a.Name, EndpointName));
+
+    private AllocatedEndpoint? GetAllocatedEndpoint() => GetEndpointAnnotation()?.AllocatedEndpoint;
 
     /// <summary>
     /// Creates a new instance of <see cref="EndpointReference"/> with the specified endpoint name.

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Logging;
@@ -32,22 +31,14 @@ internal sealed class DashboardServiceData : IAsyncDisposable
         {
             static GenericResourceSnapshot CreateResourceSnapshot(IResource resource, string resourceId, DateTime creationTimestamp, CustomResourceSnapshot snapshot)
             {
-                ImmutableArray<EnvironmentVariableSnapshot> environmentVariables = [..
-                    snapshot.EnvironmentVariables.Select(e => new EnvironmentVariableSnapshot(e.Name, e.Value, e.IsFromSpec))];
-
-                ImmutableArray<UrlSnapshot> urls =
-                [
-                    ..snapshot.Urls.Select(u => new UrlSnapshot(u.Name, u.Url, u.IsInternal)),
-                ];
-
                 return new GenericResourceSnapshot(snapshot)
                 {
                     Uid = resourceId,
                     CreationTimeStamp = snapshot.CreationTimeStamp ?? creationTimestamp,
                     Name = resourceId,
                     DisplayName = resource.Name,
-                    Urls = urls,
-                    Environment = environmentVariables,
+                    Urls = snapshot.Urls,
+                    Environment = snapshot.EnvironmentVariables,
                     ExitCode = snapshot.ExitCode,
                     State = snapshot.State
                 };

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -35,15 +35,9 @@ internal sealed class DashboardServiceData : IAsyncDisposable
                 ImmutableArray<EnvironmentVariableSnapshot> environmentVariables = [..
                     snapshot.EnvironmentVariables.Select(e => new EnvironmentVariableSnapshot(e.Name, e.Value, e.IsFromSpec))];
 
-                ImmutableArray<ResourceServiceSnapshot> services =
+                ImmutableArray<UrlSnapshot> urls =
                 [
-                    ..snapshot.Urls.Select(u => new ResourceServiceSnapshot(u.Name, u.Url, null)),
-                    ..snapshot.Services.Select(e => new ResourceServiceSnapshot(e.Name, e.AllocatedAddress, e.AllocatedPort))
-                ];
-
-                ImmutableArray<EndpointSnapshot> endpoints = [
-                    ..snapshot.Urls.Select(u => new EndpointSnapshot(u.Url, u.Url)),
-                    ..snapshot.Endpoints.Select(e => new EndpointSnapshot(e.EndpointUrl, e.ProxyUrl))
+                    ..snapshot.Urls.Select(u => new UrlSnapshot(u.Name, u.Url, u.IsInternal)),
                 ];
 
                 return new GenericResourceSnapshot(snapshot)
@@ -52,11 +46,10 @@ internal sealed class DashboardServiceData : IAsyncDisposable
                     CreationTimeStamp = snapshot.CreationTimeStamp ?? creationTimestamp,
                     Name = resourceId,
                     DisplayName = resource.Name,
-                    Endpoints = endpoints,
+                    Urls = urls,
+                    ExpectUrls = urls.Length > 0 || resource.TryGetLastAnnotation<EndpointAnnotation>(out _),
                     Environment = environmentVariables,
                     ExitCode = snapshot.ExitCode,
-                    ExpectedEndpointsCount = endpoints.Length,
-                    Services = services,
                     State = snapshot.State
                 };
             }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -47,7 +47,6 @@ internal sealed class DashboardServiceData : IAsyncDisposable
                     Name = resourceId,
                     DisplayName = resource.Name,
                     Urls = urls,
-                    ExpectUrls = urls.Length > 0 || snapshot.ExpectUrls,
                     Environment = environmentVariables,
                     ExitCode = snapshot.ExitCode,
                     State = snapshot.State

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -47,7 +47,7 @@ internal sealed class DashboardServiceData : IAsyncDisposable
                     Name = resourceId,
                     DisplayName = resource.Name,
                     Urls = urls,
-                    ExpectUrls = urls.Length > 0 || resource.TryGetLastAnnotation<EndpointAnnotation>(out _),
+                    ExpectUrls = urls.Length > 0 || snapshot.ExpectUrls,
                     Environment = environmentVariables,
                     ExitCode = snapshot.ExitCode,
                     State = snapshot.State

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -19,9 +19,11 @@ internal abstract class ResourceSnapshot
     public required int? ExitCode { get; init; }
     public required DateTime? CreationTimeStamp { get; init; }
     public required ImmutableArray<EnvironmentVariableSnapshot> Environment { get; init; }
-    public required ImmutableArray<EndpointSnapshot> Endpoints { get; init; }
-    public required ImmutableArray<ResourceServiceSnapshot> Services { get; init; }
-    public required int? ExpectedEndpointsCount { get; init; }
+
+    // Will this resource ever have any urls
+    public bool ExpectUrls { get; init; }
+
+    public required ImmutableArray<UrlSnapshot> Urls { get; init; }
 
     protected abstract IEnumerable<(string Key, Value Value)> GetProperties();
 
@@ -52,15 +54,5 @@ internal sealed class EnvironmentVariableSnapshot(string name, string? value, bo
     public bool IsFromSpec { get; } = isFromSpec;
 }
 
-internal sealed record EndpointSnapshot(string endpointUrl, string proxyUrl)
-{
-    public string EndpointUrl { get; } = endpointUrl;
-    public string ProxyUrl { get; } = proxyUrl;
-}
+internal sealed record UrlSnapshot(string Name, string Url, bool IsInternal);
 
-internal sealed class ResourceServiceSnapshot(string name, string? allocatedAddress, int? allocatedPort)
-{
-    public string Name { get; } = name;
-    public string? AllocatedAddress { get; } = allocatedAddress;
-    public int? AllocatedPort { get; } = allocatedPort;
-}

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.Globalization;
 using Aspire.Dashboard.Model;
+using Aspire.Hosting.ApplicationModel;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Hosting.Dashboard;
@@ -43,13 +44,3 @@ internal abstract class ResourceSnapshot
         }
     }
 }
-
-internal sealed class EnvironmentVariableSnapshot(string name, string? value, bool isFromSpec)
-{
-    public string Name { get; } = name;
-    public string? Value { get; } = value;
-    public bool IsFromSpec { get; } = isFromSpec;
-}
-
-internal sealed record UrlSnapshot(string Name, string Url, bool IsInternal);
-

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -20,9 +20,6 @@ internal abstract class ResourceSnapshot
     public required DateTime? CreationTimeStamp { get; init; }
     public required ImmutableArray<EnvironmentVariableSnapshot> Environment { get; init; }
 
-    // Will this resource ever have any urls
-    public bool ExpectUrls { get; init; }
-
     public required ImmutableArray<UrlSnapshot> Urls { get; init; }
 
     protected abstract IEnumerable<(string Key, Value Value)> GetProperties();

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -24,36 +24,16 @@ partial class Resource
             resource.CreatedAt = Timestamp.FromDateTime(snapshot.CreationTimeStamp.Value.ToUniversalTime());
         }
 
-        if (snapshot.ExpectedEndpointsCount.HasValue)
-        {
-            resource.ExpectedEndpointsCount = snapshot.ExpectedEndpointsCount.Value;
-        }
+        resource.ExpectUrls = snapshot.ExpectUrls;
 
         foreach (var env in snapshot.Environment)
         {
             resource.Environment.Add(new EnvironmentVariable { Name = env.Name, Value = env.Value ?? "", IsFromSpec = env.IsFromSpec });
         }
 
-        foreach (var endpoint in snapshot.Endpoints)
+        foreach (var url in snapshot.Urls)
         {
-            resource.Endpoints.Add(new Endpoint { EndpointUrl = endpoint.EndpointUrl, ProxyUrl = endpoint.ProxyUrl });
-        }
-
-        foreach (var service in snapshot.Services)
-        {
-            var serviceMessage = new Service { Name = service.Name };
-
-            if (service.AllocatedAddress is not null)
-            {
-                serviceMessage.AllocatedAddress = service.AllocatedAddress;
-            }
-
-            if (service.AllocatedPort.HasValue)
-            {
-                serviceMessage.AllocatedPort = service.AllocatedPort.Value;
-            }
-
-            resource.Services.Add(serviceMessage);
+            resource.Urls.Add(new Url { Name = url.Name, FullUrl = url.Url, IsInternal = url.IsInternal });
         }
 
         foreach (var property in snapshot.Properties)

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -24,8 +24,6 @@ partial class Resource
             resource.CreatedAt = Timestamp.FromDateTime(snapshot.CreationTimeStamp.Value.ToUniversalTime());
         }
 
-        resource.ExpectUrls = snapshot.ExpectUrls;
-
         foreach (var env in snapshot.Environment)
         {
             resource.Environment.Add(new EnvironmentVariable { Name = env.Name, Value = env.Value ?? "", IsFromSpec = env.IsFromSpec });

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -109,8 +109,12 @@ message Service {
 }
 
 message Url {
+    // The name of the url
     string name = 1;
+    // The uri of the url. Format is scheme://host:port/{*path}
     string full_url = 2;
+    // Determines if this url shows up in the details view only by default.
+    // If true, the url will not be shown in the list of urls in the top level resources view.
     bool is_internal = 3;
 }
 
@@ -133,13 +137,12 @@ message Resource {
     optional string state = 5;
     optional google.protobuf.Timestamp created_at = 6;
     repeated EnvironmentVariable environment = 7;
-    // Deprecated
-    optional int32 expected_endpoints_count = 8;
 
-    // Deprecated
-    repeated Endpoint endpoints = 9;
-    // Deprecated
-    repeated Service services = 10;
+    // Deprecated and replaced with urls
+    optional int32 expected_endpoints_count = 8 [deprecated = true];
+    repeated Endpoint endpoints = 9 [deprecated = true];
+    repeated Service services = 10 [deprecated = true];
+
     repeated ResourceCommand commands = 11;
 
     // Properties holding data not modeled directly on the message.
@@ -150,12 +153,8 @@ message Resource {
     // - Projects: process_id, project_path
     repeated ResourceProperty properties = 12;
 
+    // The list of urls that this resource exposes
     repeated Url urls = 13;
-
-    // Returns true if there will ever be any urls. Since these updates are being sent as the state
-    // of resources change, it is possible to for urls to be empty but expect_urls to be true.
-    // If urls is non-empty, expect_urls must be true.
-    bool expect_urls = 14;
 }
 
 ////////////////////////////////////////////

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -108,6 +108,12 @@ message Service {
     optional int32 allocated_port = 3;
 }
 
+message Url {
+    string name = 1;
+    string full_url = 2;
+    bool is_internal = 3;
+}
+
 message ResourceProperty {
     // Name of the data item, e.g. "container.id", "executable.pid", "project.path", ...
     string name = 1;
@@ -127,8 +133,12 @@ message Resource {
     optional string state = 5;
     optional google.protobuf.Timestamp created_at = 6;
     repeated EnvironmentVariable environment = 7;
+    // Deprecated
     optional int32 expected_endpoints_count = 8;
+
+    // Deprecated
     repeated Endpoint endpoints = 9;
+    // Deprecated
     repeated Service services = 10;
     repeated ResourceCommand commands = 11;
 
@@ -139,6 +149,9 @@ message Resource {
     // - Executables: process_id, executable_path, working_directory, arguments
     // - Projects: process_id, project_path
     repeated ResourceProperty properties = 12;
+
+    repeated Url urls = 13;
+    bool expect_urls = 14;
 }
 
 ////////////////////////////////////////////

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -151,6 +151,10 @@ message Resource {
     repeated ResourceProperty properties = 12;
 
     repeated Url urls = 13;
+
+    // Returns true if there will ever be any urls. Since these updates are being sent as the state
+    // of resources change, it is possible to for urls to be empty but expect_urls to be true.
+    // If urls is non-empty, expect_urls must be true.
     bool expect_urls = 14;
 }
 

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -463,14 +463,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
     private CustomResourceSnapshot ToSnapshot(Container container, CustomResourceSnapshot previous)
     {
-        var expectUrls = previous.ExpectUrls;
-
-        if (container.AppModelResourceName is not null &&
-            _applicationModel.TryGetValue(container.AppModelResourceName, out var appModelResource))
-        {
-            expectUrls = appModelResource.TryGetLastAnnotation<EndpointAnnotation>(out _);
-        }
-
         var containerId = container.Status?.ContainerId;
         var urls = GetUrls(container);
 
@@ -491,7 +483,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             ],
             EnvironmentVariables = environment,
             CreationTimeStamp = container.Metadata.CreationTimestamp?.ToLocalTime(),
-            ExpectUrls = expectUrls,
             Urls = urls
         };
 
@@ -516,14 +507,12 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
     private CustomResourceSnapshot ToSnapshot(Executable executable, CustomResourceSnapshot previous)
     {
-        var expectUrls = previous.ExpectUrls;
         string? projectPath = null;
 
         if (executable.AppModelResourceName is not null &&
             _applicationModel.TryGetValue(executable.AppModelResourceName, out var appModelResource))
         {
             projectPath = appModelResource is ProjectResource p ? p.GetProjectMetadata().ProjectPath : null;
-            expectUrls = appModelResource.TryGetLastAnnotation<EndpointAnnotation>(out _);
         }
 
         var urls = GetUrls(executable);
@@ -546,7 +535,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 ],
                 EnvironmentVariables = environment,
                 CreationTimeStamp = executable.Metadata.CreationTimestamp?.ToLocalTime(),
-                ExpectUrls = expectUrls,
                 Urls = urls
             };
         }
@@ -564,7 +552,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             ],
             EnvironmentVariables = environment,
             CreationTimeStamp = executable.Metadata.CreationTimestamp?.ToLocalTime(),
-            ExpectUrls = expectUrls,
             Urls = urls
         };
     }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -260,8 +260,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             };
 
             // Find the associated application model resource and update it.
-            string? resourceName = null;
-            resource.Metadata.Annotations?.TryGetValue(Executable.ResourceNameAnnotation, out resourceName);
+            var resourceName = resource.AppModelResourceName;
 
             if (resourceName is not null &&
                 _applicationModel.TryGetValue(resourceName, out var appModelResource))
@@ -440,8 +439,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
         if (cr is not null)
         {
-            string? appModelResourceName = null;
-            cr.Metadata.Annotations?.TryGetValue(Executable.ResourceNameAnnotation, out appModelResourceName);
+            var appModelResourceName = cr.AppModelResourceName;
 
             if (appModelResourceName is not null &&
                 _applicationModel.TryGetValue(appModelResourceName, out var appModelResource))
@@ -466,7 +464,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
     private CustomResourceSnapshot ToSnapshot(Container container, CustomResourceSnapshot previous)
     {
         var containerId = container.Status?.ContainerId;
-        var (endpointsWithMetadata, services) = GetEndpointsAndServices(container, "Container");
+        var urls = GetUrls(container);
 
         var environment = GetEnvironmentVariables(container.Status?.EffectiveEnv ?? container.Spec.Env, container.Spec.Env);
 
@@ -485,8 +483,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             ],
             EnvironmentVariables = environment,
             CreationTimeStamp = container.Metadata.CreationTimestamp?.ToLocalTime(),
-            Endpoints = [.. endpointsWithMetadata.Select(e => (e.EndpointUrl, e.ProxyUrl))],
-            Services = services
+            Urls = urls
         };
 
         ImmutableArray<int> GetPorts()
@@ -522,51 +519,12 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 #pragma warning restore CS0612
         }
 
-        string? resourceName = null;
-        executable.Metadata.Annotations?.TryGetValue(Executable.ResourceNameAnnotation, out resourceName);
-
-        var (endpointsWithMetadata, services) = GetEndpointsAndServices(executable, "Executable");
+        var urls = GetUrls(executable);
 
         var environment = GetEnvironmentVariables(executable.Status?.EffectiveEnv, executable.Spec.Env);
 
         if (projectPath is not null)
         {
-            var endpoints = endpointsWithMetadata.Select(e => (e.EndpointUrl, e.ProxyUrl));
-
-            if (resourceName is not null &&
-                _applicationModel.TryGetValue(resourceName, out var appModelResource) &&
-                appModelResource is ProjectResource p &&
-                p.GetEffectiveLaunchProfile() is LaunchProfile profile &&
-                profile.LaunchUrl is string launchUrl)
-            {
-                // Concat the launch url from the launch profile to the urls with IsFromLaunchProfile set to true
-
-                string CombineUrls(string url, string launchUrl)
-                {
-                    if (!launchUrl.Contains("://"))
-                    {
-                        // This is relative URL
-                        url += $"/{launchUrl}";
-                    }
-                    else
-                    {
-                        // For absolute URL we need to update the port value if possible
-                        if (profile.ApplicationUrl is string applicationUrl
-                            && launchUrl.StartsWith(applicationUrl))
-                        {
-                            url = launchUrl.Replace(applicationUrl, url);
-                        }
-                    }
-
-                    return url;
-                }
-
-                endpoints = endpointsWithMetadata.Select(e => e.IsFromLaunchProfile
-                    ? (CombineUrls(e.EndpointUrl, launchUrl), CombineUrls(e.ProxyUrl, launchUrl))
-                    : (e.EndpointUrl, e.ProxyUrl)
-                );
-            }
-
             return previous with
             {
                 ResourceType = KnownResourceTypes.Project,
@@ -581,8 +539,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 ],
                 EnvironmentVariables = environment,
                 CreationTimeStamp = executable.Metadata.CreationTimestamp?.ToLocalTime(),
-                Endpoints = [.. endpoints],
-                Services = services
+                Urls = urls
             };
         }
 
@@ -599,18 +556,15 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             ],
             EnvironmentVariables = environment,
             CreationTimeStamp = executable.Metadata.CreationTimestamp?.ToLocalTime(),
-            Endpoints = [.. endpointsWithMetadata.Select(e => (e.EndpointUrl, e.ProxyUrl))],
-            Services = services
+            Urls = urls
         };
     }
 
-    private (ImmutableArray<(string EndpointUrl, string ProxyUrl, bool IsFromLaunchProfile)> Endpoints,
-            ImmutableArray<(string Name, string? AllocatedAddress, int? AllocatedPort)> Services)
-        GetEndpointsAndServices(CustomResource resource, string resourceKind)
+    private ImmutableArray<(string Name, string Url, bool IsInternal)> GetUrls(CustomResource resource)
     {
-        var endpoints = ImmutableArray.CreateBuilder<(string EndpointUrl, string ProxyUrl, bool IsFromLaunchProfile)>();
-        var services = ImmutableArray.CreateBuilder<(string Name, string? AllocatedAddress, int? AllocatedPort)>();
         var name = resource.Metadata.Name;
+
+        var urls = ImmutableArray.CreateBuilder<(string Name, string Url, bool IsInternal)>();
 
         foreach (var (_, endpoint) in _endpointsMap)
         {
@@ -619,38 +573,66 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 continue;
             }
 
-            if (endpoint.Spec.ServiceName is not null
-                && _servicesMap.TryGetValue(endpoint.Spec.ServiceName, out var service)
-                && service?.UsesHttpProtocol(out var uriScheme) == true)
+            if (endpoint.Spec.ServiceName is not null &&
+                _servicesMap.TryGetValue(endpoint.Spec.ServiceName, out var service) &&
+                service.AppModelResourceName is string resourceName &&
+                _applicationModel.TryGetValue(resourceName, out var appModelResource) &&
+                appModelResource is IResourceWithEndpoints resourceWithEndpoints &&
+                service.EndpointName is string endpointName)
             {
-                string? launchProfile = null;
-                service.Metadata.Annotations?.TryGetValue(CustomResource.LaunchProfileAnnotation, out launchProfile);
+                var ep = resourceWithEndpoints.GetEndpoint(endpointName);
 
-                var endpointString = $"{uriScheme}://{endpoint.Spec.Address}:{endpoint.Spec.Port}";
-                var proxyUrlString = $"{uriScheme}://{service.AllocatedAddress}:{service.AllocatedPort}";
-                var isFromLaunchProfile = false;
-
-                if (launchProfile is not null)
+                if (ep.EndpointAnnotation.FromLaunchProfile &&
+                    appModelResource is ProjectResource p &&
+                    p.GetEffectiveLaunchProfile() is LaunchProfile profile &&
+                    profile.LaunchUrl is string launchUrl)
                 {
-                    _ = bool.TryParse(launchProfile, out isFromLaunchProfile);
+                    // Concat the launch url from the launch profile to the urls with IsFromLaunchProfile set to true
+
+                    string CombineUrls(string url, string launchUrl)
+                    {
+                        if (!launchUrl.Contains("://"))
+                        {
+                            // This is relative URL
+                            url += $"/{launchUrl}";
+                        }
+                        else
+                        {
+                            // For absolute URL we need to update the port value if possible
+                            if (profile.ApplicationUrl is string applicationUrl
+                                && launchUrl.StartsWith(applicationUrl))
+                            {
+                                url = launchUrl.Replace(applicationUrl, url);
+                            }
+                        }
+
+                        return url;
+                    }
+
+                    if (ep.IsAllocated)
+                    {
+                        var url = CombineUrls(ep.Url, launchUrl);
+
+                        urls.Add(new(ep.EndpointName, url, false));
+                    }
+                }
+                else
+                {
+                    if (ep.IsAllocated)
+                    {
+                        urls.Add(new(ep.EndpointName, ep.Url, false));
+                    }
                 }
 
-                endpoints.Add(new(endpointString, proxyUrlString, isFromLaunchProfile));
+                if (ep.EndpointAnnotation.IsProxied)
+                {
+                    var endpointString = $"{ep.Scheme}://{endpoint.Spec.Address}:{endpoint.Spec.Port}";
+                    urls.Add(new($"{ep.EndpointName}-listen-port", endpointString, true));
+                }
             }
         }
 
-        if (_resourceAssociatedServicesMap.TryGetValue((resourceKind, name), out var resourceServiceMappings))
-        {
-            foreach (var serviceName in resourceServiceMappings)
-            {
-                if (_servicesMap.TryGetValue(serviceName, out var service))
-                {
-                    services.Add(new(service.Metadata.Name, service.AllocatedAddress, service.AllocatedPort));
-                }
-            }
-        }
-
-        return (endpoints.ToImmutable(), services.ToImmutable());
+        return urls.ToImmutable();
     }
 
     private static ImmutableArray<(string Name, string Value, bool IsFromSpec)> GetEnvironmentVariables(List<EnvVar>? effectiveSource, List<EnvVar>? specSource)
@@ -948,37 +930,36 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
     private void PrepareServices()
     {
         var serviceProducers = _model.Resources
-            .Select(r => (ModelResource: r, SBAnnotations: r.Annotations.OfType<EndpointAnnotation>()))
-            .Where(sp => sp.SBAnnotations.Any());
+            .Select(r => (ModelResource: r, Endpoints: r.Annotations.OfType<EndpointAnnotation>()))
+            .Where(sp => sp.Endpoints.Any());
 
         // We need to ensure that Services have unique names (otherwise we cannot really distinguish between
         // services produced by different resources).
         HashSet<string> serviceNames = [];
 
-        void addServiceAppResource(Service svc, IResource producingResource, EndpointAnnotation sba)
-        {
-            svc.Spec.Protocol = PortProtocol.FromProtocolType(sba.Protocol);
-            svc.Annotate(CustomResource.UriSchemeAnnotation, sba.UriScheme);
-            svc.Annotate(CustomResource.LaunchProfileAnnotation, sba.FromLaunchProfile.ToString());
-            svc.Spec.AddressAllocationMode = sba.IsProxied ? AddressAllocationModes.Localhost : AddressAllocationModes.Proxyless;
-            _appResources.Add(new ServiceAppResource(producingResource, svc, sba));
-        }
-
         foreach (var sp in serviceProducers)
         {
-            var sbAnnotations = sp.SBAnnotations.ToArray();
+            var endpoints = sp.Endpoints.ToArray();
 
-            foreach (var sba in sbAnnotations)
+            foreach (var endpoint in endpoints)
             {
-                var candidateServiceName = sbAnnotations.Length == 1 ?
-                    GetObjectNameForResource(sp.ModelResource) : GetObjectNameForResource(sp.ModelResource, sba.Name);
+                var candidateServiceName = endpoints.Length == 1
+                    ? GetObjectNameForResource(sp.ModelResource)
+                    : GetObjectNameForResource(sp.ModelResource, endpoint.Name);
+
                 var uniqueServiceName = GenerateUniqueServiceName(serviceNames, candidateServiceName);
                 var svc = Service.Create(uniqueServiceName);
 
-                int? port = _options.Value.RandomizePorts is true && sba.IsProxied ? null : sba.Port;
+                var port = _options.Value.RandomizePorts is true && endpoint.IsProxied ? null : endpoint.Port;
                 svc.Spec.Port = port;
+                svc.Spec.Protocol = PortProtocol.FromProtocolType(endpoint.Protocol);
+                svc.Spec.AddressAllocationMode = endpoint.IsProxied ? AddressAllocationModes.Localhost : AddressAllocationModes.Proxyless;
 
-                addServiceAppResource(svc, sp.ModelResource, sba);
+                // So we can associate the service with the resource that produced it and the endpoint it represents.
+                svc.Annotate(CustomResource.ResourceNameAnnotation, sp.ModelResource.Name);
+                svc.Annotate(CustomResource.EndpointNameAnnotation, endpoint.Name);
+
+                _appResources.Add(new ServiceAppResource(sp.ModelResource, svc, endpoint));
             }
         }
     }
@@ -1002,8 +983,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             // The working directory is always relative to the app host project directory (if it exists).
             exe.Spec.WorkingDirectory = executable.WorkingDirectory;
             exe.Spec.ExecutionType = ExecutionType.Process;
-            exe.Annotate(Executable.OtelServiceNameAnnotation, exe.Metadata.Name);
-            exe.Annotate(Executable.ResourceNameAnnotation, executable.Name);
+            exe.Annotate(CustomResource.OtelServiceNameAnnotation, exe.Metadata.Name);
+            exe.Annotate(CustomResource.ResourceNameAnnotation, executable.Name);
 
             var exeAppResource = new AppResource(executable, exe);
             AddServicesProducedInfo(executable, exe, exeAppResource);
@@ -1029,8 +1010,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             exeSpec.WorkingDirectory = Path.GetDirectoryName(projectMetadata.ProjectPath);
 
             IAnnotationHolder annotationHolder = ers.Spec.Template;
-            annotationHolder.Annotate(Executable.OtelServiceNameAnnotation, ers.Metadata.Name);
-            annotationHolder.Annotate(Executable.ResourceNameAnnotation, project.Name);
+            annotationHolder.Annotate(CustomResource.OtelServiceNameAnnotation, ers.Metadata.Name);
+            annotationHolder.Annotate(CustomResource.ResourceNameAnnotation, project.Name);
 
             var projectLaunchConfiguration = new ProjectLaunchConfiguration();
             projectLaunchConfiguration.ProjectPath = projectMetadata.ProjectPath;
@@ -1425,8 +1406,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
             var ctr = Container.Create(GetObjectNameForResource(container), containerImageName);
 
-            ctr.Annotate(Container.ResourceNameAnnotation, container.Name);
-            ctr.Annotate(Container.OtelServiceNameAnnotation, container.Name);
+            ctr.Annotate(CustomResource.ResourceNameAnnotation, container.Name);
+            ctr.Annotate(CustomResource.OtelServiceNameAnnotation, container.Name);
 
             if (container.TryGetContainerMounts(out var containerMounts))
             {

--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -220,9 +220,6 @@ internal static class ContainerState
 
 internal sealed class Container : CustomResource<ContainerSpec, ContainerStatus>
 {
-    public const string ResourceNameAnnotation = "resource-name";
-    public const string OtelServiceNameAnnotation = "otel-service-name";
-
     [JsonConstructor]
     public Container(ContainerSpec spec) : base(spec) { }
 

--- a/src/Aspire.Hosting/Dcp/Model/Executable.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Executable.cs
@@ -118,8 +118,6 @@ internal sealed class Executable : CustomResource<ExecutableSpec, ExecutableStat
     [Obsolete] public const string CSharpDisableLaunchProfileAnnotation = "csharp-disable-launch-profile";
 
     public const string LaunchConfigurationsAnnotation = "executable.usvc-dev.developer.microsoft.com/launch-configurations";
-    public const string OtelServiceNameAnnotation = "otel-service-name";
-    public const string ResourceNameAnnotation = "resource-name";
 
     [JsonConstructor]
     public Executable(ExecutableSpec spec) : base(spec) { }

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -20,8 +20,11 @@ internal abstract class CustomResource : KubernetesObject, IMetadata<V1ObjectMet
 {
     public const string ServiceProducerAnnotation = "service-producer";
     public const string ServiceConsumerAnnotation = "service-consumer";
-    public const string UriSchemeAnnotation = "uri-scheme";
-    public const string LaunchProfileAnnotation = "launchProfile";
+    public const string EndpointNameAnnotation = "endpoint-name";
+    public const string ResourceNameAnnotation = "resource-name";
+    public const string OtelServiceNameAnnotation = "otel-service-name";
+
+    public string? AppModelResourceName => Metadata.Annotations?.TryGetValue(ResourceNameAnnotation, out var value) is true ? value : null;
 
     [JsonPropertyName("metadata")]
     public V1ObjectMeta Metadata { get; set; } = new V1ObjectMeta();

--- a/src/Aspire.Hosting/Dcp/Model/Service.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Service.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using k8s.Models;
 
@@ -89,13 +88,7 @@ internal sealed class Service : CustomResource<ServiceSpec, ServiceStatus>
     public string? AllocatedAddress => Spec.Address ?? Status?.EffectiveAddress;
     public bool HasCompleteAddress => AllocatedPort > 0 && !string.IsNullOrEmpty(AllocatedAddress);
 
-    public bool UsesHttpProtocol([NotNullWhen(true)] out string? uriScheme)
-    {
-        uriScheme = null;
-        return Metadata.Annotations?.TryGetValue(UriSchemeAnnotation, out uriScheme) == true
-            && (string.Equals(uriScheme, "http", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(uriScheme, "https", StringComparison.OrdinalIgnoreCase));
-    }
+    public string? EndpointName => Metadata.Annotations?.TryGetValue(EndpointNameAnnotation, out var value) is true ? value : null;
 
     public void ApplyAddressInfoFrom(Service other)
     {

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -45,18 +45,18 @@ public static class ParameterResourceBuilderExtensions
         {
             ResourceType = "Parameter",
             Properties = [
-                ("parameter.secret", secret.ToString()),
-                (CustomResourceKnownProperties.Source, connectionString ? $"ConnectionStrings:{name}" : $"Parameters:{name}")
+                new("parameter.secret", secret.ToString()),
+                new(CustomResourceKnownProperties.Source, connectionString ? $"ConnectionStrings:{name}" : $"Parameters:{name}")
             ]
         };
 
         try
         {
-            state = state with { Properties = [.. state.Properties, ("Value", resource.Value)] };
+            state = state with { Properties = [.. state.Properties, new("Value", resource.Value)] };
         }
         catch (DistributedApplicationException ex)
         {
-            state = state with { State = "FailedToStart", Properties = [.. state.Properties, ("Value", ex.Message)] };
+            state = state with { State = "FailedToStart", Properties = [.. state.Properties, new("Value", ex.Message)] };
         }
 
         return builder.AddResource(resource)

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -154,6 +154,53 @@ public sealed class ResourceEndpointHelpersTests
             });
     }
 
+    [Fact]
+    public void GetEndpoints_ExlcudesIncludeInternalUrls()
+    {
+        var endpoints = GetEndpoints(CreateResource([
+            new("First", "https://localhost:8080/test", isInternal:true),
+            new("Test", "https://localhost:8081/test2", isInternal:false)
+        ]));
+
+        Assert.Collection(endpoints,
+            e =>
+            {
+                Assert.Equal("https://localhost:8081/test2", e.Text);
+                Assert.Equal("Test", e.Name);
+                Assert.Equal("https://localhost:8081/test2", e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8081, e.Port);
+            });
+    }
+
+    [Fact]
+    public void GetEndpoints_IncludesIncludeInternalUrls()
+    {
+        var endpoints = GetEndpoints(CreateResource([
+            new("First", "https://localhost:8080/test", isInternal:true),
+            new("Test", "https://localhost:8081/test2", isInternal:false)
+        ]),
+        includeInteralUrls: true);
+
+        Assert.Collection(endpoints,
+            e =>
+            {
+                Assert.Equal("https://localhost:8080/test", e.Text);
+                Assert.Equal("First", e.Name);
+                Assert.Equal("https://localhost:8080/test", e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8080, e.Port);
+            },
+            e =>
+            {
+                Assert.Equal("https://localhost:8081/test2", e.Text);
+                Assert.Equal("Test", e.Name);
+                Assert.Equal("https://localhost:8081/test2", e.Url);
+                Assert.Equal("localhost", e.Address);
+                Assert.Equal(8081, e.Port);
+            });
+    }
+
     private static ResourceViewModel CreateResource(ImmutableArray<UrlViewModel> urls)
     {
         return new ResourceViewModel

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Frozen;
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Aspire.Dashboard.Model;
@@ -15,10 +14,6 @@ public class ResourceOutgoingPeerResolverTests
 {
     private static ResourceViewModel CreateResource(string name, string? serviceAddress = null, int? servicePort = null)
     {
-        ImmutableArray<ResourceServiceViewModel> resourceServices = serviceAddress is null || servicePort is null
-            ? ImmutableArray<ResourceServiceViewModel>.Empty
-            : [new ResourceServiceViewModel("http", serviceAddress, servicePort)];
-
         return new ResourceViewModel
         {
             Name = name,
@@ -26,11 +21,10 @@ public class ResourceOutgoingPeerResolverTests
             DisplayName = name,
             Uid = Guid.NewGuid().ToString(),
             CreationTimeStamp = DateTime.UtcNow,
-            Environment = ImmutableArray<EnvironmentVariableViewModel>.Empty,
-            Endpoints = ImmutableArray<EndpointViewModel>.Empty,
-            Services = resourceServices,
+            Environment = [],
             ExpectedEndpointsCount = 0,
             Properties = FrozenDictionary<string, Value>.Empty,
+            Urls = servicePort is null || servicePort is null ? [] : [new UrlViewModel(name, $"http://{serviceAddress}:{servicePort}", isInternal: false)],
             State = null,
             Commands = []
         };

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -22,7 +22,7 @@ public class ResourceOutgoingPeerResolverTests
             Uid = Guid.NewGuid().ToString(),
             CreationTimeStamp = DateTime.UtcNow,
             Environment = [],
-            ExpectedEndpointsCount = 0,
+            ExpectUrls = serviceAddress is not null && serviceAddress is not null,
             Properties = FrozenDictionary<string, Value>.Empty,
             Urls = servicePort is null || servicePort is null ? [] : [new UrlViewModel(name, $"http://{serviceAddress}:{servicePort}", isInternal: false)],
             State = null,

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -22,9 +22,8 @@ public class ResourceOutgoingPeerResolverTests
             Uid = Guid.NewGuid().ToString(),
             CreationTimeStamp = DateTime.UtcNow,
             Environment = [],
-            ExpectUrls = serviceAddress is not null && serviceAddress is not null,
             Properties = FrozenDictionary<string, Value>.Empty,
-            Urls = servicePort is null || servicePort is null ? [] : [new UrlViewModel(name, $"http://{serviceAddress}:{servicePort}", isInternal: false)],
+            Urls = servicePort is null || servicePort is null ? [] : [new UrlViewModel(name, new($"http://{serviceAddress}:{servicePort}"), isInternal: false)],
             State = null,
             Commands = []
         };

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -190,10 +190,8 @@ public class ResourcePublisherTests
             ExitCode = null,
             CreationTimeStamp = null,
             DisplayName = "",
-            Endpoints = [],
+            Urls = [],
             Environment = [],
-            ExpectedEndpointsCount = null,
-            Services = [],
         };
     }
 }

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -19,7 +19,7 @@ public class ResourceNotificationTests
             .WithInitialState(new()
             {
                 ResourceType = "MyResource",
-                Properties = [("A", "B")],
+                Properties = [new("A", "B")],
             });
 
         var annotation = custom.Resource.Annotations.OfType<ResourceSnapshotAnnotation>().SingleOrDefault();
@@ -32,7 +32,7 @@ public class ResourceNotificationTests
         Assert.Empty(state.EnvironmentVariables);
         Assert.Collection(state.Properties, c =>
         {
-            Assert.Equal("A", c.Key);
+            Assert.Equal("A", c.Name);
             Assert.Equal("B", c.Value);
         });
     }
@@ -64,9 +64,9 @@ public class ResourceNotificationTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var enumerableTask = GetValuesAsync(cts.Token);
 
-        await notificationService.PublishUpdateAsync(resource, state => state with { Properties = state.Properties.Add(("A", "value")) });
+        await notificationService.PublishUpdateAsync(resource, state => state with { Properties = state.Properties.Add(new("A", "value")) });
 
-        await notificationService.PublishUpdateAsync(resource, state => state with { Properties = state.Properties.Add(("B", "value")) });
+        await notificationService.PublishUpdateAsync(resource, state => state with { Properties = state.Properties.Add(new("B", "value")) });
 
         var values = await enumerableTask;
 
@@ -76,14 +76,14 @@ public class ResourceNotificationTests
                 Assert.Equal(resource, c.Resource);
                 Assert.Equal("myResource", c.ResourceId);
                 Assert.Equal("CustomResource", c.Snapshot.ResourceType);
-                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Key == "A").Value);
+                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Name == "A").Value);
             },
             c =>
             {
                 Assert.Equal(resource, c.Resource);
                 Assert.Equal("myResource", c.ResourceId);
                 Assert.Equal("CustomResource", c.Snapshot.ResourceType);
-                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Key == "B").Value);
+                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Name == "B").Value);
             });
     }
 
@@ -115,11 +115,11 @@ public class ResourceNotificationTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var enumerableTask = GetValuesAsync(cts.Token);
 
-        await notificationService.PublishUpdateAsync(resource1, state => state with { Properties = state.Properties.Add(("A", "value")) });
+        await notificationService.PublishUpdateAsync(resource1, state => state with { Properties = state.Properties.Add(new("A", "value")) });
 
-        await notificationService.PublishUpdateAsync(resource2, state => state with { Properties = state.Properties.Add(("B", "value")) });
+        await notificationService.PublishUpdateAsync(resource2, state => state with { Properties = state.Properties.Add(new("B", "value")) });
 
-        await notificationService.PublishUpdateAsync(resource1, "replica1", state => state with { Properties = state.Properties.Add(("C", "value")) });
+        await notificationService.PublishUpdateAsync(resource1, "replica1", state => state with { Properties = state.Properties.Add(new("C", "value")) });
 
         var values = await enumerableTask;
 
@@ -129,21 +129,21 @@ public class ResourceNotificationTests
                 Assert.Equal(resource1, c.Resource);
                 Assert.Equal("myResource1", c.ResourceId);
                 Assert.Equal("CustomResource", c.Snapshot.ResourceType);
-                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Key == "A").Value);
+                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Name == "A").Value);
             },
             c =>
             {
                 Assert.Equal(resource2, c.Resource);
                 Assert.Equal("myResource2", c.ResourceId);
                 Assert.Equal("CustomResource", c.Snapshot.ResourceType);
-                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Key == "B").Value);
+                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Name == "B").Value);
             },
             c =>
             {
                 Assert.Equal(resource1, c.Resource);
                 Assert.Equal("replica1", c.ResourceId);
                 Assert.Equal("CustomResource", c.Snapshot.ResourceType);
-                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Key == "C").Value);
+                Assert.Equal("value", c.Snapshot.Properties.Single(p => p.Name == "C").Value);
             });
     }
 


### PR DESCRIPTION
- The resource server used to have a services and endpoints split, that is now a single object called a url which has a name, a full url (uri format) and a bool for if that endpoint is internal (or an implementation detail). Internal urls only show up in the details pane.
- Clean up the way we extract urls from the dcp information by mapping the app model resource and endpoint within each service resource in DCP.
- Updated tests

Fixes https://github.com/dotnet/aspire/issues/3078

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3103)