### PR TITLE
Allow packages to not go stable

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,9 @@
     <VersionPrefix>8.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview.5</PreReleaseVersionLabel>
     <UseVSTestRunner>true</UseVSTestRunner>
+    <!-- Enable to remove prerelease label. -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->


### PR DESCRIPTION
Fixes #2541

cc: @eerhardt 

With these changes, now individual projects can decide to stay marked as preview even when the rest of the repo is producing stable packages. Once we branch for GA, We will update `StabilizePackageVersion` and set it to `true` meaning that the repo will start producing stable packages. That said, individual projects will be able to stay in prerelease by adding the following property in their .csproj:

```xml
    <PropertyGroup>
        <!-- This project will remain producing prerelease versions, even when the rest of the repo is producing stable packages -->
        <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
    </PropertyGroup>
``` 

This model is the same as the one used by dotnet/runtime repo.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3116)