### PR TITLE
Fix SqlClient component activity name

### DIFF
--- a/src/Vendoring/.editorconfig
+++ b/src/Vendoring/.editorconfig
@@ -15,3 +15,5 @@ dotnet_diagnostic.CA1852.severity = silent
 # IDE0060: Remove unused parameters
 dotnet_diagnostic.IDE0060.severity = silent
 
+# IDE0005: Using directive is unnecessary
+dotnet_diagnostic.IDE0005.severity = silent

--- a/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -17,7 +17,7 @@ internal sealed class SqlActivitySourceHelper
 {
     public const string MicrosoftSqlServerDatabaseSystemName = "mssql";
 
-    public static readonly AssemblyName AssemblyName = typeof(SqlActivitySourceHelper).Assembly.GetName();
+    public static readonly AssemblyName AssemblyName = new AssemblyName("OpenTelemetry.Instrumentation.SqlClient");
     public static readonly string ActivitySourceName = AssemblyName.Name;
     public static readonly Version Version = AssemblyName.Version;
     public static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());

--- a/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
+++ b/src/Vendoring/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs
@@ -17,11 +17,10 @@ internal sealed class SqlActivitySourceHelper
 {
     public const string MicrosoftSqlServerDatabaseSystemName = "mssql";
 
-    public static readonly AssemblyName AssemblyName = new AssemblyName("OpenTelemetry.Instrumentation.SqlClient");
-    public static readonly string ActivitySourceName = AssemblyName.Name;
-    public static readonly Version Version = AssemblyName.Version;
+    public const string ActivitySourceName = "OpenTelemetry.Instrumentation.SqlClient";
+    public static readonly Version Version = new Version(1, 7, 0, 1173);
     public static readonly ActivitySource ActivitySource = new(ActivitySourceName, Version.ToString());
-    public static readonly string ActivityName = ActivitySourceName + ".Execute";
+    public const string ActivityName = ActivitySourceName + ".Execute";
 
     public static readonly IEnumerable<KeyValuePair<string, object>> CreationTags = new[]
     {

--- a/src/Vendoring/README.md
+++ b/src/Vendoring/README.md
@@ -28,6 +28,11 @@ git checkout tags/Instrumentation.SqlClient-1.7.0-beta.1
 
 - Copy files from `src/OpenTelemetry.Instrumentation.SqlClient`:
     - `**\*.cs`
+- Update `SqlActivitySourceHelper` with:
+  ```csharp
+  public const string ActivitySourceName = "OpenTelemetry.Instrumentation.SqlClient";
+  public static readonly Version Version = new Version(1, 7, 0, 1173);
+  ```
 
 ### Customizations
 


### PR DESCRIPTION
The conformance tests should have failed but they did not. And did not for other components with the same problem (Redis). We need to investigate.

Note that traces work fine without this change because we are calling `AddSqlClientInstrumentation()` which uses the same wrong activity name. But this could be an issue if other libraries are using the name coming from the nuget package.

/cc @rajkumar-rangaraj @reyang since the azure sdk has the same problem.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3118)