### PR TITLE
Organize dashboard config to use strongly typed options, support primary/secondary API keys and rotation

### DIFF
--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -185,5 +185,6 @@
     <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="Utils\KnownProperties.cs" />
     <Compile Include="$(SharedDir)Model\KnownResourceTypes.cs" Link="Utils\KnownResourceTypes.cs" />
     <Compile Include="$(SharedDir)CircularBuffer.cs" Link="Otlp\Storage\CircularBuffer.cs" />
+    <Compile Include="$(SharedDir)DashboardConfigNames.cs" Link="Utils\DashboardConfigNames.cs" />
   </ItemGroup>
 </Project>

--- a/src/Aspire.Dashboard/Authentication/OtlpApiKey/OtlpApiKeyAuthenticationHandler.cs
+++ b/src/Aspire.Dashboard/Authentication/OtlpApiKey/OtlpApiKeyAuthenticationHandler.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Encodings.Web;
+using Aspire.Dashboard.Configuration;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 
@@ -11,22 +12,30 @@ public class OtlpApiKeyAuthenticationHandler : AuthenticationHandler<OtlpApiKeyA
 {
     public const string ApiKeyHeaderName = "x-otlp-api-key";
 
-    public OtlpApiKeyAuthenticationHandler(IOptionsMonitor<OtlpApiKeyAuthenticationHandlerOptions> options, ILoggerFactory logger, UrlEncoder encoder) : base(options, logger, encoder)
+    private readonly IOptionsMonitor<DashboardOptions> _dashboardOptions;
+
+    public OtlpApiKeyAuthenticationHandler(IOptionsMonitor<DashboardOptions> dashboardOptions, IOptionsMonitor<OtlpApiKeyAuthenticationHandlerOptions> options, ILoggerFactory logger, UrlEncoder encoder) : base(options, logger, encoder)
     {
+        _dashboardOptions = dashboardOptions;
     }
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        if (string.IsNullOrEmpty(Options.OtlpApiKey))
+        var options = _dashboardOptions.CurrentValue.Otlp;
+
+        if (string.IsNullOrEmpty(options.PrimaryApiKey))
         {
             throw new InvalidOperationException("OTLP API key is not configured.");
         }
 
         if (Context.Request.Headers.TryGetValue(ApiKeyHeaderName, out var apiKey))
         {
-            if (Options.OtlpApiKey != apiKey)
+            if (options.PrimaryApiKey != apiKey)
             {
-                return Task.FromResult(AuthenticateResult.Fail("Incoming API key doesn't match required API key."));
+                if (string.IsNullOrEmpty(options.SecondaryApiKey) || options.SecondaryApiKey != apiKey)
+                {
+                    return Task.FromResult(AuthenticateResult.Fail($"Incoming API key from '{ApiKeyHeaderName}' header doesn't match configured API key."));
+                }
             }
         }
         else
@@ -45,5 +54,4 @@ public static class OtlpApiKeyAuthenticationDefaults
 
 public sealed class OtlpApiKeyAuthenticationHandlerOptions : AuthenticationSchemeOptions
 {
-    public string? OtlpApiKey { get; set; }
 }

--- a/src/Aspire.Dashboard/Authentication/OtlpCompositeAuthenticationHandler.cs
+++ b/src/Aspire.Dashboard/Authentication/OtlpCompositeAuthenticationHandler.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Aspire.Dashboard.Authentication.OtlpApiKey;
 using Aspire.Dashboard.Authentication.OtlpConnection;
+using Aspire.Dashboard.Configuration;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Certificate;
 using Microsoft.Extensions.Options;
@@ -12,6 +13,7 @@ using Microsoft.Extensions.Options;
 namespace Aspire.Dashboard.Authentication;
 
 public sealed class OtlpCompositeAuthenticationHandler(
+    IOptionsMonitor<DashboardOptions> dashboardOptions,
     IOptionsMonitor<OtlpCompositeAuthenticationHandlerOptions> options,
     ILoggerFactory logger,
     UrlEncoder encoder)
@@ -19,6 +21,8 @@ public sealed class OtlpCompositeAuthenticationHandler(
 {
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
+        var options = dashboardOptions.CurrentValue;
+
         foreach (var scheme in GetRelevantAuthenticationSchemes())
         {
             var result = await Context.AuthenticateAsync(scheme).ConfigureAwait(false);
@@ -37,11 +41,11 @@ public sealed class OtlpCompositeAuthenticationHandler(
         {
             yield return OtlpConnectionAuthenticationDefaults.AuthenticationScheme;
 
-            if (Options.OtlpAuthMode is OtlpAuthMode.ApiKey)
+            if (options.Otlp.AuthMode is OtlpAuthMode.ApiKey)
             {
                 yield return OtlpApiKeyAuthenticationDefaults.AuthenticationScheme;
             }
-            else if (Options.OtlpAuthMode is OtlpAuthMode.ClientCertificate)
+            else if (options.Otlp.AuthMode is OtlpAuthMode.ClientCertificate)
             {
                 yield return CertificateAuthenticationDefaults.AuthenticationScheme;
             }
@@ -56,5 +60,4 @@ public static class OtlpCompositeAuthenticationDefaults
 
 public sealed class OtlpCompositeAuthenticationHandlerOptions : AuthenticationSchemeOptions
 {
-    public OtlpAuthMode OtlpAuthMode { get; set; }
 }

--- a/src/Aspire.Dashboard/Configuration/DashboardClientCertificateSource.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardClientCertificateSource.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Configuration;
+
+public enum DashboardClientCertificateSource
+{
+    File,
+    KeyStore
+}

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Aspire.Dashboard.Configuration;
 
@@ -47,6 +48,8 @@ public sealed class ResourceServiceClientCertificateOptions
     public string? FilePath { get; set; }
     public string? Password { get; set; }
     public string? Subject { get; set; }
+    public string? StoreName { get; set; }
+    public StoreLocation? Location { get; set; }
 }
 
 public sealed class OtlpOptions

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -48,7 +48,7 @@ public sealed class ResourceServiceClientCertificateOptions
     public string? FilePath { get; set; }
     public string? Password { get; set; }
     public string? Subject { get; set; }
-    public string? StoreName { get; set; }
+    public string? Store { get; set; }
     public StoreLocation? Location { get; set; }
 }
 

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -13,7 +13,7 @@ public sealed class DashboardOptions
     public OtlpOptions Otlp { get; set; } = new OtlpOptions();
     public FrontendOptions Frontend { get; set; } = new FrontendOptions();
     public ResourceServiceClientOptions ResourceServiceClient { get; set; } = new ResourceServiceClientOptions();
-    public TelemetryLimits TelemetryLimits { get; set; } = new TelemetryLimits();
+    public TelemetryLimitOptions TelemetryLimits { get; set; } = new TelemetryLimitOptions();
 }
 
 public sealed class ResourceServiceClientOptions
@@ -130,7 +130,7 @@ public sealed class FrontendOptions
     }
 }
 
-public sealed class TelemetryLimits
+public sealed class TelemetryLimitOptions
 {
     public int MaxLogCount { get; set; } = 10_000;
     public int MaxTraceCount { get; set; } = 10_000;

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -1,0 +1,138 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Dashboard.Configuration;
+
+public sealed class DashboardOptions
+{
+    public string? ApplicationName { get; set; }
+    public OtlpOptions Otlp { get; set; } = new OtlpOptions();
+    public FrontendOptions Frontend { get; set; } = new FrontendOptions();
+    public ResourceServiceClientOptions ResourceServiceClient { get; set; } = new ResourceServiceClientOptions();
+    public TelemetryLimits TelemetryLimits { get; set; } = new TelemetryLimits();
+}
+
+public sealed class ResourceServiceClientOptions
+{
+    private Uri? _parsedUrl;
+
+    public string? Url { get; set; }
+    public ResourceClientAuthMode? AuthMode { get; set; }
+    public ResourceServiceClientCertificateOptions ClientCertificates { get; set; } = new ResourceServiceClientCertificateOptions();
+
+    public Uri? GetUri() => _parsedUrl;
+
+    internal bool TryParseOptions([NotNullWhen(false)] out string? errorMessage)
+    {
+        if (!string.IsNullOrEmpty(Url))
+        {
+            if (!Uri.TryCreate(Url, UriKind.Absolute, out _parsedUrl))
+            {
+                errorMessage = $"Failed to parse resource service client endpoint URL '{Url}'.";
+                return false;
+            }
+        }
+
+        errorMessage = null;
+        return true;
+    }
+}
+
+public sealed class ResourceServiceClientCertificateOptions
+{
+    public DashboardClientCertificateSource? Source { get; set; }
+    public string? FilePath { get; set; }
+    public string? Password { get; set; }
+    public string? Subject { get; set; }
+}
+
+public sealed class OtlpOptions
+{
+    private Uri? _parsedEndpointUrl;
+
+    public string? PrimaryApiKey { get; set; }
+    public string? SecondaryApiKey { get; set; }
+    public OtlpAuthMode? AuthMode { get; set; }
+    public string? EndpointUrl { get; set; }
+
+    public Uri GetEndpointUri()
+    {
+        Debug.Assert(_parsedEndpointUrl is not null, "Should have been parsed during validation.");
+        return _parsedEndpointUrl;
+    }
+
+    internal bool TryParseOptions([NotNullWhen(false)] out string? errorMessage)
+    {
+        if (string.IsNullOrEmpty(EndpointUrl))
+        {
+            errorMessage = "OTLP endpoint URL is not configured. Specify a Dashboard:Otlp:EndpointUrl value.";
+            return false;
+        }
+        else
+        {
+            if (!Uri.TryCreate(EndpointUrl, UriKind.Absolute, out _parsedEndpointUrl))
+            {
+                errorMessage = $"Failed to parse OTLP endpoint URL '{EndpointUrl}'.";
+                return false;
+            }
+        }
+
+        errorMessage = null;
+        return true;
+    }
+}
+
+public sealed class FrontendOptions
+{
+    private List<Uri>? _parsedEndpointUrls;
+
+    public string? EndpointUrls { get; set; }
+    public FrontendAuthMode? AuthMode { get; set; }
+
+    public IReadOnlyList<Uri> GetEndpointUris()
+    {
+        Debug.Assert(_parsedEndpointUrls is not null, "Should have been parsed during validation.");
+        return _parsedEndpointUrls;
+    }
+
+    internal bool TryParseOptions([NotNullWhen(false)] out string? errorMessage)
+    {
+        if (string.IsNullOrEmpty(EndpointUrls))
+        {
+            errorMessage = "One or more frontend endpoint URLs are not configured. Specify a Dashboard:Frontend:EndpointUrls value.";
+            return false;
+        }
+        else
+        {
+            var parts = EndpointUrls.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var uris = new List<Uri>(parts.Length);
+            foreach (var part in parts)
+            {
+                if (!Uri.TryCreate(part, UriKind.Absolute, out var uri))
+                {
+                    errorMessage = $"Failed to parse frontend endpoint URLs '{EndpointUrls}'.";
+                    return false;
+                }
+
+                uris.Add(uri);
+            }
+            _parsedEndpointUrls = uris;
+        }
+
+        errorMessage = null;
+        return true;
+    }
+}
+
+public sealed class TelemetryLimits
+{
+    public int MaxLogCount { get; set; } = 10_000;
+    public int MaxTraceCount { get; set; } = 10_000;
+    public int MaxMetricsCount { get; set; } = 50_000; // Allows for 1 metric point per second for over 12 hours.
+    public int MaxAttributeCount { get; set; } = 128;
+    public int MaxAttributeLength { get; set; } = int.MaxValue;
+    public int MaxSpanEventCount { get; set; } = int.MaxValue;
+}

--- a/src/Aspire.Dashboard/Configuration/FrontendAuthMode.cs
+++ b/src/Aspire.Dashboard/Configuration/FrontendAuthMode.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Configuration;
+
+public enum FrontendAuthMode
+{
+    Unsecured,
+    OpenIdConnect
+}

--- a/src/Aspire.Dashboard/Configuration/OtlpAuthMode.cs
+++ b/src/Aspire.Dashboard/Configuration/OtlpAuthMode.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Aspire.Dashboard.Authentication;
+namespace Aspire.Dashboard.Configuration;
 
 public enum OtlpAuthMode
 {

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -17,6 +17,7 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
 
     public void PostConfigure(string? name, DashboardOptions options)
     {
+        // Copy aliased config values to the strongly typed options.
         if (_configuration[DashboardConfigNames.DashboardOtlpUrlName.ConfigKey] is { Length: > 0 } otlpUrl)
         {
             options.Otlp.EndpointUrl = otlpUrl;

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard.Configuration;
+
+public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<DashboardOptions>
+{
+    private readonly IConfiguration _configuration;
+
+    public PostConfigureDashboardOptions(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public void PostConfigure(string? name, DashboardOptions options)
+    {
+        if (_configuration[DashboardConfigNames.DashboardOtlpUrlName.ConfigKey] is { Length: > 0 } otlpUrl)
+        {
+            options.Otlp.EndpointUrl = otlpUrl;
+        }
+        if (_configuration[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] is { Length: > 0 } frontendUrls)
+        {
+            options.Frontend.EndpointUrls = frontendUrls;
+        }
+        if (_configuration[DashboardConfigNames.ResourceServiceUrlName.ConfigKey] is { Length: > 0 } resourceServiceUrl)
+        {
+            options.ResourceServiceClient.Url = resourceServiceUrl;
+        }
+        if (_configuration.GetBool(DashboardConfigNames.DashboardInsecureAllowAnonymousName.ConfigKey) ?? false)
+        {
+            options.Frontend.AuthMode = FrontendAuthMode.Unsecured;
+            options.Otlp.AuthMode = OtlpAuthMode.Unsecured;
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Configuration/ResourceClientAuthMode.cs
+++ b/src/Aspire.Dashboard/Configuration/ResourceClientAuthMode.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Configuration;
+
+public enum ResourceClientAuthMode
+{
+    Unsecured,
+    Certificate
+}

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard.Configuration;
+
+public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions>
+{
+    public ValidateOptionsResult Validate(string? name, DashboardOptions options)
+    {
+        var errorMessages = new List<string>();
+
+        if (!options.Frontend.TryParseOptions(out var frontendParseErrorMessage))
+        {
+            errorMessages.Add(frontendParseErrorMessage);
+        }
+
+        if (!options.Otlp.TryParseOptions(out var otlpParseErrorMessage))
+        {
+            errorMessages.Add(otlpParseErrorMessage);
+        }
+
+        if (!options.ResourceServiceClient.TryParseOptions(out var resourceServiceClientParseErrorMessage))
+        {
+            errorMessages.Add(resourceServiceClientParseErrorMessage);
+        }
+
+        switch (options.Otlp.AuthMode)
+        {
+            case OtlpAuthMode.Unsecured:
+                break;
+            case OtlpAuthMode.ApiKey:
+                if (string.IsNullOrEmpty(options.Otlp.PrimaryApiKey))
+                {
+                    errorMessages.Add("PrimaryApiKey is required when OTLP authentication mode is API key. Specify a Dashboard:Otlp:PrimaryApiKey value.");
+                }
+                break;
+            case OtlpAuthMode.ClientCertificate:
+                break;
+            case null:
+                errorMessages.Add($"OTLP endpoint authentication is not configured. Either specify DOTNET_DASHBOARD_INSECURE_ALLOW_ANONYMOUS with a value of true, or specify Dashboard:Otlp:AuthMode. Possible values: {string.Join(", ", typeof(OtlpAuthMode).GetEnumNames())}");
+                break;
+            default:
+                errorMessages.Add($"Unexpected OTLP authentication mode: {options.Otlp.AuthMode}");
+                break;
+        }
+
+        if (options.ResourceServiceClient.GetUri() != null)
+        {
+            switch (options.ResourceServiceClient.AuthMode)
+            {
+                case ResourceClientAuthMode.Unsecured:
+                    break;
+                case ResourceClientAuthMode.Certificate:
+
+                    switch (options.ResourceServiceClient.ClientCertificates.Source)
+                    {
+                        case DashboardClientCertificateSource.File:
+                            if (string.IsNullOrEmpty(options.ResourceServiceClient.ClientCertificates.FilePath))
+                            {
+                                errorMessages.Add("Dashboard:ResourceServiceClient:ClientCertificate:Source is \"File\", but no Dashboard:ResourceServiceClient:ClientCertificate:FilePath is configured.");
+                            }
+                            break;
+                        case DashboardClientCertificateSource.KeyStore:
+                            if (string.IsNullOrEmpty(options.ResourceServiceClient.ClientCertificates.Subject))
+                            {
+                                errorMessages.Add("Dashboard:ResourceServiceClient:ClientCertificate:Source is \"KeyStore\", but no Dashboard:ResourceServiceClient:ClientCertificate:Subject is configured.");
+                            }
+                            break;
+                        default:
+                            errorMessages.Add($"Unexpected resource service client certificate source: {options.Otlp.AuthMode}");
+                            break;
+                    }
+                    break;
+                default:
+                    errorMessages.Add($"Unexpected resource service client authentication mode: {options.Otlp.AuthMode}");
+                    break;
+            }
+        }
+
+        return errorMessages.Count > 0
+            ? ValidateOptionsResult.Fail(errorMessages)
+            : ValidateOptionsResult.Success;
+    }
+}

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -76,7 +76,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
 
         var dashboardConfigSection = builder.Configuration.GetSection("Dashboard");
-        builder.Services.Configure<DashboardOptions>(dashboardConfigSection);
+        builder.Services.AddOptions<DashboardOptions>()
+            .Bind(dashboardConfigSection)
+            .ValidateOnStart();
         builder.Services.AddSingleton<IPostConfigureOptions<DashboardOptions>, PostConfigureDashboardOptions>();
         builder.Services.AddSingleton<IValidateOptions<DashboardOptions>, ValidateDashboardOptions>();
 
@@ -124,8 +126,6 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         _app = builder.Build();
 
         _dashboardOptionsMonitor = _app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>();
-        // Get options to run validation during startup.
-        _ = _dashboardOptionsMonitor.CurrentValue;
 
         var logger = _app.Services.GetRequiredService<ILoggerFactory>().CreateLogger<DashboardWebApplication>();
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -8,9 +8,11 @@ using Aspire.Dashboard.Authentication;
 using Aspire.Dashboard.Authentication.OtlpApiKey;
 using Aspire.Dashboard.Authentication.OtlpConnection;
 using Aspire.Dashboard.Components;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Grpc;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Hosting;
 using Microsoft.AspNetCore.Authentication.Certificate;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -19,6 +21,7 @@ using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
@@ -26,17 +29,11 @@ namespace Aspire.Dashboard;
 
 public sealed class DashboardWebApplication : IAsyncDisposable
 {
-    internal const string FrontendAuthModeKey = "Frontend:AuthMode";
-
-    internal const string OtlpAuthModeKey = "Otlp:AuthMode";
-    internal const string OtlpApiKeyKey = "Otlp:ApiKey";
-
-    internal const string DashboardOtlpUrlVariableName = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL";
     internal const string DashboardOtlpUrlDefaultValue = "http://localhost:18889";
-    internal const string DashboardUrlVariableName = "ASPNETCORE_URLS";
     internal const string DashboardUrlDefaultValue = "http://localhost:18888";
 
     private readonly WebApplication _app;
+    private readonly IOptionsMonitor<DashboardOptions>? _dashboardOptionsMonitor;
     private Func<EndpointInfo>? _browserEndPointAccessor;
     private Func<EndpointInfo>? _otlpServiceEndPointAccessor;
 
@@ -48,6 +45,11 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     public Func<EndpointInfo> OtlpServiceEndPointAccessor
     {
         get => _otlpServiceEndPointAccessor ?? throw new InvalidOperationException("WebApplication not started yet.");
+    }
+
+    public IOptionsMonitor<DashboardOptions> DashboardOptionsMonitor
+    {
+        get => _dashboardOptionsMonitor ?? throw new InvalidOperationException("WebApplication not started yet.");
     }
 
     /// <summary>
@@ -67,12 +69,23 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error);
 #endif
 
-        var dashboardConfig = LoadDashboardConfig(builder.Configuration);
+        // Allow for a user specified JSON config file on disk. Throw an error if the specified file doesn't exist.
+        if (builder.Configuration[DashboardConfigNames.DashboardConfigFilePathName.ConfigKey] is { Length: > 0 } configFilePath)
+        {
+            builder.Configuration.AddJsonFile(configFilePath, optional: false, reloadOnChange: true);
+        }
 
-        ConfigureKestrelEndpoints(builder, dashboardConfig);
+        var dashboardConfigSection = builder.Configuration.GetSection("Dashboard");
+        builder.Services.Configure<DashboardOptions>(dashboardConfigSection);
+        builder.Services.AddSingleton<IPostConfigureOptions<DashboardOptions>, PostConfigureDashboardOptions>();
+        builder.Services.AddSingleton<IValidateOptions<DashboardOptions>, ValidateDashboardOptions>();
 
-        var browserHttpsPort = dashboardConfig.BrowserUris.FirstOrDefault(IsHttps)?.Port;
-        var isAllHttps = browserHttpsPort is not null && IsHttps(dashboardConfig.OtlpUri);
+        var dashboardOptions = GetDashboardOptions(builder, dashboardConfigSection);
+
+        ConfigureKestrelEndpoints(builder, dashboardOptions);
+
+        var browserHttpsPort = dashboardOptions.Frontend.GetEndpointUris().FirstOrDefault(IsHttps)?.Port;
+        var isAllHttps = browserHttpsPort is not null && IsHttps(dashboardOptions.Otlp.GetEndpointUri());
         if (isAllHttps)
         {
             // Explicitly configure the HTTPS redirect port as we're possibly listening on multiple HTTPS addresses
@@ -80,7 +93,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             builder.Services.Configure<HttpsRedirectionOptions>(options => options.HttpsPort = browserHttpsPort);
         }
 
-        ConfigureAuthentication(builder, dashboardConfig);
+        ConfigureAuthentication(builder, dashboardOptions);
 
         // Add services to the container.
         builder.Services.AddRazorComponents().AddInteractiveServerComponents();
@@ -109,6 +122,10 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddLocalization();
 
         _app = builder.Build();
+
+        _dashboardOptionsMonitor = _app.Services.GetRequiredService<IOptionsMonitor<DashboardOptions>>();
+        // Get options to run validation during startup.
+        _ = _dashboardOptionsMonitor.CurrentValue;
 
         var logger = _app.Services.GetRequiredService<ILoggerFactory>().CreateLogger<DashboardWebApplication>();
 
@@ -210,39 +227,59 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         _app.MapGrpcService<OtlpLogsService>();
     }
 
+    /// <summary>
+    /// Load <see cref="DashboardOptions"/> from configuration without using DI. This performs
+    /// the same steps as getting the options from DI but without the need for a service provider.
+    /// </summary>
+    private static DashboardOptions GetDashboardOptions(WebApplicationBuilder builder, IConfigurationSection dashboardConfigSection)
+    {
+        var dashboardOptions = new DashboardOptions();
+        dashboardConfigSection.Bind(dashboardOptions);
+        new PostConfigureDashboardOptions(builder.Configuration).PostConfigure(name: string.Empty, dashboardOptions);
+        var result = new ValidateDashboardOptions().Validate(name: string.Empty, dashboardOptions);
+        if (result.Failed)
+        {
+            throw new OptionsValidationException(optionsName: string.Empty, typeof(DashboardOptions), result.Failures);
+        }
+
+        return dashboardOptions;
+    }
+
     // Kestrel endpoints are loaded from configuration. This is done so that advanced configuration of endpoints is
     // possible from the caller. e.g., using environment variables to configure each endpoint's TLS certificate.
-    private void ConfigureKestrelEndpoints(WebApplicationBuilder builder, DashboardStartupConfiguration dashboardStartupConfig)
+    private void ConfigureKestrelEndpoints(WebApplicationBuilder builder, DashboardOptions dashboardOptions)
     {
         // A single endpoint is configured if URLs are the same and the port isn't dynamic.
-        var singleEndpoint = dashboardStartupConfig.BrowserUris.Length == 1 && dashboardStartupConfig.BrowserUris[0] == dashboardStartupConfig.OtlpUri && dashboardStartupConfig.OtlpUri.Port != 0;
+        var frontendUris = dashboardOptions.Frontend.GetEndpointUris();
+        var otlpUri = dashboardOptions.Otlp.GetEndpointUri();
+        var singleEndpoint = frontendUris.Count == 1 && frontendUris[0] == otlpUri && otlpUri.Port != 0;
 
         var initialValues = new Dictionary<string, string?>();
-        var browserEndpointNames = new List<string>(capacity: dashboardStartupConfig.BrowserUris.Length);
+        var browserEndpointNames = new List<string>(capacity: frontendUris.Count);
 
         if (!singleEndpoint)
         {
             // Translate high-level config settings such as DOTNET_DASHBOARD_OTLP_ENDPOINT_URL and ASPNETCORE_URLS
             // to Kestrel's schema for loading endpoints from configuration.
-            AddEndpointConfiguration(initialValues, "Otlp", dashboardStartupConfig.OtlpUri.OriginalString, HttpProtocols.Http2, requiredClientCertificate: dashboardStartupConfig.OtlpAuthMode == OtlpAuthMode.ClientCertificate);
-            if (dashboardStartupConfig.BrowserUris.Length == 1)
+            AddEndpointConfiguration(initialValues, "Otlp", otlpUri.OriginalString, HttpProtocols.Http2, requiredClientCertificate: dashboardOptions.Otlp.AuthMode == OtlpAuthMode.ClientCertificate);
+            if (frontendUris.Count == 1)
             {
                 browserEndpointNames.Add("Browser");
-                AddEndpointConfiguration(initialValues, "Browser", dashboardStartupConfig.BrowserUris[0].OriginalString);
+                AddEndpointConfiguration(initialValues, "Browser", frontendUris[0].OriginalString);
             }
             else
             {
-                for (var i = 0; i < dashboardStartupConfig.BrowserUris.Length; i++)
+                for (var i = 0; i < frontendUris.Count; i++)
                 {
                     var name = $"Browser{i}";
                     browserEndpointNames.Add(name);
-                    AddEndpointConfiguration(initialValues, name, dashboardStartupConfig.BrowserUris[i].OriginalString);
+                    AddEndpointConfiguration(initialValues, name, frontendUris[i].OriginalString);
                 }
             }
         }
         else
         {
-            AddEndpointConfiguration(initialValues, "Otlp", dashboardStartupConfig.OtlpUri.OriginalString, HttpProtocols.Http1AndHttp2, requiredClientCertificate: dashboardStartupConfig.OtlpAuthMode == OtlpAuthMode.ClientCertificate);
+            AddEndpointConfiguration(initialValues, "Otlp", otlpUri.OriginalString, HttpProtocols.Http1AndHttp2, requiredClientCertificate: dashboardOptions.Otlp.AuthMode == OtlpAuthMode.ClientCertificate);
         }
 
         static void AddEndpointConfiguration(Dictionary<string, string?> values, string endpointName, string url, HttpProtocols? protocols = null, bool requiredClientCertificate = false)
@@ -322,23 +359,17 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
     }
 
-    private static void ConfigureAuthentication(WebApplicationBuilder builder, DashboardStartupConfiguration dashboardStartupConfig)
+    private static void ConfigureAuthentication(WebApplicationBuilder builder, DashboardOptions dashboardOptions)
     {
         var authentication = builder.Services
             .AddAuthentication()
-            .AddScheme<OtlpCompositeAuthenticationHandlerOptions, OtlpCompositeAuthenticationHandler>(OtlpCompositeAuthenticationDefaults.AuthenticationScheme, o =>
-            {
-                o.OtlpAuthMode = dashboardStartupConfig.OtlpAuthMode;
-            })
-            .AddScheme<OtlpApiKeyAuthenticationHandlerOptions, OtlpApiKeyAuthenticationHandler>(OtlpApiKeyAuthenticationDefaults.AuthenticationScheme, o =>
-            {
-                o.OtlpApiKey = dashboardStartupConfig.OtlpApiKey;
-            })
+            .AddScheme<OtlpCompositeAuthenticationHandlerOptions, OtlpCompositeAuthenticationHandler>(OtlpCompositeAuthenticationDefaults.AuthenticationScheme, o => { })
+            .AddScheme<OtlpApiKeyAuthenticationHandlerOptions, OtlpApiKeyAuthenticationHandler>(OtlpApiKeyAuthenticationDefaults.AuthenticationScheme, o => { })
             .AddScheme<OtlpConnectionAuthenticationHandlerOptions, OtlpConnectionAuthenticationHandler>(OtlpConnectionAuthenticationDefaults.AuthenticationScheme, o => { })
             .AddCertificate(options =>
             {
                 // Bind options to configuration so they can be overridden by environment variables.
-                builder.Configuration.Bind("CertificateAuthentication", options);
+                builder.Configuration.Bind("Dashboard:Otlp:CertificateAuthOptions", options);
 
                 options.Events = new CertificateAuthenticationEvents
                 {
@@ -362,7 +393,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 };
             });
 
-        if (dashboardStartupConfig.FrontendAuthMode == FrontendAuthMode.OpenIdConnect)
+        if (dashboardOptions.Frontend.AuthMode == FrontendAuthMode.OpenIdConnect)
         {
             authentication.AddPolicyScheme(FrontendAuthenticationDefaults.AuthenticationScheme, displayName: FrontendAuthenticationDefaults.AuthenticationScheme, o =>
             {
@@ -409,7 +440,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                     .RequireClaim(OtlpAuthorization.OtlpClaimName)
                     .Build());
 
-            if (dashboardStartupConfig.FrontendAuthMode == FrontendAuthMode.OpenIdConnect)
+            if (dashboardOptions.Frontend.AuthMode == FrontendAuthMode.OpenIdConnect)
             {
                 // Frontend is secured with OIDC, so delegate to that authentication scheme.
                 options.AddPolicy(
@@ -419,7 +450,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                         .RequireAuthenticatedUser()
                         .Build());
             }
-            else if (dashboardStartupConfig.FrontendAuthMode == FrontendAuthMode.Unsecured)
+            else
             {
                 // Frontend is unsecured so our policy doesn't need any special handling.
                 options.AddPolicy(
@@ -427,10 +458,6 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                     policy: new AuthorizationPolicyBuilder()
                         .RequireAssertion(_ => true)
                         .Build());
-            }
-            else
-            {
-                throw new NotSupportedException($"Unexpected {nameof(FrontendAuthMode)} enum member.");
             }
         });
     }
@@ -448,73 +475,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
     private static bool IsHttps(Uri uri) => string.Equals(uri.Scheme, "https", StringComparison.Ordinal);
 
-    private static DashboardStartupConfiguration LoadDashboardConfig(IConfiguration configuration)
-    {
-        var browserUris = configuration.GetUris(DashboardUrlVariableName, new(DashboardUrlDefaultValue));
-        if (browserUris.Length == 0)
-        {
-            throw new InvalidOperationException($"At least one URL for Aspire dashboard browser endpoint with {DashboardOtlpUrlDefaultValue} is required.");
-        }
-
-        var frontendAuthMode = configuration.GetEnum<FrontendAuthMode>(FrontendAuthModeKey);
-
-        var otlpUris = configuration.GetUris(DashboardOtlpUrlVariableName, new(DashboardOtlpUrlDefaultValue));
-        if (otlpUris.Length != 1)
-        {
-            throw new InvalidOperationException($"One URL for Aspire dashboard OTLP endpoint with {DashboardUrlDefaultValue} is required, not {otlpUris.Length}.");
-        }
-
-        var otlpAuthMode = configuration.GetEnum<OtlpAuthMode>(OtlpAuthModeKey);
-
-        string? otlpApiKey = null;
-
-        switch (otlpAuthMode)
-        {
-            case OtlpAuthMode.ApiKey:
-                otlpApiKey = configuration[OtlpApiKeyKey];
-                if (string.IsNullOrEmpty(otlpApiKey))
-                {
-                    throw new InvalidOperationException($"{OtlpAuthModeKey} value of {nameof(OtlpAuthMode.ApiKey)} requires an API key from {OtlpApiKeyKey}.");
-                }
-                break;
-            case OtlpAuthMode.ClientCertificate:
-                if (!IsHttps(otlpUris[0]))
-                {
-                    throw new InvalidOperationException($"{OtlpAuthModeKey} value of {nameof(OtlpAuthMode.ClientCertificate)} requires a HTTPS OTLP endpoint.");
-                }
-                break;
-            default:
-                break;
-        }
-
-        return new DashboardStartupConfiguration
-        {
-            BrowserUris = browserUris,
-            FrontendAuthMode = frontendAuthMode,
-            OtlpUri = otlpUris[0],
-            OtlpAuthMode = otlpAuthMode,
-            OtlpApiKey = otlpApiKey
-        };
-    }
-
-    private enum FrontendAuthMode
-    {
-        Unsecured,
-        OpenIdConnect
-    }
-
     public static class FrontendAuthenticationDefaults
     {
         public const string AuthenticationScheme = "Frontend";
-    }
-
-    private sealed class DashboardStartupConfiguration
-    {
-        public required Uri[] BrowserUris { get; init; }
-        public required Uri OtlpUri { get; init; }
-        public required OtlpAuthMode OtlpAuthMode { get; init; }
-        public required FrontendAuthMode FrontendAuthMode { get; init; }
-        public required string? OtlpApiKey { get; init; }
     }
 }
 

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -158,7 +158,11 @@ internal sealed class DashboardClient : IDashboardClient
 
             X509CertificateCollection GetKeyStoreCertificate()
             {
-                var subject = _dashboardOptions.ResourceServiceClient.ClientCertificates.Subject!;
+                Debug.Assert(
+                    _dashboardOptions.ResourceServiceClient.ClientCertificates.Subject != null,
+                    "Subject is validated as not null when configuration is loaded.");
+
+                var subject = _dashboardOptions.ResourceServiceClient.ClientCertificates.Subject;
                 var storeName = _dashboardOptions.ResourceServiceClient.ClientCertificates.Store ?? "My";
                 var location = _dashboardOptions.ResourceServiceClient.ClientCertificates.Location ?? StoreLocation.CurrentUser;
 

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -159,12 +159,10 @@ internal sealed class DashboardClient : IDashboardClient
             X509CertificateCollection GetKeyStoreCertificate()
             {
                 var subject = _dashboardOptions.ResourceServiceClient.ClientCertificates.Subject!;
+                var storeName = _dashboardOptions.ResourceServiceClient.ClientCertificates.StoreName ?? "My";
+                var location = _dashboardOptions.ResourceServiceClient.ClientCertificates.Location ?? StoreLocation.CurrentUser;
 
-                var storeProperties = new KeyStoreProperties { Name = "My", Location = StoreLocation.CurrentUser };
-
-                configuration.Bind("ResourceServiceClient:ClientCertificate:KeyStore", storeProperties);
-
-                using var store = new X509Store(storeName: storeProperties.Name, storeLocation: storeProperties.Location);
+                using var store = new X509Store(storeName: storeName, storeLocation: location);
 
                 store.Open(OpenFlags.ReadOnly);
 

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -150,7 +150,11 @@ internal sealed class DashboardClient : IDashboardClient
 
             X509CertificateCollection GetFileCertificate()
             {
-                var filePath = _dashboardOptions.ResourceServiceClient.ClientCertificates.FilePath!;
+                Debug.Assert(
+                    _dashboardOptions.ResourceServiceClient.ClientCertificates.FilePath != null,
+                    "FilePath is validated as not null when configuration is loaded.");
+
+                var filePath = _dashboardOptions.ResourceServiceClient.ClientCertificates.FilePath;
                 var password = _dashboardOptions.ResourceServiceClient.ClientCertificates.Password;
 
                 return [new X509Certificate2(filePath, password)];

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -159,7 +159,7 @@ internal sealed class DashboardClient : IDashboardClient
             X509CertificateCollection GetKeyStoreCertificate()
             {
                 var subject = _dashboardOptions.ResourceServiceClient.ClientCertificates.Subject!;
-                var storeName = _dashboardOptions.ResourceServiceClient.ClientCertificates.StoreName ?? "My";
+                var storeName = _dashboardOptions.ResourceServiceClient.ClientCertificates.Store ?? "My";
                 var location = _dashboardOptions.ResourceServiceClient.ClientCertificates.Location ?? StoreLocation.CurrentUser;
 
                 using var store = new X509Store(storeName: storeName, storeLocation: location);

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Configuration;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Metrics.V1;
@@ -24,11 +24,11 @@ public class OtlpApplication
     private readonly Dictionary<OtlpInstrumentKey, OtlpInstrument> _instruments = new();
 
     private readonly ILogger _logger;
-    private readonly TelemetryOptions _options;
+    private readonly TelemetryLimits _options;
 
     public KeyValuePair<string, string>[] Properties { get; }
 
-    public OtlpApplication(Resource resource, IReadOnlyDictionary<string, OtlpApplication> applications, ILogger logger, TelemetryOptions options)
+    public OtlpApplication(Resource resource, IReadOnlyDictionary<string, OtlpApplication> applications, ILogger logger, TelemetryLimits options)
     {
         var properties = new List<KeyValuePair<string, string>>();
         foreach (var attribute in resource.Attributes)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
@@ -24,11 +24,11 @@ public class OtlpApplication
     private readonly Dictionary<OtlpInstrumentKey, OtlpInstrument> _instruments = new();
 
     private readonly ILogger _logger;
-    private readonly TelemetryLimits _options;
+    private readonly TelemetryLimitOptions _options;
 
     public KeyValuePair<string, string>[] Properties { get; }
 
-    public OtlpApplication(Resource resource, IReadOnlyDictionary<string, OtlpApplication> applications, ILogger logger, TelemetryLimits options)
+    public OtlpApplication(Resource resource, IReadOnlyDictionary<string, OtlpApplication> applications, ILogger logger, TelemetryLimitOptions options)
     {
         var properties = new List<KeyValuePair<string, string>>();
         foreach (var attribute in resource.Attributes)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -106,7 +106,7 @@ public static class OtlpHelpers
         return (long)(nanoseconds / TimeSpan.NanosecondsPerTick);
     }
 
-    public static KeyValuePair<string, string>[] ToKeyValuePairs(this RepeatedField<KeyValue> attributes, TelemetryLimits options)
+    public static KeyValuePair<string, string>[] ToKeyValuePairs(this RepeatedField<KeyValue> attributes, TelemetryLimitOptions options)
     {
         if (attributes.Count == 0)
         {
@@ -119,7 +119,7 @@ public static class OtlpHelpers
         return values;
     }
 
-    public static KeyValuePair<string, string>[] ToKeyValuePairs(this RepeatedField<KeyValue> attributes, TelemetryLimits options, Func<KeyValue, bool> filter)
+    public static KeyValuePair<string, string>[] ToKeyValuePairs(this RepeatedField<KeyValue> attributes, TelemetryLimitOptions options, Func<KeyValue, bool> filter)
     {
         if (attributes.Count == 0)
         {
@@ -150,7 +150,7 @@ public static class OtlpHelpers
         return values.ToArray();
     }
 
-    public static void CopyKeyValuePairs(RepeatedField<KeyValue> attributes, TelemetryLimits options, out int copyCount, [NotNull] ref KeyValuePair<string, string>[]? copiedAttributes)
+    public static void CopyKeyValuePairs(RepeatedField<KeyValue> attributes, TelemetryLimitOptions options, out int copyCount, [NotNull] ref KeyValuePair<string, string>[]? copiedAttributes)
     {
         copyCount = Math.Min(attributes.Count, options.MaxAttributeCount);
 
@@ -166,7 +166,7 @@ public static class OtlpHelpers
         CopyKeyValues(attributes, copiedAttributes, options);
     }
 
-    private static void CopyKeyValues(RepeatedField<KeyValue> attributes, KeyValuePair<string, string>[] copiedAttributes, TelemetryLimits options)
+    private static void CopyKeyValues(RepeatedField<KeyValue> attributes, KeyValuePair<string, string>[] copiedAttributes, TelemetryLimitOptions options)
     {
         var copyCount = Math.Min(attributes.Count, options.MaxAttributeCount);
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -19,7 +19,7 @@ public class OtlpInstrument
     public required string Unit { get; init; }
     public required OtlpInstrumentType Type { get; init; }
     public required OtlpMeter Parent { get; init; }
-    public required TelemetryLimits Options { get; init; }
+    public required TelemetryLimitOptions Options { get; init; }
 
     public Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> Dimensions { get; } = new(ScopeAttributesComparer.Instance);
     public Dictionary<string, List<string>> KnownAttributeValues { get; } = new();

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -3,8 +3,8 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
-using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Metrics.V1;
@@ -19,7 +19,7 @@ public class OtlpInstrument
     public required string Unit { get; init; }
     public required OtlpInstrumentType Type { get; init; }
     public required OtlpMeter Parent { get; init; }
-    public required TelemetryOptions Options { get; init; }
+    public required TelemetryLimits Options { get; init; }
 
     public Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> Dimensions { get; } = new(ScopeAttributesComparer.Instance);
     public Dictionary<string, List<string>> KnownAttributeValues { get; } = new();
@@ -71,7 +71,7 @@ public class OtlpInstrument
     {
         var isFirst = Dimensions.Count == 0;
         var durableAttributes = comparableAttributes.ToArray();
-        var dimension = new DimensionScope(Options.MetricsCountLimit, durableAttributes);
+        var dimension = new DimensionScope(Options.MaxMetricsCount, durableAttributes);
         Dimensions.Add(durableAttributes, dimension);
 
         var keys = KnownAttributeValues.Keys.Union(durableAttributes.Select(a => a.Key)).Distinct();

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -22,7 +22,7 @@ public class OtlpLogEntry
     public OtlpApplication Application { get; }
     public OtlpScope Scope { get; }
 
-    public OtlpLogEntry(LogRecord record, OtlpApplication logApp, OtlpScope scope, TelemetryLimits options)
+    public OtlpLogEntry(LogRecord record, OtlpApplication logApp, OtlpScope scope, TelemetryLimitOptions options)
     {
         string? originalFormat = null;
         string? parentId = null;

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Configuration;
 using OpenTelemetry.Proto.Logs.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
@@ -22,7 +22,7 @@ public class OtlpLogEntry
     public OtlpApplication Application { get; }
     public OtlpScope Scope { get; }
 
-    public OtlpLogEntry(LogRecord record, OtlpApplication logApp, OtlpScope scope, TelemetryOptions options)
+    public OtlpLogEntry(LogRecord record, OtlpApplication logApp, OtlpScope scope, TelemetryLimits options)
     {
         string? originalFormat = null;
         string? parentId = null;
@@ -49,7 +49,7 @@ public class OtlpLogEntry
         Flags = record.Flags;
         Severity = MapSeverity(record.SeverityNumber);
 
-        Message = OtlpHelpers.TruncateString(record.Body.GetString(), options.AttributeLengthLimit);
+        Message = OtlpHelpers.TruncateString(record.Body.GetString(), options.MaxAttributeLength);
         OriginalFormat = originalFormat;
         SpanId = record.SpanId.ToHexString();
         TraceId = record.TraceId.ToHexString();

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Configuration;
 using OpenTelemetry.Proto.Common.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
@@ -15,7 +15,7 @@ public class OtlpMeter
 
     public ReadOnlyMemory<KeyValuePair<string, string>> Attributes { get; }
 
-    public OtlpMeter(InstrumentationScope scope, TelemetryOptions options)
+    public OtlpMeter(InstrumentationScope scope, TelemetryLimits options)
     {
         MeterName = scope.Name;
         Version = scope.Version;

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
@@ -15,7 +15,7 @@ public class OtlpMeter
 
     public ReadOnlyMemory<KeyValuePair<string, string>> Attributes { get; }
 
-    public OtlpMeter(InstrumentationScope scope, TelemetryLimits options)
+    public OtlpMeter(InstrumentationScope scope, TelemetryLimitOptions options)
     {
         MeterName = scope.Name;
         Version = scope.Version;

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
@@ -25,7 +25,7 @@ public class OtlpScope
         Version = string.Empty;
     }
 
-    public OtlpScope(InstrumentationScope scope, TelemetryLimits options)
+    public OtlpScope(InstrumentationScope scope, TelemetryLimitOptions options)
     {
         ScopeName = scope.Name;
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Configuration;
 using OpenTelemetry.Proto.Common.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
@@ -25,7 +25,7 @@ public class OtlpScope
         Version = string.Empty;
     }
 
-    public OtlpScope(InstrumentationScope scope, TelemetryOptions options)
+    public OtlpScope(InstrumentationScope scope, TelemetryLimits options)
     {
         ScopeName = scope.Name;
 

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -18,13 +18,6 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public sealed class TelemetryRepository
 {
-    internal const string LogCountLimitKey = "DOTNET_DASHBOARD_OTEL_LOG_COUNT_LIMIT";
-    internal const string TraceCountLimitKey = "DOTNET_DASHBOARD_OTEL_TRACE_COUNT_LIMIT";
-    internal const string MetricsCountLimitKey = "DOTNET_DASHBOARD_OTEL_METRIC_COUNT_LIMIT";
-    internal const string AttributeCountLimitKey = "DOTNET_DASHBOARD_OTEL_ATTRIBUTE_COUNT_LIMIT";
-    internal const string AttributeLengthLimitKey = "DOTNET_DASHBOARD_OTEL_ATTRIBUTE_LENGTH_LIMIT";
-    internal const string SpanEventCountLimitKey = "DOTNET_DASHBOARD_OTEL_SPAN_EVENT_COUNT_LIMIT";
-
     private readonly object _lock = new();
     internal readonly ILogger _logger;
     internal TimeSpan _subscriptionMinExecuteInterval = TimeSpan.FromMilliseconds(100);

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -684,7 +684,7 @@ public sealed class TelemetryRepository
         }
     }
 
-    private static OtlpSpan CreateSpan(OtlpApplication application, Span span, OtlpTrace trace, TelemetryLimits options)
+    private static OtlpSpan CreateSpan(OtlpApplication application, Span span, OtlpTrace trace, TelemetryLimitOptions options)
     {
         var id = span.SpanId?.ToHexString();
         if (id is null)

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -1,8 +1,10 @@
 # .NET Aspire Dashboard
 
-The .NET Aspire is a browser based app to view information about the app you're developing:
+The .NET Aspire Dashboard is a browser-based app to view run-time information about your distributed application.
 
-- The resources that make up your app, such as .NET projects, executables and containers.
+The dashboard shows:
+
+- Resources that make up your app, such as .NET projects, executables and containers.
 - Live console logs of resources.
 - Live telemetry, such as structured logs, traces and metrics.
 
@@ -19,7 +21,6 @@ Example JSON configuration file:
 ```json
 {
   "Dashboard": {
-    "ApplicationName": "My cool app",
     "TelemetryLimits": {
       "MaxLogCount": 1000,
       "MaxTraceCount": 1000,
@@ -55,8 +56,8 @@ For client certification authentication, set `Dashboard:Otlp:AuthMode` to `Certi
 
 For API key authentication, set `Dashboard:Otlp:AuthMode` to `ApiKey`, then add the following configuration:
 
-- `Dashboard:Otlp:PrimaryApiKey` specifies the primary API key. This is required.
-- `Dashboard:Otlp:SecondaryApiKey` specifies the secondary API key. This is optional.
+- `Dashboard:Otlp:PrimaryApiKey` specifies the primary API key. (required, string)
+- `Dashboard:Otlp:SecondaryApiKey` specifies the secondary API key. (optional, string)
 
 It may also be run unsecured. Set `Dashboard:Otlp:AuthMode` to `Unsecured`. The OTLP endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
 

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -74,7 +74,6 @@ The resource service client supports certificates. Set `Dashboard:ResourceServic
     - `Dashboard:ResourceServiceClient:ClientCertificate:Subject` (required, string)
     - `Dashboard:ResourceServiceClient:ClientCertificate:Store` (optional, [`StoreName`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storename), defaults to `My`)
     - `Dashboard:ResourceServiceClient:ClientCertificate:Location` (optional, [`StoreLocation`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storelocation), defaults to `CurrentUser`)
-- `Dashboard:ResourceServiceClient:Ssl` (optional, [`SslClientAuthenticationOptions`](https://learn.microsoft.com/dotnet/api/system.net.security.sslclientauthenticationoptions))
 
 To opt-out of authentication, set `Dashboard:ResourceServiceClient:AuthMode` to `Unsecured`. This completely disables all security for the resource service client. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
 
@@ -88,6 +87,8 @@ Telemetry is stored in-memory. To avoid excessive memory usage, the dashboard ha
 - `Dashboard:TelemetryLimits:MaxAttributeCount` specifies the maximum number of attributes on telemetry. Defaults to 128.
 - `Dashboard:TelemetryLimits:MaxAttributeLength` specifies the maximum length of attributes. Defaults to unlimited.
 - `Dashboard:TelemetryLimits:MaxSpanEventCount` specifies the maximum number of events on span attributes. Defaults to unlimited.
+
+Limits are per-resource. For example, a `MaxLogCount` value of 10,000 configures the dashboard to store up to 10,000 log entries per-resource.
 
 ### Other
 

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -1,65 +1,94 @@
 # .NET Aspire Dashboard
 
+The .NET Aspire is a browser based app to view information about the app you're developing:
+
+- The resources that make up your app, such as .NET projects, executables and containers.
+- Live console logs of resources.
+- Live telemetry, such as structured logs, traces and metrics.
+
 ## Configuration
 
-Configuration is obtained through `IConfiguration`, so it can be provided in several ways, such as via environment variables.
+The dashboard must be configured when it is started. There are a number of ways to provide configuration:
 
-The dashboard has two kinds of endpoints: a browser endpoint for viewing the dashboard UI and an OTLP endpoint that hosts an OTLP service and receives telemetry.
+- Command line arguments.
+- Environment variables. The `:` delimiter should be replaced with double underscore (`__`) in environment variable names.
+- Optional JSON configuration file. The `DOTNET_DASHBOARD_CONFIG_FILE_PATH` setting can be used to specify a JSON configuration file.
 
-- `ASPNETCORE_URLS` specifies one or more HTTP endpoints through which the dashboard frontend is served. Defaults to http://localhost:18888.
-- `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` specifies the OTLP endpoint. Defaults to http://localhost:18889.
+Example JSON configuration file:
 
-Endpoints are given names in Kestrel (`Browser` and `Otlp`) and can be configured using [Kestrel endpoint configuration](https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/endpoints#configure-endpoints-in-appsettingsjson).
+```json
+{
+  "Dashboard": {
+    "ApplicationName": "My cool app",
+    "TelemetryLimits": {
+      "MaxLogCount": 1000,
+      "MaxTraceCount": 1000,
+      "MaxMetricsCount": 1000
+    }
+  }
+}
+```
 
-For example, the default certificate used by HTTPS endpoints can be configured using the `ASPNETCORE_Kestrel__Certificates__Default__Path` and `ASPNETCORE_Kestrel__Certificates__Default__Password` environment variables. Alternatively, the certificate can be configured for individual endpoints, such as `ASPNETCORE_Kestrel__Endpoints__Browser__Path`, etc.
+### Common configuration
 
-### Frontend
+- `ASPNETCORE_URLS` specifies one or more HTTP endpoints through which the dashboard frontend is served. The frontend endpoint is used to view the dashboard in a browser. Defaults to http://localhost:18888.
+- `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` specifies the OTLP endpoint. OTLP endpoint hosts an OTLP service and recevies telemetry. Defaults to http://localhost:18889.
+- `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` specifies the dashboard doesn't use authentication and accepts anonymous access. This setting is a shortcut to configuring `Dashboard:Frontend:AuthMode` and `Dashboard:Otlp:AuthMode` to `Unsecured`.
+- `DOTNET_DASHBOARD_CONFIG_FILE_PATH` specifies the path for an optional JSON configuration file.
 
-The dashboard's web application frontend supports OpenID Connect (OIDC). Set `Frontend:AuthMode` to `OpenIdConnect`, then add the following configuration:
+### Frontend authentication
+
+The dashboard's frontend supports OpenID Connect (OIDC). Set `Dashboard:Frontend:AuthMode` to `OpenIdConnect`, then add the following configuration:
 
 - `Authentication:Schemes:OpenIdConnect:Authority` &mdash; URL to the identity provider (IdP)
 - `Authentication:Schemes:OpenIdConnect:ClientId` &mdash; Identity of the relying party (RP)
 - `Authentication:Schemes:OpenIdConnect:ClientSecret`&mdash; A secret that only the real RP would know
 - Other properties of [`OpenIdConnectOptions`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.builder.openidconnectoptions) specified in configuration container `Authentication:Schemes:OpenIdConnect:*`
 
-It may also be run unsecured. Set `Frontend:AuthMode` to `Unsecured`. This completely disables all security for the dashboard frontend. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+It may also be run unsecured. Set `Dashboard:Frontend:AuthMode` to `Unsecured`. The frontend endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
 
-### Resources
-
-- `DOTNET_RESOURCE_SERVICE_ENDPOINT_URL` specifies the gRPC endpoint to which the dashboard connects for its data. There's no default. If this variable is unspecified, the dashboard shows OTEL data but no resource list or console logs.
-
-The resource service client supports certificates. Set `ResourceServiceClient:AuthMode` to `Certificate`, then add the following configuration:
-
-- `ResourceServiceClient:ClientCertificate:Source` (required) one of:
-  - `File` to load the cert from a file path, configured with:
-    - `ResourceServiceClient:ClientCertificate:FilePath` (required, string)
-    - `ResourceServiceClient:ClientCertificate:Password` (optional, string)
-  - `KeyStore` to load the cert from a key store, configured with:
-    - `ResourceServiceClient:ClientCertificate:Subject` (required, string)
-    - `ResourceServiceClient:ClientCertificate:KeyStore:Name` (optional, [`StoreName`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storename), defaults to `My`)
-    - `ResourceServiceClient:ClientCertificate:KeyStore:Location` (optional, [`StoreLocation`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storelocation), defaults to `CurrentUser`)
-- `ResourceServiceClient:Ssl` (optional, [`SslClientAuthenticationOptions`](https://learn.microsoft.com/dotnet/api/system.net.security.sslclientauthenticationoptions))
-
-To opt-out of authentication, set `ResourceServiceClient:AuthMode` to `Unsecured`. This completely disables all security for the resource service client. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
-
-### OTLP
+### OTLP authentication
 
 The OTLP endpoint can be secured with [client certificate](https://learn.microsoft.com/aspnet/core/security/authentication/certauth) or API key authentication.
 
-- `Otlp:AuthMode` specifies the authentication mode on the OTLP endpoint. Possible values are `Certificate`, `ApiKey`, `Unsecured`. This configuration is required.
-- `Otlp:ApiKey` specifies the API key for the OTLP endpoint when API key authentication is enabled. This configuration is required for API key authentication.
+For client certification authentication, set `Dashboard:Otlp:AuthMode` to `Certificate`.
+
+For API key authentication, set `Dashboard:Otlp:AuthMode` to `ApiKey`, then add the following configuration:
+
+- `Dashboard:Otlp:PrimaryApiKey` specifies the primary API key. This is required.
+- `Dashboard:Otlp:SecondaryApiKey` specifies the secondary API key. This is optional.
+
+It may also be run unsecured. Set `Dashboard:Otlp:AuthMode` to `Unsecured`. The OTLP endpoint will allow anonymous access. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
+
+### Resources
+
+- `Dashboard:ResourceServiceClient:Url` specifies the gRPC endpoint to which the dashboard connects for its data. There's no default. If this variable is unspecified, the dashboard shows OTEL data but no resource list or console logs.
+
+The resource service client supports certificates. Set `Dashboard:ResourceServiceClient:AuthMode` to `Certificate`, then add the following configuration:
+
+- `Dashboard:ResourceServiceClient:ClientCertificate:Source` (required) one of:
+  - `File` to load the cert from a file path, configured with:
+    - `Dashboard:ResourceServiceClient:ClientCertificate:FilePath` (required, string)
+    - `Dashboard:ResourceServiceClient:ClientCertificate:Password` (optional, string)
+  - `KeyStore` to load the cert from a key store, configured with:
+    - `Dashboard:ResourceServiceClient:ClientCertificate:Subject` (required, string)
+    - `Dashboard:ResourceServiceClient:ClientCertificate:KeyStore:Name` (optional, [`StoreName`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storename), defaults to `My`)
+    - `Dashboard:ResourceServiceClient:ClientCertificate:KeyStore:Location` (optional, [`StoreLocation`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storelocation), defaults to `CurrentUser`)
+- `Dashboard:ResourceServiceClient:Ssl` (optional, [`SslClientAuthenticationOptions`](https://learn.microsoft.com/dotnet/api/system.net.security.sslclientauthenticationoptions))
+
+To opt-out of authentication, set `Dashboard:ResourceServiceClient:AuthMode` to `Unsecured`. This completely disables all security for the resource service client. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.
 
 #### Telemetry Limits
 
 Telemetry is stored in-memory. To avoid excessive memory usage, the dashboard has limits on the count and size of stored telemetry. When a count limit is reached, new telemetry is added, and the oldest telemetry is removed. When a size limit is reached, data is truncated to the limit.
 
-- `DOTNET_DASHBOARD_OTEL_LOG_COUNT_LIMIT` specifies the maximum number of log entries. Defaults to 10,000.
-- `DOTNET_DASHBOARD_OTEL_TRACE_COUNT_LIMIT` specifies the maximum number of traces. Defaults to 10,000.
-- `DOTNET_DASHBOARD_OTEL_METRIC_COUNT_LIMIT` specifies the maximum number of metric data points. Defaults to 50,000.
-- `DOTNET_DASHBOARD_OTEL_ATTRIBUTE_COUNT_LIMIT` specifies the maximum number of attributes on telemetry. Defaults to 128.
-- `DOTNET_DASHBOARD_OTEL_ATTRIBUTE_LENGTH_LIMIT` specifies the maximum length of attributes. Defaults to unlimited.
-- `DOTNET_DASHBOARD_OTEL_SPAN_EVENT_COUNT_LIMIT` specifies the maximum number of events on span attributes. Defaults to unlimited.
+- `Dashboard:TelemetryLimits:MaxLogCount` specifies the maximum number of log entries. Defaults to 10,000.
+- `Dashboard:TelemetryLimits:MaxTraceCount` specifies the maximum number of traces. Defaults to 10,000.
+- `Dashboard:TelemetryLimits:MaxMetricsCount` specifies the maximum number of metric data points. Defaults to 50,000.
+- `Dashboard:TelemetryLimits:MaxAttributeCount` specifies the maximum number of attributes on telemetry. Defaults to 128.
+- `Dashboard:TelemetryLimits:MaxAttributeLength` specifies the maximum length of attributes. Defaults to unlimited.
+- `Dashboard:TelemetryLimits:MaxSpanEventCount` specifies the maximum number of events on span attributes. Defaults to unlimited.
 
 ### Other
 
-- `DOTNET_DASHBOARD_APPLICATION_NAME` specifies the application name to be displayed in the UI. This applies only when no resource service URL is specified. When a resource service exists, the service specifies the application name.
+- `Dashboard:ApplicationName` specifies the application name to be displayed in the UI. This applies only when no resource service URL is specified. When a resource service exists, the service specifies the application name.

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -72,8 +72,8 @@ The resource service client supports certificates. Set `Dashboard:ResourceServic
     - `Dashboard:ResourceServiceClient:ClientCertificate:Password` (optional, string)
   - `KeyStore` to load the cert from a key store, configured with:
     - `Dashboard:ResourceServiceClient:ClientCertificate:Subject` (required, string)
-    - `Dashboard:ResourceServiceClient:ClientCertificate:KeyStore:Name` (optional, [`StoreName`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storename), defaults to `My`)
-    - `Dashboard:ResourceServiceClient:ClientCertificate:KeyStore:Location` (optional, [`StoreLocation`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storelocation), defaults to `CurrentUser`)
+    - `Dashboard:ResourceServiceClient:ClientCertificate:Store` (optional, [`StoreName`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storename), defaults to `My`)
+    - `Dashboard:ResourceServiceClient:ClientCertificate:Location` (optional, [`StoreLocation`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.x509certificates.storelocation), defaults to `CurrentUser`)
 - `Dashboard:ResourceServiceClient:Ssl` (optional, [`SslClientAuthenticationOptions`](https://learn.microsoft.com/dotnet/api/system.net.security.sslclientauthenticationoptions))
 
 To opt-out of authentication, set `Dashboard:ResourceServiceClient:AuthMode` to `Unsecured`. This completely disables all security for the resource service client. This setting is used during local development, but is not recommended if you attempt to host the dashboard in other settings.

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -22,6 +22,7 @@
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
     <Compile Include="$(SharedDir)TaskHelpers.cs" Link="Utils\TaskHelpers.cs" />
     <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
+    <Compile Include="$(SharedDir)DashboardConfigNames.cs" Link="Utils\DashboardConfigNames.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -714,7 +714,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
             // No auth in local dev experience
             context.EnvironmentVariables[DashboardConfigNames.ResourceServiceAuthModeName.EnvVarName] = "Unsecured"; // No auth in local dev experience
-            context.EnvironmentVariables[DashboardConfigNames.FrontendAuthModeName.EnvVarName] = "Unsecured";
+            context.EnvironmentVariables[DashboardConfigNames.DashboardFrontendAuthModeName.EnvVarName] = "Unsecured";
 
             if (configuration["AppHost:OtlpApiKey"] is { } otlpApiKey)
             {
@@ -785,7 +785,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             },
             new()
             {
-                Name = DashboardConfigNames.FrontendAuthModeName.EnvVarName,
+                Name = DashboardConfigNames.DashboardFrontendAuthModeName.EnvVarName,
                 Value = "Unsecured" // No auth in local dev experience
             },
             new()

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -708,22 +708,22 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
             var grpcEndpointUrl = await _dashboardEndpointProvider.GetResourceServiceUriAsync(context.CancellationToken).ConfigureAwait(false);
 
-            context.EnvironmentVariables["ASPNETCORE_URLS"] = appHostApplicationUrl;
-            context.EnvironmentVariables["DOTNET_RESOURCE_SERVICE_ENDPOINT_URL"] = grpcEndpointUrl;
-            context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_ENDPOINT_URL"] = otlpEndpointUrl;
+            context.EnvironmentVariables[DashboardConfigNames.DashboardFrontendUrlName.EnvVarName] = appHostApplicationUrl;
+            context.EnvironmentVariables[DashboardConfigNames.ResourceServiceUrlName.EnvVarName] = grpcEndpointUrl;
+            context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpUrlName.EnvVarName] = otlpEndpointUrl;
 
             // No auth in local dev experience
-            context.EnvironmentVariables["ResourceServiceClient__AuthMode"] = "Unsecured";
-            context.EnvironmentVariables["Frontend__AuthMode"] = "Unsecured";
+            context.EnvironmentVariables[DashboardConfigNames.ResourceServiceAuthModeName.EnvVarName] = "Unsecured"; // No auth in local dev experience
+            context.EnvironmentVariables[DashboardConfigNames.FrontendAuthModeName.EnvVarName] = "Unsecured";
 
             if (configuration["AppHost:OtlpApiKey"] is { } otlpApiKey)
             {
-                context.EnvironmentVariables["Otlp__AuthMode"] = "ApiKey"; // Matches value in OtlpAuthMode enum.
-                context.EnvironmentVariables["Otlp__ApiKey"] = otlpApiKey;
+                context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpAuthModeName.EnvVarName] = "ApiKey"; // Matches value in OtlpAuthMode enum.
+                context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.EnvVarName] = otlpApiKey;
             }
             else
             {
-                context.EnvironmentVariables["DOTNET_DASHBOARD_OTLP_AUTH_MODE"] = "None"; // Matches value in OtlpAuthMode enum.
+                context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpAuthModeName.EnvVarName] = "Unsecured"; // Matches value in OtlpAuthMode enum.
             }
         }));
     }
@@ -775,27 +775,27 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         [
             new()
             {
-                Name = "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL",
+                Name = DashboardConfigNames.ResourceServiceUrlName.EnvVarName,
                 Value = grpcEndpointUrl
             },
             new()
             {
-                Name = "ResourceServiceClient__AuthMode",
+                Name = DashboardConfigNames.ResourceServiceAuthModeName.EnvVarName,
                 Value = "Unsecured" // No auth in local dev experience
             },
             new()
             {
-                Name = "Frontend__AuthMode",
+                Name = DashboardConfigNames.FrontendAuthModeName.EnvVarName,
                 Value = "Unsecured" // No auth in local dev experience
             },
             new()
             {
-                Name = "ASPNETCORE_URLS",
+                Name = DashboardConfigNames.DashboardFrontendUrlName.EnvVarName,
                 Value = dashboardUrls
             },
             new()
             {
-                Name = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL",
+                Name = DashboardConfigNames.DashboardOtlpUrlName.EnvVarName,
                 Value = otlpEndpointUrl
             },
             new()
@@ -810,12 +810,12 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             dashboardExecutableSpec.Env.AddRange([
                 new()
                 {
-                    Name = "Otlp__ApiKey",
+                    Name = DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.EnvVarName,
                     Value = otlpApiKey
                 },
                 new()
                 {
-                    Name = "Otlp__AuthMode",
+                    Name = DashboardConfigNames.DashboardOtlpAuthModeName.EnvVarName,
                     Value = "ApiKey" // Matches value in OtlpAuthMode enum.
                 }
             ]);
@@ -825,8 +825,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             dashboardExecutableSpec.Env.AddRange([
                 new()
                 {
-                    Name = "DOTNET_DASHBOARD_OTLP_AUTH_MODE",
-                    Value = "None" // Matches value in OtlpAuthMode enum.
+                    Name = DashboardConfigNames.DashboardOtlpAuthModeName.EnvVarName,
+                    Value = "Unsecured" // Matches value in OtlpAuthMode enum.
                 }
             ]);
         }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -713,17 +713,17 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpUrlName.EnvVarName] = otlpEndpointUrl;
 
             // No auth in local dev experience
-            context.EnvironmentVariables[DashboardConfigNames.ResourceServiceAuthModeName.EnvVarName] = "Unsecured"; // No auth in local dev experience
+            context.EnvironmentVariables[DashboardConfigNames.ResourceServiceAuthModeName.EnvVarName] = "Unsecured";
             context.EnvironmentVariables[DashboardConfigNames.DashboardFrontendAuthModeName.EnvVarName] = "Unsecured";
 
             if (configuration["AppHost:OtlpApiKey"] is { } otlpApiKey)
             {
-                context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpAuthModeName.EnvVarName] = "ApiKey"; // Matches value in OtlpAuthMode enum.
+                context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpAuthModeName.EnvVarName] = "ApiKey";
                 context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.EnvVarName] = otlpApiKey;
             }
             else
             {
-                context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpAuthModeName.EnvVarName] = "Unsecured"; // Matches value in OtlpAuthMode enum.
+                context.EnvironmentVariables[DashboardConfigNames.DashboardOtlpAuthModeName.EnvVarName] = "Unsecured";
             }
         }));
     }

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+internal static class DashboardConfigNames
+{
+    public static readonly ConfigName DashboardFrontendUrlName = new("ASPNETCORE_URLS");
+    public static readonly ConfigName DashboardOtlpUrlName = new("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL");
+    public static readonly ConfigName DashboardInsecureAllowAnonymousName = new("DOTNET_DASHBOARD_INSECURE_ALLOW_ANONYMOUS");
+    public static readonly ConfigName DashboardConfigFilePathName = new("DOTNET_DASHBOARD_CONFIG_FILE_PATH");
+    public static readonly ConfigName ResourceServiceUrlName = new("DOTNET_RESOURCE_SERVICE_ENDPOINT_URL");
+
+    public static readonly ConfigName DashboardOtlpAuthModeName = new("Dashboard:Otlp:AuthMode", "DASHBOARD__OTLP__AUTHMODE");
+    public static readonly ConfigName DashboardOtlpPrimaryApiKeyName = new("Dashboard:Otlp:PrimaryApiKey", "DASHBOARD__OTLP__PRIMARYAPIKEY");
+    public static readonly ConfigName DashboardOtlpSecondaryApiKeyName = new("Dashboard:Otlp:SecondaryApiKey", "DASHBOARD__OTLP__SECONDARYAPIKEY");
+    public static readonly ConfigName DashboardFrontendAuthModeName = new("Dashboard:Frontend:AuthMode", "DASHBOARD__FRONTEND__AUTHMODE");
+    public static readonly ConfigName ResourceServiceAuthModeName = new("Dashboard:ResourceServiceClient:AuthMode", "DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE");
+}
+
+internal readonly struct ConfigName(string configKey, string? envVarName = null)
+{
+    public string ConfigKey { get; } = configKey;
+    public string EnvVarName { get; } = envVarName ?? configKey;
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -51,7 +51,7 @@ public class PlotlyChartTests : TestContext
         Services.AddSingleton<IInstrumentUnitResolver, TestInstrumentUnitResolver>();
         Services.AddSingleton<BrowserTimeProvider, TestTimeProvider>();
 
-        var options = new TelemetryLimits();
+        var options = new TelemetryLimitOptions();
         var instrument = new OtlpInstrument
         {
             Name = "Name-<b>Bold</b>",

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
-using Aspire.Dashboard.Otlp.Storage;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -51,7 +51,7 @@ public class PlotlyChartTests : TestContext
         Services.AddSingleton<IInstrumentUnitResolver, TestInstrumentUnitResolver>();
         Services.AddSingleton<BrowserTimeProvider, TestTimeProvider>();
 
-        var options = new TelemetryOptions();
+        var options = new TelemetryLimits();
         var instrument = new OtlpInstrument
         {
             Name = "Name-<b>Bold</b>",

--- a/tests/Aspire.Dashboard.Tests/CustomAssert.cs
+++ b/tests/Aspire.Dashboard.Tests/CustomAssert.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography.X509Certificates;
+using Aspire.Dashboard.Configuration;
+using Aspire.Hosting;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Net.Client.Configuration;
@@ -26,10 +28,10 @@ public static class IntegrationTestHelpers
     {
         var initialData = new Dictionary<string, string?>
         {
-            [DashboardWebApplication.DashboardUrlVariableName] = "http://127.0.0.1:0",
-            [DashboardWebApplication.DashboardOtlpUrlVariableName] = "http://127.0.0.1:0",
-            [DashboardWebApplication.OtlpAuthModeKey] = "Unsecured",
-            [DashboardWebApplication.FrontendAuthModeKey] = "Unsecured"
+            [DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "http://127.0.0.1:0",
+            [DashboardConfigNames.DashboardOtlpUrlName.ConfigKey] = "http://127.0.0.1:0",
+            [DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = nameof(OtlpAuthMode.Unsecured),
+            [DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.Unsecured)
         };
 
         additionalConfiguration?.Invoke(initialData);

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -10,6 +10,7 @@ using Grpc.Net.Client.Configuration;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -45,7 +46,18 @@ public static class IntegrationTestHelpers
             {
                 o.Rules.Clear();
             });
+
+            // Remove environment variable source of configuration.
+            var sources = ((IConfigurationBuilder)builder.Configuration).Sources;
+            foreach (var item in sources.ToList())
+            {
+                if (item is EnvironmentVariablesConfigurationSource)
+                {
+                    sources.Remove(item);
+                }
+            }            
             builder.Configuration.AddConfiguration(config);
+
             builder.Logging.AddXunit(testOutputHelper);
             builder.Logging.SetMinimumLevel(LogLevel.Trace);
             if (testSink != null)

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpServiceTests.cs
@@ -2,11 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Security.Cryptography.X509Certificates;
-using Aspire.Dashboard.Authentication;
+using System.Text.Json.Nodes;
 using Aspire.Dashboard.Authentication.OtlpApiKey;
+using Aspire.Dashboard.Configuration;
+using Aspire.Hosting;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging.Testing;
 using OpenTelemetry.Proto.Collector.Logs.V1;
 using Xunit;
 using Xunit.Abstractions;
@@ -23,7 +26,7 @@ public class OtlpServiceTests
     }
 
     [Fact]
-    public async void CallService_OtlpEndPoint_Success()
+    public async Task CallService_OtlpEndPoint_Success()
     {
         // Arrange
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper);
@@ -40,14 +43,14 @@ public class OtlpServiceTests
     }
 
     [Fact]
-    public async void CallService_OtlpEndPoint_RequiredApiKeyMissing_Failure()
+    public async Task CallService_OtlpEndPoint_RequiredApiKeyMissing_Failure()
     {
         // Arrange
         var apiKey = "TestKey123!";
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
         {
-            config[DashboardWebApplication.OtlpAuthModeKey] = OtlpAuthMode.ApiKey.ToString();
-            config[DashboardWebApplication.OtlpApiKeyKey] = apiKey;
+            config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
+            config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
         });
         await app.StartAsync();
 
@@ -62,14 +65,14 @@ public class OtlpServiceTests
     }
 
     [Fact]
-    public async void CallService_OtlpEndPoint_RequiredApiKeyWrong_Failure()
+    public async Task CallService_OtlpEndPoint_RequiredApiKeyWrong_Failure()
     {
         // Arrange
         var apiKey = "TestKey123!";
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
         {
-            config[DashboardWebApplication.OtlpAuthModeKey] = OtlpAuthMode.ApiKey.ToString();
-            config[DashboardWebApplication.OtlpApiKeyKey] = apiKey;
+            config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
+            config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
         });
         await app.StartAsync();
 
@@ -89,14 +92,14 @@ public class OtlpServiceTests
     }
 
     [Fact]
-    public async void CallService_OtlpEndPoint_RequiredApiKeySent_Success()
+    public async Task CallService_OtlpEndPoint_RequiredApiKeySent_Success()
     {
         // Arrange
         var apiKey = "TestKey123!";
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
         {
-            config[DashboardWebApplication.OtlpAuthModeKey] = OtlpAuthMode.ApiKey.ToString();
-            config[DashboardWebApplication.OtlpApiKeyKey] = apiKey;
+            config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
+            config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
         });
         await app.StartAsync();
 
@@ -116,7 +119,105 @@ public class OtlpServiceTests
     }
 
     [Fact]
-    public async void CallService_BrowserEndPoint_Failure()
+    public async Task CallService_OtlpEndPoint_RequiredSecondaryApiKeySent_Success()
+    {
+        // Arrange
+        var apiKey = "TestKey123!";
+        var secondaryApiKey = "!321yeKtseT";
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ApiKey.ToString();
+            config[DashboardConfigNames.DashboardOtlpPrimaryApiKeyName.ConfigKey] = apiKey;
+            config[DashboardConfigNames.DashboardOtlpSecondaryApiKeyName.ConfigKey] = secondaryApiKey;
+        });
+        await app.StartAsync();
+
+        using var channel = GrpcChannel.ForAddress($"http://{app.OtlpServiceEndPointAccessor().EndPoint}");
+        var client = new LogsService.LogsServiceClient(channel);
+
+        var metadata = new Metadata
+        {
+            { OtlpApiKeyAuthenticationHandler.ApiKeyHeaderName, secondaryApiKey }
+        };
+
+        // Act
+        var response = await client.ExportAsync(new ExportLogsServiceRequest(), metadata);
+
+        // Assert
+        Assert.Equal(0, response.PartialSuccess.RejectedLogRecords);
+    }
+
+    [Fact]
+    public async Task CallService_OtlpEndPoint_ExternalFile_FileChanged_UseConfiguredKey()
+    {
+        // Arrange
+        var apiKey = "TestKey123!";
+        var configPath = Path.GetTempFileName();
+        var configJson = new JsonObject
+        {
+            ["Dashboard"] = new JsonObject
+            {
+                ["Otlp"] = new JsonObject
+                {
+                    ["AuthMode"] = OtlpAuthMode.ApiKey.ToString(),
+                    ["PrimaryApiKey"] = apiKey
+                }
+            }
+        };
+        File.WriteAllText(configPath, configJson.ToString());
+
+        var testSink = new TestSink();
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config[DashboardConfigNames.DashboardConfigFilePathName.ConfigKey] = configPath;
+        }, testSink: testSink);
+        await app.StartAsync();
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var monitorRegistration = app.DashboardOptionsMonitor.OnChange((o, n) =>
+        {
+            tcs.TrySetResult();
+        });
+
+        using var channel = GrpcChannel.ForAddress($"http://{app.OtlpServiceEndPointAccessor().EndPoint}");
+        var client = new LogsService.LogsServiceClient(channel);
+
+        var metadata = new Metadata
+        {
+            { OtlpApiKeyAuthenticationHandler.ApiKeyHeaderName, apiKey }
+        };
+
+        // Act 1
+        var response1 = await client.ExportAsync(new ExportLogsServiceRequest(), metadata);
+
+        // Assert 1
+        Assert.Equal(0, response1.PartialSuccess.RejectedLogRecords);
+
+        // Change config file
+        configJson = new JsonObject
+        {
+            ["Dashboard"] = new JsonObject
+            {
+                ["Otlp"] = new JsonObject
+                {
+                    ["AuthMode"] = OtlpAuthMode.ApiKey.ToString(),
+                    ["PrimaryApiKey"] = "Different"
+                }
+            }
+        };
+        File.WriteAllText(configPath, configJson.ToString());
+
+        await tcs.Task;
+
+        // Act 2
+        var ex = await Assert.ThrowsAsync<RpcException>(() => client.ExportAsync(new ExportLogsServiceRequest(), metadata).ResponseAsync);
+
+        // Assert 2
+        Assert.Equal(StatusCode.Unauthenticated, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task CallService_BrowserEndPoint_Failure()
     {
         // Arrange
         X509Certificate2? clientCallbackCert = null;
@@ -124,7 +225,7 @@ public class OtlpServiceTests
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
         {
             // Change dashboard to HTTPS so the caller can negotiate a HTTP/2 connection.
-            config[DashboardWebApplication.DashboardUrlVariableName] = "https://127.0.0.1:0";
+            config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "https://127.0.0.1:0";
         });
         await app.StartAsync();
 
@@ -147,15 +248,15 @@ public class OtlpServiceTests
     }
 
     [Fact]
-    public async void CallService_OtlpEndpoint_RequiredClientCertificateMissing_Failure()
+    public async Task CallService_OtlpEndpoint_RequiredClientCertificateMissing_Failure()
     {
         // Arrange
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
         {
             // Change dashboard to HTTPS so the caller can negotiate a HTTP/2 connection.
-            config[DashboardWebApplication.DashboardOtlpUrlVariableName] = "https://127.0.0.1:0";
+            config[DashboardConfigNames.DashboardOtlpUrlName.ConfigKey] = "https://127.0.0.1:0";
 
-            config[DashboardWebApplication.OtlpAuthModeKey] = OtlpAuthMode.ClientCertificate.ToString();
+            config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ClientCertificate.ToString();
         });
         await app.StartAsync();
 
@@ -179,7 +280,7 @@ public class OtlpServiceTests
     }
 
     [Fact]
-    public async void CallService_OtlpEndpoint_RequiredClientCertificateValid_Success()
+    public async Task CallService_OtlpEndpoint_RequiredClientCertificateValid_Success()
     {
         // Arrange
         X509Certificate2? clientCallbackCert = null;
@@ -187,12 +288,12 @@ public class OtlpServiceTests
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
         {
             // Change dashboard to HTTPS so the caller can negotiate a HTTP/2 connection.
-            config[DashboardWebApplication.DashboardOtlpUrlVariableName] = "https://127.0.0.1:0";
+            config[DashboardConfigNames.DashboardOtlpUrlName.ConfigKey] = "https://127.0.0.1:0";
 
-            config[DashboardWebApplication.OtlpAuthModeKey] = OtlpAuthMode.ClientCertificate.ToString();
+            config[DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = OtlpAuthMode.ClientCertificate.ToString();
 
-            config["CertificateAuthentication:AllowedCertificateTypes"] = "SelfSigned";
-            config["CertificateAuthentication:ValidateValidityPeriod"] = "false";
+            config["Dashboard:Otlp:CertificateAuthOptions:AllowedCertificateTypes"] = "SelfSigned";
+            config["Dashboard:Otlp:CertificateAuthOptions:ValidateValidityPeriod"] = "false";
         });
         await app.StartAsync();
 

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
 using Aspire.V1;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.Model;
@@ -14,21 +16,29 @@ namespace Aspire.Dashboard.Tests.Model;
 public sealed class DashboardClientTests
 {
     private readonly IConfiguration _configuration;
+    private readonly IOptions<DashboardOptions> _dashboardOptions;
 
     public DashboardClientTests()
     {
-        var configuration = new ConfigurationManager();
-        configuration.AddInMemoryCollection([
-            new("ResourceServiceClient:AuthMode", "Unsecured"),
-            new("DOTNET_RESOURCE_SERVICE_ENDPOINT_URL", "http://localhost:12345")
-        ]);
-        _configuration = configuration;
+        _configuration = new ConfigurationManager();
+
+        var options = new DashboardOptions
+        {
+            ResourceServiceClient =
+            {
+                AuthMode = ResourceClientAuthMode.Unsecured,
+                Url = "http://localhost:12345"
+            }
+        };
+        options.ResourceServiceClient.TryParseOptions(out _);
+
+        _dashboardOptions = Options.Create(options);
     }
 
     [Fact]
     public async Task SubscribeResources_OnCancel_ChannelRemoved()
     {
-        await using var instance = new DashboardClient(NullLoggerFactory.Instance, _configuration);
+        await using var instance = CreateResourceServiceClient();
         instance.SetInitialDataReceived();
 
         IDashboardClient client = instance;
@@ -58,7 +68,7 @@ public sealed class DashboardClientTests
     [Fact]
     public async Task SubscribeResources_OnDispose_ChannelRemoved()
     {
-        await using var instance = new DashboardClient(NullLoggerFactory.Instance, _configuration);
+        await using var instance = CreateResourceServiceClient();
         instance.SetInitialDataReceived();
 
         IDashboardClient client = instance;
@@ -86,7 +96,7 @@ public sealed class DashboardClientTests
     [Fact]
     public async Task SubscribeResources_ThrowsIfDisposed()
     {
-        await using IDashboardClient client = new DashboardClient(NullLoggerFactory.Instance, _configuration);
+        await using IDashboardClient client = CreateResourceServiceClient();
 
         await client.DisposeAsync();
 
@@ -96,7 +106,7 @@ public sealed class DashboardClientTests
     [Fact]
     public async Task SubscribeResources_IncreasesSubscriberCount()
     {
-        await using var instance = new DashboardClient(NullLoggerFactory.Instance, _configuration);
+        await using var instance = CreateResourceServiceClient();
         instance.SetInitialDataReceived();
 
         IDashboardClient client = instance;
@@ -115,7 +125,7 @@ public sealed class DashboardClientTests
     [Fact]
     public async Task SubscribeResources_HasInitialData_InitialDataReturned()
     {
-        await using var instance = new DashboardClient(NullLoggerFactory.Instance, _configuration);
+        await using var instance = CreateResourceServiceClient();
 
         IDashboardClient client = instance;
 
@@ -135,5 +145,10 @@ public sealed class DashboardClientTests
         var (initialData, subscription) = await subscribeTask;
 
         Assert.Single(initialData);
+    }
+
+    private DashboardClient CreateResourceServiceClient()
+    {
+        return new DashboardClient(NullLoggerFactory.Instance, _configuration, _dashboardOptions);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -563,7 +563,7 @@ public class LogTests
     public void AddLogs_AttributeLimits_LimitsApplied()
     {
         // Arrange
-        var repository = CreateRepository(attributeCountLimit: 5, attributeLengthLimit: 16);
+        var repository = CreateRepository(maxAttributeCount: 5, maxAttributeLength: 16);
 
         // Act
         var attributes = new List<KeyValuePair<string, string>>

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
@@ -99,7 +99,7 @@ public class MetricsTests
     public void AddMetrics_AttributeLimits_LimitsApplied()
     {
         // Arrange
-        var repository = CreateRepository(attributeCountLimit: 5, attributeLengthLimit: 16);
+        var repository = CreateRepository(maxAttributeCount: 5, maxAttributeLength: 16);
 
         var metricAttributes = new List<KeyValuePair<string, string>>();
         var meterAttributes = new List<KeyValuePair<string, string>>();
@@ -299,7 +299,7 @@ public class MetricsTests
     public void AddMetrics_Capacity_ValuesRemoved()
     {
         // Arrange
-        var repository = CreateRepository(metricsCountLimit: 3);
+        var repository = CreateRepository(maxMetricsCount: 3);
 
         // Act
         var addContext = new AddContext();

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
@@ -3,11 +3,12 @@
 
 using System.Globalization;
 using System.Text;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
@@ -189,35 +190,31 @@ internal static class TestHelpers
     }
 
     public static TelemetryRepository CreateRepository(
-        int? metricsCountLimit = null,
-        int? attributeCountLimit = null,
-        int? attributeLengthLimit = null,
-        int? spanEventCountLimit = null,
+        int? maxMetricsCount = null,
+        int? maxAttributeCount = null,
+        int? maxAttributeLength = null,
+        int? maxSpanEventCount = null,
         TimeSpan? subscriptionMinExecuteInterval = null)
     {
-        var inMemorySettings = new Dictionary<string, string?>();
-        if (metricsCountLimit != null)
+        var options = new TelemetryLimits();
+        if (maxMetricsCount != null)
         {
-            inMemorySettings[TelemetryRepository.MetricsCountLimitKey] = metricsCountLimit.Value.ToString(CultureInfo.InvariantCulture);
+            options.MaxMetricsCount = maxMetricsCount.Value;
         }
-        if (attributeCountLimit != null)
+        if (maxAttributeCount != null)
         {
-            inMemorySettings[TelemetryRepository.AttributeCountLimitKey] = attributeCountLimit.Value.ToString(CultureInfo.InvariantCulture);
+            options.MaxAttributeCount = maxAttributeCount.Value;
         }
-        if (attributeLengthLimit != null)
+        if (maxAttributeLength != null)
         {
-            inMemorySettings[TelemetryRepository.AttributeLengthLimitKey] = attributeLengthLimit.Value.ToString(CultureInfo.InvariantCulture);
+            options.MaxAttributeLength = maxAttributeLength.Value;
         }
-        if (spanEventCountLimit != null)
+        if (maxSpanEventCount != null)
         {
-            inMemorySettings[TelemetryRepository.SpanEventCountLimitKey] = spanEventCountLimit.Value.ToString(CultureInfo.InvariantCulture);
+            options.MaxSpanEventCount = maxSpanEventCount.Value;
         }
 
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(inMemorySettings)
-            .Build();
-
-        var repository = new TelemetryRepository(configuration, NullLoggerFactory.Instance);
+        var repository = new TelemetryRepository(NullLoggerFactory.Instance, Options.Create(new DashboardOptions { TelemetryLimits = options }));
         if (subscriptionMinExecuteInterval != null)
         {
             repository._subscriptionMinExecuteInterval = subscriptionMinExecuteInterval.Value;

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
@@ -196,7 +196,7 @@ internal static class TestHelpers
         int? maxSpanEventCount = null,
         TimeSpan? subscriptionMinExecuteInterval = null)
     {
-        var options = new TelemetryLimits();
+        var options = new TelemetryLimitOptions();
         if (maxMetricsCount != null)
         {
             options.MaxMetricsCount = maxMetricsCount.Value;

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -399,7 +399,7 @@ public class TraceTests
     public void AddTraces_AttributeAndEventLimits_LimitsApplied()
     {
         // Arrange
-        var repository = CreateRepository(attributeCountLimit: 5, attributeLengthLimit: 16, spanEventCountLimit: 5);
+        var repository = CreateRepository(maxAttributeCount: 5, maxAttributeLength: 16, maxSpanEventCount: 5);
 
         var attributes = new List<KeyValuePair<string, string>>();
         for (var i = 0; i < 10; i++)

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -13,7 +13,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
     private readonly DistributedApplication _app = fixture.Application;
 
     [LocalOnlyFact]
-    public async void HasEndPoints()
+    public async Task HasEndPoints()
     {
         // Get an endpoint from a resource
         var workerEndpoint = _app.GetEndpoint("myworker1", "myendpoint1");

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -738,7 +738,7 @@ public class AzureBicepResourceTests
     }
 
     [Fact]
-    public async void AsAzureSqlDatabase()
+    public async Task AsAzureSqlDatabase()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 

--- a/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
+++ b/tests/Aspire.Hosting.Tests/Oracle/AddOracleDatabaseTests.cs
@@ -108,7 +108,7 @@ public class AddOracleTests
     }
 
     [Fact]
-    public async void OracleCreatesConnectionStringWithDatabase()
+    public async Task OracleCreatesConnectionStringWithDatabase()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
         appBuilder.AddOracle("orcl")


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2996

* Change dashboard config to be loaded via [options](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-8.0)
  * Use options validation
  * Use options post config to apply shortcut config over the top of structured config, e.g. `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` is set to `Dashboard:Otlp:EndpointUrl`.
* Change OLTP API key auth to have primary and secondary keys
* Change OTLP API key auth to use `IOptionsMonitor<T>` to get latest keys after config changes
* Add `DOTNET_DASHBOARD_CONFIG_FILE_PATH` which configs a location to load JSON from a file. This can be used in cloud hosting scenarios to point at a mounted volume. Changes to the file can be applied to dashboard without restarting the app (for API key rotation without process restart)
* Tests

TODO:
* ~Resource service endpoint URL doesn't use new config yet~
* ~Update dashboard readme~
* ~Remove old code~
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3119)