### PR TITLE
Fix typo in method name "Forwaded" -> "Forwarded"

### DIFF
--- a/src/Aspire.Hosting/Lifecycle/IDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting/Lifecycle/IDistributedApplicationLifecycleHook.cs
@@ -33,7 +33,7 @@ public interface IDistributedApplicationLifecycleHook
     }
 
     /// <summary>
-    /// Executes arfter the orchestrator has created the resources in the application model.
+    /// Executes after the orchestrator has created the resources in the application model.
     /// </summary>
     /// <remarks>
     /// There is no guarantee that the resources have fully started or are in a working state when this method is called.

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -228,7 +228,7 @@ public static class ProjectResourceBuilderExtensions
     /// </summary>
     /// <param name="builder">The project resource builder.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<ProjectResource> DisableForwadedHeaders(this IResourceBuilder<ProjectResource> builder)
+    public static IResourceBuilder<ProjectResource> DisableForwardedHeaders(this IResourceBuilder<ProjectResource> builder)
     {
         builder.WithAnnotation<DisableForwardedHeadersAnnotation>(ResourceAnnotationMutationBehavior.Replace);
         return builder;

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -213,11 +213,11 @@ public class ProjectResourceTests
     }
 
     [Fact]
-    public void DisabledForwadedHeadersAddsAnnotationToProject()
+    public void DisabledForwardedHeadersAddsAnnotationToProject()
     {
         var appBuilder = CreateBuilder();
 
-        appBuilder.AddProject<Projects.ServiceA>("projectName").DisableForwadedHeaders();
+        appBuilder.AddProject<Projects.ServiceA>("projectName").DisableForwardedHeaders();
         using var app = appBuilder.Build();
 
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
@@ -239,7 +239,7 @@ public class ProjectResourceTests
         var project = appBuilder.AddProject<TestProjectWithLaunchSettings>("projectName");
         if (disableForwardedHeaders)
         {
-            project.DisableForwadedHeaders();
+            project.DisableForwardedHeaders();
         }
 
         using var app = appBuilder.Build();


### PR DESCRIPTION
Fix typo of public method using "Forwaded" instead of "Forwarded".
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3123)