### PR TITLE
Allowing for versioning in deployments.

### DIFF
--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -4,6 +4,7 @@
 #pragma warning disable ASPIRE0001 // Because we use the CDK callbacks.
 
 using Aspire.Hosting.Azure;
+using Aspire.Hosting.Azure.KeyVault;
 using Azure.Provisioning.KeyVaults;
 using Azure.ResourceManager.ApplicationInsights.Models;
 using Azure.ResourceManager.OperationalInsights.Models;
@@ -26,9 +27,15 @@ var blobs = storage.AddBlobs("blobs");
 var sqldb = builder.AddSqlServer("sql").AsAzureSqlDatabase().AddDatabase("sqldb");
 
 var signaturesecret = builder.AddParameter("signaturesecret");
-var keyvault = builder.AddAzureKeyVault("mykv", (_, construct, keyVault) =>
+var keyvault = builder.AddAzureKeyVault("mykv", (def) =>
 {
-    var secret = new KeyVaultSecret(construct, name: "mysecret");
+    var secret = new KeyVaultSecret(def.Construct, def.KeyVault, name: "mysecret");
+    secret.AssignProperty(x => x.Properties.Value, signaturesecret);
+});
+
+var secureKeyVault = builder.AddAzureKeyVault<MoreSecureAzureKeyVaultAzureKeyVaultDefinition>("securekv", (def) =>
+{
+    var secret = new KeyVaultSecret(def.Construct, def.KeyVault, name: "mysecret");
     secret.AssignProperty(x => x.Properties.Value, signaturesecret);
 });
 

--- a/playground/cdk/CdkSample.AppHost/aspire-manifest.json
+++ b/playground/cdk/CdkSample.AppHost/aspire-manifest.json
@@ -72,6 +72,16 @@
         "signaturesecret": "{signaturesecret.value}"
       }
     },
+    "securekv": {
+      "type": "azure.bicep.v0",
+      "connectionString": "{securekv.outputs.vaultUri}",
+      "path": "securekv.module.bicep",
+      "params": {
+        "principalId": "",
+        "principalType": "",
+        "signaturesecret": "{signaturesecret.value}"
+      }
+    },
     "cache": {
       "type": "azure.bicep.v0",
       "connectionString": "{cache.secretOutputs.connectionString}",

--- a/playground/cdk/CdkSample.AppHost/securekv.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/securekv.module.bicep
@@ -1,0 +1,52 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+@description('')
+param principalId string
+
+@description('')
+param principalType string
+
+@description('')
+param signaturesecret string
+
+
+resource keyVault_brAPeys65 'Microsoft.KeyVault/vaults@2022-07-01' = {
+  name: toLower(take(concat('securekv', uniqueString(resourceGroup().id)), 24))
+  location: location
+  tags: {
+    'aspire-resource-name': 'securekv'
+  }
+  properties: {
+    tenantId: tenant().tenantId
+    sku: {
+      name: 'standard'
+      family: 'A'
+    }
+    enableRbacAuthorization: true
+    createMode: 'recover'
+  }
+}
+
+resource roleAssignment_dH6ucCy4w 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: keyVault_brAPeys65
+  name: guid(keyVault_brAPeys65.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483'))
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '00482a5a-887f-4fb3-b363-3b7fe8e74483')
+    principalId: principalId
+    principalType: principalType
+  }
+}
+
+resource keyVaultSecret_isTm9TWCm 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  parent: keyVault_brAPeys65
+  name: 'mysecret'
+  location: location
+  properties: {
+    value: signaturesecret
+  }
+}
+
+output vaultUri string = keyVault_brAPeys65.properties.vaultUri

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceDefinitions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceDefinitions.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Azure.Provisioning.Authorization;
+
+namespace Aspire.Hosting.Azure.KeyVault;
+
+/// <summary>
+/// 
+/// </summary>
+/// <param name="construct"></param>
+/// <param name="resourceBuilder"></param>
+public abstract class AzureKeyVaultDefinition(ResourceModuleConstruct construct, IResourceBuilder<AzureKeyVaultResource> resourceBuilder)
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public ResourceModuleConstruct Construct { get; } = construct;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public IResourceBuilder<AzureKeyVaultResource> Builder { get; } = resourceBuilder;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public abstract global::Azure.Provisioning.KeyVaults.KeyVault KeyVault { get; protected set; }
+}
+
+/// <summary>
+/// 
+/// </summary>
+public class DefaultAzureKeyVaultAzureKeyVaultDefinition : AzureKeyVaultDefinition
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="construct"></param>
+    /// <param name="resourceBuilder"></param>
+    public DefaultAzureKeyVaultAzureKeyVaultDefinition(ResourceModuleConstruct construct, IResourceBuilder<AzureKeyVaultResource> resourceBuilder) : base(construct, resourceBuilder)
+    {
+        KeyVault = new global::Azure.Provisioning.KeyVaults.KeyVault(construct, name: construct.Resource.Name);
+        KeyVault.AddOutput("vaultUri", x => x.Properties.VaultUri);
+
+        KeyVault.Properties.Tags["aspire-resource-name"] = construct.Resource.Name;
+
+        var keyVaultAdministratorRoleAssignment = KeyVault.AssignRole(RoleDefinition.KeyVaultAdministrator);
+        keyVaultAdministratorRoleAssignment.AssignProperty(x => x.PrincipalId, construct.PrincipalIdParameter);
+        keyVaultAdministratorRoleAssignment.AssignProperty(x => x.PrincipalType, construct.PrincipalTypeParameter);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public override global::Azure.Provisioning.KeyVaults.KeyVault KeyVault { get; protected set; }
+}
+
+/// <summary>
+/// 
+/// </summary>
+public class MoreSecureAzureKeyVaultAzureKeyVaultDefinition : AzureKeyVaultDefinition
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="construct"></param>
+    /// <param name="resourceBuilder"></param>
+    public MoreSecureAzureKeyVaultAzureKeyVaultDefinition(ResourceModuleConstruct construct, IResourceBuilder<AzureKeyVaultResource> resourceBuilder) : base(construct, resourceBuilder)
+    {
+        KeyVault = new global::Azure.Provisioning.KeyVaults.KeyVault(construct, name: construct.Resource.Name);
+        KeyVault.AddOutput("vaultUri", x => x.Properties.VaultUri);
+
+        KeyVault.Properties.Tags["aspire-resource-name"] = construct.Resource.Name;
+
+        var keyVaultAdministratorRoleAssignment = KeyVault.AssignRole(RoleDefinition.KeyVaultAdministrator);
+        keyVaultAdministratorRoleAssignment.AssignProperty(x => x.PrincipalId, construct.PrincipalIdParameter);
+        keyVaultAdministratorRoleAssignment.AssignProperty(x => x.PrincipalType, construct.PrincipalTypeParameter);
+
+        KeyVault.AssignProperty(x => x.Properties.CreateMode, "'recover'");
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public override global::Azure.Provisioning.KeyVaults.KeyVault KeyVault { get; protected set; }
+}


### PR DESCRIPTION
This is a draft exploring two changes:

1. Change CDK callback to be a context object (currently called a definition).
2. Provide a generic overload for AddAzureKeyVault(...) which allows the type of the definition to be supplied.
3. Depending on the definition the shape of the Bicep produced varies.
4. There is a default definition that the non-generic overloads use.

Trying to kill two birds with one stone here. We want to simplify the callbacks on the CDK resource types, but we also want a way to allow for changing what it means to deploy a KeyVault if best practices change over time.

This PR won't go in as is (we'll back out some of the default/versioning stuff) but just want to get a feel for what we would ship in the future would feel like (we will probably introduce the context/definition object in GA).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3124)