### PR TITLE
Hide Parameters from the Dashboard by default

### DIFF
--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -44,6 +44,8 @@ public static class ParameterResourceBuilderExtensions
         var state = new CustomResourceSnapshot()
         {
             ResourceType = "Parameter",
+            // hide parameters by default
+            State = "Hidden",
             Properties = [
                 new("parameter.secret", secret.ToString()),
                 new(CustomResourceKnownProperties.Source, connectionString ? $"ConnectionStrings:{name}" : $"Parameters:{name}")

--- a/tests/Aspire.Hosting.Tests/AddParameterTests.cs
+++ b/tests/Aspire.Hosting.Tests/AddParameterTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class AddParameterTests
+{
+    [Fact]
+    public void ParametersAreHiddenByDefault()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        appBuilder.Configuration["Parameters:pass"] = "pass1";
+
+        appBuilder.AddParameter("pass", secret: true);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parameterResource = Assert.Single(appModel.Resources.OfType<ParameterResource>());
+        var annotation = parameterResource.Annotations.OfType<ResourceSnapshotAnnotation>().SingleOrDefault();
+
+        Assert.NotNull(annotation);
+
+        var state = annotation.InitialSnapshot;
+
+        Assert.Equal("Hidden", state.State);
+        Assert.Collection(state.Properties,
+            prop =>
+            {
+                Assert.Equal("parameter.secret", prop.Name);
+                Assert.Equal("True", prop.Value);
+            },
+            prop =>
+            {
+                Assert.Equal(CustomResourceKnownProperties.Source, prop.Name);
+                Assert.Equal("Parameters:pass", prop.Value);
+            },
+            prop =>
+            {
+                Assert.Equal("Value", prop.Name);
+                Assert.Equal("pass1", prop.Value);
+            });
+    }
+
+    [Fact]
+    public void MissingParametersAreFailedToStart()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+
+        appBuilder.AddParameter("pass");
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var parameterResource = Assert.Single(appModel.Resources.OfType<ParameterResource>());
+        var annotation = parameterResource.Annotations.OfType<ResourceSnapshotAnnotation>().SingleOrDefault();
+
+        Assert.NotNull(annotation);
+
+        var state = annotation.InitialSnapshot;
+
+        Assert.Equal("FailedToStart", state.State);
+        Assert.Collection(state.Properties,
+            prop =>
+            {
+                Assert.Equal("parameter.secret", prop.Name);
+                Assert.Equal("False", prop.Value);
+            },
+            prop =>
+            {
+                Assert.Equal(CustomResourceKnownProperties.Source, prop.Name);
+                Assert.Equal("Parameters:pass", prop.Value);
+            },
+            prop =>
+            {
+                Assert.Equal("Value", prop.Name);
+                Assert.Contains("configuration key 'Parameters:pass' is missing", prop.Value?.ToString());
+            });
+    }
+}


### PR DESCRIPTION
They only show up if they "FailedToStart"

Fix https://github.com/dotnet/aspire/issues/3149
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3156)