### PR TITLE
Remove obsolete CopySrcInsteadOfClone source-build property

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -8,9 +8,4 @@
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true' or '$(DotNetBuild)' == 'true'">
     <ProjectToBuild Include="$(RepoRoot)src\Microsoft.NET.Sdk.Aspire\Microsoft.NET.Sdk.Aspire.csproj" />
   </ItemGroup>
-
-  <!-- When building from source, we want to use the live repo contents as opposed to cloning the repo. -->
-  <PropertyGroup Condition="'$(ArcadeBuildFromSource)' == 'true'">
-    <CopySrcInsteadOfClone>true</CopySrcInsteadOfClone>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Copy is now the default/only behavior.  This property was removed with https://github.com/dotnet/source-build/issues/4117
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3180)