### PR TITLE
Make sure copy button is tab-accessible and visible on tab

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -34,7 +34,12 @@
     }
 
     @{
-        (string, object)[] uncapturedAttributes = [("alt", PreCopyToolTip), ("title", string.Empty), ("aria-label", Loc[nameof(ControlsStrings.GridValueCopyToClipboard)])];
+        (string, object)[] uncapturedAttributes = [
+            ("alt", PreCopyToolTip),
+            ("title", string.Empty),
+            ("aria-label", Loc[nameof(ControlsStrings.GridValueCopyToClipboard)]),
+            ("tabindex", "0")
+        ];
     }
 
     <FluentButton Appearance="Appearance.Lightweight"

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -20,6 +20,6 @@
     cursor: pointer;
 }
 
-::deep:hover .defaultHidden {
+::deep:hover .defaultHidden, ::deep:focus-within .defaultHidden  {
     opacity: 1;  /* safari has a bug where hover is not always called on an invisible element, so we use opacity instead */
 }


### PR DESCRIPTION
We can add a tabindex to GridValue buttons to make sure they are keyboard navigable in data grids, and we can use the focus-within event to set opacity on keyboard focus

Fixes #3175

![Animation](https://github.com/dotnet/aspire/assets/20359921/737a0f54-9c48-4435-90e6-d8cf29ae33d4)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3192)