### PR TITLE
Improve generation of OTLP API key

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -8,6 +8,7 @@ using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Publishing;
+using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -170,7 +171,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                 _innerBuilder.Configuration.AddInMemoryCollection(
                     new Dictionary<string, string?>
                     {
-                        ["AppHost:OtlpApiKey"] = Guid.NewGuid().ToString()
+                        ["AppHost:OtlpApiKey"] = TokenGenerator.GenerateToken()
                     }
                 );
             }

--- a/src/Aspire.Hosting/Utils/TokenGenerator.cs
+++ b/src/Aspire.Hosting/Utils/TokenGenerator.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace Aspire.Hosting.Utils;
+
+internal static class TokenGenerator
+{
+    public static string GenerateToken()
+    {
+        var s = PasswordGenerator.Generate(minLength: 24, lower: true, upper: true, numeric: true, special: true, minLower: 0, minUpper: 0, minNumeric: 0, minSpecial: 0);
+        var bytes = Encoding.UTF8.GetBytes(s);
+
+#if NET9_0
+        return Convert.ToHexStringLower(bytes);
+#else
+        return Convert.ToHexString(bytes).ToLower();
+#endif
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/3195

@mitchdenny Is this better than `Guid.ToString()`? Also, I'd added a small helper class for generating tokens. Keep consistency in the places we're doing it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3203)