### PR TITLE
[tests] EndToEnd tests: use a simple lock for writing to output stringBuilder

### DIFF
--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
@@ -70,6 +70,7 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
         await BuildProjectAsync();
 
         // Run project
+        object outputLock = new();
         var output = new StringBuilder();
         var projectsParsed = new TaskCompletionSource();
         var appRunning = new TaskCompletionSource();
@@ -107,7 +108,10 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
                 return;
             }
 
-            output.AppendLine(e.Data);
+            lock(outputLock)
+            {
+                output.AppendLine(e.Data);
+            }
             _testOutput.WriteLine($"[apphost] {e.Data}");
 
             if (e.Data?.StartsWith("$ENDPOINTS: ") == true)
@@ -129,7 +133,10 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
                 return;
             }
 
-            output.AppendLine(e.Data);
+            lock(outputLock)
+            {
+                output.AppendLine(e.Data);
+            }
             _testOutput.WriteLine($"[apphost] {e.Data}");
         };
 
@@ -153,6 +160,7 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
         var failedAppTask = _appExited.Task;
         var timeoutTask = Task.Delay(TimeSpan.FromMinutes(5));
 
+        string outputMessage;
         var resultTask = await Task.WhenAny(successfulTask, failedAppTask, timeoutTask);
         if (resultTask == failedAppTask)
         {
@@ -165,7 +173,10 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
                 _testOutput.WriteLine($"\tand timed out waiting for the full output");
             }
 
-            var outputMessage = output.ToString();
+            lock(outputLock)
+            {
+                outputMessage = output.ToString();
+            }
             var exceptionMessage = $"App run failed: {Environment.NewLine}{outputMessage}";
             if (outputMessage.Contains("docker was found but appears to be unhealthy", StringComparison.OrdinalIgnoreCase))
             {
@@ -175,7 +186,12 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
             // should really fail and quit after this
             throw new ArgumentException(exceptionMessage);
         }
-        Assert.True(resultTask == successfulTask, $"App run failed: {Environment.NewLine}{output}");
+
+        lock(outputLock)
+        {
+            outputMessage = output.ToString();
+        }
+        Assert.True(resultTask == successfulTask, $"App run failed: {Environment.NewLine}{outputMessage}");
 
         var client = CreateHttpClient();
         foreach (var project in Projects.Values)


### PR DESCRIPTION
.. to avoid failures like:
```
[xUnit.net 00:01:13.85]     Aspire.EndToEnd.Tests.IntegrationServicesTests.VerifyComponentWorks(resourceName: mongodb) [FAIL]
[xUnit.net 00:01:13.85]       System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than or equal to the size of the collection. (Parameter 'chunkLength')
[xUnit.net 00:01:13.85]       Stack Trace:
[xUnit.net 00:01:13.85]            at System.Text.StringBuilder.ToString()
[xUnit.net 00:01:13.85]            at System.Runtime.CompilerServices.DefaultInterpolatedStringHandler.AppendFormatted[T](T value)
[xUnit.net 00:01:13.85]         /_/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs(178,0): at Aspire.EndToEnd.Tests.IntegrationServicesFixture.InitializeAsync()
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3205)