### PR TITLE
[tests] Add some extra logging for testproject

### DIFF
--- a/tests/Shared/WorkloadTesting/BuildEnvironment.cs
+++ b/tests/Shared/WorkloadTesting/BuildEnvironment.cs
@@ -148,6 +148,7 @@ public class BuildEnvironment
         {
             LogRootPath = Environment.CurrentDirectory;
         }
+        EnvVars["TEST_LOG_PATH"] = LogRootPath;
 
         if (Directory.Exists(TmpPath))
         {

--- a/tests/testproject/TestProject.AppHost/Program.cs
+++ b/tests/testproject/TestProject.AppHost/Program.cs
@@ -10,8 +10,10 @@ _ = Task.Run(async () =>
     var s = Console.ReadLine();
     if (s == "Stop")
     {
+        Console.WriteLine ($"*** Got 'Stop'");
         if (testProgram.App is not null)
         {
+            Console.WriteLine ($"*** \tStopping app");
             await testProgram.App.StopAsync();
         }
     }

--- a/tests/testproject/TestProject.AppHost/appsettings.json
+++ b/tests/testproject/TestProject.AppHost/appsettings.json
@@ -1,10 +1,10 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Trace",
       "Microsoft.AspNetCore": "Debug",
-      "Aspire.Hosting.Dcp": "Debug",
-      "Aspire": "Debug"
+      "Aspire.Hosting.Dcp": "Trace",
+      "Aspire": "Trace"
     }
   }
 }

--- a/tests/testproject/TestProject.IntegrationServiceA/Program.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Program.cs
@@ -2,6 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.TestProject;
+// using Serilog.Extensions.Logging;
+
+string? logPath = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
+if (logPath is not null)
+{
+    AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
+        File.WriteAllText(Path.Combine(logPath, "IntegrationServiceA-exception.log"), eventArgs.ExceptionObject.ToString());
+}
 
 var builder = WebApplication.CreateBuilder(args);
 string? skipResourcesValue = Environment.GetEnvironmentVariable("SKIP_RESOURCES");

--- a/tests/testproject/TestProject.IntegrationServiceA/appsettings.json
+++ b/tests/testproject/TestProject.IntegrationServiceA/appsettings.json
@@ -1,9 +1,9 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Trace",
       "Microsoft.AspNetCore": "Warning",
-      "Aspire.Hosting.Dcp": "Debug"
+      "Aspire.Hosting.Dcp": "Trace"
     }
   },
   "AllowedHosts": "*"

--- a/tests/testproject/TestProject.ServiceA/Program.cs
+++ b/tests/testproject/TestProject.ServiceA/Program.cs
@@ -5,6 +5,13 @@ using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 
 var builder = WebApplication.CreateBuilder(args);
+string? logPath = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
+if (logPath is not null)
+{
+    AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
+        File.WriteAllText(Path.Combine(logPath, "servicea-exception.log"), eventArgs.ExceptionObject.ToString());
+};
+
 var app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");

--- a/tests/testproject/TestProject.ServiceA/appsettings.json
+++ b/tests/testproject/TestProject.ServiceA/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Trace",
       "Microsoft.AspNetCore": "Warning"
     }
   },

--- a/tests/testproject/TestProject.ServiceB/Program.cs
+++ b/tests/testproject/TestProject.ServiceB/Program.cs
@@ -2,6 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 var builder = WebApplication.CreateBuilder(args);
+string? logPath = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
+if (logPath is not null)
+{
+    AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
+        File.WriteAllText(Path.Combine(logPath, "serviceb-exception.log"), eventArgs.ExceptionObject.ToString());
+}
 var app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");

--- a/tests/testproject/TestProject.ServiceB/appsettings.json
+++ b/tests/testproject/TestProject.ServiceB/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Trace",
       "Microsoft.AspNetCore": "Warning"
     }
   },

--- a/tests/testproject/TestProject.ServiceC/Program.cs
+++ b/tests/testproject/TestProject.ServiceC/Program.cs
@@ -2,6 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 var builder = WebApplication.CreateBuilder(args);
+string? logPath = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
+if (logPath is not null)
+{
+    AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
+        File.WriteAllText(Path.Combine(logPath, "servicec-exception.log"), eventArgs.ExceptionObject.ToString());
+}
+
 var app = builder.Build();
 
 app.MapGet("/", () => "Hello World!");

--- a/tests/testproject/TestProject.ServiceC/appsettings.json
+++ b/tests/testproject/TestProject.ServiceC/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Trace",
       "Microsoft.AspNetCore": "Warning"
     }
   },

--- a/tests/testproject/TestProject.WorkerA/Program.cs
+++ b/tests/testproject/TestProject.WorkerA/Program.cs
@@ -3,6 +3,12 @@
 
 using TestProject.WorkerA;
 
+string? logPath = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
+if (logPath is not null)
+{
+    AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
+        File.WriteAllText(Path.Combine(logPath, "workloada-exception.log"), eventArgs.ExceptionObject.ToString());
+}
 var builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddHostedService<Worker>();
 


### PR DESCRIPTION
Add a `TEST_LOG_PATH` environment variable where unhandled exceptions for the various service projects can be logged.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3206)