### PR TITLE
Retry on YamlException when loading Kubernetes client configuration

### DIFF
--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -297,6 +297,8 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         {
             var configurationReadRetry = new RetryStrategyOptions()
             {
+                // Handle exceptions caused by races between writing and reading the configuration file.
+                // If the file is loaded while it is still being written, this can result in a YamlException being thrown.
                 ShouldHandle = new PredicateBuilder().Handle<KubeConfigException>().Handle<YamlException>(),
                 BackoffType = DelayBackoffType.Constant,
                 MaxRetryAttempts = dcpOptions.Value.KubernetesConfigReadRetryCount,

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly;
 using Polly.Retry;
+using YamlDotNet.Core;
 
 namespace Aspire.Hosting.Dcp;
 
@@ -296,7 +297,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         {
             var configurationReadRetry = new RetryStrategyOptions()
             {
-                ShouldHandle = new PredicateBuilder().Handle<KubeConfigException>(),
+                ShouldHandle = new PredicateBuilder().Handle<KubeConfigException>().Handle<YamlException>(),
                 BackoffType = DelayBackoffType.Constant,
                 MaxRetryAttempts = dcpOptions.Value.KubernetesConfigReadRetryCount,
                 MaxDelay = TimeSpan.FromMilliseconds(dcpOptions.Value.KubernetesConfigReadRetryIntervalMilliseconds),


### PR DESCRIPTION
I encountered this while running an integration test:
![image](https://github.com/dotnet/aspire/assets/203839/0c88be0b-1d79-4334-8a7b-fcaf8f8d9fbc)

My assumption is that this is caused by a race between writing and ready the Kubernetes client configuration file. By handling the resulting `YamlException`, we allow the process to be retried.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3229)