### PR TITLE
Add WithManagementPlugin() method for RabbitMQ management plugin

### DIFF
--- a/playground/TestShop/AppHost/Program.cs
+++ b/playground/TestShop/AppHost/Program.cs
@@ -15,6 +15,7 @@ var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice
 var rabbitMqPassword = builder.AddParameter("rabbitmq-password", secret: true);
 var messaging = builder.AddRabbitMQ("messaging", password: rabbitMqPassword)
                        .WithDataVolume()
+                       .WithManagementPlugin()
                        .PublishAsContainer();
 
 var basketService = builder.AddProject("basketservice", @"..\BasketService\BasketService.csproj")

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -45,7 +45,7 @@ public static class RabbitMQBuilderExtensions
         if (builder.ExecutionContext.IsRunMode)
         {
             // Configure for management plugin
-            rabbitmq.WithImage(RabbitMQContainerImageTags.Image, RabbitMQContainerImageTags.TagMangement)
+            rabbitmq.WithImage(RabbitMQContainerImageTags.Image, RabbitMQContainerImageTags.TagManagement)
                     .WithHttpEndpoint(containerPort: 15672, name: RabbitMQServerResource.ManagementEndpointName);
         }
         else

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -16,7 +16,7 @@ public static class RabbitMQBuilderExtensions
     /// Adds a RabbitMQ container to the application model.
     /// </summary>
     /// <remarks>
-    /// The default image is "rabbitmq". The default tag is "3-management" when running and "3" when publishing.
+    /// The default image and tag are "rabbitmq" and "3".
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -35,23 +35,13 @@ public static class RabbitMQBuilderExtensions
 
         var rabbitMq = new RabbitMQServerResource(name, userName?.Resource, passwordParameter);
         var rabbitmq = builder.AddResource(rabbitMq)
+                              .WithImage(RabbitMQContainerImageTags.Image, RabbitMQContainerImageTags.Tag)
                               .WithEndpoint(hostPort: port, containerPort: 5672, name: RabbitMQServerResource.PrimaryEndpointName)
                               .WithEnvironment(context =>
                               {
                                   context.EnvironmentVariables["RABBITMQ_DEFAULT_USER"] = rabbitMq.UserNameReference;
                                   context.EnvironmentVariables["RABBITMQ_DEFAULT_PASS"] = rabbitMq.PasswordParameter;
                               });
-
-        if (builder.ExecutionContext.IsRunMode)
-        {
-            // Configure for management plugin
-            rabbitmq.WithImage(RabbitMQContainerImageTags.Image, RabbitMQContainerImageTags.TagManagement)
-                    .WithHttpEndpoint(containerPort: 15672, name: RabbitMQServerResource.ManagementEndpointName);
-        }
-        else
-        {
-            rabbitmq.WithImage(RabbitMQContainerImageTags.Image, RabbitMQContainerImageTags.Tag);
-        }
 
         return rabbitmq;
     }
@@ -78,6 +68,115 @@ public static class RabbitMQBuilderExtensions
     public static IResourceBuilder<RabbitMQServerResource> WithDataBindMount(this IResourceBuilder<RabbitMQServerResource> builder, string source, bool isReadOnly = false)
         => builder.WithBindMount(source, "/var/lib/rabbitmq", isReadOnly)
                   .RunWithStableNodeName();
+
+    /// <summary>
+    /// Configures the RabbitMQ container resource to enable the RabbitMQ management plugin.
+    /// </summary>
+    /// <remarks>
+    /// This method only supports the default RabbitMQ container image and tags, e.g. <c>3</c>, <c>3.12-alpine</c>, <c>3.12.13-management-alpine</c>, etc.<br />
+    /// Calling this method on a resource configured with an unrecognized image registry, name, or tag will result in a <see cref="DistributedApplicationException"/> being thrown.
+    /// </remarks>
+    /// <param name="builder">The resource builder.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <exception cref="DistributedApplicationException">Thrown when the current container image and tag do not match the defaults for <see cref="RabbitMQServerResource"/>.</exception>
+    public static IResourceBuilder<RabbitMQServerResource> WithManagementPlugin(this IResourceBuilder<RabbitMQServerResource> builder)
+    {
+        var handled = false;
+        var containerAnnotations = builder.Resource.Annotations.OfType<ContainerImageAnnotation>().ToList();
+
+        if (containerAnnotations.Count == 1
+            && containerAnnotations[0].Registry is null
+            && string.Equals(containerAnnotations[0].Image, RabbitMQContainerImageTags.Image, StringComparison.OrdinalIgnoreCase))
+        {
+            // Existing annotation is in a state we can update to enable the management plugin
+            // See tag details at https://hub.docker.com/_/rabbitmq
+
+            const string management = "-management";
+            const string alpine = "-alpine";
+
+            var annotation = containerAnnotations[0];
+            var existingTag = annotation.Tag;
+
+            if (string.IsNullOrEmpty(existingTag))
+            {
+                // Set to default tag with management
+                annotation.Tag = RabbitMQContainerImageTags.TagManagement;
+                handled = true;
+            }
+            else if (existingTag.EndsWith(management, StringComparison.OrdinalIgnoreCase)
+                     || existingTag.EndsWith($"{management}{alpine}", StringComparison.OrdinalIgnoreCase))
+            {
+                // Already using the management tag
+                handled = true;
+            }
+            else if (existingTag.EndsWith(alpine, StringComparison.OrdinalIgnoreCase)
+                     && existingTag.Length > alpine.Length)
+            {
+                // Transform tag like "3.12-alpine" to "3.12-management-alpine"
+                var tagPrefix = existingTag[..existingTag.IndexOf(alpine)];
+                annotation.Tag = $"{tagPrefix}{management}{alpine}";
+                handled = true;
+            }
+            else if (IsVersion(existingTag))
+            {
+                // Tag is in version format so just append "-management"
+                annotation.Tag = $"{existingTag}{management}";
+                handled = true;
+            }
+        }
+
+        if (handled)
+        {
+            builder.WithHttpEndpoint(containerPort: 15672, name: RabbitMQServerResource.ManagementEndpointName);
+            return builder;
+        }
+
+        throw new DistributedApplicationException($"Cannot configure the RabbitMQ resource '{builder.Resource.Name}' to enable the management plugin as it uses an unrecognized container image registry, name, or tag.");
+    }
+
+    private static bool IsVersion(string tag)
+    {
+        // Must not be empty or null
+        if (string.IsNullOrEmpty(tag))
+        {
+            return false;
+        }
+
+        // First char must be a digit
+        if (!char.IsAsciiDigit(tag[0]))
+        {
+            return false;
+        }
+
+        // Last char must be digit
+        if (!char.IsAsciiDigit(tag[^1]))
+        {
+            return false;
+        }
+
+        // If a single digit no more to check
+        if (tag.Length == 1)
+        {
+            return true;
+        }
+
+        // Skip first char as we already checked it's a digit
+        var lastCharIsDigit = true;
+        for (var i = 1; i < tag.Length; i++)
+        {
+            var c = tag[i];
+            
+            if (!(char.IsAsciiDigit(c) || c == '.') // Interim chars must be digits or a period
+                || !lastCharIsDigit && c == '.') // '.' can only follow a digit
+            {
+                return false;
+            }
+
+            lastCharIsDigit = char.IsAsciiDigit(c);
+        }
+
+        return true;
+    }
 
     private static IResourceBuilder<RabbitMQServerResource> RunWithStableNodeName(this IResourceBuilder<RabbitMQServerResource> builder)
     {

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -46,7 +46,7 @@ public static class RabbitMQBuilderExtensions
         {
             // Configure for management plugin
             rabbitmq.WithImage(RabbitMQContainerImageTags.Image, RabbitMQContainerImageTags.TagMangement)
-                    .WithHttpEndpoint(containerPort: 15672, name: RabbitMQServerResource.MangementEndpointName);
+                    .WithHttpEndpoint(containerPort: 15672, name: RabbitMQServerResource.ManagementEndpointName);
         }
         else
         {

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQContainerImageTags.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQContainerImageTags.cs
@@ -7,5 +7,5 @@ internal static class RabbitMQContainerImageTags
 {
     public const string Image = "rabbitmq";
     public const string Tag = "3";
-    public const string TagMangement = $"{Tag}-management";
+    public const string TagManagement = $"{Tag}-management";
 }

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQContainerImageTags.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQContainerImageTags.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.RabbitMQ;
+
+internal static class RabbitMQContainerImageTags
+{
+    public const string Image = "rabbitmq";
+    public const string Tag = "3";
+    public const string TagMangement = $"{Tag}-management";
+}

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
@@ -9,6 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 public class RabbitMQServerResource : ContainerResource, IResourceWithConnectionString, IResourceWithEnvironment
 {
     internal const string PrimaryEndpointName = "tcp";
+    internal const string MangementEndpointName = "management";
     private const string DefaultUserName = "guest";
 
     /// <summary>

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQServerResource.cs
@@ -9,7 +9,7 @@ namespace Aspire.Hosting.ApplicationModel;
 public class RabbitMQServerResource : ContainerResource, IResourceWithConnectionString, IResourceWithEnvironment
 {
     internal const string PrimaryEndpointName = "tcp";
-    internal const string MangementEndpointName = "management";
+    internal const string ManagementEndpointName = "management";
     private const string DefaultUserName = "guest";
 
     /// <summary>

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -14,8 +14,11 @@ namespace Aspire.Hosting;
 public static class RedisBuilderExtensions
 {
     /// <summary>
-    /// Adds a Redis container to the application model. The default image is "redis" and tag is "latest". This version the package defaults to the 7.2.4 tag of the redis container image
+    /// Adds a Redis container to the application model.
     /// </summary>
+    /// <remarks>
+    /// The default image is "redis" and the tag is "7.2.4".
+    /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="port">The host port to bind the underlying container to.</param>

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -15,8 +15,7 @@ public class AddRabbitMQTests
     [InlineData(DistributedApplicationOperation.Publish)]
     public void AddRabbitMQContainerWithDefaultsAddsAnnotationMetadata(DistributedApplicationOperation operation)
     {
-        DistributedApplicationOptions options = operation == DistributedApplicationOperation.Run ? new() : new() { Args = ["Publishing:Publisher=manifest"] };
-        var appBuilder = DistributedApplication.CreateBuilder(options);
+        var appBuilder = TestDistributedApplicationBuilder.Create(operation);
 
         appBuilder.AddRabbitMQ("rabbit");
 

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -164,7 +164,7 @@ public class AddRabbitMQTests
     [InlineData(true)]
     public async Task VerifyManifest(bool withManagementPlugin)
     {
-        using var builder = TestDistributedApplicationBuilder.Create();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
         var rabbit = builder.AddRabbitMQ("rabbit");
         if (withManagementPlugin)

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -118,6 +118,7 @@ public class AddRabbitMQTests
     [InlineData(".123")]
     [InlineData(".")]
     [InlineData(".1.2")]
+    [InlineData("1.2.")]
     [InlineData("1.٩.3")]
     [InlineData("1.2..3")]
     [InlineData("not-supported")]

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -25,7 +25,19 @@ public sealed class TestDistributedApplicationBuilder : IDisposable, IDistribute
     public DistributedApplicationExecutionContext ExecutionContext => _innerBuilder.ExecutionContext;
     public IResourceCollection Resources => _innerBuilder.Resources;
 
-    public static TestDistributedApplicationBuilder Create() => new TestDistributedApplicationBuilder(DistributedApplication.CreateBuilder());
+    public static TestDistributedApplicationBuilder Create(DistributedApplicationOperation operation = DistributedApplicationOperation.Run)
+    {
+        if (operation == DistributedApplicationOperation.Publish)
+        {
+            var options = new DistributedApplicationOptions
+            {
+                Args = ["Publishing:Publisher=manifest"]
+            };
+            return new(DistributedApplication.CreateBuilder(options));
+        }
+
+        return new(DistributedApplication.CreateBuilder());
+    }
 
     private TestDistributedApplicationBuilder(IDistributedApplicationBuilder builder)
     {


### PR DESCRIPTION
This change adds a `WithManagementPlugin()` extension method for the RabbitMQ resource to update the container image with the management plugin enabled and expose its HTTP endpoint. The method checks that the image name and tag are known and supported before updating the tag to enable the management plugin, otherwise it throws.

It also updates the doc comments to better match the format used for the Redis resource.

Fixes #2067

![image](https://github.com/dotnet/aspire/assets/249088/a868aa7f-9c25-438a-ad65-bfb7a41ce241)

![image](https://github.com/dotnet/aspire/assets/249088/97032785-9be5-46ca-bce0-5333ffccef5e)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3230)