### PR TITLE
Rename config value to use unsecured instead of insecure

### DIFF
--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -30,7 +30,7 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
         {
             options.ResourceServiceClient.Url = resourceServiceUrl;
         }
-        if (_configuration.GetBool(DashboardConfigNames.DashboardInsecureAllowAnonymousName.ConfigKey) ?? false)
+        if (_configuration.GetBool(DashboardConfigNames.DashboardUnsecuredAllowAnonymousName.ConfigKey) ?? false)
         {
             options.Frontend.AuthMode = FrontendAuthMode.Unsecured;
             options.Otlp.AuthMode = OtlpAuthMode.Unsecured;

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Dashboard.Configuration;
@@ -39,7 +40,7 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
             case OtlpAuthMode.ClientCertificate:
                 break;
             case null:
-                errorMessages.Add($"OTLP endpoint authentication is not configured. Either specify DOTNET_DASHBOARD_INSECURE_ALLOW_ANONYMOUS with a value of true, or specify Dashboard:Otlp:AuthMode. Possible values: {string.Join(", ", typeof(OtlpAuthMode).GetEnumNames())}");
+                errorMessages.Add($"OTLP endpoint authentication is not configured. Either specify {DashboardConfigNames.DashboardUnsecuredAllowAnonymousName.ConfigKey} with a value of true, or specify ${DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey}. Possible values: {string.Join(", ", typeof(OtlpAuthMode).GetEnumNames())}");
                 break;
             default:
                 errorMessages.Add($"Unexpected OTLP authentication mode: {options.Otlp.AuthMode}");

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -7,7 +7,7 @@ internal static class DashboardConfigNames
 {
     public static readonly ConfigName DashboardFrontendUrlName = new("ASPNETCORE_URLS");
     public static readonly ConfigName DashboardOtlpUrlName = new("DOTNET_DASHBOARD_OTLP_ENDPOINT_URL");
-    public static readonly ConfigName DashboardInsecureAllowAnonymousName = new("DOTNET_DASHBOARD_INSECURE_ALLOW_ANONYMOUS");
+    public static readonly ConfigName DashboardUnsecuredAllowAnonymousName = new("DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS");
     public static readonly ConfigName DashboardConfigFilePathName = new("DOTNET_DASHBOARD_CONFIG_FILE_PATH");
     public static readonly ConfigName ResourceServiceUrlName = new("DOTNET_RESOURCE_SERVICE_ENDPOINT_URL");
 

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -214,7 +214,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
             additionalConfiguration: data =>
             {
                 data.Remove(DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey);
-                data[DashboardConfigNames.DashboardInsecureAllowAnonymousName.ConfigKey] = bool.TrueString;
+                data[DashboardConfigNames.DashboardUnsecuredAllowAnonymousName.ConfigKey] = bool.TrueString;
             });
 
         // Act


### PR DESCRIPTION
We're using unsecured everywhere else. And this setting defaults the frontend and OTLP endpoint auth modes to unsecured. Seems like it should be consistent.

If merged, I'll backport to P5.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3233)