### PR TITLE
Update API key auth to use fixed time comparison

### DIFF
--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 
 namespace Aspire.Dashboard.Configuration;
 
@@ -55,6 +56,8 @@ public sealed class ResourceServiceClientCertificateOptions
 public sealed class OtlpOptions
 {
     private Uri? _parsedEndpointUrl;
+    private byte[]? _primaryApiKeyBytes;
+    private byte[]? _secondaryApiKeyBytes;
 
     public string? PrimaryApiKey { get; set; }
     public string? SecondaryApiKey { get; set; }
@@ -66,6 +69,14 @@ public sealed class OtlpOptions
         Debug.Assert(_parsedEndpointUrl is not null, "Should have been parsed during validation.");
         return _parsedEndpointUrl;
     }
+
+    public byte[] GetPrimaryApiKeyBytes()
+    {
+        Debug.Assert(_primaryApiKeyBytes is not null, "Should have been parsed during validation.");
+        return _primaryApiKeyBytes;
+    }
+
+    public byte[]? GetSecondaryApiKeyBytes() => _secondaryApiKeyBytes;
 
     internal bool TryParseOptions([NotNullWhen(false)] out string? errorMessage)
     {
@@ -82,6 +93,9 @@ public sealed class OtlpOptions
                 return false;
             }
         }
+
+        _primaryApiKeyBytes = PrimaryApiKey != null ? Encoding.UTF8.GetBytes(PrimaryApiKey) : null;
+        _secondaryApiKeyBytes = SecondaryApiKey != null ? Encoding.UTF8.GetBytes(SecondaryApiKey) : null;
 
         errorMessage = null;
         return true;

--- a/tests/Aspire.Dashboard.Tests/OtlpApiKeyAuthenticationHandlerTests.cs
+++ b/tests/Aspire.Dashboard.Tests/OtlpApiKeyAuthenticationHandlerTests.cs
@@ -1,0 +1,115 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Encodings.Web;
+using Aspire.Dashboard.Authentication.OtlpApiKey;
+using Aspire.Dashboard.Configuration;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class OtlpApiKeyAuthenticationHandlerTests
+{
+    [Fact]
+    public async Task AuthenticateAsync_NoHeader_Failure()
+    {
+        // Arrange
+        var handler = await CreateAuthHandlerAsync(primaryApiKey: "abc", secondaryApiKey: null, otlpApiKeyHeader: null);
+
+        // Act
+        var result = await handler.AuthenticateAsync();
+
+        // Assert
+        Assert.NotNull(result.Failure);
+        Assert.Equal($"API key from '{OtlpApiKeyAuthenticationHandler.ApiKeyHeaderName}' header is missing.", result.Failure.Message);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_BigApiKeys_NoMatch_Failure()
+    {
+        // Arrange
+        var handler = await CreateAuthHandlerAsync(primaryApiKey: new string('!', 1000), secondaryApiKey: null, otlpApiKeyHeader: new string('!', 999));
+
+        // Act
+        var result = await handler.AuthenticateAsync();
+
+        // Assert
+        Assert.NotNull(result.Failure);
+        Assert.Equal($"Incoming API key from '{OtlpApiKeyAuthenticationHandler.ApiKeyHeaderName}' header doesn't match configured API key.", result.Failure.Message);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_BigApiKeys_Match_Success()
+    {
+        // Arrange
+        var handler = await CreateAuthHandlerAsync(primaryApiKey: new string('!', 1000), secondaryApiKey: null, otlpApiKeyHeader: new string('!', 1000));
+
+        // Act
+        var result = await handler.AuthenticateAsync();
+
+        // Assert
+        Assert.Null(result.Failure);
+    }
+
+    [Theory]
+    [InlineData("abc", null, "abc", true)]
+    [InlineData("abcd", null, "abc", false)]
+    [InlineData("abc", null, "abcd", false)]
+    [InlineData("abc", "abcd", "abcd", true)]
+    public async Task AuthenticateAsync_MatchHeader_Success(string primaryApiKey, string secondaryApiKey, string otlpApiKeyHeader, bool success)
+    {
+        // Arrange
+        var handler = await CreateAuthHandlerAsync(primaryApiKey, secondaryApiKey, otlpApiKeyHeader);
+
+        // Act
+        var result = await handler.AuthenticateAsync();
+
+        // Assert
+        Assert.Equal(success, result.Failure == null);
+    }
+
+    private static async Task<OtlpApiKeyAuthenticationHandler> CreateAuthHandlerAsync(string primaryApiKey, string? secondaryApiKey, string? otlpApiKeyHeader)
+    {
+        var options = new DashboardOptions
+        {
+            Otlp =
+            {
+                EndpointUrl = "http://localhost",
+                PrimaryApiKey = primaryApiKey,
+                SecondaryApiKey = secondaryApiKey
+            }
+        };
+        Assert.True(options.Otlp.TryParseOptions(out _));
+
+        var handler = new OtlpApiKeyAuthenticationHandler(
+            new TestOptionsMonitor<DashboardOptions>(options),
+            new TestOptionsMonitor<OtlpApiKeyAuthenticationHandlerOptions>(new OtlpApiKeyAuthenticationHandlerOptions()),
+            NullLoggerFactory.Instance,
+            UrlEncoder.Default);
+
+        var httpContext = new DefaultHttpContext();
+        if (otlpApiKeyHeader != null)
+        {
+            httpContext.Request.Headers[OtlpApiKeyAuthenticationHandler.ApiKeyHeaderName] = otlpApiKeyHeader;
+        }
+        await handler.InitializeAsync(new AuthenticationScheme("Test", "Test", handler.GetType()), httpContext);
+        return handler;
+    }
+
+    private sealed class TestOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public TestOptionsMonitor(T options) => CurrentValue = options;
+
+        public T CurrentValue { get; }
+
+        public T Get(string? name) => CurrentValue;
+
+        public IDisposable OnChange(Action<T, string> listener) => throw new NotImplementedException();
+
+        public IDisposable OnChange(Action<T> listener) => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Be better than string != string.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3238)