### PR TITLE
Introduce WithEnvironment overload for custom connection string keys #3002

### DIFF
--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -129,7 +129,7 @@ public static class ResourceBuilderExtensions
         IResourceBuilder<IResourceWithConnectionString> sourceBuilder)
         where T : IResourceWithEnvironment
     {
-        return builder.WithEnvironment(async context =>
+        return builder.WithEnvironment(context =>
         {
             context.EnvironmentVariables[envVarName] = new ConnectionStringReference(sourceBuilder.Resource, optional: false);
         });

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -124,14 +124,14 @@ public static class ResourceBuilderExtensions
     /// <param name="sourceBuilder">The resource builder of the referenced service from which to pull the connection string.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<T> WithEnvironment<T>(
-        this IResourceBuilder<T> builder, 
-        string envVarName, 
-        IResourceBuilder<IResourceWithConnectionString> sourceBuilder) 
+        this IResourceBuilder<T> builder,
+        string envVarName,
+        IResourceBuilder<IResourceWithConnectionString> sourceBuilder)
         where T : IResourceWithEnvironment
     {
-        return builder.WithEnvironment(context =>
+        return builder.WithEnvironment(async context =>
         {
-            var connectionString = sourceBuilder.Resource.GetConnectionString();
+            var connectionString = await sourceBuilder.Resource.GetConnectionStringAsync().ConfigureAwait(true);
 
             if (string.IsNullOrEmpty(connectionString))
             {

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -116,7 +116,7 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Configures a connection string from a referenced resource builder to be set as an environment variable with a custom name.
+    /// Adds an environment variable to the resource with the connection string from the referenced resource.
     /// </summary>
     /// <typeparam name="T">The destination resource type.</typeparam>
     /// <param name="builder">The destination resource builder to which the environment variable will be added.</param>

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -121,17 +121,17 @@ public static class ResourceBuilderExtensions
     /// <typeparam name="T">The destination resource type.</typeparam>
     /// <param name="builder">The destination resource builder to which the environment variable will be added.</param>
     /// <param name="envVarName">The name of the environment variable under which the connection string will be set.</param>
-    /// <param name="sourceBuilder">The resource builder of the referenced service from which to pull the connection string.</param>
+    /// <param name="resource">The resource builder of the referenced service from which to pull the connection string.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<T> WithEnvironment<T>(
         this IResourceBuilder<T> builder,
         string envVarName,
-        IResourceBuilder<IResourceWithConnectionString> sourceBuilder)
+        IResourceBuilder<IResourceWithConnectionString> resource)
         where T : IResourceWithEnvironment
     {
         return builder.WithEnvironment(context =>
         {
-            context.EnvironmentVariables[envVarName] = new ConnectionStringReference(sourceBuilder.Resource, optional: false);
+            context.EnvironmentVariables[envVarName] = new ConnectionStringReference(resource.Resource, optional: false);
         });
     }
 

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -131,14 +131,7 @@ public static class ResourceBuilderExtensions
     {
         return builder.WithEnvironment(async context =>
         {
-            var connectionString = await sourceBuilder.Resource.GetConnectionStringAsync().ConfigureAwait(true);
-
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                throw new DistributedApplicationException($"A connection string for '{sourceBuilder.Resource.Name}' could not be retrieved.");
-            }
-
-            context.EnvironmentVariables[envVarName] = connectionString;
+            context.EnvironmentVariables[envVarName] = new ConnectionStringReference(sourceBuilder.Resource, optional: false);
         });
     }
 

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -116,6 +116,33 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Configures a connection string from a referenced resource builder to be set as an environment variable with a custom name.
+    /// </summary>
+    /// <typeparam name="T">The destination resource type.</typeparam>
+    /// <param name="builder">The destination resource builder to which the environment variable will be added.</param>
+    /// <param name="envVarName">The name of the environment variable under which the connection string will be set.</param>
+    /// <param name="sourceBuilder">The resource builder of the referenced service from which to pull the connection string.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithEnvironment<T>(
+        this IResourceBuilder<T> builder, 
+        string envVarName, 
+        IResourceBuilder<IResourceWithConnectionString> sourceBuilder) 
+        where T : IResourceWithEnvironment
+    {
+        return builder.WithEnvironment(context =>
+        {
+            var connectionString = sourceBuilder.Resource.GetConnectionString();
+
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                throw new DistributedApplicationException($"A connection string for '{sourceBuilder.Resource.Name}' could not be retrieved.");
+            }
+
+            context.EnvironmentVariables[envVarName] = connectionString;
+        });
+    }
+
+    /// <summary>
     /// Adds the arguments to be passed to a container resource when the container is started.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -171,6 +171,28 @@ public class WithEnvironmentTests
         Assert.Equal("{test.connectionString};name=1", manifestConfig["HOST"]);
     }
 
+    [Fact]
+    public async Task EnvironmentWithConnectionStringSetsProperEnvironmentVariable()
+    {
+        // Arrange
+        const string sourceCon = "sourceConnectionString";
+        using var testProgram = CreateTestProgram();
+        var sourceBuilder = testProgram.AppBuilder.AddResource(new TestResource("sourceService", sourceCon));
+        var targetBuilder = testProgram.AppBuilder.AddContainer("targetContainer", "targetImage");
+
+        string envVarName = "CUSTOM_CONNECTION_STRING";
+
+        // Act
+        targetBuilder.WithEnvironment(envVarName, sourceBuilder);
+        testProgram.Build();
+
+        // Call environment variable callbacks with the Publish operation.
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(targetBuilder.Resource, DistributedApplicationOperation.Publish);
+
+        // Assert
+        Assert.Single(config, kvp => kvp.Key == envVarName && kvp.Value == "{sourceService.connectionString}");
+    }
+
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString
     {
         public ReferenceExpression ConnectionStringExpression =>

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -186,11 +186,17 @@ public class WithEnvironmentTests
         targetBuilder.WithEnvironment(envVarName, sourceBuilder);
         testProgram.Build();
 
-        // Call environment variable callbacks with the Publish operation.
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(targetBuilder.Resource, DistributedApplicationOperation.Publish);
+        // Call environment variable callbacks for the Run operation.
+        var runConfig = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(targetBuilder.Resource, DistributedApplicationOperation.Run);
 
         // Assert
-        Assert.Single(config, kvp => kvp.Key == envVarName && kvp.Value == "{sourceService.connectionString}");
+        Assert.Single(runConfig, kvp => kvp.Key == envVarName && kvp.Value == sourceCon);
+
+        // Call environment variable callbacks for the Publish operation.
+        var publishConfig = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(targetBuilder.Resource, DistributedApplicationOperation.Publish);
+
+        // Assert
+        Assert.Single(publishConfig, kvp => kvp.Key == envVarName && kvp.Value == "{sourceService.connectionString}");
     }
 
     private sealed class TestResource(string name, string connectionString) : Resource(name), IResourceWithConnectionString


### PR DESCRIPTION
This PR introduces a new overload for `WithEnvironment` method in the `ResourceBuilderExtensions` class, which allows setting the connection string of a resource under a custom environment variable name.

#### Changes
- Added `WithEnvironment` overload to accept a custom environment variable name.

#### Background
The issue #3002 describes a scenario where existing projects do not use the 'ConnectionStrings__' prefix for environment variables. 

#### Example Usage
```csharp
builder.AddProject<Projects.Web>("web").WithEnvironment("CustomEnvVarName", redis);
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3239)