### PR TITLE
[release/8.0-preview5] Backport of 3177 (ASPIRE_ALLOW_UNSECURED_TRANSPORT)

### DIFF
--- a/playground/AWS/AWS.AppHost/Properties/launchSettings.json
+++ b/playground/AWS/AWS.AppHost/Properties/launchSettings.json
@@ -1,6 +1,18 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15068;http://localhost:15069",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16216",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -9,7 +21,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16216"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16216",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "manifest-publish": {

--- a/playground/AzureSearchEndToEnd/AzureSearch.AppHost/Properties/launchSettings.json
+++ b/playground/AzureSearchEndToEnd/AzureSearch.AppHost/Properties/launchSettings.json
@@ -1,28 +1,41 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "http": {
+    "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:15288",
+      "applicationUrl": "https://localhost:15287;http://localhost:15288",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16155"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16155",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
       },
-    },
-    "generate-manifest": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "dotnetRunMessages": true,
-      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
-      "applicationUrl": "http://localhost:15288",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16155"
+      "http": {
+        "commandName": "Project",
+        "dotnetRunMessages": true,
+        "launchBrowser": true,
+        "applicationUrl": "http://localhost:15288",
+        "environmentVariables": {
+          "ASPNETCORE_ENVIRONMENT": "Development",
+          "DOTNET_ENVIRONMENT": "Development",
+          "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16155",
+          "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+          "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+        },
+        "generate-manifest": {
+          "commandName": "Project",
+          "launchBrowser": true,
+          "dotnetRunMessages": true,
+          "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+          "applicationUrl": "http://localhost:15288",
+          "environmentVariables": {
+            "ASPNETCORE_ENVIRONMENT": "Development",
+            "DOTNET_ENVIRONMENT": "Development",
+            "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16155"
+          }
+        }
       }
     }
-  }
 }

--- a/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Properties/launchSettings.json
+++ b/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Properties/launchSettings.json
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/CustomResources/CustomResources.AppHost/Properties/launchSettings.json
+++ b/playground/CustomResources/CustomResources.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/DatabaseMigration/DatabaseMigration.AppHost/Properties/launchSettings.json
+++ b/playground/DatabaseMigration/DatabaseMigration.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Properties/launchSettings.json
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Properties/launchSettings.json
@@ -1,6 +1,18 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15215;http://localhost:15216",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16195",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -9,7 +21,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16195"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16195",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Properties/launchSettings.json
+++ b/playground/ParameterEndToEnd/ParameterEndToEnd.AppHost/Properties/launchSettings.json
@@ -1,6 +1,33 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https-UseContainer": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
+    "https-UseConnectionString": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "SimulateProduction": "true"
+      }
+    },
     "http-UseContainer": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +37,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "http-UseConnectionString": {
@@ -22,8 +51,10 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
         "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
-        "SimulateProduction": "true"
+        "SimulateProduction": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/Properties/launchSettings.json
+++ b/playground/PostgresEndToEnd/PostgresEndToEnd.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/Properties/launchSettings.json
+++ b/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/Properties/launchSettings.json
+++ b/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/Stress/Stress.AppHost/Properties/launchSettings.json
+++ b/playground/Stress/Stress.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/TestShop/AppHost/Properties/launchSettings.json
+++ b/playground/TestShop/AppHost/Properties/launchSettings.json
@@ -23,7 +23,8 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17031",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/bicep/BicepSample.AppHost/Properties/launchSettings.json
+++ b/playground/bicep/BicepSample.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/cdk/CdkSample.AppHost/Properties/launchSettings.json
+++ b/playground/cdk/CdkSample.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/dapr/AppHost/Properties/launchSettings.json
+++ b/playground/dapr/AppHost/Properties/launchSettings.json
@@ -1,5 +1,18 @@
 {
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16031",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "launchBrowser": true,
@@ -9,7 +22,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/mongo/Mongo.AppHost/Properties/launchSettings.json
+++ b/playground/mongo/Mongo.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/mysql/MySqlDb.AppHost/Properties/launchSettings.json
+++ b/playground/mysql/MySqlDb.AppHost/Properties/launchSettings.json
@@ -1,6 +1,18 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15223;http://localhost:15224",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16160",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -9,7 +21,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16160"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16160",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/nats/Nats.AppHost/Properties/launchSettings.json
+++ b/playground/nats/Nats.AppHost/Properties/launchSettings.json
@@ -1,5 +1,17 @@
 {
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:18887;http://localhost:18888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16160",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
+      }
+    },
     "http": {
       "commandName": "Project",
       "launchBrowser": true,
@@ -8,7 +20,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16160"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16160",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/orleans/OrleansAppHost/Properties/launchSettings.json
+++ b/playground/orleans/OrleansAppHost/Properties/launchSettings.json
@@ -1,5 +1,18 @@
 {
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16031",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "launchBrowser": true,
@@ -9,7 +22,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16031",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/seq/Seq.AppHost/Properties/launchSettings.json
+++ b/playground/seq/Seq.AppHost/Properties/launchSettings.json
@@ -1,6 +1,19 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -10,7 +23,9 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/playground/signalr/SignalRAppHost/Properties/launchSettings.json
+++ b/playground/signalr/SignalRAppHost/Properties/launchSettings.json
@@ -1,6 +1,18 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15015;http://localhost:15016",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16099",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -9,7 +21,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16099"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16099",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(SharedDir)IConfigurationExtensions.cs" Link="Utils\IConfigurationExtensions.cs" />
     <Compile Include="$(SharedDir)KnownFormats.cs" Link="Utils\KnownFormats.cs" />
     <Compile Include="$(SharedDir)KnownResourceNames.cs" Link="Utils\KnownResourceNames.cs" />
+    <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
     <Compile Include="$(SharedDir)PathNormalizer.cs" Link="Utils\PathNormalizer.cs" />
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
     <Compile Include="$(SharedDir)TaskHelpers.cs" Link="Utils\TaskHelpers.cs" />

--- a/src/Aspire.Hosting/Dashboard/TransportOptions.cs
+++ b/src/Aspire.Hosting/Dashboard/TransportOptions.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Dashboard;
+
+internal class TransportOptions
+{
+    public bool AllowUnsecureTransport { get; set; }
+}

--- a/src/Aspire.Hosting/Dashboard/TransportOptionsValidator.cs
+++ b/src/Aspire.Hosting/Dashboard/TransportOptionsValidator.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Dashboard;
+
+internal class TransportOptionsValidator(IConfiguration configuration, DistributedApplicationExecutionContext executionContext, DistributedApplicationOptions distributedApplicationOptions) : IValidateOptions<TransportOptions>
+{
+    public ValidateOptionsResult Validate(string? name, TransportOptions transportOptions)
+    {
+        var effectiveAllowUnsecureTransport = transportOptions.AllowUnsecureTransport || distributedApplicationOptions.DisableDashboard || distributedApplicationOptions.AllowUnsecuredTransport;
+
+        if (executionContext.IsPublishMode || effectiveAllowUnsecureTransport)
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        // Validate ASPNETCORE_URLS
+        var applicationUrls = configuration[KnownConfigNames.AspNetCoreUrls];
+        if (string.IsNullOrEmpty(applicationUrls))
+        {
+            return ValidateOptionsResult.Fail($"AppHost does not have applicationUrl in launch profile, or {KnownConfigNames.AspNetCoreUrls} environment variable set.");
+        }
+
+        var firstApplicationUrl = applicationUrls.Split(";").First();
+
+        if (!Uri.TryCreate(firstApplicationUrl, UriKind.Absolute, out var parsedFirstApplicationUrl))
+        {
+            return ValidateOptionsResult.Fail($"The 'applicationUrl' setting of the launch profile has value '{firstApplicationUrl}' which could not be parsed as a URI.");
+        }
+
+        if (parsedFirstApplicationUrl.Scheme == "http")
+        {
+            return ValidateOptionsResult.Fail($"The 'applicationUrl' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/dotnet/aspire/allowunsecuredtransport for more details.");
+        }
+
+        // Vaidate DOTNET_DASHBOARD_OTLP_ENDPOINT_URL
+        var dashboardOtlpEndpointUrl = configuration[KnownConfigNames.DashboardOtlpEndpointUrl];
+        if (string.IsNullOrEmpty(dashboardOtlpEndpointUrl))
+        {
+            return ValidateOptionsResult.Fail($"AppHost does not have the {KnownConfigNames.DashboardOtlpEndpointUrl} setting defined.");
+        }
+
+        if (!Uri.TryCreate(dashboardOtlpEndpointUrl, UriKind.Absolute, out var parsedDashboardOtlpEndpointUrl))
+        {
+            return ValidateOptionsResult.Fail($"The {KnownConfigNames.DashboardOtlpEndpointUrl} setting with a value of '{dashboardOtlpEndpointUrl}' could not be parsed as a URI.");
+        }
+
+        if (parsedDashboardOtlpEndpointUrl.Scheme == "http")
+        {
+            return ValidateOptionsResult.Fail($"The '{KnownConfigNames.DashboardOtlpEndpointUrl}' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/dotnet/aspire/allowunsecuredtransport for more details.");
+        }
+
+        // Vaidate DOTNET_DASHBOARD_RESOURCE_SERVER_ENDPOINT_URL
+        var resourceServiceEndpointUrl = configuration[KnownConfigNames.ResourceServiceEndpointUrl];
+        if (string.IsNullOrEmpty(resourceServiceEndpointUrl))
+        {
+            return ValidateOptionsResult.Fail($"AppHost does not have the {KnownConfigNames.ResourceServiceEndpointUrl} setting defined.");
+        }
+
+        if (!Uri.TryCreate(resourceServiceEndpointUrl, UriKind.Absolute, out var parsedResourceServiceEndpointUrl))
+        {
+            return ValidateOptionsResult.Fail($"The {KnownConfigNames.ResourceServiceEndpointUrl} setting with a value of '{resourceServiceEndpointUrl}' could not be parsed as a URI.");
+        }
+
+        if (parsedResourceServiceEndpointUrl.Scheme == "http")
+        {
+            return ValidateOptionsResult.Fail($"The '{KnownConfigNames.ResourceServiceEndpointUrl}' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/dotnet/aspire/allowunsecuredtransport for more details.");
+        }
+
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/Aspire.Hosting/DistributedApplicationOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationOptions.cs
@@ -43,6 +43,11 @@ public sealed class DistributedApplicationOptions
 
     internal bool DashboardEnabled => !DisableDashboard;
 
+    /// <summary>
+    /// Allows the use of HTTP urls for for the AppHost resource endpoint.
+    /// </summary>
+    public bool AllowUnsecuredTransport { get; set; }
+
     private string? ResolveProjectDirectory()
     {
         var assemblyMetadata = Assembly?.GetCustomAttributes<AssemblyMetadataAttribute>();

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+internal static class KnownConfigNames
+{
+    public static string AspNetCoreUrls = "ASPNETCORE_URLS";
+    public static string AllowUnsecuredTransport = "ASPIRE_ALLOW_UNSECURED_TRANSPORT";
+    public static string DashboardOtlpEndpointUrl = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL";
+    public static string ResourceServiceEndpointUrl = "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL";
+}

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
@@ -51,6 +51,7 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
         {
             BuildEnvironment.EnvVars["TestsRunningOutsideOfRepo"] = "true";
         }
+        BuildEnvironment.EnvVars.Add("ASPIRE_ALLOW_UNSECURED_TRANSPORT", "true");
     }
 
     public async Task InitializeAsync()

--- a/tests/Aspire.Hosting.Testing.Tests/Aspire.Hosting.Testing.Tests.csproj
+++ b/tests/Aspire.Hosting.Testing.Tests/Aspire.Hosting.Testing.Tests.csproj
@@ -13,6 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)KnownConfigNames.cs" Link="Utils\KnownConfigNames.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Aspire.Hosting.AppHost\Aspire.Hosting.AppHost.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Testing\Aspire.Hosting.Testing.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />

--- a/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationFixtureOfT.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationFixtureOfT.cs
@@ -4,7 +4,7 @@ using Xunit.Sdk;
 
 namespace Aspire.Hosting.Testing.Tests;
 
-public sealed class DistributedApplicationFixture<TEntryPoint> : DistributedApplicationFactory<TEntryPoint>, IAsyncLifetime where TEntryPoint : class
+public class DistributedApplicationFixture<TEntryPoint> : DistributedApplicationFactory<TEntryPoint>, IAsyncLifetime where TEntryPoint : class
 {
     public DistributedApplicationFixture()
     {

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -15,7 +15,6 @@ public class TestingBuilderTests
     {
         var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.TestingAppHost1_AppHost>();
         await using var app = await appHost.BuildAsync();
-
         await app.StartAsync();
 
         // Get an endpoint from a resource

--- a/tests/Aspire.Hosting.Tests/Dashboard/TransportOptionsValidatorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/TransportOptionsValidatorTests.cs
@@ -1,0 +1,327 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dashboard;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Dashboard;
+
+public class TransportOptionsValidatorTests
+{
+    [Fact]
+    public void ValidationFailsWhenHttpUrlSpecifiedWithAllowSecureTransportSetToFalse()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"The 'applicationUrl' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/dotnet/aspire/allowunsecuredtransport for more details.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void InvalidTransportOptionSucceedValidationInPublishMode()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Succeeded, result.FailureMessage);
+    }
+
+    [Fact]
+    public void InvalidTransportOptionSucceedValidationWithDashboardDisabled()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions()
+        {
+            DisableDashboard = true
+        };
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Succeeded, result.FailureMessage);
+    }
+
+    [Fact]
+    public void InvalidTransportOptionSucceedValidationWithDistributedAppOptionsFlag()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions()
+        {
+            AllowUnsecuredTransport = true
+        };
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Succeeded, result.FailureMessage);
+    }
+
+    [Fact]
+    public void ValidationFailsWithInvalidUrl()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var invalidUrl = "...invalid...url...";
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = invalidUrl;
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"The 'applicationUrl' setting of the launch profile has value '{invalidUrl}' which could not be parsed as a URI.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void ValidationFailsWithMissingUrl()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"AppHost does not have applicationUrl in launch profile, or {KnownConfigNames.AspNetCoreUrls} environment variable set.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void ValidationFailsWithStringEmptyUrl()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = string.Empty;
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"AppHost does not have applicationUrl in launch profile, or {KnownConfigNames.AspNetCoreUrls} environment variable set.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void ValidationFailsWhenResourceUrlNotDefined()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownConfigNames.ResourceServiceEndpointUrl] = string.Empty;
+        config[KnownConfigNames.DashboardOtlpEndpointUrl] = "https://localhost:1236";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"AppHost does not have the {KnownConfigNames.ResourceServiceEndpointUrl} setting defined.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void ValidationFailsWhenOtlpUrlNotDefined()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownConfigNames.ResourceServiceEndpointUrl] = "https://localhost:1235";
+        config[KnownConfigNames.DashboardOtlpEndpointUrl] = string.Empty;
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"AppHost does not have the {KnownConfigNames.DashboardOtlpEndpointUrl} setting defined.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void ValidationFailsWhenResourceServiceUrlMalformed()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var invalidUrl = "...invalid...url...";
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownConfigNames.ResourceServiceEndpointUrl] = invalidUrl;
+        config[KnownConfigNames.DashboardOtlpEndpointUrl] = "https://localhost:1236";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"The {KnownConfigNames.ResourceServiceEndpointUrl} setting with a value of '{invalidUrl}' could not be parsed as a URI.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void ValidationFailsWhenOtlpUrlMalformed()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var invalidUrl = "...invalid...url...";
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownConfigNames.ResourceServiceEndpointUrl] = "https://localhost:1235";
+        config[KnownConfigNames.DashboardOtlpEndpointUrl] = invalidUrl;
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"The {KnownConfigNames.DashboardOtlpEndpointUrl} setting with a value of '{invalidUrl}' could not be parsed as a URI.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void ValidationFailsWhenDashboardOtlpUrlIsHttp()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownConfigNames.ResourceServiceEndpointUrl] = "https://localhost:1235";
+        config[KnownConfigNames.DashboardOtlpEndpointUrl] = "http://localhost:1236";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"The '{KnownConfigNames.DashboardOtlpEndpointUrl}' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/dotnet/aspire/allowunsecuredtransport for more details.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void ValidationFailsWhenResourceServiceUrlIsHttp()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownConfigNames.ResourceServiceEndpointUrl] = "http://localhost:1235";
+        config[KnownConfigNames.DashboardOtlpEndpointUrl] = "https://localhost:1236";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Equal(
+            $"The '{KnownConfigNames.ResourceServiceEndpointUrl}' setting must be an https address unless the '{KnownConfigNames.AllowUnsecuredTransport}' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/dotnet/aspire/allowunsecuredtransport for more details.",
+            result.FailureMessage
+            );
+    }
+
+    [Fact]
+    public void ValidationSucceedsWhenHttpUrlSpecifiedWithAllowSecureTransportSetToTrue()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = true;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "http://localhost:1234";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Succeeded, result.FailureMessage);
+    }
+
+    [Fact]
+    public void ValidationSucceedsWhenHttpsUrlSpecifiedWithAllowSecureTransportSetToTrue()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = true;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Succeeded, result.FailureMessage);
+    }
+
+    [Fact]
+    public void ValidationSucceedsWhenHttpsUrlSpecifiedWithAllowSecureTransportSetToFalse()
+    {
+        var distributedApplicationOptions = new DistributedApplicationOptions();
+        var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run);
+        var options = new TransportOptions();
+        options.AllowUnsecureTransport = false;
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        config[KnownConfigNames.AspNetCoreUrls] = "https://localhost:1234";
+        config[KnownConfigNames.DashboardOtlpEndpointUrl] = "https://localhost:1235";
+        config[KnownConfigNames.ResourceServiceEndpointUrl] = "https://localhost:1236";
+
+        var validator = new TransportOptionsValidator(config, executionContext, distributedApplicationOptions);
+        var result = validator.Validate(null, options);
+        Assert.True(result.Succeeded, result.FailureMessage);
+    }
+}

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -9,8 +9,9 @@ using Aspire.TestProject;
 
 public class TestProgram : IDisposable
 {
-    private TestProgram(string[] args, Assembly assembly, bool includeIntegrationServices, bool includeNodeApp, bool disableDashboard)
+    private TestProgram(string[] args, Assembly assembly, bool includeIntegrationServices, bool includeNodeApp, bool disableDashboard, bool allowUnsecuredTransport)
     {
+
         ISet<TestResourceNames>? resourcesToSkip = null;
         for (int i = 0; i < args.Length; i++)
         {
@@ -33,7 +34,7 @@ public class TestProgram : IDisposable
             disableDashboard = true;
         }
 
-        AppBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { Args = args, DisableDashboard = disableDashboard, AssemblyName = assembly.FullName });
+        AppBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions { Args = args, DisableDashboard = disableDashboard, AssemblyName = assembly.FullName, AllowUnsecuredTransport = allowUnsecuredTransport });
 
         var serviceAPath = Path.Combine(Projects.TestProject_AppHost.ProjectPath, @"..\TestProject.ServiceA\TestProject.ServiceA.csproj");
 
@@ -123,8 +124,8 @@ public class TestProgram : IDisposable
         AppBuilder.Services.AddLifecycleHook<EndPointWriterHook>();
     }
 
-    public static TestProgram Create<T>(string[]? args = null, bool includeIntegrationServices = false, bool includeNodeApp = false, bool disableDashboard = true) =>
-        new TestProgram(args ?? [], typeof(T).Assembly, includeIntegrationServices, includeNodeApp, disableDashboard);
+    public static TestProgram Create<T>(string[]? args = null, bool includeIntegrationServices = false, bool includeNodeApp = false, bool disableDashboard = true, bool allowUnsecuredTransport = true) =>
+        new TestProgram(args ?? [], typeof(T).Assembly, includeIntegrationServices, includeNodeApp, disableDashboard, allowUnsecuredTransport);
 
     public IDistributedApplicationBuilder AppBuilder { get; private set; }
     public IResourceBuilder<ProjectResource> ServiceABuilder { get; private set; }


### PR DESCRIPTION
Backport of #3177 to release/8.0-preview5

/cc @eerhardt

## Customer Impact

Forces the use of HTTPS for ASPNETCORE_URLS, DOTNET_DASHBOARD_OTLP_ENDPOINT_URL, DOTNET_RESOURCE_SERVICE_ENDPOINT_URL environment variables/config settings UNLESS the ASPIRE_ALLOW_UNSECURED_TRANSPORT variable is set to true, or the dashboard is disabled via options.

## Testing

Automated tests pass. Added 100% coverage for the validation logic as well as manual testing.

## Risk

Moderate. This is an intentional breaking change in P5 which will require people to add configuration to their launch settings if they have existing projects. Tempaltes were previously updated to satisfy these new validation rules. The thinking is that we want people to take this pain down to ease P6 and GA adoption.