### PR TITLE
Automatically AddAzureProvisioning when Azure resource type is used.

### DIFF
--- a/playground/AspireEventHub/EventHubs.AppHost/Program.cs
+++ b/playground/AspireEventHub/EventHubs.AppHost/Program.cs
@@ -1,7 +1,5 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureProvisioning();
-
 // required for the event processor client which will use the connectionName to get the connectionString.
 var blob = builder.AddAzureStorage("ehstorage")
     .AddBlobs("checkpoints");

--- a/playground/AzureSearchEndToEnd/AzureSearch.AppHost/Program.cs
+++ b/playground/AzureSearchEndToEnd/AzureSearch.AppHost/Program.cs
@@ -3,8 +3,6 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureProvisioning();
-
 var azureSearch = builder.AddAzureSearch("search");
 
 builder.AddProject<Projects.AzureSearch_ApiService>("api")

--- a/playground/AzureSearchEndToEnd/AzureSearch.AppHost/Properties/launchSettings.json
+++ b/playground/AzureSearchEndToEnd/AzureSearch.AppHost/Properties/launchSettings.json
@@ -11,31 +11,32 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16155",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037"
-      },
-      "http": {
-        "commandName": "Project",
-        "dotnetRunMessages": true,
-        "launchBrowser": true,
-        "applicationUrl": "http://localhost:15288",
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Development",
-          "DOTNET_ENVIRONMENT": "Development",
-          "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16155",
-          "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
-          "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
-        },
-        "generate-manifest": {
-          "commandName": "Project",
-          "launchBrowser": true,
-          "dotnetRunMessages": true,
-          "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
-          "applicationUrl": "http://localhost:15288",
-          "environmentVariables": {
-            "ASPNETCORE_ENVIRONMENT": "Development",
-            "DOTNET_ENVIRONMENT": "Development",
-            "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16155"
-          }
-        }
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15288",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16155",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    },
+    "generate-manifest": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+      "applicationUrl": "http://localhost:15288",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16155"
       }
     }
+  }
 }

--- a/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Program.cs
+++ b/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/Program.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureProvisioning();
-
 var storage = builder.AddAzureStorage("storage").RunAsEmulator(container =>
 {
     container.WithDataBindMount();

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -3,8 +3,6 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureProvisioning();
-
 var db = builder.AddAzureCosmosDB("cosmos")
                 .AddDatabase("db")
                 .RunAsEmulator();

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
@@ -3,8 +3,6 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureProvisioning();
-
 var deploymentAndModelName = "gpt-35-turbo";
 var openai = builder.AddAzureOpenAI("openai").AddDeployment(
     new(deploymentAndModelName, deploymentAndModelName, "0613")

--- a/playground/bicep/BicepSample.AppHost/Program.cs
+++ b/playground/bicep/BicepSample.AppHost/Program.cs
@@ -5,8 +5,6 @@ using Aspire.Hosting.Azure;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureProvisioning();
-
 var parameter = builder.AddParameter("val");
 
 AzureBicepResource? temp00 = null;

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -9,7 +9,6 @@ using Azure.ResourceManager.ApplicationInsights.Models;
 using Azure.ResourceManager.OperationalInsights.Models;
 
 var builder = DistributedApplication.CreateBuilder(args);
-builder.AddAzureProvisioning();
 
 var cosmosdb = builder.AddAzureCosmosDB("cosmos").AddDatabase("cosmosdb");
 

--- a/playground/signalr/SignalRAppHost/Program.cs
+++ b/playground/signalr/SignalRAppHost/Program.cs
@@ -1,6 +1,5 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddAzureProvisioning();
 var signalr = builder.AddAzureSignalR("signalr1");
 
 builder.AddProject<Projects.SignalRWeb>("webfrontend")

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -37,6 +37,8 @@ public static class AzureAppConfigurationExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureAppConfigurationResource> AddAzureAppConfiguration(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureAppConfigurationResource>, ResourceModuleConstruct, AppConfigurationStore>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var store = new AppConfigurationStore(construct, name: name, skuName: "standard");

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -37,6 +37,8 @@ public static class AzureApplicationInsightsExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureApplicationInsightsResource> AddAzureApplicationInsights(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureApplicationInsightsResource>, ResourceModuleConstruct, ApplicationInsightsComponent>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var appInsights = new ApplicationInsightsComponent(construct, name: name);

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -38,6 +38,8 @@ public static class AzureOpenAIExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureOpenAIResource> AddAzureOpenAI(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureOpenAIResource>, ResourceModuleConstruct, CognitiveServicesAccount, IEnumerable<CognitiveServicesAccountDeployment>>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var cogServicesAccount = new CognitiveServicesAccount(construct, "OpenAI", name: name);

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -38,6 +38,8 @@ public static class AzureCosmosExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureCosmosDBResource> AddAzureCosmosDB(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureCosmosDBResource>, ResourceModuleConstruct, CosmosDBAccount, IEnumerable<CosmosDBSqlDatabase>>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var cosmosAccount = new CosmosDBAccount(construct, CosmosDBAccountKind.GlobalDocumentDB, name: name);

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -40,6 +40,8 @@ public static class AzureEventHubsExtensions
     public static IResourceBuilder<AzureEventHubsResource> AddAzureEventHubs(this IDistributedApplicationBuilder builder, string name,
         Action<IResourceBuilder<AzureEventHubsResource>, ResourceModuleConstruct, EventHubsNamespace>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var eventHubsNamespace = new EventHubsNamespace(construct, name: name);

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -37,6 +37,8 @@ public static class AzureKeyVaultResourceExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureKeyVaultResource> AddAzureKeyVault(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureKeyVaultResource>, ResourceModuleConstruct, KeyVault>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var keyVault = construct.AddKeyVault(name: construct.Resource.Name);

--- a/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
@@ -37,6 +37,8 @@ public static class AzureLogAnalyticsWorkspaceExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureLogAnalyticsWorkspaceResource> AddAzureLogAnalyticsWorkspace(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureLogAnalyticsWorkspaceResource>, ResourceModuleConstruct, OperationalInsightsWorkspace>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var workspace = new OperationalInsightsWorkspace(construct, name: name, sku: new OperationalInsightsWorkspaceSku(OperationalInsightsWorkspaceSkuName.PerGB2018));

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -59,7 +59,7 @@ public static class AzurePostgresExtensions
             postgres.AssignProperty(x => x.Sku.Tier, "'Burstable'");
             postgres.AssignProperty(x => x.Version, "'16'");
             postgres.AssignProperty(x => x.HighAvailability.Mode, "'Disabled'");
-            postgres.AssignProperty(x => x.StorageSizeInGB, "32");
+            postgres.AssignProperty(x => x.Storage.StorageSizeInGB, "32");
             postgres.AssignProperty(x => x.Backup.BackupRetentionDays, "7");
             postgres.AssignProperty(x => x.Backup.GeoRedundantBackup, "'Disabled'");
             postgres.AssignProperty(x => x.AvailabilityZone, "'1'");

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -47,6 +47,8 @@ public static class AzurePostgresExtensions
         Action<IResourceBuilder<AzurePostgresResource>, ResourceModuleConstruct, PostgreSqlFlexibleServer>? configureResource,
         bool useProvisioner = false)
     {
+        builder.ApplicationBuilder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var administratorLogin = new Parameter("administratorLogin");
@@ -57,7 +59,7 @@ public static class AzurePostgresExtensions
             postgres.AssignProperty(x => x.Sku.Tier, "'Burstable'");
             postgres.AssignProperty(x => x.Version, "'16'");
             postgres.AssignProperty(x => x.HighAvailability.Mode, "'Disabled'");
-            postgres.AssignProperty(x => x.Storage.StorageSizeInGB, "32");
+            postgres.AssignProperty(x => x.StorageSizeInGB, "32");
             postgres.AssignProperty(x => x.Backup.BackupRetentionDays, "7");
             postgres.AssignProperty(x => x.Backup.GeoRedundantBackup, "'Disabled'");
             postgres.AssignProperty(x => x.AvailabilityZone, "'1'");

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -41,6 +41,8 @@ public static class AzureRedisExtensions
 
     internal static IResourceBuilder<RedisResource> PublishAsAzureRedisInternal(this IResourceBuilder<RedisResource> builder, Action<IResourceBuilder<AzureRedisResource>, ResourceModuleConstruct, RedisCache>? configureResource, bool useProvisioner = false)
     {
+        builder.ApplicationBuilder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var redisCache = new RedisCache(construct, name: builder.Resource.Name);

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -40,6 +40,8 @@ public static class AzureSearchExtensions
         string name,
         Action<IResourceBuilder<AzureSearchResource>, ResourceModuleConstruct, SearchService>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         AzureSearchResource resource = new(name, ConfigureSearch);
         return builder.AddResource(resource)
                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -38,6 +38,8 @@ public static class AzureServiceBusExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureServiceBusResource> AddAzureServiceBus(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureServiceBusResource>, ResourceModuleConstruct, ServiceBusNamespace>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var serviceBusNamespace = new ServiceBusNamespace(construct, name: name);

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -37,6 +37,8 @@ public static class AzureSignalRExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureSignalRResource> AddAzureSignalR(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureSignalRResource>, ResourceModuleConstruct, SignalRService>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var service = new SignalRService(construct, name: name);

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -15,6 +15,8 @@ public static class AzureSqlExtensions
 {
     internal static IResourceBuilder<SqlServerServerResource> PublishAsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder, Action<IResourceBuilder<AzureSqlServerResource>, ResourceModuleConstruct, SqlServer, IEnumerable<SqlDatabase>>? configureResource, bool useProvisioner = false)
     {
+        builder.ApplicationBuilder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var sqlServer = new SqlServer(construct, builder.Resource.Name);

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -39,6 +39,8 @@ public static class AzureStorageExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureStorageResource> AddAzureStorage(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureStorageResource>, ResourceModuleConstruct, StorageAccount>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var storageAccount = construct.AddStorageAccount(

--- a/src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs
@@ -22,6 +22,8 @@ public static class AzureBicepResourceExtensions
     /// <returns>An <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureBicepResource> AddBicepTemplate(this IDistributedApplicationBuilder builder, string name, string bicepFile)
     {
+        builder.AddAzureProvisioning();
+
         var path = Path.GetFullPath(Path.Combine(builder.AppHostDirectory, bicepFile));
         var resource = new AzureBicepResource(name, templateFile: path, templateString: null);
         return builder.AddResource(resource)
@@ -37,6 +39,8 @@ public static class AzureBicepResourceExtensions
     /// <returns>An <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureBicepResource> AddBicepTemplateString(this IDistributedApplicationBuilder builder, string name, string bicepContent)
     {
+        builder.AddAzureProvisioning();
+
         var resource = new AzureBicepResource(name, templateFile: null, templateString: bicepContent);
         return builder.AddResource(resource)
                       .WithManifestPublishingCallback(resource.WriteToManifest);

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -92,6 +92,8 @@ public static class AzureConstructResourceExtensions
     /// <returns></returns>
     public static IResourceBuilder<AzureConstructResource> AddAzureConstruct(this IDistributedApplicationBuilder builder, string name, Action<ResourceModuleConstruct> configureConstruct)
     {
+        builder.AddAzureProvisioning();
+
         var resource = new AzureConstructResource(name, configureConstruct);
         return builder.AddResource(resource)
                       .WithManifestPublishingCallback(resource.WriteToManifest);

--- a/src/Aspire.Hosting.Azure/Exceptions.cs
+++ b/src/Aspire.Hosting.Azure/Exceptions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure;
+
+internal class AzureCliNotOnPathException : DistributedApplicationException
+{
+    public AzureCliNotOnPathException() { }
+    public AzureCliNotOnPathException(string message) : base(message) { }
+    public AzureCliNotOnPathException(string message, Exception inner) : base(message, inner) { }
+}
+
+internal class FailedToApplyEnvironmentException : DistributedApplicationException
+{
+    public FailedToApplyEnvironmentException() { }
+    public FailedToApplyEnvironmentException(string message) : base(message) { }
+    public FailedToApplyEnvironmentException(string message, Exception inner) : base(message, inner) { }
+}
+

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -104,6 +104,14 @@ internal sealed class AzureProvisioner(
                 })
                 .ConfigureAwait(false);
             }
+            catch (MissingConfigurationException)
+            {
+                await UpdateStateAsync(resource, s => s with
+                {
+                    State = new("Missing subscription configuration", KnownResourceStateStyles.Error)
+                })
+                .ConfigureAwait(false);
+            }
             catch (Exception)
             {
                 await UpdateStateAsync(resource, s => s with

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -263,6 +263,11 @@ internal sealed class AzureProvisioner(
 
                 resource.ProvisioningTaskCompletionSource?.TrySetResult();
             }
+            catch (MissingConfigurationException ex)
+            {
+                resourceLogger.LogCritical("Resource could not be provisioned because Azure subscription, location, and resource group information is missing. See https://aka.ms/dotnet/aspire/azure/provisioning for more details.");
+                resource.ProvisioningTaskCompletionSource?.TrySetException(ex);
+            }
             catch (JsonException ex)
             {
                 resourceLogger.LogError(ex, "Error provisioning {ResourceName} because user secrets file is not well-formed JSON.", resource.Name);

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -263,6 +263,11 @@ internal sealed class AzureProvisioner(
 
                 resource.ProvisioningTaskCompletionSource?.TrySetResult();
             }
+            catch (AzureCliNotOnPathException ex)
+            {
+                resourceLogger.LogCritical("Using Azure resources during local development requires the installation of the Azure CLI. See https://aka.ms/dotnet/aspire/azcli for instructions.");
+                resource.ProvisioningTaskCompletionSource?.TrySetException(ex);
+            }
             catch (MissingConfigurationException ex)
             {
                 resourceLogger.LogCritical("Resource could not be provisioned because Azure subscription, location, and resource group information is missing. See https://aka.ms/dotnet/aspire/azure/provisioning for more details.");

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -125,8 +125,7 @@ internal sealed class BicepProvisioner(
 
         if (FindFullPathFromPath("az") is not { } azPath)
         {
-            resourceLogger.LogCritical("Using Azure resources during local development requires the installation of the Azure CLI. See https://aka.ms/dotnet/aspire/azcli for instructions.");
-            return;
+            throw new AzureCliNotOnPathException();
         }
 
         var template = resource.GetBicepTemplateFile();

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -123,8 +123,11 @@ internal sealed class BicepProvisioner(
 
         PopulateWellKnownParameters(resource, context);
 
-        var azPath = FindFullPathFromPath("az") ??
-            throw new InvalidOperationException("Azure CLI not found in PATH");
+        if (FindFullPathFromPath("az") is not { } azPath)
+        {
+            resourceLogger.LogCritical("Using Azure resources during local development requires the installation of the Azure CLI. See https://aka.ms/dotnet/aspire/azcli for instructions.");
+            return;
+        }
 
         var template = resource.GetBicepTemplateFile();
 

--- a/src/Aspire.Hosting/Exceptions.cs
+++ b/src/Aspire.Hosting/Exceptions.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+internal class FailedToApplyEnvironmentException : DistributedApplicationException
+{
+    public FailedToApplyEnvironmentException() { }
+    public FailedToApplyEnvironmentException(string message) : base(message) { }
+    public FailedToApplyEnvironmentException(string message, Exception inner) : base(message, inner) { }
+}

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.CognitiveServices\Aspire.Hosting.Azure.CognitiveServices.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.PostgreSQL\Aspire.Hosting.Azure.PostgreSQL.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.CosmosDB\Aspire.Hosting.Azure.CosmosDB.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.EventHubs\Aspire.Hosting.Azure.EventHubs.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Storage\Aspire.Hosting.Azure.Storage.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ServiceBus\Aspire.Hosting.Azure.ServiceBus.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.Sql\Aspire.Hosting.Azure.Sql.csproj" IsAspireProjectResource="false" />

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -5,12 +5,14 @@
 
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Azure;
+using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.CognitiveServices;
 using Azure.Provisioning.CosmosDB;
 using Azure.Provisioning.Storage;
 using Azure.ResourceManager.Storage.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Aspire.Hosting.Tests.Azure;
@@ -29,6 +31,38 @@ public class AzureBicepResourceTests
         Assert.Equal("content", bicepResource.Resource.TemplateString);
         Assert.Equal("value1", bicepResource.Resource.Parameters["param1"]);
         Assert.Equal("value2", bicepResource.Resource.Parameters["param2"]);
+    }
+
+    [Fact]
+    public void AzureExtensionsAutomaticallyAddAzureProvisioning()
+    {
+        Action<IDistributedApplicationBuilder>[] extensionCalls = [
+            (IDistributedApplicationBuilder builder) => builder.AddAzureAppConfiguration("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureApplicationInsights("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureOpenAI("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureCosmosDB("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureEventHubs("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureKeyVault("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureLogAnalyticsWorkspace("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddPostgres("x").AsAzurePostgresFlexibleServer(),
+            (IDistributedApplicationBuilder builder) => builder.AddRedis("x").AsAzureRedis(),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureSearch("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureServiceBus("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureSignalR("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddSqlServer("x").AsAzureSqlDatabase(),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureStorage("x"),
+            ];
+
+        foreach (var extensionCall in extensionCalls)
+        {
+            using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Run);
+            extensionCall(builder);
+
+            var app = builder.Build();
+            var hooks = app.Services.GetServices<IDistributedApplicationLifecycleHook>();
+            var provisionerHook = hooks.OfType<AzureProvisioner>();
+            Assert.Single<AzureProvisioner>(provisionerHook);
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -39,6 +39,10 @@ public class AzureBicepResourceTests
         Action<IDistributedApplicationBuilder>[] extensionCalls = [
             (IDistributedApplicationBuilder builder) => builder.AddAzureAppConfiguration("x"),
             (IDistributedApplicationBuilder builder) => builder.AddAzureApplicationInsights("x"),
+            (IDistributedApplicationBuilder builder) => builder.AddBicepTemplate("x", "template.bicep"),
+            (IDistributedApplicationBuilder builder) => builder.AddBicepTemplateString("x", "content"),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureConstruct("x", _ => { }),
+            (IDistributedApplicationBuilder builder) => builder.AddAzureOpenAI("x"),
             (IDistributedApplicationBuilder builder) => builder.AddAzureOpenAI("x"),
             (IDistributedApplicationBuilder builder) => builder.AddAzureCosmosDB("x"),
             (IDistributedApplicationBuilder builder) => builder.AddAzureEventHubs("x"),


### PR DESCRIPTION
Partially addresses https://github.com/dotnet/aspire/issues/2590

This PR will automatically call `AddAzureProvisioning`.

This PR also improves the error message if there is a provisioning issue due to missing configuration data.

This is what you will now see if a resource fails to provision because it is missing subscription information:

![image](https://github.com/dotnet/aspire/assets/513398/949ae016-cab3-4d28-8505-0576f8daac89)

Resources that depend on the resource via enviroment variables have also had some improvements to their error logging:

![image](https://github.com/dotnet/aspire/assets/513398/8b630842-71a9-461a-9f05-05f0c9ac0c17)

I haven't removed the exceptions completely on the dependent resources because there are some cases where this could obscure a real issue. So if you turn on debug level logging for DCP you can get the full exception shown (example):

![image](https://github.com/dotnet/aspire/assets/513398/09227673-d8bb-40b8-8566-77a28a3448e4)

I do not put this debug information in the dashboard (its in the console). This is because the ResourceLoggerService infrastructure doesn't really honor any config settings for controlling verbosity levels. We should probably decide what we want to do here around controlling verbosity of resource loggers.

