### PR TITLE
Fix broken environment variables in dashboard in dev

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -774,8 +774,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
         var resourceServiceUrl = await _dashboardEndpointProvider.GetResourceServiceUriAsync(cancellationToken).ConfigureAwait(false);
 
+        var environment = configuration["ASPNETCORE_ENVIRONMENT"] ?? "Production";
+
         var env = new List<KeyValuePair<string, string>>
         {
+            KeyValuePair.Create("ASPNETCORE_ENVIRONMENT", environment),
             KeyValuePair.Create(DashboardConfigNames.DashboardFrontendUrlName.EnvVarName, dashboardUrls),
             KeyValuePair.Create(DashboardConfigNames.ResourceServiceUrlName.EnvVarName, resourceServiceUrl),
             KeyValuePair.Create(DashboardConfigNames.DashboardOtlpUrlName.EnvVarName, otlpEndpointUrl),


### PR DESCRIPTION
[This change](https://github.com/dotnet/aspire/pull/3207) removed ASPNETCORE_ENVIRONMENT which breaks when running the executable in dev scenarios.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3253)