### PR TITLE
Show https endpoints more consistently

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -53,7 +53,7 @@
                         ViewKey="ResourcesList">
         <Summary>
             @{
-                var gridTemplateColumns = HasResourcesWithCommands ? "1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr 1fr" : "1fr 2fr 1.25fr 1.5fr 2.5fr 2fr 1fr 1fr";
+                var gridTemplateColumns = HasResourcesWithCommands ? "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr 1fr" : "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr";
             }
             <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading">
                 <ChildContent>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -18,63 +18,81 @@
     }
 }
 
-<FluentOverflow Class="endpoint-overflow">
-    <ChildContent>
-        @for (var i = 0; i < displayedEndpoints.Count; i++)
-        {
-            var displayedEndpoint = displayedEndpoints[i];
-            var isLast = i == displayedEndpoints.Count - 1;
+@if (displayedEndpoints.Count == 1)
+{
+    var displayedEndpoint = displayedEndpoints[0];
+    if (displayedEndpoint.Url != null)
+    {
+        <a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Text</a>
+    }
+    else
+    {
+        @displayedEndpoint.Text
+    }
+}
+else
+{
+    // Make sure that endpoints have a consistent ordering. Show https first, then everything else.
+    displayedEndpoints = displayedEndpoints.OrderByDescending(e => e.Url?.StartsWith("https") == true).ThenBy(e=> e.Url ?? e.Text).ToList();
 
-            <FluentOverflowItem Data="displayedEndpoint">
-                @if (displayedEndpoint.Url != null)
-                {
-                    <a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Text</a>
-                }
-                else
-                {
-                    @displayedEndpoint.Text
-                }
-                @if (!isLast)
-                {
-                    <span>,</span>
-                }
-            </FluentOverflowItem>
-        }
-    </ChildContent>
-    <MoreButtonTemplate Context="overflow">
-        <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
-            @($"+{overflow.ItemsOverflow.Count()}")
-        </FluentButton>
-    </MoreButtonTemplate>
-    <OverflowTemplate Context="overflow">
-        @{
-            var items = overflow.ItemsOverflow.ToList();
-        }
-        <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200">
-            <Header>
-                Endpoints
-            </Header>
-            <Body>
-                <div style="max-height:400px; overflow-x:hidden; overflow-y: auto; padding:5px 10px;">
-                    @foreach (var item in items)
+    <FluentOverflow Class="endpoint-overflow">
+        <ChildContent>
+            @for (var i = 0; i < displayedEndpoints.Count; i++)
+            {
+                var displayedEndpoint = displayedEndpoints[i];
+                var isLast = i == displayedEndpoints.Count - 1;
+
+                <FluentOverflowItem Data="displayedEndpoint">
+                    @if (displayedEndpoint.Url != null)
                     {
-                        var d = (DisplayedEndpoint)item.Data!;
-                        <div style="margin-bottom: 4px;">
-                            @if (d.Url != null)
-                            {
-                                <a href="@d.Url" target="_blank">@d.Text</a>
-                            }
-                            else
-                            {
-                                @d.Text
-                            }
-                        </div>
+                        <a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Text</a>
                     }
-                </div>
-            </Body>
-        </FluentPopover>
-    </OverflowTemplate>
-</FluentOverflow>
+                    else
+                    {
+                        @displayedEndpoint.Text
+                    }
+                    @if (!isLast)
+                    {
+                        <span>,</span>
+                    }
+                </FluentOverflowItem>
+            }
+        </ChildContent>
+        <MoreButtonTemplate Context="overflow">
+            <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
+                @($"+{overflow.ItemsOverflow.Count()}")
+            </FluentButton>
+        </MoreButtonTemplate>
+        <OverflowTemplate Context="overflow">
+            @{
+                var items = overflow.ItemsOverflow.ToList();
+            }
+            <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200">
+                <Header>
+                    Endpoints
+                </Header>
+                <Body>
+                    <div style="max-height:400px; overflow-x:hidden; overflow-y: auto; padding:5px 10px;">
+                        @foreach (var item in items)
+                        {
+                            var d = (DisplayedEndpoint)item.Data!;
+                            <div style="margin-bottom: 4px;">
+                                @if (d.Url != null)
+                                {
+                                    <a href="@d.Url" target="_blank">@d.Text</a>
+                                }
+                                else
+                                {
+                                    @d.Text
+                                }
+                            </div>
+                        }
+                    </div>
+                </Body>
+            </FluentPopover>
+        </OverflowTemplate>
+    </FluentOverflow>
+}
 
 @if (!string.IsNullOrEmpty(additionalMessage))
 {


### PR DESCRIPTION
A couple of quick changes that hopefully mostly fix #3106 (for now at least).

- Give the Endpoints column a little bit more room and take a little bit of room away from the Name column (now that we show less in that column)
- If there's only one entry in the Endpoints column, display it directly and do not use the FluentOverflow component. It'll be displayed with normal ellipsis truncation.
- Sort the endpoints so that https comes first.

This does _not_ address the part of #3106 where the first endpoint (of more than one) would fit in the space, but overflow doesn't show it (because it doesn't fit next to the +n button). That would take a change in the underlying overflow component.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3266)