### PR TITLE
Re-enables IDE protocol v1 support.

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -989,19 +989,30 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             {
                 exeSpec.ExecutionType = ExecutionType.IDE;
 
+                if (_dcpInfo?.Version?.CompareTo(DcpVersion.MinimumVersionIdeProtocolV1) >= 0)
+                {
+                    projectLaunchConfiguration.DisableLaunchProfile = project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _);
+                    if (!projectLaunchConfiguration.DisableLaunchProfile && project.TryGetLastAnnotation<LaunchProfileAnnotation>(out var lpa))
+                    {
+                        projectLaunchConfiguration.LaunchProfile = lpa.LaunchProfileName;
+                    }
+                }
+                else
+                {
 #pragma warning disable CS0612 // These annotations are obsolete; remove in Aspire Preview 6
-                annotationHolder.Annotate(Executable.CSharpProjectPathAnnotation, projectMetadata.ProjectPath);
+                    annotationHolder.Annotate(Executable.CSharpProjectPathAnnotation, projectMetadata.ProjectPath);
 
-                // ExcludeLaunchProfileAnnotation takes precedence over LaunchProfileAnnotation.
-                if (project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
-                {
-                    annotationHolder.Annotate(Executable.CSharpDisableLaunchProfileAnnotation, "true");
-                }
-                else if (project.TryGetLastAnnotation<LaunchProfileAnnotation>(out var lpa))
-                {
-                    annotationHolder.Annotate(Executable.CSharpLaunchProfileAnnotation, lpa.LaunchProfileName);
-                }
+                    // ExcludeLaunchProfileAnnotation takes precedence over LaunchProfileAnnotation.
+                    if (project.TryGetLastAnnotation<ExcludeLaunchProfileAnnotation>(out _))
+                    {
+                        annotationHolder.Annotate(Executable.CSharpDisableLaunchProfileAnnotation, "true");
+                    }
+                    else if (project.TryGetLastAnnotation<LaunchProfileAnnotation>(out var lpa))
+                    {
+                        annotationHolder.Annotate(Executable.CSharpLaunchProfileAnnotation, lpa.LaunchProfileName);
+                    }
 #pragma warning restore CS0612
+                }
             }
             else
             {

--- a/src/Aspire.Hosting/Dcp/DcpVersion.cs
+++ b/src/Aspire.Hosting/Dcp/DcpVersion.cs
@@ -6,7 +6,7 @@ namespace Aspire.Hosting.Dcp;
 internal static class DcpVersion
 {
     public static Version MinimumVersionInclusive = new Version(0, 1, 55);
-    public static Version MinimumVersionIdeProtocolV1 = new Version(0, 1, 59);
+    public static Version MinimumVersionIdeProtocolV1 = new Version(0, 1, 61);
 
     /// <summary>
     /// Development build version proxy, considered always "current" and supporting latest features. 


### PR DESCRIPTION
Corresponding change in DCP will make it tolerate any combination of IDE tooling and app host libraries. That is, DCP will be able to use both old and new-style annotations and will probe the IDE for protocol supported, translating the requests as necessary.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3269)