### PR TITLE
use WaitForExitAsync instead of Exited event to ensure process output is read

### DIFF
--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -107,7 +107,7 @@ internal static partial class ProcessUtil
                 {
                     processLifetimeTcs.TrySetResult(new ProcessResult(process.ExitCode));
                 }
-            }, TaskScheduler.Default).ConfigureAwait(false);
+            }, TaskScheduler.Current).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -83,21 +83,6 @@ internal static partial class ProcessUtil
 
         var processLifetimeTcs = new TaskCompletionSource<ProcessResult>();
 
-        process.Exited += (_, e) =>
-        {
-            startupComplete.Wait();
-
-            if (processSpec.ThrowOnNonZeroReturnCode && process.ExitCode != 0)
-            {
-                processLifetimeTcs.TrySetException(new InvalidOperationException(
-                    $"Command {processSpec.ExecutablePath} {processSpec.Arguments} returned non-zero exit code {process.ExitCode}"));
-            }
-            else
-            {
-                processLifetimeTcs.TrySetResult(new ProcessResult(process.ExitCode));
-            }
-        };
-
         try
         {
 #if ASPIRE_EVENTSOURCE
@@ -108,6 +93,21 @@ internal static partial class ProcessUtil
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
             processSpec.OnStart?.Invoke(process.Id);
+
+            process.WaitForExitAsync().ContinueWith(t =>
+            {
+                startupComplete.Wait();
+
+                if (processSpec.ThrowOnNonZeroReturnCode && process.ExitCode != 0)
+                {
+                    processLifetimeTcs.TrySetException(new InvalidOperationException(
+                        $"Command {processSpec.ExecutablePath} {processSpec.Arguments} returned non-zero exit code {process.ExitCode}"));
+                }
+                else
+                {
+                    processLifetimeTcs.TrySetResult(new ProcessResult(process.ExitCode));
+                }
+            }, TaskScheduler.Default).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -107,7 +107,7 @@ internal static partial class ProcessUtil
                 {
                     processLifetimeTcs.TrySetResult(new ProcessResult(process.ExitCode));
                 }
-            }, TaskScheduler.Current);
+            }, TaskScheduler.Default);
         }
         finally
         {

--- a/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
+++ b/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs
@@ -107,7 +107,7 @@ internal static partial class ProcessUtil
                 {
                     processLifetimeTcs.TrySetResult(new ProcessResult(process.ExitCode));
                 }
-            }, TaskScheduler.Current).ConfigureAwait(false);
+            }, TaskScheduler.Current);
         }
         finally
         {


### PR DESCRIPTION
I wanted to pull down the repo to see if I could help contribute to the Orleans component, but quickly ran into an error which prevented me from running any apphost:

```
dotnet run --project playground/TestShop/AppHost/AppHost.csproj
Building...
info: Aspire.Hosting.DistributedApplication[0]
      Aspire version: 8.1.0-dev
info: Aspire.Hosting.DistributedApplication[0]
      Distributed application starting.
info: Aspire.Hosting.DistributedApplication[0]
      Application host directory is: /Users/tkimmett/source/aspire/playground/TestShop/AppHost
Process terminated. Assertion failed.
DCP info should not be null at this point
   at Aspire.Hosting.Dcp.ApplicationExecutor.RunApplicationAsync(CancellationToken cancellationToken) in /Users/tkimmett/source/aspire/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs:line 103
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Aspire.Hosting.Dcp.ApplicationExecutor.RunApplicationAsync(CancellationToken cancellationToken)
   at Aspire.Hosting.Dcp.DcpHostService.StartAsync(CancellationToken cancellationToken) in /Users/tkimmett/source/aspire/src/Aspire.Hosting/Dcp/DcpHostService.cs:line 70
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.SetExistingTaskResult(Task`1 task, TResult result)
   at Aspire.Hosting.Dcp.DcpDependencyCheck.GetDcpInfoAsync(CancellationToken cancellationToken) in /Users/tkimmett/source/aspire/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs:line 123
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(IAsyncStateMachineBox box, Boolean allowInlining)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Threading.Tasks.Task.CancellationPromise`1.System.Threading.Tasks.ITaskCompletionAction.Invoke(Task completingTask)
   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)
   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)
   at System.Threading.Tasks.TaskCompletionSource`1.TrySetResult(TResult result)
   at Aspire.Hosting.Dcp.Process.ProcessUtil.<>c__DisplayClass2_0.<Run>b__2(Object _, EventArgs e) in /Users/tkimmett/source/aspire/src/Aspire.Hosting/Dcp/Process/ProcessUtil.cs:line 97
   at System.Diagnostics.Process.RaiseOnExited()
   at System.Diagnostics.Process.CompletionCallback(Object waitHandleContext, Boolean wasSignaled)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.PortableThreadPool.CompleteWait(RegisteredWaitHandle handle, Boolean timedOut)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback()
```

This error did not happen every time I tried to run an apphost, but it definitely happened more often than not.

After some debugging of `DcpDependencyCheck.GetDcpInfoAsync()`, I discovered that the [`task` returned from `ProcessUtil.Run()`](https://github.com/dotnet/aspire/blob/11719715b4d861510c3993e2d86d3fec617c66d3/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs#L73) was completing before any output could be read. I was able to find a [discussion of this issue](https://stackoverflow.com/a/18616369/1832585) which alluded to the possibility of a process exiting before its output was fully read. I also found [this dotnet runtime issue](https://github.com/dotnet/runtime/issues/42556) that was resolved quite a while ago, but again, points to some odd behavior around the order of events for `System.Diagnostics.Process`.

In the end, I simply swapped from using the `Exited` event to using `process.WaitForExitAsync()`.



<details><summary>My system info for reference:</summary>
<pre>
dotnet --info
.NET SDK:
 Version:           8.0.201
 Commit:            4c2d78f037
 Workload version:  8.0.200-manifests.ccccdd05
-
Runtime Environment:
 OS Name:     Mac OS X
 OS Version:  14.4
 OS Platform: Darwin
 RID:         osx-arm64
 Base Path:   /usr/local/share/dotnet/sdk/8.0.201/
-
.NET workloads installed:
 [aspire]
   Installation Source: SDK 8.0.200
   Manifest Version:    8.1.0-preview.1.24178.9/8.0.100
   Manifest Path:       /usr/local/share/dotnet/sdk-manifests/8.0.100/microsoft.net.sdk.aspire/8.1.0-preview.1.24178.9/WorkloadManifest.json
   Install Type:        FileBased
-
Host:
  Version:      8.0.2
  Architecture: arm64
  Commit:       1381d5ebd2
-
.NET SDKs installed:
  8.0.201 [/usr/local/share/dotnet/sdk]
-
.NET runtimes installed:
  Microsoft.AspNetCore.App 8.0.2 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 8.0.2 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
</pre>
</details> 