### PR TITLE
Put all database connection strings in keyvault too

### DIFF
--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -105,14 +105,13 @@ public static class AzurePostgresExtensions
                                                         .WithManifestPublishingCallback(resource.WriteToManifest)
                                                         .WithLoginAndPassword(builder.Resource);
 
-        // Use this implementation of pg
-        builder.Resource.PostgresResource = resource;
-
         if (useProvisioner)
         {
+            // Use this implementation of pg
+            builder.Resource.PostgresResource = resource;
+
             // Used to hold a reference to the azure surrogate for use with the provisioner.
             builder.WithAnnotation(new AzureBicepResourceAnnotation(resource));
-            builder.WithConnectionStringRedirection(resource);
 
             // Remove the container annotation so that DCP doesn't do anything with it.
             if (builder.Resource.Annotations.OfType<ContainerImageAnnotation>().SingleOrDefault() is { } containerAnnotation)

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -91,8 +91,7 @@ public static class AzurePostgresExtensions
 
             foreach (var database in builder.Resource.Databases)
             {
-                var secret = new KeyVaultSecret(construct, name: database.Key);
-                secret.AssignProperty(x => x.Properties.Value, $"'{severConnectionString.Value};Database={database.Value}'");
+                var secret = new KeyVaultSecret(construct, name: database.Key, connectionString: new DatabaseConnectionString(severConnectionString, database.Value));
                 azureResource.DatabaseConnectionStrings[database.Value] = new BicepSecretOutputReference(database.Key, azureResource);
             }
 
@@ -125,13 +124,9 @@ public static class AzurePostgresExtensions
         return builder;
     }
 
-    class DatabaseConnectionString : ConnectionString
-    {
-        public DatabaseConnectionString(string value) : base(value)
-        {
-        }
-    }
-
+    class DatabaseConnectionString(PostgreSqlConnectionString parent, string databaseName) :
+        ConnectionString($"{parent.Value};Database={databaseName}");
+    
     /// <summary>
     /// Configures Postgres Server resource to be deployed as Azure Postgres Flexible Server.
     /// </summary>

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresResource.cs
@@ -12,7 +12,8 @@ namespace Aspire.Hosting.Azure;
 /// <param name="configureConstruct">Callback to configure construct.</param>
 public class AzurePostgresResource(PostgresServerResource innerResource, Action<ResourceModuleConstruct> configureConstruct) :
     AzureConstructResource(innerResource.Name, configureConstruct),
-    IResourceWithConnectionString
+    IResourceWithConnectionString,
+    IPostgresResource
 {
     /// <summary>
     /// Gets the "connectionString" secret output reference from the bicep template for the Azure Postgres Flexible Server.
@@ -28,6 +29,18 @@ public class AzurePostgresResource(PostgresServerResource innerResource, Action<
     /// <inheritdoc/>
     public override string Name => innerResource.Name;
 
+    internal Dictionary<string, BicepSecretOutputReference> DatabaseConnectionStrings { get; } = [];
+
     /// <inheritdoc />
     public override ResourceAnnotationCollection Annotations => innerResource.Annotations;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="databaseName"></param>
+    /// <returns></returns>
+    public ReferenceExpression GetDatabaseConnectionString(string databaseName)
+    {
+        return ReferenceExpression.Create($"{DatabaseConnectionStrings[databaseName]}");
+    }
 }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresDatabaseResource.cs
@@ -9,7 +9,10 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="postgresParentResource">The PostgreSQL parent resource associated with this database.</param>
-public class PostgresDatabaseResource(string name, string databaseName, PostgresServerResource postgresParentResource) : Resource(name), IResourceWithParent<PostgresServerResource>, IResourceWithConnectionString
+public class PostgresDatabaseResource(string name, string databaseName, PostgresServerResource postgresParentResource) :
+    Resource(name),
+    IResourceWithParent<PostgresServerResource>,
+    IResourceWithConnectionString
 {
     /// <summary>
     /// Gets the parent PostgresSQL container resource.
@@ -20,7 +23,7 @@ public class PostgresDatabaseResource(string name, string databaseName, Postgres
     /// Gets the connection string expression for the Postgres database.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-       ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
+       Parent.GetDatabaseConnectionString(DatabaseName);
 
     /// <summary>
     /// Gets the database name.

--- a/src/Aspire.Hosting.PostgreSQL/PostgresServerResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresServerResource.cs
@@ -68,7 +68,7 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
     /// <returns></returns>
     public ReferenceExpression GetDatabaseConnectionString(string databaseName) =>
         PostgresResource?.GetDatabaseConnectionString(databaseName) ??
-        ReferenceExpression.Create($"{ConnectionStringExpression};Database={databaseName}");
+        ReferenceExpression.Create($"{this};Database={databaseName}");
 
     private readonly Dictionary<string, string> _databases = new(StringComparers.ResourceName);
 

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -1007,7 +1007,7 @@ public class AzureBicepResourceTests
                 value: 'Host=${postgreSqlFlexibleServer_NYWb9Nbel.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=dbName'
               }
             }
-
+            
             """;
         Assert.Equal(expectedBicep, manifest.BicepText);
     }

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -147,7 +147,7 @@ public class AddPostgresTests
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
         var postgresResource = Assert.Single(appModel.Resources.OfType<PostgresServerResource>());
-        var postgresConnectionString = await postgresResource.GetConnectionStringAsync();
+        var postgresConnectionString = await ((IResourceWithConnectionString)postgresResource).GetConnectionStringAsync();
         var postgresDatabaseResource = Assert.Single(appModel.Resources.OfType<PostgresDatabaseResource>());
         var postgresDatabaseConnectionStringResource = (IResourceWithConnectionString)postgresDatabaseResource;
         var dbConnectionString = await postgresDatabaseConnectionStringResource.GetConnectionStringAsync();


### PR DESCRIPTION
- Change how we intercept postgres with IPostgresResource
- Add db connection strings into keyvault directly and reference them from there.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3277)