### PR TITLE
update OpenTelemetry.Instrumentation.GrpcNetClient version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -110,7 +110,7 @@
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.7.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.7.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />


### PR DESCRIPTION
This was skipped by dependabot as it's preview and not "in the same range" -- see https://github.com/dependabot/dependabot-core/issues/8161#issuecomment-1830607348

Incidentally, some of the otel packages are now 1.8 (eg., OpenTelemtry.Extensions.Hosting is 1.8.0-rc.1). If we want to consume 1.8.0 (stable) at GA, we should pick those up. @samsp-msft 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3288)