### PR TITLE
Fix the dapr scheme to be http so that the sidecar works

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -137,7 +137,7 @@
     <PackageVersion Include="Testcontainers.Redis" Version="$(TestcontainersPackageVersion)" />
     <PackageVersion Include="Testcontainers.Nats" Version="$(TestcontainersPackageVersion)" />
     <!-- playground apps dependencies -->
-    <PackageVersion Include="Dapr.AspNetCore" Version="1.12.0" />
+    <PackageVersion Include="Dapr.AspNetCore" Version="1.13.0" />
     <PackageVersion Include="Microsoft.Orleans.Clustering.AzureStorage" Version="8.1.0-nightly.20240126.1" />
     <PackageVersion Include="Microsoft.Orleans.Persistence.AzureStorage" Version="8.1.0-nightly.20240126.1" />
     <PackageVersion Include="Microsoft.Orleans.Server" Version="8.1.0-nightly.20240126.1" />

--- a/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
+++ b/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -151,9 +151,9 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         context.EnvironmentVariables.TryAdd("DAPR_HTTP_ENDPOINT", http);
                     }));
 
-            daprCli.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: "grpc", port: sidecarOptions?.DaprGrpcPort));
-            daprCli.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: "http", port: sidecarOptions?.DaprHttpPort));
-            daprCli.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: "metrics", port: sidecarOptions?.MetricsPort));
+            daprCli.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "grpc", port: sidecarOptions?.DaprGrpcPort));
+            daprCli.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "http", port: sidecarOptions?.DaprHttpPort));
+            daprCli.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, uriScheme: "http", name: "metrics", port: sidecarOptions?.MetricsPort));
             if (sidecarOptions?.EnableProfiling == true)
             {
                 daprCli.Annotations.Add(new EndpointAnnotation(ProtocolType.Tcp, name: "profile", port: sidecarOptions?.ProfilePort));

--- a/src/Aspire.Hosting.Dapr/IDistributedApplicationBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Dapr/IDistributedApplicationBuilderExtensions.cs
@@ -46,6 +46,12 @@ public static class IDistributedApplicationBuilderExtensions
 
         return builder
             .AddResource(resource)
+            .WithInitialState(new()
+            {
+                Properties = [],
+                ResourceType = "DaprComponent",
+                State = "Hidden"
+            })
             .WithAnnotation(new ManifestPublishingCallbackAnnotation(context => WriteDaprComponentResourceToManifest(context, resource)));
     }
 

--- a/src/Aspire.Hosting.Dapr/IDistributedApplicationComponentBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Dapr/IDistributedApplicationComponentBuilderExtensions.cs
@@ -54,7 +54,13 @@ public static class IDistributedApplicationResourceBuilderExtensions
         // Add Dapr is idempoent, so we can call it multiple times.
         builder.ApplicationBuilder.AddDapr();
 
-        var sidecarBuilder = builder.ApplicationBuilder.AddResource(new DaprSidecarResource($"{builder.Resource.Name}-dapr"));
+        var sidecarBuilder = builder.ApplicationBuilder.AddResource(new DaprSidecarResource($"{builder.Resource.Name}-dapr"))
+                                                       .WithInitialState(new()
+                                                       {
+                                                           Properties = [],
+                                                           ResourceType = "DaprSidecar",
+                                                           State = "Hidden"
+                                                       });
 
         configureSidecar(sidecarBuilder);
 

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -110,7 +110,8 @@ public class DistributedApplication : IHost, IAsyncDisposable
         RunAsync().Wait();
     }
 
-    private async Task ExecuteBeforeStartHooksAsync(CancellationToken cancellationToken)
+    // Internal for testing
+    internal async Task ExecuteBeforeStartHooksAsync(CancellationToken cancellationToken)
     {
         AspireEventSource.Instance.AppBeforeStartHooksStart();
 

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.OperationalInsights\Aspire.Hosting.Azure.OperationalInsights.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.ApplicationInsights\Aspire.Hosting.Azure.ApplicationInsights.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Azure.AppConfiguration\Aspire.Hosting.Azure.AppConfiguration.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\..\src\Aspire.Hosting.Dapr\Aspire.Hosting.Dapr.csproj" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.MongoDB\Aspire.Hosting.MongoDB.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.MySql\Aspire.Hosting.MySql.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Aspire.Hosting.Nats\Aspire.Hosting.Nats.csproj" IsAspireProjectResource="false" />

--- a/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
@@ -15,6 +15,12 @@ public class DaprTests
     public async Task WithDaprSideCarAddsAnnotationAndSidecarResource()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
+        builder.AddDapr(o =>
+        {
+            // Fake path to avoid throwing
+            o.DaprPath = "dapr";
+        });
+
         builder.AddContainer("name", "image")
             .WithEndpoint("http", e =>
             {

--- a/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dapr;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Dapr;
+
+public class DaprTests
+{
+    [Fact]
+    public async Task WithDaprSideCarAddsAnnotationAndSidecarResource()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.AddContainer("name", "image")
+            .WithEndpoint("http", e =>
+            {
+                e.Port = 8000;
+                e.AllocatedEndpoint = new(e, "localhost", 80);
+            })
+            .WithDaprSidecar();
+
+        using var app = builder.Build();
+        await app.ExecuteBeforeStartHooksAsync(default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        Assert.Equal(3, model.Resources.Count);
+        var container = Assert.Single(model.Resources.OfType<ContainerResource>());
+        var sidecarResource = Assert.Single(model.Resources.OfType<IDaprSidecarResource>());
+        var sideCarCli = Assert.Single(model.Resources.OfType<ExecutableResource>());
+
+        Assert.True(sideCarCli.TryGetEndpoints(out var endpoints));
+
+        var ports = new Dictionary<string, int>
+        {
+            ["http"] = 3500,
+            ["grpc"] = 50001,
+            ["metrics"] = 9090
+        };
+
+        foreach (var e in endpoints)
+        {
+            e.AllocatedEndpoint = new(e, "localhost", ports[e.Name]);
+        }
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(container);
+        var sidecarArgs = await ArgumentEvaluator.GetArgumentListAsync(sideCarCli);
+
+        Assert.Equal("http://localhost:3500", config["DAPR_HTTP_ENDPOINT"]);
+        Assert.Equal("http://localhost:50001", config["DAPR_GRPC_ENDPOINT"]);
+
+        var expectedArgs = new[]
+        {
+            "run",
+            "--app-id",
+            "name",
+            "--app-port",
+            "80",
+            "--dapr-grpc-port",
+            "{{- portForServing \"name-dapr-cli_grpc\" -}}",
+            "--dapr-http-port",
+            "{{- portForServing \"name-dapr-cli_http\" -}}",
+            "--metrics-port",
+            "{{- portForServing \"name-dapr-cli_metrics\" -}}",
+            "--app-channel-address",
+            "localhost"
+        };
+
+        Assert.Equal(expectedArgs, sidecarArgs);
+        Assert.NotNull(container.Annotations.OfType<DaprSidecarAnnotation>());
+    }
+}


### PR DESCRIPTION
[This change](https://github.com/dotnet/aspire/pull/2812) broke the url because the scheme defaults to tcp (same as the protocol). This change also hides the dapr resources until we have a useful way to show them in the dashboard.

PS: This doesn't work yet, I have no idea why I can't call through the dapr side car.

https://github.com/dotnet/aspire/issues/3290

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3292)