### PR TITLE
Ensure logAnalyticsWorkspaceId parameter is present in Aspire manifest.

### DIFF
--- a/playground/bicep/BicepSample.AppHost/Program.cs
+++ b/playground/bicep/BicepSample.AppHost/Program.cs
@@ -47,6 +47,9 @@ var cosmosDb = builder.AddAzureCosmosDB("cosmos")
 var logAnalytics = builder.AddAzureLogAnalyticsWorkspace("lawkspc");
 var appInsights = builder.AddAzureApplicationInsights("ai", logAnalytics);
 
+// To verify that AZD will populate the LAW parameter.
+builder.AddAzureApplicationInsights("aiwithoutlaw");
+
 // Redis takes forever to spin up...
 var redis = builder.AddRedis("redis")
                    .AsAzureRedis();

--- a/playground/bicep/BicepSample.AppHost/Program.cs
+++ b/playground/bicep/BicepSample.AppHost/Program.cs
@@ -44,7 +44,8 @@ var pg = builder.AddPostgres("postgres2", administratorLogin, administratorLogin
 var cosmosDb = builder.AddAzureCosmosDB("cosmos")
                       .AddDatabase("db3");
 
-var appInsights = builder.AddAzureApplicationInsights("ai");
+var logAnalytics = builder.AddAzureLogAnalyticsWorkspace("lawkspc");
+var appInsights = builder.AddAzureApplicationInsights("ai", logAnalytics);
 
 // Redis takes forever to spin up...
 var redis = builder.AddRedis("redis")

--- a/playground/bicep/BicepSample.AppHost/aiwithoutlaw.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/aiwithoutlaw.module.bicep
@@ -1,0 +1,29 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+@description('')
+param applicationType string = 'web'
+
+@description('')
+param kind string = 'web'
+
+@description('')
+param logAnalyticsWorkspaceId string
+
+
+resource applicationInsightsComponent_YlZN71uia 'Microsoft.Insights/components@2020-02-02' = {
+  name: toLower(take(concat('aiwithoutlaw', uniqueString(resourceGroup().id)), 24))
+  location: location
+  tags: {
+    'aspire-resource-name': 'aiwithoutlaw'
+  }
+  kind: kind
+  properties: {
+    Application_Type: applicationType
+    WorkspaceResourceId: logAnalyticsWorkspaceId
+  }
+}
+
+output appInsightsConnectionString string = applicationInsightsComponent_YlZN71uia.properties.ConnectionString

--- a/playground/bicep/BicepSample.AppHost/aspire-manifest.json
+++ b/playground/bicep/BicepSample.AppHost/aspire-manifest.json
@@ -23,7 +23,7 @@
     },
     "test0": {
       "type": "azure.bicep.v0",
-      "path": "../../../../../Users/midenn/AppData/Local/Temp/tmpvqsa5k.tmp.bicep"
+      "path": "test0.bicep"
     },
     "kv3": {
       "type": "azure.bicep.v0",
@@ -128,6 +128,14 @@
       "path": "ai.module.bicep",
       "params": {
         "logAnalyticsWorkspaceId": "{lawkspc.outputs.logAnalyticsWorkspaceId}"
+      }
+    },
+    "aiwithoutlaw": {
+      "type": "azure.bicep.v0",
+      "connectionString": "{aiwithoutlaw.outputs.appInsightsConnectionString}",
+      "path": "aiwithoutlaw.module.bicep",
+      "params": {
+        "logAnalyticsWorkspaceId": ""
       }
     },
     "redis": {

--- a/playground/bicep/BicepSample.AppHost/aspire-manifest.json
+++ b/playground/bicep/BicepSample.AppHost/aspire-manifest.json
@@ -23,7 +23,7 @@
     },
     "test0": {
       "type": "azure.bicep.v0",
-      "path": "../../../../../../Users/davifowl/AppData/Local/Temp/tmppj1k21.tmp.bicep"
+      "path": "../../../../../Users/midenn/AppData/Local/Temp/tmpvqsa5k.tmp.bicep"
     },
     "kv3": {
       "type": "azure.bicep.v0",
@@ -118,10 +118,17 @@
         "keyVaultName": ""
       }
     },
+    "lawkspc": {
+      "type": "azure.bicep.v0",
+      "path": "lawkspc.module.bicep"
+    },
     "ai": {
       "type": "azure.bicep.v0",
       "connectionString": "{ai.outputs.appInsightsConnectionString}",
-      "path": "ai.module.bicep"
+      "path": "ai.module.bicep",
+      "params": {
+        "logAnalyticsWorkspaceId": "{lawkspc.outputs.logAnalyticsWorkspaceId}"
+      }
     },
     "redis": {
       "type": "azure.bicep.v0",

--- a/playground/bicep/BicepSample.AppHost/lawkspc.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/lawkspc.module.bicep
@@ -1,0 +1,20 @@
+targetScope = 'resourceGroup'
+
+@description('')
+param location string = resourceGroup().location
+
+
+resource operationalInsightsWorkspace_cxL77xv9Y 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: toLower(take(concat('lawkspc', uniqueString(resourceGroup().id)), 24))
+  location: location
+  tags: {
+    'aspire-resource-name': 'lawkspc'
+  }
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+}
+
+output logAnalyticsWorkspaceId string = operationalInsightsWorkspace_cxL77xv9Y.id

--- a/playground/bicep/BicepSample.AppHost/test0.bicep
+++ b/playground/bicep/BicepSample.AppHost/test0.bicep
@@ -1,0 +1,2 @@
+param location string = ''
+output val0 string = location

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Aspire.Hosting.Azure.OperationalInsights\Aspire.Hosting.Azure.OperationalInsights.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -23,7 +23,21 @@ public static class AzureApplicationInsightsExtensions
     public static IResourceBuilder<AzureApplicationInsightsResource> AddAzureApplicationInsights(this IDistributedApplicationBuilder builder, string name)
     {
 #pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        return builder.AddAzureApplicationInsights(name, (_, _, _) => { });
+        return builder.AddAzureApplicationInsights(name, null, null);
+#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    }
+
+    /// <summary>
+    /// Adds an Azure Application Insights resource to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
+    /// <param name="logAnalyticsWorkspace">A resource builder for the log analytics workspace.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{AzureApplicationInsightsResource}"/>.</returns>
+    public static IResourceBuilder<AzureApplicationInsightsResource> AddAzureApplicationInsights(this IDistributedApplicationBuilder builder, string name, IResourceBuilder<AzureLogAnalyticsWorkspaceResource>? logAnalyticsWorkspace)
+    {
+#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        return builder.AddAzureApplicationInsights(name, logAnalyticsWorkspace, null);
 #pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
@@ -37,6 +51,20 @@ public static class AzureApplicationInsightsExtensions
     [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureApplicationInsightsResource> AddAzureApplicationInsights(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureApplicationInsightsResource>, ResourceModuleConstruct, ApplicationInsightsComponent>? configureResource)
     {
+        return builder.AddAzureApplicationInsights(name, null, configureResource);
+    }
+
+    /// <summary>
+    /// Adds an Azure Application Insights resource to the application model.
+    /// </summary>
+    /// <param name="builder">The builder for the distributed application.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="logAnalyticsWorkspace">A resource builder for the log analytics workspace.</param>
+    /// <param name="configureResource">Optional callback to configure the Application Insights resource.</param>
+    /// <returns></returns>
+    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    public static IResourceBuilder<AzureApplicationInsightsResource> AddAzureApplicationInsights(this IDistributedApplicationBuilder builder, string name, IResourceBuilder<AzureLogAnalyticsWorkspaceResource>? logAnalyticsWorkspace, Action<IResourceBuilder<AzureApplicationInsightsResource>, ResourceModuleConstruct, ApplicationInsightsComponent>? configureResource)
+    {
         builder.AddAzureProvisioning();
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
@@ -45,7 +73,19 @@ public static class AzureApplicationInsightsExtensions
             appInsights.Properties.Tags["aspire-resource-name"] = construct.Resource.Name;
             appInsights.AssignProperty(p => p.ApplicationType, new Parameter("applicationType", defaultValue: "web"));
             appInsights.AssignProperty(p => p.Kind, new Parameter("kind", defaultValue: "web"));
-            appInsights.AssignProperty(p => p.WorkspaceResourceId, new Parameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId));
+
+            if (logAnalyticsWorkspace != null)
+            {
+                appInsights.AssignProperty(p => p.WorkspaceResourceId, logAnalyticsWorkspace.Resource.WorkspaceId, AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId);
+            }
+            else
+            {
+                // If the user does not supply a log analytics workspace of their own we still create a parameter on the Aspire
+                // side and the CDK side so that AZD can fill the value in with the one it generates.
+                construct.Resource.Parameters.Add(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, "");
+                appInsights.AssignProperty(p => p.WorkspaceResourceId, new Parameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId));
+
+            }
 
             appInsights.AddOutput("appInsightsConnectionString", p => p.ConnectionString);
 
@@ -56,6 +96,7 @@ public static class AzureApplicationInsightsExtensions
                 configureResource(resourceBuilder, construct, appInsights);
             }
         };
+
         var resource = new AzureApplicationInsightsResource(name, configureConstruct);
 
         return builder.AddResource(resource)

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -73,10 +73,6 @@ public class AzureBicepResource(string name, string? templateFile = null, string
         {
             isTempFile = directory is null;
 
-            //path = TempDirectory is null
-            //    ? Path.GetTempFileName() + ".bicep"
-            //    : Path.Combine(TempDirectory, $"{Name.ToLowerInvariant()}.bicep");
-
             path = TempDirectory is null
                 ? Path.Combine(directory ?? Directory.CreateTempSubdirectory("aspire").FullName, $"{Name.ToLowerInvariant()}.bicep")
                 : Path.Combine(TempDirectory, $"{Name.ToLowerInvariant()}.bicep");

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -73,8 +73,12 @@ public class AzureBicepResource(string name, string? templateFile = null, string
         {
             isTempFile = directory is null;
 
+            //path = TempDirectory is null
+            //    ? Path.GetTempFileName() + ".bicep"
+            //    : Path.Combine(TempDirectory, $"{Name.ToLowerInvariant()}.bicep");
+
             path = TempDirectory is null
-                ? Path.GetTempFileName() + ".bicep"
+                ? Path.Combine(directory ?? Directory.CreateTempSubdirectory("aspire").FullName, $"{Name.ToLowerInvariant()}.bicep")
                 : Path.Combine(TempDirectory, $"{Name.ToLowerInvariant()}.bicep");
 
             if (TemplateResourceName is null)


### PR DESCRIPTION
Fixes #3133 and #3273

To fix this I've added an argument to the `AddAzureApplicationInsights(...)` extension methods that allows it to take an `IResourceBuilder<AzureLogAnalyticsWorkspaceResource>` and uses a reference to that resource to populate the `logAnalyticsWorkspaceId` parameter in the manifest.

If this value is not passed in we still ensure that the parameter is in the manifest so that it can be supplied by AZD.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3296)