### PR TITLE
Infer AWS SDK config for a project from AWS references

### DIFF
--- a/playground/AWS/AWS.AppHost/Program.cs
+++ b/playground/AWS/AWS.AppHost/Program.cs
@@ -20,15 +20,15 @@ var awsResources = builder.AddAWSCloudFormationTemplate("AspireSampleDevResource
 //var awsExistingResource = builder.AddAWSCloudFormationStack("ExistingStackName")
 //                        .WithReference(awsConfig);
 
+// The AWS SDK Config reference is inferred from the CloudFormation resource associated to the project. If the
+// project doesn't have a CloudFormation resource the AWS SDK Config reference can be assigned using the
+// WithReference method.
 builder.AddProject<Projects.Frontend>("Frontend")
        .WithExternalHttpEndpoints()
         // Demonstrating binding all of the output variables to a section in IConfiguration. By default they are bound to the AWS::Resources prefix.
         // The prefix is configurable by the optional configSection parameter.
         .WithReference(awsResources)
         // Demonstrating binding a single output variable to environment variable in the project.
-        .WithEnvironment("ChatTopicArnEnv", awsResources.GetOutput("ChatTopicArn"))
-        // Assign the SDK config to the project. The service clients created in the project relying on environment config
-        // will pick up these configuration.
-        .WithReference(awsConfig);
+        .WithEnvironment("ChatTopicArnEnv", awsResources.GetOutput("ChatTopicArn"));
 
 builder.Build().Run();

--- a/src/Aspire.Hosting.AWS/README.md
+++ b/src/Aspire.Hosting.AWS/README.md
@@ -36,6 +36,10 @@ builder.AddProject<Projects.Frontend>("Frontend")
         .WithReference(awsConfig)
 ```
 
+If a project has a reference to an AWS resource like the AWS CloudFormation resources that have an AWS SDK configuration
+the project will infer the AWS SDK configuration from the AWS resource. For example if you call the `WithReference` passing
+in the CloudFormation resource then a second `WithReference` call passing in the AWS SDK configuration is not necessary.
+
 ## Provisioning application resources with AWS CloudFormation
 
 AWS application resources like Amazon DynamoDB tables or Amazon Simple Queue Service (SQS) queues can be provisioned during AppHost

--- a/src/Aspire.Hosting.AWS/SDKResourceExtensions.cs
+++ b/src/Aspire.Hosting.AWS/SDKResourceExtensions.cs
@@ -62,23 +62,7 @@ public static class SDKResourceExtensions
                 return;
             }
 
-            if (!string.IsNullOrEmpty(awsSdkConfig.Profile))
-            {
-                // The environment variable that AWSSDK.Extensions.NETCore.Setup will look for via IConfiguration.
-                context.EnvironmentVariables["AWS__Profile"] = awsSdkConfig.Profile;
-
-                // The environment variable the service clients look for service clients created without AWSSDK.Extensions.NETCore.Setup.
-                context.EnvironmentVariables["AWS_PROFILE"] = awsSdkConfig.Profile;
-            }
-
-            if (awsSdkConfig.Region != null)
-            {
-                // The environment variable that AWSSDK.Extensions.NETCore.Setup will look for via IConfiguration.
-                context.EnvironmentVariables["AWS__Region"] = awsSdkConfig.Region.SystemName;
-
-                // The environment variable the service clients look for service clients created without AWSSDK.Extensions.NETCore.Setup.
-                context.EnvironmentVariables["AWS_REGION"] = awsSdkConfig.Region.SystemName;
-            }
+            SdkUtilities.ApplySDKConfig(context, awsSdkConfig, true);
         });
 
         return builder;

--- a/src/Aspire.Hosting.AWS/SdkUtilities.cs
+++ b/src/Aspire.Hosting.AWS/SdkUtilities.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using System.Text;
 using Amazon.Runtime;
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.CloudFormation;
 
 namespace Aspire.Hosting.AWS;
@@ -39,5 +40,32 @@ internal static class SdkUtilities
         }
 
         args.Headers[UserAgentHeader] = currentValue + " " + suffix;
+    }
+
+    internal static void ApplySDKConfig(EnvironmentCallbackContext context, IAWSSDKConfig awsSdkConfig, bool force)
+    {
+        if (!string.IsNullOrEmpty(awsSdkConfig.Profile))
+        {
+            if (force || !context.EnvironmentVariables.ContainsKey("AWS__Profile"))
+            {
+                // The environment variable that AWSSDK.Extensions.NETCore.Setup will look for via IConfiguration.
+                context.EnvironmentVariables["AWS__Profile"] = awsSdkConfig.Profile;
+
+                // The environment variable the service clients look for service clients created without AWSSDK.Extensions.NETCore.Setup.
+                context.EnvironmentVariables["AWS_PROFILE"] = awsSdkConfig.Profile;
+            }
+        }
+
+        if (awsSdkConfig.Region != null)
+        {
+            if (force || !context.EnvironmentVariables.ContainsKey("AWS__Region"))
+            {
+                // The environment variable that AWSSDK.Extensions.NETCore.Setup will look for via IConfiguration.
+                context.EnvironmentVariables["AWS__Region"] = awsSdkConfig.Region.SystemName;
+
+                // The environment variable the service clients look for service clients created without AWSSDK.Extensions.NETCore.Setup.
+                context.EnvironmentVariables["AWS_REGION"] = awsSdkConfig.Region.SystemName;
+            }
+        }
     }
 }


### PR DESCRIPTION
When a project has a reference to an AWS CloudFormation resource that project can now infer the AWS SDK configuration from the reference CloudFormation. This avoids users having to add the AWS SDK configuration to both the CloudFormation resource and Project resource. It might be possible a user wants a different AWS SDK configuration then was used for CloudFormation. For example use a profile with reduced permissions. If a user still calls `WithReference` with an AWS SDK configuration it will override any inferred AWS SDK configuration.

Basically this
```csharp
var awsConfig = builder.AddAWSSDKConfig()
                        .WithProfile("default")
                        .WithRegion(RegionEndpoint.USWest2);

var awsResources = builder.AddAWSCloudFormationTemplate("AspireSampleDevResources", "app-resources.template")
                        .WithReference(awsConfig);

builder.AddProject<Projects.Frontend>("Frontend")
       .WithExternalHttpEndpoints()
       .WithReference(awsResources)
       .WithReference(awsSdkConfig);
```

Changes to 
```csharp
var awsConfig = builder.AddAWSSDKConfig()
                        .WithProfile("default")
                        .WithRegion(RegionEndpoint.USWest2);

var awsResources = builder.AddAWSCloudFormationTemplate("AspireSampleDevResources", "app-resources.template")
                        .WithReference(awsConfig);

builder.AddProject<Projects.Frontend>("Frontend")
       .WithExternalHttpEndpoints()
       .WithReference(awsResources);
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3303)