### PR TITLE
Added ability to resolve target port

### DIFF
--- a/src/Aspire.Hosting.Dapr/CommandLineBuilder.cs
+++ b/src/Aspire.Hosting.Dapr/CommandLineBuilder.cs
@@ -6,9 +6,9 @@ using System.Text;
 
 namespace Aspire.Hosting.Dapr;
 
-internal delegate IEnumerable<string> CommandLineArgBuilder();
+internal delegate IEnumerable<object> CommandLineArgBuilder();
 
-internal sealed record CommandLine(string FileName, IEnumerable<string> Arguments)
+internal sealed record CommandLine(string FileName, IEnumerable<object> Arguments)
 {
     public string ArgumentString
     {
@@ -178,6 +178,26 @@ internal static class CommandLineArgs
         };
     }
 
+    public static CommandLineArgBuilder ModelNamedObjectArg(string name, object value)
+    {
+        return () =>
+        {
+            return [name, value];
+        };
+    }
+
+    public static CommandLineArgBuilder ModelNamedObjectArg<T>(string name, object value, bool assignValue = false) where T : struct
+    {
+        return () =>
+        {
+            string? stringValue = Convert.ToString(value, CultureInfo.InvariantCulture);
+
+            return stringValue is not null
+                ? ModelNamedStringArg(name, stringValue, assignValue)()
+                : Enumerable.Empty<string>();
+        };
+    }
+
     public static CommandLineArgBuilder PostOptionsArgs(params CommandLineArgBuilder[] args)
     {
         return PostOptionsArgs(null, args);
@@ -190,7 +210,7 @@ internal static class CommandLineArgs
 
     public static CommandLineArgBuilder PostOptionsArgs(string? separator, IEnumerable<CommandLineArgBuilder> args)
     {
-        IEnumerable<string> GeneratePostOptionsArgs()
+        IEnumerable<object> GeneratePostOptionsArgs()
         {
             bool postOptions = false;
 

--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -94,10 +94,10 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
             }
 
             var daprAppPortArg = (int? port) => ModelNamedArg("--app-port", port);
-            var daprGrpcPortArg = (string? port) => ModelNamedArg("--dapr-grpc-port", port);
-            var daprHttpPortArg = (string? port) => ModelNamedArg("--dapr-http-port", port);
-            var daprMetricsPortArg = (string? port) => ModelNamedArg("--metrics-port", port);
-            var daprProfilePortArg = (string? port) => ModelNamedArg("--profile-port", port);
+            var daprGrpcPortArg = (object port) => ModelNamedObjectArg("--dapr-grpc-port", port);
+            var daprHttpPortArg = (object port) => ModelNamedObjectArg("--dapr-http-port", port);
+            var daprMetricsPortArg = (object port) => ModelNamedObjectArg("--metrics-port", port);
+            var daprProfilePortArg = (object port) => ModelNamedObjectArg("--profile-port", port);
             var daprAppChannelAddressArg = (string? address) => ModelNamedArg("--app-channel-address", address);
 
             var appId = sidecarOptions?.AppId ?? resource.Name;
@@ -182,13 +182,21 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                             }
                         }
 
-                        updatedArgs.AddRange(daprGrpcPortArg($"{{{{- portForServing \"{daprCliResourceName}_grpc\" -}}}}")());
-                        updatedArgs.AddRange(daprHttpPortArg($"{{{{- portForServing \"{daprCliResourceName}_http\" -}}}}")());
-                        updatedArgs.AddRange(daprMetricsPortArg($"{{{{- portForServing \"{daprCliResourceName}_metrics\" -}}}}")());
+                        var grpc = daprCli.GetEndpoint("grpc");
+                        var http = daprCli.GetEndpoint("http");
+                        var metrics = daprCli.GetEndpoint("metrics");
+
+                        updatedArgs.AddRange(daprGrpcPortArg(grpc.Property(EndpointProperty.TargetPort))());
+                        updatedArgs.AddRange(daprHttpPortArg(http.Property(EndpointProperty.TargetPort))());
+                        updatedArgs.AddRange(daprMetricsPortArg(metrics.Property(EndpointProperty.TargetPort))());
+
                         if (sidecarOptions?.EnableProfiling == true)
                         {
-                            updatedArgs.AddRange(daprProfilePortArg($"{{{{- portForServing \"{daprCliResourceName}_profile\" -}}}}")());
+                            var profiling = daprCli.GetEndpoint("profiling");
+
+                            updatedArgs.AddRange(daprProfilePortArg(profiling.Property(EndpointProperty.TargetPort))());
                         }
+
                         if (sidecarOptions?.AppChannelAddress is null && httpEndPoint is not null)
                         {
                             updatedArgs.AddRange(daprAppChannelAddressArg(httpEndPoint.Host)());

--- a/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
@@ -18,7 +18,8 @@ public class AllocatedEndpoint
     /// <param name="address">The IP address of the endpoint.</param>
     /// <param name="containerHostAddress">The address of the container host.</param>
     /// <param name="port">The port number of the endpoint.</param>
-    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port, string? containerHostAddress = null)
+    /// <param name="dcpServiceName">The name of the DCP service.</param>
+    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port, string? containerHostAddress = null, string? dcpServiceName = null)
     {
         ArgumentNullException.ThrowIfNull(endpoint);
         ArgumentOutOfRangeException.ThrowIfLessThan(port, 1, nameof(port));
@@ -28,6 +29,7 @@ public class AllocatedEndpoint
         Address = address;
         ContainerHostAddress = containerHostAddress;
         Port = port;
+        DcpServiceName = dcpServiceName;
     }
 
     /// <summary>
@@ -64,6 +66,11 @@ public class AllocatedEndpoint
     /// URI in string representation.
     /// </summary>
     public string UriString => $"{UriScheme}://{EndPointString}";
+
+    /// <summary>
+    /// The associated service name created in DCP for this endpoint.
+    /// </summary>
+    public string? DcpServiceName { get; }
 
     /// <summary>
     /// Returns a string representation of the allocated endpoint URI.

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -26,9 +26,8 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// <param name="port">Desired port for the service.</param>
     /// <param name="targetPort">This is the port the resource is listening on. If the endpoint is used for the container, it is the container port.</param>
     /// <param name="isExternal">Indicates that this endpoint should be exposed externally at publish time.</param>
-    /// <param name="env">The name of the environment variable that will be set to the port number of this endpoint.</param>
     /// <param name="isProxied">Specifies if the endpoint will be proxied by DCP. Defaults to true.</param>
-    public EndpointAnnotation(ProtocolType protocol, string? uriScheme = null, string? transport = null, string? name = null, int? port = null, int? targetPort = null, bool? isExternal = null, string? env = null, bool isProxied = true)
+    public EndpointAnnotation(ProtocolType protocol, string? uriScheme = null, string? transport = null, string? name = null, int? port = null, int? targetPort = null, bool? isExternal = null, bool isProxied = true)
     {
         // If the URI scheme is null, we'll adopt either udp:// or tcp:// based on the
         // protocol. If the name is null, we'll use the URI scheme as the default. This
@@ -47,7 +46,6 @@ public sealed class EndpointAnnotation : IResourceAnnotation
         Port = port;
         TargetPort = targetPort ?? port;
         IsExternal = isExternal ?? false;
-        EnvironmentVariable = env;
         IsProxied = isProxied;
     }
 
@@ -92,11 +90,6 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     /// Indicates that this endpoint should be exposed externally at publish time.
     /// </summary>
     public bool IsExternal { get; set; }
-
-    /// <summary>
-    /// The name of the environment variable that will be set to the port number of this endpoint.
-    /// </summary>
-    public string? EnvironmentVariable { get; set; }
 
     /// <summary>
     /// Indicates that this endpoint should be managed by DCP. This means it can be replicated and use a different port internally than the one publicly exposed.

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -34,6 +34,11 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     /// </summary>
     public bool IsAllocated => _isAllocated ??= GetAllocatedEndpoint() is not null;
 
+    /// <summary>
+    /// Gets a value indicating whether the endpoint exists.
+    /// </summary>
+    public bool Exists => GetEndpointAnnotation() is not null;
+
     string IManifestExpressionProvider.ValueExpression => GetExpression();
 
     ValueTask<string?> IValueProvider.GetValueAsync(CancellationToken cancellationToken) => new(Url);
@@ -49,6 +54,7 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
             EndpointProperty.Host or EndpointProperty.IPV4Host => "host",
             EndpointProperty.Port => "port",
             EndpointProperty.Scheme => "scheme",
+            EndpointProperty.TargetPort => "targetPort",
             _ => throw new InvalidOperationException($"The property '{property}' is not supported for the endpoint '{EndpointName}'.")
         };
 
@@ -73,6 +79,11 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     public int Port => AllocatedEndpoint.Port;
 
     /// <summary>
+    /// Gets the target port for this endpoint. If the port is dynamically allocated, this will return <see langword="null"/>.
+    /// </summary>
+    public int? TargetPort => EndpointAnnotation.TargetPort;
+
+    /// <summary>
     /// Gets the host for this endpoint.
     /// </summary>
     public string Host => AllocatedEndpoint.Address ?? "localhost";
@@ -85,14 +96,14 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     /// <summary>
     /// Gets the scheme for this endpoint.
     /// </summary>
-    public string Scheme => AllocatedEndpoint.UriScheme;
+    public string Scheme => EndpointAnnotation.UriScheme;
 
     /// <summary>
     /// Gets the URL for this endpoint.
     /// </summary>
     public string Url => AllocatedEndpoint.UriString;
 
-    private AllocatedEndpoint AllocatedEndpoint =>
+    internal AllocatedEndpoint AllocatedEndpoint =>
         GetAllocatedEndpoint()
         ?? throw new InvalidOperationException($"The endpoint `{EndpointName}` is not allocated for the resource `{Resource.Name}`.");
 
@@ -158,7 +169,7 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
     /// Gets the value of the property of the endpoint.
     /// </summary>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
-    /// <returns>A <see cref="String"/> containing the selected <see cref="EndpointProperty"/> value.</returns>
+    /// <returns>A <see cref="string"/> containing the selected <see cref="EndpointProperty"/> value.</returns>
     /// <exception cref="InvalidOperationException">Throws when the selected <see cref="EndpointProperty"/> enumeration is not known.</exception>
     public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken) => Property switch
     {
@@ -167,8 +178,26 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
         EndpointProperty.IPV4Host => new("127.0.0.1"),
         EndpointProperty.Port => new(Endpoint.Port.ToString(CultureInfo.InvariantCulture)),
         EndpointProperty.Scheme => new(Endpoint.Scheme),
+        EndpointProperty.TargetPort => new(ComputeTargetPort()),
         _ => throw new InvalidOperationException($"The property '{Property}' is not supported for the endpoint '{Endpoint.EndpointName}'.")
     };
+
+    private string? ComputeTargetPort()
+    {
+        // We have a target port, so we can return it directly.
+        if (Endpoint.TargetPort is int port)
+        {
+            return port.ToString(CultureInfo.InvariantCulture);
+        }
+
+        // There is no way to resolve the value of the target port until runtime. Even then, replicas make this very complex because
+        // the target port is not known until the replica is allocated.
+        // Instead, we return an expression that will be resolved at runtime by the orchestrator.
+        return $$$"""{{- portForServing "{{{DcpServiceName}}}" -}}""";
+    }
+
+    private string DcpServiceName => Endpoint.AllocatedEndpoint.DcpServiceName
+        ?? throw new InvalidOperationException("The endpoint does not have an associated service name in the orchestrator.");
 
     IEnumerable<object> IValueWithReferences.References => [Endpoint];
 }
@@ -197,5 +226,9 @@ public enum EndpointProperty
     /// <summary>
     /// The scheme of the endpoint.
     /// </summary>
-    Scheme
+    Scheme,
+    /// <summary>
+    /// The target port of the endpoint.
+    /// </summary>
+    TargetPort
 }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -623,7 +623,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 if (ep.EndpointAnnotation.IsProxied)
                 {
                     var endpointString = $"{ep.Scheme}://{endpoint.Spec.Address}:{endpoint.Spec.Port}";
-                    urls.Add(new(Name: $"{ep.EndpointName}-listen-port", Url: endpointString, IsInternal: true));
+                    urls.Add(new(Name: $"{ep.EndpointName} target port", Url: endpointString, IsInternal: true));
                 }
             }
         }
@@ -891,7 +891,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                     sp.EndpointAnnotation,
                     sp.EndpointAnnotation.IsProxied ? svc.AllocatedAddress! : "localhost",
                     (int)svc.AllocatedPort!,
-                    containerHostAddress: appResource.ModelResource.IsContainer() ? containerHost : null);
+                    containerHostAddress: appResource.ModelResource.IsContainer() ? containerHost : null,
+                    dcpServiceName: svc.Metadata.Name);
             }
         }
     }
@@ -1034,18 +1035,14 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 // and the environment variables/application URLs inside CreateExecutableAsync().
                 exeSpec.Args.Add("--no-launch-profile");
 
-                var launchProfileName = project.SelectLaunchProfileName();
-                if (!string.IsNullOrEmpty(launchProfileName))
+                var launchProfile = project.GetEffectiveLaunchProfile();
+                if (launchProfile is not null && !string.IsNullOrWhiteSpace(launchProfile.CommandLineArgs))
                 {
-                    var launchProfile = project.GetEffectiveLaunchProfile();
-                    if (launchProfile is not null && !string.IsNullOrWhiteSpace(launchProfile.CommandLineArgs))
+                    var cmdArgs = launchProfile.CommandLineArgs.Split((string?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                    if (cmdArgs is not null && cmdArgs.Length > 0)
                     {
-                        var cmdArgs = launchProfile.CommandLineArgs.Split((string?)null, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
-                        if (cmdArgs is not null && cmdArgs.Length > 0)
-                        {
-                            exeSpec.Args.Add("--");
-                            exeSpec.Args.AddRange(cmdArgs);
-                        }
+                        exeSpec.Args.Add("--");
+                        exeSpec.Args.AddRange(cmdArgs);
                     }
                 }
             }
@@ -1185,32 +1182,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             Logger = resourceLogger
         };
 
-        // Need to apply configuration settings manually; see PrepareExecutables() for details.
-        if (er.ModelResource is ProjectResource project && project.SelectLaunchProfileName() is { } launchProfileName && project.GetLaunchSettings() is { } launchSettings)
-        {
-            ApplyLaunchProfile(er, config, launchProfileName, launchSettings);
-        }
-        else
-        {
-            if (er.ServicesProduced.Count > 0)
-            {
-                if (er.ModelResource is ProjectResource)
-                {
-                    var urls = er.ServicesProduced.Where(IsUnspecifiedHttpService).Select(sar =>
-                    {
-                        var url = sar.EndpointAnnotation.UriScheme + "://localhost:{{- portForServing \"" + sar.Service.Metadata.Name + "\" -}}";
-                        return url;
-                    });
-
-                    // REVIEW: Should we assume ASP.NET Core?
-                    // We're going to use http and https urls as ASPNETCORE_URLS
-                    config["ASPNETCORE_URLS"] = string.Join(";", urls);
-                }
-
-                InjectPortEnvVars(er, config);
-            }
-        }
-
         if (er.ModelResource.TryGetEnvironmentVariables(out var envVarAnnotations))
         {
             foreach (var ann in envVarAnnotations)
@@ -1312,72 +1283,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         }
 
         return value;
-    }
-
-    private static void ApplyLaunchProfile(AppResource executableResource, Dictionary<string, object> config, string launchProfileName, LaunchSettings launchSettings)
-    {
-        // Populate DOTNET_LAUNCH_PROFILE environment variable for consistency with "dotnet run" and "dotnet watch".
-        config.Add("DOTNET_LAUNCH_PROFILE", launchProfileName);
-
-        var launchProfile = launchSettings.Profiles[launchProfileName];
-        if (!string.IsNullOrWhiteSpace(launchProfile.ApplicationUrl))
-        {
-            if (executableResource.DcpResource is ExecutableReplicaSet)
-            {
-                var urls = executableResource.ServicesProduced.Where(IsUnspecifiedHttpService).Select(sar =>
-                {
-                    var url = sar.EndpointAnnotation.UriScheme + "://localhost:{{- portForServing \"" + sar.Service.Metadata.Name + "\" -}}";
-                    return url;
-                });
-
-                config.Add("ASPNETCORE_URLS", string.Join(";", urls));
-            }
-            else
-            {
-                config.Add("ASPNETCORE_URLS", launchProfile.ApplicationUrl);
-            }
-
-            InjectPortEnvVars(executableResource, config);
-        }
-
-        foreach (var envVar in launchProfile.EnvironmentVariables)
-        {
-            string value = Environment.ExpandEnvironmentVariables(envVar.Value);
-            config[envVar.Key] = value;
-        }
-    }
-
-    private static void InjectPortEnvVars(AppResource executableResource, Dictionary<string, object> config)
-    {
-        ServiceAppResource? httpsServiceAppResource = null;
-        // Inject environment variables for services produced by this executable.
-        foreach (var serviceProduced in executableResource.ServicesProduced)
-        {
-            var name = serviceProduced.Service.Metadata.Name;
-            var envVar = serviceProduced.EndpointAnnotation.EnvironmentVariable;
-
-            if (envVar is not null)
-            {
-                config.Add(envVar, $"{{{{- portForServing \"{name}\" }}}}");
-            }
-
-            if (httpsServiceAppResource is null && serviceProduced.EndpointAnnotation.UriScheme == "https")
-            {
-                httpsServiceAppResource = serviceProduced;
-            }
-        }
-
-        // REVIEW: If you run as an executable, we don't know that you're an ASP.NET Core application so we don't want to
-        // inject ASPNETCORE_HTTPS_PORT.
-        if (executableResource.ModelResource is ProjectResource)
-        {
-            // Add the environment variable for the HTTPS port if we have an HTTPS service. This will make sure the
-            // HTTPS redirection middleware avoids redirecting to the internal port.
-            if (httpsServiceAppResource is not null)
-            {
-                config.Add("ASPNETCORE_HTTPS_PORT", $"{{{{- portFor \"{httpsServiceAppResource.Service.Metadata.Name}\" }}}}");
-            }
-        }
     }
 
     private void PrepareContainers()
@@ -1535,14 +1440,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 }
 
                 dcpContainerResource.Spec.Ports.Add(portSpec);
-
-                var name = sp.Service.Metadata.Name;
-                var envVar = sp.EndpointAnnotation.EnvironmentVariable;
-
-                if (envVar is not null)
-                {
-                    config.Add(envVar, $"{{{{- portForServing \"{name}\" }}}}");
-                }
             }
         }
 
@@ -1731,17 +1628,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         }
 
         return uniqueName;
-    }
-
-    // Returns true if this resource represents an HTTP service endpoint which does not specify an environment variable for the endpoint.
-    // This is used to decide whether the endpoint should be propagated via the ASPNETCORE_URLS environment variable.
-    private static bool IsUnspecifiedHttpService(ServiceAppResource serviceAppResource)
-    {
-        return serviceAppResource.EndpointAnnotation is
-        {
-            UriScheme: "http" or "https",
-            EnvironmentVariable: null or { Length: 0 }
-        };
     }
 
     public async Task DeleteResourcesAsync(CancellationToken cancellationToken = default)

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -366,8 +366,6 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 TryAddDependentResources(value);
             }
 
-            WritePortBindingEnvironmentVariables(resource);
-
             Writer.WriteEndObject();
         }
     }
@@ -410,26 +408,6 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
             }
 
             Writer.WriteEndArray();
-        }
-    }
-
-    /// <summary>
-    /// Write environment variables for port bindings related to <see cref="EndpointAnnotation"/> annotations.
-    /// </summary>
-    /// <param name="resource">The <see cref="IResource"/> which contains <see cref="EndpointAnnotation"/> annotations.</param>
-    public void WritePortBindingEnvironmentVariables(IResource resource)
-    {
-        if (resource.TryGetEndpoints(out var endpoints))
-        {
-            foreach (var endpoint in endpoints)
-            {
-                if (endpoint.EnvironmentVariable is null)
-                {
-                    continue;
-                }
-
-                Writer.WriteString(endpoint.EnvironmentVariable, $"{{{resource.Name}.bindings.{endpoint.Name}.targetPort}}");
-            }
         }
     }
 

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class ResourceBuilderExtensions
     /// <param name="name">The name of the environment variable.</param>
     /// <param name="value">The value of the environment variable.</param>
     /// <returns>A resource configured with the specified environment variable.</returns>
-    public static IResourceBuilder<T> WithEnvironment<T>(this IResourceBuilder<T> builder, string name, in ExpressionInterpolatedStringHandler value)
+    public static IResourceBuilder<T> WithEnvironment<T>(this IResourceBuilder<T> builder, string name, in ReferenceExpression.ExpressionInterpolatedStringHandler value)
         where T : IResourceWithEnvironment
     {
         var expression = value.GetExpression();
@@ -416,8 +416,18 @@ public static class ResourceBuilderExtensions
             name: name,
             port: port,
             targetPort: targetPort,
-            env: env,
             isProxied: isProxied);
+
+        // Set the environment variable on the resource
+        if (env is not null && builder.Resource is IResourceWithEndpoints resourceWithEndpoints and IResourceWithEnvironment)
+        {
+            var endpointReference = new EndpointReference(resourceWithEndpoints, annotation);
+
+            builder.WithAnnotation(new EnvironmentCallbackAnnotation(context =>
+            {
+                context.EnvironmentVariables[env] = endpointReference.Property(EndpointProperty.TargetPort);
+            }));
+        }
 
         return builder.WithAnnotation(annotation);
     }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -457,7 +457,7 @@ public class AzureBicepResourceTests
 
         appInsights.Resource.Outputs["appInsightsConnectionString"] = "myinstrumentationkey";
 
-        var serviceA = builder.AddProject<Projects.ServiceA>("serviceA")
+        var serviceA = builder.AddProject<ProjectA>("serviceA")
             .WithReference(appInsights);
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(serviceA.Resource);
@@ -1513,7 +1513,7 @@ public class AzureBicepResourceTests
         var ai = builder.AddAzureApplicationInsights("ai").PublishAsConnectionString();
         var serviceBus = builder.AddAzureServiceBus("servicebus").PublishAsConnectionString();
 
-        var serviceA = builder.AddProject<Projects.ServiceA>("serviceA")
+        var serviceA = builder.AddProject<ProjectA>("serviceA")
             .WithReference(ai)
             .WithReference(serviceBus);
 
@@ -1617,5 +1617,12 @@ public class AzureBicepResourceTests
 
             """;
         Assert.Equal(expectedBicep, manifest.BicepText);
+    }
+
+    private sealed class ProjectA : IProjectMetadata
+    {
+        public string ProjectPath => "projectA";
+
+        public LaunchSettings LaunchSettings { get; } = new();
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
@@ -50,7 +50,7 @@ public class DaprTests
 
         foreach (var e in endpoints)
         {
-            e.AllocatedEndpoint = new(e, "localhost", ports[e.Name]);
+            e.AllocatedEndpoint = new(e, "localhost", ports[e.Name], dcpServiceName: e.Name);
         }
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(container);
@@ -67,11 +67,11 @@ public class DaprTests
             "--app-port",
             "80",
             "--dapr-grpc-port",
-            "{{- portForServing \"name-dapr-cli_grpc\" -}}",
+            "{{- portForServing \"grpc\" -}}",
             "--dapr-http-port",
-            "{{- portForServing \"name-dapr-cli_http\" -}}",
+            "{{- portForServing \"http\" -}}",
             "--metrics-port",
-            "{{- portForServing \"name-dapr-cli_metrics\" -}}",
+            "{{- portForServing \"metrics\" -}}",
             "--app-channel-address",
             "localhost"
         };

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -143,8 +143,7 @@ public class ProjectResourceTests
         var projectResources = appModel.GetProjectResources();
 
         var resource = Assert.Single(projectResources);
-        // LaunchProfileAnnotation isn't public, so we just check the type name
-        Assert.Contains(resource.Annotations, a => a.GetType().Name == "LaunchProfileAnnotation");
+        Assert.Contains(resource.Annotations, a => a is LaunchProfileAnnotation);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -102,7 +103,7 @@ public class WithEndpointTests
     }
 
     [Fact]
-    public void CanAddEndpointsWithContainerPortAndEnv()
+    public async Task CanAddEndpointsWithContainerPortAndEnv()
     {
         using var testProgram = CreateTestProgram();
         testProgram.AppBuilder.AddExecutable("foo", "foo", ".")
@@ -114,13 +115,16 @@ public class WithEndpointTests
         var exeResources = appModel.GetExecutableResources();
 
         var resource = Assert.Single(exeResources);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
+
         Assert.Equal("foo", resource.Name);
         var endpoints = resource.Annotations.OfType<EndpointAnnotation>().ToArray();
         Assert.Single(endpoints);
         Assert.Equal("mybinding", endpoints[0].Name);
         Assert.Equal(3001, endpoints[0].TargetPort);
         Assert.Equal("http", endpoints[0].UriScheme);
-        Assert.Equal("PORT", endpoints[0].EnvironmentVariable);
+        Assert.Equal("3001", config["PORT"]);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -11,105 +12,96 @@ public class WithEnvironmentTests
     [Fact]
     public async Task EnvironmentReferencingEndpointPopulatesWithBindingUrl()
     {
-        using var testProgram = CreateTestProgram();
+        using var builder = TestDistributedApplicationBuilder.Create();
 
-        // Create a binding and its metching annotation (simulating DCP behavior)
-        testProgram.ServiceABuilder.WithHttpsEndpoint(1000, 2000, "mybinding");
-        testProgram.ServiceABuilder.WithEndpoint(
-            "mybinding",
-            e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000));
+        var projectA = builder.AddProject<ProjectA>("project")
+                              .WithHttpsEndpoint(port: 1000, targetPort: 2000, "mybinding")
+                              .WithEndpoint("mybinding", e =>
+                              {
+                                  e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 2000);
+                              });
 
-        testProgram.ServiceBBuilder.WithEnvironment("myName", testProgram.ServiceABuilder.GetEndpoint("mybinding"));
+        var projectB = builder.AddProject<ProjectB>("projectB")
+                               .WithEnvironment("myName", projectA.GetEndpoint("mybinding"));
 
-        testProgram.Build();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectB.Resource);
 
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceBBuilder.Resource);
-
-        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("myName"));
-        Assert.Equal(1, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "myName" && kvp.Value == "https://localhost:2000");
+        Assert.Equal("https://localhost:2000", config["myName"]);
     }
 
     [Fact]
     public async Task SimpleEnvironmentWithNameAndValue()
     {
-        using var testProgram = CreateTestProgram();
+        using var builder = TestDistributedApplicationBuilder.Create();
 
-        testProgram.ServiceABuilder.WithEnvironment("myName", "value");
+        var project = builder.AddProject<ProjectA>("projectA")
+            .WithEnvironment("myName", "value");
 
-        testProgram.Build();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(project.Resource);
 
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource);
-
-        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("myName"));
-        Assert.Equal(1, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "myName" && kvp.Value == "value");
+        Assert.Equal("value", config["myName"]);
     }
 
     [Fact]
     public async Task EnvironmentCallbackPopulatesValueWhenCalled()
     {
-        using var testProgram = CreateTestProgram();
+        using var builder = TestDistributedApplicationBuilder.Create();
 
         var environmentValue = "value";
-        testProgram.ServiceABuilder.WithEnvironment("myName", () => environmentValue);
+        var projectA = builder.AddProject<ProjectA>("projectA").WithEnvironment("myName", () => environmentValue);
 
-        testProgram.Build();
         environmentValue = "value2";
 
         // Call environment variable callbacks.
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource);
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectA.Resource);
 
-        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("myName"));
-        Assert.Equal(1, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "myName" && kvp.Value == "value2");
+        Assert.Equal("value2", config["myName"]);
     }
 
     [Fact]
     public async Task EnvironmentCallbackPopulatesValueWhenParameterResourceProvided()
     {
-        using var testProgram = CreateTestProgram();
-        testProgram.AppBuilder.Configuration["Parameters:parameter"] = "MY_PARAMETER_VALUE";
-        var parameter = testProgram.AppBuilder.AddParameter("parameter");
+        using var builder = TestDistributedApplicationBuilder.Create();
 
-        testProgram.ServiceABuilder.WithEnvironment("MY_PARAMETER", parameter);
+        builder.Configuration["Parameters:parameter"] = "MY_PARAMETER_VALUE";
 
-        testProgram.Build();
+        var parameter = builder.AddParameter("parameter");
 
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource);
+        var projectA = builder.AddProject<ProjectA>("projectA")
+            .WithEnvironment("MY_PARAMETER", parameter);
 
-        Assert.Contains(config, kvp => kvp.Key == "MY_PARAMETER" && kvp.Value == "MY_PARAMETER_VALUE");
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectA.Resource);
+
+        Assert.Equal("MY_PARAMETER_VALUE", config["MY_PARAMETER"]);
     }
 
     [Fact]
     public async Task EnvironmentCallbackPopulatesWithExpressionPlaceholderWhenPublishingManifest()
     {
-        using var testProgram = CreateTestProgram();
-        var parameter = testProgram.AppBuilder.AddParameter("parameter");
+        using var builder = TestDistributedApplicationBuilder.Create();
 
-        testProgram.ServiceABuilder.WithEnvironment("MY_PARAMETER", parameter);
+        var parameter = builder.AddParameter("parameter");
 
-        testProgram.Build();
+        var projectA = builder.AddProject<ProjectA>("projectA")
+            .WithEnvironment("MY_PARAMETER", parameter);
 
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource,
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectA.Resource,
             DistributedApplicationOperation.Publish);
 
-        Assert.Contains(config, kvp => kvp.Key == "MY_PARAMETER" && kvp.Value == "{parameter.value}");
+        Assert.Equal("{parameter.value}", config["MY_PARAMETER"]);
     }
 
     [Fact]
     public async Task EnvironmentCallbackThrowsWhenParameterValueMissingInDcpMode()
     {
-        using var testProgram = CreateTestProgram();
-        var parameter = testProgram.AppBuilder.AddParameter("parameter");
+        using var builder = TestDistributedApplicationBuilder.Create();
 
-        testProgram.ServiceABuilder.WithEnvironment("MY_PARAMETER", parameter);
+        var parameter = builder.AddParameter("parameter");
 
-        testProgram.Build();
+        var projectA = builder.AddProject<ProjectA>("projectA")
+            .WithEnvironment("MY_PARAMETER", parameter);
 
-        var annotations = testProgram.ServiceABuilder.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
-
-        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () => await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource));
+        var exception = await Assert.ThrowsAsync<DistributedApplicationException>(async () => await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectA.Resource));
 
         Assert.Equal("Parameter resource could not be used because configuration key 'Parameters:parameter' is missing and the Parameter has no default value.", exception.Message);
     }
@@ -117,34 +109,32 @@ public class WithEnvironmentTests
     [Fact]
     public async Task ComplexEnvironmentCallbackPopulatesValueWhenCalled()
     {
-        using var testProgram = CreateTestProgram();
+        using var builder = TestDistributedApplicationBuilder.Create();
 
         var environmentValue = "value";
-        testProgram.ServiceABuilder.WithEnvironment((context) =>
-        {
-            context.EnvironmentVariables["myName"] = environmentValue;
-        });
+        var projectA = builder.AddProject<ProjectA>("projectA")
+                              .WithEnvironment(context =>
+                              {
+                                  context.EnvironmentVariables["myName"] = environmentValue;
+                              });
 
-        testProgram.Build();
         environmentValue = "value2";
 
         // Call environment variable callbacks.
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(testProgram.ServiceABuilder.Resource);
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(projectA.Resource);
 
-        var servicesKeysCount = config.Keys.Count(k => k.StartsWith("myName"));
-        Assert.Equal(1, servicesKeysCount);
-        Assert.Contains(config, kvp => kvp.Key == "myName" && kvp.Value == "value2");
+        Assert.Equal("value2", config["myName"]);
     }
 
     [Fact]
     public async Task EnvironmentVariableExpressions()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        using var builder = TestDistributedApplicationBuilder.Create();
 
         var test = builder.AddResource(new TestResource("test", "connectionString"));
 
         var container = builder.AddContainer("container1", "image")
-                               .WithHttpEndpoint(name: "primary")
+                               .WithHttpEndpoint(name: "primary", targetPort: 10005)
                                .WithEndpoint("primary", ep =>
                                {
                                    ep.AllocatedEndpoint = new AllocatedEndpoint(ep, "localhost", 90);
@@ -155,36 +145,64 @@ public class WithEnvironmentTests
         var containerB = builder.AddContainer("container2", "imageB")
                                 .WithEnvironment("URL", $"{endpoint}/foo")
                                 .WithEnvironment("PORT", $"{endpoint.Property(EndpointProperty.Port)}")
+                                .WithEnvironment("TARGET_PORT", $"{endpoint.Property(EndpointProperty.TargetPort)}")
                                 .WithEnvironment("HOST", $"{test.Resource};name=1");
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerB.Resource);
         var manifestConfig = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerB.Resource, DistributedApplicationOperation.Publish);
 
-        Assert.Equal(3, config.Count);
+        Assert.Equal(4, config.Count);
         Assert.Equal($"http://localhost:90/foo", config["URL"]);
         Assert.Equal("90", config["PORT"]);
+        Assert.Equal("10005", config["TARGET_PORT"]);
         Assert.Equal("connectionString;name=1", config["HOST"]);
 
-        Assert.Equal(3, manifestConfig.Count);
+        Assert.Equal(4, manifestConfig.Count);
         Assert.Equal("{container1.bindings.primary.url}/foo", manifestConfig["URL"]);
         Assert.Equal("{container1.bindings.primary.port}", manifestConfig["PORT"]);
+        Assert.Equal("{container1.bindings.primary.targetPort}", manifestConfig["TARGET_PORT"]);
         Assert.Equal("{test.connectionString};name=1", manifestConfig["HOST"]);
+    }
+
+    [Fact]
+    public async Task EnvironmentVariableWithDynamicTargetPort()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var container = builder.AddContainer("container1", "image")
+                               .WithHttpEndpoint(name: "primary")
+                               .WithEndpoint("primary", ep =>
+                               {
+                                   ep.AllocatedEndpoint = new AllocatedEndpoint(ep, "localhost", 90, dcpServiceName: "container1_primary");
+                               });
+
+        var endpoint = container.GetEndpoint("primary");
+
+        var containerB = builder.AddContainer("container2", "imageB")
+                                .WithEnvironment("TARGET_PORT", $"{endpoint.Property(EndpointProperty.TargetPort)}");
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerB.Resource);
+
+        var pair = Assert.Single(config);
+        Assert.Equal("TARGET_PORT", pair.Key);
+        Assert.Equal("""{{- portForServing "container1_primary" -}}""", pair.Value);
     }
 
     [Fact]
     public async Task EnvironmentWithConnectionStringSetsProperEnvironmentVariable()
     {
         // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+
         const string sourceCon = "sourceConnectionString";
-        using var testProgram = CreateTestProgram();
-        var sourceBuilder = testProgram.AppBuilder.AddResource(new TestResource("sourceService", sourceCon));
-        var targetBuilder = testProgram.AppBuilder.AddContainer("targetContainer", "targetImage");
+
+        var sourceBuilder = builder.AddResource(new TestResource("sourceService", sourceCon));
+        var targetBuilder = builder.AddContainer("targetContainer", "targetImage");
 
         string envVarName = "CUSTOM_CONNECTION_STRING";
 
         // Act
         targetBuilder.WithEnvironment(envVarName, sourceBuilder);
-        testProgram.Build();
 
         // Call environment variable callbacks for the Run operation.
         var runConfig = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(targetBuilder.Resource, DistributedApplicationOperation.Run);
@@ -205,5 +223,16 @@ public class WithEnvironmentTests
             ReferenceExpression.Create($"{connectionString}");
     }
 
-    private static TestProgram CreateTestProgram(string[]? args = null) => TestProgram.Create<WithReferenceTests>(args);
+    private sealed class ProjectA : IProjectMetadata
+    {
+        public string ProjectPath => "projectA";
+
+        public LaunchSettings LaunchSettings { get; } = new();
+    }
+
+    private sealed class ProjectB : IProjectMetadata
+    {
+        public string ProjectPath => "projectB";
+        public LaunchSettings LaunchSettings { get; } = new();
+    }
 }


### PR DESCRIPTION
- Change how we process and expose target ports. This change makes it possible to avoid using any internals of DCP to access and resolve target ports from any resource.
- More launch profile processing to the project resource defaults.
- Remove logic in the manifest writing that wrote a special env variable. This should just work now  like everything else.
- Exposed TargetPort and Exists on EndpointReference.
- Use this new target property with dapr.
- Added a ReferenceExpressionBuilder which makes it possible to dynamically build a ReferenceExpression.
- Endpoints and env are evaluated earlier now so change remove tests that add default launch profile on real projects without allocating those endpoints.

cc @DamianEdwards this should fix dapr and the tests.

Goal is to have this go into p6 (API fit and finish).