### PR TITLE
Update FluentUI Blazor to 4.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -83,8 +83,8 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="13.0.11" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.5.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.5.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.6.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.6.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.24.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.5" />


### PR DESCRIPTION
We have two things coming in for Preview 6/GA (accessibility and login status UI) that will/might make use of a 4.6+ release. To make sure we're getting coverage/validation on testing for any regressions, going ahead and updating main to 4.6 here. We can update to whichever the build is that contains the accessibility changes as soon as it is available, but I'm assuming that will contain a much smaller delta than the 4.6 -> 4.6 change does.

@kvenkatrajan I assume this then should be backported to release/8.0 as well, so we are getting the testing/validation on that branch specifically?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3322)