### PR TITLE
Add missing QueuePolicy in AWS Playground AppHost

### DIFF
--- a/playground/AWS/AWS.AppHost/app-resources.template
+++ b/playground/AWS/AWS.AppHost/app-resources.template
@@ -20,6 +20,32 @@
                     {"Protocol" : "sqs", "Endpoint" : {"Fn::GetAtt" : [ "ChatMessagesQueue", "Arn"]}}
                 ]
             }
+        },
+        "ChatMessagesQueuePolicy": {
+            "Type": "AWS::SQS::QueuePolicy",
+            "Properties": {
+                "Queues": [
+                    { "Ref": "ChatMessagesQueue" }
+                ],
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": "sqs:SendMessage",
+                            "Principal": {
+                                "Service": "sns.amazonaws.com"
+                            },
+                            "Resource": { "Fn::GetAtt": [ "ChatMessagesQueue", "Arn" ] },
+                            "Condition": {
+                                "ArnEquals": {
+                                    "aws:SourceArn": { "Ref": "ChatTopic" }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
         }
     },
     "Outputs" : {


### PR DESCRIPTION
The sample CloudFormation template configures a subscription for the SQS Queue to receive messages from the SNS Topic, but no QueuePolicy is configured which results in: `User: arn:aws:iam::111111111111:user/DUB.SQS is not authorized to perform: sqs:sendmessage on resource: arn:aws:sqs:eu-west-1:222222222222:AspireSampleDevResources-ChatMessagesQueue-abcdef123456 because no resource-based policy allows the sqs:sendmessage action`.

This pull request adds a QueuePolicy allowing SNS to deliver messages to the ChatMessagesQueue.