### PR TITLE
Publish build assets in the build stage

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -129,6 +129,7 @@ extends:
           enableTelemetry: true
           enableSourceBuild: true
           enableSourceIndex: false
+          publishAssetsImmediately: true
           # Publish build logs
           enablePublishBuildArtifacts: true
           # Publish test logs
@@ -204,27 +205,4 @@ extends:
             LclPackageId: 'LCL-JUNO-PROD-ASPIRE'
             MirrorRepo: aspire
             MirrorBranch: main
-
-    - template: /eng/common/templates-official/post-build/post-build.yml@self
-      parameters:
-        validateDependsOn:
-        - build
-        publishAssetsImmediately: true
-        enableSymbolValidation: false
-        enableSigningValidation: false
-        enableNugetValidation: false
-        enableSourceLinkValidation: false
-        SDLValidationParameters:
-          enable: false
-          params: ' -SourceToolsList $(_TsaSourceToolsList)
-            -TsaInstanceURL $(_TsaInstanceURL)
-            -TsaProjectName $(_TsaProjectName)
-            -TsaNotificationEmail $(_TsaNotificationEmail)
-            -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-            -TsaBugAreaPath $(_TsaBugAreaPath)
-            -TsaIterationPath $(_TsaIterationPath)
-            -TsaRepositoryName $(_TsaRepositoryName)
-            -TsaCodebaseName $(_TsaCodebaseName)
-            -TsaOnboard $(_TsaOnboard)
-            -TsaPublish $(_TsaPublish)'
 

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -209,12 +209,11 @@ extends:
       parameters:
         validateDependsOn:
         - build
-        publishingInfraVersion: 3
+        publishAssetsImmediately: true
         enableSymbolValidation: false
         enableSigningValidation: false
         enableNugetValidation: false
         enableSourceLinkValidation: false
-        # these param values come from the DotNet-Winforms-SDLValidation-Params azdo variable group
         SDLValidationParameters:
           enable: false
           params: ' -SourceToolsList $(_TsaSourceToolsList)


### PR DESCRIPTION
As per offline discussion with @mmitche. This is a build optimisation.

* Before 1ES:
![image](https://github.com/dotnet/aspire/assets/4403806/339cbbfe-ed3f-4ef7-9743-73c874d810eb)
* With 1ES:
![image](https://github.com/dotnet/aspire/assets/4403806/6cfa7b47-8ce5-427f-921a-1462d5dec6c0)

* After:
![image](https://github.com/dotnet/aspire/assets/4403806/291a7286-4b3a-4b84-a22b-db93f06ed17f)



Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2419842&view=logs&j=d17d50ef-afac-5d4b-95a6-3014ce5cf7a4&t=95fe4740-169e-5ca1-2f88-330db40deac4
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3334)