### PR TITLE
Custom Manifest Output & Custom Identities for Projects

### DIFF
--- a/src/Aspire.Hosting.Azure/ApplicationModel/UserAssignedIdentityAnnotation.cs
+++ b/src/Aspire.Hosting.Azure/ApplicationModel/UserAssignedIdentityAnnotation.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure.ApplicationModel;
+
+/// <summary>
+/// Represents a user assigned identity that should be assigned to a project.
+/// </summary>
+public class UserAssignedIdentityAnnotation : CustomManifestOutputAnnotation
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="UserAssignedIdentityAnnotation"/>.
+    /// </summary>
+    /// <param name="identityId">The identity ID to be assigned to the </param>
+    public UserAssignedIdentityAnnotation(string identityId) : base("userAssignedIdentities", identityId)
+    {
+    }
+}

--- a/src/Aspire.Hosting.Azure/ApplicationModel/UserAssignedIdentityAnnotation.cs
+++ b/src/Aspire.Hosting.Azure/ApplicationModel/UserAssignedIdentityAnnotation.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Azure.ApplicationModel;
@@ -11,10 +12,47 @@ namespace Aspire.Hosting.Azure.ApplicationModel;
 public class UserAssignedIdentityAnnotation : CustomManifestOutputAnnotation
 {
     /// <summary>
+    /// The Environment Variable Prefix.
+    /// </summary>
+    public string EnvironmentVariablePrefix => ((UserAssignedIdentityDescriptor)Value).EnvironmentVariablePrefix;
+
+    /// <summary>
     /// Initializes a new instance of <see cref="UserAssignedIdentityAnnotation"/>.
     /// </summary>
-    /// <param name="identityId">The identity ID to be assigned to the </param>
-    public UserAssignedIdentityAnnotation(string identityId) : base("userAssignedIdentities", identityId)
+    /// <param name="envPrefix">Environment Variable prefix for the Client ID.</param>
+    /// <param name="clientId">The identity's Client ID for usage within the app.</param>
+    /// <param name="identityResourceId">The identity Resource ID for assignment to the container app.</param>
+    public UserAssignedIdentityAnnotation(string envPrefix, string clientId, string identityResourceId) : base("userAssignedIdentities", new UserAssignedIdentityDescriptor(envPrefix, clientId, identityResourceId))
     {
     }
+}
+
+/// <summary>
+/// User Assigned Identity Descriptor for output in to the manifest.
+/// </summary>
+public sealed record UserAssignedIdentityDescriptor
+{
+    /// <summary>
+    /// Identity Client ID.
+    /// </summary>
+    [JsonPropertyName("clientId")]
+    public string ClientId { get; init; }
+    /// <summary>
+    /// Identity Resource ID.
+    /// </summary>
+    [JsonPropertyName("resourceId")]
+    public string IdentityResourceId { get; init; }
+    /// <summary>
+    /// Environment Variable Prefix.
+    /// </summary>
+    [JsonPropertyName("env")]
+    public string EnvironmentVariablePrefix { get; init; }
+
+    /// <summary>
+    /// Creates a new <see cref="UserAssignedIdentityDescriptor"/>.
+    /// </summary>
+    /// <param name="envPrefix">Environment Variable prefix for the Client ID.</param>
+    /// <param name="clientId">The identity's Client ID for usage within the app.</param>
+    /// <param name="identityResourceId">The identity Resource ID for assignment to the container app.</param>
+    public UserAssignedIdentityDescriptor(string envPrefix, string clientId, string identityResourceId) => (ClientId, IdentityResourceId, EnvironmentVariablePrefix) = (clientId, identityResourceId, envPrefix);
 }

--- a/src/Aspire.Hosting.Azure/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure/ProjectResourceBuilderExtensions.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// Provides extension methods for building a project resource.
+/// </summary>
+public static class ProjectResourceBuilderExtensions
+{
+    /// <summary>
+    /// Adds a User Assigned Identity to the project.
+    /// </summary>
+    /// <param name="builder">The project resource builder.</param>
+    /// <param name="identityId">The ID of the Managed Identity.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<ProjectResource> WithUserAssignedIdentity(this IResourceBuilder<ProjectResource> builder, string identityId)
+    {
+        builder.WithAnnotation(new UserAssignedIdentityAnnotation(identityId));
+        return builder;
+    }
+}

--- a/src/Aspire.Hosting.Azure/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Azure/ProjectResourceBuilderExtensions.cs
@@ -22,4 +22,15 @@ public static class ProjectResourceBuilderExtensions
         builder.WithAnnotation(new UserAssignedIdentityAnnotation(identityId));
         return builder;
     }
+
+    /// <summary>
+    /// Adds a User Assigned Identity to the project using a Bicep output reference.
+    /// </summary>
+    /// <param name="builder">The project resource builder.</param>
+    /// <param name="bicepOutputReference">The reference to the bicep output.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<ProjectResource> WithUserAssignedIdentity(this IResourceBuilder<ProjectResource> builder, BicepOutputReference bicepOutputReference)
+    {
+        return builder.WithAnnotation(new UserAssignedIdentityAnnotation(bicepOutputReference.ValueExpression));
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/CustomManifestOutputAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomManifestOutputAnnotation.cs
@@ -1,14 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
-
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
 /// Represents a custom annotation that can be applied to a resource with varying methods of implementation depending on the consumer of the manifest.
 ///
-/// Produces output such as `"custom": { "name": "value" }`.
+/// Produces output such as `"name": [
+///     "value"
+/// ]`.
 /// </summary>
 public class CustomManifestOutputAnnotation : IResourceAnnotation
 {
@@ -23,32 +23,14 @@ public class CustomManifestOutputAnnotation : IResourceAnnotation
     public object Value { get; }
 
     /// <summary>
-    /// The type of value being written.
-    /// </summary>
-    public JsonValueKind ValueKind { get; } = JsonValueKind.String;
-
-    /// <summary>
-    /// Create a custom annotation with the specified name and value, where the value is a string.
+    /// Create a custom annotation with the specified name and value.
     /// </summary>
     /// <param name="name">Name of the annotation.</param>
-    /// <param name="value">String value.</param>
-    public CustomManifestOutputAnnotation(string name, string value)
+    /// <param name="value">Value to be serialized and output.</param>
+    public CustomManifestOutputAnnotation(string name, object value)
     {
         Name = name;
         Value = value;
-    }
-
-    /// <summary>
-    /// Create a custom annotation with the specified name, value and type.
-    /// </summary>
-    /// <param name="name">Name of the annotation.</param>
-    /// <param name="value">Value of the annotation.</param>
-    /// <param name="valueKind">Type of the value to be output.</param>
-    public CustomManifestOutputAnnotation(string name, object value, JsonValueKind valueKind)
-    {
-        Name = name;
-        Value = value;
-        ValueKind = valueKind;
     }
 }
 

--- a/src/Aspire.Hosting/ApplicationModel/CustomManifestOutputAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomManifestOutputAnnotation.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a custom annotation that can be applied to a resource with varying methods of implementation depending on the consumer of the manifest.
+///
+/// Produces output such as `"custom": { "name": "value" }`.
+/// </summary>
+public sealed class CustomManifestOutputAnnotation : IResourceAnnotation
+{
+    /// <summary>
+    /// Name of the custom manifest annotation.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Value of the custom manifest annotation.
+    /// </summary>
+    public object Value { get; }
+
+    /// <summary>
+    /// The type of value being written.
+    /// </summary>
+    public JsonValueKind ValueKind { get; } = JsonValueKind.String;
+
+    /// <summary>
+    /// Create a custom annotation with the specified name and value, where the value is a string.
+    /// </summary>
+    /// <param name="name">Name of the annotation.</param>
+    /// <param name="value">String value.</param>
+    public CustomManifestOutputAnnotation(string name, string value)
+    {
+        Name = name;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Create a custom annotation with the specified name, value and type.
+    /// </summary>
+    /// <param name="name">Name of the annotation.</param>
+    /// <param name="value">Value of the annotation.</param>
+    /// <param name="valueKind">Type of the value to be output.</param>
+    public CustomManifestOutputAnnotation(string name, object value, JsonValueKind valueKind)
+    {
+        Name = name;
+        Value = value;
+        ValueKind = valueKind;
+    }
+}
+

--- a/src/Aspire.Hosting/ApplicationModel/CustomManifestOutputAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomManifestOutputAnnotation.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.ApplicationModel;
 ///
 /// Produces output such as `"custom": { "name": "value" }`.
 /// </summary>
-public sealed class CustomManifestOutputAnnotation : IResourceAnnotation
+public class CustomManifestOutputAnnotation : IResourceAnnotation
 {
     /// <summary>
     /// Name of the custom manifest annotation.

--- a/tests/Aspire.Hosting.Tests/Azure/AzureProjectProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureProjectProvisionerTests.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Azure;
+using Aspire.Hosting.Utils;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Azure;
+
+public class AzureProjectProvisionerTests
+{
+    [Fact]
+    public async Task EnsureUserAssignedIdentityAddedToManifest()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var projectResource = builder.AddProject<Projects.ServiceA>("servicea")
+            .WithUserAssignedIdentity("00000000-0000-0000-0000-000000000000");
+
+        var manifest = await ManifestUtils.GetManifest(projectResource.Resource);
+
+        var expectedManifest = """
+           {
+             "type": "project.v0",
+             "path": "../../../../../tests/testproject/TestProject.ServiceA/TestProject.ServiceA.csproj",
+             "env": {
+               "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+               "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true"
+             },
+             "bindings": {
+               "http": {
+                 "scheme": "http",
+                 "protocol": "tcp",
+                 "transport": "http",
+                 "port": 5156
+               }
+             },
+             "userAssignedIdentities": [
+               "00000000-0000-0000-0000-000000000000"
+             ]
+           }
+           """;
+
+        Assert.Equal(expectedManifest, manifest.ToString());
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Azure/AzureProjectProvisionerTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureProjectProvisionerTests.cs
@@ -15,7 +15,7 @@ public class AzureProjectProvisionerTests
         using var builder = TestDistributedApplicationBuilder.Create();
 
         var projectResource = builder.AddProject<Projects.ServiceA>("servicea")
-            .WithUserAssignedIdentity("00000000-0000-0000-0000-000000000000");
+            .WithUserAssignedIdentity("TEST", "00000000-0000-0000-0000-000000000000", "/subscriptions/<subscription_id>/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-user");
 
         var manifest = await ManifestUtils.GetManifest(projectResource.Resource);
 
@@ -36,7 +36,51 @@ public class AzureProjectProvisionerTests
                }
              },
              "userAssignedIdentities": [
-               "00000000-0000-0000-0000-000000000000"
+               {
+                 "clientId": "00000000-0000-0000-0000-000000000000",
+                 "resourceId": "/subscriptions/\u003Csubscription_id\u003E/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-user",
+                 "env": "TEST"
+               }
+             ]
+           }
+           """;
+
+        Assert.Equal(expectedManifest, manifest.ToString());
+    }
+
+    [Fact]
+    public async Task EnsureUserAssignedIdentityFromBicepAddedToManifest()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var bicepResource = builder.AddBicepTemplateString("identities", "test");
+        var projectResource = builder.AddProject<Projects.ServiceA>("servicea")
+            .WithUserAssignedIdentity("TEST", bicepResource.GetOutput("clientId"), bicepResource.GetOutput("resourceId"));
+
+        var manifest = await ManifestUtils.GetManifest(projectResource.Resource);
+
+        var expectedManifest = """
+           {
+             "type": "project.v0",
+             "path": "../../../../../tests/testproject/TestProject.ServiceA/TestProject.ServiceA.csproj",
+             "env": {
+               "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+               "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true"
+             },
+             "bindings": {
+               "http": {
+                 "scheme": "http",
+                 "protocol": "tcp",
+                 "transport": "http",
+                 "port": 5156
+               }
+             },
+             "userAssignedIdentities": [
+               {
+                 "clientId": "{identities.outputs.clientId}",
+                 "resourceId": "{identities.outputs.resourceId}",
+                 "env": "TEST"
+               }
              ]
            }
            """;

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -5,7 +5,6 @@ using System.Text.Json;
 using Aspire.Hosting.Publishing;
 using Aspire.Hosting.Tests.Helpers;
 using Aspire.Hosting.Utils;
-using IdentityModel.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -534,12 +533,12 @@ public class ManifestGenerationTests
         var resources = publisher.ManifestDocument.RootElement.GetProperty("resources");
 
         var service = resources.GetProperty("servicea");
-        var annotation = service.TryGetValue("testStringAnnotation");
-        Assert.Equal(JsonValueKind.Array, annotation.ValueKind);
-        Assert.Equal("TestValue", annotation[0].GetString());
-        Assert.True(service.TryGetValue("testTrueAnnotation")[0].GetBoolean());
-        Assert.False(service.TryGetValue("testFalseAnnotation")[0].GetBoolean());
-        Assert.Equal(42, service.TryGetValue("testNumberAnnotation")[0].GetInt32());
+        Assert.True(service.TryGetProperty("testStringAnnotation", out var testStringAnnotation));
+        Assert.Equal(JsonValueKind.Array, testStringAnnotation.ValueKind);
+        Assert.Equal("TestValue", testStringAnnotation[0].GetString());
+        Assert.True(service.GetProperty("testTrueAnnotation")[0].GetBoolean());
+        Assert.False(service.GetProperty("testFalseAnnotation")[0].GetBoolean());
+        Assert.Equal(42, service.GetProperty("testNumberAnnotation")[0].GetInt32());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -521,9 +521,9 @@ public class ManifestGenerationTests
 
         program.ServiceABuilder
             .WithAnnotation(new CustomManifestOutputAnnotation("testStringAnnotation", "TestValue"))
-            .WithAnnotation(new CustomManifestOutputAnnotation("testTrueAnnotation", true, JsonValueKind.True))
-            .WithAnnotation(new CustomManifestOutputAnnotation("testFalseAnnotation", false, JsonValueKind.False))
-            .WithAnnotation(new CustomManifestOutputAnnotation("testNumberAnnotation", 42, JsonValueKind.Number));
+            .WithAnnotation(new CustomManifestOutputAnnotation("testTrueAnnotation", true))
+            .WithAnnotation(new CustomManifestOutputAnnotation("testFalseAnnotation", false))
+            .WithAnnotation(new CustomManifestOutputAnnotation("testNumberAnnotation", 42));
 
         // Build AppHost so that publisher can be resolved.
         program.Build();


### PR DESCRIPTION
I'm not sure if this is helpful to the wider project, but the ability to support different Managed Identities for a deployed Project is super useful.

Some semi-related issues: https://github.com/dotnet/aspire/issues/2730 https://github.com/dotnet/aspire/issues/1864 

### What is this

For example, consider 4 apps (A, B, C, D). We may want to configure that A and B can access C, but only B can access D. Within ACA by default it's a free for all so we have to rely on our own auth implementation.

The best way to do this is with specific managed identities for each application and use MSAL for request authorisation, yet right now there is no System Assigned Identity and only the User Assigned Identity that's used for the Container Registry.

This change introduces 2 core concepts:
- `Aspire.Hosting`: Custom Manifest Output (via Annotation)
- `Aspire.Hosting.Azure`: User Assigned Identity support against the project resource

The former allows anyone to define a custom output in to the manifest that may be useful for other tools in the future, but is basically groundwork to support this Azure specific extension.

The latter can be used either with hardcoded paths or through a Bicep/AzureConstruct (https://github.com/dotnet/aspire/pull/2429)* Resource.

### Usage

```csharp
var projectResource = builder.AddProject<Projects.ServiceA>("servicea")
    .WithUserAssignedIdentity("IDEN1", "00000000-0000-0000-0000-000000000000", "/subscriptions/<subscription_id>/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-user")
    .WithUserAssignedIdentity("IDEN2", bicepResource.GetOutput("clientId"), bicepResource.GetOutput("resourceId"));
```

This outputs the following to the manifest:

```json
"userAssignedIdentities": [
 {
   "clientId": "00000000-0000-0000-0000-000000000000",
   "resourceId": "/subscriptions/\u003Csubscription_id\u003E/resourcegroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-user",
   "env": "IDEN1"
 }
 {
   "clientId": "{identities.outputs.clientId}",
   "resourceId": "{identities.outputs.resourceId}",
   "env": "IDEN2"
 }
]
```

Which can then be consumed by `azd` (See https://github.com/Azure/azure-dev/pull/3634) that add in the appropriate Client IDs for the app to use, in this case `IDEN1_CLIENT_ID` and `IDEN2_CLIENT_ID`.

### Other approaches considered
Originally, I'd planned to just output the Resource ID from here that would be consumed by `azd` to wire up the `userAssignedIdentity` on the container as that's the only thing really required that can't be done outside of Bicep. The `WithUserAssignedIdentity` would then wire up both the output of this Resource ID and the Environment Variable separately.

Whilst this reduces the amount of work that `azd` would have to do, it feels a bit less "general purpose".

What I mean by that is two fold, in our scenario we'd like both the Client ID for use in external apps (done as part of this) and the Principal ID (can be easily added to this - right now we just look up using the resource ID) for assignment of this identity to an app registration to use in the Graph API.

Basically, having _more_ information in the manifest feels preferable to less, even if it means slightly more work for `azd` to perform.

------

As I said at the start, I'm not sure how this really fits in to Aspire as a whole as it's definitively deployment related, but it's helped me to wire things up much easier in a "proper" way as the alternative is modifying the generated Bicep and .yaml files for each container, whereas with this we only need to provide the Bicep for the Identity creation (and in the future, hopefully use the new Construct methods).

This as usual with my stuff relates to https://github.com/Azure/azure-dev/discussions/3184, and whilst I'm aware that changes are incoming I didn't see anything about managed identity per-app support in any other discussions.

`*` There probably needs `Aspire.Hosting.Azure.ManagedServiceIdentities` or similar which I'd be happy to contribute as part of this PR if you confirm this is a right path to take. It's obviously a relatively simple resource:

```csharp
var bicepResource = builder.AddAzureConstruct("identity", construct =>
{
    var uai = new UserAssignedIdentity(construct, name: "testIdentity");
    uai.AddOutput("resourceId", sa => sa.Id);
    uai.AddOutput("clientId", sa => sa.ClientId);
});
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3339)