### PR TITLE
[release/8.0] Dashboard should request log streams only when the user gestures to display them

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Aspire.Dashboard.Otlp.Storage;
 using Microsoft.Extensions.Logging;
@@ -15,11 +16,29 @@ public class ResourceLoggerService
 {
     private readonly ConcurrentDictionary<string, ResourceLoggerState> _loggers = new();
 
+    private Action<(string, ResourceLoggerState)>? _loggerAdded;
+    private event Action<(string, ResourceLoggerState)> LoggerAdded
+    {
+        add
+        {
+            _loggerAdded += value;
+
+            foreach (var logger in _loggers)
+            {
+                value((logger.Key, logger.Value));
+            }
+        }
+        remove
+        {
+            _loggerAdded -= value;
+        }
+    }
+
     /// <summary>
     /// Gets the logger for the resource to write to.
     /// </summary>
     /// <param name="resource">The resource name</param>
-    /// <returns>An <see cref="ILogger"/>.</returns>
+    /// <returns>An <see cref="ILogger"/> which represents the resource.</returns>
     public ILogger GetLogger(IResource resource)
     {
         ArgumentNullException.ThrowIfNull(resource);
@@ -31,7 +50,7 @@ public class ResourceLoggerService
     /// Gets the logger for the resource to write to.
     /// </summary>
     /// <param name="resourceName">The name of the resource from the Aspire application model.</param>
-    /// <returns>An <see cref="ILogger"/> which repesents the named resource.</returns>
+    /// <returns>An <see cref="ILogger"/> which represents the named resource.</returns>
     public ILogger GetLogger(string resourceName)
     {
         ArgumentNullException.ThrowIfNull(resourceName);
@@ -42,8 +61,20 @@ public class ResourceLoggerService
     /// <summary>
     /// Watch for changes to the log stream for a resource.
     /// </summary>
+    /// <param name="resource">The resource to watch for logs.</param>
+    /// <returns>An async enumerable that returns the logs as they are written.</returns>
+    public IAsyncEnumerable<IReadOnlyList<LogLine>> WatchAsync(IResource resource)
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+
+        return WatchAsync(resource.Name);
+    }
+
+    /// <summary>
+    /// Watch for changes to the log stream for a resource.
+    /// </summary>
     /// <param name="resourceName">The resource name</param>
-    /// <returns></returns>
+    /// <returns>An async enumerable that returns the logs as they are written.</returns>
     public IAsyncEnumerable<IReadOnlyList<LogLine>> WatchAsync(string resourceName)
     {
         ArgumentNullException.ThrowIfNull(resourceName);
@@ -52,15 +83,39 @@ public class ResourceLoggerService
     }
 
     /// <summary>
-    /// Watch for changes to the log stream for a resource.
+    /// Watch for subscribers to the log stream for a resource.
     /// </summary>
-    /// <param name="resource">The resource to watch for logs.</param>
-    /// <returns></returns>
-    public IAsyncEnumerable<IReadOnlyList<LogLine>> WatchAsync(IResource resource)
+    /// <returns>
+    /// An async enumerable that returns when the first subscriber is added to a log,
+    /// or when the last subscriber is removed.
+    /// </returns>
+    public async IAsyncEnumerable<LogSubscriber> WatchAnySubscribersAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(resource);
+        var channel = Channel.CreateUnbounded<LogSubscriber>();
 
-        return WatchAsync(resource.Name);
+        void OnLoggerAdded((string Name, ResourceLoggerState State) loggerItem)
+        {
+            var (name, state) = loggerItem;
+
+            state.OnSubscribersChanged += (hasSubscribers) =>
+            {
+                channel.Writer.TryWrite(new(name, hasSubscribers));
+            };
+        }
+
+        LoggerAdded += OnLoggerAdded;
+
+        try
+        {
+            await foreach (var entry in channel.Reader.ReadAllAsync(cancellationToken))
+            {
+                yield return entry;
+            }
+        }
+        finally
+        {
+            LoggerAdded -= OnLoggerAdded;
+        }
     }
 
     /// <summary>
@@ -91,8 +146,27 @@ public class ResourceLoggerService
         }
     }
 
+    /// <summary>
+    /// Clears the log stream's backlog for the resource.
+    /// </summary>
+    public void ClearBacklog(string resourceName)
+    {
+        ArgumentNullException.ThrowIfNull(resourceName);
+
+        if (_loggers.TryGetValue(resourceName, out var logger))
+        {
+            logger.ClearBacklog();
+        }
+    }
+
     private ResourceLoggerState GetResourceLoggerState(string resourceName) =>
-        _loggers.GetOrAdd(resourceName, _ => new ResourceLoggerState());
+        _loggers.GetOrAdd(resourceName, (name, context) =>
+        {
+            var state = new ResourceLoggerState();
+            context._loggerAdded?.Invoke((name, state));
+            return state;
+        },
+        this);
 
     /// <summary>
     /// A logger for the resource to write to.
@@ -102,7 +176,6 @@ public class ResourceLoggerService
         private readonly ResourceLogger _logger;
         private readonly CancellationTokenSource _logStreamCts = new();
 
-        // History of logs, capped at 10000 entries.
         private readonly CircularBuffer<LogLine> _backlog = new(10000);
 
         /// <summary>
@@ -113,21 +186,112 @@ public class ResourceLoggerService
             _logger = new ResourceLogger(this);
         }
 
+        private Action<bool>? _onSubscribersChanged;
+        public event Action<bool> OnSubscribersChanged
+        {
+            add
+            {
+                _onSubscribersChanged += value;
+
+                var hasSubscribers = false;
+
+                lock (this)
+                {
+                    if (_onNewLog is not null) // we have subscribers
+                    {
+                        hasSubscribers = true;
+                    }
+                }
+
+                if (hasSubscribers)
+                {
+                    value(hasSubscribers);
+                }
+            }
+            remove
+            {
+                _onSubscribersChanged -= value;
+            }
+        }
+
         /// <summary>
         /// Watch for changes to the log stream for a resource.
         /// </summary>
         /// <returns>The log stream for the resource.</returns>
-        public IAsyncEnumerable<IReadOnlyList<LogLine>> WatchAsync()
+        public async IAsyncEnumerable<IReadOnlyList<LogLine>> WatchAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            lock (_backlog)
+            var channel = Channel.CreateUnbounded<LogLine>();
+
+            using var _ = _logStreamCts.Token.Register(() => channel.Writer.TryComplete());
+
+            void Log(LogLine log)
             {
-                // REVIEW: Performance makes me very sad, but we can optimize this later.
-                return new LogAsyncEnumerable(this, _backlog.ToList());
+                channel.Writer.TryWrite(log);
+            }
+
+            OnNewLog += Log;
+
+            // ensure the backlog snapshot is taken after subscribing to OnNewLog
+            // to ensure the backlog snapshot contains the correct logs. The backlog
+            // can get cleared when there are no subscribers, so we ensure we are subscribing first.
+
+            // REVIEW: Performance makes me very sad, but we can optimize this later.
+            var backlogSnapshot = GetBacklogSnapshot();
+            if (backlogSnapshot.Length > 0)
+            {
+                yield return backlogSnapshot;
+            }
+
+            try
+            {
+                await foreach (var entry in channel.GetBatchesAsync(cancellationToken: cancellationToken))
+                {
+                    yield return entry;
+                }
+            }
+            finally
+            {
+                OnNewLog -= Log;
+
+                channel.Writer.TryComplete();
             }
         }
 
         // This provides the fan out to multiple subscribers.
-        private Action<LogLine>? OnNewLog { get; set; }
+        private Action<LogLine>? _onNewLog;
+        private event Action<LogLine> OnNewLog
+        {
+            add
+            {
+                bool raiseSubscribersChanged;
+                lock (this)
+                {
+                    raiseSubscribersChanged = _onNewLog is null; // is this the first subscriber?
+
+                    _onNewLog += value;
+                }
+
+                if (raiseSubscribersChanged)
+                {
+                    _onSubscribersChanged?.Invoke(true);
+                }
+            }
+            remove
+            {
+                bool raiseSubscribersChanged;
+                lock (this)
+                {
+                    _onNewLog -= value;
+
+                    raiseSubscribersChanged = _onNewLog is null; // is this the last subscriber?
+                }
+
+                if (raiseSubscribersChanged)
+                {
+                    _onSubscribersChanged?.Invoke(false);
+                }
+            }
+        }
 
         /// <summary>
         /// The logger for the resource to write to. This will write updates to the live log stream for this resource.
@@ -143,7 +307,23 @@ public class ResourceLoggerService
             _logStreamCts.Cancel();
         }
 
-        private sealed class ResourceLogger(ResourceLoggerState annotation) : ILogger
+        public void ClearBacklog()
+        {
+            lock (_backlog)
+            {
+                _backlog.Clear();
+            }
+        }
+
+        private LogLine[] GetBacklogSnapshot()
+        {
+            lock (_backlog)
+            {
+                return [.. _backlog];
+            }
+        }
+
+        private sealed class ResourceLogger(ResourceLoggerState loggerState) : ILogger
         {
             private int _lineNumber;
 
@@ -153,7 +333,7 @@ public class ResourceLoggerService
 
             public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
             {
-                if (annotation._logStreamCts.IsCancellationRequested)
+                if (loggerState._logStreamCts.IsCancellationRequested)
                 {
                     // Noop if logging after completing the stream
                     return;
@@ -163,52 +343,23 @@ public class ResourceLoggerService
                 var isErrorMessage = logLevel >= LogLevel.Error;
 
                 LogLine logLine;
-                lock (annotation._backlog)
+                lock (loggerState._backlog)
                 {
                     _lineNumber++;
                     logLine = new LogLine(_lineNumber, log, isErrorMessage);
 
-                    annotation._backlog.Add(logLine);
+                    loggerState._backlog.Add(logLine);
                 }
 
-                annotation.OnNewLog?.Invoke(logLine);
-            }
-        }
-
-        private sealed class LogAsyncEnumerable(ResourceLoggerState annotation, List<LogLine> backlogSnapshot) : IAsyncEnumerable<IReadOnlyList<LogLine>>
-        {
-            public async IAsyncEnumerator<IReadOnlyList<LogLine>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-            {
-                if (backlogSnapshot.Count > 0)
-                {
-                    yield return backlogSnapshot;
-                }
-
-                var channel = Channel.CreateUnbounded<LogLine>();
-
-                using var _ = annotation._logStreamCts.Token.Register(() => channel.Writer.TryComplete());
-
-                void Log(LogLine log)
-                {
-                    channel.Writer.TryWrite(log);
-                }
-
-                annotation.OnNewLog += Log;
-
-                try
-                {
-                    await foreach (var entry in channel.GetBatchesAsync(cancellationToken: cancellationToken))
-                    {
-                        yield return entry;
-                    }
-                }
-                finally
-                {
-                    annotation.OnNewLog -= Log;
-
-                    channel.Writer.TryComplete();
-                }
+                loggerState._onNewLog?.Invoke(logLine);
             }
         }
     }
 }
+
+/// <summary>
+/// Represents a log subscriber for a resource.
+/// </summary>
+/// <param name="Name">The the resource name.</param>
+/// <param name="AnySubscribers">Determines if there are any subscribers.</param>
+public readonly record struct LogSubscriber(string Name, bool AnySubscribers);

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 
@@ -22,8 +23,40 @@ public class ResourceNotificationService(ILogger<ResourceNotificationService> lo
     /// Watch for changes to the state for all resources.
     /// </summary>
     /// <returns></returns>
-    public IAsyncEnumerable<ResourceEvent> WatchAsync() =>
-        new AllResourceUpdatesAsyncEnumerable(this);
+    public async IAsyncEnumerable<ResourceEvent> WatchAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Return the last snapshot for each resource.
+        foreach (var state in _resourceNotificationStates)
+        {
+            var (resource, resourceId) = state.Key;
+
+            if (state.Value.LastSnapshot is not null)
+            {
+                yield return new ResourceEvent(resource, resourceId, state.Value.LastSnapshot);
+            }
+        }
+
+        var channel = Channel.CreateUnbounded<ResourceEvent>();
+
+        void WriteToChannel(ResourceEvent resourceEvent) =>
+            channel.Writer.TryWrite(resourceEvent);
+
+        OnResourceUpdated += WriteToChannel;
+
+        try
+        {
+            await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken))
+            {
+                yield return item;
+            }
+        }
+        finally
+        {
+            OnResourceUpdated -= WriteToChannel;
+
+            channel.Writer.TryComplete();
+        }
+    }
 
     /// <summary>
     /// Updates the snapshot of the <see cref="CustomResourceSnapshot"/> for a resource.
@@ -37,9 +70,9 @@ public class ResourceNotificationService(ILogger<ResourceNotificationService> lo
 
         lock (notificationState)
         {
-            var previousState = GetInitialSnapshot(resource, notificationState);
+            var previousState = GetCurrentSnapshot(resource, notificationState);
 
-            var newState = stateFactory(previousState!);
+            var newState = stateFactory(previousState);
 
             notificationState.LastSnapshot = newState;
 
@@ -64,7 +97,7 @@ public class ResourceNotificationService(ILogger<ResourceNotificationService> lo
         return PublishUpdateAsync(resource, resource.Name, stateFactory);
     }
 
-    private static CustomResourceSnapshot? GetInitialSnapshot(IResource resource, ResourceNotificationState notificationState)
+    private static CustomResourceSnapshot GetCurrentSnapshot(IResource resource, ResourceNotificationState notificationState)
     {
         var previousState = notificationState.LastSnapshot;
 
@@ -88,44 +121,6 @@ public class ResourceNotificationService(ILogger<ResourceNotificationService> lo
 
     private ResourceNotificationState GetResourceNotificationState(IResource resource, string resourceId) =>
         _resourceNotificationStates.GetOrAdd((resource, resourceId), _ => new ResourceNotificationState());
-
-    private sealed class AllResourceUpdatesAsyncEnumerable(ResourceNotificationService resourceNotificationService) : IAsyncEnumerable<ResourceEvent>
-    {
-        public async IAsyncEnumerator<ResourceEvent> GetAsyncEnumerator(CancellationToken cancellationToken = default)
-        {
-            // Return the last snapshot for each resource.
-            foreach (var state in resourceNotificationService._resourceNotificationStates)
-            {
-                var (resource, resourceId) = state.Key;
-
-                if (state.Value.LastSnapshot is not null)
-                {
-                    yield return new ResourceEvent(resource, resourceId, state.Value.LastSnapshot);
-                }
-            }
-
-            var channel = Channel.CreateUnbounded<ResourceEvent>();
-
-            void WriteToChannel(ResourceEvent resourceEvent) =>
-                channel.Writer.TryWrite(resourceEvent);
-
-            resourceNotificationService.OnResourceUpdated += WriteToChannel;
-
-            try
-            {
-                await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken))
-                {
-                    yield return item;
-                }
-            }
-            finally
-            {
-                resourceNotificationService.OnResourceUpdated -= WriteToChannel;
-
-                channel.Writer.TryComplete();
-            }
-        }
-    }
 
     /// <summary>
     /// The annotation that allows publishing and subscribing to changes in the state of a resource.

--- a/src/Aspire.Hosting/Dcp/ResourceLogSource.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceLogSource.cs
@@ -39,12 +39,15 @@ internal sealed class ResourceLogSource<TResource>(
         var stderrStreamTask = Task.Run(() => StreamLogsAsync(stderrStream, isError: true), cancellationToken);
 
         // End the enumeration when both streams have been read to completion.
-        _ = Task.WhenAll(stdoutStreamTask, stderrStreamTask).ContinueWith
-            (_ => { channel.Writer.TryComplete(); },
-            cancellationToken,
-            TaskContinuationOptions.None,
-            TaskScheduler.Default).ConfigureAwait(false);
 
+        async Task WaitForStreamsToCompleteAsync()
+        {
+            await Task.WhenAll(stdoutStreamTask, stderrStreamTask).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+            channel.Writer.TryComplete();
+        }
+
+        _ = WaitForStreamsToCompleteAsync();
+        
         await foreach (var batch in channel.GetBatchesAsync(cancellationToken: cancellationToken))
         {
             yield return batch;

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -48,7 +48,7 @@ public class ResourceNotificationTests
         {
             var values = new List<ResourceEvent>();
 
-            await foreach (var item in notificationService.WatchAsync().WithCancellation(cancellationToken))
+            await foreach (var item in notificationService.WatchAsync(cancellationToken))
             {
                 values.Add(item);
 
@@ -99,7 +99,7 @@ public class ResourceNotificationTests
         {
             var values = new List<ResourceEvent>();
 
-            await foreach (var item in notificationService.WatchAsync().WithCancellation(cancellation))
+            await foreach (var item in notificationService.WatchAsync(cancellation))
             {
                 values.Add(item);
 


### PR DESCRIPTION
## Customer Impact

Currently the dashboard requests log streams for all application resources at the startup or shortly after. This is not efficient, especially for Containers, where each log stream is associated with a separate container orchestrator (CLI) running in the background.

If you have many projects and containers running in your app, these unnecessary background processes use resources on your machine.

## Testing
I manually tested launching an app, switching between console logs. Ensuring that after no longer viewing a container's console logs, the docker logs process goes away.

Existing tests pass. Added new unit tests.

## Risk

Medium-low. This changes how console logs are streamed from DCP to the AppHost to the Dashboard. 

___________

Change the AppHost to only subscribe to DCP's logs when there is a subscriber for the logs.

Fix #2789

* Show logs

* Remove the "StreamingLogger" because that causes subsequent subscribers to not see what was already written.

Fix duplicate logs issue by clearing out the backlog when the last subscriber leaves.

* Fix a concurrency issue with the backlog. Ensure the backlog is only snap shotted after subscribing to the log.

Fix existing tests for new functionality and add an additional test.

* PR feedback

Only clear the backlog on containers and executables.

* PR feedback.

Move lock out of async iterator.

* Clean up code.

- Remove count and instead check if the delegate is null to indicate whether there are subscribers or not.
- Remove the separate IAsyncEnumerable classes and just use `async IAsyncEnumerable` methods.

* Fix a race at startup when logs aren't available.

Employ a 2nd loop that listens for both "has subscribers" and "logs available".

* Simplify ResourceNotificationService.WatchAsync.

* Fix test build

* Address PR feedback

- Set SingleReader=true on the logInformationChannel.
- Add comment and assert that LogsAvailable can only turn true and can't go back to false.

---------
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3343)