### PR TITLE
Add Servicing-consider to new release PRs

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -1,6 +1,6 @@
 id: labelManagement.issueOpened
 name: New Issues
-description: Adds CodeFlow link to new PRs
+description: Adds information when PRs are opened
 owner:
 resource: repository
 disabled: false
@@ -15,3 +15,16 @@ configuration:
               action: Opened
         then:
           - addCodeFlowLink
+      - description: Add Servicing-consider label to PRs against release branches
+        if:
+          - payloadType: Pull_Request
+          - isAction:
+              action: Opened
+          - not:
+              hasLabel:
+                label: Servicing-consider
+          - targetsBranch:
+              branch: release/8.0
+        then:
+          - addLabel:
+              label: Servicing-consider


### PR DESCRIPTION
Adding automation so our PRs targeting release/8.0 branch would automatically get the Servicing-consider label

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3369)