### PR TITLE
Update table every second, reuse existing metric values if possible

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
@@ -14,12 +14,13 @@
 }
 
 <div id="metric-table-container" style="height: 40vh; overflow-y: auto; margin-bottom: 20px; max-width:1200px;">
+    @* ItemKey is to preserve row focus by associating rows with their associated time *@
     <FluentDataGrid
         Items="@_metricsView"
         ItemSize="35"
         Virtualize="true"
         GridTemplateColumns="@string.Join(" ", Enumerable.Repeat("1fr", columnCount))"
-        @* preserve row focus by associating rows with their associated time *@ ItemKey="@(item => item.DateTime)">
+        ItemKey="@(item => item.DateTime)">
         <ChildContent>
             <TemplateColumn Title="@Loc[nameof(ControlsStrings.MetricTableStartColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, TimeProvider.ToLocal(context.DateTime), MillisecondsDisplay.None, CultureInfo.CurrentCulture))" Tooltip="true">
                 @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, TimeProvider.ToLocal(context.DateTime))

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
@@ -14,7 +14,12 @@
 }
 
 <div id="metric-table-container" style="height: 40vh; overflow-y: auto; margin-bottom: 20px; max-width:1200px;">
-    <FluentDataGrid Items="@_metricsView" ItemSize="35" Virtualize="true" GridTemplateColumns="@string.Join(" ", Enumerable.Repeat("1fr", columnCount))">
+    <FluentDataGrid
+        Items="@_metricsView"
+        ItemSize="35"
+        Virtualize="true"
+        GridTemplateColumns="@string.Join(" ", Enumerable.Repeat("1fr", columnCount))"
+        @* preserve row focus by associating rows with their associated time *@ ItemKey="@(item => item.DateTime)">
         <ChildContent>
             <TemplateColumn Title="@Loc[nameof(ControlsStrings.MetricTableStartColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, TimeProvider.ToLocal(context.DateTime), MillisecondsDisplay.None, CultureInfo.CurrentCulture))" Tooltip="true">
                 @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, TimeProvider.ToLocal(context.DateTime))

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
@@ -21,6 +21,7 @@ public partial class MetricTable : ChartBase
     private OtlpInstrument? _instrument;
     private bool _showCount;
     private bool _onlyShowValueChanges = true;
+    private DateTimeOffset? _lastUpdate;
 
     private readonly CancellationTokenSource _waitTaskCancellationTokenSource = new();
 
@@ -31,6 +32,14 @@ public partial class MetricTable : ChartBase
 
     protected override async Task OnChartUpdated(List<ChartTrace> traces, List<DateTimeOffset> xValues, bool tickUpdate, DateTimeOffset inProgressDataTime)
     {
+        // Only update table every second
+        if (inProgressDataTime - _lastUpdate < TimeSpan.FromSeconds(1))
+        {
+            return;
+        }
+
+        _lastUpdate = inProgressDataTime;
+
         if (!Equals(_instrument?.Name, InstrumentViewModel.Instrument?.Name) || _showCount != InstrumentViewModel.ShowCount)
         {
             _metrics.Clear();
@@ -42,8 +51,6 @@ public partial class MetricTable : ChartBase
         _showCount = InstrumentViewModel.ShowCount;
 
         _metrics = UpdateMetrics(out var xValuesToAnnounce, traces, xValues);
-
-        await InvokeAsync(StateHasChanged);
 
         if (xValuesToAnnounce.Count == 0)
         {
@@ -81,6 +88,11 @@ public partial class MetricTable : ChartBase
         for (var i = 0; i < xValues.Count; i++)
         {
             var xValue = xValues[i];
+            if (_metrics.TryGetValue(xValue, out var oldMetric))
+            {
+                newMetrics.Add(xValue, oldMetric);
+                continue;
+            }
 
             KeyValuePair<DateTimeOffset, MetricViewBase>? previousMetric = newMetrics.LastOrDefault(dt => dt.Key < xValue);
 

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
@@ -32,7 +32,7 @@ public partial class MetricTable : ChartBase
 
     protected override async Task OnChartUpdated(List<ChartTrace> traces, List<DateTimeOffset> xValues, bool tickUpdate, DateTimeOffset inProgressDataTime)
     {
-        // Only update table every second
+        // Only update table every second to batch updates. New data coming every 200ms may be disorienting for screen-reader users.
         if (inProgressDataTime - _lastUpdate < TimeSpan.FromSeconds(1))
         {
             return;
@@ -88,11 +88,6 @@ public partial class MetricTable : ChartBase
         for (var i = 0; i < xValues.Count; i++)
         {
             var xValue = xValues[i];
-            if (_metrics.TryGetValue(xValue, out var oldMetric))
-            {
-                newMetrics.Add(xValue, oldMetric);
-                continue;
-            }
 
             KeyValuePair<DateTimeOffset, MetricViewBase>? previousMetric = newMetrics.LastOrDefault(dt => dt.Key < xValue);
 


### PR DESCRIPTION
We can associate rows with the underlying data's time range so that focus is not lost when the data is updated, if keyboard focus is active inside the table.

Fixes #3363

![Animation](https://github.com/dotnet/aspire/assets/20359921/46fbe97c-375f-4f21-a7cc-764d405469bc)
