### PR TITLE
Rename DcpServiceName to TargetPortExpression

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
@@ -18,8 +18,8 @@ public class AllocatedEndpoint
     /// <param name="address">The IP address of the endpoint.</param>
     /// <param name="containerHostAddress">The address of the container host.</param>
     /// <param name="port">The port number of the endpoint.</param>
-    /// <param name="dcpServiceName">The name of the DCP service.</param>
-    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port, string? containerHostAddress = null, string? dcpServiceName = null)
+    /// <param name="targetPortExpression">A string representing how to retrieve the target port of the <see cref="AllocatedEndpoint"/> instance.</param>
+    public AllocatedEndpoint(EndpointAnnotation endpoint, string address, int port, string? containerHostAddress = null, string? targetPortExpression = null)
     {
         ArgumentNullException.ThrowIfNull(endpoint);
         ArgumentOutOfRangeException.ThrowIfLessThan(port, 1, nameof(port));
@@ -29,7 +29,7 @@ public class AllocatedEndpoint
         Address = address;
         ContainerHostAddress = containerHostAddress;
         Port = port;
-        DcpServiceName = dcpServiceName;
+        TargetPortExpression = targetPortExpression;
     }
 
     /// <summary>
@@ -68,9 +68,9 @@ public class AllocatedEndpoint
     public string UriString => $"{UriScheme}://{EndPointString}";
 
     /// <summary>
-    /// The associated service name created in DCP for this endpoint.
+    /// A string representing how to retrieve the target port of the <see cref="AllocatedEndpoint"/> instance.
     /// </summary>
-    public string? DcpServiceName { get; }
+    public string? TargetPortExpression { get; }
 
     /// <summary>
     /// Returns a string representation of the allocated endpoint URI.

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -193,11 +193,9 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
         // There is no way to resolve the value of the target port until runtime. Even then, replicas make this very complex because
         // the target port is not known until the replica is allocated.
         // Instead, we return an expression that will be resolved at runtime by the orchestrator.
-        return $$$"""{{- portForServing "{{{DcpServiceName}}}" -}}""";
+        return Endpoint.AllocatedEndpoint.TargetPortExpression
+            ?? throw new InvalidOperationException("The endpoint does not have an associated TargetPortExpression from the orchestrator.");
     }
-
-    private string DcpServiceName => Endpoint.AllocatedEndpoint.DcpServiceName
-        ?? throw new InvalidOperationException("The endpoint does not have an associated service name in the orchestrator.");
 
     IEnumerable<object> IValueWithReferences.References => [Endpoint];
 }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1021,7 +1021,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                     sp.EndpointAnnotation.IsProxied ? svc.AllocatedAddress! : "localhost",
                     (int)svc.AllocatedPort!,
                     containerHostAddress: appResource.ModelResource.IsContainer() ? containerHost : null,
-                    dcpServiceName: svc.Metadata.Name);
+                    targetPortExpression: $$$"""{{- portForServing "{{{svc.Metadata.Name}}}" -}}""");
             }
         }
     }

--- a/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
@@ -50,7 +50,7 @@ public class DaprTests
 
         foreach (var e in endpoints)
         {
-            e.AllocatedEndpoint = new(e, "localhost", ports[e.Name], dcpServiceName: e.Name);
+            e.AllocatedEndpoint = new(e, "localhost", ports[e.Name], targetPortExpression: $$$"""{{- portForServing "{{{e.Name}}}" -}}""");
         }
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(container);

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -173,7 +173,7 @@ public class WithEnvironmentTests
                                .WithHttpEndpoint(name: "primary")
                                .WithEndpoint("primary", ep =>
                                {
-                                   ep.AllocatedEndpoint = new AllocatedEndpoint(ep, "localhost", 90, dcpServiceName: "container1_primary");
+                                   ep.AllocatedEndpoint = new AllocatedEndpoint(ep, "localhost", 90, targetPortExpression: """{{- portForServing "container1_primary" -}}""");
                                });
 
         var endpoint = container.GetEndpoint("primary");


### PR DESCRIPTION
This allows us to not leak "DCP" into the public API and keeps DCP-isms contained in the DCP code.

This is a follow up from https://github.com/dotnet/aspire/pull/3305#discussion_r1550128438.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3371)