### PR TITLE
Do not set TargetPort to Port when IsProxying is also set

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -44,9 +44,23 @@ public sealed class EndpointAnnotation : IResourceAnnotation
         _transport = transport;
         Name = name;
         Port = port;
-        TargetPort = targetPort ?? port;
+
+        TargetPort = targetPort;
+
+        // If the target port was not explicitly set and the service is not being proxied,
+        // we can set the target port to the port.
+        if (TargetPort is null && !isProxied)
+        {
+            TargetPort = port;
+        }
+
         IsExternal = isExternal ?? false;
         IsProxied = isProxied;
+
+        if (TargetPort is int && Port is int && TargetPort == Port && IsProxied)
+        {
+            throw new ArgumentException($"When {nameof(isProxied)} is true, {nameof(targetPort)} must not be equal to {nameof(port)}.");
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -56,11 +56,6 @@ public sealed class EndpointAnnotation : IResourceAnnotation
 
         IsExternal = isExternal ?? false;
         IsProxied = isProxied;
-
-        if (TargetPort is int && Port is int && TargetPort == Port && IsProxied)
-        {
-            throw new ArgumentException($"When {nameof(isProxied)} is true, {nameof(targetPort)} must not be equal to {nameof(port)}.");
-        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1692,7 +1692,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             {
                 if (sp.EndpointAnnotation.TargetPort is null)
                 {
-                    throw new InvalidOperationException($"The endpoint for container resource {modelResourceName} must specify the ContainerPort");
+                    throw new InvalidOperationException($"The endpoint for container resource '{modelResourceName}' must specify the ContainerPort");
                 }
 
                 sp.DcpServiceProducerAnnotation.Port = sp.EndpointAnnotation.TargetPort;
@@ -1707,6 +1707,17 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 // DCP will not allocate a port for this proxyless service
                 // so we need to specify what the port is so DCP is aware of it.
                 sp.DcpServiceProducerAnnotation.Port = sp.EndpointAnnotation.Port;
+            }
+            else
+            {
+                Debug.Assert(sp.EndpointAnnotation.IsProxied);
+
+                var ep = sp.EndpointAnnotation;
+                if (ep.TargetPort is int && ep.Port is int && ep.TargetPort == ep.Port)
+                {
+                    throw new InvalidOperationException(
+                        $"The endpoint for non-container resource '{modelResourceName}' requested a proxy ({nameof(ep.IsProxied)} is true). Non-container resources cannot be proxied when both {nameof(ep.TargetPort)} and {nameof(ep.Port)} are specified with the same value.");
+                }
             }
 
             dcpResource.AnnotateAsObjectList(CustomResource.ServiceProducerAnnotation, sp.DcpServiceProducerAnnotation);

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1692,7 +1692,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             {
                 if (sp.EndpointAnnotation.TargetPort is null)
                 {
-                    throw new InvalidOperationException($"The endpoint for container resource '{modelResourceName}' must specify the ContainerPort");
+                    throw new InvalidOperationException($"The endpoint for container resource '{modelResourceName}' must specify the TargetPort");
                 }
 
                 sp.DcpServiceProducerAnnotation.Port = sp.EndpointAnnotation.TargetPort;

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -284,7 +284,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                     (_, _, int target, _) => target,
 
                     // Container resources get their default listening port from the exposed port.
-                    (ContainerResource, _, _, int port) => port,
+                    (ContainerResource, _, null, int port) => port,
 
                     // Project resources get their default listening port from the deployment tool
                     // ideally we would default to a known port but we don't know it at this point

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -278,14 +278,17 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                 Writer.WriteString("protocol", endpoint.Protocol.ToString().ToLowerInvariant());
                 Writer.WriteString("transport", endpoint.Transport);
 
-                int? targetPort = (resource, endpoint.UriScheme, endpoint.TargetPort) switch
+                int? targetPort = (resource, endpoint.UriScheme, endpoint.TargetPort, endpoint.Port) switch
                 {
                     // The port was specified so use it
-                    (_, _, int port) => port,
+                    (_, _, int target, _) => target,
 
-                    // Project resources get their default port from the deployment tool
+                    // Container resources get their default listening port from the exposed port.
+                    (ContainerResource, _, _, int port) => port,
+
+                    // Project resources get their default listening port from the deployment tool
                     // ideally we would default to a known port but we don't know it at this point
-                    (ProjectResource, var scheme, null) when scheme is "http" or "https" => null,
+                    (ProjectResource, var scheme, null, _) when scheme is "http" or "https" => null,
 
                     // Allocate a dynamic port
                     _ => PortAllocator.AllocatePort()


### PR DESCRIPTION
When creating endpoint annotations, if a TargetPort is equal to the Port for a non-Container resource (and non-null) and IsProxying is true, that is an error: DCP cannot bind a proxy to a port which the target service is also bound to.

This PR does two things:
1. We do not set `TargetPort` to `Port` automatically if `IsProxying` is true.
2. If the resource is not a container and `TargetPort == Port && IsProxying`, then we throw during startup

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3372)