### PR TITLE
Lift up the dependency of Newtonsoft.Json in Cosmos components

### DIFF
--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
@@ -21,6 +21,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+
+    <!-- Pinned version for Component Governance - Remove when root dependencies are updated tracked by https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4302 -->
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/Aspire.Microsoft.Azure.Cosmos.csproj
@@ -22,7 +22,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 
-    <!-- Pinned version for Component Governance - Remove when root dependencies are updated tracked by https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4302 -->
+    <!-- Pinned version for Component Governance
+      Newtonsoft.Json is transitive dependency from Cosmos package.
+      See the following link on Cosmos repo for more detail https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
@@ -23,6 +23,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+
+    <!-- Pinned version for Component Governance - Remove when root dependencies are updated tracked by https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4302 -->
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
@@ -24,7 +24,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 
-    <!-- Pinned version for Component Governance - Remove when root dependencies are updated tracked by https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4302 -->
+    <!-- Pinned version for Component Governance
+      Newtonsoft.Json is transitive dependency from Cosmos package.
+      See the following link on Cosmos repo for more detail https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313 -->
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 


### PR DESCRIPTION
FYI @Pilchie @danmoseley 

cc: @eerhardt @sebastienros 

https://github.com/dotnet/aspire/pull/2049 was trying to remove this CG alert but because this was a transitive dependency, it didn't actually remove the issue. This PR is adding an explicit reference to both of the Aspire Components which has the transitive dependency triggering CG alerts in order to address this.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3373)