### PR TITLE
[release/8.0] [tests] EndToEnd - add test scenarios (#3113)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,8 +45,6 @@
     <BuildArch Condition=" '$(BuildArch)' == '' ">amd64</BuildArch>
     <DcpDir>$(NuGetPackageRoot)microsoft.developercontrolplane.$(BuildOs)-$(BuildArch)/$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)/tools/</DcpDir>
 
-    <TestArchiveTestsDir>$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'tests'))</TestArchiveTestsDir>
-    <TestArchiveTestsDirForWorkloadTests Condition="'$(TestArchiveTestsDirForWorkloadTests)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'workload-tests'))</TestArchiveTestsDirForWorkloadTests>
     <!-- TODO: Need to figure out we can automatically detect target framework here. This property
                is specified to support dashboard path metadata generation on the inner loop. -->
     <AspireDashboardDir>$(MSBuildThisFileDirectory)/artifacts/bin/Aspire.Dashboard/$(Configuration)/net8.0/</AspireDashboardDir>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,8 +4,6 @@
     <ReadMePath>$(MSBuildProjectDirectory)\README.md</ReadMePath>
     <ReadMeExists Condition="Exists('$(ReadMePath)')">true</ReadMeExists>
     <PackageReadmeFile Condition="'$(PackageReadmeFile)' == '' And '$(ReadMeExists)' == 'true'">README.md</PackageReadmeFile>
-
-    <TestArchiveTestsDir Condition="'$(IsWorkloadTestProject)' == 'true'">$(TestArchiveTestsDirForWorkloadTests)</TestArchiveTestsDir>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
+++ b/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
@@ -16,6 +16,7 @@
     <DefineConstants Condition="'$(TestsRunningOutsideOfRepo)' == 'true'">TESTS_RUNNING_OUTSIDE_OF_REPO;$(DefineConstants)</DefineConstants>
 
     <XunitRunnerJson>xunit.runner.json</XunitRunnerJson>
+    <TestArchiveTestsDir>$(TestArchiveTestsDirForEndToEndTests)</TestArchiveTestsDir>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesFixture.cs
@@ -27,12 +27,14 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
     public static bool TestsRunningOutsideOfRepo;
 #endif
 
+    public static string? TestScenario = EnvironmentVariables.TestScenario;
     public Dictionary<string, ProjectInfo> Projects => _projects!;
     public BuildEnvironment BuildEnvironment { get; init; }
     public ProjectInfo IntegrationServiceA => Projects["integrationservicea"];
 
     private Process? _appHostProcess;
     private readonly TaskCompletionSource _appExited = new();
+    private TestResourceNames _resourcesToSkip;
     private Dictionary<string, ProjectInfo>? _projects;
     private readonly IMessageSink _diagnosticMessageSink;
     private readonly TestOutputWrapper _testOutput;
@@ -80,9 +82,13 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
         _appHostProcess = new Process();
 
         string processArguments = $"run --no-build -- ";
-        if (GetResourcesToSkip() is var resourcesToSkip && resourcesToSkip.Count > 0)
+        _resourcesToSkip = GetResourcesToSkip();
+        if (_resourcesToSkip != TestResourceNames.None)
         {
-            processArguments += $"--skip-resources {string.Join(',', resourcesToSkip)}";
+            if (_resourcesToSkip.ToCSVString() is string skipArg)
+            {
+                processArguments += $"--skip-resources {skipArg}";
+            }
         }
         _appHostProcess.StartInfo = new ProcessStartInfo(BuildEnvironment.DotNet, processArguments)
         {
@@ -269,8 +275,22 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
         testOutput.WriteLine("--------------------------- Docker info (end) ---------------------------");
     }
 
-    public async Task DumpComponentLogsAsync(string component, ITestOutputHelper? testOutputArg = null)
+    public async Task DumpComponentLogsAsync(TestResourceNames resource, ITestOutputHelper? testOutputArg = null)
     {
+        string component = resource switch
+        {
+            TestResourceNames.cosmos => "cosmos",
+            TestResourceNames.kafka => "kafka",
+            TestResourceNames.mongodb => "mongodb",
+            TestResourceNames.mysql or TestResourceNames.efmysql => "mysql",
+            TestResourceNames.oracledatabase => "oracledatabase",
+            TestResourceNames.postgres or TestResourceNames.efnpgsql => "postgres",
+            TestResourceNames.rabbitmq => "rabbitmq",
+            TestResourceNames.redis => "redis",
+            TestResourceNames.sqlserver => "sqlserver",
+            _ => throw new ArgumentException($"Unknown resource: {resource}")
+        };
+
         var testOutput = testOutputArg ?? _testOutput!;
         var cts = new CancellationTokenSource();
 
@@ -316,23 +336,56 @@ public sealed class IntegrationServicesFixture : IAsyncLifetime
         }
     }
 
-    private static ISet<string> GetResourcesToSkip()
+    public void EnsureAppHasResources(TestResourceNames expectedResourceNames)
     {
-        HashSet<string> resourcesToSkip = new();
+        foreach (var ename in Enum.GetValues<TestResourceNames>())
+        {
+            if (ename != TestResourceNames.None && expectedResourceNames.HasFlag(ename) && _resourcesToSkip.HasFlag(ename))
+            {
+                throw new InvalidOperationException($"The required resource '{ename}' was skipped for the app run for TestScenario: {TestScenario}. Make sure that the TEST_SCENARIO environment variable matches the intended scenario for the test. Resources that were skipped: {string.Join(",", _resourcesToSkip)}. TestScenario: {TestScenario} ");
+            }
+        }
+    }
+
+    private static TestResourceNames GetResourcesToSkip()
+    {
+        TestResourceNames resourcesToInclude = TestScenario switch
+        {
+            "oracle" => TestResourceNames.oracledatabase,
+            "cosmos" => TestResourceNames.cosmos,
+            "basicservices" => TestResourceNames.kafka
+                              | TestResourceNames.mongodb
+                              | TestResourceNames.rabbitmq
+                              | TestResourceNames.redis
+                              | TestResourceNames.postgres
+                              | TestResourceNames.efnpgsql
+                              | TestResourceNames.mysql
+                              | TestResourceNames.efmysql
+                              | TestResourceNames.sqlserver,
+            "" or null => TestResourceNames.All,
+            _ => throw new ArgumentException($"Unknown test scenario '{TestScenario}'")
+        };
+
+        TestResourceNames resourcesToSkip = TestResourceNames.All & ~resourcesToInclude;
+
+        // always skip cosmos on macos/arm64
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
         {
-            resourcesToSkip.Add(nameof(TestResourceNames.cosmos));
+            resourcesToSkip |= TestResourceNames.cosmos;
         }
-
-        if (BuildEnvironment.IsRunningOnCI)
+        if (string.IsNullOrEmpty(TestScenario))
         {
-            resourcesToSkip.Add(nameof(TestResourceNames.cosmos));
-            resourcesToSkip.Add(nameof(TestResourceNames.oracledatabase));
+            // no scenario specified
+            if (BuildEnvironment.IsRunningOnCI)
+            {
+                resourcesToSkip |= TestResourceNames.cosmos;
+                resourcesToSkip |= TestResourceNames.oracledatabase;
+            }
         }
 
-        resourcesToSkip.Add(nameof(TestResourceNames.dashboard));
+        // always skip the dashboard
+        resourcesToSkip |= TestResourceNames.dashboard;
 
         return resourcesToSkip;
     }
-
 }

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
@@ -22,17 +22,19 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
     }
 
     [Theory]
+    [Trait("scenario", "basicservices")]
     [InlineData(TestResourceNames.mongodb)]
     [InlineData(TestResourceNames.mysql)]
-    [InlineData(TestResourceNames.pomelo)]
+    [InlineData(TestResourceNames.efmysql)]
     [InlineData(TestResourceNames.postgres)]
+    [InlineData(TestResourceNames.efnpgsql)]
     [InlineData(TestResourceNames.rabbitmq)]
     [InlineData(TestResourceNames.redis)]
     [InlineData(TestResourceNames.sqlserver)]
-    [InlineData(TestResourceNames.efnpgsql)]
     public Task VerifyComponentWorks(TestResourceNames resourceName)
         => RunTestAsync(async () =>
         {
+            _integrationServicesFixture.EnsureAppHasResources(resourceName);
             try
             {
                 var response = await _integrationServicesFixture.IntegrationServiceA.HttpGetAsync("http", $"/{resourceName}/verify");
@@ -42,30 +44,34 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
             }
             catch
             {
-                await _integrationServicesFixture.DumpComponentLogsAsync(resourceName.ToString().ToLowerInvariant(), _testOutput);
+                await _integrationServicesFixture.DumpComponentLogsAsync(resourceName, _testOutput);
                 throw;
             }
         });
 
-    // FIXME: open issue
-    [ConditionalTheory]
-    [SkipOnCI("not working on CI yet")]
-    [InlineData(TestResourceNames.cosmos)]
-    [InlineData(TestResourceNames.oracledatabase)]
-    public Task VerifyComponentWorksDisabledOnCI(TestResourceNames resourceName)
+    [Fact(Skip="https://github.com/dotnet/aspire/issues/3161")]
+    [Trait("scenario", "oracle")]
+    public Task VerifyOracleComponentWorks()
+        => VerifyComponentWorks(TestResourceNames.oracledatabase);
+
+    [ConditionalFact]
+    [Trait("scenario", "cosmos")]
+    public Task VerifyCosmosComponentWorks()
     {
-        if (resourceName == TestResourceNames.cosmos && RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
         {
-            throw new SkipException($"Skipping '{resourceName}' test because the emulator isn't supported on macOS ARM64.");
+            throw new SkipException($"Skipping 'cosmos' test because the emulator isn't supported on macOS ARM64.");
         }
 
-        return VerifyComponentWorks(resourceName);
+        return VerifyComponentWorks(TestResourceNames.cosmos);
     }
 
     [Fact]
+    [Trait("scenario", "basicservices")]
     public Task KafkaComponentCanProduceAndConsume()
         => RunTestAsync(async() =>
         {
+            _integrationServicesFixture.EnsureAppHasResources(TestResourceNames.kafka);
             string topic = $"topic-{Guid.NewGuid()}";
 
             var response = await _integrationServicesFixture.IntegrationServiceA.HttpGetAsync("http", $"/kafka/produce/{topic}");
@@ -78,6 +84,10 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
         });
 
     [Fact]
+    // Include all the scenarios here so this test gets run for all of them.
+    [Trait("scenario", "cosmos")]
+    [Trait("scenario", "oracle")]
+    [Trait("scenario", "basicservices")]
     public Task VerifyHealthyOnIntegrationServiceA()
         => RunTestAsync(async () =>
         {

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -611,7 +611,7 @@ public class ManifestGenerationTests
                     "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
                     "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
                     "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
-                    "SKIP_RESOURCES": "",
+                    "SKIP_RESOURCES": "None",
                     "ConnectionStrings__tempdb": "{tempdb.connectionString}",
                     "ConnectionStrings__mysqldb": "{mysqldb.connectionString}",
                     "ConnectionStrings__redis": "{redis.connectionString}",

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,6 +1,12 @@
 <Project>
 
   <Import Project="..\Directory.Build.props" />
+  <PropertyGroup>
+    <TestArchiveTestsDir Condition="'$(TestArchiveTestsDir)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'tests'))</TestArchiveTestsDir>
+    <TestArchiveTestsDirForWorkloadTests Condition="'$(TestArchiveTestsDirForWorkloadTests)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'workload-tests'))</TestArchiveTestsDirForWorkloadTests>
+    <TestArchiveTestsDirForEndToEndTests Condition="'$(TestArchiveTestsDirForEndToEndTests)' == ''">$([MSBuild]::NormalizeDirectory($(ArtifactsDir), 'helix', 'e2e-tests'))</TestArchiveTestsDirForEndToEndTests>
+  </PropertyGroup>
+
   <Import Project="Shared\Aspire.Workload.Testing.props" Condition="'$(IsWorkloadTestProject)' == 'true'" />
 
   <PropertyGroup>

--- a/tests/Shared/WorkloadTesting/EnvironmentVariables.cs
+++ b/tests/Shared/WorkloadTesting/EnvironmentVariables.cs
@@ -15,4 +15,5 @@ public static class EnvironmentVariables
     public static readonly bool    TestsRunningOutsideOfRepo     = Environment.GetEnvironmentVariable("TestsRunningOutsideOfRepo") is "true";
     public static readonly string  BuildConfiguration        = Environment.GetEnvironmentVariable("BUILD_CONFIGURATION") ?? "Debug";
     public static readonly string? TestAssetsPath            = Environment.GetEnvironmentVariable("TEST_ASSETS_PATH");
+    public static readonly string? TestScenario              = Environment.GetEnvironmentVariable("TEST_SCENARIO");
 }

--- a/tests/send-to-helix-workload-tests.targets
+++ b/tests/send-to-helix-workload-tests.targets
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <WorkItemArchiveWildCardWorkloadTests>$(TestArchiveTestsDirForWorkloadTests)**/*.zip</WorkItemArchiveWildCardWorkloadTests>
+    <_E2ETestsArchivePath>$(TestArchiveTestsDirForEndToEndTests)Aspire.EndToEnd.Tests.zip</_E2ETestsArchivePath>
+
+    <BuildHelixWorkItemsDependsOn>$(BuildHelixWorkItemsDependsOn);BuildHelixWorkItemsForEnd2EndTests</BuildHelixWorkItemsDependsOn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,9 +39,19 @@
     <HelixPostCommand Condition="'$(OS)' != 'Windows_NT'" Include="docker ps -aq | xargs docker stop | xargs docker rm" />
   </ItemGroup>
 
-  <Target Name="BuildHelixWorkItemsForEnd2EndTests" Condition="@(_DefaultWorkItemsWorkloadTests->Count()) > 0">
+  <Target Name="BuildHelixWorkItemsForEnd2EndTests" Condition="'$(_E2ETestsArchivePath)' != '' and Exists($(_E2ETestsArchivePath))">
     <PropertyGroup>
-      <_WorkItemTimeoutForWorkloadTests>00:20:00</_WorkItemTimeoutForWorkloadTests>
+      <_TestScenarioEnvVar Condition="'$(OS)' == 'Windows_NT'">%TEST_SCENARIO%</_TestScenarioEnvVar>
+      <_TestScenarioEnvVar Condition="'$(OS)' != 'Windows_NT'">${TEST_SCENARIO}</_TestScenarioEnvVar>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_TestRunCommandArguments Include="--filter scenario=$(_TestScenarioEnvVar)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_WorkItemTimeoutForEndToEndTests>00:20:00</_WorkItemTimeoutForEndToEndTests>
+      <_WorkItemName>$([System.IO.Path]::GetFileNameWithoutExtension($(_E2ETestsArchivePath)))</_WorkItemName>
 
       <HelixPreCommands>$(HelixPreCommands);@(HelixPreCommand)</HelixPreCommands>
       <HelixPostCommands>$(HelixPostCommands);@(HelixPostCommand)</HelixPostCommands>
@@ -51,18 +64,21 @@
            Text="Could not find dotnet-coverage tool. %24(_DotNetCoverageToolPath)=$(_DotNetCoverageToolPath)" />
 
     <ItemGroup>
+      <_E2ETestScenarios Include="basicservices" />
+      <_E2ETestScenarios Include="cosmos" />
+
       <HelixCorrelationPayload Include="$(ArtifactsBinDir)dotnet-latest" Destination="dotnet-latest" />
       <HelixCorrelationPayload Include="$(ArtifactsShippingPackagesDir)" Destination="built-nugets" />
 
-      <HelixWorkItem Include="@(_DefaultWorkItemsWorkloadTests -> '%(FileName)')">
-        <PayloadArchive>%(Identity)</PayloadArchive>
-        <PreCommands Condition="'$(OS)' == 'Windows_NT'">set &quot;TEST_NAME=%(FileName)&quot;</PreCommands>
-        <PreCommands Condition="'$(OS)' != 'Windows_NT'">export &quot;TEST_NAME=%(FileName)&quot;</PreCommands>
+      <HelixWorkItem Include="@(_E2ETestScenarios -> '$(_WorkItemName)-%(Identity)')">
+        <PayloadArchive>$(_E2ETestsArchivePath)</PayloadArchive>
+        <PreCommands Condition="'$(OS)' == 'Windows_NT'">set &quot;TEST_NAME=$(_WorkItemName)&quot; &amp; set TEST_SCENARIO=%(Identity) &amp; set &quot;CODE_COV_FILE_SUFFIX=-%(Identity)&quot;</PreCommands>
+        <PreCommands Condition="'$(OS)' != 'Windows_NT'">export &quot;TEST_NAME=$(_WorkItemName)&quot; &amp;&amp; export TEST_SCENARIO=%(Identity) &amp;&amp; export &quot;CODE_COV_FILE_SUFFIX=-%(Identity)&quot;</PreCommands>
         <Command>$(_TestRunCommand)</Command>
-        <Timeout>$(_WorkItemTimeoutForWorkloadTests)</Timeout>
+        <Timeout>$(_WorkItemTimeoutForEndToEndTests)</Timeout>
 
         <!-- Download results file so coverage files can be extracted -->
-        <DownloadFilesFromResults>logs/%(FileName).cobertura.xml</DownloadFilesFromResults>
+        <DownloadFilesFromResults>logs/Aspire.EndToEnd.Tests-%(Identity).cobertura.xml</DownloadFilesFromResults>
       </HelixWorkItem>
     </ItemGroup>
   </Target>

--- a/tests/send-to-helix.proj
+++ b/tests/send-to-helix.proj
@@ -11,6 +11,8 @@
 
     <GlobalJsonContent>$([System.IO.File]::ReadAllText('$(RepoRoot)global.json'))</GlobalJsonContent>
     <DotNetCliVersion>$([System.Text.RegularExpressions.Regex]::Match($(GlobalJsonContent), '(%3F&lt;="dotnet": ").*(%3F=")'))</DotNetCliVersion>
+
+    <BuildHelixWorkItemsDependsOn>BuildHelixWorkItemsForDefaultTests</BuildHelixWorkItemsDependsOn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -21,14 +23,17 @@
     <_HelixCorrelationPayloadEnvVar Condition="'$(OS)' != 'Windows_NT'">$HELIX_CORRELATION_PAYLOAD</_HelixCorrelationPayloadEnvVar>
     <_HelixCorrelationPayloadEnvVar Condition="'$(OS)' == 'Windows_NT'">%HELIX_CORRELATION_PAYLOAD%</_HelixCorrelationPayloadEnvVar>
 
-    <_TestNameEnvVar Condition="'$(OS)' != 'Windows_NT'">$TEST_NAME</_TestNameEnvVar>
+    <_TestNameEnvVar Condition="'$(OS)' != 'Windows_NT'">${TEST_NAME}</_TestNameEnvVar>
     <_TestNameEnvVar Condition="'$(OS)' == 'Windows_NT'">%TEST_NAME%</_TestNameEnvVar>
+
+    <_CodeCoverageReportFileNameSuffixEnvVar Condition="'$(OS)' != 'Windows_NT'">${CODE_COV_FILE_SUFFIX}</_CodeCoverageReportFileNameSuffixEnvVar>
+    <_CodeCoverageReportFileNameSuffixEnvVar Condition="'$(OS)' == 'Windows_NT'">%CODE_COV_FILE_SUFFIX%</_CodeCoverageReportFileNameSuffixEnvVar>
   </PropertyGroup>
 
   <ItemGroup>
     <_TestCoverageCommand Include="$(_HelixCorrelationPayloadEnvVar)/dotnet-coverage/dotnet-coverage collect" />
     <_TestCoverageCommand Include="--settings $(_HelixCorrelationPayloadEnvVar)/support-data/CodeCoverage.config" />
-    <_TestCoverageCommand Include="--output $(_HelixLogsPath)/$(_TestNameEnvVar).cobertura.xml" />
+    <_TestCoverageCommand Include="--output $(_HelixLogsPath)/$(_TestNameEnvVar)$(_CodeCoverageReportFileNameSuffixEnvVar).cobertura.xml" />
 
     <_TestRunCommandArguments Include="dotnet test" />
     <_TestRunCommandArguments Include="-s .runsettings" />
@@ -44,7 +49,7 @@
     <_TestRunCommandArguments Include="full" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)send-to-helix-workload-tests.proj" />
+  <Import Project="$(MSBuildThisFileDirectory)send-to-helix-workload-tests.targets" />
 
   <Target Name="BuildHelixWorkItemsForDefaultTests" DependsOnTargets="_StageDependenciesForHelix">
     <PropertyGroup>
@@ -103,7 +108,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="BuildHelixWorkItems" DependsOnTargets="BuildHelixWorkItemsForDefaultTests;BuildHelixWorkItemsForEnd2EndTests">
+  <Target Name="BuildHelixWorkItems" DependsOnTargets="$(BuildHelixWorkItemsDependsOn)">
     <Message Text="HelixCorrelationPayload: %(HelixCorrelationPayload.Identity)" Condition="'$(HelixDryRun)' == 'true' and @(HelixWorkItem->Count()) > 0" Importance="High" />
     <Message Text="HelixWorkItem: %(HelixWorkItem.Identity), Command: %(HelixWorkItem.Command), PreCommands: %(HelixWorkItem.PreCommands) with PayloadArchive: %(HelixWorkItem.PayloadArchive)" Condition="'$(HelixDryRun)' == 'true' and @(HelixWorkItem->Count()) > 0" Importance="High" />
     <Error Text="Stopping the build for dry run" Condition="'$(HelixDryRun)' == 'true'" />

--- a/tests/testproject/Common/TestResourceNames.cs
+++ b/tests/testproject/Common/TestResourceNames.cs
@@ -1,32 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.TestProject;
 
+[Flags]
 public enum TestResourceNames
 {
-    cosmos,
-    dashboard,
-    kafka,
-    mongodb,
-    mysql,
-    oracledatabase,
-    pomelo,
-    postgres,
-    rabbitmq,
-    redis,
-    sqlserver,
-    efnpgsql
+    None = 0,
+    cosmos = 1 << 0,
+    dashboard = 1 << 1,
+    kafka = 1 << 2,
+    mongodb = 1 << 3,
+    mysql = 1 << 4,
+    oracledatabase = 1 << 5,
+    efmysql = 1 << 6,
+    postgres = 1 << 7,
+    rabbitmq = 1 << 8,
+    redis = 1 << 9,
+    sqlserver = 1 << 10,
+    efnpgsql = 1 << 11,
+    All = cosmos | dashboard | kafka | mongodb | mysql | oracledatabase | efmysql | postgres | rabbitmq | redis | sqlserver | efnpgsql
 }
 
 public static class TestResourceNamesExtensions
 {
-    public static ISet<TestResourceNames> Parse(IEnumerable<string> resourceNames)
+    public static TestResourceNames Parse(IEnumerable<string> resourceNames)
     {
-        HashSet<TestResourceNames> resourcesToSkip = new();
+        TestResourceNames resourcesToSkip = TestResourceNames.None;
         foreach (var resourceName in resourceNames)
         {
             if (Enum.TryParse<TestResourceNames>(resourceName, ignoreCase: true, out var name))
             {
-                resourcesToSkip.Add(name);
+                resourcesToSkip |= name;
             }
             else
             {
@@ -35,5 +40,11 @@ public static class TestResourceNamesExtensions
         }
 
         return resourcesToSkip;
+    }
+
+    public static string ToCSVString(this TestResourceNames resourceNames)
+    {
+        return string.Join(',', Enum.GetValues<TestResourceNames>()
+                            .Where(ename => ename != TestResourceNames.None && resourceNames.HasFlag(ename)));
     }
 }

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -11,8 +11,7 @@ public class TestProgram : IDisposable
 {
     private TestProgram(string[] args, Assembly assembly, bool includeIntegrationServices, bool includeNodeApp, bool disableDashboard, bool allowUnsecuredTransport)
     {
-
-        ISet<TestResourceNames>? resourcesToSkip = null;
+        TestResourceNames resourcesToSkip = TestResourceNames.None;
         for (int i = 0; i < args.Length; i++)
         {
             if (args[i].StartsWith("--skip-resources", StringComparison.InvariantCultureIgnoreCase))
@@ -28,8 +27,7 @@ public class TestProgram : IDisposable
                 }
             }
         }
-        resourcesToSkip ??= new HashSet<TestResourceNames>();
-        if (resourcesToSkip.Contains(TestResourceNames.dashboard))
+        if (resourcesToSkip.HasFlag(TestResourceNames.dashboard))
         {
             disableDashboard = true;
         }
@@ -62,14 +60,14 @@ public class TestProgram : IDisposable
             IntegrationServiceABuilder = AppBuilder.AddProject<Projects.IntegrationServiceA>("integrationservicea");
             IntegrationServiceABuilder = IntegrationServiceABuilder.WithEnvironment("SKIP_RESOURCES", string.Join(',', resourcesToSkip));
 
-            if (!resourcesToSkip.Contains(TestResourceNames.sqlserver))
+            if (!resourcesToSkip.HasFlag(TestResourceNames.sqlserver))
             {
                 var sqlserverDbName = "tempdb";
                 var sqlserver = AppBuilder.AddSqlServer("sqlserver")
                     .AddDatabase(sqlserverDbName);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(sqlserver);
             }
-            if (!resourcesToSkip.Contains(TestResourceNames.mysql))
+            if (!resourcesToSkip.HasFlag(TestResourceNames.mysql) || !resourcesToSkip.HasFlag(TestResourceNames.efmysql))
             {
                 var mysqlDbName = "mysqldb";
                 var mysql = AppBuilder.AddMySql("mysql")
@@ -77,12 +75,12 @@ public class TestProgram : IDisposable
                     .AddDatabase(mysqlDbName);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(mysql);
             }
-            if (!resourcesToSkip.Contains(TestResourceNames.redis))
+            if (!resourcesToSkip.HasFlag(TestResourceNames.redis))
             {
                 var redis = AppBuilder.AddRedis("redis");
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(redis);
             }
-            if (!resourcesToSkip.Contains(TestResourceNames.postgres))
+            if (!resourcesToSkip.HasFlag(TestResourceNames.postgres) || !resourcesToSkip.HasFlag(TestResourceNames.efnpgsql))
             {
                 var postgresDbName = "postgresdb";
                 var postgres = AppBuilder.AddPostgres("postgres")
@@ -90,31 +88,31 @@ public class TestProgram : IDisposable
                     .AddDatabase(postgresDbName);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(postgres);
             }
-            if (!resourcesToSkip.Contains(TestResourceNames.rabbitmq))
+            if (!resourcesToSkip.HasFlag(TestResourceNames.rabbitmq))
             {
                 var rabbitmq = AppBuilder.AddRabbitMQ("rabbitmq");
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(rabbitmq);
             }
-            if (!resourcesToSkip.Contains(TestResourceNames.mongodb))
+            if (!resourcesToSkip.HasFlag(TestResourceNames.mongodb))
             {
                 var mongoDbName = "mymongodb";
                 var mongodb = AppBuilder.AddMongoDB("mongodb")
                     .AddDatabase(mongoDbName);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(mongodb);
             }
-            if (!resourcesToSkip.Contains(TestResourceNames.oracledatabase))
+            if (!resourcesToSkip.HasFlag(TestResourceNames.oracledatabase))
             {
                 var oracleDbName = "freepdb1";
                 var oracleDatabase = AppBuilder.AddOracle("oracledatabase")
                     .AddDatabase(oracleDbName);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(oracleDatabase);
             }
-            if (!resourcesToSkip.Contains(TestResourceNames.kafka))
+            if (!resourcesToSkip.HasFlag(TestResourceNames.kafka))
             {
                 var kafka = AppBuilder.AddKafka("kafka");
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(kafka);
             }
-            if (!resourcesToSkip.Contains(TestResourceNames.cosmos))
+            if (!resourcesToSkip.HasFlag(TestResourceNames.cosmos))
             {
                 var cosmos = AppBuilder.AddAzureCosmosDB("cosmos").RunAsEmulator();
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(cosmos);

--- a/tests/testproject/TestProject.IntegrationServiceA/MySql/PomeloEFCoreMySqlExtensions.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/MySql/PomeloEFCoreMySqlExtensions.cs
@@ -7,10 +7,10 @@ public static class PomeloEFCoreMySqlExtensions
 {
     public static void MapPomeloEFCoreMySqlApi(this WebApplication app)
     {
-        app.MapGet("/pomelo/verify", VerifyPomeloEFCoreMySqlAsync);
+        app.MapGet("/efmysql/verify", VerifyPomeloEFCoreMySqlAsync);
     }
 
-    private static IResult VerifyPomeloEFCoreMySqlAsync(PomeloDbContext dbContext)
+    private static IResult VerifyPomeloEFCoreMySqlAsync(PomeloMySqlDbContext dbContext)
     {
         try
         {

--- a/tests/testproject/TestProject.IntegrationServiceA/MySql/PomeloMySqlDbContext.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/MySql/PomeloMySqlDbContext.cs
@@ -3,6 +3,6 @@
 
 using Microsoft.EntityFrameworkCore;
 
-public class PomeloDbContext(DbContextOptions<PomeloDbContext> options) : DbContext(options)
+public class PomeloMySqlDbContext(DbContextOptions<PomeloMySqlDbContext> options) : DbContext(options)
 {
 }


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspire/pull/3113 into release/8.0


## Original Description:

Test scenarios allow defining different groupings for tests to be run. This is useful for CI to run the tests in separate helix items.

```csharp
        TestResourceNames resourcesToInclude = TestScenario switch
        {
            "oracle" => TestResourceNames.oracledatabase,
            "cosmos" => TestResourceNames.cosmos,
            "scenario0" => TestResourceNames.kafka
                              | TestResourceNames.mongodb
                              | TestResourceNames.rabbitmq
                              | TestResourceNames.redis
                              | TestResourceNames.postgres
                              | TestResourceNames.efnpgsql
                              | TestResourceNames.mysql
                              | TestResourceNames.efmysql
                              | TestResourceNames.sqlserver,
            "" or null => TestResourceNames.All,
            _ => throw new ArgumentException($"Unknown test scenario '{TestScenario}'")
        };
```

Once `eforacle` is added it can run with the `oracle` scenario.

The default is to run all the tests.

Also:
- Enable `cosmos` E2E tests on helix
- make `TestResourceNames` into a `[Flag]` enum so multiple can be expressed at the same time.
- And support dumping docker container logs for resources where the resource name does not match the container name prefix. For example `efnpgsql` vs `postgres`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3377)