### PR TITLE
Uses new Azure.Provisioning packages which have been split by resource

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,22 +33,22 @@
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.25.1" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.Redis" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.Resources" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.Search" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.SignalR" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.Sql" Version="0.1.0-alpha.20240403.2" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Redis" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Resources" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Search" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.SignalR" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Sql" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="0.2.0-beta.1" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAuthenticationCertificatePackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,22 @@
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.25.1" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="0.1.0-beta.2" />
+    <PackageVersion Include="Azure.Provisioning" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.Redis" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.Resources" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.Search" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.SignalR" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.Sql" Version="0.1.0-alpha.20240403.2" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="0.1.0-alpha.20240403.2" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAuthenticationCertificatePackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,21 +34,21 @@
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.Provisioning" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Redis" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Resources" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Search" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.SignalR" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Sql" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="0.2.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Redis" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Resources" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Search" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.SignalR" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Sql" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="0.1.0-beta.1" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAuthenticationCertificatePackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion)" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -19,10 +19,17 @@
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="orleans-nightly" value="https://orleans.pkgs.visualstudio.com/orleans-public/_packaging/orleans-nightly/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
+    <add key="azure-sdk-for-net-dev" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="dotnet9-transport">
       <package pattern="*WorkloadBuildTasks*" />
+    </packageSource>
+    <packageSource key="azure-sdk-for-net-dev">
+      <package pattern="Azure.Provisioning" />
+      <package pattern="Azure.Provisioning.*" />
+      <package pattern="Azure.ResourceManager" />
+      <package pattern="Azure.ResourceManager.*" />
     </packageSource>
     <packageSource key="dotnet-public">
       <package pattern="*" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -19,17 +19,10 @@
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="orleans-nightly" value="https://orleans.pkgs.visualstudio.com/orleans-public/_packaging/orleans-nightly/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
-    <add key="azure-sdk-for-net-dev" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="dotnet9-transport">
       <package pattern="*WorkloadBuildTasks*" />
-    </packageSource>
-    <packageSource key="azure-sdk-for-net-dev">
-      <package pattern="Azure.Provisioning" />
-      <package pattern="Azure.Provisioning.*" />
-      <package pattern="Azure.ResourceManager" />
-      <package pattern="Azure.ResourceManager.*" />
     </packageSource>
     <packageSource key="dotnet-public">
       <package pattern="*" />

--- a/eng/refreshManifests.ps1
+++ b/eng/refreshManifests.ps1
@@ -1,0 +1,2 @@
+..\build.cmd
+get-childitem ..\playground\*AppHost.csproj -Recurse | % { "Generating Manifest for: $_"; dotnet run --no-build --project $_.FullName --launch-profile generate-manifest }

--- a/playground/AWS/AWS.AppHost/Properties/launchSettings.json
+++ b/playground/AWS/AWS.AppHost/Properties/launchSettings.json
@@ -26,7 +26,7 @@
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
-    "manifest-publish": {
+    "generate-manifest": {
       "commandName": "Project",
       "commandLineArgs": "--publisher manifest --output-path ./aspire-manifest.json",
       "dotnetRunMessages": true,

--- a/playground/AspireEventHub/EventHubs.AppHost/Properties/launchSettings.json
+++ b/playground/AspireEventHub/EventHubs.AppHost/Properties/launchSettings.json
@@ -11,6 +11,18 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16201"
       }
+    },
+    "generate-manifest": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+      "applicationUrl": "http://localhost:15270",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16201"
+      }
     }
   }
 }

--- a/playground/AspireEventHub/EventHubs.AppHost/aspire-manifest.json
+++ b/playground/AspireEventHub/EventHubs.AppHost/aspire-manifest.json
@@ -44,12 +44,14 @@
         "http": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "external": true
         },
         "https": {
           "scheme": "https",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "external": true
         }
       }
     }

--- a/playground/AspireEventHub/EventHubs.AppHost/ehstorage.module.bicep
+++ b/playground/AspireEventHub/EventHubs.AppHost/ehstorage.module.bicep
@@ -10,8 +10,8 @@ param principalId string
 param principalType string
 
 
-resource storageAccount_X1L2R0Ykm 'Microsoft.Storage/storageAccounts@2022-09-01' = {
-  name: toLower(take(concat('ehstorage', uniqueString(resourceGroup().id)), 24))
+resource storageAccount_59pNEh4K4 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: toLower(take('ehstorage${uniqueString(resourceGroup().id)}', 24))
   location: location
   tags: {
     'aspire-resource-name': 'ehstorage'
@@ -22,19 +22,22 @@ resource storageAccount_X1L2R0Ykm 'Microsoft.Storage/storageAccounts@2022-09-01'
   kind: 'StorageV2'
   properties: {
     accessTier: 'Hot'
+    networkAcls: {
+      defaultAction: 'Deny'
+    }
   }
 }
 
-resource blobService_6Eo0U74qO 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
-  parent: storageAccount_X1L2R0Ykm
+resource blobService_5WQ0wIU09 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
+  parent: storageAccount_59pNEh4K4
   name: 'default'
   properties: {
   }
 }
 
-resource roleAssignment_QJKNfwb9n 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount_X1L2R0Ykm
-  name: guid(storageAccount_X1L2R0Ykm.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
+resource roleAssignment_LrhalXYOv 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount_59pNEh4K4
+  name: guid(storageAccount_59pNEh4K4.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
     principalId: principalId
@@ -42,9 +45,9 @@ resource roleAssignment_QJKNfwb9n 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource roleAssignment_XX2YmbC7m 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount_X1L2R0Ykm
-  name: guid(storageAccount_X1L2R0Ykm.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'))
+resource roleAssignment_DDmC2vNE8 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount_59pNEh4K4
+  name: guid(storageAccount_59pNEh4K4.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3')
     principalId: principalId
@@ -52,9 +55,9 @@ resource roleAssignment_XX2YmbC7m 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource roleAssignment_osDAIpL0k 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount_X1L2R0Ykm
-  name: guid(storageAccount_X1L2R0Ykm.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
+resource roleAssignment_4tZWfnMZF 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount_59pNEh4K4
+  name: guid(storageAccount_59pNEh4K4.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
     principalId: principalId
@@ -62,6 +65,6 @@ resource roleAssignment_osDAIpL0k 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-output blobEndpoint string = storageAccount_X1L2R0Ykm.properties.primaryEndpoints.blob
-output queueEndpoint string = storageAccount_X1L2R0Ykm.properties.primaryEndpoints.queue
-output tableEndpoint string = storageAccount_X1L2R0Ykm.properties.primaryEndpoints.table
+output blobEndpoint string = storageAccount_59pNEh4K4.properties.primaryEndpoints.blob
+output queueEndpoint string = storageAccount_59pNEh4K4.properties.primaryEndpoints.queue
+output tableEndpoint string = storageAccount_59pNEh4K4.properties.primaryEndpoints.table

--- a/playground/AspireEventHub/EventHubs.AppHost/ehstorage.module.bicep
+++ b/playground/AspireEventHub/EventHubs.AppHost/ehstorage.module.bicep
@@ -23,6 +23,7 @@ resource storageAccount_59pNEh4K4 'Microsoft.Storage/storageAccounts@2022-09-01'
   properties: {
     accessTier: 'Hot'
     networkAcls: {
+      bypass: 'AzureServices'
       defaultAction: 'Deny'
     }
   }

--- a/playground/AspireEventHub/EventHubs.AppHost/ehstorage.module.bicep
+++ b/playground/AspireEventHub/EventHubs.AppHost/ehstorage.module.bicep
@@ -23,8 +23,7 @@ resource storageAccount_59pNEh4K4 'Microsoft.Storage/storageAccounts@2022-09-01'
   properties: {
     accessTier: 'Hot'
     networkAcls: {
-      bypass: 'AzureServices'
-      defaultAction: 'Deny'
+      defaultAction: 'Allow'
     }
   }
 }

--- a/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
+++ b/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
@@ -13,8 +13,8 @@ param principalId string
 param principalType string
 
 
-resource eventHubsNamespace_skb4aVCrD 'Microsoft.EventHub/namespaces@2022-10-01-preview' = {
-  name: toLower(take(concat('eventhubns', uniqueString(resourceGroup().id)), 24))
+resource eventHubsNamespace_wORIGuvCQ 'Microsoft.EventHub/namespaces@2021-11-01' = {
+  name: toLower(take('eventhubns${uniqueString(resourceGroup().id)}', 24))
   location: location
   tags: {
     'aspire-resource-name': 'eventhubns'
@@ -23,13 +23,12 @@ resource eventHubsNamespace_skb4aVCrD 'Microsoft.EventHub/namespaces@2022-10-01-
     name: sku
   }
   properties: {
-    minimumTlsVersion: '1.2'
   }
 }
 
-resource roleAssignment_cky0ZiKdq 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: eventHubsNamespace_skb4aVCrD
-  name: guid(eventHubsNamespace_skb4aVCrD.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f526a384-b230-433a-b45c-95f59c4a2dec'))
+resource roleAssignment_2so8CKuFt 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: eventHubsNamespace_wORIGuvCQ
+  name: guid(eventHubsNamespace_wORIGuvCQ.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f526a384-b230-433a-b45c-95f59c4a2dec'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f526a384-b230-433a-b45c-95f59c4a2dec')
     principalId: principalId
@@ -37,12 +36,12 @@ resource roleAssignment_cky0ZiKdq 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource eventHub_BTiIwkSy2 'Microsoft.EventHub/namespaces/eventhubs@2022-10-01-preview' = {
-  parent: eventHubsNamespace_skb4aVCrD
+resource eventHub_4BpPMTltx 'Microsoft.EventHub/namespaces/eventhubs@2021-11-01' = {
+  parent: eventHubsNamespace_wORIGuvCQ
   name: 'hub'
   location: location
   properties: {
   }
 }
 
-output eventHubsEndpoint string = eventHubsNamespace_skb4aVCrD.properties.serviceBusEndpoint
+output eventHubsEndpoint string = eventHubsNamespace_wORIGuvCQ.properties.serviceBusEndpoint

--- a/playground/AzureSearchEndToEnd/AzureSearch.AppHost/aspire-manifest.json
+++ b/playground/AzureSearchEndToEnd/AzureSearch.AppHost/aspire-manifest.json
@@ -22,12 +22,14 @@
         "http": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "external": true
         },
         "https": {
           "scheme": "https",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "external": true
         }
       }
     }

--- a/playground/AzureSearchEndToEnd/AzureSearch.AppHost/search.module.bicep
+++ b/playground/AzureSearchEndToEnd/AzureSearch.AppHost/search.module.bicep
@@ -10,8 +10,8 @@ param principalId string
 param principalType string
 
 
-resource searchService_7WkaGluF0 'Microsoft.Search/searchServices@2023-11-01' = {
-  name: toLower(take(concat('search', uniqueString(resourceGroup().id)), 24))
+resource searchService_j3umigYGT 'Microsoft.Search/searchServices@2023-11-01' = {
+  name: toLower(take('search${uniqueString(resourceGroup().id)}', 24))
   location: location
   tags: {
     'aspire-resource-name': 'search'
@@ -27,9 +27,9 @@ resource searchService_7WkaGluF0 'Microsoft.Search/searchServices@2023-11-01' = 
   }
 }
 
-resource roleAssignment_7uytIREoa 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: searchService_7WkaGluF0
-  name: guid(searchService_7WkaGluF0.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8ebe5a00-799e-43f5-93ac-243d3dce84a7'))
+resource roleAssignment_f77ijNEYF 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: searchService_j3umigYGT
+  name: guid(searchService_j3umigYGT.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8ebe5a00-799e-43f5-93ac-243d3dce84a7'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8ebe5a00-799e-43f5-93ac-243d3dce84a7')
     principalId: principalId
@@ -37,9 +37,9 @@ resource roleAssignment_7uytIREoa 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource roleAssignment_QpFzCj55x 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: searchService_7WkaGluF0
-  name: guid(searchService_7WkaGluF0.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7ca78c08-252a-4471-8644-bb5ff32d4ba0'))
+resource roleAssignment_s0J7B4aGN 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: searchService_j3umigYGT
+  name: guid(searchService_j3umigYGT.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7ca78c08-252a-4471-8644-bb5ff32d4ba0'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7ca78c08-252a-4471-8644-bb5ff32d4ba0')
     principalId: principalId
@@ -47,4 +47,4 @@ resource roleAssignment_QpFzCj55x 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-output connectionString string = 'Endpoint=https://${searchService_7WkaGluF0.name}.search.windows.net'
+output connectionString string = 'Endpoint=https://${searchService_j3umigYGT.name}.search.windows.net'

--- a/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/storage.module.bicep
+++ b/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/storage.module.bicep
@@ -10,8 +10,8 @@ param principalId string
 param principalType string
 
 
-resource storageAccount_65zdmu5tK 'Microsoft.Storage/storageAccounts@2022-09-01' = {
-  name: toLower(take(concat('storage', uniqueString(resourceGroup().id)), 24))
+resource storageAccount_1XR3Um8QY 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: toLower(take('storage${uniqueString(resourceGroup().id)}', 24))
   location: location
   tags: {
     'aspire-resource-name': 'storage'
@@ -22,19 +22,22 @@ resource storageAccount_65zdmu5tK 'Microsoft.Storage/storageAccounts@2022-09-01'
   kind: 'StorageV2'
   properties: {
     accessTier: 'Hot'
+    networkAcls: {
+      defaultAction: 'Deny'
+    }
   }
 }
 
-resource blobService_24WqMwYy8 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
-  parent: storageAccount_65zdmu5tK
+resource blobService_vTLU20GRg 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
+  parent: storageAccount_1XR3Um8QY
   name: 'default'
   properties: {
   }
 }
 
-resource roleAssignment_ryHNwVXTs 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount_65zdmu5tK
-  name: guid(storageAccount_65zdmu5tK.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
+resource roleAssignment_Gz09cEnxb 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount_1XR3Um8QY
+  name: guid(storageAccount_1XR3Um8QY.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
     principalId: principalId
@@ -42,9 +45,9 @@ resource roleAssignment_ryHNwVXTs 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource roleAssignment_hqRD0luQx 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount_65zdmu5tK
-  name: guid(storageAccount_65zdmu5tK.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'))
+resource roleAssignment_HRj6MDafS 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount_1XR3Um8QY
+  name: guid(storageAccount_1XR3Um8QY.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3')
     principalId: principalId
@@ -52,9 +55,9 @@ resource roleAssignment_hqRD0luQx 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource roleAssignment_5PGf5zmoW 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount_65zdmu5tK
-  name: guid(storageAccount_65zdmu5tK.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
+resource roleAssignment_r0wA6OpKE 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount_1XR3Um8QY
+  name: guid(storageAccount_1XR3Um8QY.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
     principalId: principalId
@@ -62,6 +65,6 @@ resource roleAssignment_5PGf5zmoW 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-output blobEndpoint string = storageAccount_65zdmu5tK.properties.primaryEndpoints.blob
-output queueEndpoint string = storageAccount_65zdmu5tK.properties.primaryEndpoints.queue
-output tableEndpoint string = storageAccount_65zdmu5tK.properties.primaryEndpoints.table
+output blobEndpoint string = storageAccount_1XR3Um8QY.properties.primaryEndpoints.blob
+output queueEndpoint string = storageAccount_1XR3Um8QY.properties.primaryEndpoints.queue
+output tableEndpoint string = storageAccount_1XR3Um8QY.properties.primaryEndpoints.table

--- a/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/storage.module.bicep
+++ b/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/storage.module.bicep
@@ -23,7 +23,7 @@ resource storageAccount_1XR3Um8QY 'Microsoft.Storage/storageAccounts@2022-09-01'
   properties: {
     accessTier: 'Hot'
     networkAcls: {
-      defaultAction: 'Deny'
+      defaultAction: 'Allow'
     }
   }
 }

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
@@ -11,8 +11,8 @@ resource keyVault_IeF8jZvXV 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: keyVaultName
 }
 
-resource cosmosDBAccount_5pKmb8KAZ 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
-  name: toLower(take(concat('cosmos', uniqueString(resourceGroup().id)), 24))
+resource cosmosDBAccount_MZyw35gqp 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
+  name: toLower(take('cosmos${uniqueString(resourceGroup().id)}', 24))
   location: location
   tags: {
     'aspire-resource-name': 'cosmos'
@@ -32,8 +32,8 @@ resource cosmosDBAccount_5pKmb8KAZ 'Microsoft.DocumentDB/databaseAccounts@2023-0
   }
 }
 
-resource cosmosDBSqlDatabase_OquHUsfBg 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2023-04-15' = {
-  parent: cosmosDBAccount_5pKmb8KAZ
+resource cosmosDBSqlDatabase_LFJis0a6w 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2023-04-15' = {
+  parent: cosmosDBAccount_MZyw35gqp
   name: 'db'
   location: location
   properties: {
@@ -48,6 +48,6 @@ resource keyVaultSecret_Ddsc3HjrA 'Microsoft.KeyVault/vaults/secrets@2022-07-01'
   name: 'connectionString'
   location: location
   properties: {
-    value: 'AccountEndpoint=${cosmosDBAccount_5pKmb8KAZ.properties.documentEndpoint};AccountKey=${cosmosDBAccount_5pKmb8KAZ.listkeys(cosmosDBAccount_5pKmb8KAZ.apiVersion).primaryMasterKey}'
+    value: 'AccountEndpoint=${cosmosDBAccount_MZyw35gqp.properties.documentEndpoint};AccountKey=${cosmosDBAccount_MZyw35gqp.listkeys(cosmosDBAccount_MZyw35gqp.apiVersion).primaryMasterKey}'
   }
 }

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
@@ -10,8 +10,8 @@ param principalId string
 param principalType string
 
 
-resource cognitiveServicesAccount_6g8jyEjX5 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
-  name: toLower(take(concat('openai', uniqueString(resourceGroup().id)), 24))
+resource cognitiveServicesAccount_wXAGTFUId 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
+  name: toLower(take('openai${uniqueString(resourceGroup().id)}', 24))
   location: location
   kind: 'OpenAI'
   sku: {
@@ -23,9 +23,9 @@ resource cognitiveServicesAccount_6g8jyEjX5 'Microsoft.CognitiveServices/account
   }
 }
 
-resource roleAssignment_X7ie0XqR2 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: cognitiveServicesAccount_6g8jyEjX5
-  name: guid(cognitiveServicesAccount_6g8jyEjX5.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442'))
+resource roleAssignment_Hsk8rxWY8 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: cognitiveServicesAccount_wXAGTFUId
+  name: guid(cognitiveServicesAccount_wXAGTFUId.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a001fd3d-188f-4b5d-821b-7da978bf7442')
     principalId: principalId
@@ -33,8 +33,8 @@ resource roleAssignment_X7ie0XqR2 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource cognitiveServicesAccountDeployment_f9rYX6SRK 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01' = {
-  parent: cognitiveServicesAccount_6g8jyEjX5
+resource cognitiveServicesAccountDeployment_hU1MaqMLH 'Microsoft.CognitiveServices/accounts/deployments@2023-05-01' = {
+  parent: cognitiveServicesAccount_wXAGTFUId
   name: 'gpt-35-turbo'
   sku: {
     name: 'Standard'
@@ -42,11 +42,11 @@ resource cognitiveServicesAccountDeployment_f9rYX6SRK 'Microsoft.CognitiveServic
   }
   properties: {
     model: {
-      name: 'gpt-35-turbo'
       format: 'OpenAI'
+      name: 'gpt-35-turbo'
       version: '0613'
     }
   }
 }
 
-output connectionString string = 'Endpoint=${cognitiveServicesAccount_6g8jyEjX5.properties.endpoint}'
+output connectionString string = 'Endpoint=${cognitiveServicesAccount_wXAGTFUId.properties.endpoint}'

--- a/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/ProxylessEndToEnd/ProxylessEndToEnd.AppHost/aspire-manifest.json
@@ -9,6 +9,7 @@
           "scheme": "tcp",
           "protocol": "tcp",
           "transport": "tcp",
+          "port": 9999,
           "targetPort": 6379
         }
       }
@@ -26,7 +27,8 @@
         "http": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "port": 12345
         },
         "https": {
           "scheme": "https",
@@ -48,7 +50,8 @@
         "http": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 13456
         }
       }
     }

--- a/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/sql1.module.bicep
+++ b/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/sql1.module.bicep
@@ -10,15 +10,14 @@ param principalId string
 param principalName string
 
 
-resource sqlServer_MXlkl0TrE 'Microsoft.Sql/servers@2020-11-01-preview' = {
-  name: toLower(take(concat('sql1', uniqueString(resourceGroup().id)), 24))
+resource sqlServer_x8iP8H24Z 'Microsoft.Sql/servers@2020-11-01-preview' = {
+  name: toLower(take('sql1${uniqueString(resourceGroup().id)}', 24))
   location: location
   tags: {
     'aspire-resource-name': 'sql1'
   }
   properties: {
     version: '12.0'
-    minimalTlsVersion: '1.2'
     publicNetworkAccess: 'Enabled'
     administrators: {
       administratorType: 'ActiveDirectory'
@@ -30,8 +29,8 @@ resource sqlServer_MXlkl0TrE 'Microsoft.Sql/servers@2020-11-01-preview' = {
   }
 }
 
-resource sqlFirewallRule_zucOewiTI 'Microsoft.Sql/servers/firewallRules@2020-11-01-preview' = {
-  parent: sqlServer_MXlkl0TrE
+resource sqlFirewallRule_9yJsWRmBv 'Microsoft.Sql/servers/firewallRules@2020-11-01-preview' = {
+  parent: sqlServer_x8iP8H24Z
   name: 'AllowAllAzureIps'
   properties: {
     startIpAddress: '0.0.0.0'
@@ -39,12 +38,12 @@ resource sqlFirewallRule_zucOewiTI 'Microsoft.Sql/servers/firewallRules@2020-11-
   }
 }
 
-resource sqlDatabase_pLQwSRl2h 'Microsoft.Sql/servers/databases@2020-11-01-preview' = {
-  parent: sqlServer_MXlkl0TrE
+resource sqlDatabase_9KOoL8JWT 'Microsoft.Sql/servers/databases@2020-11-01-preview' = {
+  parent: sqlServer_x8iP8H24Z
   name: 'db1'
   location: location
   properties: {
   }
 }
 
-output sqlServerFqdn string = sqlServer_MXlkl0TrE.properties.fullyQualifiedDomainName
+output sqlServerFqdn string = sqlServer_x8iP8H24Z.properties.fullyQualifiedDomainName

--- a/playground/Stress/Stress.AppHost/aspire-manifest.json
+++ b/playground/Stress/Stress.AppHost/aspire-manifest.json
@@ -12,152 +12,182 @@
         "http-5180": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5180
         },
         "http-5181": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5181
         },
         "http-5182": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5182
         },
         "http-5183": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5183
         },
         "http-5184": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5184
         },
         "http-5185": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5185
         },
         "http-5186": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5186
         },
         "http-5187": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5187
         },
         "http-5188": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5188
         },
         "http-5189": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5189
         },
         "http-5190": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5190
         },
         "http-5191": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5191
         },
         "http-5192": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5192
         },
         "http-5193": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5193
         },
         "http-5194": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5194
         },
         "http-5195": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5195
         },
         "http-5196": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5196
         },
         "http-5197": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5197
         },
         "http-5198": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5198
         },
         "http-5199": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5199
         },
         "http-5200": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5200
         },
         "http-5201": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5201
         },
         "http-5202": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5202
         },
         "http-5203": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5203
         },
         "http-5204": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5204
         },
         "http-5205": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5205
         },
         "http-5206": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5206
         },
         "http-5207": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5207
         },
         "http-5208": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5208
         },
         "http-5209": {
           "scheme": "http",
           "protocol": "tcp",
-          "transport": "http"
+          "transport": "http",
+          "targetPort": 5209
         }
       }
     },

--- a/playground/bicep/BicepSample.AppHost/storage.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/storage.module.bicep
@@ -23,7 +23,7 @@ resource storageAccount_1XR3Um8QY 'Microsoft.Storage/storageAccounts@2022-09-01'
   properties: {
     accessTier: 'Hot'
     networkAcls: {
-      defaultAction: 'Deny'
+      defaultAction: 'Allow'
     }
   }
 }

--- a/playground/bicep/BicepSample.AppHost/storage.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/storage.module.bicep
@@ -22,6 +22,9 @@ resource storageAccount_1XR3Um8QY 'Microsoft.Storage/storageAccounts@2022-09-01'
   kind: 'StorageV2'
   properties: {
     accessTier: 'Hot'
+    networkAcls: {
+      defaultAction: 'Deny'
+    }
   }
 }
 

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIRE0001 // Because we use the CDK callbacks.
+#pragma warning disable AZPROVISION001 // Because we use the CDK callbacks.
 
 using Aspire.Hosting.Azure;
 using Azure.Provisioning.KeyVaults;

--- a/playground/cdk/CdkSample.AppHost/storage.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/storage.module.bicep
@@ -29,7 +29,7 @@ resource storageAccount_1XR3Um8QY 'Microsoft.Storage/storageAccounts@2022-09-01'
   properties: {
     accessTier: 'Hot'
     networkAcls: {
-      defaultAction: 'Deny'
+      defaultAction: 'Allow'
     }
   }
 }

--- a/playground/cdk/CdkSample.AppHost/storage.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/storage.module.bicep
@@ -28,6 +28,9 @@ resource storageAccount_1XR3Um8QY 'Microsoft.Storage/storageAccounts@2022-09-01'
   kind: 'StorageV2'
   properties: {
     accessTier: 'Hot'
+    networkAcls: {
+      defaultAction: 'Deny'
+    }
   }
 }
 

--- a/playground/orleans/OrleansAppHost/aspire-manifest.json
+++ b/playground/orleans/OrleansAppHost/aspire-manifest.json
@@ -29,10 +29,10 @@
         "Orleans__GrainStorage__Default__ProviderType": "AzureBlobStorage",
         "Orleans__GrainStorage__Default__ServiceKey": "grainstate",
         "ConnectionStrings__grainstate": "{grainstate.connectionString}",
-        "Orleans__ClusterId": "02348447ebc64775888d944ac74b95ef",
-        "Orleans__EnableDistributedTracing": "true",
+        "Orleans__ClusterId": "0c0f5014e5164ac8925353c6e697e65c",
         "Orleans__Endpoints__SiloPort": "{silo.bindings.orleans-silo.targetPort}",
-        "Orleans__Endpoints__GatewayPort": "{silo.bindings.orleans-gateway.targetPort}"
+        "Orleans__Endpoints__GatewayPort": "{silo.bindings.orleans-gateway.targetPort}",
+        "Orleans__EnableDistributedTracing": "true"
       },
       "bindings": {
         "http": {

--- a/playground/orleans/OrleansAppHost/aspire-manifest.json
+++ b/playground/orleans/OrleansAppHost/aspire-manifest.json
@@ -29,7 +29,7 @@
         "Orleans__GrainStorage__Default__ProviderType": "AzureBlobStorage",
         "Orleans__GrainStorage__Default__ServiceKey": "grainstate",
         "ConnectionStrings__grainstate": "{grainstate.connectionString}",
-        "Orleans__ClusterId": "37fce84be012459bba47b663214a1cc3",
+        "Orleans__ClusterId": "bf827dc3e0d6415b9bc9285a64cd0d90",
         "Orleans__Endpoints__SiloPort": "{silo.bindings.orleans-silo.targetPort}",
         "Orleans__Endpoints__GatewayPort": "{silo.bindings.orleans-gateway.targetPort}",
         "Orleans__EnableDistributedTracing": "true"

--- a/playground/orleans/OrleansAppHost/aspire-manifest.json
+++ b/playground/orleans/OrleansAppHost/aspire-manifest.json
@@ -29,7 +29,7 @@
         "Orleans__GrainStorage__Default__ProviderType": "AzureBlobStorage",
         "Orleans__GrainStorage__Default__ServiceKey": "grainstate",
         "ConnectionStrings__grainstate": "{grainstate.connectionString}",
-        "Orleans__ClusterId": "0c0f5014e5164ac8925353c6e697e65c",
+        "Orleans__ClusterId": "37fce84be012459bba47b663214a1cc3",
         "Orleans__Endpoints__SiloPort": "{silo.bindings.orleans-silo.targetPort}",
         "Orleans__Endpoints__GatewayPort": "{silo.bindings.orleans-gateway.targetPort}",
         "Orleans__EnableDistributedTracing": "true"

--- a/playground/orleans/OrleansAppHost/aspire-manifest.json
+++ b/playground/orleans/OrleansAppHost/aspire-manifest.json
@@ -29,7 +29,7 @@
         "Orleans__GrainStorage__Default__ProviderType": "AzureBlobStorage",
         "Orleans__GrainStorage__Default__ServiceKey": "grainstate",
         "ConnectionStrings__grainstate": "{grainstate.connectionString}",
-        "Orleans__ClusterId": "8578f94495f94302a742fd92fb958ece",
+        "Orleans__ClusterId": "c7673f46dfc745c8b4492b957aa42408",
         "Orleans__Endpoints__SiloPort": "{silo.bindings.orleans-silo.targetPort}",
         "Orleans__Endpoints__GatewayPort": "{silo.bindings.orleans-gateway.targetPort}",
         "Orleans__EnableDistributedTracing": "true"

--- a/playground/orleans/OrleansAppHost/aspire-manifest.json
+++ b/playground/orleans/OrleansAppHost/aspire-manifest.json
@@ -29,7 +29,7 @@
         "Orleans__GrainStorage__Default__ProviderType": "AzureBlobStorage",
         "Orleans__GrainStorage__Default__ServiceKey": "grainstate",
         "ConnectionStrings__grainstate": "{grainstate.connectionString}",
-        "Orleans__ClusterId": "bf827dc3e0d6415b9bc9285a64cd0d90",
+        "Orleans__ClusterId": "8578f94495f94302a742fd92fb958ece",
         "Orleans__Endpoints__SiloPort": "{silo.bindings.orleans-silo.targetPort}",
         "Orleans__Endpoints__GatewayPort": "{silo.bindings.orleans-gateway.targetPort}",
         "Orleans__EnableDistributedTracing": "true"

--- a/playground/orleans/OrleansAppHost/storage.module.bicep
+++ b/playground/orleans/OrleansAppHost/storage.module.bicep
@@ -10,8 +10,8 @@ param principalId string
 param principalType string
 
 
-resource storageAccount_65zdmu5tK 'Microsoft.Storage/storageAccounts@2022-09-01' = {
-  name: toLower(take(concat('storage', uniqueString(resourceGroup().id)), 24))
+resource storageAccount_1XR3Um8QY 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: toLower(take('storage${uniqueString(resourceGroup().id)}', 24))
   location: location
   tags: {
     'aspire-resource-name': 'storage'
@@ -22,19 +22,22 @@ resource storageAccount_65zdmu5tK 'Microsoft.Storage/storageAccounts@2022-09-01'
   kind: 'StorageV2'
   properties: {
     accessTier: 'Hot'
+    networkAcls: {
+      defaultAction: 'Deny'
+    }
   }
 }
 
-resource blobService_24WqMwYy8 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
-  parent: storageAccount_65zdmu5tK
+resource blobService_vTLU20GRg 'Microsoft.Storage/storageAccounts/blobServices@2022-09-01' = {
+  parent: storageAccount_1XR3Um8QY
   name: 'default'
   properties: {
   }
 }
 
-resource roleAssignment_ryHNwVXTs 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount_65zdmu5tK
-  name: guid(storageAccount_65zdmu5tK.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
+resource roleAssignment_Gz09cEnxb 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount_1XR3Um8QY
+  name: guid(storageAccount_1XR3Um8QY.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')
     principalId: principalId
@@ -42,9 +45,9 @@ resource roleAssignment_ryHNwVXTs 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource roleAssignment_hqRD0luQx 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount_65zdmu5tK
-  name: guid(storageAccount_65zdmu5tK.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'))
+resource roleAssignment_HRj6MDafS 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount_1XR3Um8QY
+  name: guid(storageAccount_1XR3Um8QY.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3')
     principalId: principalId
@@ -52,9 +55,9 @@ resource roleAssignment_hqRD0luQx 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-resource roleAssignment_5PGf5zmoW 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount_65zdmu5tK
-  name: guid(storageAccount_65zdmu5tK.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
+resource roleAssignment_r0wA6OpKE 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount_1XR3Um8QY
+  name: guid(storageAccount_1XR3Um8QY.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '974c5e8b-45b9-4653-ba55-5f855dd0fb88')
     principalId: principalId
@@ -62,6 +65,6 @@ resource roleAssignment_5PGf5zmoW 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-output blobEndpoint string = storageAccount_65zdmu5tK.properties.primaryEndpoints.blob
-output queueEndpoint string = storageAccount_65zdmu5tK.properties.primaryEndpoints.queue
-output tableEndpoint string = storageAccount_65zdmu5tK.properties.primaryEndpoints.table
+output blobEndpoint string = storageAccount_1XR3Um8QY.properties.primaryEndpoints.blob
+output queueEndpoint string = storageAccount_1XR3Um8QY.properties.primaryEndpoints.queue
+output tableEndpoint string = storageAccount_1XR3Um8QY.properties.primaryEndpoints.table

--- a/playground/orleans/OrleansAppHost/storage.module.bicep
+++ b/playground/orleans/OrleansAppHost/storage.module.bicep
@@ -23,7 +23,7 @@ resource storageAccount_1XR3Um8QY 'Microsoft.Storage/storageAccounts@2022-09-01'
   properties: {
     accessTier: 'Hot'
     networkAcls: {
-      defaultAction: 'Deny'
+      defaultAction: 'Allow'
     }
   }
 }

--- a/playground/signalr/SignalRAppHost/signalr1.module.bicep
+++ b/playground/signalr/SignalRAppHost/signalr1.module.bicep
@@ -10,8 +10,8 @@ param principalId string
 param principalType string
 
 
-resource signalRService_VaTic5fAI 'Microsoft.SignalRService/signalR@2022-02-01' = {
-  name: toLower(take(concat('signalr1', uniqueString(resourceGroup().id)), 24))
+resource signalRService_w7kmeqf4Y 'Microsoft.SignalRService/signalR@2022-02-01' = {
+  name: toLower(take('signalr1${uniqueString(resourceGroup().id)}', 24))
   location: location
   tags: {
     'aspire-resource-name': 'signalr1'
@@ -36,9 +36,9 @@ resource signalRService_VaTic5fAI 'Microsoft.SignalRService/signalR@2022-02-01' 
   }
 }
 
-resource roleAssignment_3I0AXMYDY 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: signalRService_VaTic5fAI
-  name: guid(signalRService_VaTic5fAI.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '420fcaa2-552c-430f-98ca-3264be4806c7'))
+resource roleAssignment_UoLS3XHY0 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: signalRService_w7kmeqf4Y
+  name: guid(signalRService_w7kmeqf4Y.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '420fcaa2-552c-430f-98ca-3264be4806c7'))
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '420fcaa2-552c-430f-98ca-3264be4806c7')
     principalId: principalId
@@ -46,4 +46,4 @@ resource roleAssignment_3I0AXMYDY 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
-output hostName string = signalRService_VaTic5fAI.properties.hostName
+output hostName string = signalRService_w7kmeqf4Y.properties.hostName

--- a/src/Aspire.Hosting.Azure.AppConfiguration/Aspire.Hosting.Azure.AppConfiguration.csproj
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/Aspire.Hosting.Azure.AppConfiguration.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.AppConfiguration" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -22,9 +22,9 @@ public static class AzureAppConfigurationExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureAppConfigurationResource> AddAzureAppConfiguration(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureAppConfiguration(name, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public static class AzureAppConfigurationExtensions
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.AppConfiguration.AppConfigurationStore"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureAppConfigurationResource> AddAzureAppConfiguration(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureAppConfigurationResource>, ResourceModuleConstruct, AppConfigurationStore>? configureResource)
     {
         builder.AddAzureProvisioning();

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -4,8 +4,8 @@
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
+using Azure.Provisioning;
 using Azure.Provisioning.AppConfiguration;
-using Azure.Provisioning.Authorization;
 
 namespace Aspire.Hosting;
 

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\Aspire.Hosting.Azure.OperationalInsights\Aspire.Hosting.Azure.OperationalInsights.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.ApplicationInsights" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -84,7 +84,7 @@ public static class AzureApplicationInsightsExtensions
             {
                 // ... otherwise if we are in run mode, the provisioner expects us to create one ourselves.
                 var autoInjectedLogAnalyticsWorkspace = new OperationalInsightsWorkspace(construct, name: $"law-{construct.Resource.Name}");
-                appInsights.Properties.Tags["aspire-resource-name"] = $"law-{construct.Resource.Name}";
+                autoInjectedLogAnalyticsWorkspace.Properties.Tags["aspire-resource-name"] = $"law-{construct.Resource.Name}";
                 autoInjectedLogAnalyticsWorkspace.AssignProperty(p => p.Sku.Name, "'PerGB2018'");
 
                 // If the user does not supply a log analytics workspace of their own we still create a parameter on the Aspire

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -84,7 +84,6 @@ public static class AzureApplicationInsightsExtensions
                 // side and the CDK side so that AZD can fill the value in with the one it generates.
                 construct.Resource.Parameters.Add(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, "");
                 appInsights.AssignProperty(p => p.WorkspaceResourceId, new Parameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId));
-
             }
 
             appInsights.AddOutput("appInsightsConnectionString", p => p.ConnectionString);

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -83,8 +83,9 @@ public static class AzureApplicationInsightsExtensions
             else if (builder.ExecutionContext.IsRunMode)
             {
                 // ... otherwise if we are in run mode, the provisioner expects us to create one ourselves.
-                var autoInjectedLogAnalyticsWorkspace = new OperationalInsightsWorkspace(construct, name: $"law-{construct.Resource.Name}");
-                autoInjectedLogAnalyticsWorkspace.Properties.Tags["aspire-resource-name"] = $"law-{construct.Resource.Name}";
+                var autoInjectedLogAnalyticsWorkspaceName = $"law-{construct.Resource.Name}";
+                var autoInjectedLogAnalyticsWorkspace = new OperationalInsightsWorkspace(construct, name: autoInjectedLogAnalyticsWorkspaceName);
+                autoInjectedLogAnalyticsWorkspace.Properties.Tags["aspire-resource-name"] = autoInjectedLogAnalyticsWorkspaceName;
                 autoInjectedLogAnalyticsWorkspace.AssignProperty(p => p.Sku.Name, "'PerGB2018'");
 
                 // If the user does not supply a log analytics workspace of their own we still create a parameter on the Aspire

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -23,9 +23,9 @@ public static class AzureApplicationInsightsExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{AzureApplicationInsightsResource}"/>.</returns>
     public static IResourceBuilder<AzureApplicationInsightsResource> AddAzureApplicationInsights(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureApplicationInsights(name, null, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -37,9 +37,9 @@ public static class AzureApplicationInsightsExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{AzureApplicationInsightsResource}"/>.</returns>
     public static IResourceBuilder<AzureApplicationInsightsResource> AddAzureApplicationInsights(this IDistributedApplicationBuilder builder, string name, IResourceBuilder<AzureLogAnalyticsWorkspaceResource>? logAnalyticsWorkspace)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureApplicationInsights(name, logAnalyticsWorkspace, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public static class AzureApplicationInsightsExtensions
     /// <param name="name">The name of the resource.</param>
     /// <param name="configureResource">Optional callback to configure the Application Insights resource.</param>
     /// <returns></returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureApplicationInsightsResource> AddAzureApplicationInsights(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureApplicationInsightsResource>, ResourceModuleConstruct, ApplicationInsightsComponent>? configureResource)
     {
         return builder.AddAzureApplicationInsights(name, null, configureResource);
@@ -63,7 +63,7 @@ public static class AzureApplicationInsightsExtensions
     /// <param name="logAnalyticsWorkspace">A resource builder for the log analytics workspace.</param>
     /// <param name="configureResource">Optional callback to configure the Application Insights resource.</param>
     /// <returns></returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureApplicationInsightsResource> AddAzureApplicationInsights(this IDistributedApplicationBuilder builder, string name, IResourceBuilder<AzureLogAnalyticsWorkspaceResource>? logAnalyticsWorkspace, Action<IResourceBuilder<AzureApplicationInsightsResource>, ResourceModuleConstruct, ApplicationInsightsComponent>? configureResource)
     {
         builder.AddAzureProvisioning();

--- a/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.CognitiveServices" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
-using Azure.Provisioning.Authorization;
+using Azure.Provisioning;
 using Azure.Provisioning.CognitiveServices;
 using Azure.ResourceManager.CognitiveServices.Models;
 

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -23,9 +23,9 @@ public static class AzureOpenAIExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureOpenAIResource> AddAzureOpenAI(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureOpenAI(name, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public static class AzureOpenAIExtensions
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.CognitiveServices.CognitiveServicesAccount"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureOpenAIResource> AddAzureOpenAI(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureOpenAIResource>, ResourceModuleConstruct, CognitiveServicesAccount, IEnumerable<CognitiveServicesAccountDeployment>>? configureResource)
     {
         builder.AddAzureProvisioning();

--- a/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
+++ b/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.CosmosDB" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -48,6 +48,12 @@ public static class AzureCosmosExtensions
             cosmosAccount.AssignProperty(x => x.Locations[0].LocationName, "location");
             cosmosAccount.AssignProperty(x => x.Locations[0].FailoverPriority, "0");
 
+            if (builder.ExecutionContext.IsPublishMode)
+            {
+                // If we are in publish mode then we lock things down to just Azure services.
+                cosmosAccount.AssignProperty(x => x.NetworkAclBypass, "'AzureServices'");
+            }
+
             cosmosAccount.Properties.Tags["aspire-resource-name"] = construct.Resource.Name;
 
             var keyVaultNameParameter = new Parameter("keyVaultName");

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -48,12 +48,6 @@ public static class AzureCosmosExtensions
             cosmosAccount.AssignProperty(x => x.Locations[0].LocationName, "location");
             cosmosAccount.AssignProperty(x => x.Locations[0].FailoverPriority, "0");
 
-            if (builder.ExecutionContext.IsPublishMode)
-            {
-                // If we are in publish mode then we lock things down to just Azure services.
-                cosmosAccount.AssignProperty(x => x.NetworkAclBypass, "'AzureServices'");
-            }
-
             cosmosAccount.Properties.Tags["aspire-resource-name"] = construct.Resource.Name;
 
             var keyVaultNameParameter = new Parameter("keyVaultName");

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -24,9 +24,9 @@ public static class AzureCosmosExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureCosmosDBResource> AddAzureCosmosDB(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureCosmosDB(name, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
     /// <summary>
     /// Adds an Azure Cosmos DB connection to the application model.
@@ -35,7 +35,7 @@ public static class AzureCosmosExtensions
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="configureResource"></param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureCosmosDBResource> AddAzureCosmosDB(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureCosmosDBResource>, ResourceModuleConstruct, CosmosDBAccount, IEnumerable<CosmosDBSqlDatabase>>? configureResource)
     {
         builder.AddAzureProvisioning();

--- a/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
+++ b/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.EventHubs" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -23,9 +23,9 @@ public static class AzureEventHubsExtensions
     public static IResourceBuilder<AzureEventHubsResource> AddAzureEventHubs(
         this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // This API requires opting into experimental features
+#pragma warning disable AZPROVISION001 // This API requires opting into experimental features
         return builder.AddAzureEventHubs(name, null);
-#pragma warning restore ASPIRE0001 // This API requires opting into experimental features
+#pragma warning restore AZPROVISION001 // This API requires opting into experimental features
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public static class AzureEventHubsExtensions
     /// <param name="name">The name of the resource.</param>
     /// <param name="configureResource">Optional callback to configure the Event Hubs namespace.</param>
     /// <returns></returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureEventHubsResource> AddAzureEventHubs(this IDistributedApplicationBuilder builder, string name,
         Action<IResourceBuilder<AzureEventHubsResource>, ResourceModuleConstruct, EventHubsNamespace>? configureResource)
     {
@@ -81,9 +81,9 @@ public static class AzureEventHubsExtensions
     /// <param name="name">The name of the Event Hub.</param>
     public static IResourceBuilder<AzureEventHubsResource> AddEventHub(this IResourceBuilder<AzureEventHubsResource> builder, string name)
     {
-#pragma warning disable ASPIRE0001 // This API requires opting into experimental features
+#pragma warning disable AZPROVISION001 // This API requires opting into experimental features
         return builder.AddEventHub(name, null);
-#pragma warning restore ASPIRE0001 // This API requires opting into experimental features
+#pragma warning restore AZPROVISION001 // This API requires opting into experimental features
     }
 
     /// <summary>
@@ -92,7 +92,7 @@ public static class AzureEventHubsExtensions
     /// <param name="builder">The Azure Event Hubs resource builder.</param>
     /// <param name="name">The name of the Event Hub.</param>
     /// <param name="configureHub">Optional callback to customize the Event Hub.</param>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureEventHubsResource> AddEventHub(this IResourceBuilder<AzureEventHubsResource> builder,
         string name, Action<IResourceBuilder<AzureEventHubsResource>, ResourceModuleConstruct, EventHub>? configureHub)
     {

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning;
-using Azure.Provisioning.Authorization;
 using Azure.Provisioning.EventHubs;
 
 namespace Aspire.Hosting;

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsResource.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable AZPROVISION001
+
 using Aspire.Hosting.ApplicationModel;
 using Azure.Provisioning.EventHubs;
 

--- a/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
+++ b/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.KeyVault" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -44,13 +44,6 @@ public static class AzureKeyVaultResourceExtensions
             var keyVault = construct.AddKeyVault(name: construct.Resource.Name);
             keyVault.AddOutput("vaultUri", x => x.Properties.VaultUri);
 
-            if (builder.ExecutionContext.IsPublishMode)
-            {
-                // If we are in publish mode then we lock things down to just Azure services.
-                keyVault.AssignProperty(p => p.Properties.NetworkRuleSet.DefaultAction, "'Deny'");
-                keyVault.AssignProperty(p => p.Properties.NetworkRuleSet.Bypass, "'AzureServices'");
-            }
-
             keyVault.Properties.Tags["aspire-resource-name"] = construct.Resource.Name;
 
             var keyVaultAdministratorRoleAssignment = keyVault.AssignRole(RoleDefinition.KeyVaultAdministrator);

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -44,6 +44,13 @@ public static class AzureKeyVaultResourceExtensions
             var keyVault = construct.AddKeyVault(name: construct.Resource.Name);
             keyVault.AddOutput("vaultUri", x => x.Properties.VaultUri);
 
+            if (builder.ExecutionContext.IsPublishMode)
+            {
+                // If we are in publish mode then we lock things down to just Azure services.
+                keyVault.AssignProperty(p => p.Properties.NetworkRuleSet.DefaultAction, "'Deny'");
+                keyVault.AssignProperty(p => p.Properties.NetworkRuleSet.Bypass, "'AzureServices'");
+            }
+
             keyVault.Properties.Tags["aspire-resource-name"] = construct.Resource.Name;
 
             var keyVaultAdministratorRoleAssignment = keyVault.AssignRole(RoleDefinition.KeyVaultAdministrator);

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
-using Azure.Provisioning.Authorization;
+using Azure.Provisioning;
 using Azure.Provisioning.KeyVaults;
 
 namespace Aspire.Hosting;

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -22,9 +22,9 @@ public static class AzureKeyVaultResourceExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureKeyVaultResource> AddAzureKeyVault(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureKeyVault(name, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public static class AzureKeyVaultResourceExtensions
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.KeyVaults.KeyVault"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureKeyVaultResource> AddAzureKeyVault(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureKeyVaultResource>, ResourceModuleConstruct, KeyVault>? configureResource)
     {
         builder.AddAzureProvisioning();

--- a/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.OperationalInsights" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
@@ -22,9 +22,9 @@ public static class AzureLogAnalyticsWorkspaceExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureLogAnalyticsWorkspaceResource> AddAzureLogAnalyticsWorkspace(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureLogAnalyticsWorkspace(name, (_, _, _) => { });
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public static class AzureLogAnalyticsWorkspaceExtensions
     /// <param name="name">The name of the resource.</param>
     /// <param name="configureResource">Optional callback to configure the Azure Log Analytics Workspace resource.</param>
     /// <returns></returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureLogAnalyticsWorkspaceResource> AddAzureLogAnalyticsWorkspace(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureLogAnalyticsWorkspaceResource>, ResourceModuleConstruct, OperationalInsightsWorkspace>? configureResource)
     {
         builder.AddAzureProvisioning();

--- a/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.PostgreSQL\Aspire.Hosting.PostgreSQL.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.PostgreSql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable AZPROVISION001
+
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -118,7 +118,7 @@ public static class AzurePostgresExtensions
     /// <param name="builder">The <see cref="IResourceBuilder{PostgresServerResource}"/> builder.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServer"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{PostgresServerResource}"/> builder.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<PostgresServerResource> PublishAsAzurePostgresFlexibleServer(
         this IResourceBuilder<PostgresServerResource> builder,
         Action<IResourceBuilder<AzurePostgresResource>, ResourceModuleConstruct, PostgreSqlFlexibleServer>? configureResource)
@@ -136,9 +136,9 @@ public static class AzurePostgresExtensions
     public static IResourceBuilder<PostgresServerResource> PublishAsAzurePostgresFlexibleServer(
         this IResourceBuilder<PostgresServerResource> builder)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.PublishAsAzurePostgresFlexibleServer(null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -149,9 +149,9 @@ public static class AzurePostgresExtensions
     public static IResourceBuilder<PostgresServerResource> AsAzurePostgresFlexibleServer(
         this IResourceBuilder<PostgresServerResource> builder)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AsAzurePostgresFlexibleServer(null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -160,7 +160,7 @@ public static class AzurePostgresExtensions
     /// <param name="builder">The <see cref="IResourceBuilder{PostgresServerResource}"/> builder.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServer"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{PostgresServerResource}"/> builder.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<PostgresServerResource> AsAzurePostgresFlexibleServer(
         this IResourceBuilder<PostgresServerResource> builder,
         Action<IResourceBuilder<AzurePostgresResource>, ResourceModuleConstruct, PostgreSqlFlexibleServer>? configureResource)

--- a/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
+++ b/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Redis\Aspire.Hosting.Redis.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.Redis" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable AZPROVISION001
+
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
@@ -22,9 +24,7 @@ public static class AzureRedisExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{RedisResource}"/> builder.</returns>
     public static IResourceBuilder<RedisResource> PublishAsAzureRedis(this IResourceBuilder<RedisResource> builder)
     {
-#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.PublishAsAzureRedis(null);
-#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -93,9 +93,7 @@ public static class AzureRedisExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{RedisResource}"/> builder.</returns>
     public static IResourceBuilder<RedisResource> AsAzureRedis(this IResourceBuilder<RedisResource> builder)
     {
-#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AsAzureRedis(null);
-#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -22,9 +22,9 @@ public static class AzureRedisExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{RedisResource}"/> builder.</returns>
     public static IResourceBuilder<RedisResource> PublishAsAzureRedis(this IResourceBuilder<RedisResource> builder)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.PublishAsAzureRedis(null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -33,7 +33,7 @@ public static class AzureRedisExtensions
     /// <param name="builder">The <see cref="IResourceBuilder{RedisResource}"/> builder.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.Redis.RedisCache"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{RedisResource}"/> builder.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<RedisResource> PublishAsAzureRedis(this IResourceBuilder<RedisResource> builder, Action<IResourceBuilder<AzureRedisResource>, ResourceModuleConstruct, RedisCache>? configureResource)
     {
         return builder.PublishAsAzureRedisInternal(configureResource);
@@ -93,9 +93,9 @@ public static class AzureRedisExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{RedisResource}"/> builder.</returns>
     public static IResourceBuilder<RedisResource> AsAzureRedis(this IResourceBuilder<RedisResource> builder)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AsAzureRedis(null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ public static class AzureRedisExtensions
     /// <param name="builder">The <see cref="IResourceBuilder{RedisResource}"/> builder.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.Redis.RedisCache"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{RedisResource}"/> builder.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<RedisResource> AsAzureRedis(this IResourceBuilder<RedisResource> builder, Action<IResourceBuilder<AzureRedisResource>, ResourceModuleConstruct, RedisCache>? configureResource)
     {
         return builder.PublishAsAzureRedisInternal(configureResource, useProvisioner: true);

--- a/src/Aspire.Hosting.Azure.Search/Aspire.Hosting.Azure.Search.csproj
+++ b/src/Aspire.Hosting.Azure.Search/Aspire.Hosting.Azure.Search.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.Search" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
-using Azure.Provisioning.Authorization;
+using Azure.Provisioning;
 using Azure.Provisioning.Search;
 using Azure.ResourceManager.Search.Models;
 

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -23,9 +23,9 @@ public static class AzureSearchExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{AzureSearchConstructResource}"/>.</returns>
     public static IResourceBuilder<AzureSearchResource> AddAzureSearch(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureSearch(name, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
     /// <summary>
     /// Adds an Azure AI Search service resource to the application model.
@@ -34,7 +34,7 @@ public static class AzureSearchExtensions
     /// <param name="name">The name of the Azure AI Search resource.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.Search.SearchService"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{AzureSearchConstructResource}"/>.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureSearchResource> AddAzureSearch(
         this IDistributedApplicationBuilder builder,
         string name,

--- a/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
+++ b/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.ServiceBus" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -22,9 +22,9 @@ public static class AzureServiceBusExtensions
     /// <returns></returns>
     public static IResourceBuilder<AzureServiceBusResource> AddAzureServiceBus(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureServiceBus(name, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public static class AzureServiceBusExtensions
     /// <param name="name">The name of the resource.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.ServiceBus.ServiceBusNamespace"/> resource.</param>
     /// <returns></returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureServiceBusResource> AddAzureServiceBus(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureServiceBusResource>, ResourceModuleConstruct, ServiceBusNamespace>? configureResource)
     {
         builder.AddAzureProvisioning();
@@ -108,9 +108,9 @@ public static class AzureServiceBusExtensions
     /// <param name="name">The name of the queue.</param>
     public static IResourceBuilder<AzureServiceBusResource> AddQueue(this IResourceBuilder<AzureServiceBusResource> builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddQueue(name, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -119,7 +119,7 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The Azure Service Bus resource builder.</param>
     /// <param name="name">The name of the queue.</param>
     /// <param name="configureQueue">Callback to configure the underlying <see cref="global::Azure.Provisioning.ServiceBus.ServiceBusQueue"/> resource.</param>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureServiceBusResource> AddQueue(this IResourceBuilder<AzureServiceBusResource> builder, string name, Action<IResourceBuilder<AzureServiceBusResource>, ResourceModuleConstruct, ServiceBusQueue>? configureQueue)
     {
         builder.Resource.Queues.Add((name, configureQueue));
@@ -133,9 +133,9 @@ public static class AzureServiceBusExtensions
     /// <param name="name">The name of the topic.</param>
     public static IResourceBuilder<AzureServiceBusResource> AddTopic(this IResourceBuilder<AzureServiceBusResource> builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddTopic(name, configureTopic: null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -144,7 +144,7 @@ public static class AzureServiceBusExtensions
     /// <param name="builder">The Azure Service Bus resource builder.</param>
     /// <param name="name">The name of the topic.</param>
     /// <param name="configureTopic">Callback to configure the underlying <see cref="global::Azure.Provisioning.ServiceBus.ServiceBusTopic"/> resource.</param>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureServiceBusResource> AddTopic(this IResourceBuilder<AzureServiceBusResource> builder, string name, Action<IResourceBuilder<AzureServiceBusResource>, ResourceModuleConstruct, ServiceBusTopic>? configureTopic)
     {
         builder.Resource.Topics.Add((name, configureTopic));
@@ -159,9 +159,9 @@ public static class AzureServiceBusExtensions
     /// <param name="subscriptionName">The name of the subscription.</param>
     public static IResourceBuilder<AzureServiceBusResource> AddSubscription(this IResourceBuilder<AzureServiceBusResource> builder, string topicName, string subscriptionName)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddSubscription(topicName, subscriptionName, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -171,7 +171,7 @@ public static class AzureServiceBusExtensions
     /// <param name="topicName">The name of the topic.</param>
     /// <param name="subscriptionName">The name of the subscription.</param>
     /// <param name="configureSubscription">Callback to configure the underlying <see cref="global::Azure.Provisioning.ServiceBus.ServiceBusSubscription"/> resource.</param>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureServiceBusResource> AddSubscription(this IResourceBuilder<AzureServiceBusResource> builder, string topicName, string subscriptionName, Action<IResourceBuilder<AzureServiceBusResource>, ResourceModuleConstruct, ServiceBusSubscription>? configureSubscription)
     {
         builder.Resource.Subscriptions.Add((topicName, subscriptionName, configureSubscription));

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning;
-using Azure.Provisioning.Authorization;
 using Azure.Provisioning.ServiceBus;
 
 namespace Aspire.Hosting;

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable AZPROVISION001
+
 using Aspire.Hosting.ApplicationModel;
 using Azure.Provisioning.ServiceBus;
 

--- a/src/Aspire.Hosting.Azure.SignalR/Aspire.Hosting.Azure.SignalR.csproj
+++ b/src/Aspire.Hosting.Azure.SignalR/Aspire.Hosting.Azure.SignalR.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.SignalR" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
-using Azure.Provisioning.Authorization;
+using Azure.Provisioning;
 using Azure.Provisioning.SignalR;
 
 namespace Aspire.Hosting;

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -22,9 +22,9 @@ public static class AzureSignalRExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<AzureSignalRResource> AddAzureSignalR(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureSignalR(name, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public static class AzureSignalRExtensions
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.SignalR.SignalRService"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureSignalRResource> AddAzureSignalR(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureSignalRResource>, ResourceModuleConstruct, SignalRService>? configureResource)
     {
         builder.AddAzureProvisioning();

--- a/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
+++ b/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.SqlServer\Aspire.Hosting.SqlServer.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.Sql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable AZPROVISION001
+
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
@@ -93,9 +95,7 @@ public static class AzureSqlExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<SqlServerServerResource> PublishAsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder)
     {
-#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.PublishAsAzureSqlDatabase(null);
-#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -117,9 +117,7 @@ public static class AzureSqlExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<SqlServerServerResource> AsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder)
     {
-#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AsAzureSqlDatabase(null);
-#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -93,9 +93,9 @@ public static class AzureSqlExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<SqlServerServerResource> PublishAsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.PublishAsAzureSqlDatabase(null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ public static class AzureSqlExtensions
     /// <param name="builder">The builder for the SQL Server resource.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.Sql.SqlServer"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<SqlServerServerResource> PublishAsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder, Action<IResourceBuilder<AzureSqlServerResource>, ResourceModuleConstruct, SqlServer, IEnumerable<SqlDatabase>>? configureResource)
     {
         return builder.PublishAsAzureSqlDatabase(configureResource, useProvisioner: false);
@@ -117,9 +117,9 @@ public static class AzureSqlExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<SqlServerServerResource> AsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AsAzureSqlDatabase(null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -128,7 +128,7 @@ public static class AzureSqlExtensions
     /// <param name="builder">The builder for the SQL Server resource.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.Sql.SqlServer"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<SqlServerServerResource> AsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder, Action<IResourceBuilder<AzureSqlServerResource>, ResourceModuleConstruct, SqlServer, IEnumerable<SqlDatabase>>? configureResource)
     {
         return builder.PublishAsAzureSqlDatabase(configureResource, useProvisioner: true);

--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.Storage" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -49,6 +49,20 @@ public static class AzureStorageExtensions
                 sku: StorageSkuName.StandardGrs
                 );
 
+            // NOTE: Currently the CDK injects networkAcls by default and sets them to deny. This is sub-optimimal
+            //       as we'd probably want the default to omit this field altogether and accept the default of
+            //       Allow. However because that isn't possible we explicitly set the default action to allow
+            //       in Run mode and Deny in publish mode with an exception for Azure services.
+            if (builder.ExecutionContext.IsRunMode)
+            {
+                storageAccount.AssignProperty(p => p.NetworkRuleSet.DefaultAction, "'Allow'");
+            }
+            else
+            {
+                storageAccount.AssignProperty(p => p.NetworkRuleSet.DefaultAction, "'Deny'");
+                storageAccount.AssignProperty(p => p.NetworkRuleSet.Bypass, "'AzureServices'");
+            }
+
             storageAccount.Properties.Tags["aspire-resource-name"] = construct.Resource.Name;
 
             var blobService = new BlobService(construct);

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -24,9 +24,9 @@ public static class AzureStorageExtensions
     /// <returns></returns>
     public static IResourceBuilder<AzureStorageResource> AddAzureStorage(this IDistributedApplicationBuilder builder, string name)
     {
-#pragma warning disable ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         return builder.AddAzureStorage(name, null);
-#pragma warning restore ASPIRE0001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     /// <summary>
@@ -36,7 +36,7 @@ public static class AzureStorageExtensions
     /// <param name="name">The name of the resource.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.Storage.StorageAccount"/> resource.</param>
     /// <returns></returns>
-    [Experimental("ASPIRE0001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureStorageResource> AddAzureStorage(this IDistributedApplicationBuilder builder, string name, Action<IResourceBuilder<AzureStorageResource>, ResourceModuleConstruct, StorageAccount>? configureResource)
     {
         builder.AddAzureProvisioning();

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -49,19 +49,10 @@ public static class AzureStorageExtensions
                 sku: StorageSkuName.StandardGrs
                 );
 
-            // NOTE: Currently the CDK injects networkAcls by default and sets them to deny. This is sub-optimimal
-            //       as we'd probably want the default to omit this field altogether and accept the default of
-            //       Allow. However because that isn't possible we explicitly set the default action to allow
-            //       in Run mode and Deny in publish mode with an exception for Azure services.
-            if (builder.ExecutionContext.IsRunMode)
-            {
-                storageAccount.AssignProperty(p => p.NetworkRuleSet.DefaultAction, "'Allow'");
-            }
-            else
-            {
-                storageAccount.AssignProperty(p => p.NetworkRuleSet.DefaultAction, "'Deny'");
-                storageAccount.AssignProperty(p => p.NetworkRuleSet.Bypass, "'AzureServices'");
-            }
+            // Unfortunately Azure Storage does not list ACA as one of the resource types in which
+            // the AzureServices firewall policy works. This means that we need this Azure Storage
+            // account to have its default action set to Allow.
+            storageAccount.AssignProperty(p => p.NetworkRuleSet.DefaultAction, "'Allow'");
 
             storageAccount.Properties.Tags["aspire-resource-name"] = construct.Resource.Name;
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Aspire.Hosting.Utils;
-using Azure.Provisioning.Authorization;
+using Azure.Provisioning;
 using Azure.Provisioning.Storage;
 using Azure.ResourceManager.Storage.Models;
 

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -24,6 +24,8 @@
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
     <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="Azure.Provisioning" />
+    <PackageReference Include="Azure.Provisioning.KeyVault" />
+    <PackageReference Include="Azure.Provisioning.Resources" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#pragma warning disable AZPROVISION001
+
 using System.Linq.Expressions;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -551,7 +551,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               name: toLower(take('appInsights${uniqueString(resourceGroup().id)}', 24))
               location: location
               tags: {
-                'aspire-resource-name': 'law-appInsights'
+                'aspire-resource-name': 'appInsights'
               }
               kind: kind
               properties: {
@@ -563,6 +563,9 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             resource operationalInsightsWorkspace_smwjw0Wga 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
               name: toLower(take('law-appInsights${uniqueString(resourceGroup().id)}', 24))
               location: location
+              tags: {
+                'aspire-resource-name': 'law-appInsights'
+              }
               properties: {
                 sku: {
                   name: 'PerGB2018'

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -335,7 +335,6 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                     failoverPriority: 0
                   }
                 ]
-                networkAclBypass: 'AzureServices'
               }
             }
 
@@ -921,10 +920,6 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                   name: 'standard'
                 }
                 enableRbacAuthorization: true
-                networkAcls: {
-                  bypass: 'AzureServices'
-                  defaultAction: 'Deny'
-                }
               }
             }
 
@@ -1925,8 +1920,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               properties: {
                 accessTier: 'Hot'
                 networkAcls: {
-                  bypass: 'AzureServices'
-                  defaultAction: 'Deny'
+                  defaultAction: 'Allow'
                 }
               }
             }

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#pragma warning disable ASPIRE0001 // Because we are testing CDK callbacks.
+#pragma warning disable AZPROVISION001 // Because we are testing CDK callbacks.
 
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Azure;


### PR DESCRIPTION
This PR (draft until we get a `0.1.0-beta.x build`) incorporates a change that the Azure SDK team has made around the `Azure.Provisioning` package. They are breaking it up into multiple packages. Here is what is in this PR:

# Migration to Azure.Provisioning.* packages

The Azure SDK team has split up the `Azure.Provisioning` packages into mutliple packages based on resource. This is something that we had always planned on happening as it better aligns with the way their engineering system works. We held off doing it for P5 due to the tight timeframe but it is now ready for P6.

# Fix for AppInsights/LogAnalytics issue

Through some manual testing I found an edge case that I hadn't tested earlier in relation to integration of log analytics and app insights. If someone does not provide a log analytics workspace explicitly then we were not creating one (we used to with our Bicep based approach). This was not an issue for deployment with AZD because it would inject the log analytics workspace ID. However if you don't provide a workspace AND you use the Azure Provisioner the deployment would fail. This PR includes fixes for that issue as well as covering test cases so that we don't accidentally regress this behavior.

# Firewall rules

Reacted to some changes in the firewall configuration for resources via the CDK. Unfortunately we won't be able to add an IP based firewall for KeyVault, Storage, and Cosmos resources. For KeyVault and Storage - they don't treat ACA as a trusted service (probably got something to do with the highly ephemeral IP ranges for this service). For Cosmos you can enable the firewall, but upon inspection of the side effects of doing this manually in the Portal it appears that a set of hard coded IP values are added. This is probably not something that we want to do in Aspire so we'll be better off waiting until we figure out how to make Aspire work well with virutal networks.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3383)