### PR TITLE
Explicitly specify grpc OTLP protocol with env var

### DIFF
--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -37,6 +37,11 @@ public static class OtlpConfigurationExtensions
             var url = configuration[DashboardOtlpUrlVariableName] ?? DashboardOtlpUrlDefaultValue;
             context.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = new HostUrl(url);
 
+            // The dashboard currently only supports OTLP over gRPC.
+            // Most SDK's OTLP exporters default to gRPC but we should be explicit in case there are exporters
+            // that prefer another protocol. We want them to use grpc.
+            context.EnvironmentVariables["OTEL_EXPORTER_OTLP_PROTOCOL"] = "grpc";
+
             // Set the service name and instance id to the resource name and UID. Values are injected by DCP.
             context.EnvironmentVariables["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id={{- .Name -}}";
             context.EnvironmentVariables["OTEL_SERVICE_NAME"] = "{{- index .Annotations \"otel-service-name\" -}}";

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -60,6 +60,11 @@ public class ProjectResourceTests
             },
             env =>
             {
+                Assert.Equal("OTEL_EXPORTER_OTLP_PROTOCOL", env.Key);
+                Assert.Equal("grpc", env.Value);
+            },
+            env =>
+            {
                 Assert.Equal("OTEL_SERVICE_NAME", env.Key);
                 Assert.Equal("{{- index .Annotations \"otel-service-name\" -}}", env.Value);
             },

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -55,13 +55,13 @@ public class ProjectResourceTests
             },
             env =>
             {
-                Assert.Equal("OTEL_RESOURCE_ATTRIBUTES", env.Key);
-                Assert.Equal("service.instance.id={{- .Name -}}", env.Value);
+                Assert.Equal("OTEL_EXPORTER_OTLP_PROTOCOL", env.Key);
+                Assert.Equal("grpc", env.Value);
             },
             env =>
             {
-                Assert.Equal("OTEL_EXPORTER_OTLP_PROTOCOL", env.Key);
-                Assert.Equal("grpc", env.Value);
+                Assert.Equal("OTEL_RESOURCE_ATTRIBUTES", env.Key);
+                Assert.Equal("service.instance.id={{- .Name -}}", env.Value);
             },
             env =>
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/3166

Most SDK's OTLP exporters default to gRPC but we should be explicit in case there are exporters that prefer another protocol. We want them to use grpc.

I think Python is an example of a protocol that defaults to Protobuf/JSON over HTTP. Customer report of trouble getting Aspire working because they used HTTP.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3384)