### PR TITLE
Make status column icons colorblind friendly

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -51,12 +51,12 @@ else if (!string.IsNullOrEmpty(Resource.StateStyle))
                         Class="severity-icon" />
             break;
         case "success":
-            <FluentIcon Icon="Icons.Filled.Size16.Circle"
+            <FluentIcon Icon="Icons.Filled.Size16.CheckmarkCircle"
                         Color="Color.Success"
                         Class="severity-icon" />
             break;
         case "info":
-            <FluentIcon Icon="Icons.Filled.Size16.Circle"
+            <FluentIcon Icon="Icons.Filled.Size16.Info"
                         Color="Color.Info"
                         Class="severity-icon" />
             break;


### PR DESCRIPTION
Ensures these icons are differentiated not only by colour, but also by icon.

Also fixes this issue, pointed out offline by @timheuer:

![image](https://github.com/dotnet/aspire/assets/350947/9bc90dd8-c30d-477b-a7e6-7d05a483c0ea)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3401)