### PR TITLE
Update readme for Azure SignalR hosting

### DIFF
--- a/src/Aspire.Hosting.Azure.SignalR/README.md
+++ b/src/Aspire.Hosting.Azure.SignalR/README.md
@@ -27,9 +27,18 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(signalR);
 ```
 
+The `WithReference` method configures a connection in the `MyService` project named `sr`. In the _Program.cs_ file of `MyService`, the Azure SignalR connection can be consumed using the client library [Microsoft.Azure.SignalR](https://www.nuget.org/packages/Microsoft.Azure.SignalR):
+
+```csharp
+builder.Services.AddSignalR()
+    .AddNamedAzureSignalR("sr");
+```
+
 ## Additional documentation
 
 * https://github.com/dotnet/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/dotnet/aspire/real-time/azure-signalr-scenario
+* https://learn.microsoft.com/azure/azure-signalr/signalr-overview
 
 ## Feedback & contributing
 


### PR DESCRIPTION
Fixes #3390 by updating readme to note that the named SignalR method on the client will leverage the created connection string, matching our documentation already.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3410)