### PR TITLE
Add support for git worktrees in tests

### DIFF
--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -127,7 +127,8 @@ builder.Build().Run();
     {
         string directory = AppContext.BaseDirectory;
 
-        while (directory != null && !Directory.Exists(Path.Combine(directory, ".git")))
+        // To support git worktrees, check for either a directory or a file named ".git"
+        while (directory != null && !Directory.Exists(Path.Combine(directory, ".git")) && !File.Exists(Path.Combine(directory, ".git")))
         {
             directory = Directory.GetParent(directory)!.FullName;
         }

--- a/tests/Shared/WorkloadTesting/BuildEnvironment.cs
+++ b/tests/Shared/WorkloadTesting/BuildEnvironment.cs
@@ -31,7 +31,8 @@ public class BuildEnvironment
         DirectoryInfo? solutionRoot = new(AppContext.BaseDirectory);
         while (solutionRoot != null)
         {
-            if (Directory.Exists(Path.Combine(solutionRoot.FullName, ".git")))
+            // To support git worktrees, check for either a directory or a file named ".git"
+            if (Directory.Exists(Path.Combine(solutionRoot.FullName, ".git")) || File.Exists(Path.Combine(solutionRoot.FullName, ".git")))
             {
                 break;
             }


### PR DESCRIPTION
git worktrees use a `.git` file instead of a `.git` directory.
This PR fixes the places where we're assuming that `.git` is a directory.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3434)