### PR TITLE
Use ConfigureAwait(false) when enumerating IAsyncEnumerable

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -47,7 +47,7 @@ public sealed partial class LogViewer
         var cancellationToken = await _cancellationSeries.NextAsync();
         var logParser = new LogParser();
 
-        await foreach (var batch in batches.WithCancellation(cancellationToken))
+        await foreach (var batch in batches.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             if (batch.Count is 0)
             {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -105,7 +105,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
             _resourceSubscriptionTask = Task.Run(async () =>
             {
-                await foreach (var changes in subscription.WithCancellation(_resourceSubscriptionCancellation.Token))
+                await foreach (var changes in subscription.WithCancellation(_resourceSubscriptionCancellation.Token).ConfigureAwait(false))
                 {
                     // TODO: This could be updated to be more efficent.
                     // It should apply on the resource changes in a batch and then update the UI.

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -160,7 +160,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             // Listen for updates and apply.
             _resourceSubscriptionTask = Task.Run(async () =>
             {
-                await foreach (var changes in subscription.WithCancellation(_watchTaskCancellationTokenSource.Token))
+                await foreach (var changes in subscription.WithCancellation(_watchTaskCancellationTokenSource.Token).ConfigureAwait(false))
                 {
                     foreach (var (changeType, resource) in changes)
                     {

--- a/src/Aspire.Dashboard/Model/DashboardClient.cs
+++ b/src/Aspire.Dashboard/Model/DashboardClient.cs
@@ -281,7 +281,7 @@ internal sealed class DashboardClient : IDashboardClient
                 {
                     var call = _client!.WatchResources(new WatchResourcesRequest { IsReconnect = errorCount != 0 }, cancellationToken: cancellationToken);
 
-                    await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: cancellationToken))
+                    await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
                     {
                         List<ResourceViewModelChange>? changes = null;
 
@@ -448,7 +448,7 @@ internal sealed class DashboardClient : IDashboardClient
         {
             try
             {
-                await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: combinedTokens.Token))
+                await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken: combinedTokens.Token).ConfigureAwait(false))
                 {
                     var logLines = new ResourceLogLine[response.LogLines.Count];
 
@@ -467,7 +467,7 @@ internal sealed class DashboardClient : IDashboardClient
             }
         }, combinedTokens.Token);
 
-        await foreach (var batch in channel.GetBatchesAsync(TimeSpan.FromMilliseconds(100), combinedTokens.Token))
+        await foreach (var batch in channel.GetBatchesAsync(TimeSpan.FromMilliseconds(100), combinedTokens.Token).ConfigureAwait(false))
         {
             if (batch.Count == 1)
             {

--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -39,7 +39,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
                 await RaisePeerChangesAsync().ConfigureAwait(false);
             }
 
-            await foreach (var changes in subscription.WithCancellation(_watchContainersTokenSource.Token))
+            await foreach (var changes in subscription.WithCancellation(_watchContainersTokenSource.Token).ConfigureAwait(false))
             {
                 foreach (var (changeType, resource) in changes)
                 {

--- a/src/Aspire.Hosting.AWS/CloudFormation/CloudFormationStackExecutor.cs
+++ b/src/Aspire.Hosting.AWS/CloudFormation/CloudFormationStackExecutor.cs
@@ -493,7 +493,7 @@ internal sealed class CloudFormationStackExecutor(
 
     private async Task<Stack?> FindstackAsync()
     {
-        await foreach (var stack in cloudFormationClient.Paginators.DescribeStacks(new DescribeStacksRequest()).Stacks)
+        await foreach (var stack in cloudFormationClient.Paginators.DescribeStacks(new DescribeStacksRequest()).Stacks.ConfigureAwait(false))
         {
             if (string.Equals(cloudFormationResource.Name, stack.StackName, StringComparison.Ordinal))
             {

--- a/src/Aspire.Hosting.Azure/Provisioning/IAzureResourceEnumerator.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/IAzureResourceEnumerator.cs
@@ -23,7 +23,7 @@ internal sealed class AzureResourceEnumerator<TResource>(
 
     async IAsyncEnumerable<ArmResource> IAzureResourceEnumerator.GetResources(ResourceGroupResource resourceGroup)
     {
-        await foreach (var resource in GetResources(resourceGroup))
+        await foreach (var resource in GetResources(resourceGroup).ConfigureAwait(false))
         {
             yield return resource;
         }

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureResourceProvisionerOfT.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureResourceProvisionerOfT.cs
@@ -84,7 +84,7 @@ internal abstract class AzureResourceProvisioner<TResource> : IAzureResourceProv
         CancellationToken cancellationToken)
     {
         var roleAssignments = armClient.GetRoleAssignments(resourceId);
-        await foreach (var ra in roleAssignments.GetAllAsync(cancellationToken: cancellationToken))
+        await foreach (var ra in roleAssignments.GetAllAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             if (ra.Data.PrincipalId == principalId &&
                 ra.Data.RoleDefinitionId.Equals(roleDefinitionId))

--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -107,7 +107,7 @@ public class ResourceLoggerService
 
         try
         {
-            await foreach (var entry in channel.Reader.ReadAllAsync(cancellationToken))
+            await foreach (var entry in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
                 yield return entry;
             }
@@ -244,7 +244,7 @@ public class ResourceLoggerService
 
             try
             {
-                await foreach (var entry in channel.GetBatchesAsync(cancellationToken: cancellationToken))
+                await foreach (var entry in channel.GetBatchesAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
                 {
                     yield return entry;
                 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -45,7 +45,7 @@ public class ResourceNotificationService(ILogger<ResourceNotificationService> lo
 
         try
         {
-            await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken))
+            await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
                 yield return item;
             }

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -75,7 +75,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
 
             await responseStream.WriteAsync(new() { InitialData = data }).ConfigureAwait(false);
 
-            await foreach (var batch in updates.WithCancellation(cts.Token))
+            await foreach (var batch in updates.WithCancellation(cts.Token).ConfigureAwait(false))
             {
                 WatchResourcesChanges changes = new();
 
@@ -129,7 +129,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                 return;
             }
 
-            await foreach (var group in subscription.WithCancellation(cts.Token))
+            await foreach (var group in subscription.WithCancellation(cts.Token).ConfigureAwait(false))
             {
                 WatchResourceConsoleLogsUpdate update = new();
 

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -47,7 +47,7 @@ internal sealed class DashboardServiceData : IAsyncDisposable
 
             var timestamp = DateTime.UtcNow;
 
-            await foreach (var @event in resourceNotificationService.WatchAsync().WithCancellation(cancellationToken))
+            await foreach (var @event in resourceNotificationService.WatchAsync().WithCancellation(cancellationToken).ConfigureAwait(false))
             {
                 try
                 {
@@ -92,7 +92,7 @@ internal sealed class DashboardServiceData : IAsyncDisposable
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
 
-            await foreach (var item in sequence.WithCancellation(linked.Token))
+            await foreach (var item in sequence.WithCancellation(linked.Token).ConfigureAwait(false))
             {
                 yield return item;
             }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -203,7 +203,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
         Task.Run(async () =>
         {
-            await foreach (var subscribers in loggerService.WatchAnySubscribersAsync())
+            await foreach (var subscribers in loggerService.WatchAnySubscribersAsync().ConfigureAwait(false))
             {
                 _logInformationChannel.Writer.TryWrite(new(subscribers.Name, LogsAvailable: null, subscribers.AnySubscribers));
             }
@@ -218,7 +218,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         {
             var resourceLogState = new Dictionary<string, (bool logsAvailable, bool hasSubscribers)>();
 
-            await foreach (var entry in _logInformationChannel.Reader.ReadAllAsync(cancellationToken))
+            await foreach (var entry in _logInformationChannel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
                 var logsAvailable = false;
                 var hasSubscribers = false;
@@ -447,7 +447,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                     // Pump the logs from the enumerable into the logger
                     var logger = loggerService.GetLogger(resource.Metadata.Name);
 
-                    await foreach (var batch in enumerable.WithCancellation(cts.Token))
+                    await foreach (var batch in enumerable.WithCancellation(cts.Token).ConfigureAwait(false))
                     {
                         foreach (var (content, isError) in batch)
                         {
@@ -938,7 +938,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             await execution.ExecuteAsync(async (attemptCancellationToken) =>
             {
                 IAsyncEnumerable<(WatchEventType, Service)> serviceChangeEnumerator = kubernetesService.WatchAsync<Service>(cancellationToken: attemptCancellationToken);
-                await foreach (var (evt, updated) in serviceChangeEnumerator)
+                await foreach (var (evt, updated) in serviceChangeEnumerator.ConfigureAwait(false))
                 {
                     if (evt == WatchEventType.Bookmark) { continue; } // Bookmarks do not contain any data.
 

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -206,7 +206,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
             },
             cancellationToken).ConfigureAwait(false);
 
-        await foreach (var item in result)
+        await foreach (var item in result.ConfigureAwait(false))
         {
             yield return item;
         }

--- a/src/Aspire.Hosting/Dcp/ResourceLogSource.cs
+++ b/src/Aspire.Hosting/Dcp/ResourceLogSource.cs
@@ -48,7 +48,7 @@ internal sealed class ResourceLogSource<TResource>(
 
         _ = WaitForStreamsToCompleteAsync();
         
-        await foreach (var batch in channel.GetBatchesAsync(cancellationToken: cancellationToken))
+        await foreach (var batch in channel.GetBatchesAsync(cancellationToken: cancellationToken).ConfigureAwait(false))
         {
             yield return batch;
         }


### PR DESCRIPTION
This PR qualms the complaints the `EnsureWarningsAreEmittedWhenProjectReferencingLibraries` tests when I run it locally, and it's in-line with our existing practice of using `.ConfigureAwait(false)` in Aspire.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3436)