### PR TITLE
Do not use ExecutionType.IDE when not debugging

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1115,7 +1115,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             var projectLaunchConfiguration = new ProjectLaunchConfiguration();
             projectLaunchConfiguration.ProjectPath = projectMetadata.ProjectPath;
 
-            if (!string.IsNullOrEmpty(configuration[DebugSessionPortVar]))
+            if (!string.IsNullOrEmpty(configuration[DebugSessionPortVar]) && Debugger.IsAttached)
             {
                 exeSpec.ExecutionType = ExecutionType.IDE;
 


### PR DESCRIPTION
When running tests from Visual Studio IntPreview (a build from last week), I observe that we are telling DCP to execute projects & executables via the IDE even when we are not debugging the tests. This fails because the IDE does not have a debug session when not debugging. This fix works around the issue by only enabling IDE execution when the debugger is attached.

The specific error I see is:
```
  | [2024-04-02T22:04:08] Aspire.Hosting.Dcp.dcpctrl.ExecutableReconciler Error: failed to start Executable	{"Executable": {"name":"servicea_3e8589f4-ej16bj0"}, "Reconciliation": 97, "error": "run session could not be started: failed to connect to IDE run session notification endpoint: websocket: bad handshake"}
```

EDIT: I cannot seem to reproduce this on the current build, so perhaps it's been fixed in VS?

cc @BillHiebert @karolz-ms 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3438)