### PR TITLE
Add User Profile Menu for OpenID Connect login

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/UserProfile.razor
+++ b/src/Aspire.Dashboard/Components/Controls/UserProfile.razor
@@ -10,7 +10,7 @@
                                    FooterLink="">
                     <HeaderTemplate>
                         <FluentStack VerticalAlignment="VerticalAlignment.Center">
-                            <FluentLabel>@Loc[nameof(Resources.Login.SignedInAs)]</FluentLabel>
+                            <FluentLabel>@Loc[nameof(Resources.Login.LoggedInAs)]</FluentLabel>
                             <FluentSpacer />
                             <form @formname="sign-out-form" class="sign-out-form" action="authentication/logout" method="post">
                                 <AntiforgeryToken />

--- a/src/Aspire.Dashboard/Components/Controls/UserProfile.razor
+++ b/src/Aspire.Dashboard/Components/Controls/UserProfile.razor
@@ -1,0 +1,33 @@
+﻿<AuthorizeView>
+    <Authorized>
+        @if (_showUserProfileMenu)
+        {
+            <div class="profile-menu-container">
+                <FluentProfileMenu Initials="@_initials"
+                                   EMail="@_username"
+                                   FullName="@_name"
+                                   ButtonSize="@ButtonSize"
+                                   FooterLink="">
+                    <HeaderTemplate>
+                        <FluentStack VerticalAlignment="VerticalAlignment.Center">
+                            <FluentLabel>OpenID Connect</FluentLabel>
+                            <FluentSpacer />
+                            <form @formname="sign-out-form" class="sign-out-form" action="authentication/logout" method="post">
+                                <AntiforgeryToken />
+                                <FluentButton Appearance="Appearance.Stealth" Type="ButtonType.Submit">Sign out</FluentButton>
+                            </form>
+                        </FluentStack>
+                    </HeaderTemplate>
+                    <ChildContent>
+                        <FluentStack class="inner-persona-container">
+                            <FluentPersona Initials="@_initials" ImageSize="@ImageSize" Class="inner-persona">
+                                <div class="full-name">@_name</div>
+                                <div class="user-id">@_username</div>
+                            </FluentPersona>
+                        </FluentStack>
+                    </ChildContent>
+                </FluentProfileMenu>
+            </div>
+        }
+    </Authorized>
+</AuthorizeView>

--- a/src/Aspire.Dashboard/Components/Controls/UserProfile.razor
+++ b/src/Aspire.Dashboard/Components/Controls/UserProfile.razor
@@ -10,7 +10,7 @@
                                    FooterLink="">
                     <HeaderTemplate>
                         <FluentStack VerticalAlignment="VerticalAlignment.Center">
-                            <FluentLabel>OpenID Connect</FluentLabel>
+                            <FluentLabel>@Loc[nameof(Resources.Login.SignedInAs)]</FluentLabel>
                             <FluentSpacer />
                             <form @formname="sign-out-form" class="sign-out-form" action="authentication/logout" method="post">
                                 <AntiforgeryToken />

--- a/src/Aspire.Dashboard/Components/Controls/UserProfile.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/UserProfile.razor.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Claims;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Extensions;
+using Aspire.Dashboard.Resources;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard.Components.Controls;
+
+public partial class UserProfile : ComponentBase
+{
+    [Inject]
+    public required IOptionsMonitor<DashboardOptions> DashboardOptions { get; set; }
+
+    [CascadingParameter]
+    public required Task<AuthenticationState> AuthenticationState { get; set; }
+
+    [Inject]
+    public required IStringLocalizer<Login> Loc { get; set; }
+
+    [Inject]
+    public required ILogger<UserProfile> Logger { get; set; }
+
+    [Parameter]
+    public string ButtonSize { get; set; } = "24px";
+
+    [Parameter]
+    public string ImageSize { get; set; } = "52px";
+
+    private bool _showUserProfileMenu;
+    private string? _name;
+    private string? _username;
+    private string? _initials;
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (DashboardOptions.CurrentValue.Frontend.AuthMode == FrontendAuthMode.OpenIdConnect)
+        {
+            var authState = await AuthenticationState;
+
+            var claimsIdentity = authState.User.Identity as ClaimsIdentity;
+
+            if (claimsIdentity?.IsAuthenticated == true)
+            {
+                _showUserProfileMenu = true;
+                _name = claimsIdentity.FindFirst(DashboardOptions.CurrentValue.OpenIdConnect.GetNameClaimTypes());
+                if (string.IsNullOrWhiteSpace(_name))
+                {
+                    // Make sure there's always a name, even if that name is a placeholder
+                    _name = Loc[nameof(Login.AuthorizedUser)];
+                }
+
+                _username = claimsIdentity.FindFirst(DashboardOptions.CurrentValue.OpenIdConnect.GetUsernameClaimTypes());
+                _initials = _name.GetInitials();
+            }
+            else
+            {
+                // If we don't have an authenticated user, don't show the user profile menu. This shouldn't happen.
+                _showUserProfileMenu = false;
+                _name = null;
+                _username = null;
+                _initials = null;
+                Logger.LogError("Dashboard:Frontend:AuthMode is configured for OpenIDConnect, but there is no authenticated user.");
+            }
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/UserProfile.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/UserProfile.razor.cs
@@ -48,14 +48,14 @@ public partial class UserProfile : ComponentBase
             if (claimsIdentity?.IsAuthenticated == true)
             {
                 _showUserProfileMenu = true;
-                _name = claimsIdentity.FindFirst(DashboardOptions.CurrentValue.OpenIdConnect.GetNameClaimTypes());
+                _name = claimsIdentity.FindFirst(DashboardOptions.CurrentValue.Frontend.OpenIdConnect.GetNameClaimTypes());
                 if (string.IsNullOrWhiteSpace(_name))
                 {
                     // Make sure there's always a name, even if that name is a placeholder
                     _name = Loc[nameof(Login.AuthorizedUser)];
                 }
 
-                _username = claimsIdentity.FindFirst(DashboardOptions.CurrentValue.OpenIdConnect.GetUsernameClaimTypes());
+                _username = claimsIdentity.FindFirst(DashboardOptions.CurrentValue.Frontend.OpenIdConnect.GetUsernameClaimTypes());
                 _initials = _name.GetInitials();
             }
             else

--- a/src/Aspire.Dashboard/Components/Controls/UserProfile.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/UserProfile.razor.css
@@ -1,0 +1,60 @@
+
+/*
+    Workaround for issue in fluent-anchored-region when the content
+    is near the top-right corner of the screen. Addressed in
+    https://github.com/microsoft/fluentui-blazor/pull/1795 which
+    we can use instead when it is available
+*/
+.profile-menu-container ::deep .fluent-profile-menu fluent-anchored-region {
+    transform: unset !important;
+    left: unset;
+    right: -4px;
+}
+
+::deep fluent-button[appearance=stealth]:not(:hover):not(:active)::part(control) {
+    background-color: var(--neutral-layer-floating);
+}
+
+::deep fluent-button[appearance=stealth]:hover::part(control) {
+    background-color: var(--neutral-fill-secondary-hover);
+}
+
+::deep .fluent-profile-menu > .fluent-persona {
+    margin: 0 4px;
+}
+
+::deep .fluent-profile-menu > .fluent-persona > .initials {
+    font-size: var(--type-ramp-minus-1-font-size);
+}
+
+::deep .full-name,
+::deep .user-id {
+    color: var(--neutral-foreground-rest);
+    max-width: 200px;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+}
+
+::deep .full-name {
+    font-size: var(--type-ramp-base-font-size);
+}
+
+::deep .user-id {
+    font-size: var(--type-ramp-minus-1-font-size);
+    font-weight: normal;
+    max-width: 200px;
+}
+
+::deep .inner-persona-container {
+    height: 100%;
+}
+
+::deep .fluent-persona.inner-persona {
+    margin-right: 40px;
+    align-items: normal;
+}
+
+/* The form takes up space and throws off the alignment if we don't change its display */
+::deep .sign-out-form {
+    display: flex;
+}

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -30,6 +30,7 @@
                         Title="@Loc[nameof(Layout.MainLayoutLaunchSettings)]" aria-label="@Loc[nameof(Layout.MainLayoutLaunchSettings)]">
             <FluentIcon Value="@(new Icons.Regular.Size24.Settings())" Color="Color.Neutral" />
         </FluentButton>
+        <UserProfile />
     </FluentHeader>
     <NavMenu />
     <div class="messagebar-container">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -50,6 +50,7 @@
 
 ::deep.layout > header {
     grid-area: head;
+    /*overflow-x: clip;*/
 }
 
 ::deep.layout > .nav-menu-container {
@@ -74,9 +75,9 @@
     margin-left: auto;
 }
 
-::deep.layout > header fluent-button[appearance=stealth]:not(:hover)::part(control),
-::deep.layout > header fluent-anchor[appearance=stealth]:not(:hover)::part(control),
-::deep.layout > header fluent-anchor[appearance=stealth].logo::part(control),
+::deep.layout > header > .header-gutters > fluent-button[appearance=stealth]:not(:hover)::part(control),
+::deep.layout > header > .header-gutters > fluent-anchor[appearance=stealth]:not(:hover)::part(control),
+::deep.layout > header > .header-gutters > fluent-anchor[appearance=stealth].logo::part(control),
 ::deep.layout > .aspire-icon fluent-anchor[appearance=stealth].logo::part(control) {
     background-color: var(--neutral-layer-4);
 }
@@ -86,7 +87,7 @@
     margin-bottom: 0;
 }
 
-::deep.layout > header fluent-anchor {
+::deep.layout > header > .header-gutters > fluent-anchor {
     font-size: var(--type-ramp-plus-2-font-size);
 }
 

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -50,7 +50,6 @@
 
 ::deep.layout > header {
     grid-area: head;
-    /*overflow-x: clip;*/
 }
 
 ::deep.layout > .nav-menu-container {

--- a/src/Aspire.Dashboard/Components/_Imports.razor
+++ b/src/Aspire.Dashboard/Components/_Imports.razor
@@ -3,6 +3,7 @@
 @using Aspire.Dashboard.Authentication
 @using Microsoft.AspNetCore.Authentication.OpenIdConnect
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -206,7 +206,7 @@ public sealed class OpenIdConnectOptions
         }
         else
         {
-            _usernameClaimTypes = UsernameClaimType.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+            _usernameClaimTypes = UsernameClaimType.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         }
 
         errorMessages = messages;

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -196,7 +196,7 @@ public sealed class OpenIdConnectOptions
         }
         else
         {
-            _nameClaimTypes = NameClaimType.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+            _nameClaimTypes = NameClaimType.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         }
 
         if (string.IsNullOrWhiteSpace(UsernameClaimType))

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -165,6 +165,7 @@ public sealed class TelemetryLimitOptions
     public int MaxSpanEventCount { get; set; } = int.MaxValue;
 }
 
+// Don't set values after validating/parsing options.
 public sealed class OpenIdConnectOptions
 {
     private string[]? _nameClaimTypes;

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -16,7 +16,6 @@ public sealed class DashboardOptions
     public FrontendOptions Frontend { get; set; } = new FrontendOptions();
     public ResourceServiceClientOptions ResourceServiceClient { get; set; } = new ResourceServiceClientOptions();
     public TelemetryLimitOptions TelemetryLimits { get; set; } = new TelemetryLimitOptions();
-    public OpenIdConnectOptions OpenIdConnect { get; set; } = new OpenIdConnectOptions();
 }
 
 // Don't set values after validating/parsing options.
@@ -115,6 +114,7 @@ public sealed class FrontendOptions
     public string? EndpointUrls { get; set; }
     public FrontendAuthMode? AuthMode { get; set; }
     public string? BrowserToken { get; set; }
+    public OpenIdConnectOptions OpenIdConnect { get; set; } = new OpenIdConnectOptions();
 
     public byte[]? GetBrowserTokenBytes() => _browserTokenBytes;
 

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -16,6 +16,7 @@ public sealed class DashboardOptions
     public FrontendOptions Frontend { get; set; } = new FrontendOptions();
     public ResourceServiceClientOptions ResourceServiceClient { get; set; } = new ResourceServiceClientOptions();
     public TelemetryLimitOptions TelemetryLimits { get; set; } = new TelemetryLimitOptions();
+    public OpenIdConnectOptions OpenIdConnect { get; set; } = new OpenIdConnectOptions();
 }
 
 // Don't set values after validating/parsing options.
@@ -162,4 +163,53 @@ public sealed class TelemetryLimitOptions
     public int MaxAttributeCount { get; set; } = 128;
     public int MaxAttributeLength { get; set; } = int.MaxValue;
     public int MaxSpanEventCount { get; set; } = int.MaxValue;
+}
+
+public sealed class OpenIdConnectOptions
+{
+    private string[]? _nameClaimTypes;
+    private string[]? _usernameClaimTypes;
+
+    public string NameClaimType { get; set; } = "name";
+    public string UsernameClaimType { get; set; } = "preferred_username";
+
+    public string[] GetNameClaimTypes()
+    {
+        Debug.Assert(_nameClaimTypes is not null, "Should have been parsed during validation.");
+        return _nameClaimTypes;
+    }
+
+    public string[] GetUsernameClaimTypes()
+    {
+        Debug.Assert(_usernameClaimTypes is not null, "Should have been parsed during validation.");
+        return _usernameClaimTypes;
+    }
+
+    internal bool TryParseOptions([NotNullWhen(false)] out IEnumerable<string>? errorMessages)
+    {
+        List<string>? messages = null;
+        if (string.IsNullOrWhiteSpace(NameClaimType))
+        {
+            messages ??= [];
+            messages.Add("OpenID Connect claim type for name not configured. Specify a Dashboard:OpenIdConnect:NameClaimType value.");
+        }
+        else
+        {
+            _nameClaimTypes = NameClaimType.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        if (string.IsNullOrWhiteSpace(UsernameClaimType))
+        {
+            messages ??= [];
+            messages.Add("OpenID Connect claim type for username not configured. Specify a Dashboard:OpenIdConnect:UsernameClaimType value.");
+        }
+        else
+        {
+            _usernameClaimTypes = UsernameClaimType.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        errorMessages = messages;
+
+        return messages is null;
+    }
 }

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -100,7 +100,7 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
             }
         }
 
-        if (!options.OpenIdConnect.TryParseOptions(out var messages))
+        if (!options.Frontend.OpenIdConnect.TryParseOptions(out var messages))
         {
             errorMessages.AddRange(messages);
         }

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -22,6 +22,10 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
             case FrontendAuthMode.Unsecured:
                 break;
             case FrontendAuthMode.OpenIdConnect:
+                if (!options.Frontend.OpenIdConnect.TryParseOptions(out var messages))
+                {
+                    errorMessages.AddRange(messages);
+                }
                 break;
             case FrontendAuthMode.BrowserToken:
                 if (string.IsNullOrEmpty(options.Frontend.BrowserToken))
@@ -98,11 +102,6 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
                     errorMessages.Add($"Unexpected resource service client authentication mode: {options.Otlp.AuthMode}");
                     break;
             }
-        }
-
-        if (!options.Frontend.OpenIdConnect.TryParseOptions(out var messages))
-        {
-            errorMessages.AddRange(messages);
         }
 
         return errorMessages.Count > 0

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -100,6 +100,11 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
             }
         }
 
+        if (!options.OpenIdConnect.TryParseOptions(out var messages))
+        {
+            errorMessages.AddRange(messages);
+        }
+
         return errorMessages.Count > 0
             ? ValidateOptionsResult.Fail(errorMessages)
             : ValidateOptionsResult.Success;

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -275,6 +275,10 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             });
 #endif
         }
+        else if (dashboardOptions.Frontend.AuthMode == FrontendAuthMode.OpenIdConnect)
+        {
+            _app.MapPost("/authentication/logout", () => TypedResults.SignOut(authenticationSchemes: [CookieAuthenticationDefaults.AuthenticationScheme, "OpenIdConnect"]));
+        }
     }
 
     private ILogger<DashboardWebApplication> GetLogger()

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -277,7 +277,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
         else if (dashboardOptions.Frontend.AuthMode == FrontendAuthMode.OpenIdConnect)
         {
-            _app.MapPost("/authentication/logout", () => TypedResults.SignOut(authenticationSchemes: [CookieAuthenticationDefaults.AuthenticationScheme, "OpenIdConnect"]));
+            _app.MapPost("/authentication/logout", () => TypedResults.SignOut(authenticationSchemes: [CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme]));
         }
     }
 

--- a/src/Aspire.Dashboard/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ClaimsIdentityExtensions.cs
@@ -5,7 +5,7 @@ using System.Security.Claims;
 
 namespace Aspire.Dashboard.Extensions;
 
-public static class ClaimsIdentityExtensions
+internal static class ClaimsIdentityExtensions
 {
     /// <summary>
     /// Searches the claims in the <see cref="ClaimsIdentity.Claims"/> for each of the claim types in <paramref name="claimTypes" />

--- a/src/Aspire.Dashboard/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ClaimsIdentityExtensions.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Claims;
+
+namespace Aspire.Dashboard.Extensions;
+
+public static class ClaimsIdentityExtensions
+{
+    /// <summary>
+    /// Searches the claims in the <see cref="ClaimsIdentity.Claims"/> for each of the claim types in <paramref name="claimTypes" />
+    /// in the order presented and returns the first one that it finds.
+    /// </summary>
+    public static string? FindFirst(this ClaimsIdentity identity, string[] claimTypes)
+    {
+        if (identity is null)
+        {
+            return null;
+        }
+
+        foreach (var claimType in claimTypes)
+        {
+            var claim = identity.FindFirst(claimType);
+            if (claim is not null)
+            {
+                return claim.Value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Aspire.Dashboard/Extensions/ClaimsIdentityExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ClaimsIdentityExtensions.cs
@@ -13,11 +13,6 @@ internal static class ClaimsIdentityExtensions
     /// </summary>
     public static string? FindFirst(this ClaimsIdentity identity, string[] claimTypes)
     {
-        if (identity is null)
-        {
-            return null;
-        }
-
         foreach (var claimType in claimTypes)
         {
             var claim = identity.FindFirst(claimType);

--- a/src/Aspire.Dashboard/Extensions/StringExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/StringExtensions.cs
@@ -7,24 +7,6 @@ namespace Aspire.Dashboard.Extensions;
 
 internal static class StringExtensions
 {
-    /// <summary>
-    /// Shortens a string by replacing the middle with an ellipsis.
-    /// </summary>
-    /// <param name="text">The string to shorten</param>
-    /// <param name="maxLength">The max length of the result</param>
-    public static string TrimMiddle(this string text, int maxLength)
-    {
-        if (text.Length <= maxLength)
-        {
-            return text;
-        }
-
-        var firstPart = (maxLength - 1) / 2;
-        var lastPart = firstPart + ((maxLength - 1) % 2);
-
-        return $"{text[..firstPart]}…{text[^lastPart..]}";
-    }
-
     public static string SanitizeHtmlId(this string input)
     {
         var sanitizedBuilder = new StringBuilder(capacity: input.Length);
@@ -48,5 +30,30 @@ internal static class StringExtensions
             // Check if the character is a letter, digit, underscore, or hyphen
             return char.IsLetterOrDigit(c) || c == '_' || c == '-';
         }
+    }
+
+    /// <summary>
+    /// Returns the two initial letters of the first and last words in the specified <paramref name="name"/>.
+    /// If only one word is present, a single initial is returned. If <paramref name="name"/> is null, empty or
+    /// white space only, <paramref name="defaultValue"/> is returned.
+    /// </summary>
+    public static string? GetInitials(this string name, string? defaultValue = default)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return defaultValue;
+        }
+
+        var initials = name!.Split(" ", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                            .Select(s => s[0].ToString())
+                            .ToList();
+
+        if (initials.Count > 1)
+        {
+            // If the name contained two or more words, return the initials from the first and last
+            return initials[0].ToUpperInvariant() + initials[^1].ToUpperInvariant();
+        }
+
+        return initials[0].ToUpperInvariant();
     }
 }

--- a/src/Aspire.Dashboard/Extensions/StringExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/StringExtensions.cs
@@ -41,21 +41,21 @@ internal static class StringExtensions
     [return: NotNullIfNotNull(nameof(defaultValue))]
     public static string? GetInitials(this string name, string? defaultValue = default)
     {
-        if (string.IsNullOrWhiteSpace(name))
+        var s = name.AsSpan().Trim();
+
+        if (s.Length == 0)
         {
             return defaultValue;
         }
 
-        var initials = name.Split(" ", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                           .Select(s => s[0].ToString())
-                           .ToList();
+        var lastSpaceIndex = s.LastIndexOf(' ');
 
-        if (initials.Count > 1)
+        if (lastSpaceIndex == -1)
         {
-            // If the name contained two or more words, return the initials from the first and last
-            return initials[0].ToUpperInvariant() + initials[^1].ToUpperInvariant();
+            return s[0].ToString().ToUpperInvariant();
         }
 
-        return initials[0].ToUpperInvariant();
+        // The name contained two or more words. Return the initials from the first and last.
+        return $"{char.ToUpperInvariant(s[0])}{char.ToUpperInvariant(s[lastSpaceIndex + 1])}";
     }
 }

--- a/src/Aspire.Dashboard/Extensions/StringExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/StringExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Aspire.Dashboard.Extensions;
@@ -37,6 +38,7 @@ internal static class StringExtensions
     /// If only one word is present, a single initial is returned. If <paramref name="name"/> is null, empty or
     /// white space only, <paramref name="defaultValue"/> is returned.
     /// </summary>
+    [return: NotNullIfNotNull(nameof(defaultValue))]
     public static string? GetInitials(this string name, string? defaultValue = default)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -44,9 +46,9 @@ internal static class StringExtensions
             return defaultValue;
         }
 
-        var initials = name!.Split(" ", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                            .Select(s => s[0].ToString())
-                            .ToList();
+        var initials = name.Split(" ", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                           .Select(s => s[0].ToString())
+                           .ToList();
 
         if (initials.Count > 1)
         {

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -53,10 +53,12 @@ Set `Dashboard:Frontend:AuthMode` to `BrowserToken`. Browser token authenticatio
 
 Set `Dashboard:Frontend:AuthMode` to `OpenIdConnect`, then add the following configuration:
 
-- `Authentication:Schemes:OpenIdConnect:Authority` &mdash; URL to the identity provider (IdP)
-- `Authentication:Schemes:OpenIdConnect:ClientId` &mdash; Identity of the relying party (RP)
-- `Authentication:Schemes:OpenIdConnect:ClientSecret`&mdash; A secret that only the real RP would know
+- `Authentication:Schemes:OpenIdConnect:Authority` URL to the identity provider (IdP)
+- `Authentication:Schemes:OpenIdConnect:ClientId` Identity of the relying party (RP)
+- `Authentication:Schemes:OpenIdConnect:ClientSecret` A secret that only the real RP would know
 - Other properties of [`OpenIdConnectOptions`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.builder.openidconnectoptions) specified in configuration container `Authentication:Schemes:OpenIdConnect:*`
+- `Dashboard:OpenIdConnect:NameClaimType` specifies the claim type(s) that should be used to display the authenticated user's full name. Can be a single claim type or a comma-delimited list of claim types. Defaults to `name`.
+- `Dashboard:OpenIdConnect:UsernameClaimType` specifies the claim type(s) that should be used to display the authenticated user's username. Can be a single claim type or a comma-delimited list of claim types. Defaults to `preferred_username`.
 
 ### OTLP authentication
 

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -57,8 +57,8 @@ Set `Dashboard:Frontend:AuthMode` to `OpenIdConnect`, then add the following con
 - `Authentication:Schemes:OpenIdConnect:ClientId` Identity of the relying party (RP)
 - `Authentication:Schemes:OpenIdConnect:ClientSecret` A secret that only the real RP would know
 - Other properties of [`OpenIdConnectOptions`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.builder.openidconnectoptions) specified in configuration container `Authentication:Schemes:OpenIdConnect:*`
-- `Dashboard:OpenIdConnect:NameClaimType` specifies the claim type(s) that should be used to display the authenticated user's full name. Can be a single claim type or a comma-delimited list of claim types. Defaults to `name`.
-- `Dashboard:OpenIdConnect:UsernameClaimType` specifies the claim type(s) that should be used to display the authenticated user's username. Can be a single claim type or a comma-delimited list of claim types. Defaults to `preferred_username`.
+- `Dashboard:Frontend:OpenIdConnect:NameClaimType` specifies the claim type(s) that should be used to display the authenticated user's full name. Can be a single claim type or a comma-delimited list of claim types. Defaults to `name`.
+- `Dashboard:Frontend:OpenIdConnect:UsernameClaimType` specifies the claim type(s) that should be used to display the authenticated user's username. Can be a single claim type or a comma-delimited list of claim types. Defaults to `preferred_username`.
 
 ### OTLP authentication
 

--- a/src/Aspire.Dashboard/Resources/Login.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Login.Designer.cs
@@ -124,6 +124,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Signed in as:.
+        /// </summary>
+        public static string SignedInAs {
+            get {
+                return ResourceManager.GetString("SignedInAs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enter token to log in....
         /// </summary>
         public static string TextFieldPlaceholder {

--- a/src/Aspire.Dashboard/Resources/Login.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Login.Designer.cs
@@ -97,6 +97,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Logged in as:.
+        /// </summary>
+        public static string LoggedInAs {
+            get {
+                return ResourceManager.GetString("LoggedInAs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Log in.
         /// </summary>
         public static string LogInButtonText {
@@ -120,15 +129,6 @@ namespace Aspire.Dashboard.Resources {
         public static string PageTitle {
             get {
                 return ResourceManager.GetString("PageTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Signed in as:.
-        /// </summary>
-        public static string SignedInAs {
-            get {
-                return ResourceManager.GetString("SignedInAs", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/Login.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Login.Designer.cs
@@ -61,6 +61,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Authorized User.
+        /// </summary>
+        public static string AuthorizedUser {
+            get {
+                return ResourceManager.GetString("AuthorizedUser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} dashboard.
         /// </summary>
         public static string Header {

--- a/src/Aspire.Dashboard/Resources/Login.resx
+++ b/src/Aspire.Dashboard/Resources/Login.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AuthorizedUser" xml:space="preserve">
+    <value>Authorized User</value>
+    <comment>Placeholder text for the name of the authorized user when no name claim exists</comment>
+  </data>
   <data name="Header" xml:space="preserve">
     <value>{0} dashboard</value>
     <comment>{0} is an application name</comment>

--- a/src/Aspire.Dashboard/Resources/Login.resx
+++ b/src/Aspire.Dashboard/Resources/Login.resx
@@ -141,6 +141,9 @@
     <value>{0} login</value>
     <comment>{0} is an application name</comment>
   </data>
+  <data name="SignedInAs" xml:space="preserve">
+    <value>Signed in as:</value>
+  </data>
   <data name="TextFieldPlaceholder" xml:space="preserve">
     <value>Enter token to log in...</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/Login.resx
+++ b/src/Aspire.Dashboard/Resources/Login.resx
@@ -131,6 +131,9 @@
   <data name="InvalidTokenErrorMessage" xml:space="preserve">
     <value>Invalid token. Please try again</value>
   </data>
+  <data name="LoggedInAs" xml:space="preserve">
+    <value>Logged in as:</value>
+  </data>
   <data name="LogInButtonText" xml:space="preserve">
     <value>Log in</value>
   </data>
@@ -140,9 +143,6 @@
   <data name="PageTitle" xml:space="preserve">
     <value>{0} login</value>
     <comment>{0} is an application name</comment>
-  </data>
-  <data name="SignedInAs" xml:space="preserve">
-    <value>Signed in as:</value>
   </data>
   <data name="TextFieldPlaceholder" xml:space="preserve">
     <value>Enter token to log in...</value>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.cs.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Přihlášení k aplikaci {0}</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">Zadejte token pro přihlášení...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Přihlásit se</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">Další informace</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">Přihlášení k aplikaci {0}</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">Řídicí panel aplikace {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">{0}-Dashboard</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Anmelden</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">Weitere Informationen</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">Anmeldung bei {0}</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.de.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Anmeldung bei {0}</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">Token eingeben, um sich anzumelden...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">Panel de {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.es.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Iniciar sesión en {0}</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">Escriba el token para iniciar sesión...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Iniciar sesión</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">Más información</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">Iniciar sesión en {0}</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.fr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Connexion {0}</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">Entrez un jeton pour vous connecter...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">Tableau de bord {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Connexion</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">Obtenir plus d’informations</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">Connexion {0}</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">Dashboard {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.it.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Accesso a {0}</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">Immettere il token per l'accesso...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Accedi</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">Altre informazioni</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">Accesso a {0}</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">ログイン</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">詳細情報</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">{0} ログイン</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">{0} ダッシュボード</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.ja.xlf
@@ -37,6 +37,11 @@
         <target state="translated">{0} ログイン</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">ログインするトークンを入力してください...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">{0} 대시보드</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.ko.xlf
@@ -37,6 +37,11 @@
         <target state="translated">{0} 로그인</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">로그인할 토큰 입력...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">로그인</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">자세한 정보</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">{0} 로그인</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">Pulpit nawigacyjny aplikacji {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.pl.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Logowanie do aplikacji {0}</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">Wprowadź token, aby się zalogować...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Zaloguj się</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">Więcej informacji</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">Logowanie do aplikacji {0}</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Login {0}</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">Insira o token para fazer logon...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">Painel {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Fazer logon</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">Mais informações</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">Login {0}</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Войти</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">Дополнительные сведения</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">Вход {0}</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">Панель мониторинга {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.ru.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Вход {0}</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">Введите токен для входа...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Oturum aç</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">Daha fazla bilgi</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">{0} uygulamasında oturum açma</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">{0} panosu</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.tr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">{0} uygulamasında oturum açma</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">Oturum açmak için belirteci girin...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">登录</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">详细信息</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">{0} 登录名</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">{0} 仪表板</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="translated">{0} 登录名</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">输入要登录的令牌...</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">登入</target>
         <note />
       </trans-unit>
+      <trans-unit id="LoggedInAs">
+        <source>Logged in as:</source>
+        <target state="new">Logged in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreInfoLinkText">
         <source>More information</source>
         <target state="needs-review-translation">詳細資訊</target>
@@ -36,11 +41,6 @@
         <source>{0} login</source>
         <target state="translated">{0} 登入</target>
         <note>{0} is an application name</note>
-      </trans-unit>
-      <trans-unit id="SignedInAs">
-        <source>Signed in as:</source>
-        <target state="new">Signed in as:</target>
-        <note />
       </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Login.resx">
     <body>
+      <trans-unit id="AuthorizedUser">
+        <source>Authorized User</source>
+        <target state="new">Authorized User</target>
+        <note>Placeholder text for the name of the authorized user when no name claim exists</note>
+      </trans-unit>
       <trans-unit id="Header">
         <source>{0} dashboard</source>
         <target state="translated">{0} 儀表板</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Login.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="translated">{0} 登入</target>
         <note>{0} is an application name</note>
       </trans-unit>
+      <trans-unit id="SignedInAs">
+        <source>Signed in as:</source>
+        <target state="new">Signed in as:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TextFieldPlaceholder">
         <source>Enter token to log in...</source>
         <target state="translated">輸入權杖以登入...</target>

--- a/tests/Aspire.Dashboard.Tests/StringExtensionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/StringExtensionsTests.cs
@@ -9,21 +9,27 @@ namespace Aspire.Dashboard.Tests;
 public class StringExtensionsTests
 {
     [Theory]
-    [InlineData("/usr", 5, "/usr")]
-    [InlineData("~/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 5, "~/…oj")]
-    [InlineData("~/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 25, "~/src/repos/…MyApp.csproj")]
-    [InlineData("~/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 26, "~/src/repos/…/MyApp.csproj")]
-    [InlineData("/home/username/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 5, "/h…oj")]
-    [InlineData("/home/username/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 38, "/home/username/src…/MyApp/MyApp.csproj")]
-    [InlineData("/home/username/src/repos/AspireStarterProject/MyApp/MyApp.csproj", 39, "/home/username/src/…/MyApp/MyApp.csproj")]
-    [InlineData("c:\\", 5, "c:\\")]
-    [InlineData("c:\\src\\repos\\AspireStarterProject\\MyApp\\MyApp.csproj", 5, "c:…oj")]
-    [InlineData("c:\\src\\repos\\AspireStarterProject\\MyApp\\MyApp.csproj", 32, "c:\\src\\repos\\As…App\\MyApp.csproj")]
-    [InlineData("c:\\src\\repos\\AspireStarterProject\\MyApp\\MyApp.csproj", 33, "c:\\src\\repos\\Asp…App\\MyApp.csproj")]
-    [InlineData("c:\\src\\repos\\AspireStarterProject\\MyApp\\MyApp.csproj", 48, "c:\\src\\repos\\AspireStar…oject\\MyApp\\MyApp.csproj")]
-    public void TrimMiddle(string path, int targetLength, string expectedResult)
+    [InlineData("", "DefaultValue", "DefaultValue")]
+    [InlineData("SingleNameOnly", null, "S")]
+    [InlineData("singleNameOnly", null, "S")]
+    [InlineData("Two Names", null, "TN")]
+    [InlineData("two Names", null, "TN")]
+    [InlineData("Two names", null, "TN")]
+    [InlineData("two names", null, "TN")]
+    [InlineData("With Three Names", null, "WN")]
+    [InlineData("with Three Names", null, "WN")]
+    [InlineData("With Three names", null, "WN")]
+    [InlineData("with Three names", null, "WN")]
+    [InlineData("With Hyphenated-Name", null, "WH")]
+    [InlineData("with Hyphenated-Name", null, "WH")]
+    [InlineData("With hyphenated-Name", null, "WH")]
+    [InlineData("With Hyphenated-name", null, "WH")]
+    [InlineData("with hyphenated-Name", null, "WH")]
+    [InlineData("with Hyphenated-name", null, "WH")]
+    [InlineData("with hyphenated-name", null, "WH")]
+    public void GetInitials(string name, string? defaultValue, string expectedResult)
     {
-        var actual = StringExtensions.TrimMiddle(path, targetLength);
+        var actual = StringExtensions.GetInitials(name, defaultValue);
 
         Assert.Equal(expectedResult, actual);
     }

--- a/tests/Aspire.Dashboard.Tests/StringExtensionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/StringExtensionsTests.cs
@@ -10,6 +10,8 @@ public class StringExtensionsTests
 {
     [Theory]
     [InlineData("", "DefaultValue", "DefaultValue")]
+    [InlineData("   ", "DefaultValue", "DefaultValue")]
+    [InlineData("\t", "DefaultValue", "DefaultValue")]
     [InlineData("SingleNameOnly", null, "S")]
     [InlineData("singleNameOnly", null, "S")]
     [InlineData("Two Names", null, "TN")]


### PR DESCRIPTION
Resolves #3194 
Resolves #3197 

- Introduces the `FluentProfileMenu` to the upper-right of the site header when the user is authenticated with OpenID Connect.
- Displays the user's full name and user id (often, but not always, an email) as well as their initials.
- Adds two config settings - `Dashboard:Frontend:OpenIdConnect:NameClaimType` and `Dashboard:Frontend:OpenIdConnect:UsernameClaimType` to allow for customization of which claims determine the values displayed in the profile menu
- Provides a sign out button on the profile menu allowing the user to sign out - this clears the cookie and redirects them to the IdP where they can also sign out if they wish.

A couple screenshots:

![image](https://github.com/dotnet/aspire/assets/9613109/782aa0b0-0c8b-4426-8da3-1631d58eddb9)
![image](https://github.com/dotnet/aspire/assets/9613109/859a94de-c703-4cbc-be98-4683de898196)

TODO:
- [ ] Figure out what the header of the profile menu should be. Currently says OpenID Connect since that's the auth mode we're in. Could maybe find a way to tie it to the name of the IdP?  
- [ ] Test with another IdP (so far: Entra ID and Keycloak)
- [ ] Figure out if there's anything we can do (another config setting? more docs?) to make the OpenIdConnect code we use interoperate with Keycloak's logout better (right now it gets an error because `post_logout_redirect_uri` is passed but `id_token_hint` is not, which they consider an error even though the spec doesn't appear to).

Note: Testing this PR will require you to use your own Idp since this will only appear with OpenID Connect auth enabled. If you want to test it with TestShop (or other playground apps) you'll also need to disable the automatic setting of the authmode. Easiest way I could find to do that was to comment out this line:

https://github.com/dotnet/aspire/blob/29e2b5747d7ed696b015be59518370847fced705/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs#L126

But maybe there's a better way.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3443)