### PR TITLE
[tests] Use existing container for tests executed with RemoteExecutor

### DIFF
--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
@@ -14,11 +14,9 @@ namespace Aspire.Microsoft.Data.SqlClient.Tests;
 
 public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSqlClientSettings>, IClassFixture<SqlServerContainerFixture>
 {
-    private readonly SqlServerContainerFixture _containerFixture;
+    private readonly SqlServerContainerFixture? _containerFixture;
+    private string ConnectionString { get; set; }
     protected override bool CanConnectToServer => RequiresDockerTheoryAttribute.IsSupported;
-    private string ConnectionString => RequiresDockerTheoryAttribute.IsSupported
-                                        ? _containerFixture.GetConnectionString()
-                                        : "Data Source=fake;Database=master";
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Scoped;
 
     // https://github.com/open-telemetry/opentelemetry-dotnet/blob/031ed48714e16ba4a5b099b6e14647994a0b9c1b/src/OpenTelemetry.Instrumentation.SqlClient/Implementation/SqlActivitySourceHelper.cs#L31
@@ -49,8 +47,13 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
             ("""{"Aspire": { "Microsoft": { "Data" : { "SqlClient":{ "ConnectionString": "Con", "HealthChecks": "false"}}}}}""", "Value is \"string\" but should be \"boolean\"")
         };
 
-    public ConformanceTests(SqlServerContainerFixture containerFixture)
-        => _containerFixture = containerFixture;
+    public ConformanceTests(SqlServerContainerFixture? containerFixture)
+    {
+        _containerFixture = containerFixture;
+        ConnectionString = (_containerFixture is not null && RequiresDockerTheoryAttribute.IsSupported)
+                                        ? _containerFixture.GetConnectionString()
+                                        : "Server=localhost;User ID=root;Password=password;Database=test_aspire_mysql";
+    }
 
     protected override void PopulateConfiguration(ConfigurationManager configuration, string? key = null)
         => configuration.AddInMemoryCollection(new KeyValuePair<string, string?>[1]
@@ -90,17 +93,15 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
 
     [RequiresDockerFact]
     public void TracingEnablesTheRightActivitySource()
-        => RemoteExecutor.Invoke(() => RunWithFixtureAsync(obj => obj.ActivitySourceTest(key: null))).Dispose();
+        => RemoteExecutor.Invoke(static connectionStringToUse => RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: null)),
+                                 ConnectionString).Dispose();
 
     [RequiresDockerFact]
     public void TracingEnablesTheRightActivitySource_Keyed()
-        => RemoteExecutor.Invoke(() => RunWithFixtureAsync(obj => obj.ActivitySourceTest(key: "key"))).Dispose();
+        => RemoteExecutor.Invoke(static connectionStringToUse => RunWithConnectionString(connectionStringToUse, obj => obj.ActivitySourceTest(key: "key")),
+                                 ConnectionString).Dispose();
 
-    private static async Task RunWithFixtureAsync(Action<ConformanceTests> test)
-    {
-        await using var fixture = new SqlServerContainerFixture();
-        await fixture.InitializeAsync();
-        test(new ConformanceTests(fixture));
-    }
+    private static void RunWithConnectionString(string connectionString, Action<ConformanceTests> test)
+        => test(new ConformanceTests(null) { ConnectionString = connectionString });
 
 }


### PR DESCRIPTION
The tracing tests in `ConformanceTests` for some components are run with

`RemoteExecutor.Invoke(() => RunWithFixtureAsync(obj => obj.ActivitySourceTest(key: null))).Dispose()`

.. where `RunWithFixtureAsync` starts up a `testcontainer` in the remote
process, and then runs the test. But unlike other instances of the
tracing tests, here starting up the container can take ~1min causing the `RemoteExecutor`
to fail after the default 1 min timeout.

Instead pass the connection string from the fixture to the
`RemoteExecutor`, so a new container doesn't need to be spun up.

Example log from the remote execution:

```
[testcontainers.org 00:00:02.97] Execute "/opt/mssql-tools/bin/sqlcmd -Q SELECT 1;" at Docker container d69a9831c425
[testcontainers.org 00:00:12.09] Execute "/opt/mssql-tools/bin/sqlcmd -Q SELECT 1;" at Docker container d69a9831c425
[testcontainers.org 00:00:21.15] Execute "/opt/mssql-tools/bin/sqlcmd -Q SELECT 1;" at Docker container d69a9831c425
[testcontainers.org 00:00:30.22] Execute "/opt/mssql-tools/bin/sqlcmd -Q SELECT 1;" at Docker container d69a9831c425
[testcontainers.org 00:00:39.29] Execute "/opt/mssql-tools/bin/sqlcmd -Q SELECT 1;" at Docker container d69a9831c425
[testcontainers.org 00:00:48.35] Execute "/opt/mssql-tools/bin/sqlcmd -Q SELECT 1;" at Docker container d69a9831c425
[testcontainers.org 00:00:57.42] Execute "/opt/mssql-tools/bin/sqlcmd -Q SELECT 1;" at Docker container d69a9831c425
[testcontainers.org 00:00:58.52] Execute "/opt/mssql-tools/bin/sqlcmd -Q SELECT 1;" at Docker container d69a9831c425
[testcontainers.org 00:00:59.60] Execute "/opt/mssql-tools/bin/sqlcmd -Q SELECT 1;" at Docker container d69a9831c425
[xUnit.net 00:02:38.60]     Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests.ConformanceTests_TypeSpecificConfig.TracingEnablesTheRightActivitySource [FAIL]
[xUnit.net 00:02:38.60]       Microsoft.DotNet.RemoteExecutor.RemoteExecutionException : Half-way through waiting for remote process.
[xUnit.net 00:02:38.60]       Timed out at 3/27/2024 5:35:56 PM after 60000ms waiting for remote process.
[xUnit.net 00:02:38.60]         Process ID: 36471
[xUnit.net 00:02:38.60]         Handle: 5036
[xUnit.net 00:02:38.60]         Name: dotnet
[xUnit.net 00:02:38.60]         MainModule: /datadisks/disk1/work/B5B5097E/p/dotnet-cli/dotnet
[xUnit.net 00:02:38.60]         StartTime: 3/27/2024 5:34:56 PM
[xUnit.net 00:02:38.60]         TotalProcessorTime: 00:00:02.1500000
[xUnit.net 00:02:38.60]
[xUnit.net 00:02:38.60]       Stack Trace:
[xUnit.net 00:02:38.60]         /_/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeHandle.cs(225,0): at Microsoft.DotNet.RemoteExecutor.RemoteInvokeHandle.Dispose(Boolean disposing)
[xUnit.net 00:02:38.60]         /_/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeHandle.cs(55,0): at Microsoft.DotNet.RemoteExecutor.RemoteInvokeHandle.Dispose()
[xUnit.net 00:02:38.60]         /_/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs(116,0): at Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests.ConformanceTests.TracingEnabl>
[xUnit.net 00:02:38.60]            at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
[xUnit.net 00:02:38.60]            at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```

Fixes https://github.com/dotnet/aspire/issues/3221