### PR TITLE
Fix WithReference extension return type

### DIFF
--- a/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
@@ -82,7 +82,7 @@ public static class QdrantBuilderExtensions
     /// <param name="builder">An <see cref="IResourceBuilder{T}"/> for <see cref="ProjectResource"/></param>
     /// <param name="qdrantResource">The Qdrant server resource</param>
     /// <returns></returns>
-    public static IResourceBuilder<IResourceWithEnvironment> WithReference(this IResourceBuilder<ProjectResource> builder, IResourceBuilder<QdrantServerResource> qdrantResource)
+    public static IResourceBuilder<ProjectResource> WithReference(this IResourceBuilder<ProjectResource> builder, IResourceBuilder<QdrantServerResource> qdrantResource)
     {
         builder.WithEnvironment(context =>
         {


### PR DESCRIPTION
Not caught in PR, but just discovered in use, the `WithReference` changed the shape of the type from `ProjectResource` to `IResourceWithEnvironment` -- not making it compatible with other components.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3449)