### PR TITLE
Stay on the sync context when rendering console logs

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -47,7 +47,8 @@ public sealed partial class LogViewer
         var cancellationToken = await _cancellationSeries.NextAsync();
         var logParser = new LogParser();
 
-        await foreach (var batch in batches.WithCancellation(cancellationToken))
+        // This needs to stay on the UI thread since we raise StateHasChanged() in the loop (hence the ConfigureAwait(true)).
+        await foreach (var batch in batches.WithCancellation(cancellationToken).ConfigureAwait(true))
         {
             if (batch.Count is 0)
             {

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -47,7 +47,7 @@ public sealed partial class LogViewer
         var cancellationToken = await _cancellationSeries.NextAsync();
         var logParser = new LogParser();
 
-        await foreach (var batch in batches.WithCancellation(cancellationToken).ConfigureAwait(false))
+        await foreach (var batch in batches.WithCancellation(cancellationToken))
         {
             if (batch.Count is 0)
             {


### PR DESCRIPTION
- Don't use ConfigureAwait(false)

Fixes #3458
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3459)