### PR TITLE
Increase auth cookie expiry

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -510,7 +510,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                 {
                     options.LoginPath = "/login";
                     options.ReturnUrlParameter = "returnUrl";
-                    options.ExpireTimeSpan = TimeSpan.FromDays(1);
+                    options.ExpireTimeSpan = TimeSpan.FromDays(3);
                     options.Events.OnSigningIn = context =>
                     {
                         // Add claim when signing in with cookies from browser token.


### PR DESCRIPTION
There was no security objection to a longer auth cookie expiry. Increase from 1 day to 3 days to reduce how often users see the login screen.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3468)