### PR TITLE
[release/8.0] Default to browser token auth in dashboard standalone

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -32,6 +32,9 @@
         </FluentButton>
     </FluentHeader>
     <NavMenu />
+    <div class="messagebar-container">
+        <FluentMessageBarProvider Section="@MessageBarSection" Class="top-messagebar" />
+    </div>
     <FluentBodyContent Class="custom-body-content">
         <FluentToastProvider />
         @Body

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -31,9 +31,10 @@
     width: 100vw;
     display: grid;
     grid-template-columns: auto 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto auto 1fr;
     grid-template-areas:
         "icon head"
+        "nav messagebar"
         "nav main";
     background-color: var(--fill-color);
     color: var(--neutral-foreground-rest);
@@ -60,6 +61,11 @@
 ::deep.layout > .body-content {
     grid-area: main;
     overflow-x: auto; /* allow horizontal scrolling */
+    border-left: 1px solid var(--neutral-stroke-rest);
+}
+
+::deep.layout > .messagebar-container {
+    grid-area: messagebar;
     border-top: 1px solid var(--neutral-stroke-rest);
     border-left: 1px solid var(--neutral-stroke-rest);
 }

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Aspire.Hosting;
 
 namespace Aspire.Dashboard.Configuration;
 
@@ -84,7 +85,7 @@ public sealed class OtlpOptions
     {
         if (string.IsNullOrEmpty(EndpointUrl))
         {
-            errorMessage = "OTLP endpoint URL is not configured. Specify a Dashboard:Otlp:EndpointUrl value.";
+            errorMessage = $"OTLP endpoint URL is not configured. Specify a {DashboardConfigNames.DashboardOtlpUrlName.EnvVarName} value.";
             return false;
         }
         else

--- a/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/PostConfigureDashboardOptions.cs
@@ -35,9 +35,19 @@ public sealed class PostConfigureDashboardOptions : IPostConfigureOptions<Dashbo
             options.Frontend.AuthMode = FrontendAuthMode.Unsecured;
             options.Otlp.AuthMode = OtlpAuthMode.Unsecured;
         }
+        else
+        {
+            options.Frontend.AuthMode ??= FrontendAuthMode.BrowserToken;
+            options.Otlp.AuthMode ??= OtlpAuthMode.Unsecured;
+        }
         if (options.Frontend.AuthMode == FrontendAuthMode.BrowserToken && string.IsNullOrEmpty(options.Frontend.BrowserToken))
         {
-            options.Frontend.BrowserToken = TokenGenerator.GenerateToken();
+            var token = TokenGenerator.GenerateToken();
+
+            // Set the generated token in configuration. This is required because options could be created multiple times
+            // (at startup, after CI is created, after options change). Setting the token in configuration makes it consistent.
+            _configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = token;
+            options.Frontend.BrowserToken = token;
         }
     }
 }

--- a/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
+++ b/src/Aspire.Dashboard/Model/BrowserTimeProvider.cs
@@ -5,7 +5,7 @@ namespace Aspire.Dashboard.Model;
 
 /// <summary>
 /// This time provider is used to provide the time zone information from the browser to the server.
-/// It is a different type because we want to log setting the timezone, and we want a distinct type
+/// It is a different type because we want to log setting the time zone, and we want a distinct type
 /// to register with DI:
 /// - BrowserTimeProvider must be scoped to the user's session.
 /// - The built-in TimeProvider registration must be singleton for the system time (used by auth).
@@ -29,11 +29,11 @@ public class BrowserTimeProvider : TimeProvider
     {
         if (!TimeZoneInfo.TryFindSystemTimeZoneById(timeZone, out var timeZoneInfo))
         {
-            _logger.LogWarning("Couldn't find a time zone '{TimeZone}'. Defaulting to UTC.", timeZone);
+            _logger.LogWarning("Couldn't find time zone '{TimeZone}'. Defaulting to UTC.", timeZone);
             timeZoneInfo = TimeZoneInfo.Utc;
         }
 
-        _logger.LogInformation("Browser time zone set to '{TimeZone}' with UTC offset {UtcOffset}.", timeZoneInfo.Id, timeZoneInfo.BaseUtcOffset);
+        _logger.LogDebug("Browser time zone set to '{TimeZone}' with UTC offset {UtcOffset}.", timeZoneInfo.Id, timeZoneInfo.BaseUtcOffset);
         _browserLocalTimeZone = timeZoneInfo;
     }
 }

--- a/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
+++ b/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
@@ -51,8 +51,13 @@ internal sealed class ValidateTokenMiddleware
                     var qs = HttpUtility.ParseQueryString(context.Request.QueryString.ToString());
                     qs.Remove("t");
 
+                    // Collection created by ParseQueryString handles escaping names and values.
                     var newQuerystring = qs.ToString();
-                    context.Response.Redirect($"{context.Request.Path}?{newQuerystring}");
+                    if (!string.IsNullOrEmpty(newQuerystring))
+                    {
+                        newQuerystring = "?" + newQuerystring;
+                    }
+                    context.Response.Redirect($"{context.Request.Path}{newQuerystring}");
                 }
 
                 return;

--- a/src/Aspire.Dashboard/Properties/launchSettings.json
+++ b/src/Aspire.Dashboard/Properties/launchSettings.json
@@ -4,7 +4,8 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:15887"
       },
       "applicationUrl": "https://localhost:15889;http://localhost:15888"
     }

--- a/src/Aspire.Dashboard/Resources/Layout.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Layout.Designer.cs
@@ -133,6 +133,33 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Untrusted apps can send telemetry to the dashboard..
+        /// </summary>
+        public static string MessageTelemetryBody {
+            get {
+                return ResourceManager.GetString("MessageTelemetryBody", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to More information.
+        /// </summary>
+        public static string MessageTelemetryLink {
+            get {
+                return ResourceManager.GetString("MessageTelemetryLink", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Telemetry endpoint is unsecured.
+        /// </summary>
+        public static string MessageTelemetryTitle {
+            get {
+                return ResourceManager.GetString("MessageTelemetryTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Console.
         /// </summary>
         public static string NavMenuConsoleLogsTab {

--- a/src/Aspire.Dashboard/Resources/Layout.resx
+++ b/src/Aspire.Dashboard/Resources/Layout.resx
@@ -159,4 +159,13 @@
   <data name="MainLayoutAspire" xml:space="preserve">
     <value>.NET Aspire</value>
   </data>
+  <data name="MessageTelemetryBody" xml:space="preserve">
+    <value>Untrusted apps can send telemetry to the dashboard.</value>
+  </data>
+  <data name="MessageTelemetryLink" xml:space="preserve">
+    <value>More information</value>
+  </data>
+  <data name="MessageTelemetryTitle" xml:space="preserve">
+    <value>Telemetry endpoint is unsecured</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.cs.xlf
@@ -42,6 +42,21 @@
         <target state="translated">Načíst znovu</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">Konzola</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.de.xlf
@@ -42,6 +42,21 @@
         <target state="translated">Neu laden</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">Konsole</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.es.xlf
@@ -42,6 +42,21 @@
         <target state="translated">Recargar</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">Consola</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.fr.xlf
@@ -42,6 +42,21 @@
         <target state="translated">Recharger</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">Console</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.it.xlf
@@ -42,6 +42,21 @@
         <target state="translated">Ricarica</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">Console</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ja.xlf
@@ -42,6 +42,21 @@
         <target state="translated">再読み込み</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">コンソール</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ko.xlf
@@ -42,6 +42,21 @@
         <target state="translated">다시 로드</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">콘솔</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pl.xlf
@@ -42,6 +42,21 @@
         <target state="translated">Załaduj ponownie</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">Konsola</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.pt-BR.xlf
@@ -42,6 +42,21 @@
         <target state="translated">Recarregar</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">Console</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.ru.xlf
@@ -42,6 +42,21 @@
         <target state="translated">Перезагрузить</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">Консоль</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.tr.xlf
@@ -42,6 +42,21 @@
         <target state="translated">Yeniden yükle</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">Konsol</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hans.xlf
@@ -42,6 +42,21 @@
         <target state="translated">重新加载</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">控制台</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Layout.zh-Hant.xlf
@@ -42,6 +42,21 @@
         <target state="translated">重新載入</target>
         <note />
       </trans-unit>
+      <trans-unit id="MessageTelemetryBody">
+        <source>Untrusted apps can send telemetry to the dashboard.</source>
+        <target state="new">Untrusted apps can send telemetry to the dashboard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryLink">
+        <source>More information</source>
+        <target state="new">More information</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MessageTelemetryTitle">
+        <source>Telemetry endpoint is unsecured</source>
+        <target state="new">Telemetry endpoint is unsecured</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NavMenuConsoleLogsTab">
         <source>Console</source>
         <target state="translated">主控台</target>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -45,6 +45,9 @@ fluent-toolbar[orientation=horizontal] {
     --error-counter-badge-foreground-color: var(--neutral-fill-rest);
     --kbd-background-color: var(--neutral-layer-4);
 
+    --messagebar-warning-background-color: #FDF6F3;
+    --messagebar-warning-border-color: #f4bfab;
+
     --layout-toolbar-padding: calc(var(--design-unit) * 1.5px);
 }
 
@@ -60,6 +63,9 @@ fluent-toolbar[orientation=horizontal] {
     --reconnection-ui-bg: #D6D6D6;
     --error-counter-badge-foreground-color: #ffffff;
     --kbd-background-color: var(--fill-color);
+
+    --messagebar-warning-background-color: #411200;
+    --messagebar-warning-border-color: #DA3B01;
 
     /* overrides of default fluentui-blazor styling */
     --error: #E10B11 !important;
@@ -130,6 +136,16 @@ fluent-data-grid .loading-content-cell .stack-horizontal {
 
 .custom-body-content {
     margin-right: 10px;
+}
+
+.top-messagebar {
+    padding: calc(var(--design-unit) * 2px);
+    padding-bottom: 0;
+}
+
+.fluent-messagebar.intent-warning {
+    background-color: var(--messagebar-warning-background-color) !important;
+    border: 1px solid var(--messagebar-warning-border-color) !important;
 }
 
 /* The fluent dialog's default fill color is too dark in our current dark theme.

--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -17,7 +17,7 @@ internal static class LoggingHelpers
 
         if (StringUtils.TryGetUriFromDelimitedString(dashboardUrls, ";", out var firstDashboardUrl))
         {
-            logger.LogInformation("Login to the dashboard at {DashboardUrl}", $"{firstDashboardUrl.GetLeftPart(UriPartial.Authority)}/login?t={token}");
+            logger.LogInformation("Login to the dashboard at {DashboardLoginUrl}", $"{firstDashboardUrl.GetLeftPart(UriPartial.Authority)}/login?t={token}");
         }
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendAuthTests.cs
@@ -7,6 +7,7 @@ using System.Web;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Utils;
 using Aspire.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using Xunit;
 using Xunit.Abstractions;
@@ -154,9 +155,9 @@ public class FrontendAuthTests
             },
             w =>
             {
-                Assert.Equal("Login to the dashboard at {DashboardUrl}", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal("Login to the dashboard at {DashboardLoginUrl}", GetValue(w.State, "{OriginalFormat}"));
 
-                var uri = new Uri((string)GetValue(w.State, "DashboardUrl")!, UriKind.Absolute);
+                var uri = new Uri((string)GetValue(w.State, "DashboardLoginUrl")!, UriKind.Absolute);
                 var queryString = HttpUtility.ParseQueryString(uri.Query);
                 Assert.NotNull(queryString["t"]);
             },
@@ -166,6 +167,11 @@ public class FrontendAuthTests
 
                 var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
                 Assert.NotEqual(0, uri.Port);
+            },
+            w =>
+            {
+                Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal(LogLevel.Warning, w.LogLevel);
             });
 
         object? GetValue(object? values, string key)

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -271,7 +271,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
     public async Task LogOutput_LocalhostAddress_LocalhostInLogOutput()
     {
         // Arrange
-        var testSink = new TestSink();
+        TestSink? testSink = null;
         DashboardWebApplication? app = null;
 
         int? frontendPort1 = null;
@@ -285,6 +285,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
                 frontendPort2 = ports[1];
                 otlpPort = ports[2];
 
+                testSink = new TestSink();
                 app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
                     additionalConfiguration: data =>
                     {
@@ -305,6 +306,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         }
 
         // Assert
+        Assert.NotNull(testSink);
         var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
         Assert.Collection(l,
             w =>

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -45,9 +45,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         // Assert
         Assert.Collection(ex.Failures,
             s => s.Contains("Dashboard:Frontend:EndpointUrls"),
-            s => s.Contains("Dashboard:Frontend:AuthMode"),
-            s => s.Contains("Dashboard:Otlp:EndpointUrl"),
-            s => s.Contains("Dashboard:Otlp:AuthMode"));
+            s => s.Contains("Dashboard:Otlp:EndpointUrl"));
     }
 
     [Fact]
@@ -94,7 +92,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         DashboardWebApplication? app = null;
         try
         {
-            await ServerRetryHelper.BindPortsWithRetry(async port =>
+            await ServerRetryHelper.BindPortWithRetry(async port =>
             {
                 app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
                     additionalConfiguration: initialData =>
@@ -149,7 +147,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         var testSink = new TestSink();
         try
         {
-            await ServerRetryHelper.BindPortsWithRetry(async port =>
+            await ServerRetryHelper.BindPortWithRetry(async port =>
             {
                 app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
                     additionalConfiguration: initialData =>
@@ -191,20 +189,20 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
-    public async Task Configuration_NoOtlpAuthMode_Error()
+    public async Task Configuration_NoAuthMode_DefaultAuthModes()
     {
         // Arrange & Act
-        var ex = await Assert.ThrowsAsync<OptionsValidationException>(async () =>
-        {
-            await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
-                additionalConfiguration: data =>
-                {
-                    data.Remove(DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey);
-                });
-        });
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
+            additionalConfiguration: data =>
+            {
+                data.Remove(DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey);
+                data.Remove(DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey);
+            });
 
         // Assert
-        Assert.Contains("Dashboard:Otlp:AuthMode", ex.Message);
+        Assert.Equal(FrontendAuthMode.BrowserToken, app.DashboardOptionsMonitor.CurrentValue.Frontend.AuthMode);
+        Assert.Equal(16, Convert.FromHexString(app.DashboardOptionsMonitor.CurrentValue.Frontend.BrowserToken!).Length);
+        Assert.Equal(OtlpAuthMode.Unsecured, app.DashboardOptionsMonitor.CurrentValue.Otlp.AuthMode);
     }
 
     [Fact]
@@ -214,7 +212,6 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
             additionalConfiguration: data =>
             {
-                data.Remove(DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey);
                 data[DashboardConfigNames.DashboardUnsecuredAllowAnonymousName.ConfigKey] = bool.TrueString;
             });
 
@@ -222,8 +219,8 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         // Assert
-        AssertDynamicIPEndpoint(app.FrontendEndPointAccessor);
-        AssertDynamicIPEndpoint(app.OtlpServiceEndPointAccessor);
+        Assert.Equal(FrontendAuthMode.Unsecured, app.DashboardOptionsMonitor.CurrentValue.Frontend.AuthMode);
+        Assert.Equal(OtlpAuthMode.Unsecured, app.DashboardOptionsMonitor.CurrentValue.Otlp.AuthMode);
     }
 
     [Fact]
@@ -256,6 +253,84 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
 
                 var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
                 Assert.NotEqual(0, uri.Port);
+            },
+            w =>
+            {
+                Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal(LogLevel.Warning, w.LogLevel);
+            });
+
+        object? GetValue(object? values, string key)
+        {
+            var list = values as IReadOnlyList<KeyValuePair<string, object>>;
+            return list?.SingleOrDefault(kvp => kvp.Key == key).Value;
+        }
+    }
+
+    [Fact]
+    public async Task LogOutput_LocalhostAddress_LocalhostInLogOutput()
+    {
+        // Arrange
+        var testSink = new TestSink();
+        DashboardWebApplication? app = null;
+
+        int? frontendPort1 = null;
+        int? frontendPort2 = null;
+        int? otlpPort = null;
+        try
+        {
+            await ServerRetryHelper.BindPortsWithRetry(async ports =>
+            {
+                frontendPort1 = ports[0];
+                frontendPort2 = ports[1];
+                otlpPort = ports[2];
+
+                app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
+                    additionalConfiguration: data =>
+                    {
+                        data[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = $"https://localhost:{frontendPort1};http://localhost:{frontendPort2}";
+                        data[DashboardConfigNames.DashboardOtlpUrlName.ConfigKey] = $"http://localhost:{otlpPort}";
+                    }, testSink: testSink);
+
+                // Act
+                await app.StartAsync();
+            }, NullLogger.Instance, portCount: 3);
+        }
+        finally
+        {
+            if (app is not null)
+            {
+                await app.DisposeAsync();
+            }
+        }
+
+        // Assert
+        var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
+        Assert.Collection(l,
+            w =>
+            {
+                Assert.Equal("Aspire version: {Version}", GetValue(w.State, "{OriginalFormat}"));
+            },
+            w =>
+            {
+                Assert.Equal("Now listening on: {DashboardUri}", GetValue(w.State, "{OriginalFormat}"));
+
+                var uri = new Uri((string)GetValue(w.State, "DashboardUri")!);
+                Assert.Equal("https", uri.Scheme);
+                Assert.Equal("localhost", uri.Host);
+                Assert.Equal(frontendPort1, uri.Port);
+            },
+            w =>
+            {
+                Assert.Equal("OTLP server running at: {OtlpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
+
+                var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
+                Assert.NotEqual(0, uri.Port);
+            },
+            w =>
+            {
+                Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
+                Assert.Equal(LogLevel.Warning, w.LogLevel);
             });
 
         object? GetValue(object? values, string key)


### PR DESCRIPTION
Backports https://github.com/dotnet/aspire/pull/3427

## Customer Impact

This PR changes the dashboard to default frontend auth to browser token. Previously, the dashboard would throw an error if no auth was configured unless suppressed. Providing a good default instead of an error makes using the standalone dashboard a nicer experience when getting started and it offers a secure default rather than forcing users to explicitly opt-out of auth altogether.

While making these changes, I tested the standalone dashboard much more heavily than before and found some related bugs. They're also fixed in this PR.

This PR:

* Changes dashboard to default to browser token auth in the frontend, and unsecured in OTLP endpoint
* Displays a warning about the unsecured OTLP endpoint in the console and in the UI with a message bar
* Fixes the browser token being generated multiple times
* Fixes the addresses written to the console to be the first address (matches host) instead of the last address
* Fixes the addresses written to the console to be localhost if localhost is specified.

**Demo:**

![standalone-browser-token](https://github.com/dotnet/aspire/assets/303201/65d6ad0b-0e27-4246-a6a4-262020a82ea7)

## Testing

Manual and unit tests.

## Risk

Low-Medium. Changing the default auth mode is a simple change. There is some new UI (message bar) for warning about unsecured OTLP endpoint.

## Regression?

No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3469)