### PR TITLE
Enable HSTS middleware when all endpoints are HTTPS

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -217,13 +217,13 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         else
         {
             _app.UseExceptionHandler("/Error");
-            //_app.UseHsts();
         }
 
         _app.UseStatusCodePagesWithReExecute("/error/{0}");
 
         if (isAllHttps)
         {
+            _app.UseHsts();
             _app.UseHttpsRedirection();
         }
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -217,13 +217,16 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         else
         {
             _app.UseExceptionHandler("/Error");
+            if (isAllHttps)
+            {
+                _app.UseHsts();
+            }
         }
 
         _app.UseStatusCodePagesWithReExecute("/error/{0}");
 
         if (isAllHttps)
         {
-            _app.UseHsts();
             _app.UseHttpsRedirection();
         }
 


### PR DESCRIPTION
Adds middleware to add [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) response header to dashboard.

@drewnoakes I noticed there was already a commented out call to `UseHsts` in app startup. You added it when splitting the dashboard out. Do you remember why it is there and commented out?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3471)