### PR TITLE
Don't wait until after we've started the entire app to print the token

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dcp;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Dashboard;
+
+internal class DashboardOptions
+{
+    public string? DashboardPath { get; set; }
+    public string? DashboardUrl { get; set; }
+    public string? DashboardToken { get; set; }
+    public string? OtlpEndpointUrl { get; set; }
+    public string? OtlpApiKey { get; set; }
+    public string AspNetCoreEnvironment { get; set; } = "Production";
+}
+
+internal class ConfigureDefaultDashboardOptions(IConfiguration configuration, IOptions<DcpOptions> dcpOptions) : IConfigureOptions<DashboardOptions>
+{
+    public void Configure(DashboardOptions options)
+    {
+        options.DashboardPath = dcpOptions.Value.DashboardPath;
+        options.DashboardUrl = configuration["ASPNETCORE_URLS"];
+        options.DashboardToken = configuration["AppHost:BrowserToken"];
+
+        options.OtlpEndpointUrl = configuration["DOTNET_DASHBOARD_OTLP_ENDPOINT_URL"];
+        options.OtlpApiKey = configuration["AppHost:OtlpApiKey"];
+
+        options.AspNetCoreEnvironment = configuration["ASPNETCORE_ENVIRONMENT"] ?? "Production";
+    }
+}
+
+internal class ValidateDashboardOptions : IValidateOptions<DashboardOptions>
+{
+    public ValidateOptionsResult Validate(string? name, DashboardOptions options)
+    {
+        var builder = new ValidateOptionsResultBuilder();
+
+        if (string.IsNullOrEmpty(options.DashboardUrl))
+        {
+            builder.AddError("Failed to configure dashboard resource because ASPNETCORE_URLS environment variable was not set.");
+        }
+
+        if (string.IsNullOrEmpty(options.OtlpEndpointUrl))
+        {
+            builder.AddError("Failed to configure dashboard resource because DOTNET_DASHBOARD_OTLP_ENDPOINT_URL environment variable was not set.");
+        }
+
+        return builder.Build();
+    }
+}

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -141,6 +141,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                 _innerBuilder.Services.AddSingleton<DashboardServiceHost>();
                 _innerBuilder.Services.AddHostedService(sp => sp.GetRequiredService<DashboardServiceHost>());
                 _innerBuilder.Services.AddLifecycleHook<DashboardLifecycleHook>();
+                _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DashboardOptions>, ConfigureDefaultDashboardOptions>());
+                _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DashboardOptions>, ValidateDashboardOptions>());
             }
 
             // DCP stuff

--- a/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
+++ b/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
@@ -11,8 +11,7 @@ namespace Aspire.Hosting;
 internal sealed class DistributedApplicationLifecycle(
     ILogger<DistributedApplication> logger,
     IConfiguration configuration,
-    DistributedApplicationExecutionContext executionContext,
-    DistributedApplicationOptions distributedApplicationOptions) : IHostedLifecycleService
+    DistributedApplicationExecutionContext executionContext) : IHostedLifecycleService
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
@@ -23,11 +22,6 @@ internal sealed class DistributedApplicationLifecycle(
     {
         if (executionContext.IsRunMode)
         {
-            if (distributedApplicationOptions.DashboardEnabled && configuration["AppHost:BrowserToken"] is { Length: > 0 } browserToken)
-            {
-                LoggingHelpers.WriteDashboardUrl(logger, configuration["ASPNETCORE_URLS"], browserToken);
-            }
-
             logger.LogInformation("Distributed application started. Press Ctrl+C to shut down.");
         }
 

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,8 +46,16 @@ public sealed class TestDistributedApplicationBuilder : IDisposable, IDistribute
 
         builder.Services.Configure<DcpOptions>(o =>
         {
-            o.DashboardPath = "dashboard";
-            o.CliPath = "dcp";
+            // Make sure we have a dashboard path and CLI path (but don't overwrite them if they're already set)
+            o.DashboardPath ??= "dashboard";
+            o.CliPath ??= "dcp";
+        });
+
+        builder.Services.Configure<DashboardOptions>(o =>
+        {
+            // Make sure we have a dashboard URL and OTLP endpoint URL (but don't overwrite them if they're already set)
+            o.DashboardUrl ??= "http://localhost:8080";
+            o.OtlpEndpointUrl ??= "http://localhost:4317";
         });
 
         return new(builder);


### PR DESCRIPTION
- Print it right after we print the dashboard url
- Refactored the dashboard resource to use DashboardOptions instead of DcpOptions

PS: We'll need to backport this to p6.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3472)