### PR TITLE
Name collision warning.

### DIFF
--- a/src/Aspire.Hosting.Azure.AppConfiguration/README.md
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/README.md
@@ -27,6 +27,9 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(appConfig);
 ```
 
+> NOTE: NOTE: Consider setting the name of your resource to something other than "config" or "appconfig". Even though durnig deployment random suffix will be added it is still possible to get a name collision.
+
+
 ## Additional documentation
 
 * https://learn.microsoft.com/azure/azure-app-configuration/

--- a/src/Aspire.Hosting.Azure.AppConfiguration/README.md
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/README.md
@@ -27,8 +27,7 @@ var myService = builder.AddProject<Projects.MyService>()
                        .WithReference(appConfig);
 ```
 
-> NOTE: NOTE: Consider setting the name of your resource to something other than "config" or "appconfig". Even though durnig deployment random suffix will be added it is still possible to get a name collision.
-
+> NOTE: Consider setting the name of your resource to something other than "config" or "appconfig". Even though durnig deployment random suffix will be added it is still possible to get a name collision.
 
 ## Additional documentation
 


### PR DESCRIPTION
This pull request includes a small change to the `src/Aspire.Hosting.Azure.AppConfiguration/README.md` file. The change adds a note advising users to consider setting the name of their resource to something other than "config" or "appconfig" to avoid possible name collisions.

Addresses #2954


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3474)