### PR TITLE
[release/8.0]: Print the URL with the token when we print the dashboard URL

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
+++ b/src/Aspire.Hosting/DistributedApplicationLifecycle.cs
@@ -11,8 +11,7 @@ namespace Aspire.Hosting;
 internal sealed class DistributedApplicationLifecycle(
     ILogger<DistributedApplication> logger,
     IConfiguration configuration,
-    DistributedApplicationExecutionContext executionContext,
-    DistributedApplicationOptions distributedApplicationOptions) : IHostedLifecycleService
+    DistributedApplicationExecutionContext executionContext) : IHostedLifecycleService
 {
     public Task StartAsync(CancellationToken cancellationToken)
     {
@@ -23,11 +22,6 @@ internal sealed class DistributedApplicationLifecycle(
     {
         if (executionContext.IsRunMode)
         {
-            if (distributedApplicationOptions.DashboardEnabled && configuration["AppHost:BrowserToken"] is { Length: > 0 } browserToken)
-            {
-                LoggingHelpers.WriteDashboardUrl(logger, configuration["ASPNETCORE_URLS"], browserToken);
-            }
-
             logger.LogInformation("Distributed application started. Press Ctrl+C to shut down.");
         }
 


### PR DESCRIPTION
This is a release/8.0 version of https://github.com/dotnet/aspire/pull/3472 (main contains a bigger dashboard refactoring so this is a manual change to reduce the risk.)

After the dashboard auth changes, we are waiting until the application has fully started before showing the URL with the token to authenticate, and that can take a long time when provisioning azure resources. Instead, just print the URL with the token when we print the dashboard URL.

## Customer Impact

This makes it possible to login to the dashboard when using azure resources. Without it, customers would potentially need to wait until all resources are done provisioning to use the dashboard (with the correct auth token).

## Testing

Existing test pass, and manual verification.

## Risk

Low

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3475)