### PR TITLE
Add max-width to endpoint popup

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -72,11 +72,11 @@ else
                     Endpoints
                 </Header>
                 <Body>
-                    <div style="max-height:400px; overflow-x:hidden; overflow-y: auto; padding:5px 10px;">
+                    <div class="endpoint-popup">
                         @foreach (var item in items)
                         {
                             var d = (DisplayedEndpoint)item.Data!;
-                            <div style="margin-bottom: 4px;">
+                            <div class="endpoint-link">
                                 @if (d.Url != null)
                                 {
                                     <a href="@d.Url" target="_blank">@d.Text</a>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -79,11 +79,11 @@ else
                             <div class="endpoint-link">
                                 @if (d.Url != null)
                                 {
-                                    <a href="@d.Url" target="_blank">@d.Text</a>
+                                    <a href="@d.Url" target="_blank" title="@d.Text">@d.Text</a>
                                 }
                                 else
                                 {
-                                    @d.Text
+                                    <span title="@d.Text">@d.Text</span>
                                 }
                             </div>
                         }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
@@ -10,11 +10,11 @@
 }
 
 ::deep.endpoint-popup {
+    max-width: 500px;
     max-height: 400px;
     overflow-x: hidden;
     overflow-y: auto;
     padding: 5px 10px;
-    max-width: 500px;
 }
 
 ::deep.endpoint-link {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
@@ -8,3 +8,17 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+::deep.endpoint-popup {
+    max-height: 400px;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: 5px 10px;
+    max-width: 500px;
+}
+
+::deep.endpoint-link {
+    margin-bottom: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}


### PR DESCRIPTION
Very long endpoint would make the popup excessively large and possibly push it off the screen. This PR adds a max width and trims the endpoints with ellipsis.

Before:

![image](https://github.com/dotnet/aspire/assets/303201/16592f45-f867-4bef-8348-4d898e28ff66)

After:

![image](https://github.com/dotnet/aspire/assets/303201/ef785aea-ef8d-4df3-8839-8e17ab91aa32)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3476)