### PR TITLE
[release/8.0]: Backport accessibility fixes into 8.0

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -34,7 +34,12 @@
     }
 
     @{
-        (string, object)[] uncapturedAttributes = [("alt", PreCopyToolTip), ("title", string.Empty), ("aria-label", Loc[nameof(ControlsStrings.GridValueCopyToClipboard)])];
+        (string, object)[] uncapturedAttributes = [
+            ("alt", PreCopyToolTip),
+            ("title", string.Empty),
+            ("aria-label", Loc[nameof(ControlsStrings.GridValueCopyToClipboard)]),
+            ("tabindex", "0")
+        ];
     }
 
     <FluentButton Appearance="Appearance.Lightweight"

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -20,6 +20,6 @@
     cursor: pointer;
 }
 
-::deep:hover .defaultHidden {
+::deep:hover .defaultHidden, ::deep:focus-within .defaultHidden  {
     opacity: 1;  /* safari has a bug where hover is not always called on an invisible element, so we use opacity instead */
 }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -34,7 +34,7 @@
                         <FluentCheckbox
                             Label="@resourceType"
                             @bind-Value:get="isChecked"
-                            @bind-Value:set="c => OnResourceTypeVisibilityChanged(resourceType, c)"
+                            @bind-Value:set="c => OnResourceTypeVisibilityChangedAsync(resourceType, c)"
                             />
                     }
                 </FluentStack>
@@ -44,11 +44,11 @@
                       Immediate="true"
                       @bind-Value="_filter"
                       slot="end"
-                      @bind-Value:after="HandleSearchFilterChanged" />
+                      @bind-Value:after="HandleSearchFilterChangedAsync" />
     </FluentToolbar>
     <SummaryDetailsView DetailsTitle="@(SelectedResource != null ? $"{SelectedResource.ResourceType}: {GetResourceName(SelectedResource)}" : null)"
                         ShowDetails="@(SelectedResource is not null)"
-                        OnDismiss="() => ClearSelectedResource()"
+                        OnDismiss="@(() => ClearSelectedResourceAsync(causedByUserAction: true))"
                         SelectedValue="@SelectedResource"
                         ViewKey="ResourcesList">
         <Summary>
@@ -77,9 +77,13 @@
                         <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(resource: context.Name)">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesDetailsColumnHeader)]" Sortable="false" Class="no-ellipsis">
+                        @{
+                            var id = $"details-button-{context.Uid}";
+                        }
                         <FluentButton Appearance="Appearance.Lightweight"
+                                      Id="@id"
                                       Title="@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]"
-                                      OnClick="() => ShowResourceDetails(context)">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
+                                      OnClick="@(() => ShowResourceDetailsAsync(context, id))">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
                     </TemplateColumn>
                     @if (HasResourcesWithCommands)
                     {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -10,6 +10,7 @@ using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Pages;
 
@@ -30,6 +31,8 @@ public partial class Resources : ComponentBase, IAsyncDisposable
     public required IToastService ToastService { get; init; }
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
+    [Inject]
+    public required IJSRuntime JS { get; init; }
 
     private ResourceViewModel? SelectedResource { get; set; }
 
@@ -41,6 +44,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
     private bool _isTypeFilterVisible;
     private Task? _resourceSubscriptionTask;
     private bool _isLoading = true;
+    private string? _elementIdBeforeDetailsViewOpened;
 
     public Resources()
     {
@@ -49,7 +53,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
 
     private bool Filter(ResourceViewModel resource) => _visibleResourceTypes.ContainsKey(resource.ResourceType) && (_filter.Length == 0 || resource.MatchesFilter(_filter)) && resource.State != ResourceStates.HiddenState;
 
-    protected void OnResourceTypeVisibilityChanged(string resourceType, bool isVisible)
+    protected Task OnResourceTypeVisibilityChangedAsync(string resourceType, bool isVisible)
     {
         if (isVisible)
         {
@@ -60,12 +64,12 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             _visibleResourceTypes.TryRemove(resourceType, out _);
         }
 
-        ClearSelectedResource();
+        return ClearSelectedResourceAsync();
     }
 
-    private void HandleSearchFilterChanged()
+    private Task HandleSearchFilterChangedAsync()
     {
-        ClearSelectedResource();
+        return ClearSelectedResourceAsync();
     }
 
     private bool? AreAllTypesVisible
@@ -202,11 +206,13 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         return false;
     }
 
-    private void ShowResourceDetails(ResourceViewModel resource)
+    private async Task ShowResourceDetailsAsync(ResourceViewModel resource, string buttonId)
     {
+        _elementIdBeforeDetailsViewOpened = buttonId;
+
         if (SelectedResource == resource)
         {
-            ClearSelectedResource();
+            await ClearSelectedResourceAsync();
         }
         else
         {
@@ -214,9 +220,16 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         }
     }
 
-    private void ClearSelectedResource()
+    private async Task ClearSelectedResourceAsync(bool causedByUserAction = false)
     {
         SelectedResource = null;
+
+        if (_elementIdBeforeDetailsViewOpened is not null && causedByUserAction)
+        {
+            await JS.InvokeVoidAsync("focusElement", _elementIdBeforeDetailsViewOpened);
+        }
+
+        _elementIdBeforeDetailsViewOpened = null;
     }
 
     private string GetResourceName(ResourceViewModel resource) => ResourceViewModel.GetResourceName(resource, _resourceByName);

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -34,6 +34,7 @@
             <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
             <FluentSelect TOption="SelectViewModel<LogLevel?>"
                           Items="@_logLevels"
+                          Position="SelectPosition.Below"
                           OptionText="@(c => c.Name)"
                           @bind-SelectedOption="PageViewModel.SelectedLogLevel"
                           @bind-SelectedOption:after="HandleSelectedLogLevelChangedAsync"
@@ -64,7 +65,7 @@
         SelectedValue="@SelectedLogEntry">
         <DetailsTitleTemplate>
             @{
-                var eventName = OtlpHelpers.GetValue(SelectedLogEntry!.LogEntry.Attributes, "event.name") 
+                var eventName = OtlpHelpers.GetValue(SelectedLogEntry!.LogEntry.Attributes, "event.name")
                     ?? OtlpHelpers.GetValue(SelectedLogEntry.LogEntry.Attributes, "logrecord.event.name")
                     ?? Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails)];
             }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -24,7 +24,7 @@
                         @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync" />
         <FluentSearch @bind-Value="PageViewModel.Filter"
                       @oninput="HandleFilter"
-                      @bind-Value:after="HandleClear"
+                      @bind-Value:after="HandleClearAsync"
                       Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
                       title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMessageFilter)]"
                       slot="end" />
@@ -60,7 +60,7 @@
     </FluentToolbar>
     <SummaryDetailsView
         ShowDetails="SelectedLogEntry is not null"
-        OnDismiss="() => ClearSelectedLogEntry()"
+        OnDismiss="@(() => ClearSelectedLogEntryAsync(causedByUserAction: true))"
         ViewKey="StructuredLogsList"
         SelectedValue="@SelectedLogEntry">
         <DetailsTitleTemplate>
@@ -103,7 +103,10 @@
                                 }
                             </TemplateColumn>
                             <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.DetailsColumnHeader)]" Class="no-ellipsis">
-                                <FluentButton Appearance="Appearance.Lightweight" OnClick="() => OnShowProperties(context)">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
+                                @{
+                                    var id = $"details-button-{context.InternalId}";
+                                }
+                                <FluentButton Id="@id" Appearance="Appearance.Lightweight" OnClick="@(() => OnShowPropertiesAsync(context, id))">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
                             </TemplateColumn>
                         </ChildContent>
                         <EmptyContent>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -27,6 +27,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     private Subscription? _logsSubscription;
     private bool _applicationChanged;
     private CancellationTokenSource? _filterCts;
+    private string? _elementIdBeforeDetailsViewOpened;
 
     public string BasePath => DashboardUrls.StructuredLogsBasePath;
     public string SessionStorageKey => "StructuredLogs_PageState";
@@ -147,13 +148,12 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         return this.AfterViewModelChangedAsync();
     }
 
-    private Task HandleSelectedLogLevelChangedAsync()
+    private async Task HandleSelectedLogLevelChangedAsync()
     {
         _applicationChanged = true;
 
-        ClearSelectedLogEntry();
-
-        return this.AfterViewModelChangedAsync();
+        await ClearSelectedLogEntryAsync();
+        await this.AfterViewModelChangedAsync();
     }
 
     private void UpdateSubscription()
@@ -170,11 +170,13 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         }
     }
 
-    private void OnShowProperties(OtlpLogEntry entry)
+    private async Task OnShowPropertiesAsync(OtlpLogEntry entry, string buttonId)
     {
+        _elementIdBeforeDetailsViewOpened = buttonId;
+
         if (SelectedLogEntry?.LogEntry == entry)
         {
-            ClearSelectedLogEntry();
+            await ClearSelectedLogEntryAsync();
         }
         else
         {
@@ -187,9 +189,16 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         }
     }
 
-    private void ClearSelectedLogEntry()
+    private async Task ClearSelectedLogEntryAsync(bool causedByUserAction = false)
     {
         SelectedLogEntry = null;
+
+        if (_elementIdBeforeDetailsViewOpened is not null && causedByUserAction)
+        {
+            await JS.InvokeVoidAsync("focusElement", _elementIdBeforeDetailsViewOpened);
+        }
+
+        _elementIdBeforeDetailsViewOpened = null;
     }
 
     private async Task OpenFilterAsync(LogFilter? entry)
@@ -213,7 +222,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         await DialogService.ShowPanelAsync<FilterDialog>(data, parameters);
     }
 
-    private Task HandleFilterDialog(DialogResult result)
+    private async Task HandleFilterDialog(DialogResult result)
     {
         if (result.Data is FilterDialogResult filterResult && filterResult.Filter is LogFilter filter)
         {
@@ -226,10 +235,10 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
                 ViewModel.AddFilter(filter);
             }
 
-            ClearSelectedLogEntry();
+            await ClearSelectedLogEntryAsync();
         }
 
-        return this.AfterViewModelChangedAsync();
+        await this.AfterViewModelChangedAsync();
     }
 
     private void HandleFilter(ChangeEventArgs args)
@@ -237,13 +246,14 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         if (args.Value is string newFilter)
         {
             PageViewModel.Filter = newFilter;
-            ClearSelectedLogEntry();
             _filterCts?.Cancel();
 
             // Debouncing logic. Apply the filter after a delay.
             var cts = _filterCts = new CancellationTokenSource();
             _ = Task.Run(async () =>
             {
+                await ClearSelectedLogEntryAsync();
+
                 await Task.Delay(400, cts.Token);
                 ViewModel.FilterText = newFilter;
                 await InvokeAsync(StateHasChanged);
@@ -251,11 +261,15 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         }
     }
 
-    private void HandleClear()
+    private async Task HandleClearAsync()
     {
-        _filterCts?.Cancel();
+        if (_filterCts is not null)
+        {
+            await _filterCts.CancelAsync();
+        }
+
         ViewModel.FilterText = string.Empty;
-        ClearSelectedLogEntry();
+        await ClearSelectedLogEntryAsync();
         StateHasChanged();
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -42,7 +42,7 @@
 
         <SummaryDetailsView
             ShowDetails="SelectedSpan is not null"
-            OnDismiss="() => ClearSelectedSpan()"
+            OnDismiss="@(() => ClearSelectedSpanAsync(causedByUserAction: true))"
             ViewKey="TraceDetail"
             SelectedValue="@SelectedSpan">
             <DetailsTitleTemplate>
@@ -55,7 +55,7 @@
             <Summary>
                 <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="4fr 12fr 85px">
                     <TemplateColumn Title="Name">
-                        <div class="col-long-content" title="@context.GetTooltip()" @onclick="() => OnShowProperties(context)">
+                        <div class="col-long-content" title="@context.GetTooltip()" @onclick="() => OnShowPropertiesAsync(context, null)">
                             @{
                                 var isServerOrConsumer = context.Span.Kind == OtlpSpanKind.Server || context.Span.Kind == OtlpSpanKind.Consumer;
                                 // Indent the span name based on the depth of the span.
@@ -152,7 +152,7 @@
                             </div>
                         </HeaderCellItemTemplate>
                         <ChildContent>
-                            <div class="ticks" @onclick="() => OnShowProperties(context)">
+                            <div class="ticks" @onclick="() => OnShowPropertiesAsync(context, null)">
                                 <div class="span-container" style="grid-template-columns: @context.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)% @context.Width.ToString("F2", CultureInfo.InvariantCulture)% min-content;">
                                     <div class="span-bar" style="grid-column: 2; background: @ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source));"></div>
                                     <div class="span-bar-label @(context.LabelIsRight ? "span-bar-label-right" : "span-bar-label-left")">
@@ -169,10 +169,15 @@
                         </ChildContent>
                     </TemplateColumn>
                     <TemplateColumn Title="@ControlStringsLoc[nameof(ControlsStrings.DetailsColumnHeader)]" Class="no-ellipsis">
+                        @{
+                            var id = context.Span.SpanId;
+                        }
+
                         <FluentButton
+                            Id="@id"
                             Style="margin-left: 7px;"
                             Title="@ControlStringsLoc[nameof(ControlsStrings.ViewAction)]"
-                            Appearance="Appearance.Lightweight" OnClick="() => OnShowProperties(context)">@ControlStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
+                            Appearance="Appearance.Lightweight" OnClick="@(() => OnShowPropertiesAsync(context, id))">@ControlStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
                     </TemplateColumn>
                 </FluentDataGrid>
             </Summary>

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -21,6 +21,7 @@ public class OtlpLogEntry
     public string? OriginalFormat { get; }
     public OtlpApplication Application { get; }
     public OtlpScope Scope { get; }
+    public Guid InternalId { get; }
 
     public OtlpLogEntry(LogRecord record, OtlpApplication logApp, OtlpScope scope, TelemetryLimitOptions options)
     {
@@ -56,6 +57,7 @@ public class OtlpLogEntry
         ParentId = parentId ?? string.Empty;
         Application = logApp;
         Scope = scope;
+        InternalId = Guid.NewGuid();
     }
 
     private static LogLevel MapSeverity(SeverityNumber severityNumber) => severityNumber switch

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -97,6 +97,23 @@ h1 {
  }
 
  #components-reconnect-modal {
+     /* avoid making modal take the entire screen dimensions */
+     inset: unset !important;
+
+     /* force modal to be compact, centered, slightly padded, and towards the top */
+     top: 5% !important;
+     left: 30% !important;
+     right: 30% !important;
+     height: 105px;
+     padding: 2px;
+
+     /* add a slight shadow */
+     box-shadow: 2px 2px 2px var(--neutral-fill-secondary-rest);
+
+     /* avoid modal being see-through */
+     opacity: 1 !important;
+
+     /* ensure sufficient contrast between all elements in the modal and its background */
      background-color: var(--reconnection-ui-bg) !important;
  }
 

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -419,3 +419,10 @@ window.getBrowserTimeZone = function () {
 
     return options.timeZone;
 }
+
+window.focusElement = function(selector) {
+    const element = document.getElementById(selector);
+    if (element) {
+        element.focus();
+    }
+}


### PR DESCRIPTION
Backports #3192, #3406, #3368, and #3189

## Customer Impact

#3192 makes copy buttons inside data grids accessible to keyboard-only users. The workaround for them without this pull request is to manually select the entire cell's contents.

#3406 makes the log level select on StructuredLogs pages accessible to users with high resolution + high zoom. The element is inaccessible to them without that change.

#3368 Prevents focus state from being lost when closing a details panel manually.  Otherwise, keyboard/screen-reader users will be confused when focus is removed from the page after closing the panel.

#3189 Modifies the reconnection UI to allow users to interact with on-screen elements. 

## Testing

Manual verification. See demo below (first #3192, then #3368, then #3189 at the end):

![Animation](https://github.com/dotnet/aspire/assets/20359921/8f9677a7-9e9a-4c21-9337-0d5977a9e6fb)

## Risk

Low
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3486)