### PR TITLE
Only add dashboard services if the dashboard is enabled

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -140,6 +140,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                 _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<TransportOptions>, TransportOptionsValidator>());
                 _innerBuilder.Services.AddSingleton<DashboardServiceHost>();
                 _innerBuilder.Services.AddHostedService(sp => sp.GetRequiredService<DashboardServiceHost>());
+                _innerBuilder.Services.AddSingleton<IDashboardEndpointProvider, HostDashboardEndpointProvider>();
                 _innerBuilder.Services.AddLifecycleHook<DashboardLifecycleHook>();
                 _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DashboardOptions>, ConfigureDefaultDashboardOptions>());
                 _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DashboardOptions>, ValidateDashboardOptions>());
@@ -147,7 +148,6 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
             // DCP stuff
             _innerBuilder.Services.AddSingleton<ApplicationExecutor>();
-            _innerBuilder.Services.AddSingleton<IDashboardEndpointProvider, HostDashboardEndpointProvider>();
             _innerBuilder.Services.AddSingleton<IDcpDependencyCheckService, DcpDependencyCheck>();
             _innerBuilder.Services.AddHostedService<DcpHostService>();
             _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DcpOptions>, ConfigureDefaultDcpOptions>());

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -276,6 +276,20 @@ public class DashboardResourceTests
         Assert.Empty(model.Resources);
     }
 
+    [Fact]
+    public void ContainerIsValidWithDashboardIsDisabled()
+    {
+        // Set the host environment to "Development" so that the container validates services.
+        using var builder = TestDistributedApplicationBuilder.Create(new DistributedApplicationOptions
+        {
+            DisableDashboard = true,
+            Args = ["--environment", "Development"] }
+        );
+
+        // Container validation logic runs when the service provider is built.
+        using var app = builder.Build();
+    }
+
     private sealed class MockDashboardEndpointProvider : IDashboardEndpointProvider
     {
         public Task<string> GetResourceServiceUriAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
If the dashboard is disabled, we should not add dashboard services to the container.

If the application is run in the Development environment with the dashboard disabled, this will cause a startup crash as dependency container validation will be unable to construct `HostDashboardEndpointProvider`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3489)