### PR TITLE
Make GeneratorTests tolerant of different line endings

### DIFF
--- a/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
+++ b/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
@@ -109,8 +109,9 @@ public partial class GeneratorTests
             referenceAssemblies,
             outputPath);
 
-        var actual = File.ReadAllText(outputPath);
-        var baseline = File.ReadAllText(Path.Combine("Baselines", "IntegrationTest.baseline.json"));
+        // Compare the two, normalizing line endings.
+        var actual = File.ReadAllText(outputPath).ReplaceLineEndings();
+        var baseline = File.ReadAllText(Path.Combine("Baselines", "IntegrationTest.baseline.json")).ReplaceLineEndings();
         Assert.Equal(baseline, actual);
     }
 


### PR DESCRIPTION
These tests fail for me, likely due to different git settings. This PR changes the test to tolerate different line endings (`\n` vs `\r\n`).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3490)