### PR TITLE
Fixed issues around injecting urls

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointAnnotation.cs
@@ -113,6 +113,11 @@ public sealed class EndpointAnnotation : IResourceAnnotation
     internal bool FromLaunchProfile { get; set; }
 
     /// <summary>
+    /// The environment variable that contains the target port. Setting prevents a variable from flowing into ASPNETCORE_URLS for project resources.
+    /// </summary>
+    internal string? TargetPortEnvironmentVariable { get; set; }
+
+    /// <summary>
     /// Gets or sets the allocated endpoint.
     /// </summary>
     public AllocatedEndpoint? AllocatedEndpoint { get; set; }

--- a/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReferenceExpression.cs
@@ -144,6 +144,11 @@ public class ReferenceExpressionBuilder
     private readonly List<string> _manifestExpressions = new();
 
     /// <summary>
+    /// Indicates whether the expression is empty.
+    /// </summary>
+    public bool IsEmpty => _builder.Length == 0;
+
+    /// <summary>
     /// Appends an interpolated string to the expression.
     /// </summary>
     /// <param name="handler"></param>

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -98,6 +98,7 @@ public static class ProjectResourceBuilderExtensions
 
         builder.WithOtlpExporter();
         builder.ConfigureConsoleLogs();
+        builder.SetAspNetCoreUrls();
 
         var projectResource = builder.Resource;
 
@@ -157,41 +158,6 @@ public static class ProjectResourceBuilderExtensions
                     var value = Environment.ExpandEnvironmentVariables(envVar.Value);
                     context.EnvironmentVariables.TryAdd(envVar.Key, value);
                 }
-
-                if (context.EnvironmentVariables.ContainsKey("ASPNETCORE_URLS"))
-                {
-                    // If the user has already set ASPNETCORE_URLS, we don't want to override it.
-                    return;
-                }
-
-                var aspnetCoreUrls = new ReferenceExpressionBuilder();
-
-                var processedHttpsPort = false;
-                var first = true;
-
-                // Turn http and https endpoints into a single ASPNETCORE_URLS environment variable.
-                foreach (var e in builder.Resource.GetEndpoints().Where(e => e.EndpointAnnotation.UriScheme is "http" or "https"))
-                {
-                    if (!first)
-                    {
-                        aspnetCoreUrls.AppendLiteral(";");
-                    }
-
-                    if (!processedHttpsPort && e.EndpointAnnotation.UriScheme == "https")
-                    {
-                        // Add the environment variable for the HTTPS port if we have an HTTPS service. This will make sure the
-                        // HTTPS redirection middleware avoids redirecting to the internal port.
-                        context.EnvironmentVariables["ASPNETCORE_HTTPS_PORT"] = e.Property(EndpointProperty.Port);
-
-                        processedHttpsPort = true;
-                    }
-
-                    aspnetCoreUrls.Append($"{e.Property(EndpointProperty.Scheme)}://localhost:{e.Property(EndpointProperty.TargetPort)}");
-                    first = false;
-                }
-
-                // Combine into a single expression
-                context.EnvironmentVariables["ASPNETCORE_URLS"] = aspnetCoreUrls.Build();
             });
 
             // TODO: Process command line arguments here
@@ -286,5 +252,57 @@ public static class ProjectResourceBuilderExtensions
     {
         var launchProfile = projectResource.GetEffectiveLaunchProfile(throwIfNotFound: true);
         return launchProfile?.ApplicationUrl != null;
+    }
+
+    private static void SetAspNetCoreUrls(this IResourceBuilder<ProjectResource> builder)
+    {
+        if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
+        {
+            return;
+        }
+
+        builder.WithEnvironment(context =>
+        {
+            if (context.EnvironmentVariables.ContainsKey("ASPNETCORE_URLS"))
+            {
+                // If the user has already set ASPNETCORE_URLS, we don't want to override it.
+                return;
+            }
+
+            var aspnetCoreUrls = new ReferenceExpressionBuilder();
+
+            var processedHttpsPort = false;
+            var first = true;
+
+            static bool IsValidAspNetCoreUrl(EndpointAnnotation e) =>
+                e.UriScheme is "http" or "https" && e.TargetPortEnvironmentVariable is null;
+
+            // Turn http and https endpoints into a single ASPNETCORE_URLS environment variable.
+            foreach (var e in builder.Resource.GetEndpoints().Where(e => IsValidAspNetCoreUrl(e.EndpointAnnotation)))
+            {
+                if (!first)
+                {
+                    aspnetCoreUrls.AppendLiteral(";");
+                }
+
+                if (!processedHttpsPort && e.EndpointAnnotation.UriScheme == "https")
+                {
+                    // Add the environment variable for the HTTPS port if we have an HTTPS service. This will make sure the
+                    // HTTPS redirection middleware avoids redirecting to the internal port.
+                    context.EnvironmentVariables["ASPNETCORE_HTTPS_PORT"] = e.Property(EndpointProperty.Port);
+
+                    processedHttpsPort = true;
+                }
+
+                aspnetCoreUrls.Append($"{e.Property(EndpointProperty.Scheme)}://localhost:{e.Property(EndpointProperty.TargetPort)}");
+                first = false;
+            }
+
+            if (!aspnetCoreUrls.IsEmpty)
+            {
+                // Combine into a single expression
+                context.EnvironmentVariables["ASPNETCORE_URLS"] = aspnetCoreUrls.Build();
+            }
+        });
     }
 }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -399,7 +399,7 @@ public static class ResourceBuilderExtensions
     /// <param name="port">An optional port. This is the port that will be given to other resource to communicate with this resource.</param>
     /// <param name="scheme">An optional scheme e.g. (http/https). Defaults to "tcp" if not specified.</param>
     /// <param name="name">An optional name of the endpoint. Defaults to the scheme name if not specified.</param>
-    /// <param name="env">An optional name of the environment variable to inject.</param>
+    /// <param name="env">An optional name of the environment variable that will be used to inject the <paramref name="targetPort"/>. If the target port is null one will be dynamically generated and assigned to the environment variable.</param>
     /// <param name="isExternal">Indicates that this endpoint should be exposed externally at publish time.</param>
     /// <param name="isProxied">Specifies if the endpoint will be proxied by DCP. Defaults to true.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
@@ -423,6 +423,8 @@ public static class ResourceBuilderExtensions
         // Set the environment variable on the resource
         if (env is not null && builder.Resource is IResourceWithEndpoints resourceWithEndpoints and IResourceWithEnvironment)
         {
+            annotation.TargetPortEnvironmentVariable = env;
+
             var endpointReference = new EndpointReference(resourceWithEndpoints, annotation);
 
             builder.WithAnnotation(new EnvironmentCallbackAnnotation(context =>

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -240,8 +240,114 @@ public class ProjectResourceTests
         var projectResources = appModel.GetProjectResources();
 
         var resource = Assert.Single(projectResources);
-        
+
         Assert.Contains(resource.Annotations, a => a is ExcludeLaunchProfileAnnotation);
+    }
+
+    [Fact]
+    public async Task AspNetCoreUrlsNotInjectedInPublishMode()
+    {
+        var appBuilder = CreateBuilder(operation: DistributedApplicationOperation.Publish);
+
+        appBuilder.AddProject<Projects.ServiceA>("projectName", launchProfileName: null)
+                  .WithHttpEndpoint(port: 5000, name: "http")
+                  .WithHttpsEndpoint(port: 5001, name: "https");
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var projectResources = appModel.GetProjectResources();
+
+        var resource = Assert.Single(projectResources);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
+
+        Assert.False(config.ContainsKey("ASPNETCORE_URLS"));
+        Assert.False(config.ContainsKey("ASPNETCORE_HTTPS_PORT"));
+    }
+
+    [Fact]
+    public async Task ExcludeLaunchProfileAddsHttpOrHttpsEndpointAddsToEnv()
+    {
+        var appBuilder = CreateBuilder(operation: DistributedApplicationOperation.Run);
+
+        appBuilder.AddProject<Projects.ServiceA>("projectName", launchProfileName: null)
+                  .WithHttpEndpoint(port: 5000, name: "http")
+                  .WithHttpsEndpoint(port: 5001, name: "https")
+                  .WithHttpEndpoint(port: 5002, name: "http2", env: "SOME_ENV")
+                  .WithEndpoint("http", e =>
+                  {
+                      e.AllocatedEndpoint = new(e, "localhost", e.Port!.Value, targetPortExpression: "p0");
+                  })
+                  .WithEndpoint("https", e =>
+                  {
+                      e.AllocatedEndpoint = new(e, "localhost", e.Port!.Value, targetPortExpression: "p1");
+                  })
+                  .WithEndpoint("http2", e =>
+                   {
+                       e.AllocatedEndpoint = new(e, "localhost", e.Port!.Value, targetPortExpression: "p2");
+                   });
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var projectResources = appModel.GetProjectResources();
+
+        var resource = Assert.Single(projectResources);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
+
+        Assert.Equal("http://localhost:p0;https://localhost:p1", config["ASPNETCORE_URLS"]);
+        Assert.Equal("5001", config["ASPNETCORE_HTTPS_PORT"]);
+        Assert.Equal("p2", config["SOME_ENV"]);
+    }
+
+    [Fact]
+    public async Task NoEndpointsDoesNotAddAspNetCoreUrls()
+    {
+        var appBuilder = CreateBuilder(operation: DistributedApplicationOperation.Run);
+
+        appBuilder.AddProject<Projects.ServiceA>("projectName", launchProfileName: null);
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var projectResources = appModel.GetProjectResources();
+
+        var resource = Assert.Single(projectResources);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
+
+        Assert.False(config.ContainsKey("ASPNETCORE_URLS"));
+        Assert.False(config.ContainsKey("ASPNETCORE_HTTPS_PORT"));
+    }
+
+    [Fact]
+    public async Task ProjectWithLaunchProfileAddsHttpOrHttpsEndpointAddsToEnv()
+    {
+        var appBuilder = CreateBuilder(operation: DistributedApplicationOperation.Run);
+
+        appBuilder.AddProject<TestProjectWithLaunchSettings>("projectName")
+                  .WithEndpoint("http", e =>
+                  {
+                      e.AllocatedEndpoint = new(e, "localhost", e.Port!.Value, targetPortExpression: "p0");
+                  });
+
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var projectResources = appModel.GetProjectResources();
+
+        var resource = Assert.Single(projectResources);
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
+
+        Assert.Equal("http://localhost:p0", config["ASPNETCORE_URLS"]);
+        Assert.False(config.ContainsKey("ASPNETCORE_HTTPS_PORT"));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -369,13 +369,13 @@ public class WithEndpointTests
     [Fact]
     public async Task VerifyManifestProjectWithHttpEndpointDoesNotAllocatePort()
     {
-        using var builder = TestDistributedApplicationBuilder.Create();
+        using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var project = builder.AddProject<TestProject>("proj")
             .WithHttpEndpoint(name: "hp")
             .WithHttpsEndpoint(name: "hps");
 
         var manifest = await ManifestUtils.GetManifest(project.Resource);
-        var s = manifest.ToString();
+
         var expectedManifest =
             """
             {
@@ -384,7 +384,8 @@ public class WithEndpointTests
               "env": {
                 "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
                 "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
-                "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
+                "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
+                "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true"
               },
               "bindings": {
                 "hp": {


### PR DESCRIPTION
ASP.NET Core Urls we only being injected when launch profiles. 

- Fixed issues with ASPNETCORE_URLS not working with launch profiles
- Skip ASPNETCORE_URLS for endpoints that are mapped to an environment
- Added tests

Fixes #2241
Fixes #3477
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3492)