### PR TITLE
KubernetesService: check if configuration file exists before attempting to construct client

### DIFF
--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -388,6 +388,12 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
             _kubernetes = await pipeline.ExecuteAsync<DcpKubernetesClient>(async (cancellationToken) =>
             {
                 var fileInfo = new FileInfo(locations.DcpKubeconfigPath);
+                while (!fileInfo.Exists)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(dcpOptions.Value.KubernetesConfigReadRetryIntervalMilliseconds), cancellationToken).ConfigureAwait(false);
+                    fileInfo = new FileInfo(locations.DcpKubeconfigPath);
+                }
+
                 var config = await KubernetesClientConfiguration.BuildConfigFromConfigFileAsync(kubeconfig: fileInfo, useRelativePaths: false).ConfigureAwait(false);
                 readStopwatch.Stop();
 


### PR DESCRIPTION
This reduces log noise and first-chance exception noise and might improve startup reliability marginally.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3498)