### PR TITLE
Fix `DebuggerDisplay` for `AllocatedEndpoint`

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AllocatedEndpoint.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents an endpoint allocated for a service instance.
 /// </summary>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Name}, UriString = {UriString}, EndpointNameQualifiedUriString = {EndpointNameQualifiedUriString}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Name = {Endpoint.Name}, UriString = {UriString}, EndpointNameQualifiedUriString = {EndpointNameQualifiedUriString}")]
 public class AllocatedEndpoint
 {
     /// <summary>


### PR DESCRIPTION
`AllocatedEndpoint` no longer has its own `Name` property, but it's still useful to reference the endpoint name in the display, so I kept it and updated it to point to the endpoint's Name property.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3501)