### PR TITLE
Update versions to latest found on nuget.org

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -91,15 +91,9 @@
     <PackageVersion Include="Confluent.Kafka" Version="2.3.0" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
     <PackageVersion Include="DnsClient" Version="1.7.0" />
-<<<<<<< HEAD
-    <PackageVersion Include="Google.Protobuf" Version="3.26.0" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.60.0" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.60.0" />
-=======
     <PackageVersion Include="Google.Protobuf" Version="3.26.1" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.62.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.62.0" />
->>>>>>> 938a4a78 (more updates)
     <PackageVersion Include="Grpc.Tools" Version="2.62.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="13.0.26" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,16 +5,16 @@
   <Import Project="eng/Versions.props" Condition="'$(MajorVersion)' == '' and Exists('eng/Versions.props')" />
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <TestcontainersPackageVersion>3.7.0</TestcontainersPackageVersion>
+    <TestcontainersPackageVersion>3.8.0</TestcontainersPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- AWS SDK for .NET dependencies -->
-    <PackageVersion Include="AWSSDK.CloudFormation" Version="3.7.304.2" />
-    <PackageVersion Include="AWSSDK.SQS" Version="3.7.300.55" />
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.301.3" />
-    <PackageVersion Include="AWSSDK.Core" Version="3.7.302.16" />
+    <PackageVersion Include="AWSSDK.CloudFormation" Version="3.7.306.3" />
+    <PackageVersion Include="AWSSDK.SQS" Version="3.7.300.71" />
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.301.19" />
+    <PackageVersion Include="AWSSDK.Core" Version="3.7.303.11" />
     <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.300" />
-    <PackageVersion Include="AWS.Messaging" Version="0.2.0-beta" />
+    <PackageVersion Include="AWS.Messaging" Version="0.9.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.11.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
@@ -89,32 +89,38 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(MicrosoftExtensionsHttpResiliencePackageVersion)" />
     <!-- external dependencies -->
     <PackageVersion Include="Confluent.Kafka" Version="2.3.0" />
-    <PackageVersion Include="Dapper" Version="2.1.28" />
+    <PackageVersion Include="Dapper" Version="2.1.35" />
     <PackageVersion Include="DnsClient" Version="1.7.0" />
+<<<<<<< HEAD
     <PackageVersion Include="Google.Protobuf" Version="3.26.0" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.60.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.60.0" />
+=======
+    <PackageVersion Include="Google.Protobuf" Version="3.26.1" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.62.0" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.62.0" />
+>>>>>>> 938a4a78 (more updates)
     <PackageVersion Include="Grpc.Tools" Version="2.62.0" />
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
-    <PackageVersion Include="KubernetesClient" Version="13.0.11" />
+    <PackageVersion Include="KubernetesClient" Version="13.0.26" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.6.0" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.6.0" />
     <PackageVersion Include="MongoDB.Driver" Version="2.24.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />
-    <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.5" />
+    <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.6" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageVersion Include="NATS.Net" Version="2.1.3" />
+    <PackageVersion Include="NATS.Net" Version="2.2.0" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.121" />
-    <PackageVersion Include="Polly" Version="8.3.0" />
-    <PackageVersion Include="Polly.Core" Version="8.3.0" />
-    <PackageVersion Include="Polly.Extensions" Version="8.3.0" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.1" />
+    <PackageVersion Include="Polly" Version="8.3.1" />
+    <PackageVersion Include="Polly.Core" Version="8.3.1" />
+    <PackageVersion Include="Polly.Extensions" Version="8.3.1" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageVersion Include="Qdrant.Client" Version="1.8.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.7.27" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.7.33" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0" />
     <!-- Open Telemetry -->
@@ -135,7 +141,7 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.24201.1" />
     <!-- unit test dependencies -->
     <PackageVersion Include="bUnit" Version="1.27.17" />
-    <PackageVersion Include="JsonSchema.Net" Version="6.0.4" />
+    <PackageVersion Include="JsonSchema.Net" Version="6.0.7" />
     <PackageVersion Include="Microsoft.DotNet.RemoteExecutor" Version="$(MicrosoftDotNetRemoteExecutorPackageVersion)" />
     <PackageVersion Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="$(MicrosoftExtensionsDiagnosticsTestingPackageVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -40,9 +40,9 @@
     <MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>8.0.3</MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>
     <MicrosoftAspNetCoreOpenApiPackageVersion>8.0.3</MicrosoftAspNetCoreOpenApiPackageVersion>
     <MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion>8.0.3</MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion>
-    <MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>8.0.2</MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>8.0.2</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>8.0.2</MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>
+    <MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>8.0.3</MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>
+    <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>8.0.3</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>
+    <MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>8.0.3</MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>
     <MicrosoftExtensionsFeaturesPackageVersion>8.0.3</MicrosoftExtensionsFeaturesPackageVersion>
     <MicrosoftEntityFrameworkCoreCosmosPackageVersion>8.0.3</MicrosoftEntityFrameworkCoreCosmosPackageVersion>
     <MicrosoftEntityFrameworkCoreDesignPackageVersion>8.0.3</MicrosoftEntityFrameworkCoreDesignPackageVersion>

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\..\src\Components\Aspire.Microsoft.EntityFrameworkCore.SqlServer\Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
 
-   <PackageReference Include="TestContainers.MsSql" />
+   <PackageReference Include="Testcontainers.MsSql" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.StackExchange.Redis.Tests/Aspire.StackExchange.Redis.Tests.csproj
+++ b/tests/Aspire.StackExchange.Redis.Tests/Aspire.StackExchange.Redis.Tests.csproj
@@ -15,7 +15,7 @@
 
     <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
 
-    <PackageReference Include="TestContainers.Redis" />
+    <PackageReference Include="Testcontainers.Redis" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We can decide which if any we want to port into 8.0

procedure used
1. build tree successfully using regular feeds to populate local cache with stuff currently in our feeds
2. replace nuget config to use only nuget.org feed `dotnet new nugetconfig --force`
3. `dotnet outdated -vl Major -u Aspire.sln` (installed from https://github.com/dotnet-outdated/dotnet-outdated?tab=readme-ov-file#installation)
4. fixup where properties were erased in the props file
5. revert nuget config
6. build again
7. where packages can't be found, kick off mirroring https://github.com/dotnet/arcade/blob/main/Documentation/MirroringPackages.md
(hand choose latest stable package if it's not the newest)
8. assuming mirroring is finished, build again and verify it works

But now I'm getting odd local build results so let's try here...
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3512)