### PR TITLE
Change starter template to make frontend external endpoints

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.AppHost/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.AppHost/Program.cs
@@ -10,6 +10,7 @@ builder.AddProject<Projects.AspireStarterApplication__1_Web>("webfrontend")
 #if UseRedisCache
     .WithReference(cache)
 #endif
-    .WithReference(apiService);
+    .WithReference(apiService)
+    .WithExternalHttpEndpoints();
 
 builder.Build().Run();

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.AppHost/Program.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.AppHost/Program.cs
@@ -7,10 +7,10 @@ var cache = builder.AddRedis("cache");
 var apiService = builder.AddProject<Projects.AspireStarterApplication__1_ApiService>("apiservice");
 
 builder.AddProject<Projects.AspireStarterApplication__1_Web>("webfrontend")
+    .WithExternalHttpEndpoints()
 #if UseRedisCache
     .WithReference(cache)
 #endif
-    .WithReference(apiService)
-    .WithExternalHttpEndpoints();
+    .WithReference(apiService);
 
 builder.Build().Run();


### PR DESCRIPTION
Fixes #3495 to make the frontend web app in aspire-starter template to use the `WithExternalHttpEndpoints` 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3514)