### PR TITLE
Suppress save dialog from browser token login

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Login.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor
@@ -20,7 +20,7 @@
                 <div class="token-entry">
                     <FluentTextField @ref="_tokenTextField" Id="token-text-field" @bind-Value="_formModel.Token"
                                      Placeholder="@Loc[nameof(Dashboard.Resources.Login.TextFieldPlaceholder)]"
-                                     TextFieldType="TextFieldType.Password" Class="token-entry-text" />
+                                     TextFieldType="TextFieldType.Password" AutoComplete="one-time-code" Class="token-entry-text" />
                 </div>
                 <div class="token-validation">
                     <FluentValidationMessage For="() => _formModel.Token" />


### PR DESCRIPTION
Set `autocomplete="one-time-code"` to suppress browser asking to remember the password.

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3519)