### PR TITLE
Remove invalid ArgumentNullException.ThrowIfNull call

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -68,8 +68,6 @@ public sealed class EndpointReference : IManifestExpressionProvider, IValueProvi
     /// <returns>An <see cref="EndpointReferenceExpression"/> representing the specified <see cref="EndpointProperty"/>.</returns>
     public EndpointReferenceExpression Property(EndpointProperty property)
     {
-        ArgumentNullException.ThrowIfNull(property);
-
         return new(this, property);
     }
 


### PR DESCRIPTION
`EndpointProperty` is an enum, so this call is invalid.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3531)