### PR TITLE
[release/8.0] Introduce WithEnvironment(this, string, IResourceBuilder<IResourceWithConnectionString)

### DIFF
--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -116,6 +116,26 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Adds an environment variable to the resource with the connection string from the referenced resource.
+    /// </summary>
+    /// <typeparam name="T">The destination resource type.</typeparam>
+    /// <param name="builder">The destination resource builder to which the environment variable will be added.</param>
+    /// <param name="envVarName">The name of the environment variable under which the connection string will be set.</param>
+    /// <param name="resource">The resource builder of the referenced service from which to pull the connection string.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithEnvironment<T>(
+        this IResourceBuilder<T> builder,
+        string envVarName,
+        IResourceBuilder<IResourceWithConnectionString> resource)
+        where T : IResourceWithEnvironment
+    {
+        return builder.WithEnvironment(context =>
+        {
+            context.EnvironmentVariables[envVarName] = new ConnectionStringReference(resource.Resource, optional: false);
+        });
+    }
+
+    /// <summary>
     /// Adds the arguments to be passed to a container resource when the container is started.
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -188,19 +188,21 @@ public class WithEnvironmentTests
         Assert.Equal("""{{- portForServing "container1_primary" -}}""", pair.Value);
     }
 
+    [Fact]
     public async Task EnvironmentWithConnectionStringSetsProperEnvironmentVariable()
     {
         // Arrange
+        using var builder = TestDistributedApplicationBuilder.Create();
+
         const string sourceCon = "sourceConnectionString";
-        using var testProgram = CreateTestProgram();
-        var sourceBuilder = testProgram.AppBuilder.AddResource(new TestResource("sourceService", sourceCon));
-        var targetBuilder = testProgram.AppBuilder.AddContainer("targetContainer", "targetImage");
+
+        var sourceBuilder = builder.AddResource(new TestResource("sourceService", sourceCon));
+        var targetBuilder = builder.AddContainer("targetContainer", "targetImage");
 
         string envVarName = "CUSTOM_CONNECTION_STRING";
 
         // Act
         targetBuilder.WithEnvironment(envVarName, sourceBuilder);
-        testProgram.Build();
 
         // Call environment variable callbacks for the Run operation.
         var runConfig = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(targetBuilder.Resource, DistributedApplicationOperation.Run);


### PR DESCRIPTION
Backporting changes from main:

- https://github.com/dotnet/aspire/pull/3239

## Customer Impact

Improves the WithEnvironment API to allow people to inject a connection string where the receiving resource might not be using the standard .NET Core.

## Testing

Unit tested. It has been in main for ~2 weeks and probably should have been in the branch in the first place.

## Risk

Low. Unit tests added, doesn't interact with any default code path. But does make some other backports easier if we decide to take them.

## Regression?

No
