### PR TITLE
Update ASPIRE002 warning message

### DIFF
--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <Target Name="__WarnOnAspireCapabilityMissing" BeforeTargets="PrepareForBuild" Condition="!@(ProjectCapability->AnyHaveMetadataValue('Identity', 'Aspire'))">
-    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting PackageReference?" />
+    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting.AppHost PackageReference?" />
   </Target>
 
   <Target Name="__WarnOnMininumVsVersionMissing" BeforeTargets="PrepareForBuild" Condition="'$(BuildingInsideVisualStudio)' == 'true' and $([MSBuild]::VersionLessThan('$(MSBuildVersion)', '17.10.0'))">


### PR DESCRIPTION
Update the `PackageReference` name in the ASPIRE002 warning from `Aspire.Hosting` to `Aspire.Hosting.AppHost`.

I just updated from preview 4 to preview 5 without updating my AppHost project to use `Aspire.Hosting.AppHost` instead of `Aspire.Hosting` and got confused when the build failed with this warning saying I was missing a reference to something that was there:

```console
Warning: /usr/share/dotnet/packs/Aspire.Hosting.Sdk/8.0.0-preview.5.24201.12/Sdk/Sdk.targets(39,5): warning ASPIRE002: MyProject.AppHost is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting PackageReference? [/runner/_work/myproject/myproject/src/MyProject.AppHost/MyProject.AppHost.csproj]
```

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <IsAspireHost>true</IsAspireHost>
    <OutputType>Exe</OutputType>
    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="Aspire.Hosting" />
  </ItemGroup>
  <ItemGroup>
    <ProjectReference Include="..\MyProject\MyProject.csproj" />
  </ItemGroup>
</Project>
```

Once I found the [updated docs](https://learn.microsoft.com/dotnet/aspire/get-started/build-your-first-aspire-app?tabs=visual-studio#net-aspire-app-host-project), I realised my mistake and updated my reference, which fixed the build.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3555)