### PR TITLE
Fix resource type filter keyboard navigation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,8 +98,8 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="13.0.26" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.6.0" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.6.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.6.1" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.6.1" />
     <PackageVersion Include="MongoDB.Driver" Version="2.24.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.6" />

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -18,7 +18,7 @@
                       @onclick="() => _isTypeFilterVisible = !_isTypeFilterVisible"
                       Title="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])"
                       aria-label="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])" />
-        <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible">
+        <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true">
             <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
             <Body>
                 <FluentStack Orientation="Orientation.Vertical">


### PR DESCRIPTION
Part of addressing #3173 (note: intentionally not using a closing keyword since the related bug says not to close it ourselves)

The web components folks pushed an update here and that has flowed through to the 4.6.1 update of the blazor components. This PR takes that change and adds the AutoFocus attribute to the FluentPopover.

The keyboard keys needed are a little awkward - once you open the popover by hitting space you need to hit the left arrow to move back through the checkboxes. But it does work. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3568)