### PR TITLE
Clean up error handling

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Error.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Error.razor
@@ -1,0 +1,29 @@
+﻿@page "/error"
+@using Aspire.Dashboard.Utils
+@layout EmptyLayout
+@attribute [AllowAnonymous]
+@inject IStringLocalizer<Dashboard.Resources.Routes> Loc
+
+<PageTitle>@Loc[nameof(Dashboard.Resources.Routes.ErrorHandlerPageTitle)]</PageTitle>
+
+<div class="error-backdrop">
+    <div class="error-container">
+        <div class="error-logo">
+            <AspireLogo Height="128" Width="128" />
+        </div>
+        <div class="error-entry-container">
+            <h1>@Loc[nameof(Dashboard.Resources.Routes.ErrorHandlerPageTitle)]</h1>
+            <h5>@Loc[nameof(Dashboard.Resources.Routes.ErrorHandlerPageSubtitle)]</h5>
+
+            @if (ShowRequestId)
+            {
+                <p>
+                    <strong>@Loc[nameof(Dashboard.Resources.Routes.ErrorHandlerPageRequestId)]</strong> <code>@RequestId</code>
+                </p>
+            }
+        </div>
+    </div>
+    <div class="version-info">
+        @VersionHelpers.DashboardDisplayVersion
+    </div>
+</div>

--- a/src/Aspire.Dashboard/Components/Pages/Error.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Error.razor.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using System.Diagnostics;
+
+namespace Aspire.Dashboard.Components.Pages;
+
+public partial class Error
+{
+    [CascadingParameter]
+    private HttpContext? HttpContext { get; set; }
+
+    private string? RequestId { get; set; }
+    private bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    protected override void OnInitialized() =>
+        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+}

--- a/src/Aspire.Dashboard/Components/Pages/Error.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Error.razor.css
@@ -1,0 +1,48 @@
+.error-backdrop {
+    background-color: var(--neutral-layer-4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    width: 100vw;
+}
+
+[data-theme="dark"] .error-backdrop {
+    background-color: var(--neutral-layer-3);
+}
+
+.error-container {
+    --error: #FF8181;
+    background-color: var(--neutral-layer-1);
+    padding: calc((var(--design-unit) * 7px));
+    border-radius: calc(var(--design-unit) * 2.5px);
+    display: grid;
+    grid-column-gap: calc(var(--design-unit) * 5px);
+    grid-template-columns: auto 450px;
+    grid-template-rows: auto;
+    grid-template-areas:
+        "logo entry";
+    box-shadow: 0px 0px 15px 0px rgba(0,0,0,0.75);
+}
+
+.error-logo {
+    grid-area: logo;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.error-entry-container {
+    grid-area: entry;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: calc(var(--design-unit) * 1px);
+
+}
+
+.version-info {
+    position: fixed;
+    right: calc(var(--design-unit) * 4px);
+    bottom: calc(var(--design-unit) * 3px);
+}

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -209,14 +209,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         _app.UseMiddleware<ValidateTokenMiddleware>();
 
         // Configure the HTTP request pipeline.
-        if (_app.Environment.IsDevelopment())
+        if (!_app.Environment.IsDevelopment())
         {
-            _app.UseDeveloperExceptionPage();
-            //_app.UseBrowserLink();
-        }
-        else
-        {
-            _app.UseExceptionHandler("/Error");
+            _app.UseExceptionHandler("/error");
             if (isAllHttps)
             {
                 _app.UseHsts();

--- a/src/Aspire.Dashboard/Resources/Routes.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Routes.Designer.cs
@@ -61,6 +61,33 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Request ID:.
+        /// </summary>
+        public static string ErrorHandlerPageRequestId {
+            get {
+                return ResourceManager.GetString("ErrorHandlerPageRequestId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An error occurred while processing your request.
+        /// </summary>
+        public static string ErrorHandlerPageSubtitle {
+            get {
+                return ResourceManager.GetString("ErrorHandlerPageSubtitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error.
+        /// </summary>
+        public static string ErrorHandlerPageTitle {
+            get {
+                return ResourceManager.GetString("ErrorHandlerPageTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not found.
         /// </summary>
         public static string NotFoundDescription {

--- a/src/Aspire.Dashboard/Resources/Routes.resx
+++ b/src/Aspire.Dashboard/Resources/Routes.resx
@@ -126,4 +126,13 @@
   <data name="NotFoundDetails" xml:space="preserve">
     <value>The page you requested could not be found</value>
   </data>
+  <data name="ErrorHandlerPageRequestId" xml:space="preserve">
+    <value>Request ID:</value>
+  </data>
+  <data name="ErrorHandlerPageSubtitle" xml:space="preserve">
+    <value>An error occurred while processing your request</value>
+  </data>
+  <data name="ErrorHandlerPageTitle" xml:space="preserve">
+    <value>Error</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.cs.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">Nenalezeno</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.de.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">Nicht gefunden</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.es.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">No encontrado</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.fr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">Introuvable</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.it.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">Non trovata</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.ja.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">見つかりません</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.ko.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">찾을 수 없음</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.pl.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">Nie znaleziono</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.pt-BR.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">Não encontrado</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.ru.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">Не найдено</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.tr.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">Bulunamadı</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.zh-Hans.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">未找到</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Routes.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Routes.zh-Hant.xlf
@@ -2,6 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Routes.resx">
     <body>
+      <trans-unit id="ErrorHandlerPageRequestId">
+        <source>Request ID:</source>
+        <target state="new">Request ID:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageSubtitle">
+        <source>An error occurred while processing your request</source>
+        <target state="new">An error occurred while processing your request</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ErrorHandlerPageTitle">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NotFoundDescription">
         <source>Not found</source>
         <target state="translated">找不到</target>


### PR DESCRIPTION
We had a call to `_app.UseExceptionHandler("/Error");` in our startup code, but there was no page that would actually handle that. That would, in various configurations, lead you to either a 404 page or to the login page.

Note that this only really happens for errors that occur outside of the normal operation of the site. For most exceptions, they'd be handled via the blazor circuit and you'd get the yellow bar in the browser. So you're only really likely to see this happen for more catastrophic errors when the site isn't functional at all (though it's not strictly limited to that).

This PR cleans up the code that sets that up ( `_app.UseDeveloperExceptionPage()` is already called for development environments when using `WebApplication.CreateBuilder()`) and adds a page that actually responds to that route.

Since the page renders outside of the normal circuit and we don't know how much else is broken when the error occurs, the error page does not have the main layout and more closely resembles the login page. Otherwise it is essentially the standard error page in the blazor template. We can add more in the future, but it seemed of primary importance to just fix the misconfiguration and have a page that responded to the route at all.

![image](https://github.com/dotnet/aspire/assets/9613109/e80a2d81-3a72-40e1-93e1-11f36cb1e16e)
![image](https://github.com/dotnet/aspire/assets/9613109/0baef8cc-8252-447c-afe6-d4f736bf2f2c)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3570)