### PR TITLE
Fix VerifyDockerWithBindMountWorksWithAbsolutePaths test

### DIFF
--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -409,8 +409,9 @@ public class DistributedApplicationTests
         using var testProgram = CreateTestProgram();
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
+        var sourcePath = Path.GetFullPath("/etc/path-here");
         testProgram.AppBuilder.AddContainer("redis-cli", "redis")
-            .WithBindMount("/etc/path-here", $"path-here");
+            .WithBindMount(sourcePath, "path-here");
 
         await using var app = testProgram.Build();
 
@@ -428,7 +429,7 @@ public class DistributedApplicationTests
 
         Assert.NotNull(redisContainer.Spec.VolumeMounts);
         Assert.NotEmpty(redisContainer.Spec.VolumeMounts);
-        Assert.Equal("/etc/path-here", redisContainer.Spec.VolumeMounts[0].Source);
+        Assert.Equal(sourcePath, redisContainer.Spec.VolumeMounts[0].Source);
 
         await app.StopAsync();
     }
@@ -440,7 +441,7 @@ public class DistributedApplicationTests
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         testProgram.AppBuilder.AddContainer("redis-cli", "redis")
-            .WithBindMount("etc/path-here", $"path-here");
+            .WithBindMount("etc/path-here", "path-here");
 
         await using var app = testProgram.Build();
 
@@ -471,7 +472,7 @@ public class DistributedApplicationTests
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         testProgram.AppBuilder.AddContainer("redis-cli", "redis")
-            .WithVolume("test-volume-name", $"/path-here");
+            .WithVolume("test-volume-name", "/path-here");
 
         await using var app = testProgram.Build();
 

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -213,7 +213,7 @@ public class AddRedisTests
 
         var volumeAnnotation = redis.Resource.Annotations.OfType<ContainerMountAnnotation>().Single();
 
-        Assert.Equal(Path.GetFullPath("mydata"), volumeAnnotation.Source);
+        Assert.Equal(Path.Combine(builder.AppHostDirectory, "mydata"), volumeAnnotation.Source);
         Assert.Equal("/data", volumeAnnotation.Target);
         Assert.Equal(ContainerMountType.BindMount, volumeAnnotation.Type);
         Assert.Equal(isReadOnly ?? false, volumeAnnotation.IsReadOnly);


### PR DESCRIPTION
https://github.com/dotnet/aspire/pull/3467 broke `VerifyDockerWithBindMountWorksWithAbsolutePaths`. This PR fixes it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3573)