### PR TITLE
Fix copy buttons

### DIFF
--- a/src/Aspire.Dashboard/Extensions/FluentUIExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/FluentUIExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Dashboard.Extensions;
@@ -7,12 +7,15 @@ internal static class FluentUIExtensions
 {
     public static Dictionary<string, object> GetClipboardCopyAdditionalAttributes(string? text, string? precopy, string? postcopy, params (string Attribute, object Value)[] additionalAttributes)
     {
+        // No onclick attribute is added here. The CSP restricts inline scripts, including onclick.
+        // Instead, a click event listener is added to the document and clicking the button is bubbled up to the event.
+        // The document click listener looks for a button element and these attributes.
         var attributes = new Dictionary<string, object>
         {
             { "data-text", text ?? string.Empty },
             { "data-precopy", precopy ?? string.Empty },
             { "data-postcopy", postcopy ?? string.Empty },
-            { "onclick", $"buttonCopyTextToClipboard(this)" }
+            { "data-copybutton", "true" }
         };
 
         foreach (var (attribute, value) in additionalAttributes)

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -14,6 +14,15 @@ if (firstUndefinedElement) {
     document.body.classList.remove("before-upgrade");
 }
 
+// Register a global click event listener to handle copy button clicks.
+// Required because an "onclick" attribute is denied by CSP.
+document.addEventListener("click", function (e) {
+    if (e.target.type === "button" && e.target.getAttribute("data-copybutton")) {
+        buttonCopyTextToClipboard(e.target);
+        e.stopPropagation();
+    }
+});
+
 let isScrolledToContent = false;
 let lastScrollHeight = null;
 


### PR DESCRIPTION
The CSP introduced recently prevents inline scripts. Copy buttons added an onclick attribute to buttons which is an inline script and was denied.

> Refused to execute inline event handler because it violates the following Content Security Policy directive: "script-src 'self'". Either the 'unsafe-inline' keyword,

Fix by moving event to global click event and use event bubbling.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3581)