### PR TITLE
[release/8.0] Update dependencies from microsoft/usvc-apiserver

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.2.1">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-amd64" Version="0.2.2">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>60f69128780838c2ff8724a510d66c4160fab7f9</Sha>
+      <Sha>20914ee459d5fbe302928728581b4502b588c8cd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.2.1">
+    <Dependency Name="Microsoft.DeveloperControlPlane.darwin-arm64" Version="0.2.2">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>60f69128780838c2ff8724a510d66c4160fab7f9</Sha>
+      <Sha>20914ee459d5fbe302928728581b4502b588c8cd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.2.1">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-amd64" Version="0.2.2">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>60f69128780838c2ff8724a510d66c4160fab7f9</Sha>
+      <Sha>20914ee459d5fbe302928728581b4502b588c8cd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.2.1">
+    <Dependency Name="Microsoft.DeveloperControlPlane.linux-arm64" Version="0.2.2">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>60f69128780838c2ff8724a510d66c4160fab7f9</Sha>
+      <Sha>20914ee459d5fbe302928728581b4502b588c8cd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.2.1">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-386" Version="0.2.2">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>60f69128780838c2ff8724a510d66c4160fab7f9</Sha>
+      <Sha>20914ee459d5fbe302928728581b4502b588c8cd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.2.1">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-amd64" Version="0.2.2">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>60f69128780838c2ff8724a510d66c4160fab7f9</Sha>
+      <Sha>20914ee459d5fbe302928728581b4502b588c8cd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.2.1">
+    <Dependency Name="Microsoft.DeveloperControlPlane.windows-arm64" Version="0.2.2">
       <Uri>https://github.com/microsoft/usvc-apiserver</Uri>
-      <Sha>60f69128780838c2ff8724a510d66c4160fab7f9</Sha>
+      <Sha>20914ee459d5fbe302928728581b4502b588c8cd</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Http.Resilience" Version="8.2.0">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-extensions</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,13 +11,13 @@
   <PropertyGroup>
     <!-- Package versions defined directly in <reporoot>/Directory.Packages.props -->
     <MicrosoftDotnetSdkInternalPackageVersion>8.0.100-rtm.23512.16</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftDeveloperControlPlanedarwinamd64PackageVersion>0.2.1</MicrosoftDeveloperControlPlanedarwinamd64PackageVersion>
-    <MicrosoftDeveloperControlPlanedarwinarm64PackageVersion>0.2.1</MicrosoftDeveloperControlPlanedarwinarm64PackageVersion>
-    <MicrosoftDeveloperControlPlanelinuxamd64PackageVersion>0.2.1</MicrosoftDeveloperControlPlanelinuxamd64PackageVersion>
-    <MicrosoftDeveloperControlPlanelinuxarm64PackageVersion>0.2.1</MicrosoftDeveloperControlPlanelinuxarm64PackageVersion>
-    <MicrosoftDeveloperControlPlanewindows386PackageVersion>0.2.1</MicrosoftDeveloperControlPlanewindows386PackageVersion>
-    <MicrosoftDeveloperControlPlanewindowsamd64PackageVersion>0.2.1</MicrosoftDeveloperControlPlanewindowsamd64PackageVersion>
-    <MicrosoftDeveloperControlPlanewindowsarm64PackageVersion>0.2.1</MicrosoftDeveloperControlPlanewindowsarm64PackageVersion>
+    <MicrosoftDeveloperControlPlanedarwinamd64PackageVersion>0.2.2</MicrosoftDeveloperControlPlanedarwinamd64PackageVersion>
+    <MicrosoftDeveloperControlPlanedarwinarm64PackageVersion>0.2.2</MicrosoftDeveloperControlPlanedarwinarm64PackageVersion>
+    <MicrosoftDeveloperControlPlanelinuxamd64PackageVersion>0.2.2</MicrosoftDeveloperControlPlanelinuxamd64PackageVersion>
+    <MicrosoftDeveloperControlPlanelinuxarm64PackageVersion>0.2.2</MicrosoftDeveloperControlPlanelinuxarm64PackageVersion>
+    <MicrosoftDeveloperControlPlanewindows386PackageVersion>0.2.2</MicrosoftDeveloperControlPlanewindows386PackageVersion>
+    <MicrosoftDeveloperControlPlanewindowsamd64PackageVersion>0.2.2</MicrosoftDeveloperControlPlanewindowsamd64PackageVersion>
+    <MicrosoftDeveloperControlPlanewindowsarm64PackageVersion>0.2.2</MicrosoftDeveloperControlPlanewindowsarm64PackageVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>8.0.0-beta.24172.5</MicrosoftDotNetRemoteExecutorPackageVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>8.0.0-beta.24172.5</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftDotNetBuildTasksInstallersPackageVersion>8.0.0-beta.24172.5</MicrosoftDotNetBuildTasksInstallersPackageVersion>


### PR DESCRIPTION
Backport of https://github.com/dotnet/aspire/pull/3587 to release/8.0

## Customer Impact

Updated DCP build

## Testing

DCP unit tests and local validation

## Risk
Medium

## Regression?
No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3592)