### PR TITLE
Fix login help link with CSP

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Login.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor
@@ -26,7 +26,7 @@
                     <FluentValidationMessage For="() => _formModel.Token" />
                 </div>
                 <div class="token-entry-footer">
-                    <a href="javascript:;" id="helpLink">@Loc[nameof(Dashboard.Resources.Login.WhereIsMyTokenLinkText)]</a>
+                    <a href="@NavigationManager.Uri" id="helpLink">@Loc[nameof(Dashboard.Resources.Login.WhereIsMyTokenLinkText)]</a>
                     <FluentButton Appearance="Appearance.Accent" Type="ButtonType.Submit">@Loc[nameof(Dashboard.Resources.Login.LogInButtonText)]</FluentButton>
                     <FluentTooltip Anchor="helpLink" Position="TooltipPosition.Bottom" MaxWidth="650px">
                         <div class="token-help-container">


### PR DESCRIPTION
Using an `href` value of `javascript:;` doesn't work with the CSP values used in #3354, causing the same errors as in #3581

If we weren't in Blazor, we'd just use `href="#"`. But that doesn't work here (it'll actually route to `/#` and try to navigate). Setting the href to the current URL doesn't cause the page to navigate and avoids the CSP errors, so this PR changes it to that.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3593)