### PR TITLE
Allow configuring claim requirements for frontend authorization

### DIFF
--- a/src/Aspire.Dashboard/Authentication/OpenIdConnect/AuthorizationPolicyBuilderExtensions.cs
+++ b/src/Aspire.Dashboard/Authentication/OpenIdConnect/AuthorizationPolicyBuilderExtensions.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Authorization;
+using OpenIdConnectOptions = Aspire.Dashboard.Configuration.OpenIdConnectOptions;
+
+namespace Aspire.Dashboard.Authentication.OpenIdConnect;
+
+internal static class AuthorizationPolicyBuilderExtensions
+{
+    /// <summary>
+    /// Validates that the the expected claim and value are present.
+    /// </summary>
+    /// <remarks>
+    /// Checks are controlled by configuration.
+    /// 
+    /// If <see cref="OpenIdConnectOptions.RequiredClaimType"/> is non-empty, a requirement for the claim is added.
+    /// 
+    /// If a claim is being checked and <see cref="OpenIdConnectOptions.RequiredClaimValue"/> is non-empty, then the
+    /// requirement is extended to also validate the specified value.
+    /// </remarks>
+    public static AuthorizationPolicyBuilder RequireOpenIdClaims(this AuthorizationPolicyBuilder builder, OpenIdConnectOptions options)
+    {
+        var claimType = options.RequiredClaimType;
+        var claimValue = options.RequiredClaimValue;
+
+        if (!string.IsNullOrWhiteSpace(claimType))
+        {
+            if (!string.IsNullOrWhiteSpace(claimValue))
+            {
+                builder.RequireClaim(claimType, claimValue);
+            }
+            else
+            {
+                builder.RequireClaim(claimType);
+            }
+        }
+
+        return builder;
+    }
+}

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -180,6 +180,20 @@ public sealed class OpenIdConnectOptions
     public string NameClaimType { get; set; } = "name";
     public string UsernameClaimType { get; set; } = "preferred_username";
 
+    /// <summary>
+    /// Gets the optional name of a claim that users authenticated via OpenID Connect are required to have.
+    /// If specified, users without this claim will be rejected. If <see cref="RequiredClaimValue"/>
+    /// is also specified, then the value of this claim must also match <see cref="RequiredClaimValue"/>.
+    /// </summary>
+    public string RequiredClaimType { get; set; } = "";
+
+    /// <summary>
+    /// Gets the optional value of the <see cref="RequiredClaimType"/> claim for users authenticated via
+    /// OpenID Connect. If specified, users not having this value for the corresponding claim type are
+    /// rejected.
+    /// </summary>
+    public string RequiredClaimValue { get; set; } = "";
+
     public string[] GetNameClaimTypes()
     {
         Debug.Assert(_nameClaimTypes is not null, "Should have been parsed during validation.");

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Reflection;
 using System.Security.Claims;
 using Aspire.Dashboard.Authentication;
+using Aspire.Dashboard.Authentication.OpenIdConnect;
 using Aspire.Dashboard.Authentication.OtlpApiKey;
 using Aspire.Dashboard.Authentication.OtlpConnection;
 using Aspire.Dashboard.Components;
@@ -548,11 +549,10 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             switch (dashboardOptions.Frontend.AuthMode)
             {
                 case FrontendAuthMode.OpenIdConnect:
-                    // Frontend is secured with OIDC, so delegate to that authentication scheme.
                     options.AddPolicy(
                         name: FrontendAuthorizationDefaults.PolicyName,
                         policy: new AuthorizationPolicyBuilder(FrontendAuthenticationDefaults.AuthenticationScheme)
-                            .RequireAuthenticatedUser()
+                            .RequireOpenIdClaims(options: dashboardOptions.Frontend.OpenIdConnect)
                             .Build());
                     break;
                 case FrontendAuthMode.BrowserToken:

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -59,6 +59,8 @@ Set `Dashboard:Frontend:AuthMode` to `OpenIdConnect`, then add the following con
 - Other properties of [`OpenIdConnectOptions`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.builder.openidconnectoptions) specified in configuration container `Authentication:Schemes:OpenIdConnect:*`
 - `Dashboard:Frontend:OpenIdConnect:NameClaimType` specifies the claim type(s) that should be used to display the authenticated user's full name. Can be a single claim type or a comma-delimited list of claim types. Defaults to `name`.
 - `Dashboard:Frontend:OpenIdConnect:UsernameClaimType` specifies the claim type(s) that should be used to display the authenticated user's username. Can be a single claim type or a comma-delimited list of claim types. Defaults to `preferred_username`.
+- `Dashboard:Frontend:OpenIdConnect:RequireClaimType` specifies the (optional) claim that be present for authorized users. Defaults to empty.
+- `Dashboard:Frontend:OpenIdConnect:RequireClaimValue` specifies the (optional) value of the required claim. Only used if `Dashboard:Frontend:OpenIdConnect:RequireClaimType` is also specified. Defaults to empty.
 
 ### OTLP authentication
 


### PR DESCRIPTION
Adds optional configuration that checks a given claim of a user authenticated via OIDC.

Two new configuration values are:

- `Dashboard:Frontend:OpenIdConnect:RequireClaimType` specifies the (optional) claim that be present for authorized users. Defaults to empty.
- `Dashboard:Frontend:OpenIdConnect:RequireClaimValue` specifies the (optional) value of the required claim. Only used if `Dashboard:Frontend:OpenIdConnect:RequireClaimType` is also specified. Defaults to empty.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3595)