### PR TITLE
Exclude the dashboard from the manifest

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardManifestExclusionHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardManifestExclusionHook.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
+
+namespace Aspire.Hosting.Dashboard;
+
+internal sealed class DashboardManifestExclusionHook : IDistributedApplicationLifecycleHook
+{
+    public Task BeforeStartAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
+    {
+        // When developing locally, exclude the dashboard from the manifest. This only affects our playground projects in practice.
+        if (model.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) is { } dashboardResource)
+        {
+            dashboardResource.Annotations.Add(ManifestPublishingCallbackAnnotation.Ignore);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -179,6 +179,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         // Publishing support
         _innerBuilder.Services.AddLifecycleHook<Http2TransportMutationHook>();
+        _innerBuilder.Services.AddLifecycleHook<DashboardManifestExclusionHook>();
         _innerBuilder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, ManifestPublisher>("manifest");
 
         // Overwrite registry if override specified in options

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
@@ -41,7 +41,7 @@ public class DistributedApplicationBuilderTests
         Assert.Empty(appModel.Resources);
 
         var lifecycles = app.Services.GetServices<IDistributedApplicationLifecycleHook>();
-        Assert.Equal(2, lifecycles.Count());
+        Assert.Equal(3, lifecycles.Count());
 
         var options = app.Services.GetRequiredService<IOptions<PublishingOptions>>();
         Assert.Null(options.Value.Publisher);

--- a/tests/Aspire.Hosting.Tests/Utils/ManifestUtils.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/ManifestUtils.cs
@@ -12,6 +12,13 @@ internal sealed class ManifestUtils
 {
     public static async Task<JsonNode> GetManifest(IResource resource, string? manifestDirectory = null)
     {
+        var node = await GetManifestOrNull(resource, manifestDirectory);
+        Assert.NotNull(node);
+        return node;
+    }
+
+    public static async Task<JsonNode?> GetManifestOrNull(IResource resource, string? manifestDirectory = null)
+    {
         manifestDirectory ??= Environment.CurrentDirectory;
 
         using var ms = new MemoryStream();
@@ -26,7 +33,6 @@ internal sealed class ManifestUtils
         var obj = JsonNode.Parse(ms);
         Assert.NotNull(obj);
         var resourceNode = obj[resource.Name];
-        Assert.NotNull(resourceNode);
         return resourceNode;
     }
 


### PR DESCRIPTION
This is a regression from the refactoring. We used to always exclude the dashboard resource which made it work for the playground samples. After the change, we don't look at the dashboard if we're not in run mode, this stops our playground samples from being deployed because we explicitly add the dashboard as a project resource.

This change excludes the dashboard if it is a project resource.