### PR TITLE
[tests] Move Aspire.Azure.Security.KeyVault.Tests to helix, which allow retries

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -4,8 +4,6 @@
   "localRerunCount": 1,
   "retryOnRules": [
     { "testAssembly": { "regex": "Aspire.EndToEnd.*" }, "failureMessage": { "regex": "App run failed" } },
-    { "testAssembly": { "regex": "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.*" } },
-    { "testAssembly": { "regex": "Aspire.Microsoft.EntityFrameworkCore.SqlServer.*" } },
     { "testName": "Aspire.Azure.Security.KeyVault.Tests.ConformanceTests.HealthCheckReportsExpectedStatus" }
   ]
 }

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -5,6 +5,7 @@
   "retryOnRules": [
     { "testAssembly": { "regex": "Aspire.EndToEnd.*" }, "failureMessage": { "regex": "App run failed" } },
     { "testAssembly": { "regex": "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.*" } },
-    { "testAssembly": { "regex": "Aspire.Microsoft.EntityFrameworkCore.SqlServer.*" } }
+    { "testAssembly": { "regex": "Aspire.Microsoft.EntityFrameworkCore.SqlServer.*" } },
+    { "testName": "Aspire.Azure.Security.KeyVault.Tests.ConformanceTests.HealthCheckReportsExpectedStatus" }
   ]
 }

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/Aspire.Azure.Security.KeyVault.Tests.csproj
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/Aspire.Azure.Security.KeyVault.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
+    <RunTestsOnHelix>true</RunTestsOnHelix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- **[tests] Move Aspire.Azure.Security.KeyVault.Tests to helix, which allows retrying**
- **Retry test on helix**
- **Remove unnecessary helix retries**

Related issue: https://github.com/dotnet/aspire/issues/3609
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3617)