### PR TITLE
Fix Qdrant resource to be publishable

### DIFF
--- a/playground/Qdrant/Qdrant.AppHost/Program.cs
+++ b/playground/Qdrant/Qdrant.AppHost/Program.cs
@@ -4,9 +4,10 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 var qdrant = builder.AddQdrant("qdrant")
-    .WithDataVolume("qdrant_data");
+    .WithDataVolume("qdrant-data");
 
 builder.AddProject<Projects.Qdrant_ApiService>("apiservice")
+    .WithExternalHttpEndpoints()
     .WithReference(qdrant);
 
 builder.Build().Run();

--- a/playground/Qdrant/Qdrant.AppHost/aspire-manifest.json
+++ b/playground/Qdrant/Qdrant.AppHost/aspire-manifest.json
@@ -1,0 +1,76 @@
+{
+  "resources": {
+    "qdrant": {
+      "type": "container.v0",
+      "connectionString": "Endpoint={qdrant.bindings.grpc.url};Key={qdrant-Key.value}",
+      "image": "docker.io/qdrant/qdrant:v1.8.3",
+      "volumes": [
+        {
+          "name": "qdrant-data",
+          "target": "/qdrant/storage",
+          "readOnly": false
+        }
+      ],
+      "env": {
+        "QDRANT__SERVICE__API_KEY": "{qdrant-Key.value}",
+        "QDRANT__SERVICE__ENABLE_STATIC_CONTENT": "0"
+      },
+      "bindings": {
+        "grpc": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http2",
+          "targetPort": 6334
+        },
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http",
+          "targetPort": 6333
+        }
+      }
+    },
+    "apiservice": {
+      "type": "project.v0",
+      "path": "../Qdrant.ApiService/Qdrant.ApiService.csproj",
+      "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
+        "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
+        "ConnectionStrings__qdrant": "Endpoint={qdrant.bindings.grpc.url};Key={qdrant-Key.value}",
+        "ConnectionStrings__qdrant_http": "Endpoint={qdrant.bindings.http.url};Key={qdrant-Key.value}"
+      },
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http",
+          "external": true
+        },
+        "https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http",
+          "external": true
+        }
+      }
+    },
+    "qdrant-Key": {
+      "type": "parameter.v0",
+      "value": "{qdrant-Key.inputs.value}",
+      "inputs": {
+        "value": {
+          "type": "string",
+          "secret": true,
+          "default": {
+            "generate": {
+              "minLength": 22,
+              "special": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
@@ -43,6 +43,10 @@ public static class QdrantBuilderExtensions
             .WithImage(QdrantContainerImageTags.Image, QdrantContainerImageTags.Tag)
             .WithImageRegistry(QdrantContainerImageTags.Registry)
             .WithHttpEndpoint(port: grpcPort, targetPort: QdrantPortGrpc, name: QdrantServerResource.PrimaryEndpointName)
+            .WithEndpoint(QdrantServerResource.PrimaryEndpointName, endpoint =>
+            {
+                endpoint.Transport = "http2";
+            })
             .WithHttpEndpoint(port: httpPort, targetPort: QdrantPortHttp, name: QdrantServerResource.HttpEndpointName)
             .WithEnvironment(context =>
             {

--- a/src/Aspire.Hosting.Qdrant/QdrantServerResource.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantServerResource.cs
@@ -45,12 +45,12 @@ public class QdrantServerResource : ContainerResource, IResourceWithConnectionSt
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
        ReferenceExpression.Create(
-            $"Endpoint={PrimaryEndpoint.Property(EndpointProperty.Scheme)}://{PrimaryEndpoint.Property(EndpointProperty.Host)}:{PrimaryEndpoint.Property(EndpointProperty.Port)};Key={ApiKeyParameter}");
+            $"Endpoint={PrimaryEndpoint.Property(EndpointProperty.Url)};Key={ApiKeyParameter}");
 
     /// <summary>
     /// Gets the connection string expression for the Qdrant HTTP endpoint.
     /// </summary>
     public ReferenceExpression HttpConnectionStringExpression =>
         ReferenceExpression.Create(
-            $"Endpoint={HttpEndpoint.Property(EndpointProperty.Scheme)}://{HttpEndpoint.Property(EndpointProperty.Host)}:{HttpEndpoint.Property(EndpointProperty.Port)};Key={ApiKeyParameter}");
+            $"Endpoint={HttpEndpoint.Property(EndpointProperty.Url)};Key={ApiKeyParameter}");
 }

--- a/tests/Aspire.Hosting.Tests/Qdrant/AddQdrantTests.cs
+++ b/tests/Aspire.Hosting.Tests/Qdrant/AddQdrantTests.cs
@@ -41,7 +41,7 @@ public class AddQdrantTests
         Assert.Equal("grpc", endpoint.Name);
         Assert.Null(endpoint.Port);
         Assert.Equal(ProtocolType.Tcp, endpoint.Protocol);
-        Assert.Equal("http", endpoint.Transport);
+        Assert.Equal("http2", endpoint.Transport);
         Assert.Equal("http", endpoint.UriScheme);
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
@@ -114,7 +114,7 @@ public class AddQdrantTests
         Assert.Equal("grpc", endpoint.Name);
         Assert.Null(endpoint.Port);
         Assert.Equal(ProtocolType.Tcp, endpoint.Protocol);
-        Assert.Equal("http", endpoint.Transport);
+        Assert.Equal("http2", endpoint.Transport);
         Assert.Equal("http", endpoint.UriScheme);
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(containerResource);
@@ -193,7 +193,7 @@ public class AddQdrantTests
         var expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "Endpoint={qdrant.bindings.grpc.scheme}://{qdrant.bindings.grpc.host}:{qdrant.bindings.grpc.port};Key={qdrant-Key.value}",
+              "connectionString": "Endpoint={qdrant.bindings.grpc.url};Key={qdrant-Key.value}",
               "image": "{{QdrantContainerImageTags.Registry}}/{{QdrantContainerImageTags.Image}}:{{QdrantContainerImageTags.Tag}}",
               "env": {
                 "QDRANT__SERVICE__API_KEY": "{qdrant-Key.value}",
@@ -203,7 +203,7 @@ public class AddQdrantTests
                 "grpc": {
                   "scheme": "http",
                   "protocol": "tcp",
-                  "transport": "http",
+                  "transport": "http2",
                   "targetPort": 6334
                 },
                 "http": {
@@ -231,7 +231,7 @@ public class AddQdrantTests
         var expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "Endpoint={qdrant.bindings.grpc.scheme}://{qdrant.bindings.grpc.host}:{qdrant.bindings.grpc.port};Key={QdrantApiKey.value}",
+              "connectionString": "Endpoint={qdrant.bindings.grpc.url};Key={QdrantApiKey.value}",
               "image": "{{QdrantContainerImageTags.Registry}}/{{QdrantContainerImageTags.Image}}:{{QdrantContainerImageTags.Tag}}",
               "env": {
                 "QDRANT__SERVICE__API_KEY": "{QdrantApiKey.value}",
@@ -241,7 +241,7 @@ public class AddQdrantTests
                 "grpc": {
                   "scheme": "http",
                   "protocol": "tcp",
-                  "transport": "http",
+                  "transport": "http2",
                   "targetPort": 6334
                 },
                 "http": {
@@ -277,7 +277,7 @@ public class AddQdrantTests
         Assert.False(grpcEndpoint.IsExternal);
         Assert.Equal(5503, grpcEndpoint.Port);
         Assert.Equal(ProtocolType.Tcp, grpcEndpoint.Protocol);
-        Assert.Equal("http", grpcEndpoint.Transport);
+        Assert.Equal("http2", grpcEndpoint.Transport);
         Assert.Equal("http", grpcEndpoint.UriScheme);
 
         var httpEndpoint = qdrantResource.Annotations.OfType<EndpointAnnotation>().Single(e => e.Name == "http");


### PR DESCRIPTION
1. Set the transport to be http2 on the grpc endpoint
2. Use the Url property in the connection string for simplicity

The app still doesn't work end-to-end yet. It is blocked by https://github.com/Azure/azure-dev/issues/3690, which should be fixed soon. cc @ellismg 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3618)