### PR TITLE
[release/8.0] dapr change the app port depending on the app protocol

### DIFF
--- a/src/Aspire.Hosting.Dapr/DaprSidecarOptions.cs
+++ b/src/Aspire.Hosting.Dapr/DaprSidecarOptions.cs
@@ -56,6 +56,11 @@ public sealed record DaprSidecarOptions
     public string? AppProtocol { get; init; }
 
     /// <summary>
+    /// Gets or sets the endpoint of the application the sidecar is connected to.
+    /// </summary>
+    public string? AppEndpoint { get; init; }
+
+    /// <summary>
     /// Gets or sets the command run by the Dapr CLI as part of starting the sidecar.
     /// </summary>
     public IImmutableList<string> Command { get; init; } = ImmutableList<string>.Empty;

--- a/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dapr/DaprTests.cs
@@ -77,10 +77,96 @@ public class DaprTests
             "--metrics-port",
             "{{- portForServing \"metrics\" -}}",
             "--app-channel-address",
-            "localhost"
+            "localhost",
+            "--app-protocol",
+            "http"
         };
 
         Assert.Equal(expectedArgs, sidecarArgs);
+        Assert.NotNull(container.Annotations.OfType<DaprSidecarAnnotation>());
+    }
+
+    [Theory]
+    [InlineData("https", "https", 555, "https", "localhost", 555)]
+    [InlineData(null, null, null, "http", "localhost", 8000)]
+    [InlineData("https", null, null, "https", "localhost", 8001)]
+    [InlineData(null, "https", null, "https", "localhost", 8001)]
+    [InlineData(null, null, 555, "http", "localhost", 555)]
+    [InlineData("https", "http", null, "https", "localhost", 8000)]
+    public async Task WithDaprSideCarAddsAnnotationBasedOnTheSidecarAppOptions(string? schema, string? endPoint, int? port, string expectedSchema, string expectedChannelAddress, int expectedPort)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(new DistributedApplicationOptions
+        {
+            DisableDashboard = true
+        });
+
+        builder.AddDapr(o =>
+        {
+            // Fake path to avoid throwing
+            o.DaprPath = "dapr";
+        });
+
+        var containerResource = builder.AddContainer("name", "image")
+            .WithEndpoint("http", e =>
+            {
+                e.Port = 8000;
+                e.UriScheme = "http";
+                e.AllocatedEndpoint = new(e, "localhost", 8000);
+            })
+            .WithEndpoint("https", e =>
+            {
+                e.Port = 8001;
+                e.UriScheme = "https";
+                e.AllocatedEndpoint = new(e, "localhost", 8001);
+            });
+        if (schema is null && endPoint is null && port is null)
+        {
+            containerResource.WithDaprSidecar();
+        }
+        else
+        {
+            containerResource.WithDaprSidecar(new DaprSidecarOptions()
+            {
+                AppProtocol = schema,
+                AppEndpoint = endPoint,
+                AppPort = port
+            });
+        }
+        using var app = builder.Build();
+        await app.ExecuteBeforeStartHooksAsync(default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        Assert.Equal(3, model.Resources.Count);
+        var container = Assert.Single(model.Resources.OfType<ContainerResource>());
+        var sidecarResource = Assert.Single(model.Resources.OfType<IDaprSidecarResource>());
+        var sideCarCli = Assert.Single(model.Resources.OfType<ExecutableResource>());
+
+        Assert.True(sideCarCli.TryGetEndpoints(out var endpoints));
+
+        var ports = new Dictionary<string, int>
+        {
+            ["http"] = 3500,
+            ["grpc"] = 50001,
+            ["metrics"] = 9090
+        };
+
+        foreach (var e in endpoints)
+        {
+            e.AllocatedEndpoint = new(e, "localhost", ports[e.Name], targetPortExpression: $$$"""{{- portForServing "{{{e.Name}}}" -}}""");
+        }
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(container);
+        var sidecarArgs = await ArgumentEvaluator.GetArgumentListAsync(sideCarCli);
+
+        Assert.Equal("http://localhost:3500", config["DAPR_HTTP_ENDPOINT"]);
+        Assert.Equal("http://localhost:50001", config["DAPR_GRPC_ENDPOINT"]);
+
+        // because the order of the parameters is changing, we are just checking if the important ones here.
+        var commandline = string.Join(" ", sidecarArgs);
+        Assert.Contains($"--app-port {expectedPort}", commandline);
+        Assert.Contains($"--app-channel-address {expectedChannelAddress}", commandline);
+        Assert.Contains($"--app-protocol {expectedSchema}", commandline);
         Assert.NotNull(container.Annotations.OfType<DaprSidecarAnnotation>());
     }
 }


### PR DESCRIPTION
Backpoirt https://github.com/dotnet/aspire/pull/3184 to release/8.0
Fixes https://github.com/dotnet/aspire/issues/2367

## Customer Impact
Described in https://github.com/dotnet/aspire/issues/2367. Basically, if a DAPR-enabled Aspire app uses anything other than HTTP for communication, it will fail to communicate with the DAPR sidecar, so pretty bad.

## Testing
@paule96 did manual testing and added pretty comprehensive automated test coverage of the change.

## Risk
Low IMO. The change is well localized and small. 

## Regression
Not really--the initial implementation of the feature only covered HTTP case
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3626)