### PR TITLE
Fix configuration key in error messages

### DIFF
--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -209,10 +209,11 @@ public sealed class OpenIdConnectOptions
     internal bool TryParseOptions([NotNullWhen(false)] out IEnumerable<string>? errorMessages)
     {
         List<string>? messages = null;
+
         if (string.IsNullOrWhiteSpace(NameClaimType))
         {
             messages ??= [];
-            messages.Add("OpenID Connect claim type for name not configured. Specify a Dashboard:OpenIdConnect:NameClaimType value.");
+            messages.Add("OpenID Connect claim type for name not configured. Specify a Dashboard:Frontend:OpenIdConnect:NameClaimType value.");
         }
         else
         {
@@ -222,7 +223,7 @@ public sealed class OpenIdConnectOptions
         if (string.IsNullOrWhiteSpace(UsernameClaimType))
         {
             messages ??= [];
-            messages.Add("OpenID Connect claim type for username not configured. Specify a Dashboard:OpenIdConnect:UsernameClaimType value.");
+            messages.Add("OpenID Connect claim type for username not configured. Specify a Dashboard:Frontend:OpenIdConnect:UsernameClaimType value.");
         }
         else
         {


### PR DESCRIPTION
At some point during development of #3443 the configuration key was changed and these error messages were missed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3630)