### PR TITLE
Fix generated code for .resx files

### DIFF
--- a/src/Aspire.Dashboard/Resources/Columns.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Columns.Designer.cs
@@ -21,14 +21,14 @@ namespace Aspire.Dashboard.Resources {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class Logs {
+    public class Columns {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Logs() {
+        internal Columns() {
         }
         
         /// <summary>
@@ -38,7 +38,7 @@ namespace Aspire.Dashboard.Resources {
         public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Aspire.Dashboard.Resources.Logs", typeof(Logs).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Aspire.Dashboard.Resources.Columns", typeof(Columns).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -60,20 +60,173 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to contains.
+        ///   Looks up a localized string similar to None.
         /// </summary>
-        public static string LogContains {
+        public static string EndpointsColumnDisplayNone {
             get {
-                return ResourceManager.GetString("LogContains", resourceCulture);
+                return ResourceManager.GetString("EndpointsColumnDisplayNone", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to not contains.
+        ///   Looks up a localized string similar to Starting....
         /// </summary>
-        public static string LogNotContains {
+        public static string EndpointsColumnDisplayPlaceholder {
             get {
-                return ResourceManager.GetString("LogNotContains", resourceCulture);
+                return ResourceManager.GetString("EndpointsColumnDisplayPlaceholder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exception details.
+        /// </summary>
+        public static string LogMessageColumnExceptionDetailsTitle {
+            get {
+                return ResourceManager.GetString("LogMessageColumnExceptionDetailsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Container ID: {0}.
+        /// </summary>
+        public static string ResourceNameDisplayContainerIdText {
+            get {
+                return ResourceManager.GetString("ResourceNameDisplayContainerIdText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy container ID to clipboard.
+        /// </summary>
+        public static string ResourceNameDisplayCopyContainerIdText {
+            get {
+                return ResourceManager.GetString("ResourceNameDisplayCopyContainerIdText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Process ID: {0}.
+        /// </summary>
+        public static string ResourceNameDisplayProcessIdText {
+            get {
+                return ResourceManager.GetString("ResourceNameDisplayProcessIdText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Container args.
+        /// </summary>
+        public static string SourceColumnDisplayContainerArgsTitle {
+            get {
+                return ResourceManager.GetString("SourceColumnDisplayContainerArgsTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Command: {0}.
+        /// </summary>
+        public static string SourceColumnDisplayContainerCommand {
+            get {
+                return ResourceManager.GetString("SourceColumnDisplayContainerCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Container command.
+        /// </summary>
+        public static string SourceColumnDisplayContainerCommandTitle {
+            get {
+                return ResourceManager.GetString("SourceColumnDisplayContainerCommandTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy full command to clipboard.
+        /// </summary>
+        public static string SourceColumnDisplayCopyCommandToClipboard {
+            get {
+                return ResourceManager.GetString("SourceColumnDisplayCopyCommandToClipboard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Port: {0}.
+        /// </summary>
+        public static string SourceColumnDisplayPort {
+            get {
+                return ResourceManager.GetString("SourceColumnDisplayPort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ports: {0}.
+        /// </summary>
+        public static string SourceColumnDisplayPorts {
+            get {
+                return ResourceManager.GetString("SourceColumnDisplayPorts", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Working directory: {0}.
+        /// </summary>
+        public static string SourceColumnDisplayWorkingDirectory {
+            get {
+                return ResourceManager.GetString("SourceColumnDisplayWorkingDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy image name and tag to clipboard.
+        /// </summary>
+        public static string SourceColumnSourceCopyContainerToClipboard {
+            get {
+                return ResourceManager.GetString("SourceColumnSourceCopyContainerToClipboard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy file path to clipboard.
+        /// </summary>
+        public static string SourceColumnSourceCopyFullPathToClipboard {
+            get {
+                return ResourceManager.GetString("SourceColumnSourceCopyFullPathToClipboard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is no longer running.
+        /// </summary>
+        public static string StateColumnResourceExited {
+            get {
+                return ResourceManager.GetString("StateColumnResourceExited", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} exited unexpectedly with exit code {1}.
+        /// </summary>
+        public static string StateColumnResourceExitedUnexpectedly {
+            get {
+                return ResourceManager.GetString("StateColumnResourceExitedUnexpectedly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} error logs.
+        /// </summary>
+        public static string UnreadLogErrorsBadgeErrorLogs {
+            get {
+                return ResourceManager.GetString("UnreadLogErrorsBadgeErrorLogs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 1 error log.
+        /// </summary>
+        public static string UnreadLogErrorsBadgeOneErrorLog {
+            get {
+                return ResourceManager.GetString("UnreadLogErrorsBadgeOneErrorLog", resourceCulture);
             }
         }
     }

--- a/src/Aspire.Dashboard/Resources/Logs.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Logs.Designer.cs
@@ -21,14 +21,14 @@ namespace Aspire.Dashboard.Resources {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class Columns {
+    public class Logs {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Columns() {
+        internal Logs() {
         }
         
         /// <summary>
@@ -38,7 +38,7 @@ namespace Aspire.Dashboard.Resources {
         public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Aspire.Dashboard.Resources.Columns", typeof(Columns).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Aspire.Dashboard.Resources.Logs", typeof(Logs).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -60,173 +60,20 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to None.
+        ///   Looks up a localized string similar to contains.
         /// </summary>
-        public static string EndpointsColumnDisplayNone {
+        public static string LogContains {
             get {
-                return ResourceManager.GetString("EndpointsColumnDisplayNone", resourceCulture);
+                return ResourceManager.GetString("LogContains", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Starting....
+        ///   Looks up a localized string similar to not contains.
         /// </summary>
-        public static string EndpointsColumnDisplayPlaceholder {
+        public static string LogNotContains {
             get {
-                return ResourceManager.GetString("EndpointsColumnDisplayPlaceholder", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Exception details.
-        /// </summary>
-        public static string LogMessageColumnExceptionDetailsTitle {
-            get {
-                return ResourceManager.GetString("LogMessageColumnExceptionDetailsTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Container ID: {0}.
-        /// </summary>
-        public static string ResourceNameDisplayContainerIdText {
-            get {
-                return ResourceManager.GetString("ResourceNameDisplayContainerIdText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Copy container ID to clipboard.
-        /// </summary>
-        public static string ResourceNameDisplayCopyContainerIdText {
-            get {
-                return ResourceManager.GetString("ResourceNameDisplayCopyContainerIdText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Process ID: {0}.
-        /// </summary>
-        public static string ResourceNameDisplayProcessIdText {
-            get {
-                return ResourceManager.GetString("ResourceNameDisplayProcessIdText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Container args.
-        /// </summary>
-        public static string SourceColumnDisplayContainerArgsTitle {
-            get {
-                return ResourceManager.GetString("SourceColumnDisplayContainerArgsTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Command: {0}.
-        /// </summary>
-        public static string SourceColumnDisplayContainerCommand {
-            get {
-                return ResourceManager.GetString("SourceColumnDisplayContainerCommand", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Container command.
-        /// </summary>
-        public static string SourceColumnDisplayContainerCommandTitle {
-            get {
-                return ResourceManager.GetString("SourceColumnDisplayContainerCommandTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Copy full command to clipboard.
-        /// </summary>
-        public static string SourceColumnDisplayCopyCommandToClipboard {
-            get {
-                return ResourceManager.GetString("SourceColumnDisplayCopyCommandToClipboard", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Port: {0}.
-        /// </summary>
-        public static string SourceColumnDisplayPort {
-            get {
-                return ResourceManager.GetString("SourceColumnDisplayPort", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Ports: {0}.
-        /// </summary>
-        public static string SourceColumnDisplayPorts {
-            get {
-                return ResourceManager.GetString("SourceColumnDisplayPorts", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Working directory: {0}.
-        /// </summary>
-        public static string SourceColumnDisplayWorkingDirectory {
-            get {
-                return ResourceManager.GetString("SourceColumnDisplayWorkingDirectory", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Copy image name and tag to clipboard.
-        /// </summary>
-        public static string SourceColumnSourceCopyContainerToClipboard {
-            get {
-                return ResourceManager.GetString("SourceColumnSourceCopyContainerToClipboard", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Copy file path to clipboard.
-        /// </summary>
-        public static string SourceColumnSourceCopyFullPathToClipboard {
-            get {
-                return ResourceManager.GetString("SourceColumnSourceCopyFullPathToClipboard", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} is no longer running.
-        /// </summary>
-        public static string StateColumnResourceExited {
-            get {
-                return ResourceManager.GetString("StateColumnResourceExited", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} exited unexpectedly with exit code {1}.
-        /// </summary>
-        public static string StateColumnResourceExitedUnexpectedly {
-            get {
-                return ResourceManager.GetString("StateColumnResourceExitedUnexpectedly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} error logs.
-        /// </summary>
-        public static string UnreadLogErrorsBadgeErrorLogs {
-            get {
-                return ResourceManager.GetString("UnreadLogErrorsBadgeErrorLogs", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to 1 error log.
-        /// </summary>
-        public static string UnreadLogErrorsBadgeOneErrorLog {
-            get {
-                return ResourceManager.GetString("UnreadLogErrorsBadgeOneErrorLog", resourceCulture);
+                return ResourceManager.GetString("LogNotContains", resourceCulture);
             }
         }
     }


### PR DESCRIPTION
Somehow the `.Designer.cs` files for `Columns.resx` and `Logs.resx` were inverted. Any change to one of these files would result in compilation errors due to duplicate classes.

This change renames the files so that future regeneration won't hit problems.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3632)