### PR TITLE
Fix broken find token image in HTTP

### DIFF
--- a/tests/Aspire.Dashboard.Tests/BrowserSecurityHeadersMiddlewareTests.cs
+++ b/tests/Aspire.Dashboard.Tests/BrowserSecurityHeadersMiddlewareTests.cs
@@ -44,14 +44,14 @@ public class BrowserSecurityHeadersMiddlewareTests
     }
 
     [Theory]
-    [InlineData(true, "img-src data: https:;")]
-    [InlineData(false, "img-src data: http: https:;")]
-    public async Task InvokeAsync_Scheme_ImageSourceChangesOnScheme(bool isHttps, string expectedContent)
+    [InlineData("https", "img-src data: https:;")]
+    [InlineData("http", "img-src data: http: https:;")]
+    public async Task InvokeAsync_Scheme_ImageSourceChangesOnScheme(string scheme, string expectedContent)
     {
         // Arrange
         var middleware = CreateMiddleware(environmentName: "Production");
         var httpContext = new DefaultHttpContext();
-        httpContext.Request.Scheme = isHttps ? "https" : "http";
+        httpContext.Request.Scheme = scheme;
 
         // Act
         await middleware.InvokeAsync(httpContext);

--- a/tests/Aspire.Dashboard.Tests/BrowserSecurityHeadersMiddlewareTests.cs
+++ b/tests/Aspire.Dashboard.Tests/BrowserSecurityHeadersMiddlewareTests.cs
@@ -43,6 +43,24 @@ public class BrowserSecurityHeadersMiddlewareTests
         Assert.Contains("default-src", httpContext.Response.Headers.ContentSecurityPolicy.ToString());
     }
 
+    [Theory]
+    [InlineData(true, "img-src data: https:;")]
+    [InlineData(false, "img-src data: http: https:;")]
+    public async Task InvokeAsync_Scheme_ImageSourceChangesOnScheme(bool isHttps, string expectedContent)
+    {
+        // Arrange
+        var middleware = CreateMiddleware(environmentName: "Production");
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = isHttps ? "https" : "http";
+
+        // Act
+        await middleware.InvokeAsync(httpContext);
+
+        // Assert
+        Assert.NotEqual(StringValues.Empty, httpContext.Response.Headers.ContentSecurityPolicy);
+        Assert.Contains(expectedContent, httpContext.Response.Headers.ContentSecurityPolicy.ToString());
+    }
+
     [Fact]
     public async Task InvokeAsync_Otlp_NotAdded()
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/3603

If the website is http then allow http or https images.
If the website is https then only allow https images.

Working:

![image](https://github.com/dotnet/aspire/assets/303201/4b1f5061-ce2a-4599-bd87-7597253f1591)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3635)