### PR TITLE
Fix dashboard log watching

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardOptions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using Aspire.Hosting.Dcp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -16,7 +15,6 @@ internal class DashboardOptions
     public string? OtlpEndpointUrl { get; set; }
     public string? OtlpApiKey { get; set; }
     public string AspNetCoreEnvironment { get; set; } = "Production";
-    public TimeSpan DashboardStartupTimeout { get; set; } = TimeSpan.FromSeconds(30);
 }
 
 internal class ConfigureDefaultDashboardOptions(IConfiguration configuration, IOptions<DcpOptions> dcpOptions) : IConfigureOptions<DashboardOptions>
@@ -31,12 +29,6 @@ internal class ConfigureDefaultDashboardOptions(IConfiguration configuration, IO
         options.OtlpApiKey = configuration["AppHost:OtlpApiKey"];
 
         options.AspNetCoreEnvironment = configuration["ASPNETCORE_ENVIRONMENT"] ?? "Production";
-
-        if (configuration["AppHost:DashboardStartupTimeout"] is { Length: > 0 } dashboardStartupTimeoutValue &&
-            !string.IsNullOrEmpty(dashboardStartupTimeoutValue))
-        {
-            options.DashboardStartupTimeout = TimeSpan.FromSeconds(int.Parse(dashboardStartupTimeoutValue, CultureInfo.InvariantCulture));
-        }
     }
 }
 


### PR DESCRIPTION
- When the dashboard was running as an executable, the logic we used to detect replicas was broken. Instead of trying to be clever, watch all dashboard resources and log their output. This is more robust and future proof as we only have one dashboard running at once.
- Deleted the timeout

Fixes #3612
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3636)