### PR TITLE
Persist browser token auth cookie across sessions

### DIFF
--- a/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
+++ b/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
@@ -91,7 +91,7 @@ internal sealed class ValidateTokenMiddleware
         await httpContext.SignInAsync(
             CookieAuthenticationDefaults.AuthenticationScheme,
             claims,
-            new AuthenticationProperties { IsPersistent = true, AllowRefresh = true }).ConfigureAwait(false);
+            new AuthenticationProperties { IsPersistent = true }).ConfigureAwait(false);
         return true;
     }
 }

--- a/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
+++ b/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
@@ -88,7 +88,10 @@ internal sealed class ValidateTokenMiddleware
             authenticationType: CookieAuthenticationDefaults.AuthenticationScheme);
         var claims = new ClaimsPrincipal(claimsIdentity);
 
-        await httpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, claims).ConfigureAwait(false);
+        await httpContext.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            claims,
+            new AuthenticationProperties { IsPersistent = true, AllowRefresh = true }).ConfigureAwait(false);
         return true;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/3646

The auth cookie currently has a session lifetime. My experience with the dashboard is you can close and reopen the browser and it is remembered. I thought it was persisted. But it looks like the meaning of session is ambiguous. See https://stackoverflow.com/questions/4132095/when-does-a-cookie-with-expiration-time-at-end-of-session-expire

This PR updates cookie auth to persist the cookie.
* Lifetime of the cookie is the same as the lifetime of the auth token inside the cookie - so 3 days
* Allow it to be refreshed (does this mean it can be extended for sliding experation? @halter73?)

This change means the cookie will be remembered consistently (don't need to worry about the browser deciding the session is done) and between machine restarts.

cc @davidfowl @DamianEdwards What do you think?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3654)