### PR TITLE
[release/8.0] Bump Azure.Identity to 1.11.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
     <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.1.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.10.4" />
+    <PackageVersion Include="Azure.Identity" Version="1.11.0" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.5.1" />
     <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.4" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />


### PR DESCRIPTION
CVE-2024-29992

https://dnceng.visualstudio.com/internal/_componentGovernance/dotnet-aspire?_a=alerts&typeId=20652644&alerts-view-option=active

@eerhardt there are various transitive references to this from other dependencies, as the link above shows. Is this change sufficient to pull everything to 1.11.0?
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3660)