### PR TITLE
[release/8.0] Update to 8.0.4 of ASP.NET Core

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,18 +33,19 @@
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>8.0.1</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsOptionsPackageVersion>8.0.2</MicrosoftExtensionsOptionsPackageVersion>
     <MicrosoftExtensionsPrimitivesPackageVersion>8.0.0</MicrosoftExtensionsPrimitivesPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationCertificatePackageVersion>8.0.3</MicrosoftAspNetCoreAuthenticationCertificatePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>8.0.3</MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>
-    <MicrosoftAspNetCoreOpenApiPackageVersion>8.0.3</MicrosoftAspNetCoreOpenApiPackageVersion>
-    <MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion>8.0.2</MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion>
-    <MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>8.0.2</MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>8.0.2</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>
-    <MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>8.0.2</MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>
-    <MicrosoftExtensionsFeaturesPackageVersion>8.0.3</MicrosoftExtensionsFeaturesPackageVersion>
-    <MicrosoftEntityFrameworkCoreCosmosPackageVersion>8.0.2</MicrosoftEntityFrameworkCoreCosmosPackageVersion>
-    <MicrosoftEntityFrameworkCoreDesignPackageVersion>8.0.3</MicrosoftEntityFrameworkCoreDesignPackageVersion>
-    <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>8.0.3</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
-    <MicrosoftEntityFrameworkCoreToolsPackageVersion>8.0.3</MicrosoftEntityFrameworkCoreToolsPackageVersion>
-    <MicrosoftNETRuntimeWorkloadTestingInternalVersion>9.0.0-preview.3.24158.8</MicrosoftNETRuntimeWorkloadTestingInternalVersion>
+    <MicrosoftAspNetCoreAuthenticationCertificatePackageVersion>8.0.4</MicrosoftAspNetCoreAuthenticationCertificatePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>8.0.4</MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>
+    <MicrosoftAspNetCoreOpenApiPackageVersion>8.0.4</MicrosoftAspNetCoreOpenApiPackageVersion>
+    <MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion>8.0.4</MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion>
+    <MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>8.0.4</MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>
+    <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>8.0.4</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>
+    <MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>8.0.4</MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>
+    <MicrosoftExtensionsFeaturesPackageVersion>8.0.4</MicrosoftExtensionsFeaturesPackageVersion>
+    <!-- EF -->
+    <MicrosoftEntityFrameworkCoreCosmosPackageVersion>8.0.4</MicrosoftEntityFrameworkCoreCosmosPackageVersion>
+    <MicrosoftEntityFrameworkCoreDesignPackageVersion>8.0.4</MicrosoftEntityFrameworkCoreDesignPackageVersion>
+    <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>8.0.4</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
+    <MicrosoftEntityFrameworkCoreToolsPackageVersion>8.0.4</MicrosoftEntityFrameworkCoreToolsPackageVersion>
+    <MicrosoftNETRuntimeWorkloadTestingInternalVersion>9.0.0-preview.4.24208.7</MicrosoftNETRuntimeWorkloadTestingInternalVersion>
   </PropertyGroup>
 </Project>

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/DistributedCacheConformanceTests.cs
@@ -48,7 +48,7 @@ public class DistributedCacheConformanceTests : ConformanceTests
 
             builder.AddRedisDistributedCache("redis");
 
-            var notifier = new ActivityNotifier();
+            using var notifier = new ActivityNotifier();
             builder.Services.AddOpenTelemetry().WithTracing(builder => builder.AddProcessor(notifier));
             // set the FlushInterval to to zero so the Activity gets created immediately
             builder.Services.Configure<StackExchangeRedisInstrumentationOptions>(options => options.FlushInterval = TimeSpan.Zero);
@@ -61,14 +61,26 @@ public class DistributedCacheConformanceTests : ConformanceTests
             var cache = host.Services.GetRequiredService<IDistributedCache>();
             await cache.GetAsync("myFakeKey", CancellationToken.None);
 
-            // wait for the Activity to be processed
-            await notifier.ActivityReceived.WaitAsync(TimeSpan.FromSeconds(10));
-
-            Assert.Single(notifier.ExportedActivities);
-
-            var activity = notifier.ExportedActivities[0];
-            Assert.Equal("HMGET", activity.OperationName);
-            Assert.Contains(activity.Tags, kvp => kvp.Key == "db.system" && kvp.Value == "redis");
+            // read the first 3 activities
+            var activityList = await notifier.TakeAsync(3, TimeSpan.FromSeconds(10));
+            Assert.Equal(3, activityList.Count);
+            Assert.Collection(activityList,
+                // https://github.com/dotnet/aspnetcore/pull/54239 added 2 CLIENT activities on the first call
+                activity =>
+                {
+                    Assert.Equal("CLIENT", activity.OperationName);
+                    Assert.Contains(activity.Tags, kvp => kvp.Key == "db.system" && kvp.Value == "redis");
+                },
+                activity =>
+                {
+                    Assert.Equal("CLIENT", activity.OperationName);
+                    Assert.Contains(activity.Tags, kvp => kvp.Key == "db.system" && kvp.Value == "redis");
+                },
+                activity =>
+                {
+                    Assert.Equal("HMGET", activity.OperationName);
+                    Assert.Contains(activity.Tags, kvp => kvp.Key == "db.system" && kvp.Value == "redis");
+                });
         }, ConnectionString).Dispose();
     }
 }

--- a/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/OutputCacheConformanceTests.cs
@@ -48,7 +48,7 @@ public class OutputCacheConformanceTests : ConformanceTests
 
             builder.AddRedisOutputCache("redis");
 
-            var notifier = new ActivityNotifier();
+            using var notifier = new ActivityNotifier();
             builder.Services.AddOpenTelemetry().WithTracing(builder => builder.AddProcessor(notifier));
             // set the FlushInterval to to zero so the Activity gets created immediately
             builder.Services.Configure<StackExchangeRedisInstrumentationOptions>(options => options.FlushInterval = TimeSpan.Zero);
@@ -61,14 +61,26 @@ public class OutputCacheConformanceTests : ConformanceTests
             var cacheStore = host.Services.GetRequiredService<IOutputCacheStore>();
             await cacheStore.GetAsync("myFakeKey", CancellationToken.None);
 
-            // wait for the Activity to be processed
-            await notifier.ActivityReceived.WaitAsync(TimeSpan.FromSeconds(10));
-
-            Assert.Single(notifier.ExportedActivities);
-
-            var activity = notifier.ExportedActivities[0];
-            Assert.Equal("GET", activity.OperationName);
-            Assert.Contains(activity.Tags, kvp => kvp.Key == "db.system" && kvp.Value == "redis");
+            // read the first 3 activities
+            var activityList = await notifier.TakeAsync(3, TimeSpan.FromSeconds(10));
+            Assert.Equal(3, activityList.Count);
+            Assert.Collection(activityList,
+                // https://github.com/dotnet/aspnetcore/pull/54239 added 2 CLIENT activities on the first call
+                activity =>
+                {
+                    Assert.Equal("CLIENT", activity.OperationName);
+                    Assert.Contains(activity.Tags, kvp => kvp.Key == "db.system" && kvp.Value == "redis");
+                },
+                activity =>
+                {
+                    Assert.Equal("CLIENT", activity.OperationName);
+                    Assert.Contains(activity.Tags, kvp => kvp.Key == "db.system" && kvp.Value == "redis");
+                },
+                activity =>
+                {
+                    Assert.Equal("GET", activity.OperationName);
+                    Assert.Contains(activity.Tags, kvp => kvp.Key == "db.system" && kvp.Value == "redis");
+                });
         }, ConnectionString).Dispose();
     }
 }


### PR DESCRIPTION
Port #3667 to release/8.0

- Fix Redis output and distributed caching tests in response to new tracing events emitted from https://github.com/dotnet/aspnetcore/pull/54239

## Customer Impact
Using the latest ASP.NET versions in our packages means customers get the most up-to-date ASP.NET package versions when they use our packages.

## Testing
Automated tests in the branch.

## Risk
Low

## Regression?
No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3672)