### PR TITLE
Update OTEL HTTP instrumentation packages to 1.8.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -123,8 +123,8 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.8.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
     <!-- build dependencies -->
     <PackageVersion Include="MicroBuild.Plugins.SwixBuild.Dotnet" Version="1.1.87-gba258badda" />

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -63,6 +63,9 @@ public static class OtlpConfigurationExtensions
 
                 // Configure trace sampler to send all traces to the dashboard.
                 context.EnvironmentVariables["OTEL_TRACES_SAMPLER"] = "always_on";
+
+                // Disable URL query redaction, e.g. ?myvalue=Redacted
+                context.EnvironmentVariables["OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION"] = "true";
             }
         }));
     }

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
   </ItemGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Aspire.ServiceDefaults1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Aspire.ServiceDefaults1.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
   </ItemGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/AspireStarterApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/AspireStarterApplication.1.ServiceDefaults.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
   </ItemGroup>
 

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -98,6 +98,11 @@ public class ProjectResourceTests
             },
             env =>
             {
+                Assert.Equal("OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION", env.Key);
+                Assert.Equal("true", env.Value);
+            },
+            env =>
+            {
                 Assert.Equal("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION", env.Key);
                 Assert.Equal("true", env.Value);
             },


### PR DESCRIPTION
Updated packages so URL query is redacted by default.

This PR:
* Update packages used in repo.
* Update packages used in templates.
* Pass env var to disable redaction when Aspire is run dev environment. Redaction still happens if Aspire app host is run with non-development environment, or the apps are deployed.

After package update:

![image](https://github.com/dotnet/aspire/assets/303201/ea9b8559-2275-456e-afd6-f014c939fc37)

After package update + disable env var:

![image](https://github.com/dotnet/aspire/assets/303201/56ead40c-fc03-47fa-b5f3-58035a6a6629)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3676)