### PR TITLE
Differentiate starting resources for colour-blind users

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -26,7 +26,7 @@
 }
 else if (Resource is { State: ResourceStates.StartingState })
 {
-    <FluentIcon Icon="Icons.Filled.Size16.Circle"
+    <FluentIcon Icon="Icons.Regular.Size16.CircleHint"
                 Color="Color.Info"
                 Class="severity-icon" />
 }


### PR DESCRIPTION
This makes the difference between 'Starting' and 'Unknown' states visually differentiable by glyph, rather than colour alone. Follows on from #3401.

## Before

![image](https://github.com/dotnet/aspire/assets/350947/293df65d-fa98-4d9d-a90c-0256719d9829)

## After

![image](https://github.com/dotnet/aspire/assets/350947/7eb97e93-ca88-41d5-bd88-79c37ed4d451)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3689)