### PR TITLE
Add integration test for OpenIDConnect

### DIFF
--- a/spelling.dic
+++ b/spelling.dic
@@ -36,8 +36,10 @@ nats
 noreferrer
 noopener
 npgsql
+oauth
 oninput
 openai
+openid
 orleans
 otel
 otlp

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -62,8 +62,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     /// Create a new instance of the <see cref="DashboardWebApplication"/> class.
     /// </summary>
     /// <param name="configureBuilder">Configuration the internal app builder. This is for unit testing.</param>
-    /// <param name="requireHttpsMetadataForOpenIdConnect">Allows the OpenIdConnect infrastructure to work without HTTPS, for unit testing purposes only.</param>
-    public DashboardWebApplication(Action<WebApplicationBuilder>? configureBuilder = null, bool requireHttpsMetadataForOpenIdConnect = true)
+    public DashboardWebApplication(Action<WebApplicationBuilder>? configureBuilder = null)
     {
         var builder = WebApplication.CreateBuilder();
 
@@ -117,7 +116,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             builder.Services.Configure<HttpsRedirectionOptions>(options => options.HttpsPort = browserHttpsPort);
         }
 
-        ConfigureAuthentication(builder, dashboardOptions, requireHttpsMetadataForOpenIdConnect);
+        ConfigureAuthentication(builder, dashboardOptions);
 
         // Add services to the container.
         builder.Services.AddRazorComponents().AddInteractiveServerComponents();
@@ -444,7 +443,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
     }
 
-    private static void ConfigureAuthentication(WebApplicationBuilder builder, DashboardOptions dashboardOptions, bool requireHttpsMetadataForOpenIdConnect)
+    private static void ConfigureAuthentication(WebApplicationBuilder builder, DashboardOptions dashboardOptions)
     {
         var authentication = builder.Services
             .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
@@ -514,10 +513,6 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
                     // Avoid "message.State is null or empty" due to use of CallbackPath above.
                     options.SkipUnrecognizedRequests = true;
-
-                    // Allow the requirement of HTTPS communication with the OpenIdConnect authority to be
-                    // relaxed, for unit testing purposes only.
-                    options.RequireHttpsMetadata = requireHttpsMetadataForOpenIdConnect;
                 });
                 break;
             case FrontendAuthMode.BrowserToken:

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -513,6 +513,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
                     // Avoid "message.State is null or empty" due to use of CallbackPath above.
                     options.SkipUnrecognizedRequests = true;
+
+                    // TEMPORARY: Just adding this to validate if it unblocks tests in CI
+                    options.RequireHttpsMetadata = false;
                 });
                 break;
             case FrontendAuthMode.BrowserToken:

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -14,11 +14,11 @@ using Xunit.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration;
 
-public class FrontendAuthTests
+public class FrontendBrowserTokenAuthTests
 {
     private readonly ITestOutputHelper _testOutputHelper;
 
-    public FrontendAuthTests(ITestOutputHelper testOutputHelper)
+    public FrontendBrowserTokenAuthTests(ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper;
     }

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
@@ -122,8 +122,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
                 config[DashboardConfigNames.ResourceServiceClientAuthModeName.ConfigKey] = "Unsecured";
                 config[DashboardConfigNames.ResourceServiceUrlName.ConfigKey] = "https://localhost:1234"; // won't actually exist
 
-                // Configure OIDC. We must use an actual IdP because the provider will query "/.well-known/openid-configuration"
-                // at the authority.
+                // Configure OIDC. It (the RP) will communicate with the mock authority (IdP) spun up for this test.
                 config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = "OpenIdConnect";
                 config["Authentication:Schemes:OpenIdConnect:Authority"] = authorityUrl;
                 config["Authentication:Schemes:OpenIdConnect:ClientId"] = "MyClientId";

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
@@ -27,12 +27,12 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
         // Create a fake identity provider that will return well-known configuration for OIDC to use,
         // so that we don't have to make HTTP requests across the internet from unit tests.
         var idProvider = new WebHostBuilder()
-            .UseKestrel(options =>
-            {
-                // Bind to loopback on a random available port
-                options.Listen(IPAddress.Loopback, 0, listenOptions => listenOptions.UseHttps());
-            })
+            // Bind to loopback on a random available port
+            .UseKestrel(options => options.Listen(IPAddress.Loopback, 0, listenOptions => listenOptions.UseHttps()))
+            // Respond with our configuration, for any request
             .Configure(app => app.Run(async context => await context.Response.WriteAsync(wellKnownConfiguration)))
+            // Configure logging to the console
+            .ConfigureLogging(logging => logging.AddConsole())
             .Build();
 
         await idProvider.StartAsync();

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
@@ -1,19 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using System.Net;
 using System.Web;
 using Aspire.Hosting;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Server.Features;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.Tokens;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,95 +14,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
     [Fact]
     public async Task Get_Unauthenticated_RedirectsToAuthority()
     {
-        // Create a fake identity provider that will return well-known configuration for OIDC to use,
-        // so that we don't have to make HTTP requests across the internet from unit tests.
-        var idProvider = new WebHostBuilder()
-            .ConfigureServices(services => services.AddRouting())
-            // Bind to loopback on a random available port
-            .UseKestrel(options => options.Listen(IPAddress.Loopback, 0))
-            //.UseKestrel(options => options.Listen(IPAddress.Loopback, 0, listenOptions => listenOptions.UseHttps()))
-            .Configure(app =>
-            {
-                // Based on code from https://github.com/dotnet/aspnetcore/blob/3f99d45b0b7d8f0427a3d98acc63098694613362/src/Components/test/testassets/Components.TestServer/RemoteAuthenticationStartup.cs#L37-L94
-
-                var issuer = "";
-                app.UseRouting();
-                app.UseEndpoints(endpoints =>
-                {
-                    endpoints.MapGet(
-                        ".well-known/openid-configuration",
-                        (HttpRequest request, [FromHeader] string host) =>
-                        {
-                            issuer = $"{(request.IsHttps ? "https" : "http")}://{host}";
-                            return Results.Json(new
-                            {
-                                issuer,
-                                authorization_endpoint = $"{issuer}/authorize",
-                                token_endpoint = $"{issuer}/token",
-                            });
-                        });
-
-                    var lastCode = "";
-                    endpoints.MapGet(
-                        "authorize",
-                        (string redirect_uri, string? state, string? prompt, bool? preservedExtraQueryParams) =>
-                        {
-                            // Require interaction so silent sign-in does not skip RedirectToLogin.razor.
-                            if (prompt == "none")
-                            {
-                                return Results.Redirect($"{redirect_uri}?error=interaction_required&state={state}");
-                            }
-
-                            // Verify that the extra query parameters added by RedirectToLogin.razor are preserved.
-                            if (preservedExtraQueryParams != true)
-                            {
-                                return Results.Redirect($"{redirect_uri}?error=invalid_request&error_description=extraQueryParams%20not%20preserved&state={state}");
-                            }
-
-                            lastCode = Random.Shared.Next().ToString(CultureInfo.InvariantCulture);
-                            return Results.Redirect($"{redirect_uri}?code={lastCode}&state={state}");
-                        });
-
-                    var jwtHandler = new JsonWebTokenHandler();
-                    endpoints.MapPost(
-                        "token",
-                        ([FromForm] string code) =>
-                        {
-                            if (string.IsNullOrEmpty(lastCode) && code != lastCode)
-                            {
-                                return Results.BadRequest("Bad code");
-                            }
-
-                            return Results.Json(new
-                            {
-                                token_type = "Bearer",
-                                scope = "openid profile",
-                                expires_in = 3600,
-                                id_token = jwtHandler.CreateToken(new SecurityTokenDescriptor
-                                {
-                                    Issuer = issuer,
-                                    Audience = "s6BhdRkqt3",
-                                    Claims = new Dictionary<string, object>
-                                    {
-                                        ["sub"] = "248289761001",
-                                        ["name"] = "Jane Doe",
-                                    },
-                                }),
-                            });
-                        }).DisableAntiforgery();
-                });
-            })
-            // Configure logging to the console
-            .ConfigureLogging(logging => logging.AddConsole())
-            .Build();
-
-        await idProvider.StartAsync();
-
-        var serverAddress = idProvider.ServerFeatures.Get<IServerAddressesFeature>();
-        Assert.NotNull(serverAddress);
-
-        var authorityUrl = serverAddress.Addresses.First().Replace("127.0.0.1", "localhost");
-        Assert.StartsWith("http://localhost", authorityUrl);
+        await using var authority = await MockOpenIdAuthority.CreateAsync();
 
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(
             testOutputHelper,
@@ -124,7 +26,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
 
                 // Configure OIDC. It (the RP) will communicate with the mock authority (IdP) spun up for this test.
                 config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = "OpenIdConnect";
-                config["Authentication:Schemes:OpenIdConnect:Authority"] = authorityUrl;
+                config["Authentication:Schemes:OpenIdConnect:Authority"] = authority.Url;
                 config["Authentication:Schemes:OpenIdConnect:ClientId"] = "MyClientId";
                 config["Authentication:Schemes:OpenIdConnect:ClientSecret"] = "MyClientSecret";
             });
@@ -158,7 +60,5 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("openid profile", query.Get("scope"));
 
         await app.StopAsync();
-
-        await idProvider.StopAsync();
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
@@ -1,0 +1,124 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Web;
+using Aspire.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Dashboard.Tests.Integration;
+
+public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task Get_Unauthenticated_RedirectsToAuthority()
+    {
+        // The well-known configuration JSON for our mock OpenIDConnect authority.
+        // Will be populate after the server is bound, as it needs to contain the bound
+        // port number which we won't have until later.
+        var wellKnownConfiguration = "";
+
+        // Create a fake identity provider that will return well-known configuration for OIDC to use,
+        // so that we don't have to make HTTP requests across the internet from unit tests.
+        var idProvider = new WebHostBuilder()
+            .UseKestrel(options =>
+            {
+                // Bind to loopback on a random available port
+                options.Listen(IPAddress.Loopback, 0, listenOptions => listenOptions.UseHttps());
+            })
+            .Configure(app => app.Run(async context => await context.Response.WriteAsync(wellKnownConfiguration)))
+            .Build();
+
+        await idProvider.StartAsync();
+
+        var serverAddress = idProvider.ServerFeatures.Get<IServerAddressesFeature>();
+        Assert.NotNull(serverAddress);
+
+        var authorityUrl = serverAddress.Addresses.First().Replace("127.0.0.1", "localhost");
+        Assert.StartsWith("https://localhost", authorityUrl);
+
+        // Based on configuration from: https://login.microsoftonline.com/<directory-id>/v2.0/.well-known/openid-configuration
+        wellKnownConfiguration = $$"""
+            {
+                "token_endpoint": "{{authorityUrl}}/oauth2/v2.0/token",
+                "token_endpoint_auth_methods_supported": [ "client_secret_post", "private_key_jwt", "client_secret_basic" ],
+                "jwks_uri": "{{authorityUrl}}/discovery/v2.0/keys",
+                "response_modes_supported": [ "query", "fragment", "form_post" ],
+                "subject_types_supported": [ "pairwise" ],
+                "id_token_signing_alg_values_supported": [ "RS256" ],
+                "response_types_supported": [ "code", "id_token", "code id_token", "id_token token" ],
+                "scopes_supported": [ "openid", "profile", "email", "offline_access" ],
+                "issuer": "{{authorityUrl}}/v2.0",
+                "request_uri_parameter_supported": false,
+                "userinfo_endpoint": "https://graph.microsoft.com/oidc/userinfo",
+                "authorization_endpoint": "{{authorityUrl}}/oauth2/v2.0/authorize",
+                "device_authorization_endpoint": "{{authorityUrl}}/oauth2/v2.0/devicecode",
+                "http_logout_supported": true,
+                "frontchannel_logout_supported": true,
+                "end_session_endpoint": "{{authorityUrl}}/oauth2/v2.0/logout",
+                "claims_supported": [ "sub", "iss", "cloud_instance_name", "cloud_instance_host_name", "cloud_graph_host_name", "msgraph_host",
+                    "aud", "exp", "iat", "auth_time", "acr", "nonce", "preferred_username", "name", "tid", "ver", "at_hash", "c_hash", "email" ],
+                "kerberos_endpoint": "{{authorityUrl}}/kerberos",
+                "tenant_region_scope": "WW",
+                "cloud_instance_name": "microsoftonline.com",
+                "cloud_graph_host_name": "graph.windows.net",
+                "msgraph_host": "graph.microsoft.com",
+                "rbac_url": "https://pas.windows.net"
+            }
+            """;
+
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(
+            testOutputHelper,
+            additionalConfiguration: config =>
+            {
+                // Configure the resource service, as otherwise HTTP requests are redirected to /structuredlogs before OIDC
+                config[DashboardConfigNames.ResourceServiceClientAuthModeName.ConfigKey] = "Unsecured";
+                config[DashboardConfigNames.ResourceServiceUrlName.ConfigKey] = "https://localhost:1234"; // won't actually exist
+
+                // Configure OIDC. We must use an actual IdP because the provider will query "/.well-known/openid-configuration"
+                // at the authority.
+                config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = "OpenIdConnect";
+                config["Authentication:Schemes:OpenIdConnect:Authority"] = authorityUrl;
+                config["Authentication:Schemes:OpenIdConnect:ClientId"] = "MyClientId";
+                config["Authentication:Schemes:OpenIdConnect:ClientSecret"] = "MyClientSecret";
+            });
+
+        await app.StartAsync();
+
+        var handler = new HttpClientHandler()
+        {
+            // Don't follow redirects. We want to validate where the redirect would take us.
+            AllowAutoRedirect = false
+        };
+
+        using var client = new HttpClient(handler) { BaseAddress = new Uri($"http://{app.FrontendEndPointAccessor().EndPoint}") };
+
+        // Act
+        var response = await client.GetAsync("/");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+
+        var redirectedTo = response.Headers.Location;
+
+        Assert.NotNull(redirectedTo);
+        Assert.True(redirectedTo.IsAbsoluteUri);
+        Assert.Equal("localhost", redirectedTo.Host);
+        Assert.Equal("/oauth2/v2.0/authorize", redirectedTo.AbsolutePath);
+
+        var query = HttpUtility.ParseQueryString(redirectedTo.Query);
+        Assert.Equal("MyClientId", query.Get("client_id"));
+        Assert.Equal("code", query.Get("response_type"));
+        Assert.Equal("openid profile", query.Get("scope"));
+
+        await app.StopAsync();
+
+        await idProvider.StopAsync();
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
@@ -29,6 +29,8 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
                 config["Authentication:Schemes:OpenIdConnect:Authority"] = authority.Url;
                 config["Authentication:Schemes:OpenIdConnect:ClientId"] = "MyClientId";
                 config["Authentication:Schemes:OpenIdConnect:ClientSecret"] = "MyClientSecret";
+                // Allow the requirement of HTTPS communication with the OpenIdConnect authority to be relaxed during tests.
+                config["Authentication:Schemes:OpenIdConnect:RequireHttpsMetadata"] = "false";
             });
 
         await app.StartAsync();

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
@@ -29,7 +29,8 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
         var idProvider = new WebHostBuilder()
             .ConfigureServices(services => services.AddRouting())
             // Bind to loopback on a random available port
-            .UseKestrel(options => options.Listen(IPAddress.Loopback, 0, listenOptions => listenOptions.UseHttps()))
+            .UseKestrel(options => options.Listen(IPAddress.Loopback, 0))
+            //.UseKestrel(options => options.Listen(IPAddress.Loopback, 0, listenOptions => listenOptions.UseHttps()))
             .Configure(app =>
             {
                 // Based on code from https://github.com/dotnet/aspnetcore/blob/3f99d45b0b7d8f0427a3d98acc63098694613362/src/Components/test/testassets/Components.TestServer/RemoteAuthenticationStartup.cs#L37-L94
@@ -111,7 +112,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
         Assert.NotNull(serverAddress);
 
         var authorityUrl = serverAddress.Addresses.First().Replace("127.0.0.1", "localhost");
-        Assert.StartsWith("https://localhost", authorityUrl);
+        Assert.StartsWith("http://localhost", authorityUrl);
 
         await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(
             testOutputHelper,

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -32,7 +32,9 @@ public static class IntegrationTestHelpers
             [DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "http://127.0.0.1:0",
             [DashboardConfigNames.DashboardOtlpUrlName.ConfigKey] = "http://127.0.0.1:0",
             [DashboardConfigNames.DashboardOtlpAuthModeName.ConfigKey] = nameof(OtlpAuthMode.Unsecured),
-            [DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.Unsecured)
+            [DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.Unsecured),
+            // Allow the requirement of HTTPS communication with the OpenIdConnect authority to be relaxed during tests.
+            ["Authentication:Schemes:OpenIdConnect:RequireHttpsMetadata"] = "false"
         };
 
         additionalConfiguration?.Invoke(initialData);
@@ -55,7 +57,7 @@ public static class IntegrationTestHelpers
                 {
                     sources.Remove(item);
                 }
-            }            
+            }
             builder.Configuration.AddConfiguration(config);
 
             builder.Logging.AddXunit(testOutputHelper);
@@ -71,8 +73,7 @@ public static class IntegrationTestHelpers
                     options.ServerCertificate = s_testCertificate;
                 });
             });
-        },
-        requireHttpsMetadataForOpenIdConnect: false);
+        });
 
         return dashboardWebApplication;
     }

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -71,7 +71,8 @@ public static class IntegrationTestHelpers
                     options.ServerCertificate = s_testCertificate;
                 });
             });
-        });
+        },
+        requireHttpsMetadataForOpenIdConnect: false);
 
         return dashboardWebApplication;
     }

--- a/tests/Aspire.Dashboard.Tests/Integration/MockOpenIdAuthority.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/MockOpenIdAuthority.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Integration;
+
+internal static class MockOpenIdAuthority
+{
+    /// <summary>
+    /// Creates a mock authority (identity provider) that will handle the basics of the protocol, for use in automated tests.
+    /// </summary>
+    public static async Task<Authority> CreateAsync()
+    {
+        var webHost = new WebHostBuilder()
+            .ConfigureServices(services => services.AddRouting())
+            .UseKestrel(options =>
+            {
+                // Bind to loopback on a random available port
+                options.Listen(IPAddress.Loopback, 0);
+            })
+            .Configure(app =>
+            {
+                // Based on code from https://github.com/dotnet/aspnetcore/blob/3f99d45b0b7d8f0427a3d98acc63098694613362/src/Components/test/testassets/Components.TestServer/RemoteAuthenticationStartup.cs#L37-L94
+
+                app.UseRouting();
+                app.UseEndpoints(endpoints =>
+                {
+                    var issuer = "";
+                    var lastCode = "";
+                    var jwtHandler = new JsonWebTokenHandler();
+
+                    endpoints.MapGet(
+                        ".well-known/openid-configuration",
+                        (HttpRequest request, [FromHeader] string host) =>
+                        {
+                            issuer = $"{(request.IsHttps ? "https" : "http")}://{host}";
+                            return Results.Json(new
+                            {
+                                issuer,
+                                authorization_endpoint = $"{issuer}/authorize",
+                                token_endpoint = $"{issuer}/token",
+                            });
+                        });
+
+                    endpoints.MapGet(
+                        "authorize",
+                        (string redirect_uri, string? state, string? prompt, bool? preservedExtraQueryParams) =>
+                        {
+                            // Require interaction so silent sign-in does not skip RedirectToLogin.razor.
+                            if (prompt == "none")
+                            {
+                                return Results.Redirect($"{redirect_uri}?error=interaction_required&state={state}");
+                            }
+
+                            // Verify that the extra query parameters added by RedirectToLogin.razor are preserved.
+                            if (preservedExtraQueryParams != true)
+                            {
+                                return Results.Redirect($"{redirect_uri}?error=invalid_request&error_description=extraQueryParams%20not%20preserved&state={state}");
+                            }
+
+                            lastCode = Random.Shared.Next().ToString(CultureInfo.InvariantCulture);
+                            return Results.Redirect($"{redirect_uri}?code={lastCode}&state={state}");
+                        });
+
+                    endpoints.MapPost(
+                        "token",
+                        ([FromForm] string code) =>
+                        {
+                            if (string.IsNullOrEmpty(lastCode) && code != lastCode)
+                            {
+                                return Results.BadRequest("Bad code");
+                            }
+
+                            return Results.Json(new
+                            {
+                                token_type = "Bearer",
+                                scope = "openid profile",
+                                expires_in = 3600,
+                                id_token = jwtHandler.CreateToken(new SecurityTokenDescriptor
+                                {
+                                    Issuer = issuer,
+                                    Audience = "s6BhdRkqt3",
+                                    Claims = new Dictionary<string, object>
+                                    {
+                                        ["sub"] = "248289761001",
+                                        ["name"] = "Jane Doe",
+                                    },
+                                }),
+                            });
+                        }).DisableAntiforgery();
+                });
+            })
+            .ConfigureLogging(logging =>
+            {
+                // Log to the console
+                logging.AddConsole();
+            })
+            .Build();
+
+        await webHost.StartAsync();
+
+        return new Authority(webHost, url: GetBoundAddress());
+
+        string GetBoundAddress()
+        {
+            var serverAddress = webHost.ServerFeatures.Get<IServerAddressesFeature>();
+
+            Assert.NotNull(serverAddress);
+
+            var authorityUrl = serverAddress.Addresses.First().Replace("127.0.0.1", "localhost");
+
+            Assert.StartsWith("http://localhost", authorityUrl);
+
+            return authorityUrl;
+        }
+    }
+
+    public sealed class Authority(IWebHost webHost, string url) : IAsyncDisposable
+    {
+        public string Url => url;
+
+        public async ValueTask DisposeAsync()
+        {
+            await webHost.StopAsync();
+            webHost.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Contributes to #3199

This test ensures that the server redirects an unauthenticated user to the OpenID authority correctly.

Thanks to @halter73 for [pointing towards a technique](https://github.com/dotnet/aspire/pull/3033#issuecomment-2016893891) for mocking an OpenID authority for testing purposes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3692)