### PR TITLE
Convert Seq component to use OTEL's `AddProcessor` instead of `AddOtlpExporter`

### DIFF
--- a/Aspire.sln
+++ b/Aspire.sln
@@ -447,6 +447,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrleansClient", "playground
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansContracts", "playground\orleans\OrleansContracts\OrleansContracts.csproj", "{75760E8A-7025-4F6A-B152-6622688D0E7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Seq.Tests", "tests\Aspire.Seq.Tests\Aspire.Seq.Tests.csproj", "{0505F739-6F85-4502-A554-77E0D7325F26}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1173,6 +1175,10 @@ Global
 		{75760E8A-7025-4F6A-B152-6622688D0E7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75760E8A-7025-4F6A-B152-6622688D0E7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{75760E8A-7025-4F6A-B152-6622688D0E7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0505F739-6F85-4502-A554-77E0D7325F26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0505F739-6F85-4502-A554-77E0D7325F26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0505F739-6F85-4502-A554-77E0D7325F26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0505F739-6F85-4502-A554-77E0D7325F26}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1386,6 +1392,7 @@ Global
 		{8191109E-130C-47F3-B84E-82070A6CD269} = {4981B3A5-4AFD-4191-BF7D-8692D9783D60}
 		{906B5687-31AD-4364-AD9F-B4B26113462D} = {8BAF2119-8370-4E9E-A887-D92506F8C727}
 		{75760E8A-7025-4F6A-B152-6622688D0E7D} = {8BAF2119-8370-4E9E-A887-D92506F8C727}
+		{0505F739-6F85-4502-A554-77E0D7325F26} = {4981B3A5-4AFD-4191-BF7D-8692D9783D60}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6DCEDFEC-988E-4CB3-B45B-191EB5086E0C}

--- a/playground/seq/Seq.AppHost/aspire-manifest.json
+++ b/playground/seq/Seq.AppHost/aspire-manifest.json
@@ -3,7 +3,7 @@
     "seq": {
       "type": "container.v0",
       "connectionString": "{seq.bindings.http.url}",
-      "image": "datalust/seq:2024.1",
+      "image": "docker.io/datalust/seq:2024.2",
       "env": {
         "ACCEPT_EULA": "Y"
       },

--- a/src/Aspire.Hosting.Seq/SeqContainerImageTags.cs
+++ b/src/Aspire.Hosting.Seq/SeqContainerImageTags.cs
@@ -7,5 +7,5 @@ internal static class SeqContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "datalust/seq";
-    public const string Tag = "2024.1";
+    public const string Tag = "2024.2";
 }

--- a/src/Components/Aspire.Seq/AspireSeqExtensions.cs
+++ b/src/Components/Aspire.Seq/AspireSeqExtensions.cs
@@ -57,16 +57,16 @@ public static class AspireSeqExtensions
         }
 
         builder.Services.Configure<OpenTelemetryLoggerOptions>(logging => logging.AddProcessor(
-            _ => settings.Logs.ExportProcessorType == ExportProcessorType.Batch
-                ? new BatchLogRecordExportProcessor(new OtlpLogExporter(settings.Logs))
-                : new SimpleLogRecordExportProcessor(new OtlpLogExporter(settings.Logs))
-            ));
+            _ => settings.Logs.ExportProcessorType switch {
+                ExportProcessorType.Batch => new BatchLogRecordExportProcessor(new OtlpLogExporter(settings.Logs)),
+                _ => new SimpleLogRecordExportProcessor(new OtlpLogExporter(settings.Logs))
+            }));
 
         builder.Services.ConfigureOpenTelemetryTracerProvider(tracing => tracing.AddProcessor(
-            _ => settings.Traces.ExportProcessorType == ExportProcessorType.Batch
-                ? new BatchActivityExportProcessor(new OtlpTraceExporter(settings.Traces))
-                : new SimpleActivityExportProcessor(new OtlpTraceExporter(settings.Traces))
-            ));
+            _ => settings.Traces.ExportProcessorType switch {
+                ExportProcessorType.Batch => new BatchActivityExportProcessor(new OtlpTraceExporter(settings.Traces)),
+                _ => new SimpleActivityExportProcessor(new OtlpTraceExporter(settings.Traces))
+            }));
 
         if (settings.HealthChecks)
         {

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -72,7 +72,7 @@
             },
             "ServerUrl": {
               "type": "string",
-              "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789\""
+              "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789. Overrides endpoints set on Logs and Traces .\""
             },
             "Traces": {
               "type": "object",

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -23,9 +23,101 @@
               "type": "boolean",
               "description": "Gets or sets a boolean value that indicates whetherthe Seq server health check is enabled or not."
             },
+            "LogExporterOptions": {
+              "type": "object",
+              "properties": {
+                "BatchExportProcessorOptions": {
+                  "type": "object",
+                  "properties": {
+                    "ExporterTimeoutMilliseconds": {
+                      "type": "integer"
+                    },
+                    "MaxExportBatchSize": {
+                      "type": "integer"
+                    },
+                    "MaxQueueSize": {
+                      "type": "integer"
+                    },
+                    "ScheduledDelayMilliseconds": {
+                      "type": "integer"
+                    }
+                  },
+                  "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                },
+                "Endpoint": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "ExportProcessorType": {
+                  "enum": [
+                    "Simple",
+                    "Batch"
+                  ],
+                  "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
+                },
+                "Headers": {
+                  "type": "string"
+                },
+                "Protocol": {
+                  "enum": [
+                    "Grpc",
+                    "HttpProtobuf"
+                  ]
+                },
+                "TimeoutMilliseconds": {
+                  "type": "integer"
+                }
+              }
+            },
             "ServerUrl": {
               "type": "string",
               "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789\""
+            },
+            "TraceExporterOptions": {
+              "type": "object",
+              "properties": {
+                "BatchExportProcessorOptions": {
+                  "type": "object",
+                  "properties": {
+                    "ExporterTimeoutMilliseconds": {
+                      "type": "integer"
+                    },
+                    "MaxExportBatchSize": {
+                      "type": "integer"
+                    },
+                    "MaxQueueSize": {
+                      "type": "integer"
+                    },
+                    "ScheduledDelayMilliseconds": {
+                      "type": "integer"
+                    }
+                  },
+                  "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                },
+                "Endpoint": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "ExportProcessorType": {
+                  "enum": [
+                    "Simple",
+                    "Batch"
+                  ],
+                  "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
+                },
+                "Headers": {
+                  "type": "string"
+                },
+                "Protocol": {
+                  "enum": [
+                    "Grpc",
+                    "HttpProtobuf"
+                  ]
+                },
+                "TimeoutMilliseconds": {
+                  "type": "integer"
+                }
+              }
             }
           },
           "description": "Provides the client configuration settings for connecting telemetry to a Seq server."

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -23,7 +23,7 @@
               "type": "boolean",
               "description": "Gets or sets a boolean value that indicates whetherthe Seq server health check is enabled or not."
             },
-            "LogExporterOptions": {
+            "Logs": {
               "type": "object",
               "properties": {
                 "BatchExportProcessorOptions": {
@@ -74,7 +74,7 @@
               "type": "string",
               "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789\""
             },
-            "TraceExporterOptions": {
+            "Traces": {
               "type": "object",
               "properties": {
                 "BatchExportProcessorOptions": {

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -67,7 +67,8 @@
                 "TimeoutMilliseconds": {
                   "type": "integer"
                 }
-              }
+              },
+              "description": "Gets OTLP exporter options for logs."
             },
             "ServerUrl": {
               "type": "string",
@@ -117,7 +118,8 @@
                 "TimeoutMilliseconds": {
                   "type": "integer"
                 }
-              }
+              },
+              "description": "Gets OTLP exporter options for traces."
             }
           },
           "description": "Provides the client configuration settings for connecting telemetry to a Seq server."

--- a/src/Components/Aspire.Seq/PublicAPI.Unshipped.txt
+++ b/src/Components/Aspire.Seq/PublicAPI.Unshipped.txt
@@ -8,4 +8,4 @@ Aspire.Seq.SeqSettings.SeqSettings() -> void
 Aspire.Seq.SeqSettings.ServerUrl.get -> string?
 Aspire.Seq.SeqSettings.ServerUrl.set -> void
 Microsoft.Extensions.Hosting.AspireSeqExtensions
-static Microsoft.Extensions.Hosting.AspireSeqExtensions.AddSeqEndpoint(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<Aspire.Seq.SeqSettings!>? configureSettings = null) -> void
+static Microsoft.Extensions.Hosting.AspireSeqExtensions.AddSeqEndpoint(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<Aspire.Seq.SeqSettings!>? configureSettings = null, System.Action<OpenTelemetry.Exporter.OtlpExporterOptions!>? logExporterOptions = null, System.Action<OpenTelemetry.Exporter.OtlpExporterOptions!>? traceExporterOptions = null) -> void

--- a/src/Components/Aspire.Seq/PublicAPI.Unshipped.txt
+++ b/src/Components/Aspire.Seq/PublicAPI.Unshipped.txt
@@ -4,8 +4,10 @@ Aspire.Seq.SeqSettings.ApiKey.get -> string?
 Aspire.Seq.SeqSettings.ApiKey.set -> void
 Aspire.Seq.SeqSettings.HealthChecks.get -> bool
 Aspire.Seq.SeqSettings.HealthChecks.set -> void
+Aspire.Seq.SeqSettings.LogExporterOptions.get -> OpenTelemetry.Exporter.OtlpExporterOptions!
 Aspire.Seq.SeqSettings.SeqSettings() -> void
 Aspire.Seq.SeqSettings.ServerUrl.get -> string?
 Aspire.Seq.SeqSettings.ServerUrl.set -> void
+Aspire.Seq.SeqSettings.TraceExporterOptions.get -> OpenTelemetry.Exporter.OtlpExporterOptions!
 Microsoft.Extensions.Hosting.AspireSeqExtensions
-static Microsoft.Extensions.Hosting.AspireSeqExtensions.AddSeqEndpoint(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<Aspire.Seq.SeqSettings!>? configureSettings = null, System.Action<OpenTelemetry.Exporter.OtlpExporterOptions!>? logExporterOptions = null, System.Action<OpenTelemetry.Exporter.OtlpExporterOptions!>? traceExporterOptions = null) -> void
+static Microsoft.Extensions.Hosting.AspireSeqExtensions.AddSeqEndpoint(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<Aspire.Seq.SeqSettings!>? configureSettings = null) -> void

--- a/src/Components/Aspire.Seq/PublicAPI.Unshipped.txt
+++ b/src/Components/Aspire.Seq/PublicAPI.Unshipped.txt
@@ -4,10 +4,10 @@ Aspire.Seq.SeqSettings.ApiKey.get -> string?
 Aspire.Seq.SeqSettings.ApiKey.set -> void
 Aspire.Seq.SeqSettings.HealthChecks.get -> bool
 Aspire.Seq.SeqSettings.HealthChecks.set -> void
-Aspire.Seq.SeqSettings.LogExporterOptions.get -> OpenTelemetry.Exporter.OtlpExporterOptions!
+Aspire.Seq.SeqSettings.Logs.get -> OpenTelemetry.Exporter.OtlpExporterOptions!
 Aspire.Seq.SeqSettings.SeqSettings() -> void
 Aspire.Seq.SeqSettings.ServerUrl.get -> string?
 Aspire.Seq.SeqSettings.ServerUrl.set -> void
-Aspire.Seq.SeqSettings.TraceExporterOptions.get -> OpenTelemetry.Exporter.OtlpExporterOptions!
+Aspire.Seq.SeqSettings.Traces.get -> OpenTelemetry.Exporter.OtlpExporterOptions!
 Microsoft.Extensions.Hosting.AspireSeqExtensions
 static Microsoft.Extensions.Hosting.AspireSeqExtensions.AddSeqEndpoint(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<Aspire.Seq.SeqSettings!>? configureSettings = null) -> void

--- a/src/Components/Aspire.Seq/README.md
+++ b/src/Components/Aspire.Seq/README.md
@@ -58,6 +58,19 @@ builder.AddSeqEndpoint("seq", settings => {
 });
 ```
 
+Delegates are also available to configure the OpenTelemetry exporters for logs and traces respectively:
+
+```csharp
+builder.AddSeqEndpoint("seq", settings => {
+    settings.HealthChecks = false;
+    settings.ServerUrl = "http://localhost:5341"
+}, logExporterOptions => {
+    logExporterOptions.TimeoutMilliseconds = 10000;
+}, traceExporterOptions => {
+    traceExporterOptions.TimeoutMilliseconds = 20000;
+});
+```
+
 ## AppHost extensions
 
 In your AppHost project, install the `Aspire.Hosting.Seq` library with [NuGet](https://www.nuget.org):

--- a/src/Components/Aspire.Seq/README.md
+++ b/src/Components/Aspire.Seq/README.md
@@ -54,20 +54,8 @@ Also you can pass the `Action<SeqSettings> configureSettings` delegate to set up
 ```csharp
 builder.AddSeqEndpoint("seq", settings => {
     settings.HealthChecks = false;
-    settings.ServerUrl = "http://localhost:5341"
-});
-```
-
-Delegates are also available to configure the OpenTelemetry exporters for logs and traces respectively:
-
-```csharp
-builder.AddSeqEndpoint("seq", settings => {
-    settings.HealthChecks = false;
-    settings.ServerUrl = "http://localhost:5341"
-}, logExporterOptions => {
-    logExporterOptions.TimeoutMilliseconds = 10000;
-}, traceExporterOptions => {
-    traceExporterOptions.TimeoutMilliseconds = 20000;
+    settings.ServerUrl = "http://localhost:5341";
+    settings.LogExporterOptions.TimeoutMilliseconds = 10000;
 });
 ```
 

--- a/src/Components/Aspire.Seq/README.md
+++ b/src/Components/Aspire.Seq/README.md
@@ -55,7 +55,7 @@ Also you can pass the `Action<SeqSettings> configureSettings` delegate to set up
 builder.AddSeqEndpoint("seq", settings => {
     settings.HealthChecks = false;
     settings.ServerUrl = "http://localhost:5341";
-    settings.LogExporterOptions.TimeoutMilliseconds = 10000;
+    settings.Logs.TimeoutMilliseconds = 10000;
 });
 ```
 

--- a/src/Components/Aspire.Seq/SeqSettings.cs
+++ b/src/Components/Aspire.Seq/SeqSettings.cs
@@ -28,7 +28,7 @@ public sealed class SeqSettings
     /// <summary>
     /// Gets OTLP exporter options for logs.
     /// </summary>
-    public OtlpExporterOptions LogExporterOptions
+    public OtlpExporterOptions Logs
     {
         get;
         private set;
@@ -37,7 +37,7 @@ public sealed class SeqSettings
     /// <summary>
     /// Gets OTLP exporter options for traces.
     /// </summary>
-    public OtlpExporterOptions TraceExporterOptions
+    public OtlpExporterOptions Traces
     {
         get;
         private set;

--- a/src/Components/Aspire.Seq/SeqSettings.cs
+++ b/src/Components/Aspire.Seq/SeqSettings.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using OpenTelemetry.Exporter;
+
 namespace Aspire.Seq;
 
 /// <summary>
@@ -22,4 +24,23 @@ public sealed class SeqSettings
     /// Gets or sets the base URL of the Seq server (including protocol and port). E.g. "https://example.seq.com:6789"
     /// </summary>
     public string? ServerUrl { get; set; }
+
+    /// <summary>
+    /// Gets OTLP exporter options for logs.
+    /// </summary>
+    public OtlpExporterOptions LogExporterOptions
+    {
+        get;
+        private set;
+    } = new ();
+
+    /// <summary>
+    /// Gets OTLP exporter options for traces.
+    /// </summary>
+    public OtlpExporterOptions TraceExporterOptions
+    {
+        get;
+        private set;
+    } = new ();
+
 }

--- a/src/Components/Aspire.Seq/SeqSettings.cs
+++ b/src/Components/Aspire.Seq/SeqSettings.cs
@@ -28,17 +28,10 @@ public sealed class SeqSettings
     /// <summary>
     /// Gets OTLP exporter options for logs.
     /// </summary>
-    public OtlpExporterOptions Logs
-    {
-        get;
-    } = new ();
+    public OtlpExporterOptions Logs { get; } = new ();
 
     /// <summary>
     /// Gets OTLP exporter options for traces.
     /// </summary>
-    public OtlpExporterOptions Traces
-    {
-        get;
-    } = new ();
-
+    public OtlpExporterOptions Traces { get; } = new ();
 }

--- a/src/Components/Aspire.Seq/SeqSettings.cs
+++ b/src/Components/Aspire.Seq/SeqSettings.cs
@@ -31,7 +31,6 @@ public sealed class SeqSettings
     public OtlpExporterOptions Logs
     {
         get;
-        private set;
     } = new ();
 
     /// <summary>
@@ -40,7 +39,6 @@ public sealed class SeqSettings
     public OtlpExporterOptions Traces
     {
         get;
-        private set;
     } = new ();
 
 }

--- a/src/Components/Aspire.Seq/SeqSettings.cs
+++ b/src/Components/Aspire.Seq/SeqSettings.cs
@@ -21,7 +21,7 @@ public sealed class SeqSettings
     public string? ApiKey { get; set; }
 
     /// <summary>
-    /// Gets or sets the base URL of the Seq server (including protocol and port). E.g. "https://example.seq.com:6789"
+    /// Gets or sets the base URL of the Seq server (including protocol and port). E.g. "https://example.seq.com:6789. Overrides endpoints set on <c>Logs</c> and <c>Traces</c>."
     /// </summary>
     public string? ServerUrl { get; set; }
 

--- a/tests/Aspire.Seq.Tests/Aspire.Seq.Tests.csproj
+++ b/tests/Aspire.Seq.Tests/Aspire.Seq.Tests.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>$(NetCurrent)</TargetFramework>
+        <RunTestsOnHelix>true</RunTestsOnHelix>
+        <Nullable>enable</Nullable>
+        <RootNamespace>Aspire.Seq</RootNamespace>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Components\Aspire.Seq\Aspire.Seq.csproj" />
+    <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
+
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
+++ b/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
@@ -16,6 +16,7 @@ public class SeqTests
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.AddSeqEndpoint("seq", s =>
         {
+            s.HealthChecks = false;
             s.Logs.TimeoutMilliseconds = 1000;
             s.Traces.Protocol = OtlpExportProtocol.Grpc;
         });
@@ -54,6 +55,7 @@ public class SeqTests
         builder.AddSeqEndpoint("seq", s =>
         {
             settings = s;
+            s.HealthChecks = false;
             s.ApiKey = "ABCDE12345";
             s.Logs.Headers = "speed=fast,quality=good";
             s.Traces.Headers = "quality=good,speed=fast";

--- a/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
+++ b/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
@@ -1,0 +1,25 @@
+﻿
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Exporter;
+using Xunit;
+
+namespace Aspire.Seq.Tests;
+
+public class SeqTests
+{
+    [Fact]
+    public void SeqEndpointCanBeConfigured()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddSeqEndpoint("seq", s =>
+        {
+            s.LogExporterOptions.TimeoutMilliseconds = 1000;
+            s.TraceExporterOptions.Protocol = OtlpExportProtocol.Grpc;
+        });
+
+        using var host = builder.Build();
+    }
+}

--- a/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
+++ b/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
@@ -16,8 +16,8 @@ public class SeqTests
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.AddSeqEndpoint("seq", s =>
         {
-            s.LogExporterOptions.TimeoutMilliseconds = 1000;
-            s.TraceExporterOptions.Protocol = OtlpExportProtocol.Grpc;
+            s.Logs.TimeoutMilliseconds = 1000;
+            s.Traces.Protocol = OtlpExportProtocol.Grpc;
         });
 
         using var host = builder.Build();


### PR DESCRIPTION
OpenTelemetry's `AddOtlpExporter` now throws an exception, so the Seq component is not working. 

This PR switches to `AddProcessor` and adds some configuration work to compensate for `AddProcessor` not picking up .NET's OTEL configuration (as described by @CodeBlanch  [here](https://github.com/dotnet/aspire/compare/main...CodeBlanch:seq-otel-otlp-registration?expand=1)). Adding `OtlpExporterOptions` onto Seq's configuration makes it possible to set the most vital options. 

Changes due to https://github.com/dotnet/aspire/issues/3546

Thank you to @CodeBlanch for showing the way forward!


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3697)