### PR TITLE
Fix environment variable masking being reset on component re-render

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -106,7 +106,6 @@ public partial class ResourceDetails
 
     private void ResetResourceEnvironmentVariableMasks()
     {
-        _areEnvironmentVariablesMasked = true; // By default, mask environment variables
         foreach (var vm in Resource.Environment.Where(vm => vm.IsValueMasked != _areEnvironmentVariablesMasked))
         {
             vm.IsValueMasked = _areEnvironmentVariablesMasked;

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -31,6 +31,7 @@ public partial class ResourceDetails
     private bool IsSpecOnlyToggleDisabled => !Resource.Environment.All(i => !i.FromSpec) && !GetResourceValues().Any(v => v.KnownProperty == null);
 
     private bool _showAll;
+    private ResourceViewModel? _resource;
 
     private IQueryable<EnvironmentVariableViewModel> FilteredItems =>
         Resource.Environment.Where(vm =>
@@ -92,6 +93,18 @@ public partial class ResourceDetails
             new KnownProperty(KnownProperties.Container.Args, Loc[Resources.Resources.ResourcesDetailsContainerArgumentsProperty]),
             new KnownProperty(KnownProperties.Container.Ports, Loc[Resources.Resources.ResourcesDetailsContainerPortsProperty]),
         ];
+
+        _resource = Resource;
+        ResetResourceEnvironmentVariableMasks();
+    }
+
+    protected override void OnParametersSet()
+    {
+        if (!ReferenceEquals(Resource, _resource))
+        {
+            _resource = Resource;
+            ResetResourceEnvironmentVariableMasks();
+        }
     }
 
     protected override void OnAfterRender(bool firstRender)
@@ -104,6 +117,15 @@ public partial class ResourceDetails
             {
                 vm.IsValueMasked = _areEnvironmentVariablesMasked;
             }
+        }
+    }
+
+    private void ResetResourceEnvironmentVariableMasks()
+    {
+        _areEnvironmentVariablesMasked = true; // By default, mask environment variables
+        foreach (var vm in Resource.Environment.Where(vm => vm.IsValueMasked != _areEnvironmentVariablesMasked))
+        {
+            vm.IsValueMasked = _areEnvironmentVariablesMasked;
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -93,9 +93,6 @@ public partial class ResourceDetails
             new KnownProperty(KnownProperties.Container.Args, Loc[Resources.Resources.ResourcesDetailsContainerArgumentsProperty]),
             new KnownProperty(KnownProperties.Container.Ports, Loc[Resources.Resources.ResourcesDetailsContainerPortsProperty]),
         ];
-
-        _resource = Resource;
-        ResetResourceEnvironmentVariableMasks();
     }
 
     protected override void OnParametersSet()
@@ -104,19 +101,6 @@ public partial class ResourceDetails
         {
             _resource = Resource;
             ResetResourceEnvironmentVariableMasks();
-        }
-    }
-
-    protected override void OnAfterRender(bool firstRender)
-    {
-        if (firstRender)
-        {
-            // Initially set environment variable mask state to the default value of _areEnvironmentVariablesMasked
-            // Subsequent changes are handled by updating model.IsValueMasked in ToggleMaskState
-            foreach (var vm in Resource.Environment.Where(vm => vm.IsValueMasked != _areEnvironmentVariablesMasked))
-            {
-                vm.IsValueMasked = _areEnvironmentVariablesMasked;
-            }
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -94,11 +94,16 @@ public partial class ResourceDetails
         ];
     }
 
-    protected override void OnParametersSet()
+    protected override void OnAfterRender(bool firstRender)
     {
-        foreach (var vm in Resource.Environment.Where(vm => vm.IsValueMasked != _areEnvironmentVariablesMasked))
+        if (firstRender)
         {
-            vm.IsValueMasked = _areEnvironmentVariablesMasked;
+            // Initially set environment variable mask state to the default value of _areEnvironmentVariablesMasked
+            // Subsequent changes are handled by updating model.IsValueMasked in ToggleMaskState
+            foreach (var vm in Resource.Environment.Where(vm => vm.IsValueMasked != _areEnvironmentVariablesMasked))
+            {
+                vm.IsValueMasked = _areEnvironmentVariablesMasked;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #3693

We were setting the value of environment variable masks `OnParametersSet` to the view's default mask value, which is called after its parent pane's size changes and then re-rendered. This is only needed 1) on initial component render, to set masking to the default value, and 2) when the user toggles that default, which is already handled `ToggleMaskState`.

pre:
![environmentvariablesmaskpre](https://github.com/dotnet/aspire/assets/20359921/ff7c648e-89b7-4adb-ae1a-1894d456eac1)

post:
![environmentvariablesmaskpost](https://github.com/dotnet/aspire/assets/20359921/a6746538-1f59-4de1-a0d8-e08c34ce5f2f)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3708)