### PR TITLE
[release/8.0] Seq component is broken with latest UseOtlpExporter - Convert Seq component to use OTEL's `AddProcessor` instead of `AddOtlpExporter` (#3697)

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -11,7 +11,7 @@
     },
     {
       "placeholder": "TestKey123!",
-      "_justification": "This is fake API key, used in integration tests to try to connect to OTLP services."
+      "_justification": "This is fake API key, used in integration tests to try to connect to OTLP services and other various tests."
     },
     {
       "placeholder": "!321yeKtseT",

--- a/Aspire.sln
+++ b/Aspire.sln
@@ -447,6 +447,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrleansClient", "playground
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrleansContracts", "playground\orleans\OrleansContracts\OrleansContracts.csproj", "{75760E8A-7025-4F6A-B152-6622688D0E7D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Seq.Tests", "tests\Aspire.Seq.Tests\Aspire.Seq.Tests.csproj", "{0505F739-6F85-4502-A554-77E0D7325F26}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1173,6 +1175,10 @@ Global
 		{75760E8A-7025-4F6A-B152-6622688D0E7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{75760E8A-7025-4F6A-B152-6622688D0E7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{75760E8A-7025-4F6A-B152-6622688D0E7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0505F739-6F85-4502-A554-77E0D7325F26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0505F739-6F85-4502-A554-77E0D7325F26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0505F739-6F85-4502-A554-77E0D7325F26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0505F739-6F85-4502-A554-77E0D7325F26}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1386,6 +1392,7 @@ Global
 		{8191109E-130C-47F3-B84E-82070A6CD269} = {4981B3A5-4AFD-4191-BF7D-8692D9783D60}
 		{906B5687-31AD-4364-AD9F-B4B26113462D} = {8BAF2119-8370-4E9E-A887-D92506F8C727}
 		{75760E8A-7025-4F6A-B152-6622688D0E7D} = {8BAF2119-8370-4E9E-A887-D92506F8C727}
+		{0505F739-6F85-4502-A554-77E0D7325F26} = {4981B3A5-4AFD-4191-BF7D-8692D9783D60}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6DCEDFEC-988E-4CB3-B45B-191EB5086E0C}

--- a/playground/seq/Seq.AppHost/aspire-manifest.json
+++ b/playground/seq/Seq.AppHost/aspire-manifest.json
@@ -3,7 +3,7 @@
     "seq": {
       "type": "container.v0",
       "connectionString": "{seq.bindings.http.url}",
-      "image": "datalust/seq:2024.1",
+      "image": "docker.io/datalust/seq:2024.2",
       "env": {
         "ACCEPT_EULA": "Y"
       },

--- a/src/Aspire.Hosting.Seq/SeqContainerImageTags.cs
+++ b/src/Aspire.Hosting.Seq/SeqContainerImageTags.cs
@@ -7,5 +7,5 @@ internal static class SeqContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "datalust/seq";
-    public const string Tag = "2024.1";
+    public const string Tag = "2024.2";
 }

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -23,9 +23,103 @@
               "type": "boolean",
               "description": "Gets or sets a boolean value that indicates whetherthe Seq server health check is enabled or not."
             },
+            "Logs": {
+              "type": "object",
+              "properties": {
+                "BatchExportProcessorOptions": {
+                  "type": "object",
+                  "properties": {
+                    "ExporterTimeoutMilliseconds": {
+                      "type": "integer"
+                    },
+                    "MaxExportBatchSize": {
+                      "type": "integer"
+                    },
+                    "MaxQueueSize": {
+                      "type": "integer"
+                    },
+                    "ScheduledDelayMilliseconds": {
+                      "type": "integer"
+                    }
+                  },
+                  "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                },
+                "Endpoint": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "ExportProcessorType": {
+                  "enum": [
+                    "Simple",
+                    "Batch"
+                  ],
+                  "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
+                },
+                "Headers": {
+                  "type": "string"
+                },
+                "Protocol": {
+                  "enum": [
+                    "Grpc",
+                    "HttpProtobuf"
+                  ]
+                },
+                "TimeoutMilliseconds": {
+                  "type": "integer"
+                }
+              },
+              "description": "Gets OTLP exporter options for logs."
+            },
             "ServerUrl": {
               "type": "string",
-              "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789\""
+              "description": "Gets or sets the base URL of the Seq server (including protocol and port). E.g. \"https://example.seq.com:6789. Overrides endpoints set on Logs and Traces .\""
+            },
+            "Traces": {
+              "type": "object",
+              "properties": {
+                "BatchExportProcessorOptions": {
+                  "type": "object",
+                  "properties": {
+                    "ExporterTimeoutMilliseconds": {
+                      "type": "integer"
+                    },
+                    "MaxExportBatchSize": {
+                      "type": "integer"
+                    },
+                    "MaxQueueSize": {
+                      "type": "integer"
+                    },
+                    "ScheduledDelayMilliseconds": {
+                      "type": "integer"
+                    }
+                  },
+                  "description": "Gets or sets the BatchExportProcessor options. Ignored unless ExportProcessorType is Batch."
+                },
+                "Endpoint": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "ExportProcessorType": {
+                  "enum": [
+                    "Simple",
+                    "Batch"
+                  ],
+                  "description": "Gets or sets the export processor type to be used with the OpenTelemetry Protocol Exporter. The default value is 'OpenTelemetry.ExportProcessorType.Batch'."
+                },
+                "Headers": {
+                  "type": "string"
+                },
+                "Protocol": {
+                  "enum": [
+                    "Grpc",
+                    "HttpProtobuf"
+                  ]
+                },
+                "TimeoutMilliseconds": {
+                  "type": "integer"
+                }
+              },
+              "description": "Gets OTLP exporter options for traces."
             }
           },
           "description": "Provides the client configuration settings for connecting telemetry to a Seq server."

--- a/src/Components/Aspire.Seq/README.md
+++ b/src/Components/Aspire.Seq/README.md
@@ -54,7 +54,8 @@ Also you can pass the `Action<SeqSettings> configureSettings` delegate to set up
 ```csharp
 builder.AddSeqEndpoint("seq", settings => {
     settings.HealthChecks = false;
-    settings.ServerUrl = "http://localhost:5341"
+    settings.ServerUrl = "http://localhost:5341";
+    settings.Logs.TimeoutMilliseconds = 10000;
 });
 ```
 

--- a/src/Components/Aspire.Seq/SeqSettings.cs
+++ b/src/Components/Aspire.Seq/SeqSettings.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using OpenTelemetry.Exporter;
+
 namespace Aspire.Seq;
 
 /// <summary>
@@ -19,7 +21,17 @@ public sealed class SeqSettings
     public string? ApiKey { get; set; }
 
     /// <summary>
-    /// Gets or sets the base URL of the Seq server (including protocol and port). E.g. "https://example.seq.com:6789"
+    /// Gets or sets the base URL of the Seq server (including protocol and port). E.g. "https://example.seq.com:6789. Overrides endpoints set on <c>Logs</c> and <c>Traces</c>."
     /// </summary>
     public string? ServerUrl { get; set; }
+
+    /// <summary>
+    /// Gets OTLP exporter options for logs.
+    /// </summary>
+    public OtlpExporterOptions Logs { get; } = new ();
+
+    /// <summary>
+    /// Gets OTLP exporter options for traces.
+    /// </summary>
+    public OtlpExporterOptions Traces { get; } = new ();
 }

--- a/tests/Aspire.Seq.Tests/Aspire.Seq.Tests.csproj
+++ b/tests/Aspire.Seq.Tests/Aspire.Seq.Tests.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>$(NetCurrent)</TargetFramework>
+        <RunTestsOnHelix>true</RunTestsOnHelix>
+        <Nullable>enable</Nullable>
+        <RootNamespace>Aspire.Seq</RootNamespace>
+    </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Components\Aspire.Seq\Aspire.Seq.csproj" />
+    <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
+
+  </ItemGroup>
+
+</Project>

--- a/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
+++ b/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
@@ -36,7 +36,7 @@ public class SeqTests
         {
             settings = s;
             s.ServerUrl = serverUrl;
-            s.ApiKey = "ABCDE12345";
+            s.ApiKey = "TestKey123!";
             s.Logs.Endpoint = new Uri("http://localhost:1234/ingest/otlp/v1/logs");
             s.Traces.Endpoint = new Uri("http://localhost:1234/ingest/otlp/v1/traces");
         });
@@ -56,12 +56,12 @@ public class SeqTests
         {
             settings = s;
             s.HealthChecks = false;
-            s.ApiKey = "ABCDE12345";
+            s.ApiKey = "TestKey123!";
             s.Logs.Headers = "speed=fast,quality=good";
             s.Traces.Headers = "quality=good,speed=fast";
         });
 
-        Assert.Equal("speed=fast,quality=good,X-Seq-ApiKey=ABCDE12345", settings.Logs.Headers);
-        Assert.Equal("quality=good,speed=fast,X-Seq-ApiKey=ABCDE12345", settings.Traces.Headers);
+        Assert.Equal("speed=fast,quality=good,X-Seq-ApiKey=TestKey123!", settings.Logs.Headers);
+        Assert.Equal("quality=good,speed=fast,X-Seq-ApiKey=TestKey123!", settings.Traces.Headers);
     }
 }

--- a/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
+++ b/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
@@ -1,0 +1,67 @@
+﻿
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Exporter;
+using Xunit;
+
+namespace Aspire.Seq.Tests;
+
+public class SeqTests
+{
+    [Fact]
+    public void SeqEndpointCanBeConfigured()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        builder.AddSeqEndpoint("seq", s =>
+        {
+            s.HealthChecks = false;
+            s.Logs.TimeoutMilliseconds = 1000;
+            s.Traces.Protocol = OtlpExportProtocol.Grpc;
+        });
+
+        using var host = builder.Build();
+    }
+
+    [Fact]
+    public void ServerUrlSettingOverridesExporterEndpoints()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var serverUrl = "http://localhost:9876";
+
+        SeqSettings settings = new SeqSettings();
+
+        builder.AddSeqEndpoint("seq", s =>
+        {
+            settings = s;
+            s.ServerUrl = serverUrl;
+            s.ApiKey = "ABCDE12345";
+            s.Logs.Endpoint = new Uri("http://localhost:1234/ingest/otlp/v1/logs");
+            s.Traces.Endpoint = new Uri("http://localhost:1234/ingest/otlp/v1/traces");
+        });
+
+        Assert.Equal(settings.Logs.Endpoint, new Uri("http://localhost:9876/ingest/otlp/v1/logs"));
+        Assert.Equal(settings.Traces.Endpoint, new Uri("http://localhost:9876/ingest/otlp/v1/traces"));
+    }
+
+    [Fact]
+    public void ApiKeySettingIsMergedWithConfiguredHeaders()
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        SeqSettings settings = new SeqSettings();
+
+        builder.AddSeqEndpoint("seq", s =>
+        {
+            settings = s;
+            s.HealthChecks = false;
+            s.ApiKey = "ABCDE12345";
+            s.Logs.Headers = "speed=fast,quality=good";
+            s.Traces.Headers = "quality=good,speed=fast";
+        });
+
+        Assert.Equal("speed=fast,quality=good,X-Seq-ApiKey=ABCDE12345", settings.Logs.Headers);
+        Assert.Equal("quality=good,speed=fast,X-Seq-ApiKey=ABCDE12345", settings.Traces.Headers);
+    }
+}


### PR DESCRIPTION
Backport of #3697 to release/8.0

cc @liammclennan 

## Customer Impact

The Seq component no longer works with after the OTLP update to our ServiceDefaults project.

```
Unhandled exception. System.NotSupportedException: Signal-specific AddOtlpExporter methods and the cross-cutting UseOtlpExporter method being invoked on the same IServiceCollection is not supported.
```

## Testing

New automated tests added.
Manual testing that Seq works in the playground app.

## Risk

Low. The change only affects the Seq component.

## Regression?

Yes

_____

* Switch Seq OpenTelemetry configuration from `AddOtlpExporter` to `AddProcessor`.

* Switch Seq OpenTelemetry configuration from `AddOtlpExporter` to `AddProcessor`.

* Move OTLP exporter options onto SeqSettings.cs

* Add test

* Update README

* Renamed Seq settings

* Change order of config

* Updated code doc

* ConfigurationSchema.json

* Throw an exception if ServerUrl is unspecified, but HealthChecks is enabled.

* Fix tests

* PR feedback

Fix #3546
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3728)