### PR TITLE
Move comments on generated password entropy to public API

### DIFF
--- a/playground/TestShop/AppHost/ParameterExtensions.cs
+++ b/playground/TestShop/AppHost/ParameterExtensions.cs
@@ -21,7 +21,7 @@ internal static class ParameterExtensions
     {
         ParameterDefault generatedPassword = new GenerateParameterDefault
         {
-            MinLength = 22, // enough to give 128 bits of entropy when using the default 67 possible characters. See remarks in PasswordGenerator.Generate
+            MinLength = 22, // enough to give 128 bits of entropy when using the default 67 possible characters. See remarks in GenerateParameterDefault
             Lower = lower,
             Upper = upper,
             Numeric = numeric,

--- a/src/Aspire.Hosting/ApplicationModel/ParameterDefault.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterDefault.cs
@@ -30,22 +30,35 @@ public abstract class ParameterDefault
 /// <remarks>
 /// The recommended minimum bits of entropy for a generated password is 128 bits.
 ///
+/// <para>
 /// The general calculation of bits of entropy is:
+/// </para>
 ///
-/// log base 2 (numberPossibleOutputs)
+/// <c>log base 2 (numberPossibleOutputs)</c>
 ///
+/// <para>
 /// This generator uses 23 upper case, 23 lower case (excludes i,l,o,I,L,O to prevent confusion),
 /// 10 numeric, and 11 special characters. So a total of 67 possible characters.
+/// </para>
 /// 
-/// When all character sets are enabled, the number of possible outputs is (67 ^ length).
-/// The minimum password length for 128 bits of entropy is 22 characters: log base 2 (67 ^ 22).
+/// <para>
+/// When all character sets are enabled, the number of possible outputs is <c>(67 ^ length)</c>.
+/// The minimum password length for 128 bits of entropy is 22 characters: <c>log base 2 (67 ^ 22)</c>.
+/// </para>
 ///
+/// <para>
 /// When character sets are disabled, it lowers the number of possible outputs and thus the bits of entropy.
+/// </para>
 ///
+/// <para>
 /// Using MinLower, MinUpper, MinNumeric, and MinSpecial also lowers the number of possible outputs and thus the bits of entropy.
+/// </para>
 /// 
+/// <para>
 /// A generalized lower-bound formula for the number of possible outputs is to consider a string of the form:
+/// </para>
 ///
+/// <code>
 /// {nonRequiredCharacters}{requiredCharacters}
 ///
 /// let a = MinLower, b = MinUpper, c = MinNumeric, d = MinSpecial
@@ -55,10 +68,13 @@ public abstract class ParameterDefault
 /// requiredPossibilities = 23^a * 23^b * 10^c * 11^d * (a + b + c + d)! / (a! * b! * c! * d!)
 /// 
 /// lower-bound of total possibilities = nonRequiredPossibilities * requiredPossibilities
+/// </code>
 ///
 /// Putting it all together, the lower-bound bits of entropy calculation is:
 ///
+/// <code>
 /// log base 2 [67^x * 23^a * 23^b * 10^c * 11^d * (a + b + c + d)! / (a! * b! * c! * d!)]
+/// </code>
 /// </remarks>
 public sealed class GenerateParameterDefault : ParameterDefault
 {

--- a/src/Aspire.Hosting/ApplicationModel/ParameterDefault.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterDefault.cs
@@ -27,6 +27,39 @@ public abstract class ParameterDefault
 /// <summary>
 /// Represents that a default value should be generated.
 /// </summary>
+/// <remarks>
+/// The recommended minimum bits of entropy for a generated password is 128 bits.
+///
+/// The general calculation of bits of entropy is:
+///
+/// log base 2 (numberPossibleOutputs)
+///
+/// This generator uses 23 upper case, 23 lower case (excludes i,l,o,I,L,O to prevent confusion),
+/// 10 numeric, and 11 special characters. So a total of 67 possible characters.
+/// 
+/// When all character sets are enabled, the number of possible outputs is (67 ^ length).
+/// The minimum password length for 128 bits of entropy is 22 characters: log base 2 (67 ^ 22).
+///
+/// When character sets are disabled, it lowers the number of possible outputs and thus the bits of entropy.
+///
+/// Using MinLower, MinUpper, MinNumeric, and MinSpecial also lowers the number of possible outputs and thus the bits of entropy.
+/// 
+/// A generalized lower-bound formula for the number of possible outputs is to consider a string of the form:
+///
+/// {nonRequiredCharacters}{requiredCharacters}
+///
+/// let a = MinLower, b = MinUpper, c = MinNumeric, d = MinSpecial
+/// let x = length - (a + b + c + d)
+///
+/// nonRequiredPossibilities = 67^x
+/// requiredPossibilities = 23^a * 23^b * 10^c * 11^d * (a + b + c + d)! / (a! * b! * c! * d!)
+/// 
+/// lower-bound of total possibilities = nonRequiredPossibilities * requiredPossibilities
+///
+/// Putting it all together, the lower-bound bits of entropy calculation is:
+///
+/// log base 2 [67^x * 23^a * 23^b * 10^c * 11^d * (a + b + c + d)! / (a! * b! * c! * d!)]
+/// </remarks>
 public sealed class GenerateParameterDefault : ParameterDefault
 {
     /// <summary>

--- a/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ParameterResourceBuilderExtensions.cs
@@ -151,6 +151,7 @@ public static class ParameterResourceBuilderExtensions
     /// <param name="minNumeric">The minimum number of numeric characters in the result.</param>
     /// <param name="minSpecial">The minimum number of special characters in the result.</param>
     /// <returns>The created <see cref="ParameterResource"/>.</returns>
+    /// <remarks>To ensure the generated password has enough entropy, see the remarks in <see cref="GenerateParameterDefault"/>.</remarks>
     public static ParameterResource CreateDefaultPasswordParameter(
         IDistributedApplicationBuilder builder, string name,
         bool lower = true, bool upper = true, bool numeric = true, bool special = true,
@@ -158,7 +159,7 @@ public static class ParameterResourceBuilderExtensions
     {
         var generatedPassword = new GenerateParameterDefault
         {
-            MinLength = 22, // enough to give 128 bits of entropy when using the default 67 possible characters. See remarks in PasswordGenerator.Generate
+            MinLength = 22, // enough to give 128 bits of entropy when using the default 67 possible characters. See remarks in GenerateParameterDefault
             Lower = lower,
             Upper = upper,
             Numeric = numeric,

--- a/src/Aspire.Hosting/Utils/PasswordGenerator.cs
+++ b/src/Aspire.Hosting/Utils/PasswordGenerator.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Utils;
 
@@ -22,37 +23,7 @@ internal static class PasswordGenerator
     /// Creates a cryptographically random string.
     /// </summary>
     /// <remarks>
-    /// The recommended minimum bits of entropy for a generated password is 128 bits.
-    ///
-    /// The general calculation of bits of entropy is:
-    ///
-    /// log base 2 (numberPossibleOutputs)
-    ///
-    /// This generator uses 23 upper case, 23 lower case (excludes i,l,o,I,L,O to prevent confusion),
-    /// 10 numeric, and 11 special characters. So a total of 67 possible characters.
-    /// 
-    /// When all character sets are enabled, the number of possible outputs is (67 ^ length).
-    /// The minimum password length for 128 bits of entropy is 22 characters: log base 2 (67 ^ 22).
-    ///
-    /// When character sets are disabled, it lowers the number of possible outputs and thus the bits of entropy.
-    ///
-    /// Using minLower, minUpper, minNumeric, and minSpecial also lowers the number of possible outputs and thus the bits of entropy.
-    /// 
-    /// A generalized lower-bound formula for the number of possible outputs is to consider a string of the form:
-    ///
-    /// {nonRequiredCharacters}{requiredCharacters}
-    ///
-    /// let a = minLower, b = minUpper, c = minNumeric, d = minSpecial
-    /// let x = length - (a + b + c + d)
-    ///
-    /// nonRequiredPossibilities = 67^x
-    /// requiredPossibilities = 23^a * 23^b * 10^c * 11^d * (a + b + c + d)! / (a! * b! * c! * d!)
-    /// 
-    /// lower-bound of total possibilities = nonRequiredPossibilities * requiredPossibilities
-    ///
-    /// Putting it all together, the lower-bound bits of entropy calculation is:
-    ///
-    /// log base 2 [67^x * 23^a * 23^b * 10^c * 11^d * (a + b + c + d)! / (a! * b! * c! * d!)]
+    /// <seealso cref="GenerateParameterDefault"/>.
     /// </remarks>
     public static string Generate(int minLength,
         bool lower, bool upper, bool numeric, bool special,


### PR DESCRIPTION
This allows for these comments to be seen by callers of the API so they can make educated decisions on what parameters should be set for the password generation.

Contributes to #237
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3729)