### PR TITLE
Make details panel and metric chart view usable for low res users

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -45,7 +45,7 @@
                 </div>
                 <FluentDataGrid Items="@FilteredResourceValues"
                                 ResizableColumns="true"
-                                Style="width:100%"
+                                Style="min-width:100%"
                                 GenerateHeader="GenerateHeaderOption.Sticky"
                                 GridTemplateColumns="1fr 1.5fr">
                     <TemplateColumn Title="@ControlStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Class="nameColumn">
@@ -64,7 +64,7 @@
                 </div>
                 <FluentDataGrid Items="@FilteredEndpoints"
                                 ResizableColumns="true"
-                                Style="width:100%"
+                                Style="min-width:100%"
                                 GenerateHeader="GenerateHeaderOption.Sticky"
                                 GridTemplateColumns="1fr 1.5fr">
                     <TemplateColumn Title="@ControlStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Class="nameColumn">

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -8,6 +8,7 @@
               SelectedOptionChanged="SelectedResourceChanged"
               AriaLabel="@AriaLabel"
               Class="resource-list"
+              Position="SelectPosition.Below"
               Height="@GetPopupHeight()">
     <OptionTemplate>
         <ResourceSelectOptionTemplate ViewModel="@context" />

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -6,7 +6,6 @@
     <FluentSplitter Orientation="@Orientation" Collapsed="@(!_internalShowDetails)"
                     OnResized="HandleSplitterResize"
                     Panel1Size="@_panel1Size" Panel2Size="@_panel2Size"
-                    Panel1MinSize="150px" Panel2MinSize="150px"
                     BarSize="5"
                     @ref="_splitterRef">
         <Panel1>

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.css
@@ -14,7 +14,7 @@
 }
 
 ::deep .details-container {
-    height: 100%;
+    min-height: 100%;
     overflow: auto;
     display: grid;
     grid-template-rows: auto 1fr;

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -109,3 +109,11 @@
     vertical-align: text-bottom;
     margin-left: 3px;
 }
+
+/* in small viewports, make the metric page content (chart display)
+   the viewport height so that it is easier to read */
+@media only screen and (max-width: 600px) {
+    .page-content-area {
+        height: 100vh;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -11,67 +11,70 @@
 <PageTitle><ApplicationName ResourceName="@nameof(Dashboard.Resources.Resources.ResourcesPageTitle)" Loc="@Loc" /></PageTitle>
 
 <div class="content-layout-with-toolbar">
-    <FluentToolbar Orientation="Orientation.Horizontal">
-        <h1 slot="label">@Loc[nameof(Dashboard.Resources.Resources.ResourcesHeader)]</h1>
-        <FluentButton id="typeFilterButton" slot="end"
-                      Appearance="@(AreAllTypesVisible is true ? Appearance.Stealth : Appearance.Accent)"
-                      IconEnd="@(new Icons.Regular.Size24.Filter())"
-                      @onclick="() => _isTypeFilterVisible = !_isTypeFilterVisible"
-                      Title="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])"
-                      aria-label="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])" />
-        <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true">
-            <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
-            <Body>
-                <FluentStack Orientation="Orientation.Vertical">
-                    <FluentCheckbox
-                        Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
-                        ThreeState="true"
-                        ShowIndeterminate="false"
-                        ThreeStateOrderUncheckToIntermediate="true"
-                        @bind-CheckState="AreAllTypesVisible" />
-                    @foreach (var (resourceType, _) in _allResourceTypes)
-                    {
-                        var isChecked = _visibleResourceTypes.ContainsKey(resourceType);
-                        <FluentCheckbox
-                            Label="@resourceType"
-                            @bind-Value:get="isChecked"
-                            @bind-Value:set="c => OnResourceTypeVisibilityChangedAsync(resourceType, c)"
-                            />
-                    }
-                </FluentStack>
-            </Body>
-        </FluentPopover>
-        <FluentSearch Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
-                      Immediate="true"
-                      @bind-Value="_filter"
-                      slot="end"
-                      @bind-Value:after="HandleSearchFilterChangedAsync" />
-    </FluentToolbar>
+
     <SummaryDetailsView DetailsTitle="@(SelectedResource != null ? $"{SelectedResource.ResourceType}: {GetResourceName(SelectedResource)}" : null)"
                         ShowDetails="@(SelectedResource is not null)"
                         OnDismiss="@(() => ClearSelectedResourceAsync(causedByUserAction: true))"
                         SelectedValue="@SelectedResource"
                         ViewKey="ResourcesList">
         <Summary>
+
+            <FluentToolbar Orientation="Orientation.Horizontal">
+                <h1 slot="label">@Loc[nameof(Dashboard.Resources.Resources.ResourcesHeader)]</h1>
+                <FluentButton id="typeFilterButton" slot="end"
+                              Appearance="@(AreAllTypesVisible is true ? Appearance.Stealth : Appearance.Accent)"
+                              IconEnd="@(new Icons.Regular.Size24.Filter())"
+                              @onclick="() => _isTypeFilterVisible = !_isTypeFilterVisible"
+                              Title="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])"
+                              aria-label="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])" />
+                <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true">
+                    <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
+                    <Body>
+                    <FluentStack Orientation="Orientation.Vertical">
+                        <FluentCheckbox
+                            Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
+                            ThreeState="true"
+                            ShowIndeterminate="false"
+                            ThreeStateOrderUncheckToIntermediate="true"
+                            @bind-CheckState="AreAllTypesVisible" />
+                        @foreach (var (resourceType, _) in _allResourceTypes)
+                        {
+                            var isChecked = _visibleResourceTypes.ContainsKey(resourceType);
+                            <FluentCheckbox
+                                Label="@resourceType"
+                                @bind-Value:get="isChecked"
+                                @bind-Value:set="c => OnResourceTypeVisibilityChangedAsync(resourceType, c)"
+                            />
+                        }
+                    </FluentStack>
+                    </Body>
+                </FluentPopover>
+                <FluentSearch Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
+                              Immediate="true"
+                              @bind-Value="_filter"
+                              slot="end"
+                              @bind-Value:after="HandleSearchFilterChangedAsync" />
+            </FluentToolbar>
+
             @{
                 var gridTemplateColumns = HasResourcesWithCommands ? "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr 1fr" : "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr";
             }
             <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading">
                 <ChildContent>
                     <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" Tooltip="true" TooltipText="@(c => c.ResourceType)"/>
-                    <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c))" >
-                        <ResourceNameDisplay Resource="context" FilterText="@_filter" FormatName="GetResourceName" />
+                    <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c))">
+                        <ResourceNameDisplay Resource="context" FilterText="@_filter" FormatName="GetResourceName"/>
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort" Tooltip="true" TooltipText="@(c => c.State.Humanize())">
-                        <StateColumnDisplay Resource="@context" UnviewedErrorCounts ="@_applicationUnviewedErrorCounts" />
+                        <StateColumnDisplay Resource="@context" UnviewedErrorCounts="@_applicationUnviewedErrorCounts"/>
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" TooltipText="@(context => context.CreationTimeStamp != null ? FormatHelpers.FormatDateTime(TimeProvider, context.CreationTimeStamp.Value, MillisecondsDisplay.None, CultureInfo.CurrentCulture) : null)" Tooltip="true">
-                        <StartTimeColumnDisplay Resource="@context" />
+                        <StartTimeColumnDisplay Resource="@context"/>
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetSourceColumnValueAndTooltip(ctx)?.Tooltip)">
                         @if (GetSourceColumnValueAndTooltip(context) is { } columnDisplay)
                         {
-                            <SourceColumnDisplay Resource="context" FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip" />
+                            <SourceColumnDisplay Resource="context" FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip"/>
                         }
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEndpointsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetEndpointsTooltip(ctx))">
@@ -79,7 +82,7 @@
                             Resource="context"
                             HasMultipleReplicas="HasMultipleReplicas(context)"
                             DisplayedEndpoints="@GetDisplayedEndpoints(context, out var additionalMessage)"
-                            AdditionalMessage="@additionalMessage" />
+                            AdditionalMessage="@additionalMessage"/>
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesLogsColumnHeader)]" Class="no-ellipsis">
                         <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(resource: context.Name)">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
@@ -97,12 +100,12 @@
                     {
                         <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesCommandsColumnHeader)]">
                             <ResourceCommands Commands="@context.Commands"
-                                              CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)" />
+                                              CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)"/>
                         </TemplateColumn>
                     }
                 </ChildContent>
                 <EmptyContent>
-                    <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;@Loc[nameof(Dashboard.Resources.Resources.ResourcesNoResources)]
+                    <FluentIcon Icon="Icons.Regular.Size24.AppGeneric"/>&nbsp;@Loc[nameof(Dashboard.Resources.Resources.ResourcesNoResources)]
                 </EmptyContent>
             </FluentDataGrid>
         </Summary>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -61,20 +61,20 @@
             }
             <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading">
                 <ChildContent>
-                    <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" Tooltip="true" TooltipText="@(c => c.ResourceType)"/>
+                    <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" Tooltip="true" TooltipText="@(c => c.ResourceType)" />
                     <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c))">
-                        <ResourceNameDisplay Resource="context" FilterText="@_filter" FormatName="GetResourceName"/>
+                        <ResourceNameDisplay Resource="context" FilterText="@_filter" FormatName="GetResourceName" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort" Tooltip="true" TooltipText="@(c => c.State.Humanize())">
-                        <StateColumnDisplay Resource="@context" UnviewedErrorCounts="@_applicationUnviewedErrorCounts"/>
+                        <StateColumnDisplay Resource="@context" UnviewedErrorCounts="@_applicationUnviewedErrorCounts" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" TooltipText="@(context => context.CreationTimeStamp != null ? FormatHelpers.FormatDateTime(TimeProvider, context.CreationTimeStamp.Value, MillisecondsDisplay.None, CultureInfo.CurrentCulture) : null)" Tooltip="true">
-                        <StartTimeColumnDisplay Resource="@context"/>
+                        <StartTimeColumnDisplay Resource="@context" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetSourceColumnValueAndTooltip(ctx)?.Tooltip)">
                         @if (GetSourceColumnValueAndTooltip(context) is { } columnDisplay)
                         {
-                            <SourceColumnDisplay Resource="context" FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip"/>
+                            <SourceColumnDisplay Resource="context" FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip" />
                         }
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEndpointsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetEndpointsTooltip(ctx))">
@@ -82,7 +82,7 @@
                             Resource="context"
                             HasMultipleReplicas="HasMultipleReplicas(context)"
                             DisplayedEndpoints="@GetDisplayedEndpoints(context, out var additionalMessage)"
-                            AdditionalMessage="@additionalMessage"/>
+                            AdditionalMessage="@additionalMessage" />
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesLogsColumnHeader)]" Class="no-ellipsis">
                         <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(resource: context.Name)">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
@@ -100,12 +100,12 @@
                     {
                         <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesCommandsColumnHeader)]">
                             <ResourceCommands Commands="@context.Commands"
-                                              CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)"/>
+                                              CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)" />
                         </TemplateColumn>
                     }
                 </ChildContent>
                 <EmptyContent>
-                    <FluentIcon Icon="Icons.Regular.Size24.AppGeneric"/>&nbsp;@Loc[nameof(Dashboard.Resources.Resources.ResourcesNoResources)]
+                    <FluentIcon Icon="Icons.Regular.Size24.AppGeneric" />&nbsp;@Loc[nameof(Dashboard.Resources.Resources.ResourcesNoResources)]
                 </EmptyContent>
             </FluentDataGrid>
         </Summary>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -22,23 +22,23 @@
         <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true">
             <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
             <Body>
-            <FluentStack Orientation="Orientation.Vertical">
-                <FluentCheckbox
-                    Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
-                    ThreeState="true"
-                    ShowIndeterminate="false"
-                    ThreeStateOrderUncheckToIntermediate="true"
-                    @bind-CheckState="AreAllTypesVisible" />
-                @foreach (var (resourceType, _) in _allResourceTypes)
-                {
-                    var isChecked = _visibleResourceTypes.ContainsKey(resourceType);
+                <FluentStack Orientation="Orientation.Vertical">
                     <FluentCheckbox
-                        Label="@resourceType"
-                        @bind-Value:get="isChecked"
-                        @bind-Value:set="c => OnResourceTypeVisibilityChangedAsync(resourceType, c)"
-                    />
-                }
-            </FluentStack>
+                        Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
+                        ThreeState="true"
+                        ShowIndeterminate="false"
+                        ThreeStateOrderUncheckToIntermediate="true"
+                        @bind-CheckState="AreAllTypesVisible" />
+                    @foreach (var (resourceType, _) in _allResourceTypes)
+                    {
+                        var isChecked = _visibleResourceTypes.ContainsKey(resourceType);
+                        <FluentCheckbox
+                            Label="@resourceType"
+                            @bind-Value:get="isChecked"
+                            @bind-Value:set="c => OnResourceTypeVisibilityChangedAsync(resourceType, c)"
+                        />
+                    }
+                </FluentStack>
             </Body>
         </FluentPopover>
         <FluentSearch Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -11,6 +11,42 @@
 <PageTitle><ApplicationName ResourceName="@nameof(Dashboard.Resources.Resources.ResourcesPageTitle)" Loc="@Loc" /></PageTitle>
 
 <div class="content-layout-with-toolbar">
+    <FluentToolbar Orientation="Orientation.Horizontal">
+        <h1 slot="label">@Loc[nameof(Dashboard.Resources.Resources.ResourcesHeader)]</h1>
+        <FluentButton id="typeFilterButton" slot="end"
+                      Appearance="@(AreAllTypesVisible is true ? Appearance.Stealth : Appearance.Accent)"
+                      IconEnd="@(new Icons.Regular.Size24.Filter())"
+                      @onclick="() => _isTypeFilterVisible = !_isTypeFilterVisible"
+                      Title="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])"
+                      aria-label="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])" />
+        <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true">
+            <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
+            <Body>
+            <FluentStack Orientation="Orientation.Vertical">
+                <FluentCheckbox
+                    Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
+                    ThreeState="true"
+                    ShowIndeterminate="false"
+                    ThreeStateOrderUncheckToIntermediate="true"
+                    @bind-CheckState="AreAllTypesVisible" />
+                @foreach (var (resourceType, _) in _allResourceTypes)
+                {
+                    var isChecked = _visibleResourceTypes.ContainsKey(resourceType);
+                    <FluentCheckbox
+                        Label="@resourceType"
+                        @bind-Value:get="isChecked"
+                        @bind-Value:set="c => OnResourceTypeVisibilityChangedAsync(resourceType, c)"
+                    />
+                }
+            </FluentStack>
+            </Body>
+        </FluentPopover>
+        <FluentSearch Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
+                      Immediate="true"
+                      @bind-Value="_filter"
+                      slot="end"
+                      @bind-Value:after="HandleSearchFilterChangedAsync" />
+    </FluentToolbar>
 
     <SummaryDetailsView DetailsTitle="@(SelectedResource != null ? $"{SelectedResource.ResourceType}: {GetResourceName(SelectedResource)}" : null)"
                         ShowDetails="@(SelectedResource is not null)"
@@ -18,44 +54,6 @@
                         SelectedValue="@SelectedResource"
                         ViewKey="ResourcesList">
         <Summary>
-
-            <FluentToolbar Orientation="Orientation.Horizontal">
-                <h1 slot="label">@Loc[nameof(Dashboard.Resources.Resources.ResourcesHeader)]</h1>
-                <FluentButton id="typeFilterButton" slot="end"
-                              Appearance="@(AreAllTypesVisible is true ? Appearance.Stealth : Appearance.Accent)"
-                              IconEnd="@(new Icons.Regular.Size24.Filter())"
-                              @onclick="() => _isTypeFilterVisible = !_isTypeFilterVisible"
-                              Title="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])"
-                              aria-label="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])" />
-                <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true">
-                    <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
-                    <Body>
-                    <FluentStack Orientation="Orientation.Vertical">
-                        <FluentCheckbox
-                            Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
-                            ThreeState="true"
-                            ShowIndeterminate="false"
-                            ThreeStateOrderUncheckToIntermediate="true"
-                            @bind-CheckState="AreAllTypesVisible" />
-                        @foreach (var (resourceType, _) in _allResourceTypes)
-                        {
-                            var isChecked = _visibleResourceTypes.ContainsKey(resourceType);
-                            <FluentCheckbox
-                                Label="@resourceType"
-                                @bind-Value:get="isChecked"
-                                @bind-Value:set="c => OnResourceTypeVisibilityChangedAsync(resourceType, c)"
-                            />
-                        }
-                    </FluentStack>
-                    </Body>
-                </FluentPopover>
-                <FluentSearch Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
-                              Immediate="true"
-                              @bind-Value="_filter"
-                              slot="end"
-                              @bind-Value:after="HandleSearchFilterChangedAsync" />
-            </FluentToolbar>
-
             @{
                 var gridTemplateColumns = HasResourcesWithCommands ? "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr 1fr" : "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr";
             }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -331,8 +331,8 @@ fluent-switch.table-switch::part(label) {
 .property-grid-container {
     grid-area: main;
     overflow: auto;
-    width: 100%;
-    height: 100%;
+    min-width: 100%;
+    min-height: 100%;
     padding: calc(var(--design-unit) * 1px);
     padding-top: 0;
 }


### PR DESCRIPTION
Fixes #3395
Fixes #3392
Fixes #3393

See those issues for the before experience.

1) we were enforcing a minimum panel size. This is problematic in cases of small viewports, as that can result in prohibitively small content areas for the panel you care about. We can remove the minimum size and move the resource page toolbar inside the summary area to give low res users the option to increase detail panel height. After, scrolling through you can see individual data grid items:
![image](https://github.com/dotnet/aspire/assets/20359921/2b92b310-e542-4551-aa76-643a2251fa83)

2) the above issue combined with the large height of the page header & the selects (#3393) meant that low-res, high zoom users cannot see the charts. Definitely looking for alternate approaches for this one, but what I decided to try was making the metric chart area height the size of the viewport when viewport width is less than 600px, as the resource + duration selects take up a significant percentage of screen height at those widths. After:

- you can use the splitter to make the resource select panel much larger
![image](https://github.com/dotnet/aspire/assets/20359921/485185fc-88c0-45fa-a5c9-8930dc26dbc7)

- you can use the splitter + scroll to make the graph area much larger
![image](https://github.com/dotnet/aspire/assets/20359921/8e832897-9dd4-421a-ade4-05af32fa9ab4)
