### PR TITLE
Browser token textbox immediately updates bound value on text change

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Login.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor
@@ -18,9 +18,13 @@
                     <h1><ApplicationName ResourceName="@nameof(Dashboard.Resources.Login.Header)" Loc="@Loc" /></h1>
                 </div>
                 <div class="token-entry">
+                    @*
+                    * AutoComplete value of one-time-code prevents the browser asking to save the value.
+                    * Immediate value of true ensures the value is set to the server token with every key press in textbox.
+                    *@
                     <FluentTextField @ref="_tokenTextField" Id="token-text-field" @bind-Value="_formModel.Token"
                                      Placeholder="@Loc[nameof(Dashboard.Resources.Login.TextFieldPlaceholder)]"
-                                     TextFieldType="TextFieldType.Password" AutoComplete="one-time-code" Class="token-entry-text" />
+                                     TextFieldType="TextFieldType.Password" AutoComplete="one-time-code" Class="token-entry-text" Immediate="true" />
                 </div>
                 <div class="token-validation">
                     <FluentValidationMessage For="() => _formModel.Token" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/3720

This issue doesn't break security. You still need to have entered the right token, but you can type new content afterwards and then hit enter, and login. This works because the new value hasn't been updated into the bound value.

Adding the immediate flag ensures the bound value is updated with every keypress.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3743)