### PR TITLE
Remove seqDataDirectory from public API

### DIFF
--- a/src/Aspire.Hosting.Seq/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Seq/PublicAPI.Unshipped.txt
@@ -4,4 +4,4 @@ Aspire.Hosting.ApplicationModel.SeqResource.ConnectionStringExpression.get -> As
 Aspire.Hosting.ApplicationModel.SeqResource.PrimaryEndpoint.get -> Aspire.Hosting.ApplicationModel.EndpointReference!
 Aspire.Hosting.ApplicationModel.SeqResource.SeqResource(string! name) -> void
 Aspire.Hosting.SeqBuilderExtensions
-static Aspire.Hosting.SeqBuilderExtensions.AddSeq(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, int? port = null, string? seqDataDirectory = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SeqResource!>!
+static Aspire.Hosting.SeqBuilderExtensions.AddSeq(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, int? port = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SeqResource!>!

--- a/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
@@ -10,34 +10,22 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class SeqBuilderExtensions
 {
-    // The path within the container in which Seq stores its data
-    const string SeqContainerDataDirectory = "/data";
-
     /// <summary>
     /// Adds a Seq server resource to the application model. A container is used for local development.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name to give the resource.</param>
     /// <param name="port">The host port for the Seq server.</param>
-    /// <param name="seqDataDirectory">Host directory to bind to Seq's data directory. This must already exist.</param>
     public static IResourceBuilder<SeqResource> AddSeq(
         this IDistributedApplicationBuilder builder,
         string name,
-        int? port = null,
-        string? seqDataDirectory = null)
+        int? port = null)
     {
         var seqResource = new SeqResource(name);
-        var resourceBuilder = builder.AddResource(seqResource)
+        return builder.AddResource(seqResource)
             .WithHttpEndpoint(port: port, targetPort: 80, name: SeqResource.PrimaryEndpointName)
             .WithImage(SeqContainerImageTags.Image, SeqContainerImageTags.Tag)
             .WithImageRegistry(SeqContainerImageTags.Registry)
             .WithEnvironment("ACCEPT_EULA", "Y");
-
-        if (!string.IsNullOrEmpty(seqDataDirectory))
-        {
-            resourceBuilder.WithBindMount(seqDataDirectory, SeqContainerDataDirectory);
-        }
-
-        return resourceBuilder;
     }
 }


### PR DESCRIPTION
Callers should instead follow the pattern we've established for containers that have well known directories for persistence.

Similar to #3756

cc @liammclennan 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3769)