### PR TITLE
Make console log page usable on low-res/high-zoom

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.css
@@ -1,7 +1,7 @@
 ::deep.resource-logs-layout {
     display: grid;
     grid-template-rows: auto auto 1fr;
-    height: 100%;
+    min-height: 100%;
     width: 100%;
     grid-template-areas:
         "head"


### PR DESCRIPTION
Currently, the console logs page is not usable for low-res/high-zoom users (e.g. 1280x1024, 400%) that we are required to support.

Before:
![before](https://github.com/dotnet/aspire/assets/20359921/c3c115a8-0f6f-4b02-a8e9-fb6181207e4b)


After:
![after](https://github.com/dotnet/aspire/assets/20359921/315f0ce0-a381-43e9-a6e1-bd99c21f6be1)


After for 100%, higher res (no change)
![image](https://github.com/dotnet/aspire/assets/20359921/88579ec3-3b56-41c5-9365-6ce3387cdfe3)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3776)