### PR TITLE
Fixed regression in setting target ports

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -182,12 +182,6 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
 
     private string? ComputeTargetPort()
     {
-        // We have a target port, so we can return it directly.
-        if (Endpoint.TargetPort is int port)
-        {
-            return port.ToString(CultureInfo.InvariantCulture);
-        }
-
         // There is no way to resolve the value of the target port until runtime. Even then, replicas make this very complex because
         // the target port is not known until the replica is allocated.
         // Instead, we return an expression that will be resolved at runtime by the orchestrator.

--- a/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EndpointReference.cs
@@ -182,9 +182,6 @@ public class EndpointReferenceExpression(EndpointReference endpointReference, En
 
     private string? ComputeTargetPort()
     {
-        // There is no way to resolve the value of the target port until runtime. Even then, replicas make this very complex because
-        // the target port is not known until the replica is allocated.
-        // Instead, we return an expression that will be resolved at runtime by the orchestrator.
         return Endpoint.AllocatedEndpoint.TargetPortExpression
             ?? throw new InvalidOperationException("The endpoint does not have an associated TargetPortExpression from the orchestrator.");
     }

--- a/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
-using System.Globalization;
 
 namespace Aspire.Hosting.Tests.Dcp;
 
@@ -129,8 +128,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredPort, spAnnList.Single(ann => ann.ServiceName == "CoolProgram").Port);
         var envVarVal = dcpExe.Spec.Env?.Single(v => v.Name == "NO_PORT_TARGET_PORT_SET").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "CoolProgram" -}}""", envVarVal);
     }
 
     [Fact]
@@ -162,8 +160,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredTargetPort, spAnnList.Single(ann => ann.ServiceName == "CoolProgram").Port);
         var envVarVal = dcpExe.Spec.Env?.Single(v => v.Name == "PORT_AND_TARGET_PORT_SET").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredTargetPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "CoolProgram" -}}""", envVarVal);
     }
 
     /// <summary>
@@ -218,8 +215,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredPort, spAnnList.Single(ann => ann.ServiceName == "CoolProgram").Port);
         var envVarVal = dcpExe.Spec.Env?.Single(v => v.Name == "PORT_SET_NO_TARGET_PORT").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "CoolProgram" -}}""", envVarVal);
     }
 
     [Fact]
@@ -252,8 +248,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredPort, spAnnList.Single(ann => ann.ServiceName == "CoolProgram").Port);
         var envVarVal = dcpExe.Spec.Env?.Single(v => v.Name == "NO_PORT_TARGET_PORT_SET").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "CoolProgram" -}}""", envVarVal);
     }
 
     [Fact]
@@ -286,8 +281,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredPort, spAnnList.Single(ann => ann.ServiceName == "CoolProgram").Port);
         var envVarVal = dcpExe.Spec.Env?.Single(v => v.Name == "PORT_AND_TARGET_PORT_SET").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "CoolProgram" -}}""", envVarVal);
     }
 
     /// <summary>
@@ -498,8 +492,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredTargetPort, spAnnList.Single(ann => ann.ServiceName == "database").Port);
         var envVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "NO_PORT_TARGET_PORT_SET").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredTargetPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "database" -}}""", envVarVal);
     }
 
     [Fact]
@@ -533,8 +526,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredTargetPort, spAnnList.Single(ann => ann.ServiceName == "database").Port);
         var envVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "PORT_AND_TARGET_PORT_SET").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredTargetPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "database" -}}""", envVarVal);
     }
 
     /// <summary>
@@ -613,8 +605,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredPort, spAnnList.Single(ann => ann.ServiceName == "database").Port);
         var envVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "PORT_SET_NO_TARGET_PORT").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "database" -}}""", envVarVal);
     }
 
     [Fact]
@@ -649,8 +640,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredTargetPort, spAnnList.Single(ann => ann.ServiceName == "database").Port);
         var envVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "NO_PORT_TARGET_PORT_SET").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredTargetPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "database" -}}""", envVarVal);
     }
 
     [Fact]
@@ -686,8 +676,7 @@ public class ApplicationExecutorTests
         // Desired port should be part of the service producer annotation.
         Assert.Equal(desiredTargetPort, spAnnList.Single(ann => ann.ServiceName == "database").Port);
         var envVarVal = dcpCtr.Spec.Env?.Single(v => v.Name == "PORT_AND_TARGET_PORT_SET").Value;
-        Assert.False(string.IsNullOrWhiteSpace(envVarVal));
-        Assert.Equal(desiredTargetPort, int.Parse(envVarVal, CultureInfo.InvariantCulture));
+        Assert.Equal("""{{- portForServing "database" -}}""", envVarVal);
     }
 
     private static ApplicationExecutor CreateAppExecutor(

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -117,7 +117,11 @@ public class WithEndpointTests
         using var builder = TestDistributedApplicationBuilder.Create();
 
         builder.AddExecutable("foo", "foo", ".")
-               .WithHttpEndpoint(targetPort: 3001, name: "mybinding", env: "PORT");
+               .WithHttpEndpoint(targetPort: 3001, name: "mybinding", env: "PORT")
+               .WithEndpoint("mybinding", e =>
+               {
+                   e.AllocatedEndpoint = new(e, "localhost", 8031, targetPortExpression: "3001");
+               });
 
         using var app = builder.Build();
 

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -137,7 +137,7 @@ public class WithEnvironmentTests
                                .WithHttpEndpoint(name: "primary", targetPort: 10005)
                                .WithEndpoint("primary", ep =>
                                {
-                                   ep.AllocatedEndpoint = new AllocatedEndpoint(ep, "localhost", 90);
+                                   ep.AllocatedEndpoint = new AllocatedEndpoint(ep, "localhost", 90, targetPortExpression: "10005");
                                });
 
         var endpoint = container.GetEndpoint("primary");


### PR DESCRIPTION
- Setting the target port explicitly skips using the DCP expression which stops DCP from allocating endpoints.
- Updated tests

PS: Found while updating samples.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3796)