### PR TITLE
Add OTEL env var to not redact HttpClient query string values

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -27,14 +27,6 @@ app.MapGet("/big-trace", async () =>
     return "Big trace created";
 });
 
-app.MapGet("/send-request", async () =>
-{
-    // Send a request to an API with query string parameters to test they're not redacted in local development.
-    var httpClient = new HttpClient();
-    var response = await httpClient.GetStringAsync("https://pokeapi.co/api/v2/pokemon?limit=100000&offset=0");
-    return response;
-});
-
 app.MapGet("/many-logs", (ILoggerFactory loggerFactory, CancellationToken cancellationToken) =>
 {
     var channel = Channel.CreateUnbounded<string>();

--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -27,6 +27,14 @@ app.MapGet("/big-trace", async () =>
     return "Big trace created";
 });
 
+app.MapGet("/send-request", async () =>
+{
+    // Send a request to an API with query string parameters to test they're not redacted in local development.
+    var httpClient = new HttpClient();
+    var response = await httpClient.GetStringAsync("https://pokeapi.co/api/v2/pokemon?limit=100000&offset=0");
+    return response;
+});
+
 app.MapGet("/many-logs", (ILoggerFactory loggerFactory, CancellationToken cancellationToken) =>
 {
     var channel = Channel.CreateUnbounded<string>();

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -63,9 +63,6 @@ public static class OtlpConfigurationExtensions
 
                 // Configure trace sampler to send all traces to the dashboard.
                 context.EnvironmentVariables["OTEL_TRACES_SAMPLER"] = "always_on";
-
-                // Disable URL query redaction, e.g. ?myvalue=Redacted
-                context.EnvironmentVariables["OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION"] = "true";
             }
         }));
     }

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -5,6 +5,7 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting;
 
@@ -95,6 +96,14 @@ public static class ProjectResourceBuilderExtensions
         // https://github.com/open-telemetry/opentelemetry-dotnet/pull/5495
         // Remove once retry feature in opentelemetry-dotnet is enabled by default.
         builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY", "in_memory");
+
+        // OTEL settings that are used to improve local development experience.
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode && builder.ApplicationBuilder.Environment.IsDevelopment())
+        {
+            // Disable URL query redaction, e.g. ?myvalue=Redacted
+            builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION", "true");
+            builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION", "true");
+        }
 
         builder.WithOtlpExporter();
         builder.ConfigureConsoleLogs();

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -51,6 +51,16 @@ public class ProjectResourceTests
             },
             env =>
             {
+                Assert.Equal("OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION", env.Key);
+                Assert.Equal("true", env.Value);
+            },
+            env =>
+            {
+                Assert.Equal("OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION", env.Key);
+                Assert.Equal("true", env.Value);
+            },
+            env =>
+            {
                 Assert.Equal("OTEL_EXPORTER_OTLP_ENDPOINT", env.Key);
                 Assert.Equal("http://localhost:18889", env.Value);
             },
@@ -95,11 +105,6 @@ public class ProjectResourceTests
             {
                 Assert.Equal("OTEL_TRACES_SAMPLER", env.Key);
                 Assert.Equal("always_on", env.Value);
-            },
-            env =>
-            {
-                Assert.Equal("OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION", env.Key);
-                Assert.Equal("true", env.Value);
             },
             env =>
             {


### PR DESCRIPTION
React to feedback to OTEL changes after PR was merged: https://github.com/dotnet/aspire/pull/3676/files#r1566223568

Don't redact _outgoing_ HTTP request query string values in local development.

Before:

![image](https://github.com/dotnet/aspire/assets/303201/bbbdae09-784c-474e-9537-1e3ae358cd61)

After:

![image](https://github.com/dotnet/aspire/assets/303201/34e8d1eb-f69b-4ea6-83a9-64f93f561052)

This PR:

* Adds `OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION` env var
* Moves .NET specific env vars to project resource so they're not provided to containers

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3797)