### PR TITLE
[release/8.0] Add OTEL env var to not redact HttpClient query string values

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -27,14 +27,6 @@ app.MapGet("/big-trace", async () =>
     return "Big trace created";
 });
 
-app.MapGet("/send-request", async () =>
-{
-    // Send a request to an API with query string parameters to test they're not redacted in local development.
-    var httpClient = new HttpClient();
-    var response = await httpClient.GetStringAsync("https://pokeapi.co/api/v2/pokemon?limit=100000&offset=0");
-    return response;
-});
-
 app.MapGet("/many-logs", (ILoggerFactory loggerFactory, CancellationToken cancellationToken) =>
 {
     var channel = Channel.CreateUnbounded<string>();

--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -27,6 +27,14 @@ app.MapGet("/big-trace", async () =>
     return "Big trace created";
 });
 
+app.MapGet("/send-request", async () =>
+{
+    // Send a request to an API with query string parameters to test they're not redacted in local development.
+    var httpClient = new HttpClient();
+    var response = await httpClient.GetStringAsync("https://pokeapi.co/api/v2/pokemon?limit=100000&offset=0");
+    return response;
+});
+
 app.MapGet("/many-logs", (ILoggerFactory loggerFactory, CancellationToken cancellationToken) =>
 {
     var channel = Channel.CreateUnbounded<string>();

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -63,10 +63,6 @@ public static class OtlpConfigurationExtensions
 
                 // Configure trace sampler to send all traces to the dashboard.
                 context.EnvironmentVariables["OTEL_TRACES_SAMPLER"] = "always_on";
-
-                // Disable URL query redaction, e.g. ?myvalue=Redacted
-                context.EnvironmentVariables["OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION"] = "true";
-                context.EnvironmentVariables["OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION"] = "true";
             }
         }));
     }

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -66,6 +66,7 @@ public static class OtlpConfigurationExtensions
 
                 // Disable URL query redaction, e.g. ?myvalue=Redacted
                 context.EnvironmentVariables["OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION"] = "true";
+                context.EnvironmentVariables["OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION"] = "true";
             }
         }));
     }

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -97,7 +97,8 @@ public static class ProjectResourceBuilderExtensions
         // Remove once retry feature in opentelemetry-dotnet is enabled by default.
         builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY", "in_memory");
 
-        if (builder.ApplicationBuilder.Environment.IsDevelopment())
+        // OTEL settings that are used to improve local development experience.
+        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode && builder.ApplicationBuilder.Environment.IsDevelopment())
         {
             // Disable URL query redaction, e.g. ?myvalue=Redacted
             builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION", "true");

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Utils;
-using k8s.KubeConfigModels;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -4,7 +4,9 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Utils;
+using k8s.KubeConfigModels;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting;
 
@@ -95,6 +97,13 @@ public static class ProjectResourceBuilderExtensions
         // https://github.com/open-telemetry/opentelemetry-dotnet/pull/5495
         // Remove once retry feature in opentelemetry-dotnet is enabled by default.
         builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY", "in_memory");
+
+        if (builder.ApplicationBuilder.Environment.IsDevelopment())
+        {
+            // Disable URL query redaction, e.g. ?myvalue=Redacted
+            builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION", "true");
+            builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION", "true");
+        }
 
         builder.WithOtlpExporter();
         builder.ConfigureConsoleLogs();


### PR DESCRIPTION
## Customer Impact

Previous PR - https://github.com/dotnet/aspire/pull/3681 - updated OTEL packages to redact query strings. It includes env var to not redact query strings in local development for incoming HTTP requests.

However, there is a different env var for outgoing HTTP requests. Without the env var, outgoing HTTP requests see redacted query string values in local dev.

This PR:

* Adds `OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION` env var
* Moves .NET specific env vars to project resource so they're not provided to containers

## Testing
Manual and unit testing.

## Risk
Low

## Regression?
Yes. Restore redaction in local dev that OTEL enabled.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3798)