### PR TITLE
Service Discovery: Promptly remove invalid watchers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -87,6 +87,7 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(MicrosoftExtensionsHttpResiliencePackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="$(MicrosoftExtensionsTimeProviderTestingVersion)" />
     <!-- external dependencies -->
     <PackageVersion Include="Confluent.Kafka" Version="2.3.0" />
     <PackageVersion Include="Dapper" Version="2.1.37" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,6 +46,7 @@
     <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>8.0.4</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>
     <MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>8.0.4</MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>
     <MicrosoftExtensionsFeaturesPackageVersion>8.0.4</MicrosoftExtensionsFeaturesPackageVersion>
+    <MicrosoftExtensionsTimeProviderTestingVersion>8.4.0</MicrosoftExtensionsTimeProviderTestingVersion>
     <!-- EF -->
     <MicrosoftEntityFrameworkCoreCosmosPackageVersion>8.0.4</MicrosoftEntityFrameworkCoreCosmosPackageVersion>
     <MicrosoftEntityFrameworkCoreDesignPackageVersion>8.0.4</MicrosoftEntityFrameworkCoreDesignPackageVersion>

--- a/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndpointResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/Http/HttpServiceEndpointResolver.cs
@@ -57,6 +57,10 @@ internal sealed class HttpServiceEndpointResolver(ServiceEndpointWatcherFactory 
 
                 return endpoint;
             }
+            else
+            {
+                _resolvers.TryRemove(KeyValuePair.Create(resolver.ServiceName, resolver));
+            }
         }
     }
 
@@ -140,6 +144,7 @@ internal sealed class HttpServiceEndpointResolver(ServiceEndpointWatcherFactory 
                 cleanupTasks.Add(resolver.DisposeAsync().AsTask());
             }
         }
+
         if (cleanupTasks is not null)
         {
             await Task.WhenAll(cleanupTasks).ConfigureAwait(false);

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsServiceEndpointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsServiceEndpointResolverTests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Dns.Tests;
+
+public class DnsServiceEndpointResolverTests
+{
+    [Fact]
+    public async Task ResolveServiceEndpoint_Dns_MultiShot()
+    {
+        var timeProvider = new FakeTimeProvider();
+        var services = new ServiceCollection()
+            .AddSingleton<TimeProvider>(timeProvider)
+            .AddServiceDiscoveryCore()
+            .AddDnsServiceEndpointProvider(o => o.DefaultRefreshPeriod = TimeSpan.FromSeconds(30))
+            .BuildServiceProvider();
+        var resolver = services.GetRequiredService<ServiceEndpointResolver>();
+        var initialResult = await resolver.GetEndpointsAsync("https://localhost", CancellationToken.None);
+        Assert.NotNull(initialResult);
+        Assert.True(initialResult.Endpoints.Count > 0);
+        timeProvider.Advance(TimeSpan.FromSeconds(7));
+        var secondResult = await resolver.GetEndpointsAsync("https://localhost", CancellationToken.None);
+        Assert.NotNull(secondResult);
+        Assert.True(initialResult.Endpoints.Count > 0);
+        timeProvider.Advance(TimeSpan.FromSeconds(80));
+        var thirdResult = await resolver.GetEndpointsAsync("https://localhost", CancellationToken.None);
+        Assert.NotNull(thirdResult);
+        Assert.True(initialResult.Endpoints.Count > 0);
+    }
+}

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndpointResolverTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/DnsSrvServiceEndpointResolverTests.cs
@@ -73,7 +73,7 @@ public class DnsSrvServiceEndpointResolverTests
     }
 
     [Fact]
-    public async Task ResolveServiceEndpoint_Dns()
+    public async Task ResolveServiceEndpoint_DnsSrv()
     {
         var dnsClientMock = new FakeDnsClient
         {
@@ -134,7 +134,7 @@ public class DnsSrvServiceEndpointResolverTests
     [InlineData(true)]
     [InlineData(false)]
     [Theory]
-    public async Task ResolveServiceEndpoint_Dns_MultipleProviders_PreventMixing(bool dnsFirst)
+    public async Task ResolveServiceEndpoint_DnsSrv_MultipleProviders_PreventMixing(bool dnsFirst)
     {
         var dnsClientMock = new FakeDnsClient
         {
@@ -231,21 +231,6 @@ public class DnsSrvServiceEndpointResolverTests
                     Assert.Null(hostNameFeature);
                 });
             }
-        }
-    }
-
-    public class MyConfigurationProvider : ConfigurationProvider, IConfigurationSource
-    {
-        public IConfigurationProvider Build(IConfigurationBuilder builder) => this;
-        public void SetValues(IEnumerable<KeyValuePair<string, string?>> values)
-        {
-            Data.Clear();
-            foreach (var (key, value) in values)
-            {
-                Data[key] = value;
-            }
-
-            OnReload();
         }
     }
 }

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests.csproj
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests/Microsoft.Extensions.ServiceDiscovery.Dns.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #3815 

This PR fixes a case where errors are logged to output because an `IChangeToken` changes after an instance is disposed. When the token changes, it fires off a callback which logs an `ObjectDisposedException`. The PR implements disposal of the change token subscription and ensures that endpoint watchers are removed immediately when they become invalid:

* When a watcher is invalid, remove it immediately from the resolver entry collection
* Dispose `IChangeToken` registrations when they are no longer needed or valid
* Check for disposal in watcher and throw where appropriate
* Prevent registration of timers once the watcher has been disposed

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3800)