### PR TITLE
String escaping in manifest/bicep generation.

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackAnnotation.cs
@@ -35,7 +35,7 @@ public class EnvironmentCallbackAnnotation : IResourceAnnotation
     /// Initializes a new instance of the <see cref="EnvironmentCallbackAnnotation"/> class with the specified callback action.
     /// </summary>
     /// <param name="callback">The callback action to be executed.</param>
-    public EnvironmentCallbackAnnotation(Action<Dictionary<string, object>> callback)
+    public EnvironmentCallbackAnnotation(Action<EnvironmentVariableDictionary> callback)
     {
         ArgumentNullException.ThrowIfNull(callback);
 

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
@@ -11,12 +11,12 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="executionContext">The execution context for this invocation of the AppHost.</param>
 /// <param name="environmentVariables">The environment variables associated with this execution.</param>
 /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
-public class EnvironmentCallbackContext(DistributedApplicationExecutionContext executionContext, Dictionary<string, object>? environmentVariables = null, CancellationToken cancellationToken = default)
+public class EnvironmentCallbackContext(DistributedApplicationExecutionContext executionContext, EnvironmentVariableDictionary? environmentVariables = null, CancellationToken cancellationToken = default)
 {
     /// <summary>
     /// Gets the environment variables associated with the callback context.
     /// </summary>
-    public Dictionary<string, object> EnvironmentVariables { get; } = environmentVariables ?? new();
+    public EnvironmentVariableDictionary EnvironmentVariables { get; } = environmentVariables ?? new EnvironmentVariableDictionary();
 
     /// <summary>
     /// Gets the CancellationToken associated with the callback context.

--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentVariableDictionary.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentVariableDictionary.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// An implementation of <see cref="Dictionary{TKey, TValue}"/> that only allows keys that are valid environment variable names.
+/// </summary>
+public partial class EnvironmentVariableDictionary : ValidatingDictionary<string, object>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnvironmentVariableDictionary"/> class.
+    /// </summary>
+    public EnvironmentVariableDictionary() : base(ValidateKey, null)
+    {
+    }
+
+    [GeneratedRegex(@"^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Singleline | RegexOptions.CultureInvariant)]
+    private static partial Regex EnvironmentVariableRegex();
+
+    private static bool ValidateKey(string key) => EnvironmentVariableRegex().IsMatch(key);
+}

--- a/src/Aspire.Hosting/ApplicationModel/ValidatingDictionary.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ValidatingDictionary.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <inheritdoc />
+public class ValidatingDictionary<TKey, TValue> : IDictionary<TKey, TValue> where TKey : notnull
+{
+    /// <summary>
+    /// Constructs the <see cref="ValidatingDictionary{TKey, TValue}"/> by providing callbacks that are invoked
+    /// whenever the dictionary is mutated to ensure that the keys and values are valid.
+    /// </summary>
+    /// <param name="keyValidator">Function to validate key.</param>
+    /// <param name="valueValidator">Function to validate value.</param>
+    public ValidatingDictionary(Func<TKey, bool>? keyValidator = null, Func<TValue, bool>? valueValidator = null)
+    {
+        _keyValidator = keyValidator ?? (_ => true);
+        _valueValidator = valueValidator ?? (_ => true);
+    }
+
+    private readonly Func<TKey, bool> _keyValidator;
+
+    private readonly Func<TValue, bool> _valueValidator;
+
+    private readonly IDictionary<TKey, TValue> _dictionary = new Dictionary<TKey, TValue>();
+
+    private T WhenKeyIsValid<T>(TKey key, Func<T> action)
+    {
+        if (!_keyValidator(key))
+        {
+            throw new ArgumentException("Key is invalid");
+        }
+        else
+        {
+            return action();
+        }
+    }
+
+    private void WhenKeyIsValid(TKey key, Action action)
+    {
+        if (!_keyValidator(key))
+        {
+            throw new ArgumentException("Key is invalid");
+        }
+        else
+        {
+            action();
+        }
+    }
+
+    private T WhenValueIsValid<T>(TValue value, Func<T> action)
+    {
+        if (!_valueValidator(value))
+        {
+            throw new ArgumentException("Value is invalid");
+        }
+        else
+        {
+            return action();
+        }
+    }
+
+    private void WhenValueIsValid(TValue value, Action action)
+    {
+        if (!_valueValidator(value))
+        {
+            throw new ArgumentException("Value is invalid");
+        }
+        else
+        {
+            action();
+        }
+    }
+
+    /// <inheritdoc />
+    public TValue this[TKey key]
+    {
+        get => _dictionary[key]!;
+        set => WhenKeyIsValid(key, () => WhenValueIsValid(value, () => _dictionary[key] = value));
+    }
+
+    /// <inheritdoc />
+    public ICollection<TKey> Keys => _dictionary.Keys;
+
+    /// <inheritdoc />
+    public ICollection<TValue> Values => _dictionary.Values;
+
+    /// <inheritdoc />
+    public int Count => _dictionary.Count;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => _dictionary.IsReadOnly;
+
+    /// <inheritdoc />
+    public void Add(TKey key, TValue value) => WhenKeyIsValid(key, () => WhenValueIsValid(value, () => _dictionary.Add(key, value)));
+
+    /// <inheritdoc />
+    public void Add(KeyValuePair<TKey, TValue> item) => WhenKeyIsValid(item.Key, () => WhenValueIsValid(item.Value, () => _dictionary.Add(item)));
+
+    /// <inheritdoc />
+    public void Clear() => _dictionary.Clear();
+
+    /// <inheritdoc />
+    public bool Contains(KeyValuePair<TKey, TValue> item)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public bool ContainsKey(TKey key) => _dictionary.ContainsKey(key);
+
+    /// <inheritdoc />
+    public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) => _dictionary.CopyTo(array, arrayIndex);
+
+    /// <inheritdoc />
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _dictionary.GetEnumerator();
+
+    /// <inheritdoc />
+    public bool Remove(TKey key) => _dictionary.Remove(key);
+
+    /// <inheritdoc />
+    public bool Remove(KeyValuePair<TKey, TValue> item) => _dictionary.Remove(item);
+
+    /// <inheritdoc />
+    public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => _dictionary.TryGetValue(key, out value);
+
+    IEnumerator IEnumerable.GetEnumerator() => _dictionary.GetEnumerator();
+}

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1211,7 +1211,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             }
         }
 
-        var config = new Dictionary<string, object>();
+        var config = new EnvironmentVariableDictionary();
         var context = new EnvironmentCallbackContext(_executionContext, config, cancellationToken)
         {
             Logger = resourceLogger
@@ -1411,7 +1411,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         var dcpContainerResource = (Container)cr.DcpResource;
         var modelContainerResource = cr.ModelResource;
 
-        var config = new Dictionary<string, object>();
+        var config = new EnvironmentVariableDictionary();
 
         dcpContainerResource.Spec.Env = [];
 

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -135,15 +135,17 @@ Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.Callback.get -> System.Func<Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext!, System.Threading.Tasks.Task!>!
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.EnvironmentCallbackAnnotation(string! name, System.Func<string!>! callback) -> void
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.EnvironmentCallbackAnnotation(System.Action<Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext!>! callback) -> void
-Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.EnvironmentCallbackAnnotation(System.Action<System.Collections.Generic.Dictionary<string!, object!>!>! callback) -> void
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.EnvironmentCallbackAnnotation(System.Action<Aspire.Hosting.ApplicationModel.EnvironmentVariableDictionary!>! callback) -> void
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackAnnotation.EnvironmentCallbackAnnotation(System.Func<Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext!, System.Threading.Tasks.Task!>! callback) -> void
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.CancellationToken.get -> System.Threading.CancellationToken
-Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.EnvironmentCallbackContext(Aspire.Hosting.DistributedApplicationExecutionContext! executionContext, System.Collections.Generic.Dictionary<string!, object!>? environmentVariables = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
-Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.EnvironmentVariables.get -> System.Collections.Generic.Dictionary<string!, object!>!
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.EnvironmentCallbackContext(Aspire.Hosting.DistributedApplicationExecutionContext! executionContext, Aspire.Hosting.ApplicationModel.EnvironmentVariableDictionary? environmentVariables = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.EnvironmentVariables.get -> Aspire.Hosting.ApplicationModel.EnvironmentVariableDictionary!
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.ExecutionContext.get -> Aspire.Hosting.DistributedApplicationExecutionContext!
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.Logger.get -> Microsoft.Extensions.Logging.ILogger?
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.Logger.set -> void
+Aspire.Hosting.ApplicationModel.EnvironmentVariableDictionary
+Aspire.Hosting.ApplicationModel.EnvironmentVariableDictionary.EnvironmentVariableDictionary() -> void
 Aspire.Hosting.ApplicationModel.EnvironmentVariableSnapshot
 Aspire.Hosting.ApplicationModel.EnvironmentVariableSnapshot.EnvironmentVariableSnapshot(string! Name, string? Value, bool IsFromSpec) -> void
 Aspire.Hosting.ApplicationModel.EnvironmentVariableSnapshot.IsFromSpec.get -> bool
@@ -323,6 +325,24 @@ Aspire.Hosting.ApplicationModel.UrlSnapshot.Name.init -> void
 Aspire.Hosting.ApplicationModel.UrlSnapshot.Url.get -> string!
 Aspire.Hosting.ApplicationModel.UrlSnapshot.Url.init -> void
 Aspire.Hosting.ApplicationModel.UrlSnapshot.UrlSnapshot(string! Name, string! Url, bool IsInternal) -> void
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.Add(System.Collections.Generic.KeyValuePair<TKey, TValue> item) -> void
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.Add(TKey key, TValue value) -> void
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.Clear() -> void
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.Contains(System.Collections.Generic.KeyValuePair<TKey, TValue> item) -> bool
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.ContainsKey(TKey key) -> bool
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.CopyTo(System.Collections.Generic.KeyValuePair<TKey, TValue>[]! array, int arrayIndex) -> void
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.Count.get -> int
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>>!
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.IsReadOnly.get -> bool
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.Keys.get -> System.Collections.Generic.ICollection<TKey>!
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.Remove(System.Collections.Generic.KeyValuePair<TKey, TValue> item) -> bool
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.Remove(TKey key) -> bool
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.this[TKey key].get -> TValue
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.this[TKey key].set -> void
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value) -> bool
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.ValidatingDictionary(System.Func<TKey, bool>? keyValidator = null, System.Func<TValue, bool>? valueValidator = null) -> void
+Aspire.Hosting.ApplicationModel.ValidatingDictionary<TKey, TValue>.Values.get -> System.Collections.Generic.ICollection<TValue>!
 Aspire.Hosting.ContainerResourceBuilderExtensions
 Aspire.Hosting.ContainerResourceExtensions
 Aspire.Hosting.CustomResourceExtensions

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -345,7 +345,7 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
     /// <param name="resource">The <see cref="IResource"/> which contains <see cref="EnvironmentCallbackAnnotation"/> annotations.</param>
     public async Task WriteEnvironmentVariablesAsync(IResource resource)
     {
-        var config = new Dictionary<string, object>();
+        var config = new EnvironmentVariableDictionary();
 
         var envContext = new EnvironmentCallbackContext(ExecutionContext, config, CancellationToken);
 

--- a/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
@@ -12,7 +12,7 @@ public static class EnvironmentVariableEvaluator
 
         if (resource.TryGetEnvironmentVariables(out var callbacks))
         {
-            var config = new Dictionary<string, object>();
+            var config = new EnvironmentVariableDictionary();
             var executionContext = new DistributedApplicationExecutionContext(applicationOperation);
             var context = new EnvironmentCallbackContext(executionContext, config);
 

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -10,6 +10,22 @@ namespace Aspire.Hosting.Tests;
 public class WithEnvironmentTests
 {
     [Fact]
+    public void WithEnvironmentThrowsOnInvalidEnvironmentVariableName()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+        Assert.Throws<ArgumentException>(() =>
+        {
+            builder.AddContainer("foo", "bar")
+                   .WithEnvironment("""
+                                    multi
+                                    line
+                                    env
+                                    var
+                                    """, "ok value");
+        });
+    }
+
+    [Fact]
     public async Task EnvironmentReferencingEndpointPopulatesWithBindingUrl()
     {
         using var builder = TestDistributedApplicationBuilder.Create();

--- a/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEnvironmentTests.cs
@@ -10,19 +10,22 @@ namespace Aspire.Hosting.Tests;
 public class WithEnvironmentTests
 {
     [Fact]
-    public void WithEnvironmentThrowsOnInvalidEnvironmentVariableName()
+    public async Task WithEnvironmentThrowsOnInvalidEnvironmentVariableName()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
-        Assert.Throws<ArgumentException>(() =>
+        var container = builder.AddContainer("foo", "bar")
+                .WithEnvironment("""
+                                multi
+                                line
+                                env
+                                var
+                                """, "ok value");
+        var ex = await Assert.ThrowsAsync<ArgumentException>(async () =>
         {
-            builder.AddContainer("foo", "bar")
-                   .WithEnvironment("""
-                                    multi
-                                    line
-                                    env
-                                    var
-                                    """, "ok value");
+            await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(container.Resource);
         });
+
+        Assert.Equal("Key is invalid", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
Exploring issues around #3809 and #3806. There are some issues in the way AZD is generating the Bicep without escaping things like parameter values. When you use `WithParameter("name", "string")` this isn't a problem for the value since we store that as a strong and when we use the JSON writer which takes care of the escaping for us. But there may be other similar issues.

This PR is to add tests and any fixes if necessary.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3814)