### PR TITLE
Enable dependabot updates for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,11 @@ updates:
           - "Grpc.*"
     labels:
       - "area-codeflow"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    labels:
+      - area-engineering-systems


### PR DESCRIPTION
This doesn't update anything currently. We don't use actions much currently here (unlike aspire-samples) but there are some uses and this will keep them up to date.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3821)