### PR TITLE
Service Discovery: make scheme selection more intuitive in un-specified case, add more tests

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryOptions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryOptions.cs
@@ -32,29 +32,35 @@ public sealed class ServiceDiscoveryOptions
 
     internal static string[] ApplyAllowedSchemes(IReadOnlyList<string> schemes, IList<string> allowedSchemes, bool allowAllSchemes)
     {
-        if (allowAllSchemes)
+        if (schemes.Count > 0)
         {
-            if (schemes is string[] array)
+            if (allowAllSchemes)
             {
-                return array;
+                if (schemes is string[] array && array.Length > 0)
+                {
+                    return array;
+                }
+
+                return schemes.ToArray();
             }
 
-            return schemes.ToArray();
-        }
-
-        List<string> result = [];
-        foreach (var s in schemes)
-        {
-            foreach (var allowed in allowedSchemes)
+            List<string> result = [];
+            foreach (var s in schemes)
             {
-                if (string.Equals(s, allowed, StringComparison.OrdinalIgnoreCase))
+                foreach (var allowed in allowedSchemes)
                 {
-                    result.Add(s);
-                    break;
+                    if (string.Equals(s, allowed, StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.Add(s);
+                        break;
+                    }
                 }
             }
+
+            return result.ToArray();
         }
 
-        return result.ToArray();
+        // If no schemes were specified, but a set of allowed schemes were specified, allow those.
+        return allowedSchemes.ToArray();
     }
 }


### PR DESCRIPTION
### Make scheme selection more intuitive

* If `ServiceDiscoveryOptions.AllowAllSchemes` is TRUE and the service name INCLUDES schemes (eg `https://basket`), we filter out results which do not have a matching scheme, applying the preference. i.e, `https+http` means pick only `https` endpoints if _any_ `https` endpoints are present, `http` only if _no_ `https` endpoints are present.
* If `ServiceDiscoveryOptions.AllowAllSchemes` is TRUE and the service name DOES NOT INCLUDE schemes (eg, `basket`), then we should allow all endpoints.
* If `ServiceDiscoveryOptions.AllowAllSchemes` is FALSE, the service name DOES NOT INCLUDE schemes, and `ServiceDiscoveryOptions.AllowedSchemes` contains some value (eg, `["https"]`), then we should filter to include only endpoints matching those `AllowedSchemes` values.

In pseudo code, the logic is: 

```
IncludeAll = AllowAllSchemes && ServiceName.Schemes.Count == 0
IncludedSchemes = ServiceName.Schemes.Count > 0 ? ServiceName.Schemes.Intersect(AllowedSchemes) : AllowedSchemes
```

### Always check "default" config section first when no endpoint name is specified

* When searching for a configuration section for a service and no endpoint name has been specified (i.e, the common case), we should first check the `"default"` section, then the sections corresponding to schemes. The current behavior is:
  * If the query specified any schemes, check those sections in order (`https+http` -> check `"https"` then `"http"` cfg sections)
  * If the query does not specify any schemes, check the `"default"` section.
 
The change is to always check the default section first if no endpoint name is specified.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3837)