### PR TITLE
Testing: Do not configure HttpClient resilience by default

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactoryOfT.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactoryOfT.cs
@@ -148,11 +148,8 @@ public class DistributedApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
 
     private void OnBuildingCore(DistributedApplicationBuilder applicationBuilder)
     {
-        // Patch DcpOptions configuration
         var services = applicationBuilder.Services;
-
         services.AddHttpClient();
-        services.ConfigureHttpClientDefaults(http => http.AddStandardResilienceHandler());
 
         InterceptHostCreation(applicationBuilder);
 


### PR DESCRIPTION
Since it is not straightforward to configure resilience policies after the handler has been added (see https://github.com/dotnet/extensions/issues/4814), we decided to remove these from the testing host so that developers are free to choose how resilience is configured in test projects.

cc @DamianEdwards 

Fixes #3431

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3845)