### PR TITLE
[release/8.0] API changes for components

### DIFF
--- a/src/Components/Aspire.Azure.AI.OpenAI/AspireAzureOpenAIExtensions.cs
+++ b/src/Components/Aspire.Azure.AI.OpenAI/AspireAzureOpenAIExtensions.cs
@@ -120,6 +120,6 @@ public static class AspireAzureOpenAIExtensions
             => settings.Credential;
 
         protected override bool GetTracingEnabled(AzureOpenAISettings settings)
-            => settings.Tracing;
+            => !settings.DisableTracing;
     }
 }

--- a/src/Components/Aspire.Azure.AI.OpenAI/AzureOpenAISettings.cs
+++ b/src/Components/Aspire.Azure.AI.OpenAI/AzureOpenAISettings.cs
@@ -40,12 +40,12 @@ public sealed class AzureOpenAISettings : IConnectionStringSettings
     public string? Key { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.AI.OpenAI/ConfigurationSchema.json
@@ -99,6 +99,11 @@
                       },
                       "description": "Client options for OpenAIClient."
                     },
+                    "DisableTracing": {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
                     "Endpoint": {
                       "type": "string",
                       "format": "uri",
@@ -107,11 +112,6 @@
                     "Key": {
                       "type": "string",
                       "description": "Gets or sets the key to use to authenticate to the Azure OpenAI endpoint."
-                    },
-                    "Tracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
                     }
                   },
                   "description": "The settings relevant to accessing Azure OpenAI or OpenAI."

--- a/src/Components/Aspire.Azure.AI.OpenAI/README.md
+++ b/src/Components/Aspire.Azure.AI.OpenAI/README.md
@@ -88,7 +88,7 @@ The .NET Aspire Azure AI OpenAI library supports [Microsoft.Extensions.Configura
     "Azure": {
       "AI": {
         "OpenAI": {
-          "Tracing": true,
+          "DisableTracing": false,
         }
       }
     }
@@ -101,7 +101,7 @@ The .NET Aspire Azure AI OpenAI library supports [Microsoft.Extensions.Configura
 You can also pass the `Action<AzureOpenAISettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
-builder.AddAzureAIOpenAIClient("openaiConnectionName", settings => settings.Tracing = false);
+builder.AddAzureAIOpenAIClient("openaiConnectionName", settings => settings.DisableTracing = true);
 ```
 
 You can also setup the [OpenAIClientOptions](https://learn.microsoft.com/dotnet/api/azure.ai.openai.openaiclientoptions) using the optional `Action<IAzureClientBuilder<OpenAIClient, OpenAIClientOptions>> configureClientBuilder` parameter of the `AddAzureAIOpenAIClient` method. For example, to set the client ID for this client:

--- a/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
+++ b/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
@@ -97,12 +97,12 @@ public static class AspireTablesExtensions
             => new AzureTableServiceHealthCheck(client, new AzureTableServiceHealthCheckOptions());
 
         protected override bool GetHealthCheckEnabled(AzureDataTablesSettings settings)
-            => settings.HealthChecks;
+            => !settings.DisableHealthChecks;
 
         protected override TokenCredential? GetTokenCredential(AzureDataTablesSettings settings)
             => settings.Credential;
 
         protected override bool GetTracingEnabled(AzureDataTablesSettings settings)
-            => settings.Tracing;
+            => !settings.DisableTracing;
     }
 }

--- a/src/Components/Aspire.Azure.Data.Tables/AzureDataTablesSettings.cs
+++ b/src/Components/Aspire.Azure.Data.Tables/AzureDataTablesSettings.cs
@@ -34,20 +34,20 @@ public sealed class AzureDataTablesSettings : IConnectionStringSettings
     public TokenCredential? Credential { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Data.Tables/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Data.Tables/ConfigurationSchema.json
@@ -107,20 +107,20 @@
                       "type": "string",
                       "description": "Gets or sets the connection string used to connect to the table service account."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the health check is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the health check is disabled or not.",
+                      "default": false
+                    },
+                    "DisableTracing": {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
                     },
                     "ServiceUri": {
                       "type": "string",
                       "format": "uri",
                       "description": "A 'System.Uri' referencing the table service account.\nThis is likely to be similar to \"https://{account_name}.table.core.windows.net/\" or \"https://{account_name}.table.cosmos.azure.com/\"."
-                    },
-                    "Tracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure Tables."

--- a/src/Components/Aspire.Azure.Data.Tables/README.md
+++ b/src/Components/Aspire.Azure.Data.Tables/README.md
@@ -86,8 +86,8 @@ The Azure Table storage library supports [Microsoft.Extensions.Configuration](ht
     "Azure": {
       "Data": {
         "Tables": {
-          "HealthChecks": false,
-          "Tracing": true,
+          "DisableHealthChecks": true,
+          "DisableTracing": false,
           "ClientOptions": {
             "Diagnostics": {
               "ApplicationId": "myapp"
@@ -105,7 +105,7 @@ The Azure Table storage library supports [Microsoft.Extensions.Configuration](ht
 You can also pass the `Action<AzureDataTablesSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddAzureTableClient("tables", settings => settings.HealthChecks = false);
+builder.AddAzureTableClient("tables", settings => settings.DisableHealthChecks = true);
 ```
 
 You can also setup the [TableClientOptions](https://learn.microsoft.com/dotnet/api/azure.data.tables.tableclientoptions) using the optional `Action<IAzureClientBuilder<TableServiceClient, TableClientOptions>> configureClientBuilder` parameter of the `AddAzureTableClient` method. For example, to set the first part of "User-Agent" headers for all requests issues by this client:

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/AspireEventHubsExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/AspireEventHubsExtensions.cs
@@ -26,7 +26,7 @@ public static class AspireEventHubsExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingEventHubsProcessorSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:EventHubs:{TClient}" section, where {TClient} is the type of Event Hubs client being configured, i.e. EventProcessorClient.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsBaseSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsBaseSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddAzureEventProcessorClient(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -46,7 +46,7 @@ public static class AspireEventHubsExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingEventHubsProcessorSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:EventHubs:{TClient}" section, where {TClient} is the type of Event Hubs client being configured, i.e. EventProcessorClient.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsBaseSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsBaseSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddKeyedAzureEventProcessorClient(
         this IHostApplicationBuilder builder,
         string name,
@@ -72,7 +72,7 @@ public static class AspireEventHubsExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingEventHubsPartitionReceiverSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:EventHubs:{TClient}" section, where {TClient} is the type of Event Hubs client being configured, i.e. EventProcessorClient.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsBaseSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsBaseSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddAzurePartitionReceiverClient(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -92,7 +92,7 @@ public static class AspireEventHubsExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingEventHubsPartitionReceiverSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:EventHubs:{TClient}" section, where {TClient} is the type of Event Hubs client being configured, i.e. EventProcessorClient.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsBaseSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsBaseSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddKeyedAzurePartitionReceiverClient(
         this IHostApplicationBuilder builder,
         string name,
@@ -118,7 +118,7 @@ public static class AspireEventHubsExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingEventHubsProducerSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:EventHubs:{TClient}" section, where {TClient} is the type of Event Hubs client being configured, i.e. EventProcessorClient.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsBaseSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsBaseSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddAzureEventHubProducerClient(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -138,7 +138,7 @@ public static class AspireEventHubsExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingEventHubsProducerSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:EventHubs:{TClient}" section, where {TClient} is the type of Event Hubs client being configured, i.e. EventProcessorClient.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsBaseSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsBaseSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddKeyedAzureEventHubProducerClient(
         this IHostApplicationBuilder builder,
         string name,
@@ -164,7 +164,7 @@ public static class AspireEventHubsExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingEventHubsConsumerSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:EventHubs:{TClient}" section, where {TClient} is the type of Event Hubs client being configured, i.e. EventProcessorClient.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsBaseSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsBaseSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddAzureEventHubConsumerClient(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -184,7 +184,7 @@ public static class AspireEventHubsExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingEventHubsConsumerSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:EventHubs:{TClient}" section, where {TClient} is the type of Event Hubs client being configured, i.e. EventProcessorClient.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsBaseSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsBaseSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingEventHubsSettings.ConnectionString"/> nor <see cref="AzureMessagingEventHubsSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddKeyedAzureEventHubConsumerClient(
         this IHostApplicationBuilder builder,
         string name,

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/AzureMessagingEventHubsSettings.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/AzureMessagingEventHubsSettings.cs
@@ -14,15 +14,17 @@ namespace Aspire.Azure.Messaging.EventHubs;
 /// <summary>
 /// Represents additional shared settings for configuring an Event Hubs client.
 /// </summary>
-public abstract class AzureMessagingEventHubsBaseSettings : IConnectionStringSettings
+public abstract class AzureMessagingEventHubsSettings : IConnectionStringSettings
 {
-    private bool? _tracing;
+    private bool? _disableTracing;
+
+    internal AzureMessagingEventHubsSettings() { }
 
     /// <summary>
     /// Gets or sets the connection string used to connect to the Event Hubs namespace. 
     /// </summary>
     /// <remarks>
-    /// If <see cref="ConnectionString"/> is set, it overrides <see cref="Namespace"/> and <see cref="Credential"/>.
+    /// If <see cref="ConnectionString"/> is set, it overrides <see cref="FullyQualifiedNamespace"/> and <see cref="Credential"/>.
     /// </remarks>
     public string? ConnectionString { get; set; }
 
@@ -32,7 +34,7 @@ public abstract class AzureMessagingEventHubsBaseSettings : IConnectionStringSet
     /// <remarks>
     /// Used along with <see cref="Credential"/> to establish the connection.
     /// </remarks>
-    public string? Namespace { get; set; }
+    public string? FullyQualifiedNamespace { get; set; }
 
     /// <summary>
     /// Gets or sets the name of the Event Hub.
@@ -45,20 +47,23 @@ public abstract class AzureMessagingEventHubsBaseSettings : IConnectionStringSet
     public TokenCredential? Credential { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <remarks>
     /// Event Hubs ActivitySource support in Azure SDK is experimental, the shape of Activities may change in the future without notice.
     /// It can be enabled by setting "Azure.Experimental.EnableActivitySource" <see cref="AppContext"/> switch to true.
     /// Or by setting "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE" environment variable to "true".
     /// </remarks>
-    public bool Tracing
+    /// <value>  
+    /// The default value is <see langword="false"/>.  
+    /// </value>
+    public bool DisableTracing
     {
-        get { return _tracing ??= GetTracingDefaultValue(); }
-        set { _tracing = value; }
+        get { return _disableTracing ??= !GetTracingDefaultValue(); }
+        set { _disableTracing = value; }
     }
 
-    // default Tracing to true if the experimental switch is set
+    // Defaults DisableTracing to false if the experimental switch is set
     // TODO: remove this when ActivitySource support is no longer experimental
     private static bool GetTracingDefaultValue()
     {
@@ -83,7 +88,7 @@ public abstract class AzureMessagingEventHubsBaseSettings : IConnectionStringSet
             // a event hubs namespace can't contain ';'. if it is found assume it is a connection string
             if (!connectionString.Contains(';'))
             {
-                Namespace = connectionString;
+                FullyQualifiedNamespace = connectionString;
             }
             else
             {
@@ -96,12 +101,12 @@ public abstract class AzureMessagingEventHubsBaseSettings : IConnectionStringSet
 /// <summary>
 /// Represents additional settings for configuring a <see cref="EventHubProducerClient"/>.
 /// </summary>
-public sealed class AzureMessagingEventHubsProducerSettings : AzureMessagingEventHubsBaseSettings { }
+public sealed class AzureMessagingEventHubsProducerSettings : AzureMessagingEventHubsSettings { }
 
 /// <summary>
-/// Represents additional settings for configuring an Event Hubs client that may accept a ConsumerGroup
+/// Represents additional settings for configuring a <see cref="EventHubConsumerClient"/>.
 /// </summary>
-public abstract class AzureMessagingEventHubsConsumerBaseSettings : AzureMessagingEventHubsBaseSettings
+public sealed class AzureMessagingEventHubsConsumerSettings : AzureMessagingEventHubsSettings
 {
     /// <summary>
     /// Gets or sets the name of the consumer group.
@@ -110,15 +115,15 @@ public abstract class AzureMessagingEventHubsConsumerBaseSettings : AzureMessagi
 }
 
 /// <summary>
-/// Represents additional settings for configuring a <see cref="EventHubConsumerClient"/>.
-/// </summary>
-public sealed class AzureMessagingEventHubsConsumerSettings : AzureMessagingEventHubsConsumerBaseSettings { }
-
-/// <summary>
 /// Represents additional settings for configuring a <see cref="EventProcessorClient"/>.
 /// </summary>
-public sealed class AzureMessagingEventHubsProcessorSettings : AzureMessagingEventHubsConsumerBaseSettings
+public sealed class AzureMessagingEventHubsProcessorSettings : AzureMessagingEventHubsSettings
 {
+    /// <summary>
+    /// Gets or sets the name of the consumer group.
+    /// </summary>
+    public string? ConsumerGroup { get; set; }
+
     /// <summary>
     /// Gets or sets the connection name used to obtain a connection string for an Azure BlobContainerClient. This is required when the Event Processor is used.
     /// </summary>
@@ -137,8 +142,13 @@ public sealed class AzureMessagingEventHubsProcessorSettings : AzureMessagingEve
 /// <summary>
 /// Represents additional settings for configuring a <see cref="PartitionReceiver"/>.
 /// </summary>
-public sealed class AzureMessagingEventHubsPartitionReceiverSettings : AzureMessagingEventHubsConsumerBaseSettings
+public sealed class AzureMessagingEventHubsPartitionReceiverSettings : AzureMessagingEventHubsSettings
 {
+    /// <summary>
+    /// Gets or sets the name of the consumer group.
+    /// </summary>
+    public string? ConsumerGroup { get; set; }
+
     /// <summary>
     /// Gets or sets the partition identifier.
     /// </summary>

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
@@ -114,17 +114,18 @@
                           "type": "string",
                           "description": "Gets or sets the name of the consumer group."
                         },
+                        "DisableTracing": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
                         "EventHubName": {
                           "type": "string",
                           "description": "Gets or sets the name of the Event Hub."
                         },
-                        "Namespace": {
+                        "FullyQualifiedNamespace": {
                           "type": "string",
                           "description": "Gets or sets the fully qualified Event Hubs namespace."
-                        },
-                        "Tracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not."
                         }
                       },
                       "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Consumer.EventHubConsumerClient'."
@@ -209,17 +210,18 @@
                           "type": "string",
                           "description": "Gets or sets the connection string used to connect to the Event Hubs namespace."
                         },
+                        "DisableTracing": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
                         "EventHubName": {
                           "type": "string",
                           "description": "Gets or sets the name of the Event Hub."
                         },
-                        "Namespace": {
+                        "FullyQualifiedNamespace": {
                           "type": "string",
                           "description": "Gets or sets the fully qualified Event Hubs namespace."
-                        },
-                        "Tracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not."
                         }
                       },
                       "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Producer.EventHubProducerClient'."
@@ -354,17 +356,18 @@
                           "type": "string",
                           "description": "Gets or sets the name of the consumer group."
                         },
+                        "DisableTracing": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
                         "EventHubName": {
                           "type": "string",
                           "description": "Gets or sets the name of the Event Hub."
                         },
-                        "Namespace": {
+                        "FullyQualifiedNamespace": {
                           "type": "string",
                           "description": "Gets or sets the fully qualified Event Hubs namespace."
-                        },
-                        "Tracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not."
                         }
                       },
                       "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.EventProcessorClient'."
@@ -474,21 +477,22 @@
                           "type": "string",
                           "description": "Gets or sets the name of the consumer group."
                         },
+                        "DisableTracing": {
+                          "type": "boolean",
+                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                          "default": false
+                        },
                         "EventHubName": {
                           "type": "string",
                           "description": "Gets or sets the name of the Event Hub."
                         },
-                        "Namespace": {
+                        "FullyQualifiedNamespace": {
                           "type": "string",
                           "description": "Gets or sets the fully qualified Event Hubs namespace."
                         },
                         "PartitionId": {
                           "type": "string",
                           "description": "Gets or sets the partition identifier."
-                        },
-                        "Tracing": {
-                          "type": "boolean",
-                          "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not."
                         }
                       },
                       "description": "Represents additional settings for configuring a 'Azure.Messaging.EventHubs.Primitives.PartitionReceiver'."

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubConsumerClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubConsumerClientComponent.cs
@@ -35,7 +35,7 @@ internal sealed class EventHubConsumerClientComponent : EventHubsComponent<Azure
                 new EventHubConsumerClient(settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName,
                     settings.ConnectionString, options) :
                 new EventHubConsumerClient(settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName,
-                    settings.Namespace, settings.EventHubName, cred, options);
+                    settings.FullyQualifiedNamespace, settings.EventHubName, cred, options);
         }, requiresCredential: false);
     }
 }

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubProducerClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubProducerClientComponent.cs
@@ -33,7 +33,7 @@ internal sealed class EventHubProducerClientComponent : EventHubsComponent<Azure
 
             return !string.IsNullOrEmpty(settings.ConnectionString) ?
                 new EventHubProducerClient(settings.ConnectionString, options) :
-                new EventHubProducerClient(settings.Namespace, settings.EventHubName, cred, options);
+                new EventHubProducerClient(settings.FullyQualifiedNamespace, settings.EventHubName, cred, options);
         }, requiresCredential: false);
     }
 }

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventProcessorClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventProcessorClientComponent.cs
@@ -37,7 +37,7 @@ internal sealed class EventProcessorClientComponent(IConfiguration builderConfig
             {
                 EnsureConnectionStringOrNamespaceProvided(settings, connectionName, configurationSectionName);
 
-                options.Identifier ??= GenerateClientIdentifier(settings);
+                options.Identifier ??= GenerateClientIdentifier(settings.EventHubName, settings.ConsumerGroup);
 
                 var blobClient = GetBlobContainerClient(settings, cred, configurationSectionName);
 
@@ -45,7 +45,7 @@ internal sealed class EventProcessorClientComponent(IConfiguration builderConfig
                     ? new EventProcessorClient(blobClient,
                         settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.ConnectionString)
                     : new EventProcessorClient(blobClient,
-                        settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.Namespace,
+                        settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.FullyQualifiedNamespace,
                         settings.EventHubName, cred, options);
 
                 return processor;

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/PartitionReceiverClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/PartitionReceiverClientComponent.cs
@@ -39,7 +39,7 @@ internal sealed class PartitionReceiverClientComponent()
                         $"A PartitionReceiver could not be configured. Ensure a valid PartitionId was provided in the '{configurationSectionName}' configuration section.");
                 }
 
-                options.Identifier ??= GenerateClientIdentifier(settings);
+                options.Identifier ??= GenerateClientIdentifier(settings.EventHubName, settings.ConsumerGroup);
 
                 var receiver = !string.IsNullOrEmpty(settings.ConnectionString)
                     ? new PartitionReceiver(
@@ -47,7 +47,7 @@ internal sealed class PartitionReceiverClientComponent()
                         settings.ConnectionString, settings.EventHubName, options)
                     : new PartitionReceiver(
                         settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.PartitionId, settings.EventPosition,
-                        settings.Namespace, settings.EventHubName, cred, options);
+                        settings.FullyQualifiedNamespace, settings.EventHubName, cred, options);
 
                 return receiver;
 

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/README.md
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/README.md
@@ -55,7 +55,7 @@ See the [Azure.Messaging.EventHubs documentation](https://github.com/Azure/azure
 
 ## Configuration
 
-The .NET Aspire Azure Event Hubs library provides multiple options to configure the Azure Event Hubs connection based on the requirements and conventions of your project. Note that either a `Namespace` or a `ConnectionString` is a required to be supplied.
+The .NET Aspire Azure Event Hubs library provides multiple options to configure the Azure Event Hubs connection based on the requirements and conventions of your project. Note that either a `FullyQualifiedNamespace` or a `ConnectionString` is a required to be supplied.
 
 ### Use a connection string
 

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -30,7 +30,7 @@ public static class AspireServiceBusExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingServiceBusSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:ServiceBus" section.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingServiceBusSettings.ConnectionString"/> nor <see cref="AzureMessagingServiceBusSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingServiceBusSettings.ConnectionString"/> nor <see cref="AzureMessagingServiceBusSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddAzureServiceBusClient(
         this IHostApplicationBuilder builder,
         string connectionName,
@@ -48,7 +48,7 @@ public static class AspireServiceBusExtensions
     /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureMessagingServiceBusSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientBuilder">An optional method that can be used for customizing the <see cref="IAzureClientBuilder{TClient, TOptions}"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Azure:Messaging:ServiceBus:{name}" section.</remarks>
-    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingServiceBusSettings.ConnectionString"/> nor <see cref="AzureMessagingServiceBusSettings.Namespace"/> is provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when neither <see cref="AzureMessagingServiceBusSettings.ConnectionString"/> nor <see cref="AzureMessagingServiceBusSettings.FullyQualifiedNamespace"/> is provided.</exception>
     public static void AddKeyedAzureServiceBusClient(
         this IHostApplicationBuilder builder,
         string name,
@@ -69,14 +69,14 @@ public static class AspireServiceBusExtensions
             return azureFactoryBuilder.RegisterClientFactory<ServiceBusClient, ServiceBusClientOptions>((options, cred) =>
             {
                 var connectionString = settings.ConnectionString;
-                if (string.IsNullOrEmpty(connectionString) && string.IsNullOrEmpty(settings.Namespace))
+                if (string.IsNullOrEmpty(connectionString) && string.IsNullOrEmpty(settings.FullyQualifiedNamespace))
                 {
                     throw new InvalidOperationException($"A ServiceBusClient could not be configured. Ensure valid connection information was provided in 'ConnectionStrings:{connectionName}' or specify a 'ConnectionString' or 'Namespace' in the '{configurationSectionName}' configuration section.");
                 }
 
                 return !string.IsNullOrEmpty(connectionString) ?
                     new ServiceBusClient(connectionString, options) :
-                    new ServiceBusClient(settings.Namespace, cred, options);
+                    new ServiceBusClient(settings.FullyQualifiedNamespace, cred, options);
             }, requiresCredential: false);
         }
 
@@ -84,13 +84,13 @@ public static class AspireServiceBusExtensions
             => !string.IsNullOrEmpty(settings.HealthCheckQueueName)
                     ? new AzureServiceBusQueueHealthCheck(new AzureServiceBusQueueHealthCheckOptions(settings.HealthCheckQueueName)
                     {
-                        FullyQualifiedNamespace = settings.Namespace,
+                        FullyQualifiedNamespace = settings.FullyQualifiedNamespace,
                         ConnectionString = settings.ConnectionString,
                         Credential = settings.Credential
                     })
                     : new AzureServiceBusTopicHealthCheck(new AzureServiceBusTopicHealthCheckOptions(settings.HealthCheckTopicName!)
                     {
-                        FullyQualifiedNamespace = settings.Namespace,
+                        FullyQualifiedNamespace = settings.FullyQualifiedNamespace,
                         ConnectionString = settings.ConnectionString,
                         Credential = settings.Credential
                     });
@@ -114,6 +114,6 @@ public static class AspireServiceBusExtensions
             => settings.Credential;
 
         protected override bool GetTracingEnabled(AzureMessagingServiceBusSettings settings)
-            => settings.Tracing;
+            => !settings.DisableTracing;
     }
 }

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AzureMessagingServiceBusSettings.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AzureMessagingServiceBusSettings.cs
@@ -11,13 +11,13 @@ namespace Aspire.Azure.Messaging.ServiceBus;
 /// </summary>
 public sealed class AzureMessagingServiceBusSettings : IConnectionStringSettings
 {
-    private bool? _tracing;
+    private bool? _disableTracing;
 
     /// <summary>
     /// Gets or sets the connection string used to connect to the Service Bus namespace. 
     /// </summary>
     /// <remarks>
-    /// If <see cref="ConnectionString"/> is set, it overrides <see cref="Namespace"/> and <see cref="Credential"/>.
+    /// If <see cref="ConnectionString"/> is set, it overrides <see cref="FullyQualifiedNamespace"/> and <see cref="Credential"/>.
     /// </remarks>
     public string? ConnectionString { get; set; }
 
@@ -27,7 +27,7 @@ public sealed class AzureMessagingServiceBusSettings : IConnectionStringSettings
     /// <remarks>
     /// Used along with <see cref="Credential"/> to establish the connection.
     /// </remarks>
-    public string? Namespace { get; set; }
+    public string? FullyQualifiedNamespace { get; set; }
 
     /// <summary>
     /// Gets or sets the credential used to authenticate to the Service Bus namespace.
@@ -45,20 +45,23 @@ public sealed class AzureMessagingServiceBusSettings : IConnectionStringSettings
     public string? HealthCheckTopicName { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <remarks>
     /// ServiceBus ActivitySource support in Azure SDK is experimental, the shape of Activities may change in the future without notice.
     /// It can be enabled by setting "Azure.Experimental.EnableActivitySource" <see cref="AppContext"/> switch to true.
     /// Or by setting "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE" environment variable to "true".
     /// </remarks>
-    public bool Tracing
+    /// <value>  
+    /// The default value is <see langword="false"/>.  
+    /// </value>
+    public bool DisableTracing
     {
-        get { return _tracing ??= GetTracingDefaultValue(); }
-        set { _tracing = value; }
+        get { return _disableTracing ??= !GetTracingDefaultValue(); }
+        set { _disableTracing = value; }
     }
 
-    // default Tracing to true if the experimental switch is set
+    // Defaults DisableTracing to false if the experimental switch is set
     // TODO: remove this when ActivitySource support is no longer experimental
     private static bool GetTracingDefaultValue()
     {
@@ -83,7 +86,7 @@ public sealed class AzureMessagingServiceBusSettings : IConnectionStringSettings
             // a service bus namespace can't contain ';'. if it is found assume it is a connection string
             if (!connectionString.Contains(';'))
             {
-                Namespace = connectionString;
+                FullyQualifiedNamespace = connectionString;
             }
             else
             {

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/ConfigurationSchema.json
@@ -97,6 +97,15 @@
                       "type": "string",
                       "description": "Gets or sets the connection string used to connect to the Service Bus namespace."
                     },
+                    "DisableTracing": {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
+                    "FullyQualifiedNamespace": {
+                      "type": "string",
+                      "description": "Gets or sets the fully qualified Service Bus namespace."
+                    },
                     "HealthCheckQueueName": {
                       "type": "string",
                       "description": "Name of the queue used by the health check. Mandatory to get health checks enabled."
@@ -104,14 +113,6 @@
                     "HealthCheckTopicName": {
                       "type": "string",
                       "description": "Name of the topic used by the health check. Mandatory to get health checks enabled."
-                    },
-                    "Namespace": {
-                      "type": "string",
-                      "description": "Gets or sets the fully qualified Service Bus namespace."
-                    },
-                    "Tracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not."
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure Service Bus."

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/README.md
@@ -87,7 +87,7 @@ The .NET Aspire Azure Service Bus library supports [Microsoft.Extensions.Configu
       "Messaging": {
         "ServiceBus": {
           "HealthCheckQueueName": "myQueue",
-          "Tracing": true,
+          "DisableTracing": false,
           "ClientOptions": {
             "Identifier": "CLIENT_ID"
           }

--- a/src/Components/Aspire.Azure.Search.Documents/AspireAzureSearchExtensions.cs
+++ b/src/Components/Aspire.Azure.Search.Documents/AspireAzureSearchExtensions.cs
@@ -104,12 +104,12 @@ public static class AspireAzureSearchExtensions
             => new AzureSearchIndexHealthCheck(client);
 
         protected override bool GetHealthCheckEnabled(AzureSearchSettings settings)
-            => settings.HealthChecks;
+            => !settings.DisableHealthChecks;
 
         protected override TokenCredential? GetTokenCredential(AzureSearchSettings settings)
             => settings.Credential;
 
         protected override bool GetTracingEnabled(AzureSearchSettings settings)
-            => settings.Tracing;
+            => !settings.DisableTracing;
     }
 }

--- a/src/Components/Aspire.Azure.Search.Documents/AzureSearchSettings.cs
+++ b/src/Components/Aspire.Azure.Search.Documents/AzureSearchSettings.cs
@@ -40,20 +40,20 @@ public sealed class AzureSearchSettings : IConnectionStringSettings
     public string? Key { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the Azure Search health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the Azure Search health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Search.Documents/ConfigurationSchema.json
@@ -102,24 +102,24 @@
                       },
                       "description": "Provides the client configuration options for connecting to Azure\nCognitive Search."
                     },
+                    "DisableHealthChecks": {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the Azure Search health check is disabled or not.",
+                      "default": false
+                    },
+                    "DisableTracing": {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
                     "Endpoint": {
                       "type": "string",
                       "format": "uri",
                       "description": "Gets or sets a 'System.Uri' referencing the Azure Search endpoint.\nThis is likely to be similar to \"https://{search_service}.search.windows.net\"."
                     },
-                    "HealthChecks": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Azure Search health check is enabled or not.",
-                      "default": true
-                    },
                     "Key": {
                       "type": "string",
                       "description": "Gets or sets the key to use to authenticate to the Azure Search endpoint."
-                    },
-                    "Tracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure Search."

--- a/src/Components/Aspire.Azure.Search.Documents/README.md
+++ b/src/Components/Aspire.Azure.Search.Documents/README.md
@@ -104,7 +104,7 @@ The .NET Aspire Azure Search library supports [Microsoft.Extensions.Configuratio
     "Azure": {
       "Search": {
         "Documents": {
-          "Tracing": true,
+          "DisableTracing": false,
         }
       }
     }
@@ -117,7 +117,7 @@ The .NET Aspire Azure Search library supports [Microsoft.Extensions.Configuratio
 You can also pass the `Action<AzureSearchSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
-builder.AddAzureSearchClient("searchConnectionName", settings => settings.Tracing = false);
+builder.AddAzureSearchClient("searchConnectionName", settings => settings.DisableTracing = true);
 ```
 
 You can also setup the [SearchClientOptions](https://learn.microsoft.com/dotnet/api/azure.search.documents.searchclientoptions) using the optional `Action<IAzureClientBuilder<SearchIndexClient, SearchClientOptions>> configureClientBuilder` parameter of the `AddAzureSearchClient` method. For example, to set the client ID for this client:

--- a/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
@@ -148,12 +148,12 @@ public static class AspireKeyVaultExtensions
         }
 
         protected override bool GetHealthCheckEnabled(AzureSecurityKeyVaultSettings settings)
-            => settings.HealthChecks;
+            => !settings.DisableHealthChecks;
 
         protected override TokenCredential? GetTokenCredential(AzureSecurityKeyVaultSettings settings)
             => settings.Credential;
 
         protected override bool GetTracingEnabled(AzureSecurityKeyVaultSettings settings)
-            => settings.Tracing;
+            => !settings.DisableTracing;
     }
 }

--- a/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AzureSecurityKeyVaultSettings.cs
@@ -25,20 +25,20 @@ public sealed class AzureSecurityKeyVaultSettings : IConnectionStringSettings
     public TokenCredential? Credential { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the Key Vault health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the Key Vault health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Security.KeyVault/ConfigurationSchema.json
@@ -103,15 +103,15 @@
                       },
                       "description": "Options that allow you to configure the requests sent to Key Vault."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Key Vault health check is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the Key Vault health check is disabled or not.",
+                      "default": false
                     },
-                    "Tracing": {
+                    "DisableTracing": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
                     },
                     "VaultUri": {
                       "type": "string",

--- a/src/Components/Aspire.Azure.Security.KeyVault/README.md
+++ b/src/Components/Aspire.Azure.Security.KeyVault/README.md
@@ -89,8 +89,8 @@ The .NET Aspire Azure Key Vault library supports [Microsoft.Extensions.Configura
     "Azure": {
       "Security": {
         "KeyVault": {
-          "HealthChecks": false,
-          "Tracing": true,
+          "DisableHealthChecks": true,
+          "DisableTracing": false,
           "ClientOptions": {
             "Diagnostics": {
               "ApplicationId": "myapp"
@@ -108,7 +108,7 @@ The .NET Aspire Azure Key Vault library supports [Microsoft.Extensions.Configura
 You can also pass the `Action<AzureSecurityKeyVaultSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddAzureKeyVaultClient("secrets", settings => settings.HealthChecks = false);
+builder.AddAzureKeyVaultClient("secrets", settings => settings.DisableHealthChecks = true);
 ```
 
 You can also setup the [SecretClientOptions](https://learn.microsoft.com/dotnet/api/azure.security.keyvault.secrets.secretclientoptions) using the optional `Action<IAzureClientBuilder<SecretClient, SecretClientOptions>> configureClientBuilder` parameter of the `AddAzureKeyVaultClient` method. For example, to set the first part of "User-Agent" headers for all requests issues by this client:

--- a/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
@@ -97,12 +97,12 @@ public static class AspireBlobStorageExtensions
             => new AzureBlobStorageHealthCheck(client);
 
         protected override bool GetHealthCheckEnabled(AzureStorageBlobsSettings settings)
-            => settings.HealthChecks;
+            => !settings.DisableHealthChecks;
 
         protected override TokenCredential? GetTokenCredential(AzureStorageBlobsSettings settings)
             => settings.Credential;
 
         protected override bool GetTracingEnabled(AzureStorageBlobsSettings settings)
-            => settings.Tracing;
+            => !settings.DisableTracing;
     }
 }

--- a/src/Components/Aspire.Azure.Storage.Blobs/AzureStorageBlobsSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AzureStorageBlobsSettings.cs
@@ -35,20 +35,20 @@ public sealed class AzureStorageBlobsSettings : IConnectionStringSettings
     public TokenCredential? Credential { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the Blob Storage health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the Blob Storage health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Storage.Blobs/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Blobs/ConfigurationSchema.json
@@ -160,20 +160,20 @@
                       "type": "string",
                       "description": "Gets or sets the connection string used to connect to the blob service."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Blob Storage health check is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the Blob Storage health check is disabled or not.",
+                      "default": false
+                    },
+                    "DisableTracing": {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
                     },
                     "ServiceUri": {
                       "type": "string",
                       "format": "uri",
                       "description": "A 'System.Uri' referencing the blob service.\nThis is likely to be similar to \"https://{account_name}.blob.core.windows.net\"."
-                    },
-                    "Tracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure Blob Storage."

--- a/src/Components/Aspire.Azure.Storage.Blobs/README.md
+++ b/src/Components/Aspire.Azure.Storage.Blobs/README.md
@@ -86,8 +86,8 @@ The .NET Aspire Azure Storage Blobs library supports [Microsoft.Extensions.Confi
     "Azure": {
       "Storage": {
         "Blobs": {
-          "HealthChecks": false,
-          "Tracing": true,
+          "DisableHealthChecks": true,
+          "DisableTracing": false,
           "ClientOptions": {
             "Diagnostics": {
               "ApplicationId": "myapp"

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
@@ -100,12 +100,12 @@ public static class AspireQueueStorageExtensions
             => new AzureQueueStorageHealthCheck(client, new AzureQueueStorageHealthCheckOptions());
 
         protected override bool GetHealthCheckEnabled(AzureStorageQueuesSettings settings)
-            => settings.HealthChecks;
+            => !settings.DisableHealthChecks;
 
         protected override TokenCredential? GetTokenCredential(AzureStorageQueuesSettings settings)
             => settings.Credential;
 
         protected override bool GetTracingEnabled(AzureStorageQueuesSettings settings)
-            => settings.Tracing;
+            => !settings.DisableTracing;
     }
 }

--- a/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AzureStorageQueuesSettings.cs
@@ -35,20 +35,20 @@ public sealed class AzureStorageQueuesSettings : IConnectionStringSettings
     public TokenCredential? Credential { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the Queues Storage health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the Queues Storage health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     void IConnectionStringSettings.ParseConnectionString(string? connectionString)
     {

--- a/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Storage.Queues/ConfigurationSchema.json
@@ -119,20 +119,20 @@
                       "type": "string",
                       "description": "Gets or sets the connection string used to connect to the blob service."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Queues Storage health check is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the Queues Storage health check is disabled or not.",
+                      "default": false
+                    },
+                    "DisableTracing": {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
                     },
                     "ServiceUri": {
                       "type": "string",
                       "format": "uri",
                       "description": "A 'System.Uri' referencing the queue service.\nThis is likely to be similar to \"https://{account_name}.queue.core.windows.net\"."
-                    },
-                    "Tracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to Azure Storage Queues."

--- a/src/Components/Aspire.Azure.Storage.Queues/README.md
+++ b/src/Components/Aspire.Azure.Storage.Queues/README.md
@@ -86,8 +86,8 @@ The .NET Aspire Azure Storage Queues library supports [Microsoft.Extensions.Conf
     "Azure": {
       "Storage": {
         "Queues": {
-          "HealthChecks": false,
-          "Tracing": true,
+          "DisableHealthChecks": true,
+          "DisableTracing": false,
           "ClientOptions": {
             "Diagnostics": {
               "ApplicationId": "myapp"
@@ -105,7 +105,7 @@ The .NET Aspire Azure Storage Queues library supports [Microsoft.Extensions.Conf
 You can also pass the `Action<AzureStorageQueuesSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddAzureQueueClient("queue", settings => settings.HealthChecks = false);
+builder.AddAzureQueueClient("queue", settings => settings.DisableHealthChecks = true);
 ```
 
 You can also setup the [QueueClientOptions](https://learn.microsoft.com/dotnet/api/azure.storage.queues.queueclientoptions) using the optional `Action<IAzureClientBuilder<QueueServiceClient, QueueClientOptions>> configureClientBuilder` parameter of the `AddAzureQueueClient` method. For example, to set the first part of "User-Agent" headers for all requests issues by this client:

--- a/src/Components/Aspire.Confluent.Kafka/AspireKafkaConsumerExtensions.cs
+++ b/src/Components/Aspire.Confluent.Kafka/AspireKafkaConsumerExtensions.cs
@@ -69,7 +69,7 @@ public static class AspireKafkaConsumerExtensions
             builder.Services.AddKeyedSingleton<IConsumer<TKey, TValue>>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<ConsumerConnectionFactory<TKey, TValue>>(key).Create());
         }
 
-        if (settings.Metrics)
+        if (!settings.DisableMetrics)
         {
             builder.Services.TryAddSingleton<MetricsChannel>();
             builder.Services.AddHostedService<MetricsService>();
@@ -77,7 +77,7 @@ public static class AspireKafkaConsumerExtensions
             builder.Services.AddOpenTelemetry().WithMetrics(metricBuilderProvider => metricBuilderProvider.AddMeter(ConfluentKafkaCommon.MeterName));
         }
 
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             string healthCheckName = serviceKey is null
                 ? ConfluentKafkaCommon.ConsumerHealthCheckName
@@ -125,7 +125,7 @@ public static class AspireKafkaConsumerExtensions
             logger.LogWarning("LogHandler is already set. Skipping... No logs will be written.");
         }
 
-        if (settings.Metrics)
+        if (!settings.DisableMetrics)
         {
             MetricsChannel channel = serviceProvider.GetRequiredService<MetricsChannel>();
             void OnStatistics(IConsumer<TKey, TValue> _, string json)

--- a/src/Components/Aspire.Confluent.Kafka/AspireKafkaProducerExtensions.cs
+++ b/src/Components/Aspire.Confluent.Kafka/AspireKafkaProducerExtensions.cs
@@ -69,7 +69,7 @@ public static class AspireKafkaProducerExtensions
             builder.Services.AddKeyedSingleton<IProducer<TKey, TValue>>(serviceKey, (sp, key) => sp.GetRequiredKeyedService<ProducerConnectionFactory<TKey, TValue>>(key).Create());
         }
 
-        if (settings.Metrics)
+        if (!settings.DisableMetrics)
         {
             builder.Services.TryAddSingleton<MetricsChannel>();
             builder.Services.AddHostedService<MetricsService>();
@@ -77,7 +77,7 @@ public static class AspireKafkaProducerExtensions
             builder.Services.AddOpenTelemetry().WithMetrics(metricBuilderProvider => metricBuilderProvider.AddMeter(ConfluentKafkaCommon.MeterName));
         }
 
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             string healthCheckName = serviceKey is null
                 ? ConfluentKafkaCommon.ProducerHealthCheckName
@@ -125,7 +125,7 @@ public static class AspireKafkaProducerExtensions
             logger.LogWarning("LogHandler is already set. Skipping... No logs will be written.");
         }
 
-        if (settings.Metrics)
+        if (!settings.DisableMetrics)
         {
             MetricsChannel channel = serviceProvider.GetRequiredService<MetricsChannel>();
             void OnStatistics(IProducer<TKey, TValue> _, string json)

--- a/src/Components/Aspire.Confluent.Kafka/ConfigurationSchema.json
+++ b/src/Components/Aspire.Confluent.Kafka/ConfigurationSchema.json
@@ -474,13 +474,13 @@
                       "type": "string",
                       "description": "Gets or sets the connection string of the Kafka server to connect to."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Kafka health check is enabled or not."
+                      "description": "Gets or sets a boolean value that indicates whether the Kafka health check is disabled or not."
                     },
-                    "Metrics": {
+                    "DisableMetrics": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether collecting metrics is enabled or not."
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not."
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a Kafka message broker to consume messages."
@@ -937,15 +937,15 @@
                       "type": "string",
                       "description": "Gets or sets the connection string of the Kafka server to connect to."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the Kafka health check is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the Kafka health check is disabled or not.",
+                      "default": false
                     },
-                    "Metrics": {
+                    "DisableMetrics": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether collecting metrics is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
+                      "default": false
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a Kafka message broker to produce messages."

--- a/src/Components/Aspire.Confluent.Kafka/KafkaConsumerSettings.cs
+++ b/src/Components/Aspire.Confluent.Kafka/KafkaConsumerSettings.cs
@@ -22,14 +22,20 @@ public sealed class KafkaConsumerSettings
     public ConsumerConfig Config { get; } = new ConsumerConfig();
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether collecting metrics is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.
     /// </summary>
-    public bool Metrics { get; set; } = true;
+    /// <value>
+    /// The default value is <see langword="false" />.
+    /// </value>
+    public bool DisableMetrics { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the Kafka health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the Kafka health check is disabled or not.
     /// </summary>
-    public bool HealthChecks { get; set; } = true;
+    /// <value>
+    /// The default value is <see langword="false" />.
+    /// </value>
+    public bool DisableHealthChecks { get; set; }
 
     internal void Consolidate()
     {
@@ -40,7 +46,7 @@ public sealed class KafkaConsumerSettings
             Config.BootstrapServers = ConnectionString;
         }
 
-        if (Metrics)
+        if (!DisableMetrics)
         {
             Config.StatisticsIntervalMs ??= 1000;
         }

--- a/src/Components/Aspire.Confluent.Kafka/KafkaProducerSettings.cs
+++ b/src/Components/Aspire.Confluent.Kafka/KafkaProducerSettings.cs
@@ -22,20 +22,20 @@ public sealed class KafkaProducerSettings
     public ProducerConfig Config { get; } = new ProducerConfig();
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether collecting metrics is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Metrics { get; set; } = true;
+    public bool DisableMetrics { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the Kafka health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the Kafka health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     internal void Consolidate()
     {
@@ -46,7 +46,7 @@ public sealed class KafkaProducerSettings
             Config.BootstrapServers = ConnectionString;
         }
 
-        if (Metrics)
+        if (!DisableMetrics)
         {
             Config.StatisticsIntervalMs ??= 1000;
         }

--- a/src/Components/Aspire.Confluent.Kafka/README.md
+++ b/src/Components/Aspire.Confluent.Kafka/README.md
@@ -85,7 +85,7 @@ The .NET Aspire Confluent Kafka component supports [Microsoft.Extensions.Configu
     "Confluent": {
       "Kafka": {
         "Producer": {
-          "HealthChecks": true,
+          "DisableHealthChecks": false,
           "Config": {
             "Acks": "All"
           }
@@ -105,12 +105,12 @@ The `Config` properties of both  `Aspire:Confluent:Kafka:Producer` and `Aspire.C
 Also you can pass the `Action<KafkaProducerSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-    builder.AddKafkaProducer<string, string>("messaging", settings => settings.HealthChecks = false);
+    builder.AddKafkaProducer<string, string>("messaging", settings => settings.DisableHealthChecks = true);
 ```
 
 Similarly you can configure inline a consumer from code:
 ```c#
-    builder.AddKafkaConsumer<string, string>("messaging", settings => settings.HealthChecks = false);
+    builder.AddKafkaConsumer<string, string>("messaging", settings => settings.DisableHealthChecks = true);
 ```
 
 ### Use inline delegates to configure `ProducerBuilder<TKey, TValue>` and `ConsumerBuilder<TKey, TValue>`.

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.Hosting;
 /// <summary>
 /// Azure CosmosDB extension
 /// </summary>
-public static class AspireAzureCosmosDBExtensions
+public static class AspireMicrosoftAzureCosmosDBExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Microsoft:Azure:Cosmos";
 
@@ -23,14 +23,14 @@ public static class AspireAzureCosmosDBExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
     /// <param name="connectionName">The connection name to use to find a connection string.</param>
-    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureCosmosDBSettings"/>. It's invoked after the settings are read from the configuration.</param>
+    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosDBSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
     public static void AddAzureCosmosDBClient(
         this IHostApplicationBuilder builder,
         string connectionName,
-        Action<AzureCosmosDBSettings>? configureSettings = null,
+        Action<MicrosoftAzureCosmosDBSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
     {
         AddAzureCosmosDB(builder, DefaultConfigSectionName, configureSettings, configureClientOptions, connectionName, serviceKey: null);
@@ -42,14 +42,14 @@ public static class AspireAzureCosmosDBExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
     /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection string from the ConnectionStrings configuration section.</param>
-    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="AzureCosmosDBSettings"/>. It's invoked after the settings are read from the configuration.</param>
+    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosDBSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
     public static void AddKeyedAzureCosmosDbClient(
         this IHostApplicationBuilder builder,
         string name,
-        Action<AzureCosmosDBSettings>? configureSettings = null,
+        Action<MicrosoftAzureCosmosDBSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
     {
         AddAzureCosmosDB(builder, $"{DefaultConfigSectionName}:{name}", configureSettings, configureClientOptions, connectionName: name, serviceKey: name);
@@ -58,14 +58,14 @@ public static class AspireAzureCosmosDBExtensions
     private static void AddAzureCosmosDB(
         this IHostApplicationBuilder builder,
         string configurationSectionName,
-        Action<AzureCosmosDBSettings>? configureSettings,
+        Action<MicrosoftAzureCosmosDBSettings>? configureSettings,
         Action<CosmosClientOptions>? configureClientOptions,
         string connectionName,
         string? serviceKey)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var settings = new AzureCosmosDBSettings();
+        var settings = new MicrosoftAzureCosmosDBSettings();
         builder.Configuration.GetSection(configurationSectionName).Bind(settings);
 
         if (builder.Configuration.GetConnectionString(connectionName) is string connectionString)
@@ -85,7 +85,7 @@ public static class AspireAzureCosmosDBExtensions
         var clientOptions = new CosmosClientOptions();
         // Needs to be enabled for either logging or tracing to work.
         clientOptions.CosmosClientTelemetryOptions.DisableDistributedTracing = false;
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             builder.Services.AddOpenTelemetry().WithTracing(tracerProviderBuilder =>
             {

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AssemblyInfo.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AssemblyInfo.cs
@@ -4,6 +4,6 @@
 using Aspire;
 using Aspire.Microsoft.Azure.Cosmos;
 
-[assembly: ConfigurationSchema("Aspire:Microsoft:Azure:Cosmos", typeof(AzureCosmosDBSettings))]
+[assembly: ConfigurationSchema("Aspire:Microsoft:Azure:Cosmos", typeof(MicrosoftAzureCosmosDBSettings))]
 
 [assembly: LoggingCategories("Azure-Cosmos-Operation-Request-Diagnostics")]

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
@@ -30,10 +30,10 @@
                       "type": "string",
                       "description": "Gets or sets the connection string of the Azure Cosmos database to connect to."
                     },
-                    "Tracing": {
+                    "DisableTracing": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
                     }
                   },
                   "description": "The settings relevant to accessing Azure Cosmos DB."

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/MicrosoftAzureCosmosDBSettings.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/MicrosoftAzureCosmosDBSettings.cs
@@ -8,7 +8,7 @@ namespace Aspire.Microsoft.Azure.Cosmos;
 /// <summary>
 /// The settings relevant to accessing Azure Cosmos DB.
 /// </summary>
-public sealed class AzureCosmosDBSettings
+public sealed class MicrosoftAzureCosmosDBSettings
 {
     /// <summary>
     /// Gets or sets the connection string of the Azure Cosmos database to connect to.
@@ -16,12 +16,12 @@ public sealed class AzureCosmosDBSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     /// <summary>
     /// A <see cref="Uri"/> referencing the Azure Cosmos DB Endpoint.

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -54,7 +54,7 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 
 #### Account Endpoint
 
-The recommended approach is to use an AccountEndpoint, which works with the `AzureCosmosDBSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use an AccountEndpoint, which works with the `MicrosoftAzureCosmosDBSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
 
 ```json
 {
@@ -78,7 +78,7 @@ Alternatively, an [Azure Cosmos DB connection string](https://learn.microsoft.co
 
 ### Use configuration providers
 
-The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `AzureCosmosDBSettings` and `QueueClientOptions` from configuration by using the `Aspire:Microsoft:Azure:Cosmos` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `MicrosoftAzureCosmosDBSettings` and `QueueClientOptions` from configuration by using the `Aspire:Microsoft:Azure:Cosmos` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {
@@ -86,7 +86,7 @@ The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions
     "Microsoft": {
       "Azure": {
         "Cosmos": {
-          "Tracing": true,
+          "DisableTracing": false,
         }
       }
     }
@@ -96,10 +96,10 @@ The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions
 
 ### Use inline delegates
 
-You can also pass the `Action<AzureCosmosDBSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
+You can also pass the `Action<MicrosoftAzureCosmosDBSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
-builder.AddAzureCosmosDbClient("cosmosConnectionName", settings => settings.Tracing = false);
+builder.AddAzureCosmosDbClient("cosmosConnectionName", settings => settings.DisableTracing = true);
 ```
 
 You can also setup the [CosmosClientOptions](https://learn.microsoft.com/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions) using the optional `Action<CosmosClientOptions> configureClientOptions` parameter of the `AddAzureCosmosDbClient` method. For example, to set the `ApplicationName` "User-Agent" header suffix for all requests issues by this client:

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/AspireSqlServerSqlClientExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/AspireSqlServerSqlClientExtensions.cs
@@ -81,7 +81,7 @@ public static class AspireSqlServerSqlClientExtensions
 
         // SqlClient Data Provider (Microsoft.Data.SqlClient) handles connection pooling automatically and it's on by default
         // https://learn.microsoft.com/sql/connect/ado-net/sql-server-connection-pooling
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             builder.Services.AddOpenTelemetry().WithTracing(tracerProviderBuilder =>
             {
@@ -89,7 +89,7 @@ public static class AspireSqlServerSqlClientExtensions
             });
         }
 
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             builder.TryAddHealthCheck(new HealthCheckRegistration(
                 serviceKey is null ? "SqlServer" : $"SqlServer_{connectionName}",

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/ConfigurationSchema.json
@@ -16,15 +16,15 @@
                       "type": "string",
                       "description": "Gets or sets the connection string of the SQL Server database to connect to."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the database health check is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                      "default": false
                     },
-                    "Tracing": {
+                    "DisableTracing": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a SQL Server database using SqlClient."

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/MicrosoftDataSqlClientSettings.cs
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/MicrosoftDataSqlClientSettings.cs
@@ -14,19 +14,19 @@ public sealed class MicrosoftDataSqlClientSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the database health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the database health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 }
 

--- a/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
+++ b/src/Components/Aspire.Microsoft.Data.SqlClient/README.md
@@ -69,7 +69,7 @@ The .NET Aspire SqlClient component supports [Microsoft.Extensions.Configuration
     "Microsoft": {
       "Data": {
         "SqlClient": {
-          "HealthChecks": true
+          "DisableHealthChecks": false
         }
       }
     }
@@ -82,7 +82,7 @@ The .NET Aspire SqlClient component supports [Microsoft.Extensions.Configuration
 Also you can pass the `Action<MicrosoftDataSqlClientSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddSqlServerClient("sqldata", settings => settings.HealthChecks = false);
+builder.AddSqlServerClient("sqldata", settings => settings.DisableHealthChecks = true);
 ```
 
 ## AppHost extensions

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosDBExtensions.cs
@@ -159,7 +159,7 @@ public static class AspireAzureEFCoreCosmosDBExtensions
 
     private static void ConfigureInstrumentation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TContext>(IHostApplicationBuilder builder, EntityFrameworkCoreCosmosDBSettings settings) where TContext : DbContext
     {
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             builder.Services.AddOpenTelemetry().WithTracing(tracerProviderBuilder =>
             {

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
@@ -48,6 +48,11 @@
                       "type": "string",
                       "description": "The connection string of the Azure Cosmos DB server database to connect to."
                     },
+                    "DisableTracing": {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
+                    },
                     "Region": {
                       "type": "string",
                       "description": "Gets or sets a string value that indicates what Azure region this client will run in."
@@ -56,11 +61,6 @@
                       "type": "string",
                       "pattern": "^-?(\\d{1,7}|((\\d{1,7}[\\.:])?(([01]?\\d|2[0-3]):[0-5]?\\d|([01]?\\d|2[0-3]):[0-5]?\\d:[0-5]?\\d)(\\.\\d{1,7})?))$",
                       "description": "Gets or sets the time to wait for the response to come back from the network peer."
-                    },
-                    "Tracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
                     }
                   },
                   "description": "The settings relevant to accessing Azure Cosmos DB database using EntityFrameworkCore."

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosDBSettings.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosDBSettings.cs
@@ -31,12 +31,12 @@ public sealed class EntityFrameworkCoreCosmosDBSettings
     public TokenCredential? Credential { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     /// <summary>
     /// Gets or sets a string value that indicates what Azure region this client will run in.

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
@@ -79,7 +79,7 @@ The .NET Aspire Microsoft EntityFrameworkCore Cosmos component supports [Microso
     "Microsoft": {
       "EntityFrameworkCore": {
         "Cosmos": {
-          "Tracing": false
+          "DisableTracing": true
         }
       }
     }
@@ -92,13 +92,13 @@ The .NET Aspire Microsoft EntityFrameworkCore Cosmos component supports [Microso
 Also you can pass the `Action<EntityFrameworkCoreCosmosDBSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
-    builder.AddCosmosDbContext<MyDbContext>("cosmosdb", "mydb", settings => settings.Tracing = false);
+    builder.AddCosmosDbContext<MyDbContext>("cosmosdb", "mydb", settings => settings.DisableTracing = true);
 ```
 
 or
 
 ```csharp
-    builder.EnrichCosmosDbContext<MyDbContext>(settings => settings.Tracing = false);
+    builder.EnrichCosmosDbContext<MyDbContext>(settings => settings.DisableTracing = true);
 ```
 
 ## AppHost extensions

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/ConfigurationSchema.json
@@ -62,20 +62,20 @@
                       "type": "string",
                       "description": "The connection string of the SQL server database to connect to."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the database health check is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                      "default": false
                     },
-                    "Retry": {
+                    "DisableRetry": {
                       "type": "boolean",
-                      "description": "Gets or sets whether retries should be enabled.",
-                      "default": true
+                      "description": "Gets or sets whether retries should be disabled.",
+                      "default": false
                     },
-                    "Tracing": {
+                    "DisableTracing": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a SQL Server database using EntityFrameworkCore."

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/MicrosoftEntityFrameworkCoreSqlServerSettings.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/MicrosoftEntityFrameworkCoreSqlServerSettings.cs
@@ -14,28 +14,28 @@ public sealed class MicrosoftEntityFrameworkCoreSqlServerSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets whether retries should be enabled.
+    /// Gets or sets whether retries should be disabled.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Retry { get; set; } = true;
+    public bool DisableRetry { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the database health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the database health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     /// <summary>
     /// Gets or sets the time in seconds to wait for the command to execute.

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/README.md
@@ -79,8 +79,8 @@ The .NET Aspire SQL Server EntityFrameworkCore SqlClient component supports [Mic
     "Microsoft": {
       "EntityFrameworkCore": {
         "SqlServer": {
-          "HealthChecks": false,
-          "Tracing": false
+          "DisableHealthChecks": true,
+          "DisableTracing": true
         }
       }
     }
@@ -93,13 +93,13 @@ The .NET Aspire SQL Server EntityFrameworkCore SqlClient component supports [Mic
 Also you can pass the `Action<MicrosoftEntityFrameworkCoreSqlServerSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-    builder.AddSqlServerDbContext<MyDbContext>("sqldata", settings => settings.HealthChecks = false);
+    builder.AddSqlServerDbContext<MyDbContext>("sqldata", settings => settings.DisableHealthChecks = true);
 ```
 
 or
 
 ```csharp
-    builder.EnrichSqlServerDbContext<MyDbContext>(settings => settings.HealthChecks = false);
+    builder.EnrichSqlServerDbContext<MyDbContext>(settings => settings.DisableHealthChecks = true);
 ```
 
 ## AppHost extensions

--- a/src/Components/Aspire.MongoDB.Driver/AspireMongoDBDriverExtensions.cs
+++ b/src/Components/Aspire.MongoDB.Driver/AspireMongoDBDriverExtensions.cs
@@ -84,7 +84,7 @@ public static class AspireMongoDBDriverExtensions
             configureClientSettings,
             serviceKey);
 
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             builder.Services
                 .AddOpenTelemetry()
@@ -160,7 +160,7 @@ public static class AspireMongoDBDriverExtensions
         string healthCheckName,
         MongoDBSettings settings)
     {
-        if (!settings.HealthChecks || string.IsNullOrWhiteSpace(settings.ConnectionString))
+        if (settings.DisableHealthChecks || string.IsNullOrWhiteSpace(settings.ConnectionString))
         {
             return;
         }
@@ -186,7 +186,7 @@ public static class AspireMongoDBDriverExtensions
 
         var clientSettings = MongoClientSettings.FromConnectionString(mongoDbSettings.ConnectionString);
 
-        if (mongoDbSettings.Tracing)
+        if (!mongoDbSettings.DisableTracing)
         {
             clientSettings.ClusterConfigurator = cb => cb.Subscribe(new DiagnosticsActivityEventSubscriber());
         }

--- a/src/Components/Aspire.MongoDB.Driver/ConfigurationSchema.json
+++ b/src/Components/Aspire.MongoDB.Driver/ConfigurationSchema.json
@@ -37,19 +37,19 @@
                   "type": "string",
                   "description": "Gets or sets the connection string of the MongoDB database to connect to."
                 },
+                "DisableHealthChecks": {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                  "default": false
+                },
+                "DisableTracing": {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                  "default": false
+                },
                 "HealthCheckTimeout": {
                   "type": "integer",
                   "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
-                },
-                "HealthChecks": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is enabled or not.",
-                  "default": true
-                },
-                "Tracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                  "default": true
                 }
               },
               "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."

--- a/src/Components/Aspire.MongoDB.Driver/MongoDBSettings.cs
+++ b/src/Components/Aspire.MongoDB.Driver/MongoDBSettings.cs
@@ -14,12 +14,12 @@ public sealed class MongoDBSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the MongoDB health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
     /// Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds.
@@ -27,11 +27,11 @@ public sealed class MongoDBSettings
     public int? HealthCheckTimeout { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
 }

--- a/src/Components/Aspire.MongoDB.Driver/README.md
+++ b/src/Components/Aspire.MongoDB.Driver/README.md
@@ -69,9 +69,9 @@ The .NET Aspire MongoDB component supports [Microsoft.Extensions.Configuration](
     "MongoDB": {
       "Driver": {
         "ConnectionString": "mongodb://server:port/test",
-        "HealthChecks": true,
+        "DisableHealthChecks": false,
         "HealthCheckTimeout": 10000,
-        "Tracing": true
+        "DisableTracing": false
       },
     }
   }

--- a/src/Components/Aspire.MySqlConnector/AspireMySqlConnectorExtensions.cs
+++ b/src/Components/Aspire.MySqlConnector/AspireMySqlConnectorExtensions.cs
@@ -69,7 +69,7 @@ public static class AspireMySqlConnectorExtensions
 
         // Same as SqlClient connection pooling is on by default and can be handled with connection string
         // https://mysqlconnector.net/connection-options/#Pooling
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             builder.TryAddHealthCheck(new HealthCheckRegistration(
                 serviceKey is null ? "MySql" : $"MySql_{connectionName}",
@@ -82,7 +82,7 @@ public static class AspireMySqlConnectorExtensions
                 timeout: default));
         }
 
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             builder.Services.AddOpenTelemetry()
                 .WithTracing(tracerProviderBuilder =>
@@ -91,7 +91,7 @@ public static class AspireMySqlConnectorExtensions
                 });
         }
 
-        if (settings.Metrics)
+        if (!settings.DisableMetrics)
         {
             builder.Services.AddOpenTelemetry()
                 .WithMetrics(meterProviderBuilder =>

--- a/src/Components/Aspire.MySqlConnector/ConfigurationSchema.json
+++ b/src/Components/Aspire.MySqlConnector/ConfigurationSchema.json
@@ -34,20 +34,20 @@
               "type": "string",
               "description": "The connection string of the MySQL database to connect to."
             },
-            "HealthChecks": {
+            "DisableHealthChecks": {
               "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the database health check is enabled or not.",
-              "default": true
+              "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+              "default": false
             },
-            "Metrics": {
+            "DisableMetrics": {
               "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
-              "default": true
+              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+              "default": false
             },
-            "Tracing": {
+            "DisableTracing": {
               "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-              "default": true
+              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+              "default": false
             }
           },
           "description": "Provides the client configuration settings for connecting to a MySQL database using MySqlConnector."

--- a/src/Components/Aspire.MySqlConnector/MySqlConnectorSettings.cs
+++ b/src/Components/Aspire.MySqlConnector/MySqlConnectorSettings.cs
@@ -14,26 +14,26 @@ public sealed class MySqlConnectorSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the database health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the database health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Metrics { get; set; } = true;
+    public bool DisableMetrics { get; set; }
 }

--- a/src/Components/Aspire.MySqlConnector/README.md
+++ b/src/Components/Aspire.MySqlConnector/README.md
@@ -67,8 +67,8 @@ The .NET Aspire MySQL component supports [Microsoft.Extensions.Configuration](ht
 {
   "Aspire": {
     "MySqlConnector": {
-      "HealthChecks": false,
-      "Tracing": false
+      "DisableHealthChecks": true,
+      "DisableTracing": true
     }
   }
 }
@@ -79,7 +79,7 @@ The .NET Aspire MySQL component supports [Microsoft.Extensions.Configuration](ht
 Also you can pass the `Action<MySqlConnectorSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddMySqlDataSource("mysql", settings => settings.HealthChecks = false);
+builder.AddMySqlDataSource("mysql", settings => settings.DisableHealthChecks = true);
 ```
 
 ## AppHost extensions

--- a/src/Components/Aspire.NATS.Net/AspireNatsClientExtensions.cs
+++ b/src/Components/Aspire.NATS.Net/AspireNatsClientExtensions.cs
@@ -99,7 +99,7 @@ public static class AspireNatsClientExtensions
             builder.Services.TryAddKeyedSingleton<INatsConnection>(serviceKey, static (provider, key) => provider.GetRequiredKeyedService<NatsConnection>(key));
         }
 
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             builder.TryAddHealthCheck(new HealthCheckRegistration(
                 serviceKey is null ? "NATS" : $"NATS_{connectionName}",
@@ -111,7 +111,7 @@ public static class AspireNatsClientExtensions
                 timeout: default));
         }
 
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             builder.Services
                 .AddOpenTelemetry()

--- a/src/Components/Aspire.NATS.Net/ConfigurationSchema.json
+++ b/src/Components/Aspire.NATS.Net/ConfigurationSchema.json
@@ -22,15 +22,15 @@
                   "type": "string",
                   "description": "Gets or sets the connection string of the NATS cluster to connect to."
                 },
-                "HealthChecks": {
+                "DisableHealthChecks": {
                   "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the NATS health check is enabled or not.",
-                  "default": true
+                  "description": "Gets or sets a boolean value that indicates whether the NATS health check is disabled or not.",
+                  "default": false
                 },
-                "Tracing": {
+                "DisableTracing": {
                   "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                  "default": true
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                  "default": false
                 }
               },
               "description": "Provides the client configuration settings for connecting to a NATS cluster."

--- a/src/Components/Aspire.NATS.Net/NatsClientSettings.cs
+++ b/src/Components/Aspire.NATS.Net/NatsClientSettings.cs
@@ -14,18 +14,18 @@ public sealed class NatsClientSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the NATS health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the NATS health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 }

--- a/src/Components/Aspire.NATS.Net/README.md
+++ b/src/Components/Aspire.NATS.Net/README.md
@@ -68,7 +68,7 @@ The .NET Aspire NATS component supports [Microsoft.Extensions.Configuration](htt
   "Aspire": {
     "Nats": {
       "Client": {
-        "HealthChecks": false
+        "DisableHealthChecks": true
       }
     }
   }
@@ -80,7 +80,7 @@ The .NET Aspire NATS component supports [Microsoft.Extensions.Configuration](htt
 Also you can pass the `Action<NatsClientSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddNatsClient("nats", settings => settings.HealthChecks = false);
+builder.AddNatsClient("nats", settings => settings.DisableHealthChecks = true);
 ```
 
 ## AppHost extensions

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/ConfigurationSchema.json
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/ConfigurationSchema.json
@@ -62,25 +62,25 @@
                       "type": "string",
                       "description": "Gets or sets the connection string of the PostgreSQL database to connect to."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the database health check is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                      "default": false
                     },
-                    "Metrics": {
+                    "DisableMetrics": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                      "default": false
                     },
-                    "Retry": {
+                    "DisableRetry": {
                       "type": "boolean",
-                      "description": "Gets or sets whether retries should be enabled.",
-                      "default": true
+                      "description": "Gets or sets whether retries should be disabled.",
+                      "default": false
                     },
-                    "Tracing": {
+                    "DisableTracing": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a PostgreSQL database using EntityFrameworkCore."

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/NpgsqlEntityFrameworkCorePostgreSQLSettings.cs
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/NpgsqlEntityFrameworkCorePostgreSQLSettings.cs
@@ -14,36 +14,36 @@ public sealed class NpgsqlEntityFrameworkCorePostgreSQLSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets whether retries should be enabled.
+    /// Gets or sets whether retries should be disabled.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Retry { get; set; } = true;
+    public bool DisableRetry { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the database health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the database health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Metrics { get; set; } = true;
+    public bool DisableMetrics { get; set; }
 
     /// <summary>
     /// Gets or sets the time in seconds to wait for the command to execute.

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/README.md
@@ -79,8 +79,8 @@ The .NET Aspire PostgreSQL EntityFrameworkCore Npgsql component supports [Micros
     "Npgsql": {
       "EntityFrameworkCore": {
         "PostgreSQL": {
-          "HealthChecks": false,
-          "Tracing": false
+          "DisableHealthChecks": true,
+          "DisableTracing": true
         }
       }
     }
@@ -93,13 +93,13 @@ The .NET Aspire PostgreSQL EntityFrameworkCore Npgsql component supports [Micros
 Also you can pass the `Action<NpgsqlEntityFrameworkCorePostgreSQLSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-    builder.AddNpgsqlDbContext<MyDbContext>("postgresdb", settings => settings.HealthChecks = false);
+    builder.AddNpgsqlDbContext<MyDbContext>("postgresdb", settings => settings.DisableHealthChecks = true);
 ```
 
 or
 
 ```csharp
-    builder.EnrichNpgsqlDbContext<MyDbContext>(settings => settings.HealthChecks = false);
+    builder.EnrichNpgsqlDbContext<MyDbContext>(settings => settings.DisableHealthChecks = true);
 ```
 
 ## AppHost extensions

--- a/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
+++ b/src/Components/Aspire.Npgsql/AspirePostgreSqlNpgsqlExtensions.cs
@@ -72,7 +72,7 @@ public static class AspirePostgreSqlNpgsqlExtensions
 
         // Same as SqlClient connection pooling is on by default and can be handled with connection string 
         // https://www.npgsql.org/doc/connection-string-parameters.html#pooling
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             builder.TryAddHealthCheck(new HealthCheckRegistration(
                 serviceKey is null ? "PostgreSql" : $"PostgreSql_{connectionName}",
@@ -85,7 +85,7 @@ public static class AspirePostgreSqlNpgsqlExtensions
                 timeout: default));
         }
 
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             builder.Services.AddOpenTelemetry()
                 .WithTracing(tracerProviderBuilder =>
@@ -94,7 +94,7 @@ public static class AspirePostgreSqlNpgsqlExtensions
                 });
         }
 
-        if (settings.Metrics)
+        if (!settings.DisableMetrics)
         {
             builder.Services.AddOpenTelemetry()
                 .WithMetrics(NpgsqlCommon.AddNpgsqlMetrics);

--- a/src/Components/Aspire.Npgsql/ConfigurationSchema.json
+++ b/src/Components/Aspire.Npgsql/ConfigurationSchema.json
@@ -37,20 +37,20 @@
               "type": "string",
               "description": "The connection string of the PostgreSQL database to connect to."
             },
-            "HealthChecks": {
+            "DisableHealthChecks": {
               "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the database health check is enabled or not.",
-              "default": true
+              "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+              "default": false
             },
-            "Metrics": {
+            "DisableMetrics": {
               "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
-              "default": true
+              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+              "default": false
             },
-            "Tracing": {
+            "DisableTracing": {
               "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-              "default": true
+              "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+              "default": false
             }
           },
           "description": "Provides the client configuration settings for connecting to a PostgreSQL database using Npgsql."

--- a/src/Components/Aspire.Npgsql/NpgsqlSettings.cs
+++ b/src/Components/Aspire.Npgsql/NpgsqlSettings.cs
@@ -14,26 +14,26 @@ public sealed class NpgsqlSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the database health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the database health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Metrics { get; set; } = true;
+    public bool DisableMetrics { get; set; }
 }

--- a/src/Components/Aspire.Npgsql/README.md
+++ b/src/Components/Aspire.Npgsql/README.md
@@ -67,8 +67,8 @@ The .NET Aspire PostgreSQL Npgsql component supports [Microsoft.Extensions.Confi
 {
   "Aspire": {
     "Npgsql": {
-      "HealthChecks": false,
-      "Tracing": false
+      "DisableHealthChecks": true,
+      "DisableTracing": true
     }
   }
 }
@@ -79,7 +79,7 @@ The .NET Aspire PostgreSQL Npgsql component supports [Microsoft.Extensions.Confi
 Also you can pass the `Action<NpgsqlSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-    builder.AddNpgsqlDataSource("postgresdb", settings => settings.HealthChecks = false);
+    builder.AddNpgsqlDataSource("postgresdb", settings => settings.DisableHealthChecks = true);
 ```
 
 ## AppHost extensions

--- a/src/Components/Aspire.Oracle.EntityFrameworkCore/AspireOracleEFCoreExtensions.cs
+++ b/src/Components/Aspire.Oracle.EntityFrameworkCore/AspireOracleEFCoreExtensions.cs
@@ -68,7 +68,7 @@ public static class AspireOracleEFCoreExtensions
             {
                 // Resiliency:
                 // Connection resiliency automatically retries failed database commands
-                if (settings.Retry)
+                if (!settings.DisableRetry)
                 {
                     builder.ExecutionStrategy(context => new OracleRetryingExecutionStrategy(context));
                 }
@@ -109,13 +109,13 @@ public static class AspireOracleEFCoreExtensions
         void ConfigureRetry()
         {
 #pragma warning disable EF1001 // Internal EF Core API usage.
-            if (settings.Retry || settings.CommandTimeout.HasValue)
+            if (!settings.DisableRetry || settings.CommandTimeout.HasValue)
             {
                 builder.PatchServiceDescriptor<TContext>(optionsBuilder => optionsBuilder.UseOracle(options =>
                 {
                     var extension = optionsBuilder.Options.FindExtension<OracleOptionsExtension>();
 
-                    if (settings.Retry)
+                    if (!settings.DisableRetry)
                     {
                         var executionStrategy = extension?.ExecutionStrategyFactory?.Invoke(new ExecutionStrategyDependencies(null!, optionsBuilder.Options, null!));
 
@@ -125,13 +125,13 @@ public static class AspireOracleEFCoreExtensions
                             {
                                 // Keep custom Retry strategy.
                                 // Any sub-class of OracleRetryingExecutionStrategy is a valid retry strategy
-                                // which shouldn't be replaced even with Retry == true
+                                // which shouldn't be replaced even with DisableRetry == false
                             }
                             else if (executionStrategy.GetType() != typeof(OracleExecutionStrategy))
                             {
                                 // Check OracleExecutionStrategy specifically (no 'is'), any sub-class is treated as a custom strategy.
 
-                                throw new InvalidOperationException($"{nameof(OracleEntityFrameworkCoreSettings)}.Retry can't be set when a custom Execution Strategy is configured.");
+                                throw new InvalidOperationException($"{nameof(OracleEntityFrameworkCoreSettings)}.{nameof(OracleEntityFrameworkCoreSettings.DisableRetry)} needs to be set when a custom Execution Strategy is configured.");
                             }
                             else
                             {
@@ -163,7 +163,7 @@ public static class AspireOracleEFCoreExtensions
 
     private static void ConfigureInstrumentation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TContext>(IHostApplicationBuilder builder, OracleEntityFrameworkCoreSettings settings) where TContext : DbContext
     {
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             builder.TryAddHealthCheck(
                 name: typeof(TContext).Name,

--- a/src/Components/Aspire.Oracle.EntityFrameworkCore/ConfigurationSchema.json
+++ b/src/Components/Aspire.Oracle.EntityFrameworkCore/ConfigurationSchema.json
@@ -59,14 +59,15 @@
                   "type": "string",
                   "description": "The connection string of the Oracle database to connect to."
                 },
-                "HealthChecks": {
+                "DisableHealthChecks": {
                   "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the database health check is enabled or not. The default value is true."
+                  "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                  "default": false
                 },
-                "Retry": {
+                "DisableRetry": {
                   "type": "boolean",
-                  "description": "Gets or sets whether retries should be enabled.",
-                  "default": true
+                  "description": "Gets or sets whether retries should be disabled.",
+                  "default": false
                 }
               },
               "description": "Provides the client configuration settings for connecting to a Oracle database using EntityFrameworkCore."

--- a/src/Components/Aspire.Oracle.EntityFrameworkCore/OracleEntityFrameworkCoreSettings.cs
+++ b/src/Components/Aspire.Oracle.EntityFrameworkCore/OracleEntityFrameworkCoreSettings.cs
@@ -14,18 +14,20 @@ public sealed class OracleEntityFrameworkCoreSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets whether retries should be enabled.
+    /// Gets or sets whether retries should be disabled.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Retry { get; set; } = true;
+    public bool DisableRetry { get; set; }
 
     /// <summary>
-    /// <para>Gets or sets a boolean value that indicates whether the database health check is enabled or not.</para>
-    /// <para>The default value is <see langword="true"/>.</para>
+    /// Gets or sets a boolean value that indicates whether the database health check is disabled or not.
     /// </summary>
-    public bool HealthChecks { get; set; } = true;
+    /// <value>
+    /// The default value is <see langword="false"/>.
+    /// </value>
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
     /// Gets or sets the time in seconds to wait for the command to execute.

--- a/src/Components/Aspire.Oracle.EntityFrameworkCore/README.md
+++ b/src/Components/Aspire.Oracle.EntityFrameworkCore/README.md
@@ -78,7 +78,7 @@ The .NET Aspire Oracle EntityFrameworkCore component supports [Microsoft.Extensi
   "Aspire": {
     "Oracle": {
       "EntityFrameworkCore": {
-        "HealthChecks": false
+        "DisableHealthChecks": true
       }
     }
   }
@@ -90,13 +90,13 @@ The .NET Aspire Oracle EntityFrameworkCore component supports [Microsoft.Extensi
 Also you can pass the `Action<OracleEntityFrameworkCoreSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-    builder.AddOracleDatabaseDbContext<MyDbContext>("orcl", settings => settings.HealthChecks = false);
+    builder.AddOracleDatabaseDbContext<MyDbContext>("orcl", settings => settings.DisableHealthChecks = true);
 ```
 
 or
 
 ```csharp
-    builder.EnrichOracleDatabaseDbContext<MyDbContext>(settings => settings.HealthChecks = false);
+    builder.EnrichOracleDatabaseDbContext<MyDbContext>(settings => settings.DisableHealthChecks = true);
 ```
 
 ## AppHost extensions 

--- a/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/AspireEFMySqlExtensions.cs
+++ b/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/AspireEFMySqlExtensions.cs
@@ -119,7 +119,7 @@ public static partial class AspireEFMySqlExtensions
 
                 // Resiliency:
                 // 1. Connection resiliency automatically retries failed database commands: https://github.com/PomeloFoundation/Pomelo.EntityFrameworkCore.MySql/wiki/Configuration-Options#enableretryonfailure
-                if (settings.Retry)
+                if (!settings.DisableRetry)
                 {
                     builder.EnableRetryOnFailure();
                 }
@@ -158,7 +158,7 @@ public static partial class AspireEFMySqlExtensions
         void ConfigureRetry()
         {
 #pragma warning disable EF1001 // Internal EF Core API usage.
-            if (settings.Retry || settings.CommandTimeout.HasValue)
+            if (!settings.DisableRetry || settings.CommandTimeout.HasValue)
             {
                 builder.PatchServiceDescriptor<TContext>(optionsBuilder =>
                 {
@@ -172,7 +172,7 @@ public static partial class AspireEFMySqlExtensions
                     {
                         var extension = optionsBuilder.Options.FindExtension<MySqlOptionsExtension>();
 
-                        if (settings.Retry)
+                        if (!settings.DisableRetry)
                         {
                             var executionStrategy = extension?.ExecutionStrategyFactory?.Invoke(new ExecutionStrategyDependencies(null!, optionsBuilder.Options, null!));
 
@@ -182,13 +182,13 @@ public static partial class AspireEFMySqlExtensions
                                 {
                                     // Keep custom Retry strategy.
                                     // Any sub-class of MySqlRetryingExecutionStrategy is a valid retry strategy
-                                    // which shouldn't be replaced even with Retry == true
+                                    // which shouldn't be replaced even with DisableRetry == false
                                 }
                                 else if (executionStrategy.GetType() != typeof(MySqlExecutionStrategy))
                                 {
                                     // Check MySqlExecutionStrategy specifically (no 'is'), any sub-class is treated as a custom strategy.
 
-                                    throw new InvalidOperationException($"{nameof(PomeloEntityFrameworkCoreMySqlSettings)}.Retry can't be set when a custom Execution Strategy is configured.");
+                                    throw new InvalidOperationException($"{nameof(PomeloEntityFrameworkCoreMySqlSettings)}.{nameof(PomeloEntityFrameworkCoreMySqlSettings.DisableRetry)} needs to be set when a custom Execution Strategy is configured.");
                                 }
                                 else
                                 {
@@ -222,7 +222,7 @@ public static partial class AspireEFMySqlExtensions
 
     private static void ConfigureInstrumentation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TContext>(IHostApplicationBuilder builder, PomeloEntityFrameworkCoreMySqlSettings settings) where TContext : DbContext
     {
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             // calling MapHealthChecks is the responsibility of the app, not Component
             builder.TryAddHealthCheck(
@@ -230,7 +230,7 @@ public static partial class AspireEFMySqlExtensions
                 static hcBuilder => hcBuilder.AddDbContextCheck<TContext>());
         }
 
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             builder.Services.AddOpenTelemetry()
                 .WithTracing(tracerProviderBuilder =>
@@ -240,7 +240,7 @@ public static partial class AspireEFMySqlExtensions
                 });
         }
 
-        if (settings.Metrics)
+        if (!settings.DisableMetrics)
         {
             builder.Services.AddOpenTelemetry()
                 .WithMetrics(meterProviderBuilder =>

--- a/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/ConfigurationSchema.json
+++ b/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/ConfigurationSchema.json
@@ -62,29 +62,29 @@
                       "type": "string",
                       "description": "Gets or sets the connection string of the MySQL database to connect to."
                     },
-                    "HealthChecks": {
+                    "DisableHealthChecks": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the database health check is enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the database health check is disabled or not.",
+                      "default": false
                     },
-                    "Metrics": {
+                    "DisableMetrics": {
                       "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.",
-                      "default": true
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.",
+                      "default": false
                     },
-                    "Retry": {
+                    "DisableRetry": {
                       "type": "boolean",
-                      "description": "Gets or sets whether retries should be enabled.",
-                      "default": true
+                      "description": "Gets or sets whether retries should be disabled.",
+                      "default": false
+                    },
+                    "DisableTracing": {
+                      "type": "boolean",
+                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                      "default": false
                     },
                     "ServerVersion": {
                       "type": "string",
                       "description": "Gets or sets the server version of the MySQL database to connect to."
-                    },
-                    "Tracing": {
-                      "type": "boolean",
-                      "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                      "default": true
                     }
                   },
                   "description": "Provides the client configuration settings for connecting to a MySQL database using EntityFrameworkCore."

--- a/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/PomeloEntityFrameworkCoreMySqlSettings.cs
+++ b/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/PomeloEntityFrameworkCoreMySqlSettings.cs
@@ -19,36 +19,36 @@ public sealed class PomeloEntityFrameworkCoreMySqlSettings
     public string? ServerVersion { get; set; }
 
     /// <summary>
-    /// Gets or sets whether retries should be enabled.
+    /// Gets or sets whether retries should be disabled.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Retry { get; set; } = true;
+    public bool DisableRetry { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the database health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the database health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry metrics are disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Metrics { get; set; } = true;
+    public bool DisableMetrics { get; set; }
 
     /// <summary>
     /// Gets or sets the time in seconds to wait for the command to execute.

--- a/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/README.md
+++ b/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/README.md
@@ -81,8 +81,8 @@ Example `appsettings.json` that configures some of the options:
     "Pomelo": {
       "EntityFrameworkCore": {
         "MySql": {
-          "HealthChecks": false,
-          "Tracing": false
+          "DisableHealthChecks": true,
+          "DisableTracing": true
         }
       }
     }
@@ -95,13 +95,13 @@ Example `appsettings.json` that configures some of the options:
 Also you can pass the `Action<PomeloEntityFrameworkCoreMySqlSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-    builder.AddMySqlDbContext<MyDbContext>("mysqldb", settings => settings.HealthChecks = false);
+    builder.AddMySqlDbContext<MyDbContext>("mysqldb", settings => settings.DisableHealthChecks = true);
 ```
 
 or
 
 ```csharp
-    builder.EnrichMySqlDbContext<MyDbContext>(settings => settings.HealthChecks = false);
+    builder.EnrichMySqlDbContext<MyDbContext>(settings => settings.DisableHealthChecks = true);
 ```
 
 ## AppHost extensions

--- a/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/AspireRabbitMQExtensions.cs
@@ -119,7 +119,7 @@ public static class AspireRabbitMQExtensions
 
         builder.Services.AddSingleton<RabbitMQEventSourceLogForwarder>();
 
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             // Note that RabbitMQ.Client v6.6 doesn't have built-in support for tracing. See https://github.com/rabbitmq/rabbitmq-dotnet-client/pull/1261
 
@@ -127,7 +127,7 @@ public static class AspireRabbitMQExtensions
                 .WithTracing(traceBuilder => traceBuilder.AddSource(ActivitySourceName));
         }
 
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             builder.TryAddHealthCheck(new HealthCheckRegistration(
                 serviceKey is null ? "RabbitMQ.Client" : $"RabbitMQ.Client_{connectionName}",

--- a/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
+++ b/src/Components/Aspire.RabbitMQ.Client/ConfigurationSchema.json
@@ -332,19 +332,19 @@
                   "type": "string",
                   "description": "Gets or sets the connection string of the RabbitMQ server to connect to."
                 },
-                "HealthChecks": {
+                "DisableHealthChecks": {
                   "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is enabled or not.",
-                  "default": true
+                  "description": "Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.",
+                  "default": false
+                },
+                "DisableTracing": {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                  "default": false
                 },
                 "MaxConnectRetryCount": {
                   "type": "integer",
                   "description": "Gets or sets the maximum number of connection retry attempts. Default value is 5, set it to 0 to disable the retry mechanism."
-                },
-                "Tracing": {
-                  "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                  "default": true
                 }
               },
               "description": "Provides the client configuration settings for connecting to a RabbitMQ message broker."

--- a/src/Components/Aspire.RabbitMQ.Client/README.md
+++ b/src/Components/Aspire.RabbitMQ.Client/README.md
@@ -68,7 +68,7 @@ The .NET Aspire RabbitMQ component supports [Microsoft.Extensions.Configuration]
   "Aspire": {
     "RabbitMQ": {
       "Client": {
-        "HealthChecks": false
+        "DisableHealthChecks": true
       }
     }
   }
@@ -80,7 +80,7 @@ The .NET Aspire RabbitMQ component supports [Microsoft.Extensions.Configuration]
 Also you can pass the `Action<RabbitMQClientSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddRabbitMQClient("messaging", settings => settings.HealthChecks = false);
+builder.AddRabbitMQClient("messaging", settings => settings.DisableHealthChecks = true);
 ```
 
 You can also setup the [ConnectionFactory](https://rabbitmq.github.io/rabbitmq-dotnet-client/api/RabbitMQ.Client.ConnectionFactory.html) using the `Action<ConnectionFactory> configureConnectionFactory` delegate parameter of the `AddRabbitMQClient` method. For example to set the client provided name for connections:

--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQClientSettings.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQClientSettings.cs
@@ -20,18 +20,18 @@ public sealed class RabbitMQClientSettings
     public int MaxConnectRetryCount { get; set; } = 5;
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the RabbitMQ health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the RabbitMQ health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 }

--- a/src/Components/Aspire.Seq/AspireSeqExtensions.cs
+++ b/src/Components/Aspire.Seq/AspireSeqExtensions.cs
@@ -68,7 +68,7 @@ public static class AspireSeqExtensions
                 _ => new SimpleActivityExportProcessor(new OtlpTraceExporter(settings.Traces))
             }));
 
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             if (settings.ServerUrl is not null)
             {

--- a/src/Components/Aspire.Seq/ConfigurationSchema.json
+++ b/src/Components/Aspire.Seq/ConfigurationSchema.json
@@ -19,9 +19,10 @@
               "type": "string",
               "description": "Gets or sets a Seq API key that authenticates the client to the Seq server."
             },
-            "HealthChecks": {
+            "DisableHealthChecks": {
               "type": "boolean",
-              "description": "Gets or sets a boolean value that indicates whetherthe Seq server health check is enabled or not."
+              "description": "Gets or sets a boolean value that indicates whether the Seq server health check is disabled or not.",
+              "default": false
             },
             "Logs": {
               "type": "object",

--- a/src/Components/Aspire.Seq/README.md
+++ b/src/Components/Aspire.Seq/README.md
@@ -40,7 +40,7 @@ The .NET Aspire Seq component supports [Microsoft.Extensions.Configuration](http
 {
   "Aspire": {
     "Seq": {
-      "HealthChecks": false,
+      "DisableHealthChecks": true,
       "ServerUrl": "http://localhost:5341"
     }
   }
@@ -53,7 +53,7 @@ Also you can pass the `Action<SeqSettings> configureSettings` delegate to set up
 
 ```csharp
 builder.AddSeqEndpoint("seq", settings => {
-    settings.HealthChecks = false;
+    settings.DisableHealthChecks = true;
     settings.ServerUrl = "http://localhost:5341";
     settings.Logs.TimeoutMilliseconds = 10000;
 });
@@ -67,7 +67,7 @@ In your AppHost project, install the `Aspire.Hosting.Seq` library with [NuGet](h
 dotnet add package Aspire.Hosting.Seq
 ```
 
-Then, in the _Program.cs_ file of `AppHost`, register a Seq server and propagate its configuration using the following methods (note that you must accept the [Seq End User Licence Agreement](https://datalust.co/doc/eula-current.pdf) for Seq to start):
+Then, in the _Program.cs_ file of `AppHost`, register a Seq server and propagate its configuration using the following methods (note that you must accept the [Seq End User License Agreement](https://datalust.co/doc/eula-current.pdf) for Seq to start):
 
 ```csharp
 var seq = builder.AddSeq("seq");

--- a/src/Components/Aspire.Seq/SeqSettings.cs
+++ b/src/Components/Aspire.Seq/SeqSettings.cs
@@ -11,9 +11,12 @@ namespace Aspire.Seq;
 public sealed class SeqSettings
 {
     /// <summary>
-    /// Gets or sets a boolean value that indicates whetherthe Seq server health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the Seq server health check is disabled or not.
     /// </summary>
-    public bool HealthChecks { get; set; } = true;
+    /// <value>
+    /// The default value is <see langword="false"/>.
+    /// </value>
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
     /// Gets or sets a Seq <i>API key</i> that authenticates the client to the Seq server.

--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/README.md
@@ -72,8 +72,8 @@ The Redis Distributed Cache component supports [Microsoft.Extensions.Configurati
           "ConnectTimeout": 3000,
           "ConnectRetry": 2
         },
-        "HealthChecks": false,
-        "Tracing": true
+        "DisableHealthChecks": true,
+        "DisableTracing": false
       }
     }
   }
@@ -85,7 +85,7 @@ The Redis Distributed Cache component supports [Microsoft.Extensions.Configurati
 You can also pass the `Action<StackExchangeRedisSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddRedisDistributedCache("cache", settings => settings.HealthChecks = false);
+builder.AddRedisDistributedCache("cache", settings => settings.DisableHealthChecks = true);
 ```
 
 You can also setup the [ConfigurationOptions](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#configuration-options) using the `Action<ConfigurationOptions> configureOptions` delegate parameter of the `AddRedisDistributedCache` method. For example to set the connection timeout:

--- a/src/Components/Aspire.StackExchange.Redis.OutputCaching/README.md
+++ b/src/Components/Aspire.StackExchange.Redis.OutputCaching/README.md
@@ -77,8 +77,8 @@ The Redis OutputCache component supports [Microsoft.Extensions.Configuration](ht
           "ConnectTimeout": 3000,
           "ConnectRetry": 2
         },
-        "HealthChecks": false,
-        "Tracing": true
+        "DisableHealthChecks": true,
+        "DisableTracing": false
       }
     }
   }
@@ -90,7 +90,7 @@ The Redis OutputCache component supports [Microsoft.Extensions.Configuration](ht
 You can also pass the `Action<StackExchangeRedisSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddRedisOutputCache("cache", settings => settings.HealthChecks = false);
+builder.AddRedisOutputCache("cache", settings => settings.DisableHealthChecks = true);
 ```
 
 You can also setup the [ConfigurationOptions](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#configuration-options) using the `Action<ConfigurationOptions> configureOptions` delegate parameter of the `AddRedisOutputCache` method. For example to set the connection timeout:

--- a/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
@@ -107,7 +107,7 @@ public static class AspireRedisExtensions
             builder.Services.AddKeyedSingleton<IConnectionMultiplexer>(serviceKey, (sp, _) => CreateConnection(sp, connectionName, configurationSectionName, optionsName));
         }
 
-        if (settings.Tracing)
+        if (!settings.DisableTracing)
         {
             // Supports distributed tracing
             // We don't call AddRedisInstrumentation() here as it results in the TelemetryHostedService trying to resolve & connect to IConnectionMultiplexer
@@ -125,7 +125,7 @@ public static class AspireRedisExtensions
                 });
         }
 
-        if (settings.HealthChecks)
+        if (!settings.DisableHealthChecks)
         {
             var healthCheckName = serviceKey is null ? "StackExchange.Redis" : $"StackExchange.Redis_{connectionName}";
 

--- a/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
+++ b/src/Components/Aspire.StackExchange.Redis/ConfigurationSchema.json
@@ -171,15 +171,15 @@
                   "type": "string",
                   "description": "Gets or sets the comma-delimited configuration string used to connect to the Redis server."
                 },
-                "HealthChecks": {
+                "DisableHealthChecks": {
                   "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the Redis health check is enabled or not.",
-                  "default": true
+                  "description": "Gets or sets a boolean value that indicates whether the Redis health check is disabled or not.",
+                  "default": false
                 },
-                "Tracing": {
+                "DisableTracing": {
                   "type": "boolean",
-                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.",
-                  "default": true
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                  "default": false
                 }
               },
               "description": "Provides the client configuration settings for connecting to a Redis server."

--- a/src/Components/Aspire.StackExchange.Redis/README.md
+++ b/src/Components/Aspire.StackExchange.Redis/README.md
@@ -74,8 +74,8 @@ The Redis component supports [Microsoft.Extensions.Configuration](https://learn.
           "ConnectTimeout": 3000,
           "ConnectRetry": 2
         },
-        "HealthChecks": false,
-        "Tracing": true
+        "DisableHealthChecks": true,
+        "DisableTracing": false
       }
     }
   }
@@ -87,7 +87,7 @@ The Redis component supports [Microsoft.Extensions.Configuration](https://learn.
 You can also pass the `Action<StackExchangeRedisSettings> configureSettings` delegate to set up some or all the options inline, for example to disable health checks from code:
 
 ```csharp
-builder.AddRedisClient("cache", settings => settings.HealthChecks = false);
+builder.AddRedisClient("cache", settings => settings.DisableHealthChecks = true);
 ```
 
 You can also setup the [ConfigurationOptions](https://stackexchange.github.io/StackExchange.Redis/Configuration.html#configuration-options) using the `Action<ConfigurationOptions> configureOptions` delegate parameter of the `AddRedisClient` method. For example to set the connection timeout:

--- a/src/Components/Aspire.StackExchange.Redis/StackExchangeRedisSettings.cs
+++ b/src/Components/Aspire.StackExchange.Redis/StackExchangeRedisSettings.cs
@@ -14,18 +14,18 @@ public sealed class StackExchangeRedisSettings
     public string? ConnectionString { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the Redis health check is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the Redis health check is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool HealthChecks { get; set; } = true;
+    public bool DisableHealthChecks { get; set; }
 
     /// <summary>
-    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is enabled or not.
+    /// Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.
     /// </summary>
     /// <value>
-    /// The default value is <see langword="true"/>.
+    /// The default value is <see langword="false"/>.
     /// </value>
-    public bool Tracing { get; set; } = true;
+    public bool DisableTracing { get; set; }
 }

--- a/tests/Aspire.Azure.AI.OpenAI.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/ConformanceTests.cs
@@ -31,7 +31,7 @@ public class ConformanceTests : ConformanceTests<OpenAIClient, AzureOpenAISettin
               "AI": {
                 "OpenAI": {
                   "Endpoint": "http://YOUR_URI",
-                  "Tracing": true,
+                  "DisableTracing": false,
                   "ClientOptions": {
                     "ConnectionIdleTimeout": "00:10",
                     "EnableCrossEntityTransactions": true,
@@ -51,7 +51,7 @@ public class ConformanceTests : ConformanceTests<OpenAIClient, AzureOpenAISettin
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
             ("""{"Aspire": { "Azure": { "AI":{ "OpenAI": {"Endpoint": "YOUR_URI"}}}}}""", "Value does not match format \"uri\""),
-            ("""{"Aspire": { "Azure": { "AI":{ "OpenAI": {"Endpoint": "http://YOUR_URI", "Tracing": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Azure": { "AI":{ "OpenAI": {"Endpoint": "http://YOUR_URI", "DisableTracing": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
         };
 
     protected override string ActivitySourceName => "Azure.AI.OpenAI.OpenAIClient";
@@ -99,7 +99,7 @@ public class ConformanceTests : ConformanceTests<OpenAIClient, AzureOpenAISettin
         => throw new NotImplementedException();
 
     protected override void SetTracing(AzureOpenAISettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void TriggerActivity(OpenAIClient service)
         => service.GetCompletions(new CompletionsOptions { DeploymentName = "dummy-gpt" });

--- a/tests/Aspire.Azure.Data.Tables.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Data.Tables.Tests/ConformanceTests.cs
@@ -31,8 +31,8 @@ public class ConformanceTests : ConformanceTests<TableServiceClient, AzureDataTa
               "Data": {
                 "Tables": {
                   "ServiceUri": "http://YOUR_URI",
-                  "HealthChecks": false,
-                  "Tracing": true,
+                  "DisableHealthChecks": true,
+                  "DisableTracing": false,
                   "ClientOptions": {
                     "EnableTenantDiscovery": true,
                     "Retry": {
@@ -50,7 +50,7 @@ public class ConformanceTests : ConformanceTests<TableServiceClient, AzureDataTa
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
             ("""{"Aspire": { "Azure": { "Data":{ "Tables": { "ServiceUri": "YOUR_URI"}}}}}""", "Value does not match format \"uri\""),
-            ("""{"Aspire": { "Azure": { "Data":{ "Tables": { "ServiceUri": "http://YOUR_URI", "HealthChecks": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Azure": { "Data":{ "Tables": { "ServiceUri": "http://YOUR_URI", "DisableHealthChecks": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
             ("""{"Aspire": { "Azure": { "Data":{ "Tables": { "ServiceUri": "http://YOUR_URI", "ClientOptions": {"Retry": {"Mode": "Fast"}}}}}}}""", "Value should match one of the values specified by the enum"),
             ("""{"Aspire": { "Azure": { "Data":{ "Tables": { "ServiceUri": "http://YOUR_URI", "ClientOptions": {"Retry": {"NetworkTimeout": "3S"}}}}}}}""", "The string value is not a match for the indicated regular expression")
         };
@@ -94,13 +94,13 @@ public class ConformanceTests : ConformanceTests<TableServiceClient, AzureDataTa
     }
 
     protected override void SetHealthCheck(AzureDataTablesSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetMetrics(AzureDataTablesSettings options, bool enabled)
         => throw new NotImplementedException();
 
     protected override void SetTracing(AzureDataTablesSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void TriggerActivity(TableServiceClient service)
     {
@@ -126,7 +126,7 @@ public class ConformanceTests : ConformanceTests<TableServiceClient, AzureDataTa
         try
         {
             // "test" is a pre-existing table
-            tableClient.GetTableClient("test").Query<TableEntity>(filter: "false").FirstOrDefault();
+            _ = tableClient.GetTableClient("test").Query<TableEntity>(filter: "false").FirstOrDefault();
 
             return true;
         }

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
@@ -26,7 +26,7 @@ public class AspireEventHubsExtensionsTests
     private const int EventProcessorClientIndex = 2;
     private const int PartitionReceiverIndex = 3;
 
-    private static readonly Action<HostApplicationBuilder, string, Action<AzureMessagingEventHubsBaseSettings>?>[] s_keyedClientAdders =
+    private static readonly Action<HostApplicationBuilder, string, Action<AzureMessagingEventHubsSettings>?>[] s_keyedClientAdders =
     [
         (builder, key, settings) => builder.AddKeyedAzureEventHubProducerClient(key, settings),
         (builder, key, settings) => builder.AddKeyedAzureEventHubConsumerClient(key, settings),
@@ -34,7 +34,7 @@ public class AspireEventHubsExtensionsTests
         (builder, key, settings) => builder.AddKeyedAzurePartitionReceiverClient(key, settings)
     ];
 
-    private static readonly Action<HostApplicationBuilder, string, Action<AzureMessagingEventHubsBaseSettings>?>[] s_clientAdders =
+    private static readonly Action<HostApplicationBuilder, string, Action<AzureMessagingEventHubsSettings>?>[] s_clientAdders =
     [
         (builder, name, settings) => builder.AddAzureEventHubProducerClient(name, settings),
         (builder, name, settings) => builder.AddAzureEventHubConsumerClient(name, settings),

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/AzureMessagingEventHubsSettingsTests.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/AzureMessagingEventHubsSettingsTests.cs
@@ -11,14 +11,14 @@ public class AzureMessagingEventHubsSettingsTests
     [Fact]
     public void TracingIsEnabledWhenAzureSwitchIsSet()
     {
-        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(false)).Dispose();
-        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(true), EnableTracingForAzureSdk()).Dispose();
+        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(true)).Dispose();
+        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(false), EnableTracingForAzureSdk()).Dispose();
     }
 
     private static void EnsureTracingIsEnabledWhenAzureSwitchIsSet(bool expectedValue)
     {
         // doesn't matter which concrete class we use, as the property is defined in the base class
-        Assert.Equal(expectedValue, new AzureMessagingEventHubsConsumerSettings().Tracing);
+        Assert.Equal(expectedValue, new AzureMessagingEventHubsConsumerSettings().DisableTracing);
     }
 
     private static RemoteInvokeOptions EnableTracingForAzureSdk()

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AzureMessagingServiceBusSettingsTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/AzureMessagingServiceBusSettingsTests.cs
@@ -11,12 +11,12 @@ public class AzureMessagingServiceBusSettingsTests
     [Fact]
     public void TracingIsEnabledWhenAzureSwitchIsSet()
     {
-        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(false)).Dispose();
-        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(true), ConformanceTests.EnableTracingForAzureSdk()).Dispose();
+        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(true)).Dispose();
+        RemoteExecutor.Invoke(() => EnsureTracingIsEnabledWhenAzureSwitchIsSet(false), ConformanceTests.EnableTracingForAzureSdk()).Dispose();
     }
 
     private static void EnsureTracingIsEnabledWhenAzureSwitchIsSet(bool expectedValue)
     {
-        Assert.Equal(expectedValue, new AzureMessagingServiceBusSettings().Tracing);
+        Assert.Equal(expectedValue, new AzureMessagingServiceBusSettings().DisableTracing);
     }
 }

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/ConformanceTests.cs
@@ -32,7 +32,7 @@ public abstract class ConformanceTests : ConformanceTests<ServiceBusClient, Azur
               "Messaging": {
                 "ServiceBus": {
                   "Namespace": "YOUR_NAMESPACE",
-                  "HealthChecks": true,
+                  "DisableHealthChecks": false,
                   "ClientOptions": {
                     "ConnectionIdleTimeout": "00:01",
                     "EnableCrossEntityTransactions": true,
@@ -61,7 +61,7 @@ public abstract class ConformanceTests : ConformanceTests<ServiceBusClient, Azur
     // When credentials are not available, we switch to using raw connection string (otherwise we get CredentialUnavailableException)
     protected KeyValuePair<string, string?> GetMainConfigEntry(string? key)
         => CanConnectToServer
-                ? new(CreateConfigKey("Aspire:Azure:Messaging:ServiceBus", key, nameof(AzureMessagingServiceBusSettings.Namespace)), FullyQualifiedNamespace)
+                ? new(CreateConfigKey("Aspire:Azure:Messaging:ServiceBus", key, nameof(AzureMessagingServiceBusSettings.FullyQualifiedNamespace)), FullyQualifiedNamespace)
                 : new(CreateConfigKey("Aspire:Azure:Messaging:ServiceBus", key, nameof(AzureMessagingServiceBusSettings.ConnectionString)), ConnectionString);
 
     protected override void RegisterComponent(HostApplicationBuilder builder, Action<AzureMessagingServiceBusSettings>? configure = null, string? key = null)
@@ -89,7 +89,7 @@ public abstract class ConformanceTests : ConformanceTests<ServiceBusClient, Azur
         => throw new NotImplementedException();
 
     protected override void SetTracing(AzureMessagingServiceBusSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     public static RemoteInvokeOptions EnableTracingForAzureSdk()
         => new()

--- a/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Search.Documents.Tests/ConformanceTests.cs
@@ -32,7 +32,7 @@ public class ConformanceTests : ConformanceTests<SearchIndexClient, AzureSearchS
               "Search": {
                 "Documents": {
                   "Endpoint": "http://YOUR_URI",
-                  "Tracing": true,
+                  "DisableTracing": false,
                   "ClientOptions": {
                     "Retry": {
                       "Mode": "Fixed",
@@ -49,7 +49,7 @@ public class ConformanceTests : ConformanceTests<SearchIndexClient, AzureSearchS
     protected override (string json, string error)[] InvalidJsonToErrorMessage =>
         [
             ("""{"Aspire": { "Azure": { "Search":{ "Documents": {"Endpoint": "YOUR_URI"}}}}}""", "Value does not match format \"uri\""),
-            ("""{"Aspire": { "Azure": { "Search":{ "Documents": {"Endpoint": "http://YOUR_URI", "Tracing": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Azure": { "Search":{ "Documents": {"Endpoint": "http://YOUR_URI", "DisableTracing": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
         ];
 
     protected override string ActivitySourceName => "Azure.Search.Documents.SearchIndexClient";
@@ -91,13 +91,13 @@ public class ConformanceTests : ConformanceTests<SearchIndexClient, AzureSearchS
         => RemoteExecutor.Invoke(() => ActivitySourceTest(key: "key")).Dispose();
 
     protected override void SetHealthCheck(AzureSearchSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetMetrics(AzureSearchSettings options, bool enabled)
         => throw new NotImplementedException();
 
     protected override void SetTracing(AzureSearchSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void TriggerActivity(SearchIndexClient service)
         => service.GetIndex("my-index");

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/ConfigurationTests.cs
@@ -13,9 +13,9 @@ public class ConfigurationTests
 
     [Fact]
     public void HealthCheckIsEnabledByDefault()
-        => Assert.True(new AzureSecurityKeyVaultSettings().HealthChecks);
+        => Assert.False(new AzureSecurityKeyVaultSettings().DisableHealthChecks);
 
     [Fact]
     public void TracingIsEnabledByDefault()
-        => Assert.True(new AzureSecurityKeyVaultSettings().Tracing);
+        => Assert.False(new AzureSecurityKeyVaultSettings().DisableTracing);
 }

--- a/tests/Aspire.Azure.Security.KeyVault.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Security.KeyVault.Tests/ConformanceTests.cs
@@ -36,8 +36,8 @@ public class ConformanceTests : ConformanceTests<SecretClient, AzureSecurityKeyV
               "Security": {
                 "KeyVault": {
                   "VaultUri": "http://YOUR_URI",
-                  "HealthChecks": false,
-                  "Tracing": true,
+                  "DisableHealthChecks": true,
+                  "DisableTracing": false,
                   "ClientOptions": {
                     "DisableChallengeResourceVerification": true,
                     "Retry": {
@@ -55,7 +55,7 @@ public class ConformanceTests : ConformanceTests<SecretClient, AzureSecurityKeyV
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
             ("""{"Aspire": { "Azure": { "Security":{ "KeyVault": { "VaultUri": "YOUR_URI"}}}}}""", "Value does not match format \"uri\""),
-            ("""{"Aspire": { "Azure": { "Security":{ "KeyVault": { "VaultUri": "http://YOUR_URI", "HealthChecks": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Azure": { "Security":{ "KeyVault": { "VaultUri": "http://YOUR_URI", "DisableHealthChecks": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
             ("""{"Aspire": { "Azure": { "Security":{ "KeyVault": { "VaultUri": "http://YOUR_URI", "ClientOptions": {"Retry": {"Mode": "Fast"}}}}}}}""", "Value should match one of the values specified by the enum"),
             ("""{"Aspire": { "Azure": { "Security":{ "KeyVault": { "VaultUri": "http://YOUR_URI", "ClientOptions": {"Retry": {"NetworkTimeout": "3S"}}}}}}}""", "The string value is not a match for the indicated regular expression")
         };
@@ -88,14 +88,14 @@ public class ConformanceTests : ConformanceTests<SecretClient, AzureSecurityKeyV
         }
     }
 
-    protected override void SetHealthCheck(AzureSecurityKeyVaultSettings settings, bool enabled)
-        => settings.HealthChecks = enabled;
+    protected override void SetHealthCheck(AzureSecurityKeyVaultSettings options, bool enabled)
+        => options.DisableHealthChecks = !enabled;
 
-    protected override void SetMetrics(AzureSecurityKeyVaultSettings settings, bool enabled)
+    protected override void SetMetrics(AzureSecurityKeyVaultSettings options, bool enabled)
         => throw new NotImplementedException();
 
-    protected override void SetTracing(AzureSecurityKeyVaultSettings settings, bool enabled)
-        => settings.Tracing = enabled;
+    protected override void SetTracing(AzureSecurityKeyVaultSettings options, bool enabled)
+        => options.DisableTracing = !enabled;
 
     protected override void TriggerActivity(SecretClient service)
         => service.GetSecret("IsAlive");

--- a/tests/Aspire.Azure.Storage.Blobs.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Blobs.Tests/ConformanceTests.cs
@@ -41,8 +41,8 @@ public class ConformanceTests : ConformanceTests<BlobServiceClient, AzureStorage
               "Storage": {
                 "Blobs": {
                   "ServiceUri": "http://YOUR_URI",
-                  "HealthChecks": false,
-                  "Tracing": true,
+                  "DisableHealthChecks": true,
+                  "DisableTracing": false,
                   "ClientOptions": {
                     "TrimBlobNameSlashes": true,
                     "Retry": {
@@ -60,7 +60,7 @@ public class ConformanceTests : ConformanceTests<BlobServiceClient, AzureStorage
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
             ("""{"Aspire": { "Azure": { "Storage":{ "Blobs": { "ServiceUri": "YOUR_URI"}}}}}""", "Value does not match format \"uri\""),
-            ("""{"Aspire": { "Azure": { "Storage":{ "Blobs": { "ServiceUri": "http://YOUR_URI", "HealthChecks": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Azure": { "Storage":{ "Blobs": { "ServiceUri": "http://YOUR_URI", "DisableHealthChecks": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
             ("""{"Aspire": { "Azure": { "Storage":{ "Blobs": { "ServiceUri": "http://YOUR_URI", "ClientOptions": {"Retry": {"Mode": "Fast"}}}}}}}""", "Value should match one of the values specified by the enum"),
             ("""{"Aspire": { "Azure": { "Storage":{ "Blobs": { "ServiceUri": "http://YOUR_URI", "ClientOptions": {"Retry": {"NetworkTimeout": "3S"}}}}}}}""", "The string value is not a match for the indicated regular expression")
         };
@@ -93,14 +93,14 @@ public class ConformanceTests : ConformanceTests<BlobServiceClient, AzureStorage
         }
     }
 
-    protected override void SetHealthCheck(AzureStorageBlobsSettings settings, bool enabled)
-        => settings.HealthChecks = enabled;
+    protected override void SetHealthCheck(AzureStorageBlobsSettings options, bool enabled)
+        => options.DisableHealthChecks = !enabled;
 
-    protected override void SetMetrics(AzureStorageBlobsSettings settings, bool enabled)
+    protected override void SetMetrics(AzureStorageBlobsSettings options, bool enabled)
         => throw new NotImplementedException();
 
-    protected override void SetTracing(AzureStorageBlobsSettings settings, bool enabled)
-        => settings.Tracing = enabled;
+    protected override void SetTracing(AzureStorageBlobsSettings options, bool enabled)
+        => options.DisableTracing = !enabled;
 
     protected override void TriggerActivity(BlobServiceClient service)
     {

--- a/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Azure.Storage.Queues.Tests/ConformanceTests.cs
@@ -41,8 +41,8 @@ public class ConformanceTests : ConformanceTests<QueueServiceClient, AzureStorag
               "Storage": {
                 "Queues": {
                   "ServiceUri": "http://YOUR_URI",
-                  "HealthChecks": false,
-                  "Tracing": true,
+                  "DisableHealthChecks": true,
+                  "DisableTracing": false,
                   "ClientOptions": {
                     "EnableTenantDiscovery": true,
                     "MessageEncoding": "Base64",
@@ -61,7 +61,7 @@ public class ConformanceTests : ConformanceTests<QueueServiceClient, AzureStorag
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
             ("""{"Aspire": { "Azure": { "Storage":{ "Queues": { "ServiceUri": "YOUR_URI"}}}}}""", "Value does not match format \"uri\""),
-            ("""{"Aspire": { "Azure": { "Storage":{ "Queues": { "ServiceUri": "http://YOUR_URI", "HealthChecks": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Azure": { "Storage":{ "Queues": { "ServiceUri": "http://YOUR_URI", "DisableHealthChecks": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
             ("""{"Aspire": { "Azure": { "Storage":{ "Queues": { "ClientOptions": {"MessageEncoding": "Fast"}}}}}}""", "Value should match one of the values specified by the enum"),
             ("""{"Aspire": { "Azure": { "Storage":{ "Queues": { "ClientOptions": {"Retry": {"Mode": "Fast"}}}}}}}""", "Value should match one of the values specified by the enum"),
             ("""{"Aspire": { "Azure": { "Storage":{ "Queues": { "ClientOptions": {"Retry": {"NetworkTimeout": "PT3S"}}}}}}}""", "The string value is not a match for the indicated regular expression")
@@ -96,13 +96,13 @@ public class ConformanceTests : ConformanceTests<QueueServiceClient, AzureStorag
     }
 
     protected override void SetHealthCheck(AzureStorageQueuesSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetMetrics(AzureStorageQueuesSettings options, bool enabled)
         => throw new NotImplementedException();
 
     protected override void SetTracing(AzureStorageQueuesSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void TriggerActivity(QueueServiceClient service)
     {

--- a/tests/Aspire.Confluent.Kafka.Tests/ConsumerConformanceTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/ConsumerConformanceTests.cs
@@ -41,9 +41,9 @@ public class ConsumerConformanceTests : ConformanceTests<IConsumer<string, strin
         }
     }
 
-    protected override void SetHealthCheck(KafkaConsumerSettings options, bool enabled) => options.HealthChecks = enabled;
+    protected override void SetHealthCheck(KafkaConsumerSettings options, bool enabled) => options.DisableHealthChecks = !enabled;
 
-    protected override void SetMetrics(KafkaConsumerSettings options, bool enabled) => options.Metrics = enabled;
+    protected override void SetMetrics(KafkaConsumerSettings options, bool enabled) => options.DisableMetrics = !enabled;
 
     protected override void SetTracing(KafkaConsumerSettings options, bool enabled)
     {
@@ -64,8 +64,8 @@ public class ConsumerConformanceTests : ConformanceTests<IConsumer<string, strin
                             "Kafka": {
                                 "Consumer": {
                                     "ConnectionString": "localhost:9092",
-                                    "HealthChecks": true,
-                                    "Metrics": true,
+                                    "DisableHealthChecks": false,
+                                    "DisableMetrics": false,
                                     "Config": {
                                         "GroupId": "test"
                                     }
@@ -78,7 +78,7 @@ public class ConsumerConformanceTests : ConformanceTests<IConsumer<string, strin
 
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
-            ("""{"Aspire": { "Confluent":{ "Kafka": { "Consumer": { "Metrics": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
-            ("""{"Aspire": { "Confluent":{ "Kafka": { "Consumer": { "HealthChecks": 0}}}}}""", "Value is \"integer\" but should be \"boolean\"")
+            ("""{"Aspire": { "Confluent":{ "Kafka": { "Consumer": { "DisableMetrics": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
+            ("""{"Aspire": { "Confluent":{ "Kafka": { "Consumer": { "DisableHealthChecks": 0}}}}}""", "Value is \"integer\" but should be \"boolean\"")
         };
 }

--- a/tests/Aspire.Confluent.Kafka.Tests/ProducerConformanceTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/ProducerConformanceTests.cs
@@ -40,9 +40,9 @@ public class ProducerConformanceTests : ConformanceTests<IProducer<string, strin
         }
     }
 
-    protected override void SetHealthCheck(KafkaProducerSettings options, bool enabled) => options.HealthChecks = enabled;
+    protected override void SetHealthCheck(KafkaProducerSettings options, bool enabled) => options.DisableHealthChecks = !enabled;
 
-    protected override void SetMetrics(KafkaProducerSettings options, bool enabled) => options.Metrics = enabled;
+    protected override void SetMetrics(KafkaProducerSettings options, bool enabled) => options.DisableMetrics = !enabled;
 
     protected override void SetTracing(KafkaProducerSettings options, bool enabled)
     {
@@ -64,8 +64,8 @@ public class ProducerConformanceTests : ConformanceTests<IProducer<string, strin
                             "Kafka": {
                                 "Producer": {
                                     "ConnectionString": "localhost:9092",
-                                    "HealthChecks": true,
-                                    "Metrics": true
+                                    "DisableHealthChecks": false,
+                                    "DisableMetrics": false
                                 }
                             }
                         }
@@ -74,7 +74,7 @@ public class ProducerConformanceTests : ConformanceTests<IProducer<string, strin
                 """;
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
-            ("""{"Aspire": { "Confluent":{ "Kafka": { "Producer": { "Metrics": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
-            ("""{"Aspire": { "Confluent":{ "Kafka": { "Producer": { "HealthChecks": 0}}}}}""", "Value is \"integer\" but should be \"boolean\"")
+            ("""{"Aspire": { "Confluent":{ "Kafka": { "Producer": { "DisableMetrics": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
+            ("""{"Aspire": { "Confluent":{ "Kafka": { "Producer": { "DisableHealthChecks": 0}}}}}""", "Value is \"integer\" but should be \"boolean\"")
         };
 }

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConfigurationTests.cs
@@ -9,9 +9,9 @@ public class ConfigurationTests
 {
     [Fact]
     public void ConnectionStringIsNullByDefault()
-        => Assert.Null(new AzureCosmosDBSettings().ConnectionString);
+        => Assert.Null(new MicrosoftAzureCosmosDBSettings().ConnectionString);
 
     [Fact]
     public void TracingIsEnabledByDefault()
-        => Assert.True(new AzureCosmosDBSettings().Tracing);
+        => Assert.False(new MicrosoftAzureCosmosDBSettings().DisableTracing);
 }

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Microsoft.Azure.Cosmos.Tests;
 
-public class ConformanceTests : ConformanceTests<CosmosClient, AzureCosmosDBSettings>
+public class ConformanceTests : ConformanceTests<CosmosClient, MicrosoftAzureCosmosDBSettings>
 {
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
@@ -24,7 +24,7 @@ public class ConformanceTests : ConformanceTests<CosmosClient, AzureCosmosDBSett
                 "AccountEndpoint=https://example.documents.azure.com:443/;AccountKey=fake;")
         });
 
-    protected override void RegisterComponent(HostApplicationBuilder builder, Action<AzureCosmosDBSettings>? configure = null, string? key = null)
+    protected override void RegisterComponent(HostApplicationBuilder builder, Action<MicrosoftAzureCosmosDBSettings>? configure = null, string? key = null)
     {
         if (key is null)
         {
@@ -36,13 +36,13 @@ public class ConformanceTests : ConformanceTests<CosmosClient, AzureCosmosDBSett
         }
     }
 
-    protected override void SetHealthCheck(AzureCosmosDBSettings options, bool enabled)
+    protected override void SetHealthCheck(MicrosoftAzureCosmosDBSettings options, bool enabled)
         => throw new NotImplementedException();
 
-    protected override void SetTracing(AzureCosmosDBSettings options, bool enabled)
-        => options.Tracing = enabled;
+    protected override void SetTracing(MicrosoftAzureCosmosDBSettings options, bool enabled)
+        => options.DisableTracing = !enabled;
 
-    protected override void SetMetrics(AzureCosmosDBSettings options, bool enabled)
+    protected override void SetMetrics(MicrosoftAzureCosmosDBSettings options, bool enabled)
         => throw new NotImplementedException();
 
     protected override string ValidJsonConfig => """
@@ -52,7 +52,7 @@ public class ConformanceTests : ConformanceTests<CosmosClient, AzureCosmosDBSett
               "Azure": {
                 "Cosmos": {
                   "ConnectionString": "YOUR_CONNECTION_STRING",
-                  "Tracing": true
+                  "DisableTracing": false
                 }
               }
             }

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConfigurationTests.cs
@@ -13,9 +13,9 @@ public class ConfigurationTests
 
     [Fact]
     public void HealthCheckIsEnabledByDefault()
-        => Assert.True(new MicrosoftDataSqlClientSettings().HealthChecks);
+        => Assert.False(new MicrosoftDataSqlClientSettings().DisableHealthChecks);
 
     [Fact]
     public void TracingIsEnabledByDefault()
-        => Assert.True(new MicrosoftDataSqlClientSettings().Tracing);
+        => Assert.False(new MicrosoftDataSqlClientSettings().DisableTracing);
 }

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/ConformanceTests.cs
@@ -33,8 +33,8 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
             "SqlServer": {
               "SqlClient": {
                 "ConnectionString": "YOUR_CONNECTION_STRING",
-                "HealthChecks": true,
-                "Tracing": true
+                "DisableHealthChecks": false,
+                "DisableTracing": false
               }
             }
           }
@@ -43,8 +43,8 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
 
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
-            ("""{"Aspire": { "Microsoft": { "Data" : { "SqlClient":{ "Tracing": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
-            ("""{"Aspire": { "Microsoft": { "Data" : { "SqlClient":{ "ConnectionString": "Con", "HealthChecks": "false"}}}}}""", "Value is \"string\" but should be \"boolean\"")
+            ("""{"Aspire": { "Microsoft": { "Data" : { "SqlClient":{ "DisableTracing": 0}}}}}""", "Value is \"integer\" but should be \"boolean\""),
+            ("""{"Aspire": { "Microsoft": { "Data" : { "SqlClient":{ "ConnectionString": "Con", "DisableHealthChecks": "true"}}}}}""", "Value is \"string\" but should be \"boolean\"")
         };
 
     public ConformanceTests(SqlServerContainerFixture? containerFixture)
@@ -75,10 +75,10 @@ public class ConformanceTests : ConformanceTests<SqlConnection, MicrosoftDataSql
     }
 
     protected override void SetHealthCheck(MicrosoftDataSqlClientSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetTracing(MicrosoftDataSqlClientSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void SetMetrics(MicrosoftDataSqlClientSettings options, bool enabled)
         => throw new NotImplementedException();

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/ConformanceTests.cs
@@ -40,7 +40,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, EntityFrameworkC
         => throw new NotImplementedException();
 
     protected override void SetTracing(EntityFrameworkCoreCosmosDBSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void SetMetrics(EntityFrameworkCoreCosmosDBSettings options, bool enabled)
         => throw new NotImplementedException();
@@ -52,7 +52,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, EntityFrameworkC
               "EntityFrameworkCore": {
                 "Cosmos": {
                   "ConnectionString": "YOUR_CONNECTION_STRING",
-                  "Tracing": true
+                  "DisableTracing": false
                 }
               }
             }

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
@@ -78,7 +78,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
             new KeyValuePair<string, string?>("ConnectionStrings:sqlconnection", ConnectionString),
-            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:Retry", "true"),
+            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:DisableRetry", "false"),
             new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:CommandTimeout", "608")
         ]);
 
@@ -123,7 +123,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
             new KeyValuePair<string, string?>("ConnectionStrings:sqlconnection", ConnectionString),
-            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:Retry", "false"),
+            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:DisableRetry", "true"),
         ]);
 
         builder.AddSqlServerDbContext<TestDbContext>("sqlconnection", configureDbContextOptions: optionsBuilder =>

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/ConformanceTests.cs
@@ -46,8 +46,8 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
               "EntityFrameworkCore": {
                 "SqlServer": {
                   "ConnectionString": "YOUR_CONNECTION_STRING",
-                  "HealthChecks": false,
-                  "Tracing": true
+                  "DisableHealthChecks": true,
+                  "DisableTracing": false
                 }
               }
             }
@@ -57,9 +57,9 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
 
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
-            ("""{"Aspire": { "Microsoft": { "EntityFrameworkCore":{ "SqlServer": { "Retry": "5"}}}}}""", "Value is \"string\" but should be \"boolean\""),
-            ("""{"Aspire": { "Microsoft": { "EntityFrameworkCore":{ "SqlServer": { "HealthChecks": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
-            ("""{"Aspire": { "Microsoft": { "EntityFrameworkCore":{ "SqlServer": { "Tracing": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Microsoft": { "EntityFrameworkCore":{ "SqlServer": { "DisableRetry": "5"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Microsoft": { "EntityFrameworkCore":{ "SqlServer": { "DisableHealthChecks": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Microsoft": { "EntityFrameworkCore":{ "SqlServer": { "DisableTracing": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
         };
 
     public ConformanceTests(SqlServerContainerFixture? fixture)
@@ -80,10 +80,10 @@ public class ConformanceTests : ConformanceTests<TestDbContext, MicrosoftEntityF
         => builder.AddSqlServerDbContext<TestDbContext>("sqlconnection", configure);
 
     protected override void SetHealthCheck(MicrosoftEntityFrameworkCoreSqlServerSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetTracing(MicrosoftEntityFrameworkCoreSqlServerSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void SetMetrics(MicrosoftEntityFrameworkCoreSqlServerSettings options, bool enabled)
         => throw new NotImplementedException();

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/EnrichSqlServerTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/EnrichSqlServerTests.cs
@@ -57,7 +57,7 @@ public class EnrichSqlServerTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:Retry", "true")
+            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:DisableRetry", "false")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -147,7 +147,7 @@ public class EnrichSqlServerTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:Retry", "false")
+            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:DisableRetry", "true")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -190,7 +190,7 @@ public class EnrichSqlServerTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:Retry", "true")
+            new KeyValuePair<string, string?>("Aspire:Microsoft:EntityFrameworkCore:SqlServer:DisableRetry", "false")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -270,7 +270,7 @@ public class EnrichSqlServerTests : ConformanceTests
             optionsBuilder.UseSqlServer(ConnectionString, builder => builder.ExecutionStrategy(c => new CustomExecutionStrategy(c)));
         });
 
-        builder.EnrichSqlServerDbContext<TestDbContext>(settings => settings.Retry = false);
+        builder.EnrichSqlServerDbContext<TestDbContext>(settings => settings.DisableRetry = true);
 
         using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
@@ -298,11 +298,11 @@ public class EnrichSqlServerTests : ConformanceTests
             optionsBuilder.UseSqlServer(ConnectionString, builder => builder.ExecutionStrategy(c => new CustomExecutionStrategy(c)));
         });
 
-        builder.EnrichSqlServerDbContext<TestDbContext>(settings => settings.Retry = true);
+        builder.EnrichSqlServerDbContext<TestDbContext>(settings => settings.DisableRetry = false);
         using var host = builder.Build();
 
         var exception = Assert.Throws<InvalidOperationException>(host.Services.GetRequiredService<TestDbContext>);
-        Assert.Equal("MicrosoftEntityFrameworkCoreSqlServerSettings.Retry can't be set when a custom Execution Strategy is configured.", exception.Message);
+        Assert.Equal("MicrosoftEntityFrameworkCoreSqlServerSettings.DisableRetry needs to be set when a custom Execution Strategy is configured.", exception.Message);
     }
 
     [Fact]
@@ -315,7 +315,7 @@ public class EnrichSqlServerTests : ConformanceTests
             optionsBuilder.UseSqlServer(ConnectionString, builder => builder.ExecutionStrategy(c => new CustomRetryExecutionStrategy(c)));
         });
 
-        builder.EnrichSqlServerDbContext<TestDbContext>(settings => settings.Retry = true);
+        builder.EnrichSqlServerDbContext<TestDbContext>(settings => settings.DisableRetry = false);
 
         using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();

--- a/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/AspireMongoDBDriverExtensionsTests.cs
@@ -95,7 +95,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
 
         builder.AddMongoDBClient(DefaultConnectionName, settings =>
         {
-            settings.HealthChecks = true;
+            settings.DisableHealthChecks = false;
             settings.HealthCheckTimeout = 1;
         });
 
@@ -117,7 +117,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
 
         builder.AddKeyedMongoDBClient(DefaultConnectionName, settings =>
         {
-            settings.HealthChecks = false;
+            settings.DisableHealthChecks = true;
         });
 
         using var host = builder.Build();
@@ -137,7 +137,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
 
         builder.AddKeyedMongoDBClient(key, settings =>
         {
-            settings.HealthChecks = true;
+            settings.DisableHealthChecks = false;
             settings.HealthCheckTimeout = 1;
         });
 
@@ -159,7 +159,7 @@ public class AspireMongoDBDriverExtensionsTests : IClassFixture<MongoDbContainer
 
         builder.AddMongoDBClient(DefaultConnectionName, settings =>
         {
-            settings.HealthChecks = false;
+            settings.DisableHealthChecks = true;
         });
 
         using var host = builder.Build();

--- a/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/ConformanceTests.cs
@@ -29,9 +29,9 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
             "MongoDB": {
               "Driver": {
                 "ConnectionString": "YOUR_CONNECTION_STRING",
-                "HealthChecks": true,
+                "DisableHealthChecks": false,
                 "HealthCheckTimeout": 100,
-                "Tracing": true
+                "DisableTracing": false
               }
             }
           }
@@ -45,9 +45,9 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
 
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
     {
-        ("""{"Aspire": { "MongoDB":{ "Driver": { "HealthChecks": "true"}}}}""", "Value is \"string\" but should be \"boolean\""),
+        ("""{"Aspire": { "MongoDB":{ "Driver": { "DisableHealthChecks": "true"}}}}""", "Value is \"string\" but should be \"boolean\""),
         ("""{"Aspire": { "MongoDB":{ "Driver": { "HealthCheckTimeout": "10000"}}}}""", "Value is \"string\" but should be \"integer\""),
-        ("""{"Aspire": { "MongoDB":{ "Driver": { "Tracing": "true"}}}}""", "Value is \"string\" but should be \"boolean\""),
+        ("""{"Aspire": { "MongoDB":{ "Driver": { "DisableTracing": "true"}}}}""", "Value is \"string\" but should be \"boolean\""),
     };
 
     protected override string[] RequiredLogCategories => [
@@ -84,7 +84,7 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
 
     protected override void SetHealthCheck(MongoDBSettings options, bool enabled)
     {
-        options.HealthChecks = enabled;
+        options.DisableHealthChecks = !enabled;
         options.HealthCheckTimeout = 10;
     }
 
@@ -92,7 +92,7 @@ public class ConformanceTests : ConformanceTests<IMongoClient, MongoDBSettings>,
 
     protected override void SetTracing(MongoDBSettings options, bool enabled)
     {
-        options.Tracing = enabled;
+        options.DisableTracing = !enabled;
     }
 
     protected override void TriggerActivity(IMongoClient service)

--- a/tests/Aspire.MySqlConnector.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.MySqlConnector.Tests/ConfigurationTests.cs
@@ -13,13 +13,13 @@ public class ConfigurationTests
 
     [Fact]
     public void HealthCheckIsEnabledByDefault()
-        => Assert.True(new MySqlConnectorSettings().HealthChecks);
+        => Assert.False(new MySqlConnectorSettings().DisableHealthChecks);
 
     [Fact]
     public void TracingIsEnabledByDefault()
-        => Assert.True(new MySqlConnectorSettings().Tracing);
+        => Assert.False(new MySqlConnectorSettings().DisableTracing);
 
     [Fact]
     public void MetricsAreEnabledByDefault()
-        => Assert.True(new MySqlConnectorSettings().Metrics);
+        => Assert.False(new MySqlConnectorSettings().DisableMetrics);
 }

--- a/tests/Aspire.MySqlConnector.Tests/ConformanceTests.cs
+++ b/tests/Aspire.MySqlConnector.Tests/ConformanceTests.cs
@@ -39,9 +39,9 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
           "Aspire": {
             "MySqlConnector": {
               "ConnectionString": "YOUR_CONNECTION_STRING",
-              "HealthChecks": false,
-              "Tracing": true,
-              "Metrics": true
+              "DisableHealthChecks": true,
+              "DisableTracing": false,
+              "DisableMetrics": false
             }
           }
         }
@@ -49,8 +49,8 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
 
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
-            ("""{"Aspire": { "MySqlConnector":{ "Metrics": 0}}}""", "Value is \"integer\" but should be \"boolean\""),
-            ("""{"Aspire": { "MySqlConnector":{ "ConnectionString": "Con", "HealthChecks": "false"}}}""", "Value is \"string\" but should be \"boolean\"")
+            ("""{"Aspire": { "MySqlConnector":{ "DisableMetrics": 0}}}""", "Value is \"integer\" but should be \"boolean\""),
+            ("""{"Aspire": { "MySqlConnector":{ "ConnectionString": "Con", "DisableHealthChecks": "true"}}}""", "Value is \"string\" but should be \"boolean\"")
         };
 
     public ConformanceTests(MySqlContainerFixture? containerFixture)
@@ -80,13 +80,13 @@ public class ConformanceTests : ConformanceTests<MySqlDataSource, MySqlConnector
     }
 
     protected override void SetHealthCheck(MySqlConnectorSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetTracing(MySqlConnectorSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void SetMetrics(MySqlConnectorSettings options, bool enabled)
-        => options.Metrics = enabled;
+        => options.DisableMetrics = !enabled;
 
     protected override void TriggerActivity(MySqlDataSource service)
     {

--- a/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/AspireNatsClientExtensionsTests.cs
@@ -157,14 +157,14 @@ public class AspireNatsClientExtensionsTests : IClassFixture<NatsContainerFixtur
         {
             builder.AddKeyedNatsClient(DefaultConnectionName, settings =>
             {
-                settings.HealthChecks = false;
+                settings.DisableHealthChecks = true;
             });
         }
         else
         {
             builder.AddNatsClient(DefaultConnectionName, settings =>
             {
-                settings.HealthChecks = false;
+                settings.DisableHealthChecks = true;
             });
         }
 

--- a/tests/Aspire.NATS.Net.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/ConfigurationTests.cs
@@ -13,9 +13,9 @@ public class ConfigurationTests
 
     [Fact]
     public void HealthCheckIsEnabledByDefault()
-        => Assert.True(new NatsClientSettings().HealthChecks);
+        => Assert.False(new NatsClientSettings().DisableHealthChecks);
 
     [Fact]
     public void TracingIsEnabledByDefault()
-        => Assert.True(new NatsClientSettings().Tracing);
+        => Assert.False(new NatsClientSettings().DisableTracing);
 }

--- a/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
+++ b/tests/Aspire.NATS.Net.Tests/ConformanceTests.cs
@@ -60,10 +60,10 @@ public class ConformanceTests : ConformanceTests<INatsConnection, NatsClientSett
     }
 
     protected override void SetHealthCheck(NatsClientSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetTracing(NatsClientSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void SetMetrics(NatsClientSettings options, bool enabled)
         => throw new NotImplementedException();
@@ -74,9 +74,9 @@ public class ConformanceTests : ConformanceTests<INatsConnection, NatsClientSett
                                                      "Nats": {
                                                        "Client": {
                                                          "ConnectionString": "YOUR_CONNECTION_STRING",
-                                                         "HealthChecks": false,
-                                                         "Tracing": true,
-                                                         "Metrics": true
+                                                         "DisableHealthChecks": true,
+                                                         "DisableTracing": false,
+                                                         "DisableMetrics": false
                                                        }
                                                      }
                                                    }

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/AspireEFPostgreSqlExtensionsTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/AspireEFPostgreSqlExtensionsTests.cs
@@ -130,7 +130,7 @@ public class AspireEFPostgreSqlExtensionsTests
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
             new KeyValuePair<string, string?>("ConnectionStrings:npgsql", ConnectionString),
-            new KeyValuePair<string, string?>("Aspire:Npgsql:EntityFrameworkCore:PostgreSQL:Retry", "false")
+            new KeyValuePair<string, string?>("Aspire:Npgsql:EntityFrameworkCore:PostgreSQL:DisableRetry", "true")
         ]);
 
         builder.AddNpgsqlDbContext<TestDbContext>("npgsql", configureDbContextOptions: optionsBuilder =>

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConfigurationTests.cs
@@ -13,17 +13,17 @@ public class ConfigurationTests
 
     [Fact]
     public void HealthCheckIsEnabledByDefault()
-        => Assert.True(new NpgsqlEntityFrameworkCorePostgreSQLSettings().HealthChecks);
+        => Assert.False(new NpgsqlEntityFrameworkCorePostgreSQLSettings().DisableHealthChecks);
 
     [Fact]
     public void TracingIsEnabledByDefault()
-        => Assert.True(new NpgsqlEntityFrameworkCorePostgreSQLSettings().Tracing);
+        => Assert.False(new NpgsqlEntityFrameworkCorePostgreSQLSettings().DisableTracing);
 
     [Fact]
     public void MetricsAreEnabledByDefault()
-        => Assert.True(new NpgsqlEntityFrameworkCorePostgreSQLSettings().Metrics);
+        => Assert.False(new NpgsqlEntityFrameworkCorePostgreSQLSettings().DisableMetrics);
 
     [Fact]
     public void RetriesAreEnabledByDefault()
-        => Assert.True(new NpgsqlEntityFrameworkCorePostgreSQLSettings().Retry);
+        => Assert.False(new NpgsqlEntityFrameworkCorePostgreSQLSettings().DisableRetry);
 }

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/ConformanceTests.cs
@@ -58,9 +58,9 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
               "EntityFrameworkCore": {
                 "PostgreSQL": {
                   "ConnectionString": "YOUR_CONNECTION_STRING",
-                  "HealthChecks": false,
-                  "Tracing": true,
-                  "Metrics": true
+                  "DisableHealthChecks": true,
+                  "DisableTracing": false,
+                  "DisableMetrics": false
                 }
               }
             }
@@ -70,10 +70,10 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
 
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
-            ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "Retry": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
-            ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "HealthChecks": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
-            ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "Tracing": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
-            ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "Metrics": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "DisableRetry": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "DisableHealthChecks": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "DisableTracing": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Npgsql": { "EntityFrameworkCore":{ "PostgreSQL": { "DisableMetrics": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
         };
 
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture)
@@ -94,13 +94,13 @@ public class ConformanceTests : ConformanceTests<TestDbContext, NpgsqlEntityFram
         => builder.AddNpgsqlDbContext<TestDbContext>("postgres", configure);
 
     protected override void SetHealthCheck(NpgsqlEntityFrameworkCorePostgreSQLSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetTracing(NpgsqlEntityFrameworkCorePostgreSQLSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void SetMetrics(NpgsqlEntityFrameworkCorePostgreSQLSettings options, bool enabled)
-        => options.Metrics = enabled;
+        => options.DisableMetrics = !enabled;
 
     protected override void TriggerActivity(TestDbContext service)
     {

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/EnrichNpgsqlTests.cs
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/EnrichNpgsqlTests.cs
@@ -150,7 +150,7 @@ public class EnrichNpgsqlTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Npgsql:EntityFrameworkCore:PostgreSQL:Retry", "false")
+            new KeyValuePair<string, string?>("Aspire:Npgsql:EntityFrameworkCore:PostgreSQL:DisableRetry", "true")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -194,7 +194,7 @@ public class EnrichNpgsqlTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Npgsql:EntityFrameworkCore:PostgreSQL:Retry", "true")
+            new KeyValuePair<string, string?>("Aspire:Npgsql:EntityFrameworkCore:PostgreSQL:DisableRetry", "false")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -279,7 +279,7 @@ public class EnrichNpgsqlTests : ConformanceTests
             optionsBuilder.UseNpgsql(ConnectionString, npgsql => npgsql.ExecutionStrategy(c => new CustomExecutionStrategy(c)));
         });
 
-        builder.EnrichNpgsqlDbContext<TestDbContext>(settings => settings.Retry = false);
+        builder.EnrichNpgsqlDbContext<TestDbContext>(settings => settings.DisableRetry = true);
 
         using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
@@ -308,11 +308,11 @@ public class EnrichNpgsqlTests : ConformanceTests
             optionsBuilder.UseNpgsql(ConnectionString, npgsql => npgsql.ExecutionStrategy(c => new CustomExecutionStrategy(c)));
         });
 
-        builder.EnrichNpgsqlDbContext<TestDbContext>(settings => settings.Retry = true);
+        builder.EnrichNpgsqlDbContext<TestDbContext>(settings => settings.DisableRetry = false);
         using var host = builder.Build();
 
         var exception = Assert.Throws<InvalidOperationException>(host.Services.GetRequiredService<TestDbContext>);
-        Assert.Equal("NpgsqlEntityFrameworkCorePostgreSQLSettings.Retry can't be set when a custom Execution Strategy is configured.", exception.Message);
+        Assert.Equal("NpgsqlEntityFrameworkCorePostgreSQLSettings.DisableRetry needs to be set when a custom Execution Strategy is configured.", exception.Message);
     }
 
     [Fact]
@@ -326,7 +326,7 @@ public class EnrichNpgsqlTests : ConformanceTests
             optionsBuilder.UseNpgsql(ConnectionString, npgsql => npgsql.ExecutionStrategy(c => new CustomRetryExecutionStrategy(c)));
         });
 
-        builder.EnrichNpgsqlDbContext<TestDbContext>(settings => settings.Retry = true);
+        builder.EnrichNpgsqlDbContext<TestDbContext>(settings => settings.DisableRetry = false);
 
         using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();

--- a/tests/Aspire.Npgsql.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.Npgsql.Tests/ConfigurationTests.cs
@@ -13,13 +13,13 @@ public class ConfigurationTests
 
     [Fact]
     public void HealthCheckIsEnabledByDefault()
-        => Assert.True(new NpgsqlSettings().HealthChecks);
+        => Assert.False(new NpgsqlSettings().DisableHealthChecks);
 
     [Fact]
     public void TracingIsEnabledByDefault()
-        => Assert.True(new NpgsqlSettings().Tracing);
+        => Assert.False(new NpgsqlSettings().DisableTracing);
 
     [Fact]
     public void MetricsAreEnabledByDefault()
-        => Assert.True(new NpgsqlSettings().Metrics);
+        => Assert.False(new NpgsqlSettings().DisableMetrics);
 }

--- a/tests/Aspire.Npgsql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Npgsql.Tests/ConformanceTests.cs
@@ -41,9 +41,9 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
           "Aspire": {
             "Npgsql": {
               "ConnectionString": "YOUR_CONNECTION_STRING",
-              "HealthChecks": false,
-              "Tracing": true,
-              "Metrics": true
+              "DisableHealthChecks": true,
+              "DisableTracing": false,
+              "DisableMetrics": false
             }
           }
         }
@@ -51,8 +51,8 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
 
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
-            ("""{"Aspire": { "Npgsql":{ "Metrics": 0}}}""", "Value is \"integer\" but should be \"boolean\""),
-            ("""{"Aspire": { "Npgsql":{ "ConnectionString": "Con", "HealthChecks": "false"}}}""", "Value is \"string\" but should be \"boolean\"")
+            ("""{"Aspire": { "Npgsql":{ "DisableMetrics": 0}}}""", "Value is \"integer\" but should be \"boolean\""),
+            ("""{"Aspire": { "Npgsql":{ "ConnectionString": "Con", "DisableHealthChecks": "true"}}}""", "Value is \"string\" but should be \"boolean\"")
         };
 
     public ConformanceTests(PostgreSQLContainerFixture? containerFixture)
@@ -82,13 +82,13 @@ public class ConformanceTests : ConformanceTests<NpgsqlDataSource, NpgsqlSetting
     }
 
     protected override void SetHealthCheck(NpgsqlSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetTracing(NpgsqlSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void SetMetrics(NpgsqlSettings options, bool enabled)
-        => options.Metrics = enabled;
+        => options.DisableMetrics = !enabled;
 
     protected override void TriggerActivity(NpgsqlDataSource service)
     {

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/AspireOracleEFCoreDatabaseExtensionsTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/AspireOracleEFCoreDatabaseExtensionsTests.cs
@@ -79,7 +79,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
             new KeyValuePair<string, string?>("ConnectionStrings:orclconnection", ConnectionString),
-            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:Retry", "true"),
+            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:DisableRetry", "false"),
             new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:CommandTimeout", "608")
         ]);
 
@@ -124,7 +124,7 @@ public class AspireOracleEFCoreDatabaseExtensionsTests
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
             new KeyValuePair<string, string?>("ConnectionStrings:orclconnection", ConnectionString),
-            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:Retry", "false"),
+            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:DisableRetry", "true"),
         ]);
 
         builder.AddOracleDatabaseDbContext<TestDbContext>("orclconnection", configureDbContextOptions: optionsBuilder =>

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/ConformanceTests.cs
@@ -40,7 +40,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
             "Oracle": {
               "EntityFrameworkCore": {
                 "ConnectionString": "YOUR_CONNECTION_STRING",
-                "HealthChecks": false
+                "DisableHealthChecks": true
               }
             }
           }
@@ -49,8 +49,8 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
 
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
-            ("""{"Aspire": { "Oracle": { "EntityFrameworkCore":{ "Retry": "5"}}}}""", "Value is \"string\" but should be \"boolean\""),
-            ("""{"Aspire": { "Oracle": { "EntityFrameworkCore":{ "HealthChecks": "false"}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Oracle": { "EntityFrameworkCore":{ "DisableRetry": "5"}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Oracle": { "EntityFrameworkCore":{ "DisableHealthChecks": "true"}}}}""", "Value is \"string\" but should be \"boolean\""),
         };
 
     protected override void PopulateConfiguration(ConfigurationManager configuration, string? key = null)
@@ -63,7 +63,7 @@ public class ConformanceTests : ConformanceTests<TestDbContext, OracleEntityFram
         => builder.AddOracleDatabaseDbContext<TestDbContext>("orclconnection", configure);
 
     protected override void SetHealthCheck(OracleEntityFrameworkCoreSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetTracing(OracleEntityFrameworkCoreSettings options, bool enabled)
         => throw new NotImplementedException();

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/EnrichOracleDatabaseTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/EnrichOracleDatabaseTests.cs
@@ -52,7 +52,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:Retry", "true")
+            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:DisableRetry", "false")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -142,7 +142,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:Retry", "false")
+            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:DisableRetry", "true")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -185,7 +185,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:Retry", "true")
+            new KeyValuePair<string, string?>("Aspire:Oracle:EntityFrameworkCore:DisableRetry", "false")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -265,7 +265,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
             optionsBuilder.UseOracle(ConnectionString, builder => builder.ExecutionStrategy(c => new CustomExecutionStrategy(c)));
         });
 
-        builder.EnrichOracleDatabaseDbContext<TestDbContext>(settings => settings.Retry = false);
+        builder.EnrichOracleDatabaseDbContext<TestDbContext>(settings => settings.DisableRetry = true);
 
         using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
@@ -293,11 +293,11 @@ public class EnrichOracleDatabaseTests : ConformanceTests
             optionsBuilder.UseOracle(ConnectionString, builder => builder.ExecutionStrategy(c => new CustomExecutionStrategy(c)));
         });
 
-        builder.EnrichOracleDatabaseDbContext<TestDbContext>(settings => settings.Retry = true);
+        builder.EnrichOracleDatabaseDbContext<TestDbContext>(settings => settings.DisableRetry = false);
         using var host = builder.Build();
 
         var exception = Assert.Throws<InvalidOperationException>(host.Services.GetRequiredService<TestDbContext>);
-        Assert.Equal("OracleEntityFrameworkCoreSettings.Retry can't be set when a custom Execution Strategy is configured.", exception.Message);
+        Assert.Equal("OracleEntityFrameworkCoreSettings.DisableRetry needs to be set when a custom Execution Strategy is configured.", exception.Message);
     }
 
     [Fact]
@@ -310,7 +310,7 @@ public class EnrichOracleDatabaseTests : ConformanceTests
             optionsBuilder.UseOracle(ConnectionString, builder => builder.ExecutionStrategy(c => new CustomRetryExecutionStrategy(c)));
         });
 
-        builder.EnrichOracleDatabaseDbContext<TestDbContext>(settings => settings.Retry = true);
+        builder.EnrichOracleDatabaseDbContext<TestDbContext>(settings => settings.DisableRetry = false);
 
         using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/AspireEFMySqlExtensionsTests.cs
@@ -98,7 +98,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
         builder.Configuration.AddInMemoryCollection([
             new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:ServerVersion", s_serverVersionString),
             new KeyValuePair<string, string?>("ConnectionStrings:mysql", ConnectionString),
-            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:Retry", "true")
+            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:DisableRetry", "false")
         ]);
 
         builder.AddMySqlDbContext<TestDbContext>("mysql", configureDbContextOptions: optionsBuilder =>
@@ -141,7 +141,7 @@ public class AspireEFMySqlExtensionsTests : IClassFixture<MySqlContainerFixture>
         builder.Configuration.AddInMemoryCollection([
             new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:ServerVersion", s_serverVersionString),
             new KeyValuePair<string, string?>("ConnectionStrings:mysql", ConnectionString),
-            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:Retry", "false")
+            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:DisableRetry", "true")
         ]);
 
         builder.AddMySqlDbContext<TestDbContext>("mysql", configureDbContextOptions: optionsBuilder =>

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConfigurationTests.cs
@@ -13,17 +13,17 @@ public class ConfigurationTests
 
     [Fact]
     public void HealthCheckIsEnabledByDefault()
-        => Assert.True(new PomeloEntityFrameworkCoreMySqlSettings().HealthChecks);
+        => Assert.False(new PomeloEntityFrameworkCoreMySqlSettings().DisableHealthChecks);
 
     [Fact]
     public void TracingIsEnabledByDefault()
-        => Assert.True(new PomeloEntityFrameworkCoreMySqlSettings().Tracing);
+        => Assert.False(new PomeloEntityFrameworkCoreMySqlSettings().DisableTracing);
 
     [Fact]
     public void MetricsAreEnabledByDefault()
-        => Assert.True(new PomeloEntityFrameworkCoreMySqlSettings().Metrics);
+        => Assert.False(new PomeloEntityFrameworkCoreMySqlSettings().DisableMetrics);
 
     [Fact]
     public void RetriesAreEnabledByDefault()
-        => Assert.True(new PomeloEntityFrameworkCoreMySqlSettings().Retry);
+        => Assert.False(new PomeloEntityFrameworkCoreMySqlSettings().DisableRetry);
 }

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/ConformanceTests.cs
@@ -54,9 +54,9 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
               "EntityFrameworkCore": {
                 "MySql": {
                   "ConnectionString": "YOUR_CONNECTION_STRING",
-                  "HealthChecks": false,
-                  "Tracing": true,
-                  "Metrics": true
+                  "DisableHealthChecks": true,
+                  "DisableTracing": false,
+                  "DisableMetrics": false
                 }
               }
             }
@@ -66,10 +66,10 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
 
     protected override (string json, string error)[] InvalidJsonToErrorMessage => new[]
         {
-            ("""{"Aspire": { "Pomelo": { "EntityFrameworkCore":{ "MySql": { "Retry": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
-            ("""{"Aspire": { "Pomelo": { "EntityFrameworkCore":{ "MySql": { "HealthChecks": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
-            ("""{"Aspire": { "Pomelo": { "EntityFrameworkCore":{ "MySql": { "Tracing": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
-            ("""{"Aspire": { "Pomelo": { "EntityFrameworkCore":{ "MySql": { "Metrics": "false"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Pomelo": { "EntityFrameworkCore":{ "MySql": { "DisableRetry": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Pomelo": { "EntityFrameworkCore":{ "MySql": { "DisableHealthChecks": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Pomelo": { "EntityFrameworkCore":{ "MySql": { "DisableTracing": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
+            ("""{"Aspire": { "Pomelo": { "EntityFrameworkCore":{ "MySql": { "DisableMetrics": "true"}}}}}""", "Value is \"string\" but should be \"boolean\""),
         };
 
     public ConformanceTests(MySqlContainerFixture? containerFixture)
@@ -91,13 +91,13 @@ public class ConformanceTests : ConformanceTests<TestDbContext, PomeloEntityFram
         => builder.AddMySqlDbContext<TestDbContext>("mysql", configure);
 
     protected override void SetHealthCheck(PomeloEntityFrameworkCoreMySqlSettings options, bool enabled)
-        => options.HealthChecks = enabled;
+        => options.DisableHealthChecks = !enabled;
 
     protected override void SetTracing(PomeloEntityFrameworkCoreMySqlSettings options, bool enabled)
-        => options.Tracing = enabled;
+        => options.DisableTracing = !enabled;
 
     protected override void SetMetrics(PomeloEntityFrameworkCoreMySqlSettings options, bool enabled)
-        => options.Metrics = enabled;
+        => options.DisableMetrics = !enabled;
 
     protected override void TriggerActivity(TestDbContext service)
     {

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/EnrichMySqlTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/EnrichMySqlTests.cs
@@ -70,7 +70,7 @@ public class EnrichMySqlTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:Retry", "true")
+            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:DisableRetry", "false")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -160,7 +160,7 @@ public class EnrichMySqlTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:Retry", "false")
+            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:DisableRetry", "true")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -203,7 +203,7 @@ public class EnrichMySqlTests : ConformanceTests
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([
-            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:Retry", "true")
+            new KeyValuePair<string, string?>("Aspire:Pomelo:EntityFrameworkCore:MySql:DisableRetry", "false")
         ]);
 
         builder.Services.AddDbContextPool<TestDbContext>(optionsBuilder =>
@@ -283,7 +283,7 @@ public class EnrichMySqlTests : ConformanceTests
             optionsBuilder.UseMySql(ConnectionString, DefaultVersion, builder => builder.ExecutionStrategy(c => new CustomExecutionStrategy(c)));
         });
 
-        builder.EnrichMySqlDbContext<TestDbContext>(settings => settings.Retry = false);
+        builder.EnrichMySqlDbContext<TestDbContext>(settings => settings.DisableRetry = true);
 
         using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();
@@ -311,11 +311,11 @@ public class EnrichMySqlTests : ConformanceTests
             optionsBuilder.UseMySql(ConnectionString, DefaultVersion, builder => builder.ExecutionStrategy(c => new CustomExecutionStrategy(c)));
         });
 
-        builder.EnrichMySqlDbContext<TestDbContext>(settings => settings.Retry = true);
+        builder.EnrichMySqlDbContext<TestDbContext>(settings => settings.DisableRetry = false);
         using var host = builder.Build();
 
         var exception = Assert.Throws<InvalidOperationException>(host.Services.GetRequiredService<TestDbContext>);
-        Assert.Equal("PomeloEntityFrameworkCoreMySqlSettings.Retry can't be set when a custom Execution Strategy is configured.", exception.Message);
+        Assert.Equal("PomeloEntityFrameworkCoreMySqlSettings.DisableRetry needs to be set when a custom Execution Strategy is configured.", exception.Message);
     }
 
     [Fact]
@@ -328,7 +328,7 @@ public class EnrichMySqlTests : ConformanceTests
             optionsBuilder.UseMySql(ConnectionString, DefaultVersion, builder => builder.ExecutionStrategy(c => new CustomRetryExecutionStrategy(c)));
         });
 
-        builder.EnrichMySqlDbContext<TestDbContext>(settings => settings.Retry = true);
+        builder.EnrichMySqlDbContext<TestDbContext>(settings => settings.DisableRetry = false);
 
         using var host = builder.Build();
         var context = host.Services.GetRequiredService<TestDbContext>();

--- a/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/ConformanceTests.cs
@@ -50,8 +50,8 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
                 },
                 "ConnectionString": "amqp://localhost:5672",
                 "MaxConnectRetryCount": 10,
-                "HealthChecks": true,
-                "Tracing": false
+                "DisableHealthChecks": false,
+                "DisableTracing": true
               }
             }
           }
@@ -90,18 +90,18 @@ public class ConformanceTests : ConformanceTests<IConnection, RabbitMQClientSett
         }
     }
 
-    protected override void SetHealthCheck(RabbitMQClientSettings settings, bool enabled)
-        => settings.HealthChecks = enabled;
+    protected override void SetHealthCheck(RabbitMQClientSettings options, bool enabled)
+        => options.DisableHealthChecks = !enabled;
 
     protected override void DisableRetries(RabbitMQClientSettings options)
     {
         options.MaxConnectRetryCount = 0;
     }
 
-    protected override void SetTracing(RabbitMQClientSettings settings, bool enabled)
-        => settings.Tracing = enabled;
+    protected override void SetTracing(RabbitMQClientSettings options, bool enabled)
+        => options.DisableTracing = !enabled;
 
-    protected override void SetMetrics(RabbitMQClientSettings settings, bool enabled)
+    protected override void SetMetrics(RabbitMQClientSettings options, bool enabled)
         => throw new NotImplementedException();
 
     protected override void TriggerActivity(IConnection service)

--- a/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
+++ b/tests/Aspire.Seq.Tests/SeqEndpointCanBeConfigured.cs
@@ -16,7 +16,7 @@ public class SeqTests
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.AddSeqEndpoint("seq", s =>
         {
-            s.HealthChecks = false;
+            s.DisableHealthChecks = true;
             s.Logs.TimeoutMilliseconds = 1000;
             s.Traces.Protocol = OtlpExportProtocol.Grpc;
         });
@@ -55,7 +55,7 @@ public class SeqTests
         builder.AddSeqEndpoint("seq", s =>
         {
             settings = s;
-            s.HealthChecks = false;
+            s.DisableHealthChecks = true;
             s.ApiKey = "TestKey123!";
             s.Logs.Headers = "speed=fast,quality=good";
             s.Traces.Headers = "quality=good,speed=fast";

--- a/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/AspireRedisExtensionsTests.cs
@@ -242,7 +242,7 @@ public class AspireRedisExtensionsTests : IClassFixture<RedisContainerFixture>
         builder.AddKeyedRedisClient("redis", settings =>
         {
             settings.ConnectionString = "localhost";
-            settings.Tracing = true;
+            settings.DisableTracing = ! true;
         });
         using var host = builder.Build();
 

--- a/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/ConformanceTests.cs
@@ -34,8 +34,8 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
             "StackExchange": {
               "Redis": {
                 "ConnectionString": "YOUR_ENDPOINT",
-                "HealthChecks": true,
-                "Tracing": false,
+                "DisableHealthChecks": false,
+                "DisableTracing": true,
                 "ConfigurationOptions": {
                   "CheckCertificateRevocation": true,
                   "ConnectTimeout": 5,
@@ -84,13 +84,13 @@ public class ConformanceTests : ConformanceTests<IConnectionMultiplexer, StackEx
         }
     }
 
-    protected override void SetHealthCheck(StackExchangeRedisSettings settings, bool enabled)
-        => settings.HealthChecks = enabled;
+    protected override void SetHealthCheck(StackExchangeRedisSettings options, bool enabled)
+        => options.DisableHealthChecks = !enabled;
 
-    protected override void SetTracing(StackExchangeRedisSettings settings, bool enabled)
-        => settings.Tracing = enabled;
+    protected override void SetTracing(StackExchangeRedisSettings options, bool enabled)
+        => options.DisableTracing = !enabled;
 
-    protected override void SetMetrics(StackExchangeRedisSettings settings, bool enabled)
+    protected override void SetMetrics(StackExchangeRedisSettings options, bool enabled)
         => throw new NotImplementedException();
 
     protected override void TriggerActivity(IConnectionMultiplexer service)


### PR DESCRIPTION
Backport of #3736 to release/8.0

/cc @sebastienros

## Customer Impact

Customers will have to change their configuration and code to reflect the new names and defaults of properties. No behavioral changes.

## Testing

Unit tests are covering the API changes.

## Risk

Should be low since only the API names are changing. The new default values however introduce a risk if the test coverage was lacking.

## Regression?

No.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3849)