### PR TITLE
Fix using telemetry pages with dapr sidecar + executable

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -116,7 +116,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     public void UpdateViewModelFromQuery(MetricsViewModel viewModel)
     {
         viewModel.SelectedDuration = _durations.SingleOrDefault(d => (int)d.Id.TotalMinutes == DurationMinutes) ?? _durations.Single(d => d.Id == s_defaultDuration);
-        viewModel.SelectedApplication = _applications.SingleOrDefault(e => string.Equals(ApplicationName, e.Name, StringComparisons.ResourceName)) ?? _selectApplication;
+        viewModel.SelectedApplication = _applications.GetApplication(ApplicationName, _selectApplication);
         var selectedInstance = viewModel.SelectedApplication.Id?.InstanceId;
         viewModel.Instruments = !string.IsNullOrEmpty(selectedInstance) ? TelemetryRepository.GetInstrumentsSummary(selectedInstance) : null;
 
@@ -141,7 +141,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
 
     private void UpdateApplications()
     {
-        _applications = SelectViewModelFactory.CreateApplicationsSelectViewModel(TelemetryRepository.GetApplications());
+        _applications = SelectViewModelHelpers.CreateApplicationsSelectViewModel(TelemetryRepository.GetApplications());
         _applications.Insert(0, _selectApplication);
         UpdateSubscription();
     }

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -141,7 +141,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
 
     private void UpdateApplications()
     {
-        _applications = SelectViewModelHelpers.CreateApplicationsSelectViewModel(TelemetryRepository.GetApplications());
+        _applications = ApplicationsSelectHelpers.CreateApplications(TelemetryRepository.GetApplications());
         _applications.Insert(0, _selectApplication);
         UpdateSubscription();
     }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -137,7 +137,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     private void UpdateApplications()
     {
         _applications = TelemetryRepository.GetApplications();
-        _applicationViewModels = SelectViewModelHelpers.CreateApplicationsSelectViewModel(_applications);
+        _applicationViewModels = ApplicationsSelectHelpers.CreateApplications(_applications);
         _applicationViewModels.Insert(0, _allApplication);
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -137,7 +137,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     private void UpdateApplications()
     {
         _applications = TelemetryRepository.GetApplications();
-        _applicationViewModels = SelectViewModelFactory.CreateApplicationsSelectViewModel(_applications);
+        _applicationViewModels = SelectViewModelHelpers.CreateApplicationsSelectViewModel(_applications);
         _applicationViewModels.Insert(0, _allApplication);
     }
 
@@ -332,7 +332,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
 
     public void UpdateViewModelFromQuery(StructuredLogsPageViewModel viewModel)
     {
-        PageViewModel.SelectedApplication = _applicationViewModels.SingleOrDefault(e => string.Equals(ApplicationName, e.Name, StringComparisons.ResourceName)) ?? _allApplication;
+        PageViewModel.SelectedApplication = _applicationViewModels.GetApplication(ApplicationName, _allApplication);
         ViewModel.ApplicationServiceId = PageViewModel.SelectedApplication.Id?.InstanceId;
 
         if (LogLevelText is not null && Enum.TryParse<LogLevel>(LogLevelText, ignoreCase: true, out var logLevel))

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -97,7 +97,7 @@ public partial class Traces
 
     protected override void OnParametersSet()
     {
-        _selectedApplication = _applicationViewModels.SingleOrDefault(e => string.Equals(ApplicationName, e.Name, StringComparisons.ResourceName)) ?? _allApplication;
+        _selectedApplication = _applicationViewModels.GetApplication(ApplicationName, _allApplication);
         TracesViewModel.ApplicationServiceId = _selectedApplication.Id?.InstanceId;
         UpdateSubscription();
     }
@@ -105,7 +105,7 @@ public partial class Traces
     private void UpdateApplications()
     {
         _applications = TelemetryRepository.GetApplications();
-        _applicationViewModels = SelectViewModelFactory.CreateApplicationsSelectViewModel(_applications);
+        _applicationViewModels = SelectViewModelHelpers.CreateApplicationsSelectViewModel(_applications);
         _applicationViewModels.Insert(0, _allApplication);
         UpdateSubscription();
     }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -105,7 +105,7 @@ public partial class Traces
     private void UpdateApplications()
     {
         _applications = TelemetryRepository.GetApplications();
-        _applicationViewModels = SelectViewModelHelpers.CreateApplicationsSelectViewModel(_applications);
+        _applicationViewModels = ApplicationsSelectHelpers.CreateApplications(_applications);
         _applicationViewModels.Insert(0, _allApplication);
         UpdateSubscription();
     }

--- a/src/Aspire.Dashboard/Model/Otlp/ApplicationsSelectHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/ApplicationsSelectHelpers.cs
@@ -5,7 +5,7 @@ using Aspire.Dashboard.Otlp.Model;
 
 namespace Aspire.Dashboard.Model.Otlp;
 
-public static class SelectViewModelHelpers
+public static class ApplicationsSelectHelpers
 {
     public static SelectViewModel<ResourceTypeDetails> GetApplication(this List<SelectViewModel<ResourceTypeDetails>> applications, string? name, SelectViewModel<ResourceTypeDetails> fallback)
     {
@@ -17,7 +17,7 @@ public static class SelectViewModelHelpers
         return applications.SingleOrDefault(e => e.Id?.Type is OtlpApplicationType.ReplicaInstance or OtlpApplicationType.Singleton && string.Equals(name, e.Name, StringComparisons.ResourceName)) ?? fallback;
     }
 
-    public static List<SelectViewModel<ResourceTypeDetails>> CreateApplicationsSelectViewModel(List<OtlpApplication> applications)
+    public static List<SelectViewModel<ResourceTypeDetails>> CreateApplications(List<OtlpApplication> applications)
     {
         var replicasByApplicationName = OtlpApplication.GetReplicasByApplicationName(applications);
 

--- a/src/Aspire.Dashboard/Model/Otlp/SelectViewModelHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SelectViewModelHelpers.cs
@@ -5,8 +5,18 @@ using Aspire.Dashboard.Otlp.Model;
 
 namespace Aspire.Dashboard.Model.Otlp;
 
-public class SelectViewModelFactory
+public static class SelectViewModelHelpers
 {
+    public static SelectViewModel<ResourceTypeDetails> GetApplication(this List<SelectViewModel<ResourceTypeDetails>> applications, string? name, SelectViewModel<ResourceTypeDetails> fallback)
+    {
+        if (name is null)
+        {
+            return fallback;
+        }
+
+        return applications.SingleOrDefault(e => e.Id?.Type is OtlpApplicationType.ReplicaInstance or OtlpApplicationType.Singleton && string.Equals(name, e.Name, StringComparisons.ResourceName)) ?? fallback;
+    }
+
     public static List<SelectViewModel<ResourceTypeDetails>> CreateApplicationsSelectViewModel(List<OtlpApplication> applications)
     {
         var replicasByApplicationName = OtlpApplication.GetReplicasByApplicationName(applications);

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Otlp.Model;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTelemetry.Proto.Common.V1;
+using OpenTelemetry.Proto.Resource.V1;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class ApplicationsSelectHelpersTests
+{
+    [Fact]
+    public void GetApplication_SameNameAsReplica_GetInstance()
+    {
+        // Arrange
+        var apps = new Dictionary<string, OtlpApplication>();
+
+        var appVMs = ApplicationsSelectHelpers.CreateApplications(new List<OtlpApplication>
+        {
+            CreateOtlpApplication(apps, name: "nodeapp", instanceId: "nodeapp"),
+            CreateOtlpApplication(apps, name: "nodeapp", instanceId: "nodeapp-abc"),
+            CreateOtlpApplication(apps, name: "singleton", instanceId: "singleton-abc")
+        });
+
+        Assert.Collection(appVMs,
+            app =>
+            {
+                Assert.Equal("nodeapp", app.Name);
+                Assert.Equal(OtlpApplicationType.ReplicaSet, app.Id!.Type);
+                Assert.Null(app.Id!.InstanceId);
+            },
+            app =>
+            {
+                Assert.Equal("nodeapp", app.Name);
+                Assert.Equal(OtlpApplicationType.ReplicaInstance, app.Id!.Type);
+                Assert.Equal("nodeapp", app.Id!.InstanceId);
+            },
+            app =>
+            {
+                Assert.Equal("nodeapp-abc", app.Name);
+                Assert.Equal(OtlpApplicationType.ReplicaInstance, app.Id!.Type);
+                Assert.Equal("nodeapp-abc", app.Id!.InstanceId);
+            },
+            app =>
+            {
+                Assert.Equal("singleton", app.Name);
+                Assert.Equal(OtlpApplicationType.Singleton, app.Id!.Type);
+                Assert.Equal("singleton-abc", app.Id!.InstanceId);
+            });
+
+        // Act
+        var app = appVMs.GetApplication("nodeapp", null!);
+
+        // Assert
+        Assert.Equal("nodeapp", app.Id!.InstanceId);
+        Assert.Equal(OtlpApplicationType.ReplicaInstance, app.Id!.Type);
+    }
+
+    private static OtlpApplication CreateOtlpApplication(Dictionary<string, OtlpApplication> apps, string name, string instanceId)
+    {
+        return new OtlpApplication(new Resource
+        {
+            Attributes =
+                {
+                    new KeyValue { Key = "service.name", Value = new AnyValue { StringValue = name } },
+                    new KeyValue { Key = "service.instance.id", Value = new AnyValue { StringValue = instanceId } }
+                }
+        }, apps, NullLogger.Instance, new TelemetryLimitOptions());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/3844

If a replica set has an app with an instance ID the same as a replica set name, then this error happens. It won't be a problem for dapr + projects because they have a unique suffix, but exe and containers could get it.

Fix is to tighten the data selection to ignore replica set item.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3861)