### PR TITLE
[release/8.0] Update docker image tags in playground, tests and xml docs

### DIFF
--- a/playground/Qdrant/Qdrant.AppHost/aspire-manifest.json
+++ b/playground/Qdrant/Qdrant.AppHost/aspire-manifest.json
@@ -3,7 +3,7 @@
     "qdrant": {
       "type": "container.v0",
       "connectionString": "Endpoint={qdrant.bindings.grpc.url};Key={qdrant-Key.value}",
-      "image": "docker.io/qdrant/qdrant:v1.8.3",
+      "image": "docker.io/qdrant/qdrant:v1.8.4",
       "volumes": [
         {
           "name": "qdrant-data",

--- a/playground/mongo/Mongo.AppHost/aspire-manifest.json
+++ b/playground/mongo/Mongo.AppHost/aspire-manifest.json
@@ -3,7 +3,7 @@
     "mongo": {
       "type": "container.v0",
       "connectionString": "mongodb://{mongo.bindings.tcp.host}:{mongo.bindings.tcp.port}",
-      "image": "mongo:7.0.5",
+      "image": "mongo:7.0.8",
       "bindings": {
         "tcp": {
           "scheme": "tcp",

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -14,7 +14,7 @@ public static class KafkaBuilderExtensions
     private const int KafkaBrokerPort = 9092;
 
     /// <summary>
-    /// Adds a Kafka resource to the application. A container is used for local development.  This version the package defaults to the 7.6.0 tag of the confluentinc/confluent-local container image.
+    /// Adds a Kafka resource to the application. A container is used for local development.  This version the package defaults to the 7.6.1 tag of the confluentinc/confluent-local container image.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency</param>

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -16,7 +16,7 @@ public static class MongoDBBuilderExtensions
     private const int DefaultContainerPort = 27017;
 
     /// <summary>
-    /// Adds a MongoDB resource to the application model. A container is used for local development. This version the package defaults to the 7.0.5 tag of the mongo container image.
+    /// Adds a MongoDB resource to the application model. A container is used for local development. This version the package defaults to the 7.0.8 tag of the mongo container image.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>

--- a/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
@@ -18,10 +18,10 @@ public static class QdrantBuilderExtensions
     private const string EnableStaticContentEnvVarName = "QDRANT__SERVICE__ENABLE_STATIC_CONTENT";
 
     /// <summary>
-    /// Adds a Qdrant resource to the application. A container is used for local development.  
+    /// Adds a Qdrant resource to the application. A container is used for local development.
     /// </summary>
     /// <remarks>
-    /// This version the package defaults to the v1.8.3 tag of the qdrant/qdrant container image.
+    /// This version the package defaults to the v1.8.4 tag of the qdrant/qdrant container image.
     /// The .NET client library uses the gRPC port by default to communicate and this resource exposes that endpoint.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>


### PR DESCRIPTION
Backport parts of #3869 to release/8.0

## Customer Impact

XML documentation updated to reference the updated docker image tags.

## Testing

Not required.

## Risk

Low

## Regression?

No

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3870)