### PR TITLE
[Cosmos .NET SDK] - Adds User Agent to Identify Usage

### DIFF
--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
@@ -83,7 +83,6 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
         configureSettings?.Invoke(settings);
 
         var clientOptions = new CosmosClientOptions();
-        clientOptions.ApplicationName = CosmosConstants.CosmosApplicationName;
 
         // Needs to be enabled for either logging or tracing to work.
         clientOptions.CosmosClientTelemetryOptions.DisableDistributedTracing = false;
@@ -103,6 +102,13 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
 
         configureClientOptions?.Invoke(clientOptions);
 
+        var cosmosApplicationName = CosmosConstants.CosmosApplicationName;
+        if (!string.IsNullOrEmpty(clientOptions.ApplicationName))
+        {
+            cosmosApplicationName += clientOptions.ApplicationName;
+        }
+
+        clientOptions.ApplicationName = cosmosApplicationName;
         if (serviceKey is null)
         {
             builder.Services.AddSingleton(_ => ConfigureDb());

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
@@ -104,7 +104,7 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
         var cosmosApplicationName = CosmosConstants.CosmosApplicationName;
         if (!string.IsNullOrEmpty(clientOptions.ApplicationName))
         {
-            cosmosApplicationName += clientOptions.ApplicationName;
+            cosmosApplicationName = $"{cosmosApplicationName}|{clientOptions.ApplicationName}";
         }
 
         clientOptions.ApplicationName = cosmosApplicationName;

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
@@ -83,7 +83,6 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
         configureSettings?.Invoke(settings);
 
         var clientOptions = new CosmosClientOptions();
-
         // Needs to be enabled for either logging or tracing to work.
         clientOptions.CosmosClientTelemetryOptions.DisableDistributedTracing = false;
         if (!settings.DisableTracing)

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
@@ -83,6 +83,8 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
         configureSettings?.Invoke(settings);
 
         var clientOptions = new CosmosClientOptions();
+        clientOptions.ApplicationName = CosmosConstants.CosmosApplicationName;
+
         // Needs to be enabled for either logging or tracing to work.
         clientOptions.CosmosClientTelemetryOptions.DisableDistributedTracing = false;
         if (!settings.DisableTracing)

--- a/src/Shared/Cosmos/CosmosConstants.cs
+++ b/src/Shared/Cosmos/CosmosConstants.cs
@@ -9,7 +9,7 @@ internal static class CosmosConstants
     /// Defines the application name used to interact with the aszure cosmos db. This will be suffixed to the
     /// cosmos user-agent to include with every Azure Cosmos DB service interaction.
     /// </summary>
-    internal const string CosmosApplicationName = "AspireCosmosDBClient";
+    internal const string CosmosApplicationName = "Aspire";
 
     /// <summary>
     /// Gets the well-known and documented Azure Cosmos DB emulator account key.

--- a/src/Shared/Cosmos/CosmosConstants.cs
+++ b/src/Shared/Cosmos/CosmosConstants.cs
@@ -9,7 +9,7 @@ internal static class CosmosConstants
     /// Defines the application name used to interact with the aszure cosmos db. This will be suffixed to the
     /// cosmos user-agent to include with every Azure Cosmos DB service interaction.
     /// </summary>
-    internal const string CosmosApplicationName = "AspireMicrosoftAzureCosmosDBClient";
+    internal const string CosmosApplicationName = "AspireCosmosDBClient";
 
     /// <summary>
     /// Gets the well-known and documented Azure Cosmos DB emulator account key.

--- a/src/Shared/Cosmos/CosmosConstants.cs
+++ b/src/Shared/Cosmos/CosmosConstants.cs
@@ -6,6 +6,12 @@ namespace Aspire.Hosting.Azure.Cosmos;
 internal static class CosmosConstants
 {
     /// <summary>
+    /// Defines the application name used to interact with the aszure cosmos db. This will be suffixed to the
+    /// cosmos user-agent to include with every Azure Cosmos DB service interaction.
+    /// </summary>
+    internal const string CosmosApplicationName = "AspireMicrosoftAzureCosmosDBClient";
+
+    /// <summary>
     /// Gets the well-known and documented Azure Cosmos DB emulator account key.
     /// See <a href="https://learn.microsoft.com/azure/cosmos-db/emulator#authentication"></a>
     /// </summary>


### PR DESCRIPTION
### Pull Request Description:

The purpose of this PR is to populate the `ApplicationName` parameter in the `CosmosClientOptions` so that the user agent can be generated with the necessary suffix. This will help the cosmos db team to identify if the request was originated from Aspire. A sample of the user agent will look like the below:

`cosmos-netstandard-sdk/3.39.1|0|X64|Microsoft Windows 10.0.22635|.NET 6.0.29|N|F 00000111|AspireMicrosoftAzureCosmosDBClient|`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3876)