### PR TITLE
Improve filtering of log messages when there are duplicate attributes

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Threading.Channels;
+using Microsoft.AspNetCore.Mvc;
 using Stress.ApiService;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -25,6 +26,23 @@ app.MapGet("/big-trace", async () =>
     await bigTraceCreator.CreateBigTraceAsync();
 
     return "Big trace created";
+});
+
+app.MapGet("/log-message", ([FromServices] ILogger<Program> logger) =>
+{
+    const string message = "Hello World";
+    IReadOnlyList<KeyValuePair<string, object?>> eventData = new List<KeyValuePair<string, object?>>()
+    {
+        new KeyValuePair<string, object?>("Message", message),
+        new KeyValuePair<string, object?>("ActivityId", 123),
+        new KeyValuePair<string, object?>("Level", (int) 10),
+        new KeyValuePair<string, object?>("Tid", Environment.CurrentManagedThreadId),
+        new KeyValuePair<string, object?>("Pid", Environment.ProcessId),
+    };
+
+    logger.Log(LogLevel.Information, 0, eventData, null, formatter: (_, _) => null!);
+
+    return message;
 });
 
 app.MapGet("/many-logs", (ILoggerFactory loggerFactory, CancellationToken cancellationToken) =>

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -10,7 +10,14 @@
     <DataAnnotationsValidator />
 
     <FluentStack Orientation="Orientation.Vertical" VerticalGap="8">
-        <FluentCombobox Placeholder="@Loc[nameof(Dialogs.FilterDialogFieldPlaceholder)]" Items=@Parameters @bind-Value="@_formModel.Parameter" Width="100%" Height="500px" />
+        <FluentCombobox TOption="SelectViewModel<string>"
+                        Placeholder="@Loc[nameof(Dialogs.FilterDialogFieldPlaceholder)]"
+                        Items="@_parameters"
+                        @bind-SelectedOption="@_formModel.Parameter"
+                        Width="100%"
+                        Height="500px"
+                        OptionText="@(c => c.Name)"
+                        OptionDisabled="@(c => c.Id is null)" />
 
         <FluentSelect TOption="SelectViewModel<FilterCondition>" Items="@_filterConditions" @bind-SelectedOption="@_formModel.Condition" aria-label="@Loc[Dialogs.FilterDialogConditionSelectLabel]" OptionText="@(i => i.Name)" Width="100%" />
 

--- a/src/Aspire.Dashboard/Model/Otlp/LogDialogFormModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogDialogFormModel.cs
@@ -8,7 +8,7 @@ namespace Aspire.Dashboard.Model.Otlp;
 public class LogDialogFormModel
 {
     [Required]
-    public string? Parameter { get; set; }
+    public SelectViewModel<string>? Parameter { get; set; }
     [Required]
     public SelectViewModel<FilterCondition>? Condition { get; set; }
     [Required]

--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -12,19 +12,33 @@ namespace Aspire.Dashboard.Model.Otlp;
 [DebuggerDisplay("{FilterText,nq}")]
 public class LogFilter
 {
+    public const string KnownMessageField = "log.message";
+    public const string KnownCategoryField = "log.category";
+    public const string KnownApplicationField = "log.application";
+    public const string KnownTraceIdField = "log.traceid";
+    public const string KnownSpanIdField = "log.spanid";
+    public const string KnownOriginalFormatField = "log.originalformat";
+
     public string Field { get; set; } = default!;
     public FilterCondition Condition { get; set; }
     public string Value { get; set; } = default!;
 
     public string DebuggerDisplayText => $"{Field} {ConditionToString(Condition, null)} {Value}";
 
-    public string GetDisplayText(IStringLocalizer<Logs> loc) => $"{Field} {ConditionToString(Condition, loc)} {Value}";
+    public string GetDisplayText(IStringLocalizer<Logs> loc) => $"{ResolveFieldName(Field)} {ConditionToString(Condition, loc)} {Value}";
 
-    public static List<string> GetAllPropertyNames(List<string> propertyKeys)
+    public static string ResolveFieldName(string name)
     {
-        var result = new List<string> { "Message", "Category", "Application", "TraceId", "SpanId", "OriginalFormat" };
-        result.AddRange(propertyKeys);
-        return result;
+        return name switch
+        {
+            KnownMessageField => "Message",
+            KnownApplicationField => "Application",
+            KnownTraceIdField => "TraceId",
+            KnownSpanIdField => "SpanId",
+            KnownOriginalFormatField => "OriginalFormat",
+            KnownCategoryField => "Category",
+            _ => name
+        };
     }
 
     public static string ConditionToString(FilterCondition c, IStringLocalizer<Logs>? loc) =>
@@ -87,12 +101,12 @@ public class LogFilter
     {
         return Field switch
         {
-            "Message" => x.Message,
-            "Application" => x.Application.ApplicationName,
-            "TraceId" => x.TraceId,
-            "SpanId" => x.SpanId,
-            "OriginalFormat" => x.OriginalFormat,
-            "Category" => x.Scope.ScopeName,
+            KnownMessageField => x.Message,
+            KnownApplicationField => x.Application.ApplicationName,
+            KnownTraceIdField => x.TraceId,
+            KnownSpanIdField => x.SpanId,
+            KnownOriginalFormatField => x.OriginalFormat,
+            KnownCategoryField => x.Scope.ScopeName,
             _ => x.Attributes.GetValue(Field)
         };
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/3614

Log entries have built-in fields. e.g. the message body, level, category, etc. Log entries also have custom fields. This is from structured data about a message.

It's possible for these to conflict. Structured data could be called `Message` or `Category`. If the user then asks to filter with the `Message` value, which is used? A conflict is created and it's only possible to filter the built-in fields.

This PRs fix is to give custom built-in fields an internal name, e.g. `log.message`. That is much less likely to conflict with real structured data.

Also, I added a divider (disabled select item with text `-`) between built-in fields and structured data fields to make the UI experience a bit better:

![image](https://github.com/dotnet/aspire/assets/303201/8aec0f15-4895-4abe-9db6-46d3ec6b44c4)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3881)