### PR TITLE
Fix Keyed Redis

### DIFF
--- a/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis/AspireRedisExtensions.cs
@@ -5,6 +5,7 @@ using Aspire;
 using Aspire.StackExchange.Redis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.StackExchangeRedis;
@@ -83,7 +84,7 @@ public static class AspireRedisExtensions
 
         // see comments on ConfigurationOptionsFactory for why a factory is used here
         builder.Services.AddTransient(sp => new RedisOptionsSettingsPair { OptionsName = optionsName, Settings = settings });
-        builder.Services.AddTransient<IOptionsFactory<ConfigurationOptions>, ConfigurationOptionsFactory>();
+        builder.Services.TryAddTransient<IOptionsFactory<ConfigurationOptions>, ConfigurationOptionsFactory>();
 
         builder.Services.Configure<ConfigurationOptions>(
             optionsName,

--- a/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
@@ -19,10 +19,7 @@ public sealed class RedisContainerFixture : IAsyncLifetime
     {
         if (RequiresDockerTheoryAttribute.IsSupported)
         {
-            Container = new RedisBuilder()
-                            .WithImage($"{RedisContainerImageTags.Image}:{RedisContainerImageTags.Tag}")
-                            .Build();
-            await Container.StartAsync();
+            Container = await CreateContainerAsync();
         }
     }
 
@@ -32,5 +29,15 @@ public sealed class RedisContainerFixture : IAsyncLifetime
         {
             await Container.DisposeAsync();
         }
+    }
+
+    public static async Task<RedisContainer> CreateContainerAsync()
+    {
+        var container = new RedisBuilder()
+            .WithImage($"{RedisContainerImageTags.Image}:{RedisContainerImageTags.Tag}")
+            .Build();
+        await container.StartAsync();
+
+        return container;
     }
 }


### PR DESCRIPTION
When adding 2 Redis server instances and try to use "keyed" services to talk to each, only the first connection is used for both. The 2nd connection doesn't get used.

This is because we are using a singleton `OptionsFactory<ConfigurationOptions>` that only knows about the first StackExchangeRedisSettings registered, and always uses its ConnectionString.

The fix is to teach the factory about all the Settings objects being registered, and have it find the correct one given the "options name" when it is being created.

Fix #3873

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3885)