### PR TITLE
[release/8.0] Fix the casing of AddKeyedAzureCosmosDBClient

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -47,7 +47,7 @@ When the AppHost starts up a local container running the Azure CosmosDB will als
 
 ```csharp
 // Service code
-builder.AddAzureCosmosDbClient("cosmos");
+builder.AddAzureCosmosDBClient("cosmos");
 ```
 
 ## Additional documentation

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
@@ -46,7 +46,7 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
-    public static void AddKeyedAzureCosmosDbClient(
+    public static void AddKeyedAzureCosmosDBClient(
         this IHostApplicationBuilder builder,
         string name,
         Action<MicrosoftAzureCosmosDBSettings>? configureSettings = null,

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -19,10 +19,10 @@ dotnet add package Aspire.Microsoft.Azure.Cosmos
 
 ## Usage example
 
-In the _Program.cs_ file of your project, call the `AddAzureCosmosDbClient` extension method to register a `CosmosClient` for use via the dependency injection container. The method takes a connection name parameter.
+In the _Program.cs_ file of your project, call the `AddAzureCosmosDBClient` extension method to register a `CosmosClient` for use via the dependency injection container. The method takes a connection name parameter.
 
 ```csharp
-builder.AddAzureCosmosDbClient("cosmosConnectionName");
+builder.AddAzureCosmosDBClient("cosmosConnectionName");
 ```
 
 You can then retrieve the `CosmosClient` instance using dependency injection. For example, to retrieve the client from a Web API controller:
@@ -44,10 +44,10 @@ The .NET Aspire Azure Cosmos DB library provides multiple options to configure t
 
 ### Use a connection string
 
-When using a connection string from the `ConnectionStrings` configuration section, you can provide the name of the connection string when calling `builder.AddAzureCosmosDbClient()`:
+When using a connection string from the `ConnectionStrings` configuration section, you can provide the name of the connection string when calling `builder.AddAzureCosmosDBClient()`:
 
 ```csharp
-builder.AddAzureCosmosDbClient("cosmosConnectionName");
+builder.AddAzureCosmosDBClient("cosmosConnectionName");
 ```
 
 And then the connection string will be retrieved from the `ConnectionStrings` configuration section. Two connection formats are supported:
@@ -99,13 +99,13 @@ The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions
 You can also pass the `Action<MicrosoftAzureCosmosDBSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
-builder.AddAzureCosmosDbClient("cosmosConnectionName", settings => settings.DisableTracing = true);
+builder.AddAzureCosmosDBClient("cosmosConnectionName", settings => settings.DisableTracing = true);
 ```
 
-You can also setup the [CosmosClientOptions](https://learn.microsoft.com/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions) using the optional `Action<CosmosClientOptions> configureClientOptions` parameter of the `AddAzureCosmosDbClient` method. For example, to set the `ApplicationName` "User-Agent" header suffix for all requests issues by this client:
+You can also setup the [CosmosClientOptions](https://learn.microsoft.com/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions) using the optional `Action<CosmosClientOptions> configureClientOptions` parameter of the `AddAzureCosmosDBClient` method. For example, to set the `ApplicationName` "User-Agent" header suffix for all requests issues by this client:
 
 ```csharp
-builder.AddAzureCosmosDbClient("cosmosConnectionName", configureClientOptions: clientOptions => clientOptions.ApplicationName = "myapp");
+builder.AddAzureCosmosDBClient("cosmosConnectionName", configureClientOptions: clientOptions => clientOptions.ApplicationName = "myapp");
 ```
 
 ## AppHost extensions
@@ -146,7 +146,7 @@ When the AppHost starts up a local container running the Azure CosmosDB will als
 
 ```csharp
 // Service code
-builder.AddAzureCosmosDbClient("cosmos");
+builder.AddAzureCosmosDBClient("cosmos");
 ```
 
 ## Additional documentation

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
@@ -32,7 +32,7 @@ public class ConformanceTests : ConformanceTests<CosmosClient, MicrosoftAzureCos
         }
         else
         {
-            builder.AddKeyedAzureCosmosDbClient(key, configure);
+            builder.AddKeyedAzureCosmosDBClient(key, configure);
         }
     }
 


### PR DESCRIPTION
Also fix the casing in the READMEs as well.

Backport of #3897 to release/8.0

/cc @eerhardt

## Customer Impact

Our public API is cased differently:

* AddAzureCosmosDBClient
* AddKeyedAzureCosmosDbClient

If we ship 8.0 this way, we will be forced to keep it forever since it is a stable release.

Also fixing the READMEs to have the correct case, which they were inconsistent on being right or not.

## Testing

Tests updated with the new name. I searched for "CosmosDb" and only found usages for "Cosmos" "DbContext", which is the correct EF casing of DbContext.

## Risk

Low

## Regression?

Yes, we regressed here with:

* https://github.com/dotnet/aspire/pull/2630
* https://github.com/dotnet/aspire/pull/2781

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3898)