### PR TITLE
Add Encrypt=True to test connection strings

### DIFF
--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/AspireSqlServerSqlClientExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/AspireSqlServerSqlClientExtensionsTests.cs
@@ -11,7 +11,7 @@ namespace Aspire.Microsoft.Data.SqlClient.Tests;
 
 public class AspireSqlServerSqlClientExtensionsTests
 {
-    private const string ConnectionString = "Data Source=fake;Database=master";
+    private const string ConnectionString = "Data Source=fake;Database=master;Encrypt=True";
 
     [Theory]
     [InlineData(true)]

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/AspireSqlServerEFCoreSqlClientExtensionsTests.cs
@@ -15,7 +15,7 @@ namespace Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests;
 
 public class AspireSqlServerEFCoreSqlClientExtensionsTests
 {
-    private const string ConnectionString = "Data Source=fake;Database=master";
+    private const string ConnectionString = "Data Source=fake;Database=master;Encrypt=True";
 
     [Fact]
     public void ReadsFromConnectionStringsCorrectly()
@@ -230,7 +230,7 @@ public class AspireSqlServerEFCoreSqlClientExtensionsTests
     [Fact]
     public void CanHave2DbContexts()
     {
-        const string connectionString2 = "Data Source=fake2;Database=master2";
+        const string connectionString2 = "Data Source=fake2;Database=master2;Encrypt=True";
 
         var builder = Host.CreateEmptyApplicationBuilder(null);
         builder.Configuration.AddInMemoryCollection([


### PR DESCRIPTION
This should silence some CodeQL alerts we're receiving in our backend systems.

Yes, it's test code. There's a weird policy governing when test code is / is not required to be in scope during CodeQL runs. Making these very targeted changes to the test code seemed like the path of least resistance.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3903)