### PR TITLE
[release/8.0] Event Hubs: Update EventProcessorClient component to pull BlobClient from DI (#3293)

### DIFF
--- a/playground/AspireEventHub/EventHubs.AppHost/Properties/launchSettings.json
+++ b/playground/AspireEventHub/EventHubs.AppHost/Properties/launchSettings.json
@@ -1,15 +1,44 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
+
   "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:15887;http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+      }
+    },
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:15270",
+      "applicationUrl": "http://localhost:15888",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16201"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17038",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    },
+    "generate-manifest": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "dotnetRunMessages": true,
+      "commandLineArgs": "--publisher manifest --output-path aspire-manifest.json",
+      "applicationUrl": "http://localhost:15888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16175"
       }
     },
     "generate-manifest": {

--- a/playground/AspireEventHub/EventHubsConsumer/EventHubsConsumer.csproj
+++ b/playground/AspireEventHub/EventHubsConsumer/EventHubsConsumer.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Components\Aspire.Azure.Messaging.EventHubs\Aspire.Azure.Messaging.EventHubs.csproj" />
+    <ProjectReference Include="..\..\..\src\Components\Aspire.Azure.Storage.Blobs\Aspire.Azure.Storage.Blobs.csproj" />
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
   </ItemGroup>
 

--- a/playground/AspireEventHub/EventHubsConsumer/Program.cs
+++ b/playground/AspireEventHub/EventHubsConsumer/Program.cs
@@ -21,11 +21,13 @@ if (useConsumer)
 }
 else
 {
+    // required for checkpointing our position in the event stream
+    builder.AddAzureBlobClient("checkpoints");
+
     builder.AddAzureEventProcessorClient("eventhubns",
         settings =>
         {
             settings.EventHubName = "hub";
-            settings.BlobClientConnectionName = "checkpoints";
         });
     builder.Services.AddHostedService<Processor>();
     Console.WriteLine("Starting EventProcessorClient...");

--- a/src/Components/Aspire.Azure.AI.OpenAI/AspireAzureOpenAIExtensions.cs
+++ b/src/Components/Aspire.Azure.AI.OpenAI/AspireAzureOpenAIExtensions.cs
@@ -62,9 +62,11 @@ public static class AspireAzureOpenAIExtensions
 
     private sealed class OpenAIComponent : AzureComponent<AzureOpenAISettings, OpenAIClient, OpenAIClientOptions>
     {
-        protected override IAzureClientBuilder<OpenAIClient, OpenAIClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureOpenAISettings settings, string connectionName, string configurationSectionName)
+        protected override IAzureClientBuilder<OpenAIClient, OpenAIClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureOpenAISettings settings, string connectionName,
+            string configurationSectionName)
         {
-            return azureFactoryBuilder.RegisterClientFactory<OpenAIClient, OpenAIClientOptions>((options, cred) =>
+            return azureFactoryBuilder.AddClient<OpenAIClient, OpenAIClientOptions>((options, _, _) =>
             {
                 if (settings.Endpoint is null)
                 {

--- a/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
+++ b/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
@@ -65,9 +65,11 @@ public static class AspireTablesExtensions
 
     private sealed class TableServiceComponent : AzureComponent<AzureDataTablesSettings, TableServiceClient, TableClientOptions>
     {
-        protected override IAzureClientBuilder<TableServiceClient, TableClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureDataTablesSettings settings, string connectionName, string configurationSectionName)
+        protected override IAzureClientBuilder<TableServiceClient, TableClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureDataTablesSettings settings, string connectionName,
+            string configurationSectionName)
         {
-            return azureFactoryBuilder.RegisterClientFactory<TableServiceClient, TableClientOptions>((options, cred) =>
+            return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<TableServiceClient, TableClientOptions>((options, cred) =>
             {
                 var connectionString = settings.ConnectionString;
                 if (string.IsNullOrEmpty(connectionString) && settings.ServiceUri is null)

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/AspireEventHubsExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/AspireEventHubsExtensions.cs
@@ -33,7 +33,7 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsProcessorSettings>? configureSettings = null,
         Action<IAzureClientBuilder<EventProcessorClient, EventProcessorClientOptions>>? configureClientBuilder = null)
     {
-        new EventProcessorClientComponent(builder.Configuration)
+        new EventProcessorClientComponent()
             .AddClient(builder, DefaultConfigSectionName + nameof(EventProcessorClient),
                 configureSettings, configureClientBuilder, connectionName, serviceKey: null);
     }
@@ -59,7 +59,7 @@ public static class AspireEventHubsExtensions
             .GetKeyedConfigurationSectionName(name, DefaultConfigSectionName +
                                                     nameof(EventProcessorClient));
 
-        new EventProcessorClientComponent(builder.Configuration)
+        new EventProcessorClientComponent()
             .AddClient(builder, configurationSectionName, configureSettings,
                 configureClientBuilder, connectionName: name, serviceKey: name);
     }

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/AzureMessagingEventHubsSettings.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/AzureMessagingEventHubsSettings.cs
@@ -125,17 +125,20 @@ public sealed class AzureMessagingEventHubsProcessorSettings : AzureMessagingEve
     public string? ConsumerGroup { get; set; }
 
     /// <summary>
-    /// Gets or sets the connection name used to obtain a connection string for an Azure BlobContainerClient. This is required when the Event Processor is used.
+    /// Gets or sets the IServiceProvider service key used to obtain an Azure BlobServiceClient.
     /// </summary>
-    /// <remarks>Applies only to <see cref="EventProcessorClient"/></remarks>
-    public string? BlobClientConnectionName { get; set; }
+    /// <remarks>
+    /// A BlobServiceClient is required when using the Event Processor. If a BlobClientServiceKey is not configured,
+    /// an un-keyed BlobServiceClient will be retrieved from the IServiceProvider. If a BlobServiceClient is not available in
+    /// the IServiceProvider, an exception is thrown.
+    /// </remarks>
+    public string? BlobClientServiceKey { get; set; }
 
     /// <summary>
     /// Get or sets the name of the blob container used to store the checkpoint data. If this container does not exist, Aspire will attempt to create it.
     /// If this is not provided, Aspire will attempt to automatically create a container with a name based on the Namespace, Event Hub name and Consumer Group.
     /// If a container is provided in the connection string, it will override this value and the container will be assumed to exist.
     /// </summary>
-    /// <remarks>Applies only to <see cref="EventProcessorClient"/></remarks>
     public string? BlobContainerName { get; set; }
 }
 
@@ -152,13 +155,10 @@ public sealed class AzureMessagingEventHubsPartitionReceiverSettings : AzureMess
     /// <summary>
     /// Gets or sets the partition identifier.
     /// </summary>
-    /// <remarks>Applies only to <see cref="PartitionReceiver"/></remarks>
     public string? PartitionId { get; set; }
 
     /// <summary>
     /// Gets or sets the event position to start from in the bound partition. Defaults to <see cref="EventPosition.Earliest" />.
     /// </summary>
-    /// <remarks>Applies only to <see cref="PartitionReceiver"/></remarks>
     public EventPosition EventPosition { get; set; } = EventPosition.Earliest;
 }
-

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/ConfigurationSchema.json
@@ -229,9 +229,9 @@
                     "EventProcessorClient": {
                       "type": "object",
                       "properties": {
-                        "BlobClientConnectionName": {
+                        "BlobClientServiceKey": {
                           "type": "string",
-                          "description": "Gets or sets the connection name used to obtain a connection string for an Azure BlobContainerClient. This is required when the Event Processor is used."
+                          "description": "Gets or sets the IServiceProvider service key used to obtain an Azure BlobServiceClient."
                         },
                         "BlobContainerName": {
                           "type": "string",

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubConsumerClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubConsumerClientComponent.cs
@@ -24,10 +24,11 @@ internal sealed class EventHubConsumerClientComponent : EventHubsComponent<Azure
         config.Bind(settings);
     }
 
-    protected override IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureMessagingEventHubsConsumerSettings settings,
+    protected override IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions> AddClient(
+        AzureClientFactoryBuilder azureFactoryBuilder, AzureMessagingEventHubsConsumerSettings settings,
         string connectionName, string configurationSectionName)
     {
-        return azureFactoryBuilder.RegisterClientFactory<EventHubConsumerClient, EventHubConsumerClientOptions>((options, cred) =>
+        return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<EventHubConsumerClient, EventHubConsumerClientOptions>((options, cred) =>
         {
             EnsureConnectionStringOrNamespaceProvided(settings, connectionName, configurationSectionName);
 

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubProducerClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubProducerClientComponent.cs
@@ -23,11 +23,12 @@ internal sealed class EventHubProducerClientComponent : EventHubsComponent<Azure
     {
         config.Bind(settings);
     }
-    
-    protected override IAzureClientBuilder<EventHubProducerClient, EventHubProducerClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureMessagingEventHubsProducerSettings settings,
+
+    protected override IAzureClientBuilder<EventHubProducerClient, EventHubProducerClientOptions> AddClient(
+        AzureClientFactoryBuilder azureFactoryBuilder, AzureMessagingEventHubsProducerSettings settings,
         string connectionName, string configurationSectionName)
     {
-        return azureFactoryBuilder.RegisterClientFactory<EventHubProducerClient, EventHubProducerClientOptions>((options, cred) =>
+        return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<EventHubProducerClient, EventHubProducerClientOptions>((options, cred) =>
         {
             EnsureConnectionStringOrNamespaceProvided(settings, connectionName, configurationSectionName);
 

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubsComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubsComponent.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.Hosting;
 
 internal abstract class EventHubsComponent<TSettings, TClient, TClientOptions> :
     AzureComponent<TSettings, TClient, TClientOptions>
-    where TClientOptions: class
+    where TClientOptions : class
     where TClient : class
     where TSettings : AzureMessagingEventHubsSettings, new()
 {

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventProcessorClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventProcessorClientComponent.cs
@@ -3,78 +3,75 @@
 
 using Aspire.Azure.Messaging.EventHubs;
 using Azure;
-using Azure.Core;
 using Azure.Core.Extensions;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Extensions.Hosting;
 
-internal sealed class EventProcessorClientComponent(IConfiguration builderConfiguration)
+internal sealed class EventProcessorClientComponent()
     : EventHubsComponent<AzureMessagingEventHubsProcessorSettings, EventProcessorClient, EventProcessorClientOptions>
 {
     // cannot be in base class as source generator chokes on generic placeholders
-    protected override void BindClientOptionsToConfiguration(IAzureClientBuilder<EventProcessorClient, EventProcessorClientOptions> clientBuilder, IConfiguration configuration)
+    protected override void BindClientOptionsToConfiguration(
+        IAzureClientBuilder<EventProcessorClient, EventProcessorClientOptions> clientBuilder,
+        IConfiguration configuration)
     {
 #pragma warning disable IDE0200 // Remove unnecessary lambda expression - needed so the ConfigBinder Source Generator works
         clientBuilder.ConfigureOptions(options => configuration.Bind(options));
 #pragma warning restore IDE0200
     }
 
-    protected override void BindSettingsToConfiguration(AzureMessagingEventHubsProcessorSettings settings, IConfiguration config)
+    protected override void BindSettingsToConfiguration(AzureMessagingEventHubsProcessorSettings settings,
+        IConfiguration config)
     {
         config.Bind(settings);
     }
 
-    protected override IAzureClientBuilder<EventProcessorClient, EventProcessorClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureMessagingEventHubsProcessorSettings settings,
+    protected override IAzureClientBuilder<EventProcessorClient, EventProcessorClientOptions> AddClient(
+        AzureClientFactoryBuilder azureFactoryBuilder, AzureMessagingEventHubsProcessorSettings settings,
         string connectionName, string configurationSectionName)
     {
-        return azureFactoryBuilder.RegisterClientFactory<EventProcessorClient, EventProcessorClientOptions>(
-            (options, cred) =>
+        return azureFactoryBuilder.AddClient<EventProcessorClient, EventProcessorClientOptions>(
+            (options, cred, provider) =>
             {
                 EnsureConnectionStringOrNamespaceProvided(settings, connectionName, configurationSectionName);
 
                 options.Identifier ??= GenerateClientIdentifier(settings.EventHubName, settings.ConsumerGroup);
 
-                var blobClient = GetBlobContainerClient(settings, cred, configurationSectionName);
+                var containerClient = GetBlobContainerClient(settings, provider, configurationSectionName);
 
                 var processor = !string.IsNullOrEmpty(settings.ConnectionString)
-                    ? new EventProcessorClient(blobClient,
-                        settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.ConnectionString)
-                    : new EventProcessorClient(blobClient,
+                    ? new EventProcessorClient(containerClient,
+                        settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName,
+                        settings.ConnectionString)
+                    : new EventProcessorClient(containerClient,
                         settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.FullyQualifiedNamespace,
                         settings.EventHubName, cred, options);
 
                 return processor;
-
-            }, requiresCredential: false);
+            });
     }
 
-    private BlobContainerClient GetBlobContainerClient(
-        AzureMessagingEventHubsProcessorSettings settings, TokenCredential cred, string configurationSectionName)
+    private static BlobContainerClient GetBlobContainerClient(
+        AzureMessagingEventHubsProcessorSettings settings, IServiceProvider provider, string configurationSectionName)
     {
-        if (string.IsNullOrEmpty(settings.BlobClientConnectionName))
+        // look for keyed client if one is configured. Otherwise, get an unkeyed BlobServiceClient
+        var blobClient = !string.IsNullOrEmpty(settings.BlobClientServiceKey) ?
+            provider.GetKeyedService<BlobServiceClient>(settings.BlobClientServiceKey) :
+            provider.GetService<BlobServiceClient>();
+
+        if (blobClient is null)
         {
-            // throw an invalid operation exception if the blob client connection name is not provided
             throw new InvalidOperationException(
-                $"A EventProcessorClient could not be configured. Ensure a valid blob connection name was provided in " +
-                $"the '{configurationSectionName}:BlobClientConnectionName' configuration section.");
+                $"An EventProcessorClient could not be configured. Ensure a valid 'BlobServiceClient' is available in the ServiceProvider or " +
+                $"provide the service key of the 'BlobServiceClient' in " +
+                $"the '{configurationSectionName}:BlobClientServiceKey' configuration section, or use the settings callback to configure it in code.");
         }
-
-        var blobConnectionString =
-            builderConfiguration.GetConnectionString(
-                settings.BlobClientConnectionName) ??
-                throw new InvalidOperationException(
-                    "An EventProcessorClient could not be configured. " +
-                    $"There is no connection string in Configuration with the name {settings.BlobClientConnectionName}. " +
-                    "Ensure you have configured a connection for a Azure Blob Storage Account.");
-
-        // FIXME: ideally this should be pulled from services; but thar be dragons.
-        // There is no reliable way to get the blob service client from the services collection
-        var blobUriBuilder = new BlobUriBuilder(new Uri(blobConnectionString!));
 
         // consumer group and blob container names have similar constraints (alphanumeric, hyphen) but we should sanitize nonetheless
         var consumerGroup = (string.IsNullOrWhiteSpace(settings.ConsumerGroup)) ? "default" : settings.ConsumerGroup;
@@ -84,7 +81,9 @@ internal sealed class EventProcessorClientComponent(IConfiguration builderConfig
         // connection string themselves that includes a container name in the Uri already; in this case
         // we assume it already exists and avoid the extra permission demand. The applies to any container
         // name specified in the settings.
-        if (blobUriBuilder.BlobContainerName == string.Empty)
+        bool shouldTryCreateIfNotExists = false;
+
+        if (string.IsNullOrWhiteSpace(settings.BlobContainerName))
         {
             var ns = GetNamespaceFromSettings(settings);
 
@@ -92,26 +91,23 @@ internal sealed class EventProcessorClientComponent(IConfiguration builderConfig
             if (string.IsNullOrWhiteSpace(settings.BlobContainerName))
             {
                 // If not, we'll create a container name based on the namespace, event hub name and consumer group
-                blobUriBuilder.BlobContainerName = $"{ns}-{settings.EventHubName}-{consumerGroup}";
+                settings.BlobContainerName = $"{ns}-{settings.EventHubName}-{consumerGroup}";
+                shouldTryCreateIfNotExists = true;
             }
-            else
-            {
-                // If a container name is provided, we'll use that
-                blobUriBuilder.BlobContainerName = settings.BlobContainerName;
-            }
+        }
 
-            var blobClient = new BlobContainerClient(blobUriBuilder.ToUri(), cred);
+        var containerClient = blobClient.GetBlobContainerClient(settings.BlobContainerName);
 
+        if (shouldTryCreateIfNotExists)
+        {
             try
             {
-                blobClient.CreateIfNotExists();
-
-                return blobClient;
+                containerClient.CreateIfNotExists();
             }
             catch (RequestFailedException ex)
             {
                 throw new InvalidOperationException(
-                    $"The configured container name of '{blobUriBuilder.BlobContainerName}' does not exist, " +
+                    $"The configured container name of '{settings.BlobContainerName}' does not exist, " +
                     "so an attempt was made to create it automatically and this operation failed. Please ensure the container " +
                     "exists and is specified in the connection string, or if you have provided a BlobContainerName in settings, please " +
                     "ensure it exists. If you don't supply a container name, Aspire will attempt to create one with the name 'namespace-hub-consumergroup'.",
@@ -119,6 +115,6 @@ internal sealed class EventProcessorClientComponent(IConfiguration builderConfig
             }
         }
 
-        return new BlobContainerClient(blobUriBuilder.ToUri(), cred);
+        return containerClient;
     }
 }

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/PartitionReceiverClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/PartitionReceiverClientComponent.cs
@@ -25,33 +25,34 @@ internal sealed class PartitionReceiverClientComponent()
     {
         config.Bind(settings);
     }
-    protected override IAzureClientBuilder<PartitionReceiver, PartitionReceiverOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureMessagingEventHubsPartitionReceiverSettings settings,
+    protected override IAzureClientBuilder<PartitionReceiver, PartitionReceiverOptions> AddClient(
+        AzureClientFactoryBuilder azureFactoryBuilder, AzureMessagingEventHubsPartitionReceiverSettings settings,
         string connectionName, string configurationSectionName)
     {
-        return azureFactoryBuilder.RegisterClientFactory<PartitionReceiver, PartitionReceiverOptions>(
-            (options, cred) =>
+        return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<PartitionReceiver, PartitionReceiverOptions>((options, cred) =>
+        {
+            EnsureConnectionStringOrNamespaceProvided(settings, connectionName, configurationSectionName);
+
+            if (string.IsNullOrEmpty(settings.PartitionId))
             {
-                EnsureConnectionStringOrNamespaceProvided(settings, connectionName, configurationSectionName);
+                throw new InvalidOperationException(
+                    $"A PartitionReceiver could not be configured. Ensure a valid PartitionId was provided in the '{configurationSectionName}' configuration section.");
+            }
 
-                if (string.IsNullOrEmpty(settings.PartitionId))
-                {
-                    throw new InvalidOperationException(
-                        $"A PartitionReceiver could not be configured. Ensure a valid PartitionId was provided in the '{configurationSectionName}' configuration section.");
-                }
+            options.Identifier ??= GenerateClientIdentifier(settings.EventHubName, settings.ConsumerGroup);
 
-                options.Identifier ??= GenerateClientIdentifier(settings.EventHubName, settings.ConsumerGroup);
+            var receiver = !string.IsNullOrEmpty(settings.ConnectionString)
+                ? new PartitionReceiver(
+                    settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.PartitionId,
+                    settings.EventPosition,
+                    settings.ConnectionString, settings.EventHubName, options)
+                : new PartitionReceiver(
+                    settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.PartitionId,
+                    settings.EventPosition,
+                    settings.FullyQualifiedNamespace, settings.EventHubName, cred, options);
 
-                var receiver = !string.IsNullOrEmpty(settings.ConnectionString)
-                    ? new PartitionReceiver(
-                        settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.PartitionId, settings.EventPosition,
-                        settings.ConnectionString, settings.EventHubName, options)
-                    : new PartitionReceiver(
-                        settings.ConsumerGroup ?? EventHubConsumerClient.DefaultConsumerGroupName, settings.PartitionId, settings.EventPosition,
-                        settings.FullyQualifiedNamespace, settings.EventHubName, cred, options);
+            return receiver;
 
-                return receiver;
-
-            }, requiresCredential: false);
-
+        }, requiresCredential: false);
     }
 }

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/README.md
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/README.md
@@ -107,6 +107,7 @@ The .NET Aspire Azure Event Hubs library supports [Microsoft.Extensions.Configur
         "EventHubs": {
           "EventProcessorClient": {
             "EventHubName": "MyHub",
+            "BlobContainerName": "checkpoints",
             "ClientOptions": {
               "Identifier": "PROCESSOR_ID"
             }
@@ -121,7 +122,9 @@ The .NET Aspire Azure Event Hubs library supports [Microsoft.Extensions.Configur
 You can also setup the Options type using the optional `Action<IAzureClientBuilder<EventProcessorClient, EventProcessorClientOptions>> configureClientBuilder` parameter of the `AddAzureEventProcessorClient` method. For example, to set the processor's client ID for this client:
 
 ```csharp
-builder.AddAzureEventProcessorClient("eventHubsConnectionName", configureClientBuilder: clientBuilder => clientBuilder.ConfigureOptions(options => options.Identifier = "PROCESSOR_ID"));
+builder.AddAzureEventProcessorClient("eventHubsConnectionName",
+    configureClientBuilder: clientBuilder => clientBuilder.ConfigureOptions(
+        options => options.Identifier = "PROCESSOR_ID"));
 ```
 
 ## AppHost extensions

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -64,9 +64,11 @@ public static class AspireServiceBusExtensions
 
     private sealed class MessageBusComponent : AzureComponent<AzureMessagingServiceBusSettings, ServiceBusClient, ServiceBusClientOptions>
     {
-        protected override IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureMessagingServiceBusSettings settings, string connectionName, string configurationSectionName)
+        protected override IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureMessagingServiceBusSettings settings,
+            string connectionName, string configurationSectionName)
         {
-            return azureFactoryBuilder.RegisterClientFactory<ServiceBusClient, ServiceBusClientOptions>((options, cred) =>
+            return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<ServiceBusClient, ServiceBusClientOptions>((options, cred) =>
             {
                 var connectionString = settings.ConnectionString;
                 if (string.IsNullOrEmpty(connectionString) && string.IsNullOrEmpty(settings.FullyQualifiedNamespace))

--- a/src/Components/Aspire.Azure.Search.Documents/AspireAzureSearchExtensions.cs
+++ b/src/Components/Aspire.Azure.Search.Documents/AspireAzureSearchExtensions.cs
@@ -68,9 +68,11 @@ public static class AspireAzureSearchExtensions
         // https://github.com/Azure/azure-sdk-for-net/blob/bed506dee05319ff2de27ca98500daa10573fe7d/sdk/search/Azure.Search.Documents/src/Indexes/SearchIndexClient.cs#L92
         protected override string[] ActivitySourceNames => ["Azure.Search.Documents.*"];
 
-        protected override IAzureClientBuilder<SearchIndexClient, SearchClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureSearchSettings settings, string connectionName, string configurationSectionName)
+        protected override IAzureClientBuilder<SearchIndexClient, SearchClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureSearchSettings settings, string connectionName,
+            string configurationSectionName)
         {
-            return azureFactoryBuilder.RegisterClientFactory<SearchIndexClient, SearchClientOptions>((options, cred) =>
+            return azureFactoryBuilder.AddClient<SearchIndexClient, SearchClientOptions>((options, _, _) =>
             {
                 if (settings.Endpoint is null)
                 {

--- a/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
+++ b/src/Components/Aspire.Azure.Security.KeyVault/AspireKeyVaultExtensions.cs
@@ -119,9 +119,11 @@ public static class AspireKeyVaultExtensions
 
     private sealed class KeyVaultComponent : AzureComponent<AzureSecurityKeyVaultSettings, SecretClient, SecretClientOptions>
     {
-        protected override IAzureClientBuilder<SecretClient, SecretClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureSecurityKeyVaultSettings settings, string connectionName, string configurationSectionName)
+        protected override IAzureClientBuilder<SecretClient, SecretClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureSecurityKeyVaultSettings settings,
+            string connectionName, string configurationSectionName)
         {
-            return azureFactoryBuilder.RegisterClientFactory<SecretClient, SecretClientOptions>((options, cred) =>
+            return azureFactoryBuilder.AddClient<SecretClient, SecretClientOptions>((options, cred, _) =>
             {
                 if (settings.VaultUri is null)
                 {

--- a/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Blobs/AspireBlobStorageExtensions.cs
@@ -65,9 +65,11 @@ public static class AspireBlobStorageExtensions
 
     private sealed class BlobStorageComponent : AzureComponent<AzureStorageBlobsSettings, BlobServiceClient, BlobClientOptions>
     {
-        protected override IAzureClientBuilder<BlobServiceClient, BlobClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureStorageBlobsSettings settings, string connectionName, string configurationSectionName)
+        protected override IAzureClientBuilder<BlobServiceClient, BlobClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureStorageBlobsSettings settings, string connectionName,
+            string configurationSectionName)
         {
-            return azureFactoryBuilder.RegisterClientFactory<BlobServiceClient, BlobClientOptions>((options, cred) =>
+            return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<BlobServiceClient, BlobClientOptions>((options, cred) =>
             {
                 var connectionString = settings.ConnectionString;
                 if (string.IsNullOrEmpty(connectionString) && settings.ServiceUri is null)

--- a/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
+++ b/src/Components/Aspire.Azure.Storage.Queues/AspireQueueStorageExtensions.cs
@@ -66,9 +66,11 @@ public static class AspireQueueStorageExtensions
 
     private sealed class StorageQueueComponent : AzureComponent<AzureStorageQueuesSettings, QueueServiceClient, QueueClientOptions>
     {
-        protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings, string connectionName, string configurationSectionName)
+        protected override IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddClient(
+            AzureClientFactoryBuilder azureFactoryBuilder, AzureStorageQueuesSettings settings, string connectionName,
+            string configurationSectionName)
         {
-            return azureFactoryBuilder.RegisterClientFactory<QueueServiceClient, QueueClientOptions>((options, cred) =>
+            return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<QueueServiceClient, QueueClientOptions>((options, cred) =>
             {
                 var connectionString = settings.ConnectionString;
                 if (string.IsNullOrEmpty(connectionString) && settings.ServiceUri is null)

--- a/src/Components/Common/AzureComponent.cs
+++ b/src/Components/Common/AzureComponent.cs
@@ -31,8 +31,9 @@ internal abstract class AzureComponent<TSettings, TClient, TClientOptions>
 
     protected abstract void BindClientOptionsToConfiguration(IAzureClientBuilder<TClient, TClientOptions> clientBuilder, IConfiguration configuration);
 
-    protected abstract IAzureClientBuilder<TClient, TClientOptions> AddClient<TBuilder>(TBuilder azureFactoryBuilder, TSettings settings, string connectionName, string configurationSectionName)
-        where TBuilder : IAzureClientFactoryBuilder, IAzureClientFactoryBuilderWithCredential;
+    protected abstract IAzureClientBuilder<TClient, TClientOptions> AddClient(
+        AzureClientFactoryBuilder azureFactoryBuilder, TSettings settings, string connectionName,
+        string configurationSectionName);
 
     protected abstract IHealthCheck CreateHealthCheck(TClient client, TSettings settings);
 

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/Aspire.Azure.Messaging.EventHubs.Tests.csproj
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/Aspire.Azure.Messaging.EventHubs.Tests.csproj
@@ -8,6 +8,8 @@
     <None Include="$(RepoRoot)src\Components\Aspire.Azure.Messaging.EventHubs\ConfigurationSchema.json" CopyToOutputDirectory="PreserveNewest" />
 
     <ProjectReference Include="..\..\src\Components\Aspire.Azure.Messaging.EventHubs\Aspire.Azure.Messaging.EventHubs.csproj" />
+
+    <ProjectReference Include="..\..\src\Components\Aspire.Azure.Storage.Blobs\Aspire.Azure.Storage.Blobs.csproj" />
     <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Backport of #3293 to release/8.0

## Customer Impact

On the initial PR of Azure EventHubs there was some usability / composability issues that were addressed in a follow-up PR. Even though the EventHubs component will still be in "preview" when Aspire 8.0.0 is GA, getting feedback on this change is important to ensure we have the right API for the EventHubs component. If we don't take this change, we won't be able to get true feedback on the API.

It also makes porting other changes (like the tests in https://github.com/dotnet/aspire/pull/3919) to reduce conflicts and "drift" between main and release/8.0.

## Testing

The unit tests were updated for the new functionality. playground app is updated as well.

## Risk

Low. EventHubs will still be in preview when 8.0.0 ships. There is some internal refactoring to the common Azure shared code, but it doesn't change behavior.

## Regression?
No
___
* update sample EH project launchsettings; add blob component for processor

* update azurecomponent to expose serviceprovider; update associated components; update processor for DI retrieval of blob client

* throw if blobclient cannot be retrieved from DI (this is a breaking change from P5)

* fix tests

* PR feedback

* More PR feedback

* Rename BlobClientConnectionName to BlobClientServiceKey.

Remove the need to specify a BlobClientServiceKey, and use an unkeyed client if none is provided.

* fix tests

* fixup formatting

---------
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3921)