### PR TITLE
[release/8.0] Naming Convention: Refactors AddAzureCosmosClient and AddKeyedAzureCosmosClient API Names

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
-builder.AddAzureCosmosDBClient("cosmos");
+builder.AddAzureCosmosClient("cosmos");
 builder.AddCosmosDbContext<TestCosmosContext>("cosmos", "ef");
 
 var app = builder.Build();

--- a/playground/bicep/BicepSample.ApiService/Program.cs
+++ b/playground/bicep/BicepSample.ApiService/Program.cs
@@ -16,7 +16,7 @@ builder.AddServiceDefaults();
 
 builder.AddSqlServerDbContext<MyDbContext>("db");
 builder.AddNpgsqlDbContext<MyPgDbContext>("db2");
-builder.AddAzureCosmosDBClient("cosmos");
+builder.AddAzureCosmosClient("cosmos");
 builder.AddRedisClient("redis");
 builder.AddAzureBlobClient("blob");
 builder.AddAzureTableClient("table");

--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -50,7 +50,7 @@ var myService = builder.AddProject<Projects.MyService>()
 The `WithReference` method passes that connection information into a connection string named `cosmosdb` in the `MyService` project. In the _Program.cs_ file of `MyService`, the connection can be consumed using the client library [Aspire.Microsoft.Azure.Cosmos](https://www.nuget.org/packages/Aspire.Microsoft.Azure.Cosmos):
 
 ```csharp
-builder.AddAzureCosmosDBClient("cosmosdb");
+builder.AddAzureCosmosClient("cosmosdb");
 ```
 
 ### Emulator usage
@@ -66,7 +66,7 @@ When the AppHost starts up a local container running the Azure CosmosDB will als
 
 ```csharp
 // Service code
-builder.AddAzureCosmosDBClient("cosmos");
+builder.AddAzureCosmosClient("cosmos");
 ```
 
 ## Additional documentation

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosDBExtensions.cs
@@ -27,7 +27,7 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
-    public static void AddAzureCosmosDBClient(
+    public static void AddAzureCosmosClient(
         this IHostApplicationBuilder builder,
         string connectionName,
         Action<MicrosoftAzureCosmosDBSettings>? configureSettings = null,
@@ -46,7 +46,7 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
-    public static void AddKeyedAzureCosmosDBClient(
+    public static void AddKeyedAzureCosmosClient(
         this IHostApplicationBuilder builder,
         string name,
         Action<MicrosoftAzureCosmosDBSettings>? configureSettings = null,
@@ -104,7 +104,7 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
         var cosmosApplicationName = CosmosConstants.CosmosApplicationName;
         if (!string.IsNullOrEmpty(clientOptions.ApplicationName))
         {
-            cosmosApplicationName = $"{cosmosApplicationName}|{clientOptions.ApplicationName}";
+            cosmosApplicationName = $"{cosmosApplicationName}/{clientOptions.ApplicationName}";
         }
 
         clientOptions.ApplicationName = cosmosApplicationName;

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
@@ -11,9 +11,9 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Microsoft.Extensions.Hosting;
 
 /// <summary>
-/// Azure CosmosDB extension
+/// Azure Cosmos DB extension
 /// </summary>
-public static class AspireMicrosoftAzureCosmosDBExtensions
+public static class AspireMicrosoftAzureCosmosExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Microsoft:Azure:Cosmos";
 
@@ -23,17 +23,17 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
     /// <param name="connectionName">The connection name to use to find a connection string.</param>
-    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosDBSettings"/>. It's invoked after the settings are read from the configuration.</param>
+    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
     public static void AddAzureCosmosClient(
         this IHostApplicationBuilder builder,
         string connectionName,
-        Action<MicrosoftAzureCosmosDBSettings>? configureSettings = null,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
     {
-        AddAzureCosmosDB(builder, DefaultConfigSectionName, configureSettings, configureClientOptions, connectionName, serviceKey: null);
+        AddAzureCosmosClient(builder, DefaultConfigSectionName, configureSettings, configureClientOptions, connectionName, serviceKey: null);
     }
 
     /// <summary>
@@ -42,30 +42,30 @@ public static class AspireMicrosoftAzureCosmosDBExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IHostApplicationBuilder" /> to read config from and add services to.</param>
     /// <param name="name">The name of the component, which is used as the <see cref="ServiceDescriptor.ServiceKey"/> of the service and also to retrieve the connection string from the ConnectionStrings configuration section.</param>
-    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosDBSettings"/>. It's invoked after the settings are read from the configuration.</param>
+    /// <param name="configureSettings">An optional method that can be used for customizing the <see cref="MicrosoftAzureCosmosSettings"/>. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureClientOptions">An optional method that can be used for customizing the <see cref="CosmosClientOptions"/>.</param>
     /// <remarks>Reads the configuration from "Aspire:Microsoft:Azure:Cosmos:{name}" section.</remarks>
     /// <exception cref="InvalidOperationException">If required ConnectionString is not provided in configuration section</exception>
     public static void AddKeyedAzureCosmosClient(
         this IHostApplicationBuilder builder,
         string name,
-        Action<MicrosoftAzureCosmosDBSettings>? configureSettings = null,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
     {
-        AddAzureCosmosDB(builder, $"{DefaultConfigSectionName}:{name}", configureSettings, configureClientOptions, connectionName: name, serviceKey: name);
+        AddAzureCosmosClient(builder, $"{DefaultConfigSectionName}:{name}", configureSettings, configureClientOptions, connectionName: name, serviceKey: name);
     }
 
-    private static void AddAzureCosmosDB(
+    private static void AddAzureCosmosClient(
         this IHostApplicationBuilder builder,
         string configurationSectionName,
-        Action<MicrosoftAzureCosmosDBSettings>? configureSettings,
+        Action<MicrosoftAzureCosmosSettings>? configureSettings,
         Action<CosmosClientOptions>? configureClientOptions,
         string connectionName,
         string? serviceKey)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var settings = new MicrosoftAzureCosmosDBSettings();
+        var settings = new MicrosoftAzureCosmosSettings();
         builder.Configuration.GetSection(configurationSectionName).Bind(settings);
 
         if (builder.Configuration.GetConnectionString(connectionName) is string connectionString)

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AssemblyInfo.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AssemblyInfo.cs
@@ -4,6 +4,6 @@
 using Aspire;
 using Aspire.Microsoft.Azure.Cosmos;
 
-[assembly: ConfigurationSchema("Aspire:Microsoft:Azure:Cosmos", typeof(MicrosoftAzureCosmosDBSettings))]
+[assembly: ConfigurationSchema("Aspire:Microsoft:Azure:Cosmos", typeof(MicrosoftAzureCosmosSettings))]
 
 [assembly: LoggingCategories("Azure-Cosmos-Operation-Request-Diagnostics")]

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/MicrosoftAzureCosmosSettings.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/MicrosoftAzureCosmosSettings.cs
@@ -8,7 +8,7 @@ namespace Aspire.Microsoft.Azure.Cosmos;
 /// <summary>
 /// The settings relevant to accessing Azure Cosmos DB.
 /// </summary>
-public sealed class MicrosoftAzureCosmosDBSettings
+public sealed class MicrosoftAzureCosmosSettings
 {
     /// <summary>
     /// Gets or sets the connection string of the Azure Cosmos database to connect to.

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -54,7 +54,7 @@ And then the connection string will be retrieved from the `ConnectionStrings` co
 
 #### Account Endpoint
 
-The recommended approach is to use an AccountEndpoint, which works with the `MicrosoftAzureCosmosDBSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
+The recommended approach is to use an AccountEndpoint, which works with the `MicrosoftAzureCosmosSettings.Credential` property to establish a connection. If no credential is configured, the [DefaultAzureCredential](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential) is used.
 
 ```json
 {
@@ -78,7 +78,7 @@ Alternatively, an [Azure Cosmos DB connection string](https://learn.microsoft.co
 
 ### Use configuration providers
 
-The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `MicrosoftAzureCosmosDBSettings` and `QueueClientOptions` from configuration by using the `Aspire:Microsoft:Azure:Cosmos` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `MicrosoftAzureCosmosSettings` and `QueueClientOptions` from configuration by using the `Aspire:Microsoft:Azure:Cosmos` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {
@@ -96,7 +96,7 @@ The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions
 
 ### Use inline delegates
 
-You can also pass the `Action<MicrosoftAzureCosmosDBSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
+You can also pass the `Action<MicrosoftAzureCosmosSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
 builder.AddAzureCosmosClient("cosmosConnectionName", settings => settings.DisableTracing = true);

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/README.md
@@ -19,10 +19,10 @@ dotnet add package Aspire.Microsoft.Azure.Cosmos
 
 ## Usage example
 
-In the _Program.cs_ file of your project, call the `AddAzureCosmosDBClient` extension method to register a `CosmosClient` for use via the dependency injection container. The method takes a connection name parameter.
+In the _Program.cs_ file of your project, call the `AddAzureCosmosClient` extension method to register a `CosmosClient` for use via the dependency injection container. The method takes a connection name parameter.
 
 ```csharp
-builder.AddAzureCosmosDBClient("cosmosConnectionName");
+builder.AddAzureCosmosClient("cosmosConnectionName");
 ```
 
 You can then retrieve the `CosmosClient` instance using dependency injection. For example, to retrieve the client from a Web API controller:
@@ -44,10 +44,10 @@ The .NET Aspire Azure Cosmos DB library provides multiple options to configure t
 
 ### Use a connection string
 
-When using a connection string from the `ConnectionStrings` configuration section, you can provide the name of the connection string when calling `builder.AddAzureCosmosDBClient()`:
+When using a connection string from the `ConnectionStrings` configuration section, you can provide the name of the connection string when calling `builder.AddAzureCosmosClient()`:
 
 ```csharp
-builder.AddAzureCosmosDBClient("cosmosConnectionName");
+builder.AddAzureCosmosClient("cosmosConnectionName");
 ```
 
 And then the connection string will be retrieved from the `ConnectionStrings` configuration section. Two connection formats are supported:
@@ -99,13 +99,13 @@ The .NET Aspire Microsoft Azure Cosmos DB library supports [Microsoft.Extensions
 You can also pass the `Action<MicrosoftAzureCosmosDBSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
-builder.AddAzureCosmosDBClient("cosmosConnectionName", settings => settings.DisableTracing = true);
+builder.AddAzureCosmosClient("cosmosConnectionName", settings => settings.DisableTracing = true);
 ```
 
-You can also setup the [CosmosClientOptions](https://learn.microsoft.com/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions) using the optional `Action<CosmosClientOptions> configureClientOptions` parameter of the `AddAzureCosmosDBClient` method. For example, to set the `ApplicationName` "User-Agent" header suffix for all requests issues by this client:
+You can also setup the [CosmosClientOptions](https://learn.microsoft.com/dotnet/api/microsoft.azure.cosmos.cosmosclientoptions) using the optional `Action<CosmosClientOptions> configureClientOptions` parameter of the `AddAzureCosmosClient` method. For example, to set the `ApplicationName` "User-Agent" header suffix for all requests issues by this client:
 
 ```csharp
-builder.AddAzureCosmosDBClient("cosmosConnectionName", configureClientOptions: clientOptions => clientOptions.ApplicationName = "myapp");
+builder.AddAzureCosmosClient("cosmosConnectionName", configureClientOptions: clientOptions => clientOptions.ApplicationName = "myapp");
 ```
 
 ## AppHost extensions
@@ -130,7 +130,7 @@ var myService = builder.AddProject<Projects.MyService>()
 The `AddAzureCosmosDB` method will add an Azure Cosmos DB resource to the builder. Or `AddConnectionString` can be used to read connection information from the AppHost's configuration (for example, from "user secrets") under the `ConnectionStrings:cosmosdb` config key. The `WithReference` method passes that connection information into a connection string named `cosmosdb` in the `MyService` project. In the _Program.cs_ file of `MyService`, the connection can be consumed using:
 
 ```csharp
-builder.AddAzureCosmosDBClient("cosmosdb");
+builder.AddAzureCosmosClient("cosmosdb");
 ```
 
 ### Emulator usage
@@ -146,7 +146,7 @@ When the AppHost starts up a local container running the Azure CosmosDB will als
 
 ```csharp
 // Service code
-builder.AddAzureCosmosDBClient("cosmos");
+builder.AddAzureCosmosClient("cosmos");
 ```
 
 ## Additional documentation

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.Hosting;
 /// <summary>
 /// Extension methods for configuring EntityFrameworkCore DbContext to Azure Cosmos DB
 /// </summary>
-public static class AspireAzureEFCoreCosmosDBExtensions
+public static class AspireAzureEFCoreCosmosExtensions
 {
     private const string DefaultConfigSectionName = "Aspire:Microsoft:EntityFrameworkCore:Cosmos";
     private const DynamicallyAccessedMemberTypes RequiredByEF = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties;
@@ -34,19 +34,19 @@ public static class AspireAzureEFCoreCosmosDBExtensions
     /// <param name="configureSettings">An optional delegate that can be used for customizing settings. It's invoked after the settings are read from the configuration.</param>
     /// <param name="configureDbContextOptions">An optional delegate to configure the <see cref="DbContextOptions"/> for the context.</param>
     /// <exception cref="ArgumentNullException">Thrown if mandatory <paramref name="builder"/> is null.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when mandatory <see cref="EntityFrameworkCoreCosmosDBSettings.ConnectionString"/> is not provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when mandatory <see cref="EntityFrameworkCoreCosmosSettings.ConnectionString"/> is not provided.</exception>
     public static void AddCosmosDbContext<[DynamicallyAccessedMembers(RequiredByEF)] TContext>(
         this IHostApplicationBuilder builder,
         string connectionName,
         string databaseName,
-        Action<EntityFrameworkCoreCosmosDBSettings>? configureSettings = null,
+        Action<EntityFrameworkCoreCosmosSettings>? configureSettings = null,
         Action<DbContextOptionsBuilder>? configureDbContextOptions = null) where TContext : DbContext
     {
         ArgumentNullException.ThrowIfNull(builder);
 
         builder.EnsureDbContextNotRegistered<TContext>();
 
-        var settings = builder.GetDbContextSettings<TContext, EntityFrameworkCoreCosmosDBSettings>(
+        var settings = builder.GetDbContextSettings<TContext, EntityFrameworkCoreCosmosSettings>(
             DefaultConfigSectionName,
             (settings, section) => section.Bind(settings)
         );
@@ -120,11 +120,11 @@ public static class AspireAzureEFCoreCosmosDBExtensions
     /// <exception cref="InvalidOperationException">Thrown when mandatory <see cref="DbContext"/> is not registered in DI.</exception>
     public static void EnrichCosmosDbContext<[DynamicallyAccessedMembers(RequiredByEF)] TContext>(
             this IHostApplicationBuilder builder,
-            Action<EntityFrameworkCoreCosmosDBSettings>? configureSettings = null) where TContext : DbContext
+            Action<EntityFrameworkCoreCosmosSettings>? configureSettings = null) where TContext : DbContext
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        var settings = builder.GetDbContextSettings<TContext, EntityFrameworkCoreCosmosDBSettings>(
+        var settings = builder.GetDbContextSettings<TContext, EntityFrameworkCoreCosmosSettings>(
             DefaultConfigSectionName,
             (settings, section) => section.Bind(settings)
         );
@@ -142,7 +142,7 @@ public static class AspireAzureEFCoreCosmosDBExtensions
                     extension.RequestTimeout.HasValue &&
                     extension.RequestTimeout != settings.RequestTimeout)
                 {
-                    throw new InvalidOperationException($"Conflicting values for 'RequestTimeout' were found in {nameof(EntityFrameworkCoreCosmosDBSettings)} and set in DbContextOptions<{typeof(TContext).Name}>.");
+                    throw new InvalidOperationException($"Conflicting values for 'RequestTimeout' were found in {nameof(EntityFrameworkCoreCosmosSettings)} and set in DbContextOptions<{typeof(TContext).Name}>.");
                 }
 
                 extension?.WithRequestTimeout(settings.RequestTimeout);
@@ -157,7 +157,7 @@ public static class AspireAzureEFCoreCosmosDBExtensions
         ConfigureInstrumentation<TContext>(builder, settings);
     }
 
-    private static void ConfigureInstrumentation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TContext>(IHostApplicationBuilder builder, EntityFrameworkCoreCosmosDBSettings settings) where TContext : DbContext
+    private static void ConfigureInstrumentation<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)] TContext>(IHostApplicationBuilder builder, EntityFrameworkCoreCosmosSettings settings) where TContext : DbContext
     {
         if (!settings.DisableTracing)
         {

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AssemblyInfo.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AssemblyInfo.cs
@@ -4,7 +4,7 @@
 using Aspire;
 using Aspire.Microsoft.EntityFrameworkCore.Cosmos;
 
-[assembly: ConfigurationSchema("Aspire:Microsoft:EntityFrameworkCore:Cosmos", typeof(EntityFrameworkCoreCosmosDBSettings))]
+[assembly: ConfigurationSchema("Aspire:Microsoft:EntityFrameworkCore:Cosmos", typeof(EntityFrameworkCoreCosmosSettings))]
 
 [assembly: LoggingCategories(
     "Azure-Cosmos-Operation-Request-Diagnostics",

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosSettings.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosSettings.cs
@@ -8,7 +8,7 @@ namespace Aspire.Microsoft.EntityFrameworkCore.Cosmos;
 /// <summary>
 /// The settings relevant to accessing Azure Cosmos DB database using EntityFrameworkCore.
 /// </summary>
-public sealed class EntityFrameworkCoreCosmosDBSettings
+public sealed class EntityFrameworkCoreCosmosSettings
 {
     /// <summary>
     /// The connection string of the Azure Cosmos DB server database to connect to.

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/README.md
@@ -71,7 +71,7 @@ See the [ConnectionString documentation](https://learn.microsoft.com/azure/cosmo
 
 ### Use configuration providers
 
-The .NET Aspire Microsoft EntityFrameworkCore Cosmos component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `EntityFrameworkCoreCosmosDBSettings` from configuration by using the `Aspire:Microsaoft:EntityFrameworkCore:Cosmos` key. Example `appsettings.json` that configures some of the options:
+The .NET Aspire Microsoft EntityFrameworkCore Cosmos component supports [Microsoft.Extensions.Configuration](https://learn.microsoft.com/dotnet/api/microsoft.extensions.configuration). It loads the `EntityFrameworkCoreCosmosSettings` from configuration by using the `Aspire:Microsaoft:EntityFrameworkCore:Cosmos` key. Example `appsettings.json` that configures some of the options:
 
 ```json
 {
@@ -89,7 +89,7 @@ The .NET Aspire Microsoft EntityFrameworkCore Cosmos component supports [Microso
 
 ### Use inline delegates
 
-Also you can pass the `Action<EntityFrameworkCoreCosmosDBSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
+Also you can pass the `Action<EntityFrameworkCoreCosmosSettings> configureSettings` delegate to set up some or all the options inline, for example to disable tracing from code:
 
 ```csharp
     builder.AddCosmosDbContext<MyDbContext>("cosmosdb", "mydb", settings => settings.DisableTracing = true);

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConfigurationTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConfigurationTests.cs
@@ -9,9 +9,9 @@ public class ConfigurationTests
 {
     [Fact]
     public void ConnectionStringIsNullByDefault()
-        => Assert.Null(new MicrosoftAzureCosmosDBSettings().ConnectionString);
+        => Assert.Null(new MicrosoftAzureCosmosSettings().ConnectionString);
 
     [Fact]
     public void TracingIsEnabledByDefault()
-        => Assert.False(new MicrosoftAzureCosmosDBSettings().DisableTracing);
+        => Assert.False(new MicrosoftAzureCosmosSettings().DisableTracing);
 }

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Microsoft.Azure.Cosmos.Tests;
 
-public class ConformanceTests : ConformanceTests<CosmosClient, MicrosoftAzureCosmosDBSettings>
+public class ConformanceTests : ConformanceTests<CosmosClient, MicrosoftAzureCosmosSettings>
 {
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
@@ -24,7 +24,7 @@ public class ConformanceTests : ConformanceTests<CosmosClient, MicrosoftAzureCos
                 "AccountEndpoint=https://example.documents.azure.com:443/;AccountKey=fake;")
         });
 
-    protected override void RegisterComponent(HostApplicationBuilder builder, Action<MicrosoftAzureCosmosDBSettings>? configure = null, string? key = null)
+    protected override void RegisterComponent(HostApplicationBuilder builder, Action<MicrosoftAzureCosmosSettings>? configure = null, string? key = null)
     {
         if (key is null)
         {
@@ -36,13 +36,13 @@ public class ConformanceTests : ConformanceTests<CosmosClient, MicrosoftAzureCos
         }
     }
 
-    protected override void SetHealthCheck(MicrosoftAzureCosmosDBSettings options, bool enabled)
+    protected override void SetHealthCheck(MicrosoftAzureCosmosSettings options, bool enabled)
         => throw new NotImplementedException();
 
-    protected override void SetTracing(MicrosoftAzureCosmosDBSettings options, bool enabled)
+    protected override void SetTracing(MicrosoftAzureCosmosSettings options, bool enabled)
         => options.DisableTracing = !enabled;
 
-    protected override void SetMetrics(MicrosoftAzureCosmosDBSettings options, bool enabled)
+    protected override void SetMetrics(MicrosoftAzureCosmosSettings options, bool enabled)
         => throw new NotImplementedException();
 
     protected override string ValidJsonConfig => """

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/ConformanceTests.cs
@@ -28,11 +28,11 @@ public class ConformanceTests : ConformanceTests<CosmosClient, MicrosoftAzureCos
     {
         if (key is null)
         {
-            builder.AddAzureCosmosDBClient("cosmosdb", configure);
+            builder.AddAzureCosmosClient("cosmosdb", configure);
         }
         else
         {
-            builder.AddKeyedAzureCosmosDBClient(key, configure);
+            builder.AddKeyedAzureCosmosClient(key, configure);
         }
     }
 

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/ConformanceTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/ConformanceTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests;
 
-public class ConformanceTests : ConformanceTests<TestDbContext, EntityFrameworkCoreCosmosDBSettings>
+public class ConformanceTests : ConformanceTests<TestDbContext, EntityFrameworkCoreCosmosSettings>
 {
     protected override ServiceLifetime ServiceLifetime => ServiceLifetime.Singleton;
 
@@ -33,16 +33,16 @@ public class ConformanceTests : ConformanceTests<TestDbContext, EntityFrameworkC
                 "Host=fake;Database=catalog"),
         });
 
-    protected override void RegisterComponent(HostApplicationBuilder builder, Action<EntityFrameworkCoreCosmosDBSettings>? configure = null, string? key = null)
+    protected override void RegisterComponent(HostApplicationBuilder builder, Action<EntityFrameworkCoreCosmosSettings>? configure = null, string? key = null)
         => builder.AddCosmosDbContext<TestDbContext>("cosmosdb", "TestDatabase", configure);
 
-    protected override void SetHealthCheck(EntityFrameworkCoreCosmosDBSettings options, bool enabled)
+    protected override void SetHealthCheck(EntityFrameworkCoreCosmosSettings options, bool enabled)
         => throw new NotImplementedException();
 
-    protected override void SetTracing(EntityFrameworkCoreCosmosDBSettings options, bool enabled)
+    protected override void SetTracing(EntityFrameworkCoreCosmosSettings options, bool enabled)
         => options.DisableTracing = !enabled;
 
-    protected override void SetMetrics(EntityFrameworkCoreCosmosDBSettings options, bool enabled)
+    protected override void SetMetrics(EntityFrameworkCoreCosmosSettings options, bool enabled)
         => throw new NotImplementedException();
 
     protected override string ValidJsonConfig => """

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/EnrichCosmosDbTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/EnrichCosmosDbTests.cs
@@ -16,7 +16,7 @@ public class EnrichCosmosDbTests : ConformanceTests
     private const string ConnectionString = "Host=fake;Database=catalog";
     private const string DatabaseName = "TestDatabase";
 
-    protected override void RegisterComponent(HostApplicationBuilder builder, Action<EntityFrameworkCoreCosmosDBSettings>? configure = null, string? key = null)
+    protected override void RegisterComponent(HostApplicationBuilder builder, Action<EntityFrameworkCoreCosmosSettings>? configure = null, string? key = null)
     {
         builder.Services.AddDbContextPool<TestDbContext>(options => options.UseCosmos(ConnectionString, DatabaseName));
         builder.EnrichCosmosDbContext<TestDbContext>(configure);
@@ -131,6 +131,6 @@ public class EnrichCosmosDbTests : ConformanceTests
         using var host = builder.Build();
 
         var exception = Assert.Throws<InvalidOperationException>(host.Services.GetRequiredService<TestDbContext>);
-        Assert.Equal("Conflicting values for 'RequestTimeout' were found in EntityFrameworkCoreCosmosDBSettings and set in DbContextOptions<TestDbContext>.", exception.Message);
+        Assert.Equal("Conflicting values for 'RequestTimeout' were found in EntityFrameworkCoreCosmosSettings and set in DbContextOptions<TestDbContext>.", exception.Message);
     }
 }

--- a/tests/testproject/TestProject.IntegrationServiceA/Program.cs
+++ b/tests/testproject/TestProject.IntegrationServiceA/Program.cs
@@ -66,7 +66,7 @@ if (!resourcesToSkip.HasFlag(TestResourceNames.kafka))
 
 if (!resourcesToSkip.HasFlag(TestResourceNames.cosmos))
 {
-    builder.AddAzureCosmosDBClient("cosmos");
+    builder.AddAzureCosmosClient("cosmos");
 }
 
 // Ensure healthChecks are added. Some components like Cosmos


### PR DESCRIPTION
Backport of #3906 to release/8.0

## Customer Impact

After reviewing with the Cosmos team, they decided that the runtime component APIs for Cosmos shouldn't use "CosmosDB" and instead just be "Cosmos". The Hosting APIs are left as "CosmosDB" to be consistent with the Azure.Provisioning APIs.

Also, they decided to use `/` as the delimiter in the User-Agent instead of `|`.

API Fit and Finish

## Testing

Tests are updated to the new APIs.

## Risk

Low. Just a rename and a delimiter change.

## Regression?
No
_____
- Refactors `AddAzureCosmosClient` and `AddKeyedAzureCosmosClient` API Names
- Use `/` delimiter for cosmos user agent, instead of `|`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3934)