### PR TITLE
Update Docker Image Tags

### DIFF
--- a/src/Aspire.Hosting.MongoDB/MongoDBContainerImageTags.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBContainerImageTags.cs
@@ -7,8 +7,8 @@ internal static class MongoDBContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "library/mongo";
-    public const string Tag = "7.0.8";
+    public const string Tag = "7.0";
     public const string MongoExpressRegistry = "docker.io";
-    public const string MongoExpressImage = "mongo-express";
-    public const string MongoExpressTag = "1.0.2-20";
+    public const string MongoExpressImage = "library/mongo-express";
+    public const string MongoExpressTag = "1.0";
 }

--- a/src/Aspire.Hosting.MySql/MySqlContainerImageTags.cs
+++ b/src/Aspire.Hosting.MySql/MySqlContainerImageTags.cs
@@ -7,5 +7,5 @@ internal static class MySqlContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "library/mysql";
-    public const string Tag = "8.3.0";
+    public const string Tag = "8.3";
 }

--- a/src/Aspire.Hosting.Nats/NatsContainerImageTags.cs
+++ b/src/Aspire.Hosting.Nats/NatsContainerImageTags.cs
@@ -7,5 +7,5 @@ internal static class NatsContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "library/nats";
-    public const string Tag = "2";
+    public const string Tag = "2.10";
 }

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQContainerImageTags.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQContainerImageTags.cs
@@ -7,6 +7,6 @@ internal static class RabbitMQContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "library/rabbitmq";
-    public const string Tag = "3";
+    public const string Tag = "3.13";
     public const string TagManagement = $"{Tag}-management";
 }

--- a/src/Aspire.Hosting.Redis/RedisContainerImageTags.cs
+++ b/src/Aspire.Hosting.Redis/RedisContainerImageTags.cs
@@ -7,7 +7,7 @@ internal static class RedisContainerImageTags
 {
     public const string Registry = "docker.io";
     public const string Image = "library/redis";
-    public const string Tag = "7.2.4";
+    public const string Tag = "7.2";
     public const string RedisCommanderRegistry = "docker.io";
     public const string RedisCommanderImage = "rediscommander/redis-commander";
     public const string RedisCommanderTag = "latest";

--- a/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.Tests/RabbitMQ/AddRabbitMQTests.cs
@@ -83,7 +83,7 @@ public class AddRabbitMQTests
     }
 
     [Theory]
-    [InlineData(null, "3-management")]
+    [InlineData(null, RabbitMQContainerImageTags.TagManagement)]
     [InlineData("3", "3-management")]
     [InlineData("3.12", "3.12-management")]
     [InlineData("3.12.0", "3.12.0-management")]


### PR DESCRIPTION
Following this policy:

- never 'latest' unless absolutely no other option (and then we should evaluate why that is with the owner)
- major.minor
- if no semver, choose most recent version

Containers that don't follow this pattern:

- CosmosDB Emulator uses 'latest'
- Azure Storage Azurite doesn't have major.minor
- Kafka doesn't have major.minor
- Oracle doesn't have major.minor
- Qdrant doesn't have major.minor
- Redis commander uses 'latest' (hasn't been updated in 3 years)
- SqlServer has `<year>-latest`, which is roughly equivalent to major.minor

Fix #3933
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3948)