### PR TITLE
Update sln templates to special-case CLI instead of VS

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -35,7 +35,7 @@
     {
       "modifiers": [
         {
-          "condition": "(hostIdentifier == \"vs\")",
+          "condition": "(hostIdentifier != \"dotnetcli\" && hostIdentifier != \"dotnetcli-preview\")",
           "exclude": [
             "*.sln"
           ]
@@ -219,7 +219,7 @@
   "primaryOutputs": [
     {
       "path": "AspireApplication.1.sln",
-      "condition": "(hostIdentifier != \"vs\")"
+      "condition": "(hostIdentifier != \"dotnetcli\" && hostIdentifier != \"dotnetcli-preview\")"
     },
     {
       "path": "AspireApplication.1.AppHost\\AspireApplication.1.AppHost.csproj"

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -219,7 +219,7 @@
   "primaryOutputs": [
     {
       "path": "AspireApplication.1.sln",
-      "condition": "(hostIdentifier != \"dotnetcli\" && hostIdentifier != \"dotnetcli-preview\")"
+      "condition": "(hostIdentifier == \"dotnetcli\" || hostIdentifier == \"dotnetcli-preview\")"
     },
     {
       "path": "AspireApplication.1.AppHost\\AspireApplication.1.AppHost.csproj"

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -39,7 +39,7 @@
     {
       "modifiers": [
         {
-          "condition": "(hostIdentifier == \"vs\")",
+          "condition": "(hostIdentifier != \"dotnetcli\" && hostIdentifier != \"dotnetcli-preview\")",
           "exclude": [
             "*.sln"
           ]
@@ -349,7 +349,7 @@
   "primaryOutputs": [
     {
       "path": "AspireStarterApplication.1.sln",
-      "condition": "(hostIdentifier != \"vs\")"
+      "condition": "(hostIdentifier != \"dotnetcli\" && hostIdentifier != \"dotnetcli-preview\")"
     },
     {
       "path": "AspireStarterApplication.1.AppHost\\AspireStarterApplication.1.AppHost.csproj"

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -349,7 +349,7 @@
   "primaryOutputs": [
     {
       "path": "AspireStarterApplication.1.sln",
-      "condition": "(hostIdentifier != \"dotnetcli\" && hostIdentifier != \"dotnetcli-preview\")"
+      "condition": "(hostIdentifier == \"dotnetcli\" || hostIdentifier == \"dotnetcli-preview\")"
     },
     {
       "path": "AspireStarterApplication.1.AppHost\\AspireStarterApplication.1.AppHost.csproj"


### PR DESCRIPTION
Changes the solution templates so that instead of special-casing VS and not creating the .sln file, they special-case the CLI and only create the .sln file in that case. This matches what the Blazor templates do and makes the templates work correctly in non-VS hosts like C# Dev Kit.

Fixes #3951
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3953)