### PR TITLE
Change which category/group servers are placed under in PGAdmin.

### DIFF
--- a/src/Aspire.Hosting.PostgreSQL/PgAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PgAdminConfigWriterHook.cs
@@ -34,7 +34,7 @@ internal sealed class PgAdminConfigWriterHook : IDistributedApplicationLifecycle
 
                 writer.WriteStartObject($"{serverIndex}");
                 writer.WriteString("Name", postgresInstance.Name);
-                writer.WriteString("Group", "Aspire instances");
+                writer.WriteString("Group", "Servers");
                 writer.WriteString("Host", endpoint.ContainerHost);
                 writer.WriteNumber("Port", endpoint.Port);
                 writer.WriteString("Username", "postgres");

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -406,7 +406,7 @@ public class AddPostgresTests
 
         // Make sure the first server is correct.
         Assert.Equal(pg1.Resource.Name, servers.GetProperty("1").GetProperty("Name").GetString());
-        Assert.Equal("Aspire instances", servers.GetProperty("1").GetProperty("Group").GetString());
+        Assert.Equal("Servers", servers.GetProperty("1").GetProperty("Group").GetString());
         Assert.Equal(containerHost, servers.GetProperty("1").GetProperty("Host").GetString());
         Assert.Equal(5001, servers.GetProperty("1").GetProperty("Port").GetInt32());
         Assert.Equal("postgres", servers.GetProperty("1").GetProperty("Username").GetString());
@@ -416,7 +416,7 @@ public class AddPostgresTests
 
         // Make sure the second server is correct.
         Assert.Equal(pg2.Resource.Name, servers.GetProperty("2").GetProperty("Name").GetString());
-        Assert.Equal("Aspire instances", servers.GetProperty("2").GetProperty("Group").GetString());
+        Assert.Equal("Servers", servers.GetProperty("2").GetProperty("Group").GetString());
         Assert.Equal("host2", servers.GetProperty("2").GetProperty("Host").GetString());
         Assert.Equal(5002, servers.GetProperty("2").GetProperty("Port").GetInt32());
         Assert.Equal("postgres", servers.GetProperty("2").GetProperty("Username").GetString());


### PR DESCRIPTION
I want to change where we place servers in PGAdmin nav. It is currently "Aspire instances" but there is always a "Servers" group which folks will tend to look at first (missing the specially named one we created).

This just avoids this problem entirely by putting our Aspire-managed instances under Servers.

**Before:**

![image](https://github.com/dotnet/aspire/assets/513398/e56e79f0-dd4c-4643-9886-47b5f88d115c)

**After:**

![image](https://github.com/dotnet/aspire/assets/513398/6e5c6b8d-bcfe-4be1-8181-c74dbc69fe30)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3962)