### PR TITLE
Set an upper bound on RabbitMQ dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,7 +113,7 @@
     <PackageVersion Include="Polly.Extensions" Version="8.3.1" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageVersion Include="Qdrant.Client" Version="1.8.0" />
-    <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0.0)" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.33" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0" />


### PR DESCRIPTION
Version 7 has binary breaking changes that cause the Aspire.RabbitMQ.Client component to fail loading with a MissingMethodException.

Contributes to #3956
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3972)