### PR TITLE
[release/8.0] Set an upper bound on RabbitMQ dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -112,7 +112,7 @@
     <PackageVersion Include="Polly.Extensions" Version="8.3.0" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.1" />
     <PackageVersion Include="Qdrant.Client" Version="1.8.0" />
-    <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0.0)" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.27" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0" />


### PR DESCRIPTION
Backport of #3972 to release/8.0

## Customer Impact

RabbitMQ.Client v7 has many public API breaking changes. So many that our component doesn't even load with the 7.0-alpha releases. Setting a limit on our dependency means that customers will understand they can't use the 7.0 packages with our component.

## Testing

Automated tests passing in the repo. I also ran `dotnet pack .\src\Components\Aspire.RabbitMQ.Client\` and inspected the resulting nuget package has the right dependency version:

![image](https://github.com/dotnet/aspire/assets/8291187/930575cf-8e7b-415d-aaed-0a7a40622cdb)


## Risk

Low. We are depending on the same version. Just limiting to what versions we allow users to move to when using our component.

## Regression?
No
_____

Version 7 has binary breaking changes that cause the Aspire.RabbitMQ.Client component to fail loading with a MissingMethodException.

Contributes to #3956
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3973)