### PR TITLE
[release/8.0] Update the version of NATS.Net to fix CG Alert

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -104,7 +104,7 @@
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.5" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageVersion Include="NATS.Net" Version="2.2.0" />
+    <PackageVersion Include="NATS.Net" Version="2.2.1" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.121" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -104,7 +104,7 @@
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.5" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
-    <PackageVersion Include="NATS.Net" Version="2.1.3" />
+    <PackageVersion Include="NATS.Net" Version="2.2.0" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.121" />


### PR DESCRIPTION
This change is already in main, but this PR is backporting this individual dependency bump to fix a CG alert given NATS.Net is missing some required Legal information which has been fixed in 8.0.

cc: @eerhardt  @danmoseley 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3977)