### PR TITLE
Move to Azure.Provisioning.* GA packages.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,22 +33,22 @@
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.25.2" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.3" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="0.2.0-beta.2" />
-    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning" Version="0.2.0" />
+    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.1.0" />
     <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Redis" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Resources" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Search" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.SignalR" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Sql" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Redis" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Resources" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Search" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.SignalR" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Sql" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="0.1.0" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAuthenticationCertificatePackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion)" />


### PR DESCRIPTION
Moves to `Azure.Provisioning@0.2.0` and `Azure.Provisioning.*@0.1.0` except for `Azure.Provisioning.ApplicationInsights` which is still stuck at `0.1.0-beta.1` because the `Azure.ResourceManager.ApplicationInsights` package has never shipped at GA (will be addressed next week).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3983)