### PR TITLE
[release/8.0] Backport of changing Azure.Provisioning packages to GA versions.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,22 +33,22 @@
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.25.1" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.2" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="0.2.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning" Version="0.2.0" />
+    <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.1.0" />
     <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Redis" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Resources" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Search" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.SignalR" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Sql" Version="0.1.0-beta.1" />
-    <PackageVersion Include="Azure.Provisioning.Storage" Version="0.1.0-beta.1" />
+    <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.EventHubs" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.KeyVault" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Redis" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Resources" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Search" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.ServiceBus" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.SignalR" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Sql" Version="0.1.0" />
+    <PackageVersion Include="Azure.Provisioning.Storage" Version="0.1.0" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAuthenticationCertificatePackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion)" />


### PR DESCRIPTION
Backport of #3293 to release/8.0

## Customer Impact

No longer using preview packages for Azure.Provisioning.* (except for AppInsights ... that'll be fixed next week).

## Testing

Unit tests check that the generated Bicep baseline hasn't changed.

## Risk

Low. The only change from the previous package versions was the version number. The Azure SDK team decided to hold off another change they were making.

## Regression?
No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3984)