### PR TITLE
[release/8.0] Update Components dependencies to latest stable versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,23 +15,23 @@
     <PackageVersion Include="AWSSDK.Core" Version="3.7.302.16" />
     <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.300" />
     <PackageVersion Include="AWS.Messaging" Version="0.2.0-beta" />
-    <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.11.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.AWS" Version="1.3.0-beta.1" />
     <!-- Azure SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.14" />
+    <PackageVersion Include="Azure.AI.OpenAI" Version="1.0.0-beta.16" />
     <PackageVersion Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
-    <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.1.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.11.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.11.2" />
+    <PackageVersion Include="Azure.Messaging.EventHubs.Processor" Version="5.11.2" />
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageVersion Include="Azure.Search.Documents" Version="11.5.1" />
-    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.17.4" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.17.1" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.38.1" />
-    <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.25.1" />
-    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.2" />
+    <PackageVersion Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.39.1" />
+    <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.25.2" />
+    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.3" />
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.Provisioning" Version="0.2.0" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="0.1.0" />
@@ -100,20 +100,20 @@
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.6.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.6.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.24.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />
-    <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.5" />
+    <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.6" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageVersion Include="NATS.Net" Version="2.2.1" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
-    <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.121" />
-    <PackageVersion Include="Polly.Core" Version="8.3.0" />
-    <PackageVersion Include="Polly.Extensions" Version="8.3.0" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.1" />
-    <PackageVersion Include="Qdrant.Client" Version="1.8.0" />
+    <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.21.140" />
+    <PackageVersion Include="Polly.Core" Version="8.3.1" />
+    <PackageVersion Include="Polly.Extensions" Version="8.3.1" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageVersion Include="Qdrant.Client" Version="1.9.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0.0)" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.7.27" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.7.33" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.1.0" />
     <!-- Open Telemetry -->


### PR DESCRIPTION
## Customer Impact

When customers depend on our components, they should get the latest versions of the underlying libraries that the components bring in.

## Testing

Automated tests passing in the repo.

## Risk

Low. Our components tests would catch if these new versions cause problems with our code. Most of these updates are already in `main`.

## Regression?
No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/3988)