### PR TITLE
[release/8.0] Remove `isReadOnly` argument from `WithDataVolume` and `WithDataBindMount`

### DIFF
--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -60,7 +60,7 @@ public static class OracleDatabaseBuilderExtensions
     /// <param name="name">The name of the volume. Defaults to an auto-generated name based on the application and resource names.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<OracleDatabaseServerResource> WithDataVolume(this IResourceBuilder<OracleDatabaseServerResource> builder, string? name = null)
-        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/opt/oracle/oradata", true);
+        => builder.WithVolume(name ?? VolumeNameGenerator.CreateVolumeName(builder, "data"), "/opt/oracle/oradata", false);
 
     /// <summary>
     /// Adds a bind mount for the data folder to a Oracle Database server container resource.
@@ -76,18 +76,16 @@ public static class OracleDatabaseBuilderExtensions
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>
-    /// <param name="isReadOnly">A flag that indicates if this is a read-only mount.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<OracleDatabaseServerResource> WithInitBindMount(this IResourceBuilder<OracleDatabaseServerResource> builder, string source, bool isReadOnly = true)
-        => builder.WithBindMount(source, "/opt/oracle/scripts/startup", isReadOnly);
+    public static IResourceBuilder<OracleDatabaseServerResource> WithInitBindMount(this IResourceBuilder<OracleDatabaseServerResource> builder, string source)
+        => builder.WithBindMount(source, "/opt/oracle/scripts/startup", false);
 
     /// <summary>
     /// Adds a bind mount for the database setup folder to a Oracle Database server container resource.
     /// </summary>
     /// <param name="builder">The resource builder.</param>
     /// <param name="source">The source directory on the host to mount into the container.</param>
-    /// <param name="isReadOnly">A flag that indicates if this is a read-only mount.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
-    public static IResourceBuilder<OracleDatabaseServerResource> WithDbSetupBindMount(this IResourceBuilder<OracleDatabaseServerResource> builder, string source, bool isReadOnly = true)
-        => builder.WithBindMount(source, "/opt/oracle/scripts/setup", isReadOnly);
+    public static IResourceBuilder<OracleDatabaseServerResource> WithDbSetupBindMount(this IResourceBuilder<OracleDatabaseServerResource> builder, string source)
+        => builder.WithBindMount(source, "/opt/oracle/scripts/setup", false);
 }

--- a/src/Aspire.Hosting.Oracle/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Oracle/PublicAPI.Unshipped.txt
@@ -1,0 +1,19 @@
+#nullable enable
+Aspire.Hosting.ApplicationModel.OracleDatabaseResource
+Aspire.Hosting.ApplicationModel.OracleDatabaseResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
+Aspire.Hosting.ApplicationModel.OracleDatabaseResource.DatabaseName.get -> string!
+Aspire.Hosting.ApplicationModel.OracleDatabaseResource.OracleDatabaseResource(string! name, string! databaseName, Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource! parent) -> void
+Aspire.Hosting.ApplicationModel.OracleDatabaseResource.Parent.get -> Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource.Databases.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource.OracleDatabaseServerResource(string! name, Aspire.Hosting.ApplicationModel.ParameterResource! password) -> void
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource.PasswordParameter.get -> Aspire.Hosting.ApplicationModel.ParameterResource!
+Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource.PrimaryEndpoint.get -> Aspire.Hosting.ApplicationModel.EndpointReference!
+Aspire.Hosting.OracleDatabaseBuilderExtensions
+static Aspire.Hosting.OracleDatabaseBuilderExtensions.AddDatabase(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>! builder, string! name, string? databaseName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseResource!>!
+static Aspire.Hosting.OracleDatabaseBuilderExtensions.AddOracle(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource!>? password = null, int? port = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>!
+static Aspire.Hosting.OracleDatabaseBuilderExtensions.WithDataBindMount(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>! builder, string! source) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>!
+static Aspire.Hosting.OracleDatabaseBuilderExtensions.WithDataVolume(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>! builder, string? name = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>!
+static Aspire.Hosting.OracleDatabaseBuilderExtensions.WithDbSetupBindMount(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>! builder, string! source) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>!
+static Aspire.Hosting.OracleDatabaseBuilderExtensions.WithInitBindMount(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>! builder, string! source) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.OracleDatabaseServerResource!>!


### PR DESCRIPTION
## Customer Impact

The `isReadOnly` flag was default to true. But even if it defaulted to `false` it still doesn't work with Oracle. Rather than expose an argument that doesn't work we removed it.

## Testing

The feature as it existed was not tested in the repo (because it didn't work). Existing test coverage passes though.

## Risk

Low. 

## Regression?
No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4001)