### PR TITLE
Fix safari column header heights

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -429,3 +429,14 @@ fluent-data-grid-cell.no-ellipsis {
 .endpoint-button::part(control) {
     padding: calc(((var(--design-unit) * 0.5) - var(--stroke-width)) * 1px) calc((var(--design-unit) - var(--stroke-width)) * 1px);
 }
+
+.column-header {
+    /*
+        fluent-data-grid-cells have a height of 100%, which should correspond to
+        the height of their parent fluent-data-grid-row.
+        On Safari only, this is not the case; height actually computes to the grid height.
+        We can force column headers to take the height of their parent by inheriting height
+        of their row.
+     */
+    height: inherit !important;
+}


### PR DESCRIPTION
Fixes #3958 

Taken from the comment I made in the css:

fluent-data-grid-cells have a height of 100%, which should correspond to the height of their parent fluent-data-grid-row.
On Safari only, this is not the case; height actually computes to the grid height (incorrectly). We can force column headers to take the height of their parent by inheriting the height of their row.

**Before, Safari**
<img width="1624" alt="image" src="https://github.com/dotnet/aspire/assets/20359921/e8f0dbe0-cff8-48e3-ae4a-d32d38bfb9d2">

**Before, Chrome/Edge**
<img width="1624" alt="image" src="https://github.com/dotnet/aspire/assets/20359921/5e7622a9-c0f5-46af-aa50-987dd8f21a5f">

**After, Safari**
<img width="1624" alt="image" src="https://github.com/dotnet/aspire/assets/20359921/df949d77-42c8-46de-9adc-0dee205da966">

**After, Chrome/Edge**
<img width="1624" alt="image" src="https://github.com/dotnet/aspire/assets/20359921/914b8127-9aa0-411b-a576-6d0224d8a36e">

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4013)