### PR TITLE
ServiceEndpoint.ToString() omit zero port

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Internal/ServiceEndpointImpl.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/Internal/ServiceEndpointImpl.cs
@@ -9,9 +9,13 @@ namespace Microsoft.Extensions.ServiceDiscovery.Internal;
 internal sealed class ServiceEndpointImpl(EndPoint endPoint, IFeatureCollection? features = null) : ServiceEndpoint
 {
     public override EndPoint EndPoint { get; } = endPoint;
+
     public override IFeatureCollection Features { get; } = features ?? new FeatureCollection();
+
     public override string? ToString() => EndPoint switch
     {
+        IPEndPoint ip when ip.Port == 0 => $"{ip.Address}",
+        DnsEndPoint dns when dns.Port == 0 => $"{dns.Host}",
         DnsEndPoint dns => $"{dns.Host}:{dns.Port}",
         _ => EndPoint.ToString()!
     };

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndpointTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ServiceEndpointTests.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using Xunit;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Tests;
+
+public class ServiceEndpointTests
+{
+    public static TheoryData<EndPoint> ZeroPortEndPoints => new()
+    {
+        IPEndPoint.Parse("127.0.0.1:0"),
+        new DnsEndPoint("microsoft.com", 0),
+        new UriEndPoint(new Uri("https://microsoft.com"))
+    };
+
+    public static TheoryData<EndPoint> NonZeroPortEndPoints => new()
+    {
+        IPEndPoint.Parse("127.0.0.1:8443"),
+        new DnsEndPoint("microsoft.com", 8443),
+        new UriEndPoint(new Uri("https://microsoft.com:8443"))
+    };
+
+    [Theory]
+    [MemberData(nameof(ZeroPortEndPoints))]
+    public void ServiceEndpointToStringOmitsUnspecifiedPort(EndPoint endpoint)
+    {
+        var serviceEndpoint = ServiceEndpoint.Create(endpoint);
+        var epString = serviceEndpoint.ToString();
+        Assert.DoesNotContain(":0", epString);
+    }
+
+    [Theory]
+    [MemberData(nameof(NonZeroPortEndPoints))]
+    public void ServiceEndpointToStringContainsSpecifiedPort(EndPoint endpoint)
+    {
+        var serviceEndpoint = ServiceEndpoint.Create(endpoint);
+        var epString = serviceEndpoint.ToString();
+        Assert.Contains(":8443", epString);
+    }
+}


### PR DESCRIPTION
When representing an endpoint as a string, it is better to omit a zero-value port than to include it. A value of zero means that the port was not specified by the provider and therefore the default value should be used. This is typical for DNS, since ports are not specified by DNS (excluding DNS SRV). This is required for YARP when using the DNS resolver.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4015)