### PR TITLE
[release/8.0] Support multiple deployments per cognitive service (#3448)

### DIFF
--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -53,6 +53,8 @@ public static class AzureOpenAIExtensions
 
             var resource = (AzureOpenAIResource)construct.Resource;
 
+            CognitiveServicesAccountDeployment? dependency = null;
+
             var cdkDeployments = new List<CognitiveServicesAccountDeployment>();
             foreach (var deployment in resource.Deployments)
             {
@@ -65,6 +67,17 @@ public static class AzureOpenAIExtensions
                 cdkDeployment.AssignProperty(x => x.Sku.Name, $"'{deployment.SkuName}'");
                 cdkDeployment.AssignProperty(x => x.Sku.Capacity, $"{deployment.SkuCapacity}");
                 cdkDeployments.Add(cdkDeployment);
+
+                // Subsequent deployments need an explicit dependency on the previous one
+                // to ensure they are not created in parallel. This is equivalent to @batchSize(1)
+                // which can't be defined with the CDK
+
+                if (dependency != null)
+                {
+                    cdkDeployment.AddDependency(dependency);
+                }
+
+                dependency = cdkDeployment;
             }
 
             var resourceBuilder = builder.CreateResourceBuilder(resource);


### PR DESCRIPTION
## Customer Impact

When customers try to deploy an Azure OpenAI resource with more than 1 "deployment" model (i.e. chat gpt and a text embedding), it fails during deploy:

```
Deployment Error Details:
RequestConflict: Another operation is being performed on the parent resource '/subscriptions/39efd248-7fd1-467e-9de3-cc501e6609d8/resourceGroups/rg-vslivechi2/providers/Microsoft.CognitiveServices/accounts/openaix6ts4xybeo5ws'. Please try again later.
```

This fixes the issue so multiple models can be deployed in 1 AppHost Azure OpenAI resource.

Note that multiple deployment models are used in [dotnet/eShop](https://github.com/dotnet/eShop/blob/792913070682da0ec107ec7b2c2da21e1c9a07a4/src/eShop.AppHost/Program.cs#L98-L100)

## Testing

Automated tests passing in the repo. I have manually run eshop with a local build and provisioning worked. Also verified `azd init/up` works correctly as well.

## Risk

Low to medium. The change tells Azure deployment that each deployment model is dependent on the previous, so they get deployed 1 at a time, which is how Azure OpenAI needs it to be.

## Regression?
Yes - when we moved from manual bicep to Azure Provisioning.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4022)