### PR TITLE
[release/8.0] Add configureContainer argument to WithPhpMyadmin. (#4030)

### DIFF
--- a/src/Aspire.Hosting.MySql/PhpMyAdminResource.cs
+++ b/src/Aspire.Hosting.MySql/PhpMyAdminResource.cs
@@ -4,9 +4,11 @@
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.MySql;
-internal sealed class PhpMyAdminContainerResource : ContainerResource
+
+/// <summary>
+/// Resource representing PhpMyAdmin container.
+/// </summary>
+/// <param name="name">Name of resource.</param>
+public sealed class PhpMyAdminContainerResource(string name) : ContainerResource(name)
 {
-    public PhpMyAdminContainerResource(string name) : base(name)
-    {
-    }
 }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -68,7 +68,7 @@ public static class PostgresBuilderExtensions
     /// Adds a pgAdmin 4 administration and development platform for PostgreSQL to the application model. This version the package defaults to the 8.3 tag of the dpage/pgadmin4 container image
     /// </summary>
     /// <param name="builder">The PostgreSQL server resource builder.</param>
-    /// <param name="configureContainer">Resource builder for the </param>
+    /// <param name="configureContainer">Callback to configure PgAdmin container resource.</param>
     /// <param name="containerName">The name of the container (Optional).</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<T> WithPgAdmin<T>(this IResourceBuilder<T> builder, Action<IResourceBuilder<PgAdminContainerResource>>? configureContainer = null, string? containerName = null) where T : PostgresServerResource

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -254,8 +254,8 @@ public class AddMySqlTests
     public void WithPhpMyAdminProducesValidServerConfigFile(string containerHost)
     {
         var builder = DistributedApplication.CreateBuilder();
-        var mysql1 = builder.AddMySql("mysql1").WithPhpMyAdmin(8081);
-        var mysql2 = builder.AddMySql("mysql2").WithPhpMyAdmin(8081);
+        var mysql1 = builder.AddMySql("mysql1").WithPhpMyAdmin(c => c.WithHostPort(8081));
+        var mysql2 = builder.AddMySql("mysql2").WithPhpMyAdmin(c => c.WithHostPort(8081));
 
         // Add fake allocated endpoints.
         mysql1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001, containerHost));


### PR DESCRIPTION
Backport of #4030 to release/8.0.

cc @mitchdenny 

## Customer Impact

The MySql admin container (phpmyadmin) hosting API doesn't follow the same pattern as the other admin hosting extensions (pgadin, redis commander, etc). The current pattern doesn't allow for a customer to change the image tag, or registry.

API fit and finish.

## Testing

Automated tests passing in the repo.

## Risk

Low. This only affects the MySql hosting library, and it just refactors the API. No functionality change.

## Regression?
No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4032)