### PR TITLE
Fix starter template CSS

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.Web/wwwroot/app.css
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.Web/wwwroot/app.css
@@ -1,4 +1,3 @@
-/*#if (SampleContent)*/
 html, body {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
@@ -21,7 +20,6 @@ a, .btn-link {
     padding-top: 1.1rem;
 }
 
-/*#endif*/
 h1:focus {
     outline: none;
 }


### PR DESCRIPTION
Looks like there was a small mistake in how the Blazor project was added in the Aspire Starter template.

Since there's no "include sample content" option, it seems that all the `if (SampleContent)` conditions were removed throughout all the source files. **But** it looks like the condition was accidentally left in the `app.css` file. And since the condition evaluates as false, this means some of the necessary CSS is missing from the generated project.

This results in using the wrong font and breaks some of the styling that's needed for accessibility. But it's an easy fix 😄 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4047)