### PR TITLE
Port translations from main (#4053)

### DIFF
--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Table tab</source>
-        <target state="translated">Graph. Para obtener una vista accesible, vaya a la pestaña Tabla.</target>
+        <target state="translated">Gráfico. Para obtener una vista accesible, vaya a la pestaña Tabla.</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -24,12 +24,12 @@
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Table tab</source>
-        <target state="translated">Graph. Si vous souhaitez obtenir un affichage accessible, veuillez accéder à l’onglet Tableau</target>
+        <target state="translated">Graphique. Si vous souhaitez obtenir un affichage accessible, veuillez accéder à l’onglet Tableau</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
         <source>Graph</source>
-        <target state="translated">Graph</target>
+        <target state="translated">Graphique</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerNoneSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -24,12 +24,12 @@
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Table tab</source>
-        <target state="translated">Wykres. Aby uzyskać dostępny widok, przejdź do karty Tabela</target>
+        <target state="translated">Graf. Aby uzyskać dostępny widok, przejdź do karty Tabela</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
         <source>Graph</source>
-        <target state="translated">Graph</target>
+        <target state="translated">Graf</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerNoneSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -24,12 +24,12 @@
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Table tab</source>
-        <target state="translated">Microsoft Azure Active Directory Graph. Para obter uma exibição acessível, navegue até a guia Tabela</target>
+        <target state="translated">Graph. Para obter uma exibição acessível, navegue até a guia Tabela</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
         <source>Graph</source>
-        <target state="translated">Microsoft Azure Active Directory Graph</target>
+        <target state="translated">Graph</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerNoneSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -24,12 +24,12 @@
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Table tab</source>
-        <target state="translated">График. Чтобы открыть представление с поддержкой специальных возможностей, перейдите на вкладку "Таблица"</target>
+        <target state="translated">Граф. Чтобы открыть представление с поддержкой специальных возможностей, перейдите на вкладку "Таблица"</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
         <source>Graph</source>
-        <target state="translated">График</target>
+        <target state="translated">Граф</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerNoneSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -24,12 +24,12 @@
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Table tab</source>
-        <target state="translated">Graph。有关可访问的视图，请导航到“表”选项卡</target>
+        <target state="translated">图。有关可访问的视图，请导航到“表”选项卡</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">
         <source>Graph</source>
-        <target state="translated">Graph</target>
+        <target state="translated">图</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerNoneSelected">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -24,7 +24,7 @@
       </trans-unit>
       <trans-unit id="ChartContainerGraphAccessibleLabel">
         <source>Graph. For an accessible view please navigate to the Table tab</source>
-        <target state="translated">圖表如需可存取的檢視，請瀏覽至 [資料表] 索引標籤</target>
+        <target state="translated">圖表。如需可存取的檢視，請前往 [資料表] 索引標籤</target>
         <note />
       </trans-unit>
       <trans-unit id="ChartContainerGraphTab">


### PR DESCRIPTION
This is part of https://github.com/dotnet/aspire/pull/3924 that seems correct (it's already in 8.0, where I got this from). But not all of that PR, which seems to have bugs eg dropping the term Aspire and reversing the localization of tr to English.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4068)