### PR TITLE
YARP: add special-case for localhost when setting Host value

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryDestinationResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryDestinationResolver.cs
@@ -55,7 +55,6 @@ internal sealed class ServiceDiscoveryDestinationResolver(ServiceEndpointResolve
         CancellationToken cancellationToken)
     {
         var originalUri = new Uri(originalConfig.Address);
-        var originalHost = originalConfig.Host is { Length: > 0 } h ? h : originalUri.Authority;
         var serviceName = originalUri.GetLeftPart(UriPartial.Authority);
 
         var result = await resolver.GetEndpointsAsync(serviceName, cancellationToken).ConfigureAwait(false);
@@ -90,7 +89,28 @@ internal sealed class ServiceDiscoveryDestinationResolver(ServiceEndpointResolve
             }
 
             var name = $"{originalName}[{addressString}]";
-            var config = originalConfig with { Host = originalHost, Address = resolvedAddress, Health = healthAddress };
+            string? resolvedHost;
+
+            // Use the configured 'Host' value if it is provided.
+            if (!string.IsNullOrEmpty(originalConfig.Host))
+            {
+                resolvedHost = originalConfig.Host;
+            }
+            else if (uri.IsLoopback)
+            {
+                // If there is no configured 'Host' value and the address resolves to localhost, do not set a host.
+                // This is to account for non-wildcard development certificate.
+                resolvedHost = null;
+            }
+            else
+            {
+                // Excerpt from RFC 9110 Section 7.2: The "Host" header field in a request provides the host and port information from the target URI [...]
+                // See: https://www.rfc-editor.org/rfc/rfc9110.html#field.host
+                // i.e, use Authority and not Host.
+                resolvedHost = originalUri.Authority;
+            }
+
+            var config = originalConfig with { Host = resolvedHost, Address = resolvedAddress, Health = healthAddress };
             results.Add((name, config));
         }
 


### PR DESCRIPTION
Fixes #3991

This special-cases the logic used by the YARP Service Discovery integration when an address resolves to localhost:

* If the service resolves to localhost, we *do not* set the Host property
* Add an option to opt-out and *always* respect YARP's Host value (null or not)

The core logic is this:

<details>
<summary>Original PR logic</summary>

```csharp
string? resolvedHost;
if (_yarpOptions.AlwaysUseConfiguredHostValue) // defaults to false
{
    // Always use the configured host value only.
    resolvedHost = originalConfig.Host;
}
else if (IsLocalhost(endpoint.EndPoint))
{
    // Suppress the host value for localhost
    resolvedHost = null;
}
else
{
    // Use the configured Host value if set and fall back to the authority from the input URI.
    resolvedHost = !string.IsNullOrWhiteSpace(originalConfig.Host) ? originalConfig.Host : originalUri.Authority;
}
```

</details>

```csharp
// Use the configured 'Host' value if it is provided.
if (!string.IsNullOrEmpty(originalConfig.Host))
{
    resolvedHost = originalConfig.Host;
}
else if (uri.IsLoopback)
{
    // If there is no configured 'Host' value and the address resolves to localhost, do not set a host.
    // This is to account for non-wildcard development certificate.
    resolvedHost = null;
}
else
{
    // Excerpt from RFC 9110 Section 7.2: The "Host" header field in a request provides the host and port information from the target URI [...]
    // See: https://www.rfc-editor.org/rfc/rfc9110.html#field.host
    // i.e, use Authority and not Host.
    resolvedHost = originalUri.Authority;
}
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4069)