### PR TITLE
Ensure endpoint names are unique to avoid failures later in execution.

### DIFF
--- a/src/Aspire.Hosting.Orleans/OrleansServiceClientExtensions.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansServiceClientExtensions.cs
@@ -21,7 +21,7 @@ public static class OrleansServiceClientExtensions
     public static IResourceBuilder<T> WithReference<T>(
         this IResourceBuilder<T> builder,
         OrleansServiceClient orleansServiceClient)
-        where T : IResourceWithEnvironment
+        where T : IResourceWithEnvironment, IResourceWithEndpoints
     {
         return builder.WithOrleansReference(orleansServiceClient.Service, isSilo: false);
     }

--- a/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
@@ -347,7 +347,7 @@ public static class OrleansServiceExtensions
     public static IResourceBuilder<T> WithReference<T>(
         this IResourceBuilder<T> builder,
         OrleansService orleansService)
-        where T : IResourceWithEnvironment
+        where T : IResourceWithEnvironment, IResourceWithEndpoints
     {
         return builder.WithOrleansReference(orleansService, isSilo: true);
     }
@@ -356,7 +356,7 @@ public static class OrleansServiceExtensions
         this IResourceBuilder<T> builder,
         OrleansService orleansService,
         bool isSilo)
-        where T : IResourceWithEnvironment
+        where T : IResourceWithEnvironment, IResourceWithEndpoints
     {
         var res = orleansService;
 

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -423,7 +423,7 @@ public static class ResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <exception cref="DistributedApplicationException">Throws an exception if an endpoint with the same name already exists on the specified resource.</exception>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "<Pending>")]
-    public static IResourceBuilder<T> WithEndpoint<T>(this IResourceBuilder<T> builder, int? port = null, int? targetPort = null, string? scheme = null, string? name = null, string? env = null, bool isProxied = true, bool? isExternal = null) where T : IResource
+    public static IResourceBuilder<T> WithEndpoint<T>(this IResourceBuilder<T> builder, int? port = null, int? targetPort = null, string? scheme = null, string? name = null, string? env = null, bool isProxied = true, bool? isExternal = null) where T : IResourceWithEndpoints
     {
         if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, name, StringComparisons.EndpointAnnotationName)))
         {
@@ -468,7 +468,7 @@ public static class ResourceBuilderExtensions
     /// <param name="isProxied">Specifies if the endpoint will be proxied by DCP. Defaults to true.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <exception cref="DistributedApplicationException">Throws an exception if an endpoint with the same name already exists on the specified resource.</exception>
-    public static IResourceBuilder<T> WithHttpEndpoint<T>(this IResourceBuilder<T> builder, int? port = null, int? targetPort = null, string? name = null, string? env = null, bool isProxied = true) where T : IResource
+    public static IResourceBuilder<T> WithHttpEndpoint<T>(this IResourceBuilder<T> builder, int? port = null, int? targetPort = null, string? name = null, string? env = null, bool isProxied = true) where T : IResourceWithEndpoints
     {
         return builder.WithEndpoint(targetPort: targetPort, port: port, scheme: "http", name: name, env: env, isProxied: isProxied);
     }
@@ -486,7 +486,7 @@ public static class ResourceBuilderExtensions
     /// <param name="isProxied">Specifies if the endpoint will be proxied by DCP. Defaults to true.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <exception cref="DistributedApplicationException">Throws an exception if an endpoint with the same name already exists on the specified resource.</exception>
-    public static IResourceBuilder<T> WithHttpsEndpoint<T>(this IResourceBuilder<T> builder, int? port = null, int? targetPort = null, string? name = null, string? env = null, bool isProxied = true) where T : IResource
+    public static IResourceBuilder<T> WithHttpsEndpoint<T>(this IResourceBuilder<T> builder, int? port = null, int? targetPort = null, string? name = null, string? env = null, bool isProxied = true) where T : IResourceWithEndpoints
     {
         return builder.WithEndpoint(targetPort: targetPort, port: port, scheme: "https", name: name, env: env, isProxied: isProxied);
     }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -436,7 +436,7 @@ public static class ResourceBuilderExtensions
 
         if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, annotation.Name, StringComparisons.EndpointAnnotationName)))
         {
-            throw new DistributedApplicationException($"Endpoint with name '{annotation.Name}' already exists");
+            throw new DistributedApplicationException($"Endpoint with name '{annotation.Name}' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp;). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking");
         }
 
         // Set the environment variable on the resource

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -436,7 +436,7 @@ public static class ResourceBuilderExtensions
 
         if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, annotation.Name, StringComparisons.EndpointAnnotationName)))
         {
-            throw new DistributedApplicationException($"Endpoint with name '{annotation.Name}' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp;). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking");
+            throw new DistributedApplicationException($"Endpoint with name '{annotation.Name}' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking");
         }
 
         // Set the environment variable on the resource

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -425,11 +425,6 @@ public static class ResourceBuilderExtensions
     [System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "<Pending>")]
     public static IResourceBuilder<T> WithEndpoint<T>(this IResourceBuilder<T> builder, int? port = null, int? targetPort = null, string? scheme = null, string? name = null, string? env = null, bool isProxied = true, bool? isExternal = null) where T : IResourceWithEndpoints
     {
-        if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, name, StringComparisons.EndpointAnnotationName)))
-        {
-            throw new DistributedApplicationException($"Endpoint with name '{name}' already exists");
-        }
-
         var annotation = new EndpointAnnotation(
             protocol: ProtocolType.Tcp,
             uriScheme: scheme,
@@ -438,6 +433,11 @@ public static class ResourceBuilderExtensions
             targetPort: targetPort,
             isExternal: isExternal,
             isProxied: isProxied);
+
+        if (builder.Resource.Annotations.OfType<EndpointAnnotation>().Any(sb => string.Equals(sb.Name, annotation.Name, StringComparisons.EndpointAnnotationName)))
+        {
+            throw new DistributedApplicationException($"Endpoint with name '{annotation.Name}' already exists");
+        }
 
         // Set the environment variable on the resource
         if (env is not null && builder.Resource is IResourceWithEndpoints resourceWithEndpoints and IResourceWithEnvironment)

--- a/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceNotificationTests.cs
@@ -149,7 +149,8 @@ public class ResourceNotificationTests
 
     private sealed class CustomResource(string name) : Resource(name),
         IResourceWithEnvironment,
-        IResourceWithConnectionString
+        IResourceWithConnectionString,
+        IResourceWithEndpoints
     {
         public ReferenceExpression ConnectionStringExpression =>
             ReferenceExpression.Create($"CustomConnectionString");

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -94,7 +94,7 @@ public class WithEndpointTests
                     .WithHttpsEndpoint(3000, 2000, name: "mybinding");
         });
 
-        Assert.Equal("Endpoint with name 'mybinding' already exists", ex.Message);
+        Assert.Equal("Endpoint with name 'mybinding' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp;). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class WithEndpointTests
                     .WithHttpsEndpoint(3000, 2000);
         });
 
-        Assert.Equal("Endpoint with name 'https' already exists", ex.Message);
+        Assert.Equal("Endpoint with name 'https' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp;). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class WithEndpointTests
                    .WithHttpsEndpoint(2000, name: "mybinding");
         });
 
-        Assert.Equal("Endpoint with name 'mybinding' already exists", ex.Message);
+        Assert.Equal("Endpoint with name 'mybinding' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp;). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -94,7 +94,7 @@ public class WithEndpointTests
                     .WithHttpsEndpoint(3000, 2000, name: "mybinding");
         });
 
-        Assert.Equal("Endpoint with name 'mybinding' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp;). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
+        Assert.Equal("Endpoint with name 'mybinding' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
     }
 
     [Fact]
@@ -109,7 +109,7 @@ public class WithEndpointTests
                     .WithHttpsEndpoint(3000, 2000);
         });
 
-        Assert.Equal("Endpoint with name 'https' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp;). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
+        Assert.Equal("Endpoint with name 'https' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class WithEndpointTests
                    .WithHttpsEndpoint(2000, name: "mybinding");
         });
 
-        Assert.Equal("Endpoint with name 'mybinding' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp;). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
+        Assert.Equal("Endpoint with name 'mybinding' already exists. Endpoint name may not have been explicitly specified and was derived automatically from scheme argument (e.g. 'http', 'https', or 'tcp'). Multiple calls to WithEndpoint (and related methods) may result in a conflict if name argument is not specified. Each endpoint must have a unique name. For more information on networking in .NET Aspire see: https://aka.ms/dotnet/aspire/networking", ex.Message);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -98,6 +98,21 @@ public class WithEndpointTests
     }
 
     [Fact]
+    public void AddingTwoEndpointsWithDefaultNames()
+    {
+        var ex = Assert.Throws<DistributedApplicationException>(() =>
+        {
+            using var builder = TestDistributedApplicationBuilder.Create();
+
+            builder.AddProject<ProjectA>("projecta")
+                    .WithHttpsEndpoint(3000, 1000)
+                    .WithHttpsEndpoint(3000, 2000);
+        });
+
+        Assert.Equal("Endpoint with name 'https' already exists", ex.Message);
+    }
+
+    [Fact]
     public void EndpointsWithSinglePortSameNameThrows()
     {
         var ex = Assert.Throws<DistributedApplicationException>(() =>


### PR DESCRIPTION
Builds upon changes in #4064 

Moves the uniqueness check until after the endpoint is constructed and name is derived (to share the various bits of fallback logic).

Added a test case to cover this.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4071)