### PR TITLE
Check for Dapr CLI on PATH

### DIFF
--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -294,26 +294,31 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
             {
                 if (_defaultDaprPath is null)
                 {
-                    var process = Process.Start(
-                        new ProcessStartInfo
-                        {
-                            Arguments = "version",
-                            CreateNoWindow = true,
-                            FileName = "dapr",
-                            UseShellExecute = true,
-                            WindowStyle = ProcessWindowStyle.Hidden
-                        });
+                    Process? process = null;
 
-                    if (process is null)
+                    try
                     {
-                        throw new InvalidOperationException("Unable to determine if Dapr is in the path.");
+                        process = Process.Start(
+                            new ProcessStartInfo
+                            {
+                                Arguments = "version",
+                                CreateNoWindow = true,
+                                FileName = "dapr",
+                                UseShellExecute = true,
+                                WindowStyle = ProcessWindowStyle.Hidden
+                            });
+
+                        if (process is not null)
+                        {
+                            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                    catch
+                    {
                     }
 
-                    await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-
-                    if (process.ExitCode == 0)
+                    if (process?.ExitCode == 0)
                     {
-                        // TODO: "dapr.exe" on Windows?
                         _defaultDaprPath = "dapr";
 
                         _logger.LogInformation("Dapr CLI found in the path.");


### PR DESCRIPTION
Currently the Dapr CLI is looked for at several very specific locations, depending on the platform. With this change, Aspire will default to the Dapr CLI found on PATH, if any. If none is found, falls back to one of those specific locations.

Resolves #2219
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4081)