### PR TITLE
Remove Prometheus commented out code that does not work

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
@@ -9,6 +9,9 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
+// Adds common Aspire services: service discovery, resilience, health checks and OpenTelemetry
+// This project should be referenced by each .NET Aspire service project in your solution
+// To learn more about using this project see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 namespace Microsoft.Extensions.Hosting;
 
 // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
-// This project should be referenced by each .NET Aspire service project in your solution.
+// This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
@@ -9,7 +9,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common Aspire services: service discovery, resilience, health checks and OpenTelemetry
+// Adds common .NET Aspire services: service discovery, resilience, health checks and OpenTelemetry
 // This project should be referenced by each .NET Aspire service project in your solution
 // To learn more about using this project see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
@@ -68,10 +68,6 @@ public static class Extensions
             builder.Services.AddOpenTelemetry().UseOtlpExporter();
         }
 
-        // Uncomment the following lines to enable the Prometheus exporter (requires the OpenTelemetry.Exporter.Prometheus.AspNetCore package)
-        // builder.Services.AddOpenTelemetry()
-        //    .WithMetrics(metrics => metrics.AddPrometheusExporter());
-
         // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
         //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
         //{
@@ -105,9 +101,6 @@ public static class Extensions
             {
                 Predicate = r => r.Tags.Contains("live")
             });
-
-            // Uncomment the following line to enable the Prometheus endpoint (requires the OpenTelemetry.Exporter.Prometheus.AspNetCore package)
-            // app.MapPrometheusScrapingEndpoint();
         }
 
         return app;

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.ServiceDefaults/Extensions.cs
@@ -9,9 +9,9 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks and OpenTelemetry
-// This project should be referenced by each .NET Aspire service project in your solution
-// To learn more about using this project see https://aka.ms/dotnet/aspire/service-defaults
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each .NET Aspire service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
@@ -75,10 +75,6 @@ public static class Extensions
             builder.Services.AddOpenTelemetry().UseOtlpExporter();
         }
 
-        // Uncomment the following lines to enable the Prometheus exporter (requires the OpenTelemetry.Exporter.Prometheus.AspNetCore package)
-        // builder.Services.AddOpenTelemetry()
-        //    .WithMetrics(metrics => metrics.AddPrometheusExporter());
-
         // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
         //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
         //{
@@ -100,9 +96,6 @@ public static class Extensions
 
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
-        // Uncomment the following line to enable the Prometheus endpoint (requires the OpenTelemetry.Exporter.Prometheus.AspNetCore package)
-        // app.MapPrometheusScrapingEndpoint();
-
         // Adding health checks endpoints to applications in non-development environments has security implications.
         // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
         if (app.Environment.IsDevelopment())

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
@@ -10,9 +10,9 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks and OpenTelemetry
-// This project should be referenced by each .NET Aspire service project in your solution
-// To learn more about using this project see https://aka.ms/dotnet/aspire/service-defaults
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each .NET Aspire service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
@@ -10,6 +10,9 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
+// Adds common Aspire services: service discovery, resilience, health checks and OpenTelemetry
+// This project should be referenced by each .NET Aspire service project in your solution
+// To learn more about using this project see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
@@ -11,7 +11,7 @@ using OpenTelemetry.Trace;
 namespace Microsoft.Extensions.Hosting;
 
 // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
-// This project should be referenced by each .NET Aspire service project in your solution.
+// This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common Aspire services: service discovery, resilience, health checks and OpenTelemetry
+// Adds common .NET Aspire services: service discovery, resilience, health checks and OpenTelemetry
 // This project should be referenced by each .NET Aspire service project in your solution
 // To learn more about using this project see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
@@ -9,6 +9,9 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
+// Adds common Aspire services: service discovery, resilience, health checks and OpenTelemetry
+// This project should be referenced by each .NET Aspire service project in your solution
+// To learn more about using this project see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 namespace Microsoft.Extensions.Hosting;
 
 // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
-// This project should be referenced by each .NET Aspire service project in your solution.
+// This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
@@ -68,10 +68,6 @@ public static class Extensions
             builder.Services.AddOpenTelemetry().UseOtlpExporter();
         }
 
-        // Uncomment the following lines to enable the Prometheus exporter (requires the OpenTelemetry.Exporter.Prometheus.AspNetCore package)
-        // builder.Services.AddOpenTelemetry()
-        //    .WithMetrics(metrics => metrics.AddPrometheusExporter());
-
         // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
         //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
         //{
@@ -93,9 +89,6 @@ public static class Extensions
 
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
-        // Uncomment the following line to enable the Prometheus endpoint (requires the OpenTelemetry.Exporter.Prometheus.AspNetCore package)
-        // app.MapPrometheusScrapingEndpoint();
-
         // Adding health checks endpoints to applications in non-development environments has security implications.
         // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
         if (app.Environment.IsDevelopment())

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
@@ -9,7 +9,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common Aspire services: service discovery, resilience, health checks and OpenTelemetry
+// Adds common .NET Aspire services: service discovery, resilience, health checks and OpenTelemetry
 // This project should be referenced by each .NET Aspire service project in your solution
 // To learn more about using this project see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/AspireStarterApplication.1.ServiceDefaults/Extensions.cs
@@ -9,9 +9,9 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks and OpenTelemetry
-// This project should be referenced by each .NET Aspire service project in your solution
-// To learn more about using this project see https://aka.ms/dotnet/aspire/service-defaults
+// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// This project should be referenced by each .NET Aspire service project in your solution.
+// To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions
 {
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)


### PR DESCRIPTION
As discussed this morning and logged in https://github.com/dotnet/aspire/issues/4092, removing Prometheus commented out code from the templates given it doesn't currently worked becase of https://github.com/open-telemetry/opentelemetry-dotnet-contrib/issues/1617

There are still some of these lines in the playground and test aspire projects in the repo, but limiting the changes here to only the templates.

cc: @DamianEdwards, @samsp-msft 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4096)