### PR TITLE
[release/8.0][tests] Restrict Microsoft.Extensions.ServiceDiscovery nugets to be restored only from built-nugets

### DIFF
--- a/tests/Shared/Aspire.Workload.Testing.targets
+++ b/tests/Shared/Aspire.Workload.Testing.targets
@@ -127,7 +127,8 @@
           packageSourceMapping.FirstNode.AddBeforeSelf(
             new XElement("packageSource",
               new XAttribute("key", "nuget-local"),
-              new XElement("package", new XAttribute("pattern", "*Aspire*"))));
+              new XElement("package", new XAttribute("pattern", "*Aspire*")),
+              new XElement("package", new XAttribute("pattern", "Microsoft.Extensions.ServiceDiscovery*"))));
 
           doc.Save(OutputFile);
           Log.LogMessage(MessageImportance.Low, $"Generated patched nuget.config at {OutputFile}");


### PR DESCRIPTION
…estored only from built-nugets
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4097)