### PR TITLE
Make username parameter always be injected.

### DIFF
--- a/src/Aspire.Hosting.PostgreSQL/PgAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PgAdminConfigWriterHook.cs
@@ -37,7 +37,7 @@ internal sealed class PgAdminConfigWriterHook : IDistributedApplicationLifecycle
                 writer.WriteString("Group", "Servers");
                 writer.WriteString("Host", endpoint.ContainerHost);
                 writer.WriteNumber("Port", endpoint.Port);
-                writer.WriteString("Username", "postgres");
+                writer.WriteString("Username", $"{postgresInstance.UserNameParameter.Value}");
                 writer.WriteString("SSLMode", "prefer");
                 writer.WriteString("MaintenanceDB", "postgres");
                 writer.WriteString("PasswordExecCommand", $"echo '{postgresInstance.PasswordParameter.Value}'"); // HACK: Generating a pass file and playing around with chmod is too painful.

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -31,9 +31,10 @@ public static class PostgresBuilderExtensions
         IResourceBuilder<ParameterResource>? password = null,
         int? port = null)
     {
+        var userNameParameter = userName?.Resource ?? new ParameterResource($"{name}-username", (p) => "postgres");
         var passwordParameter = password?.Resource ?? ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, $"{name}-password");
 
-        var postgresServer = new PostgresServerResource(name, userName?.Resource, passwordParameter);
+        var postgresServer = new PostgresServerResource(name, userNameParameter, passwordParameter);
         return builder.AddResource(postgresServer)
                       .WithEndpoint(port: port, targetPort: 5432, name: PostgresServerResource.PrimaryEndpointName) // Internal port is always 5432.
                       .WithImage(PostgresContainerImageTags.Image, PostgresContainerImageTags.Tag)

--- a/src/Aspire.Hosting.PostgreSQL/PostgresServerResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresServerResource.cs
@@ -19,6 +19,7 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
     /// <param name="password">A parameter that contains the PostgreSQL server password.</param>
     public PostgresServerResource(string name, ParameterResource userName, ParameterResource password) : base(name)
     {
+        ArgumentNullException.ThrowIfNull(userName);
         ArgumentNullException.ThrowIfNull(password);
 
         PrimaryEndpoint = new(this, PrimaryEndpointName);

--- a/src/Aspire.Hosting.PostgreSQL/PostgresServerResource.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresServerResource.cs
@@ -17,7 +17,7 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
     /// <param name="name">The name of the resource.</param>
     /// <param name="userName">A parameter that contains the PostgreSQL server user name, or <see langword="null"/> to use a default value.</param>
     /// <param name="password">A parameter that contains the PostgreSQL server password.</param>
-    public PostgresServerResource(string name, ParameterResource? userName, ParameterResource password) : base(name)
+    public PostgresServerResource(string name, ParameterResource userName, ParameterResource password) : base(name)
     {
         ArgumentNullException.ThrowIfNull(password);
 
@@ -34,7 +34,7 @@ public class PostgresServerResource : ContainerResource, IResourceWithConnection
     /// <summary>
     /// Gets the parameter that contains the PostgreSQL server user name.
     /// </summary>
-    public ParameterResource? UserNameParameter { get; }
+    public ParameterResource UserNameParameter { get; }
 
     internal ReferenceExpression UserNameReference =>
         UserNameParameter is not null ?

--- a/src/Aspire.Hosting.PostgreSQL/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.PostgreSQL/PublicAPI.Unshipped.txt
@@ -9,9 +9,9 @@ Aspire.Hosting.ApplicationModel.PostgresServerResource.ConnectionStringExpressio
 Aspire.Hosting.ApplicationModel.PostgresServerResource.Databases.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
 Aspire.Hosting.ApplicationModel.PostgresServerResource.GetConnectionStringAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<string?>
 Aspire.Hosting.ApplicationModel.PostgresServerResource.PasswordParameter.get -> Aspire.Hosting.ApplicationModel.ParameterResource!
-Aspire.Hosting.ApplicationModel.PostgresServerResource.PostgresServerResource(string! name, Aspire.Hosting.ApplicationModel.ParameterResource? userName, Aspire.Hosting.ApplicationModel.ParameterResource! password) -> void
+Aspire.Hosting.ApplicationModel.PostgresServerResource.PostgresServerResource(string! name, Aspire.Hosting.ApplicationModel.ParameterResource! userName, Aspire.Hosting.ApplicationModel.ParameterResource! password) -> void
 Aspire.Hosting.ApplicationModel.PostgresServerResource.PrimaryEndpoint.get -> Aspire.Hosting.ApplicationModel.EndpointReference!
-Aspire.Hosting.ApplicationModel.PostgresServerResource.UserNameParameter.get -> Aspire.Hosting.ApplicationModel.ParameterResource?
+Aspire.Hosting.ApplicationModel.PostgresServerResource.UserNameParameter.get -> Aspire.Hosting.ApplicationModel.ParameterResource!
 Aspire.Hosting.Postgres.PgAdminContainerResource
 Aspire.Hosting.Postgres.PgAdminContainerResource.PgAdminContainerResource(string! name) -> void
 Aspire.Hosting.PostgresBuilderExtensions

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -580,12 +580,12 @@ public class ManifestGenerationTests
                 },
                 "postgres": {
                   "type": "container.v0",
-                  "connectionString": "Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres-password.value}",
+                  "connectionString": "Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username={postgres-username.value};Password={postgres-password.value}",
                   "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
                   "env": {
                     "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
                     "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
-                    "POSTGRES_USER": "postgres",
+                    "POSTGRES_USER": "{postgres-username.value}",
                     "POSTGRES_PASSWORD": "{postgres-password.value}",
                     "POSTGRES_DB": "postgresdb"
                   },
@@ -718,6 +718,15 @@ public class ManifestGenerationTests
                           "minLength": 22
                         }
                       }
+                    }
+                  }
+                },
+                "postgres-username": {
+                  "type": "parameter.v0",
+                  "value": "{postgres-username.inputs.value}",
+                  "inputs": {
+                    "value": {
+                      "type": "string"
                     }
                   }
                 },

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -130,8 +130,8 @@ public class AddPostgresTests
         var connectionStringResource = postgres.Resource as IResourceWithConnectionString;
 
         var connectionString = await connectionStringResource.GetConnectionStringAsync();
-        Assert.Equal("Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres-password.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal($"Host=localhost;Port=2000;Username=postgres;Password={postgres.Resource.PasswordParameter.Value}", connectionString);
+        Assert.Equal("Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username={postgres-username.value};Password={postgres-password.value}", connectionStringResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal($"Host=localhost;Port=2000;Username={postgres.Resource.UserNameParameter.Value};Password={postgres.Resource.PasswordParameter.Value}", connectionString);
     }
 
     [Fact]
@@ -225,12 +225,12 @@ public class AddPostgresTests
         var expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "Host={pg.bindings.tcp.host};Port={pg.bindings.tcp.port};Username=postgres;Password={pg-password.value}",
+              "connectionString": "Host={pg.bindings.tcp.host};Port={pg.bindings.tcp.port};Username={pg-username.value};Password={pg-password.value}",
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
                 "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
-                "POSTGRES_USER": "postgres",
+                "POSTGRES_USER": "{pg-username.value}",
                 "POSTGRES_PASSWORD": "{pg-password.value}"
               },
               "bindings": {
@@ -320,12 +320,12 @@ public class AddPostgresTests
         expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "Host={pg3.bindings.tcp.host};Port={pg3.bindings.tcp.port};Username=postgres;Password={pass.value}",
+              "connectionString": "Host={pg3.bindings.tcp.host};Port={pg3.bindings.tcp.port};Username={pg3-username.value};Password={pass.value}",
               "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
               "env": {
                 "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
                 "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
-                "POSTGRES_USER": "postgres",
+                "POSTGRES_USER": "{pg3-username.value}",
                 "POSTGRES_PASSWORD": "{pass.value}"
               },
               "bindings": {


### PR DESCRIPTION
Fixes #4100 and #4099

This PR does a few things:

1. Changes the PgAdmin config writer hook to use the password from `UserNameParameter` on the Postgres server resource.
2. Changes the `UserNameParameter` on the postgres server resource to be non-nullable and adjust in the constructor as well.

The reason for this change is that if you want to use the Postgres database resource from a container that is not built around .NET, the connection string format that the resource exposes won't necessarily be in the format that you want. For that reason you want to be able to get at the username and password parameters and know that they are always there. The password parameter is fine, but the fact that the username parameter is optional is problematic and makes consuming code more complex.

This represents a breaking change ... see unshipped API diff.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4102)