### PR TITLE
Fix starter template's http launch profile

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/Properties/launchSettings.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/Properties/launchSettings.json
@@ -24,7 +24,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19000",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20000"
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20000",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     }
   }


### PR DESCRIPTION
The aspire sample template currently ships with a broken http launch profile.  Running the template `dotnet run --launch-profile http` results in an error.

```
The 'applicationUrl' setting must be an https address unless the 'ASPIRE_ALLOW_UNSECURED_TRANSPORT' environment variable is set to true. This configuration is commonly set in the launch profile. See https://aka.ms/dotnet/aspire/allowunsecuredtransport for more details
```

This PR fixes this by specifying the `ASPIRE_ALLOW_UNSECURED_TRANSPORT` by default to make this work.

An alternative solution could be to remove the `http` profile completely as it feels wrong to ship with a profile that is broken by default.  
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4141)