### PR TITLE
Removing constraint from templates to avoid SDK multithreading issue

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/.template.config/template.json
@@ -23,12 +23,6 @@
   "guids": [
     "98048C9C-BF28-46BA-A98E-63767EE5E3A8"
   ],
-  "constraints": {
-    "aspire": {
-      "type": "workload",
-      "args": [ "aspire" ]
-    }
-  },
   "symbols": {
     "Framework": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -43,12 +43,6 @@
       ]
     }
   ],
-  "constraints": {
-    "aspire": {
-      "type": "workload",
-      "args": [ "aspire" ]
-    }
-  },
   "symbols": {
     "Framework": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -25,12 +25,6 @@
   "identity": "Aspire.Tests.MSTest.CSharp.8.0",
   "thirdPartyNotices": "https://aka.ms/dotnet/aspire/8.0-third-party-notices",
   "groupIdentity": "Aspire.Tests.MSTest",
-  "constraints": {
-    "aspire": {
-      "type": "workload",
-      "args": [ "aspire" ]
-    }
-  },
   "symbols": {
     "Framework": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -25,12 +25,6 @@
   "identity": "Aspire.Tests.NUnit.CSharp.8.0",
   "thirdPartyNotices": "https://aka.ms/dotnet/aspire/8.0-third-party-notices",
   "groupIdentity": "Aspire.Tests.NUnit",
-  "constraints": {
-    "aspire": {
-      "type": "workload",
-      "args": [ "aspire" ]
-    }
-  },
   "symbols": {
     "Framework": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/.template.config/template.json
@@ -24,12 +24,6 @@
   "identity": "Aspire.ServiceDefaults.CSharp.8.0",
   "thirdPartyNotices": "https://aka.ms/dotnet/aspire/8.0-third-party-notices",
   "groupIdentity": "Aspire.ServiceDefaults",
-  "constraints": {
-    "aspire": {
-      "type": "workload",
-      "args": [ "aspire" ]
-    }
-  },
   "symbols": {
     "Framework": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -53,12 +53,6 @@
       ]
     }
   ],
-  "constraints": {
-    "aspire": {
-      "type": "workload",
-      "args": [ "aspire" ]
-    }
-  },
   "symbols": {
     "Framework": {
       "type": "parameter",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -25,12 +25,6 @@
   "identity": "Aspire.Tests.xUnit.CSharp.8.0",
   "thirdPartyNotices": "https://aka.ms/dotnet/aspire/8.0-third-party-notices",
   "groupIdentity": "Aspire.Tests.xUnit",
-  "constraints": {
-    "aspire": {
-      "type": "workload",
-      "args": [ "aspire" ]
-    }
-  },
   "symbols": {
     "Framework": {
       "type": "parameter",


### PR DESCRIPTION
Works around https://github.com/dotnet/aspire/issues/4145.

@dsplaisted has done a full diagnosis of the issue [here](https://github.com/dotnet/templating/issues/7946#issuecomment-2108853692), but the TL;DR is that there seems to be a multi-threading issue inside the SDK, particularly in their logic that tries to check for installed workloads. Aspire templates today have a constraint to show these templates only when the aspire workload is installed, which is technically unrequired as the templates get installed via the workload anyway. By adding this constraint, we are forcing the piece of code in the SDK with the race condition, which will make it so that around 50% of the time, aspire template creation will fail. The SDK team will fix this bug in servicing, but in the meantime we are working around the bug by removing the unnecessary constraint from our templates.

We expect a lot of people will hit this issue (essentially anyone creating aspire projects from the command line), so we'll want to service this to 8.0.1 release. (FYI: @danmoseley )


cc: @DamianEdwards @phenning 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4176)