### PR TITLE
Set read permissions to allow pgadmin container to read the generated config file

### DIFF
--- a/src/Aspire.Hosting.PostgreSQL/PgAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PgAdminConfigWriterHook.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
@@ -22,7 +21,7 @@ internal sealed class PgAdminConfigWriterHook : IDistributedApplicationLifecycle
         using var stream = new FileStream(serverFileMount.Source!, FileMode.Create);
         using var writer = new Utf8JsonWriter(stream);
         // Need to grant read access to the config file on unix like systems.
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        if (!OperatingSystem.IsWindows())
         {
             File.SetUnixFileMode(serverFileMount.Source!, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
         }

--- a/src/Aspire.Hosting.PostgreSQL/PgAdminConfigWriterHook.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PgAdminConfigWriterHook.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
@@ -20,6 +21,11 @@ internal sealed class PgAdminConfigWriterHook : IDistributedApplicationLifecycle
 
         using var stream = new FileStream(serverFileMount.Source!, FileMode.Create);
         using var writer = new Utf8JsonWriter(stream);
+        // Need to grant read access to the config file on unix like systems.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            File.SetUnixFileMode(serverFileMount.Source!, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        }
 
         var serverIndex = 1;
 


### PR DESCRIPTION
Grants read permissions to the generated pgadmin config file on unix systems such that it can be read by the user that runs in the container which may not match the local user ID.

![image](https://github.com/dotnet/aspire/assets/50252651/24402d03-b467-4a3e-80c9-8ced1af18ba8)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4191)