### PR TITLE
Register a custom container host bind entry for Aspire containers

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -95,7 +95,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
     private readonly Channel<LogInformationEntry> _logInformationChannel = Channel.CreateUnbounded<LogInformationEntry>(
         new UnboundedChannelOptions { SingleReader = true });
 
-    private string DefaultContainerHostName => configuration["AppHost:ContainerHostname"] ?? _dcpInfo?.Containers?.ContainerHostName ?? "host.docker.internal";
+    private string DefaultContainerHostName => configuration["AppHost:ContainerHostname"] ?? "host.aspire.internal";
 
     public async Task RunApplicationAsync(CancellationToken cancellationToken = default)
     {
@@ -1481,11 +1481,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             }
         }
 
+        dcpContainerResource.Spec.RunArgs ??= [];
+
         // Apply optional extra arguments to the container run command.
         if (modelContainerResource.TryGetAnnotationsOfType<ContainerRuntimeArgsCallbackAnnotation>(out var runArgsCallback))
         {
-            dcpContainerResource.Spec.RunArgs ??= [];
-
             var args = new List<object>();
 
             var containerRunArgsContext = new ContainerRuntimeArgsCallbackContext(args, cancellationToken);
@@ -1511,6 +1511,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 }
             }
         }
+
+        dcpContainerResource.Spec.RunArgs.Add("--add-host=host.aspire.internal:host-gateway");
 
         var failedToApplyArgs = false;
         if (modelContainerResource.TryGetAnnotationsOfType<CommandLineArgsCallbackAnnotation>(out var argsCallback))

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -226,7 +226,7 @@ public class DistributedApplicationTests
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         testProgram.AppBuilder.AddContainer("redis-cli", "redis")
-            .WithArgs("redis-cli", "-h", "host.docker.internal", "-p", "9999", "MONITOR")
+            .WithArgs("redis-cli", "-h", "host.aspire.internal", "-p", "9999", "MONITOR")
             .WithContainerRuntimeArgs("--add-host", "testlocalhost:127.0.0.1");
 
         await using var app = testProgram.Build();
@@ -240,7 +240,7 @@ public class DistributedApplicationTests
             item =>
             {
                 Assert.Equal("redis:latest", item.Spec.Image);
-                Assert.Equal(["redis-cli", "-h", "host.docker.internal", "-p", "9999", "MONITOR"], item.Spec.Args);
+                Assert.Equal(["redis-cli", "-h", "host.aspire.internal", "-p", "9999", "MONITOR"], item.Spec.Args);
                 Assert.Equal(["--add-host", "testlocalhost:127.0.0.1"], item.Spec.RunArgs);
             });
 

--- a/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
+++ b/tests/Aspire.Hosting.Tests/MongoDB/AddMongoDBTests.cs
@@ -135,6 +135,7 @@ public class AddMongoDBTests
     }
 
     [Theory]
+    [InlineData("host.aspire.internal")]
     [InlineData("host.docker.internal")]
     [InlineData("host.containers.internal")]
     public async Task WithMongoExpressUsesContainerHost(string containerHost)

--- a/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.Tests/MySql/AddMySqlTests.cs
@@ -211,6 +211,7 @@ public class AddMySqlTests
     }
 
     [Theory]
+    [InlineData("host.aspire.internal")]
     [InlineData("host.docker.internal")]
     [InlineData("host.containers.internal")]
     public async Task SingleMySqlInstanceProducesCorrectMySqlHostsVariable(string containerHost)
@@ -249,6 +250,7 @@ public class AddMySqlTests
     }
 
     [Theory]
+    [InlineData("host.aspire.internal")]
     [InlineData("host.docker.internal")]
     [InlineData("host.containers.internal")]
     public void WithPhpMyAdminProducesValidServerConfigFile(string containerHost)

--- a/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.Tests/Postgres/AddPostgresTests.cs
@@ -378,6 +378,7 @@ public class AddPostgresTests
     }
 
     [Theory]
+    [InlineData("host.aspire.internal")]
     [InlineData("host.docker.internal")]
     [InlineData("host.containers.internal")]
     public void WithPostgresProducesValidServersJsonFile(string containerHost)

--- a/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Tests/Redis/AddRedisTests.cs
@@ -152,6 +152,7 @@ public class AddRedisTests
     }
 
     [Theory]
+    [InlineData("host.aspire.internal")]
     [InlineData("host.docker.internal")]
     [InlineData("host.containers.internal")]
     public async Task SingleRedisInstanceProducesCorrectRedisHostsVariable(string containerHost)
@@ -175,6 +176,7 @@ public class AddRedisTests
     }
 
     [Theory]
+    [InlineData("host.aspire.internal")]
     [InlineData("host.docker.internal")]
     [InlineData("host.containers.internal")]
     public async Task MultipleRedisInstanceProducesCorrectRedisHostsVariable(string containerHost)


### PR DESCRIPTION
Rather than depending on `host.docker.internal` or `host.podman.internal` (which may not even be present in all containers), Aspire can bind its own custom domain to refer to the local host machine from the container. This change adds a new `host.aspire.internal` entry to containers created by Aspire and updates our default hostname logic to use that, regardless of the specific container runtime.

I've tested this with Docker Desktop and Podman Desktop and everything continues to work as expected (including `host.docker.internal` on Docker Desktop and `host.containers.internal` on Podman). The command being used is supported on `docker-ce` as well, so this should work for Linux users who wouldn't otherwise have a `host.docker.internal` entry.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4192)