### PR TITLE
Add support for endpoints defined in Kestrel config

### DIFF
--- a/playground/TestShop/BasketService/appsettings.json
+++ b/playground/TestShop/BasketService/appsettings.json
@@ -10,6 +10,9 @@
   "Kestrel": {
     "EndpointDefaults": {
       "Protocols": "Http2"
+    },
+    "Endpoints": {
+      "Foo": { "Url": "http://*:5002" }
     }
   },
   "Aspire": {

--- a/playground/TestShop/BasketService/appsettings.json
+++ b/playground/TestShop/BasketService/appsettings.json
@@ -10,9 +10,6 @@
   "Kestrel": {
     "EndpointDefaults": {
       "Protocols": "Http2"
-    },
-    "Endpoints": {
-      "Foo": { "Url": "http://*:5002" }
     }
   },
   "Aspire": {

--- a/src/Aspire.Hosting/IProjectMetadata.cs
+++ b/src/Aspire.Hosting/IProjectMetadata.cs
@@ -19,7 +19,7 @@ public interface IProjectMetadata : IResourceAnnotation
 
     // These are for testing
     internal LaunchSettings? LaunchSettings => null;
-    internal IConfiguration? KestrelConfiguration => null;
+    internal IConfiguration? Configuration => null;
 }
 
 [DebuggerDisplay("Type = {GetType().Name,nq}, ProjectPath = {ProjectPath}")]

--- a/src/Aspire.Hosting/IProjectMetadata.cs
+++ b/src/Aspire.Hosting/IProjectMetadata.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Configuration;
 
 namespace Aspire.Hosting;
 
@@ -16,8 +17,9 @@ public interface IProjectMetadata : IResourceAnnotation
     /// </summary>
     public string ProjectPath { get; }
 
-    // This is for testing
+    // These are for testing
     internal LaunchSettings? LaunchSettings => null;
+    internal IConfiguration? KestrelConfiguration => null;
 }
 
 [DebuggerDisplay("Type = {GetType().Name,nq}, ProjectPath = {ProjectPath}")]

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Utils;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -240,14 +241,11 @@ public static class ProjectResourceBuilderExtensions
                 var endpointConfig = endpoint.GetChildren().ToDictionary(c => c.Key, c => c.Value);
                 if (endpointConfig.TryGetValue("Url", out var url) && url != null)
                 {
-                    // DISCUSS: check whether it's correct to replace * with localhost. Not sure what * really means, but it's not a valid in new Uri().
-                    url = url.Replace("*", "localhost");
-                    var uri = new Uri(url);
-
                     // We need to turn off the proxy, because we cannot easily override Kestrel bindings
                     // DISCUSS: we use the scheme as the name instead of the endpoint name from config (endpoint.Key),
                     //   as it seems that the framework expects it to be http/https. This may not be correct.
-                    builder.WithEndpoint(name: uri.Scheme, port: uri.Port, scheme:uri.Scheme, isProxied: false);
+                    var bindingAddress = BindingAddress.Parse(url);
+                    builder.WithEndpoint(name: bindingAddress.Scheme, port: bindingAddress.Port, scheme: bindingAddress.Scheme, isProxied: false);
                 }
             }
 

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -254,7 +254,6 @@ public static class ProjectResourceBuilderExtensions
                         e.Port = endpoint.BindingAddress.Port;
                         e.UriScheme = endpoint.BindingAddress.Scheme;
                         e.IsProxied = false; // turn off the proxy, as we cannot easily override Kestrel bindings
-                        e.TargetPort = e.Port; // Should be implied, but is needed due to https://github.com/dotnet/aspire/issues/4225
                         e.Transport = adjustTransport(e);
                     },
                     createIfNotExists: true);

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -224,8 +224,8 @@ public static class ProjectResourceBuilderExtensions
             builder.WithAnnotation(new LaunchProfileAnnotation(launchProfileName));
         }
 
-        var kestrelConfig = GetKestrelConfiguration(projectResource);
-        var kestrelEndpoints = kestrelConfig.GetSection("Kestrel:Endpoints").GetChildren();
+        var config = GetConfiguration(projectResource);
+        var kestrelEndpoints = config.GetSection("Kestrel:Endpoints").GetChildren();
         var launchProfile = projectResource.GetEffectiveLaunchProfile(throwIfNotFound: true);
 
         // Get all the Kestrel configuration endpoint bindings, grouped by scheme
@@ -239,7 +239,7 @@ public static class ProjectResourceBuilderExtensions
             .GroupBy(entry => entry.BindingAddress.Scheme);
 
         // Helper to change the transport to http2 if needed
-        var isHttp2ConfiguredInAppSettings = kestrelConfig["Kestrel:EndpointDefaults:Protocols"] == "Http2";
+        var isHttp2ConfiguredInAppSettings = config["Kestrel:EndpointDefaults:Protocols"] == "Http2";
         var adjustTransport = (EndpointAnnotation e) => e.Transport = isHttp2ConfiguredInAppSettings ? "http2" : e.Transport;
 
         if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
@@ -401,14 +401,14 @@ public static class ProjectResourceBuilderExtensions
         return builder;
     }
 
-    private static IConfiguration GetKestrelConfiguration(ProjectResource projectResource)
+    private static IConfiguration GetConfiguration(ProjectResource projectResource)
     {
         var projectMetadata = projectResource.GetProjectMetadata();
 
         // For testing
-        if (projectMetadata.KestrelConfiguration is { } kestrelConfiguration)
+        if (projectMetadata.Configuration is { } configuration)
         {
-            return kestrelConfiguration;
+            return configuration;
         }
 
         var projectDirectoryPath = Path.GetDirectoryName(projectMetadata.ProjectPath)!;

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -197,7 +197,6 @@ public static class ProjectResourceBuilderExtensions
 
         builder.WithOtlpExporter();
         builder.ConfigureConsoleLogs();
-        builder.SetAspNetCoreUrls();
 
         var projectResource = builder.Resource;
 
@@ -260,6 +259,13 @@ public static class ProjectResourceBuilderExtensions
                     },
                     createIfNotExists: true);
                 }
+            }
+
+            // We don't need to set ASPNETCORE_URLS if we have Kestrel endpoints configured
+            // as Kestrel will get everything it needs from the config.
+            if (!kestrelEndpointsByScheme.Any())
+            {
+                builder.SetAspNetCoreUrls();
             }
 
             // Process the launch profile and turn it into environment variables and endpoints.

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -257,7 +257,7 @@ public static class ProjectResourceBuilderExtensions
                         e.Port = endpoint.BindingAddress.Port;
                         e.UriScheme = endpoint.BindingAddress.Scheme;
                         e.IsProxied = false; // turn off the proxy, as we cannot easily override Kestrel bindings
-                        e.TargetPort = e.Port; // Should be implied, but is needed due to sequencing bug in WithEndpoint()
+                        e.TargetPort = e.Port; // Should be implied, but is needed due to https://github.com/dotnet/aspire/issues/4225
                         e.Transport = adjustTransport(e);
                     },
                     createIfNotExists: true);
@@ -404,6 +404,12 @@ public static class ProjectResourceBuilderExtensions
     private static IConfiguration GetKestrelConfiguration(ProjectResource projectResource)
     {
         var projectMetadata = projectResource.GetProjectMetadata();
+
+        // For testing
+        if (projectMetadata.KestrelConfiguration is { } kestrelConfiguration)
+        {
+            return kestrelConfiguration;
+        }
 
         var projectDirectoryPath = Path.GetDirectoryName(projectMetadata.ProjectPath)!;
         var appSettingsPath = Path.Combine(projectDirectoryPath, "appsettings.json");

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -216,17 +216,15 @@ public static class ProjectResourceBuilderExtensions
         if (excludeLaunchProfile)
         {
             builder.WithAnnotation(new ExcludeLaunchProfileAnnotation());
-            return builder;
         }
-
-        if (!string.IsNullOrEmpty(launchProfileName))
+        else if (!string.IsNullOrEmpty(launchProfileName))
         {
             builder.WithAnnotation(new LaunchProfileAnnotation(launchProfileName));
         }
 
         var config = GetConfiguration(projectResource);
         var kestrelEndpoints = config.GetSection("Kestrel:Endpoints").GetChildren();
-        var launchProfile = projectResource.GetEffectiveLaunchProfile(throwIfNotFound: true);
+        var launchProfile = excludeLaunchProfile ? null : projectResource.GetEffectiveLaunchProfile(throwIfNotFound: true);
 
         // Get all the Kestrel configuration endpoint bindings, grouped by scheme
         var kestrelEndpointsByScheme = kestrelEndpoints

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -238,7 +238,7 @@ public static class ProjectResourceBuilderExtensions
             var kestrelEndpoints = kestrelConfig.GetSection("Kestrel:Endpoints").GetChildren();
             foreach (var endpoint in kestrelEndpoints)
             {
-                if (endpoint.GetValue<string>("Url") is var url && url != null)
+                if (endpoint["Url"] is string url)
                 {
                     // We need to turn off the proxy, because we cannot easily override Kestrel bindings
                     // DISCUSS: we use the scheme as the name instead of the endpoint name from config (endpoint.Key),

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -238,8 +238,7 @@ public static class ProjectResourceBuilderExtensions
             var kestrelEndpoints = kestrelConfig.GetSection("Kestrel:Endpoints").GetChildren();
             foreach (var endpoint in kestrelEndpoints)
             {
-                var endpointConfig = endpoint.GetChildren().ToDictionary(c => c.Key, c => c.Value);
-                if (endpointConfig.TryGetValue("Url", out var url) && url != null)
+                if (endpoint.GetValue<string>("Url") is var url && url != null)
                 {
                     // We need to turn off the proxy, because we cannot easily override Kestrel bindings
                     // DISCUSS: we use the scheme as the name instead of the endpoint name from config (endpoint.Key),

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -224,6 +224,9 @@ public static class ProjectResourceBuilderExtensions
             builder.WithAnnotation(new LaunchProfileAnnotation(launchProfileName));
         }
 
+        var kestrelConfig = GetKestrelConfiguration(projectResource);
+        var kestrelEndpoints = kestrelConfig.GetSection("Kestrel:Endpoints").GetChildren();
+
         if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
         {
             // Process the launch profile and turn it into environment variables and endpoints.
@@ -234,8 +237,6 @@ public static class ProjectResourceBuilderExtensions
             }
 
             // Check for any endpoint bindings at Kestrel configuration level
-            var kestrelConfig = GetKestrelConfiguration(projectResource);
-            var kestrelEndpoints = kestrelConfig.GetSection("Kestrel:Endpoints").GetChildren();
             foreach (var endpoint in kestrelEndpoints)
             {
                 if (endpoint["Url"] is string url)
@@ -284,7 +285,7 @@ public static class ProjectResourceBuilderExtensions
         else
         {
             // If we aren't a web project we don't automatically add bindings.
-            if (!IsWebProject(projectResource))
+            if (!IsWebProject(projectResource) && !kestrelEndpoints.Any())
             {
                 return builder;
             }

--- a/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
+++ b/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
@@ -146,7 +146,7 @@ public class KestrelConfigTests
         {
             Profiles = new()
             {
-                ["OnlyHttp"] = new LaunchProfile
+                ["OnlyHttp"] = new ()
                 {
                     ApplicationUrl = "http://localhost:5031",
                 }

--- a/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
+++ b/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
@@ -28,8 +28,8 @@ public class KestrelConfigTests
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
 
-        // The Kestrel endpoint overrides the profile endpoint
-        Assert.Equal("http://localhost:5002", config["ASPNETCORE_URLS"]);
+        // When using Kestrel, we should not be setting ASPNETCORE_URLS at all
+        Assert.False(config.ContainsKey("ASPNETCORE_URLS"));
     }
 
     [Fact]
@@ -47,13 +47,10 @@ public class KestrelConfigTests
                 Assert.Equal(7002, a.Port);
             }
             );
-
-        // We skip the EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync() call here,
-        // as it runs into an issue, and does not add that much value to the test
     }
 
     [Fact]
-    public async Task MultipleKestrelHttpEndpointsKeepTheirNames()
+    public void MultipleKestrelHttpEndpointsKeepTheirNames()
     {
         var resource = CreateTestProjectResource<ProjectWithMultipleHttpKestrelEndpoints>(operation: DistributedApplicationOperation.Run);
 
@@ -73,10 +70,6 @@ public class KestrelConfigTests
                 Assert.Equal(5003, a.Port);
             }
             );
-
-        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
-
-        Assert.Equal("http://localhost:5002;http://localhost:5003", config["ASPNETCORE_URLS"]);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
+++ b/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
@@ -1,0 +1,201 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+
+public class KestrelConfigTests
+{
+    [Fact]
+    public async Task SingleKestrelHttpEndpointIsNamedHttpAndOverridesProfile()
+    {
+        var resource = CreateTestProjectResource<ProjectWithProfileEndpointAndKestrelHttpEndpoint>(operation: DistributedApplicationOperation.Run);
+
+        Assert.Collection(
+            resource.Annotations.OfType<EndpointAnnotation>(),
+            a =>
+            {
+                // Endpoint is named "http", because there is only one Kestrel http endpoint
+                Assert.Equal("http", a.Name);
+                Assert.Equal("http", a.UriScheme);
+                Assert.Equal(5002, a.Port);
+            }
+            );
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
+
+        // The Kestrel endpoint overrides the profile endpoint
+        Assert.Equal("http://localhost:5002", config["ASPNETCORE_URLS"]);
+    }
+
+    [Fact]
+    public void SingleKestrelHttpsEndpointIsNamedHttps()
+    {
+        var resource = CreateTestProjectResource<ProjectWithKestrelHttpsEndpoint>(operation: DistributedApplicationOperation.Run);
+
+        Assert.Collection(
+            resource.Annotations.OfType<EndpointAnnotation>(),
+            a =>
+            {
+                // Endpoint is named "https"", because there is only one Kestrel https endpoint
+                Assert.Equal("https", a.Name);
+                Assert.Equal("https", a.UriScheme);
+                Assert.Equal(7002, a.Port);
+            }
+            );
+
+        // We skip the EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync() call here,
+        // as it runs into an issue, and does not add that much value to the test
+    }
+
+    [Fact]
+    public async Task MultipleKestrelHttpEndpointsKeepTheirNames()
+    {
+        var resource = CreateTestProjectResource<ProjectWithMultipleHttpKestrelEndpoints>(operation: DistributedApplicationOperation.Run);
+
+        Assert.Collection(
+            resource.Annotations.OfType<EndpointAnnotation>(),
+            a =>
+            {
+                // Endpoints keep their config names because there are multiple Kestrel http endpoints
+                Assert.Equal("FirstHttpEndpoint", a.Name);
+                Assert.Equal("http", a.UriScheme);
+                Assert.Equal(5002, a.Port);
+            },
+            a =>
+            {
+                Assert.Equal("SecondHttpEndpoint", a.Name);
+                Assert.Equal("http", a.UriScheme);
+                Assert.Equal(5003, a.Port);
+            }
+            );
+
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource);
+
+        Assert.Equal("http://localhost:5002;http://localhost:5003", config["ASPNETCORE_URLS"]);
+    }
+
+    [Fact]
+    public async Task VerifyKestrelEndpointManifestGeneration()
+    {
+        var resource = CreateTestProjectResource<ProjectWithOnlyKestrelHttpEndpoint>();
+
+        var manifest = await ManifestUtils.GetManifest(resource);
+
+        var expectedManifest = $$"""
+            {
+              "type": "project.v0",
+              "path": "another-path",
+              "env": {
+                "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+                "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
+                "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
+                "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true"
+              },
+              "bindings": {
+                "http": {
+                  "scheme": "http",
+                  "protocol": "tcp",
+                  "transport": "http"
+                },
+                "https": {
+                  "scheme": "https",
+                  "protocol": "tcp",
+                  "transport": "http"
+                }
+              }
+            }
+            """;
+
+        Assert.Equal(expectedManifest, manifest.ToString());
+    }
+
+    private static ProjectResource CreateTestProjectResource<TProject>(DistributedApplicationOperation operation = DistributedApplicationOperation.Publish) where TProject : IProjectMetadata, new()
+    {
+        var appBuilder = ProjectResourceTests.CreateBuilder(operation: operation);
+        appBuilder.AddProject<TProject>("projectName");
+        DistributedApplication app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var projectResources = appModel.GetProjectResources();
+        return Assert.Single(projectResources);
+    }
+
+    private sealed class ProjectWithOnlyKestrelHttpEndpoint : ProjectResourceTests.BaseProjectWithProfileAndConfig
+    {
+        public ProjectWithOnlyKestrelHttpEndpoint()
+        {
+            JsonConfigString = """
+            {
+              "Kestrel": {
+                "Endpoints": {
+                  "SomeHttpEndpoint": { "Url": "http://*:5002" }
+                }
+              }
+            }
+            """;
+        }
+    }
+
+    private sealed class ProjectWithProfileEndpointAndKestrelHttpEndpoint : ProjectResourceTests.BaseProjectWithProfileAndConfig
+    {
+        public ProjectWithProfileEndpointAndKestrelHttpEndpoint()
+        {
+            Profiles = new()
+            {
+                ["OnlyHttp"] = new LaunchProfile
+                {
+                    ApplicationUrl = "http://localhost:5031",
+                }
+            };
+            JsonConfigString = """
+            {
+              "Kestrel": {
+                "Endpoints": {
+                  "SomeHttpEndpoint": { "Url": "http://*:5002" }
+                }
+              }
+            }
+            """;
+        }
+    }
+
+    private sealed class ProjectWithKestrelHttpsEndpoint : ProjectResourceTests.BaseProjectWithProfileAndConfig
+    {
+        public ProjectWithKestrelHttpsEndpoint()
+        {
+            JsonConfigString = """
+            {
+              "Kestrel": {
+                "Endpoints": {
+                  "SomeHttpsEndpoint": { "Url": "https://*:7002" }
+                }
+              }
+            }
+            """;
+        }
+    }
+
+    private sealed class ProjectWithMultipleHttpKestrelEndpoints : ProjectResourceTests.BaseProjectWithProfileAndConfig
+    {
+        public ProjectWithMultipleHttpKestrelEndpoints()
+        {
+            JsonConfigString = """
+            {
+              "Kestrel": {
+                "EndpointDefaults": {
+                  "Protocols": "Http2"
+                },
+                "Endpoints": {
+                  "FirstHttpEndpoint": { "Url": "http://*:5002" },
+                  "SecondHttpEndpoint": { "Url": "http://*:5003" }
+                }
+              }
+            }
+            """;
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -583,7 +583,7 @@ public class ProjectResourceTests
     {
         public string ProjectPath => "projectC";
         public LaunchSettings LaunchSettings { get; } = new();
-        public IConfiguration KestrelConfiguration
+        public IConfiguration Configuration
         {
             get
             {

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -554,7 +554,7 @@ public class ProjectResourceTests
         {
             Profiles = new()
             {
-                ["OnlyHttp"] = new LaunchProfile
+                ["http"] = new ()
                 {
                     CommandName = "Project",
                     CommandLineArgs = "arg1 arg2",

--- a/tests/testproject/TestProject.ServiceC/Properties/launchSettings.json
+++ b/tests/testproject/TestProject.ServiceC/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -13,7 +13,8 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5271",
+      //This gets set in appsettings.json instead to test Kestrel endpoints
+      //"applicationUrl": "http://localhost:5271",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/tests/testproject/TestProject.ServiceC/appsettings.json
+++ b/tests/testproject/TestProject.ServiceC/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndPoints": {
+      "Http": {
+        "Url": "http://*:5271"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Allow endpoints to be defined in the Kestrel config as an alternative to the profile. As is the case at runtime, Kestrel config endpoints override profile endpoints.

Fixes #3456

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4205)