### PR TITLE
Changing the title of the Aspire starter project

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": ".NET Aspire Application",
+  "name": ".NET Aspire App",
   "description": "A project template for creating an empty .NET Aspire app.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": ".NET Aspire App",
+  "name": ".NET Aspire Empty App",
   "description": "A project template for creating an empty .NET Aspire app.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -10,7 +10,7 @@
     "API",
     "Service"
   ],
-  "name": ".NET Aspire App",
+  "name": ".NET Aspire Empty App",
   "defaultName": "AspireApp",
   "description": "A project template for creating an empty .NET Aspire app.",
   "shortName": "aspire",

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/.template.config/template.json
@@ -10,7 +10,7 @@
     "API",
     "Service"
   ],
-  "name": ".NET Aspire Application",
+  "name": ".NET Aspire App",
   "defaultName": "AspireApp",
   "description": "A project template for creating an empty .NET Aspire app.",
   "shortName": "aspire",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.en.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/localize/templatestrings.en.json
@@ -1,6 +1,6 @@
 {
   "author": "Microsoft",
-  "name": ".NET Aspire Starter Application",
+  "name": ".NET Aspire Starter App",
   "description": "A project template for creating a .NET Aspire app with a Blazor web frontend and web API backend service, optionally using Redis for caching.",
   "symbols/Framework/description": "The target framework for the project.",
   "symbols/Framework/choices/net8.0/description": "Target net8.0",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -11,7 +11,7 @@
     "Service",
     "Cloud"
   ],
-  "name": ".NET Aspire Starter Application",
+  "name": ".NET Aspire Starter App",
   "defaultName": "AspireApp",
   "description": "A project template for creating a .NET Aspire app with a Blazor web frontend and web API backend service, optionally using Redis for caching.",
   "shortName": "aspire-starter",


### PR DESCRIPTION
Changing the title of the Aspire starter project template from '.NET Aspire Starter Application' to '.NET Aspire Starter App'.
This is more consistent with Visual Studio.
Related issue #4178.

Let me know if this PR should go to a different branch.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4207)