### PR TITLE
A11Y - Fix options under 'Type filter' button are not accessible by keyboard

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -19,34 +19,34 @@
                       @onclick="() => _isTypeFilterVisible = !_isTypeFilterVisible"
                       Title="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])"
                       aria-label="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])" />
-        <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true">
-            <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
-            <Body>
-                <FluentStack Orientation="Orientation.Vertical">
-                    <FluentCheckbox
-                        Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
-                        ThreeState="true"
-                        ShowIndeterminate="false"
-                        ThreeStateOrderUncheckToIntermediate="true"
-                        @bind-CheckState="AreAllTypesVisible" />
-                    @foreach (var (resourceType, _) in _allResourceTypes)
-                    {
-                        var isChecked = _visibleResourceTypes.ContainsKey(resourceType);
-                        <FluentCheckbox
-                            Label="@resourceType"
-                            @bind-Value:get="isChecked"
-                            @bind-Value:set="c => OnResourceTypeVisibilityChangedAsync(resourceType, c)"
-                            />
-                    }
-                </FluentStack>
-            </Body>
-        </FluentPopover>
         <FluentSearch Placeholder="@ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)]"
                       Immediate="true"
                       @bind-Value="_filter"
                       slot="end"
                       @bind-Value:after="HandleSearchFilterChangedAsync" />
     </FluentToolbar>
+
+    <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true">
+        <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
+        <Body>
+            <FluentStack Orientation="Orientation.Vertical">
+                <FluentCheckbox Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
+                                ThreeState="true"
+                                ShowIndeterminate="false"
+                                onkeydown="e => console.log(e)"
+                                ThreeStateOrderUncheckToIntermediate="true"
+                                @bind-CheckState="AreAllTypesVisible" />
+                @foreach (var (resourceType, _) in _allResourceTypes)
+                {
+                    var isChecked = _visibleResourceTypes.ContainsKey(resourceType);
+                    <FluentCheckbox Label="@resourceType"
+                                    @bind-Value:get="isChecked"
+                                    @bind-Value:set="c => OnResourceTypeVisibilityChangedAsync(resourceType, c)" />
+                }
+            </FluentStack>
+        </Body>
+    </FluentPopover>
+
     <SummaryDetailsView DetailsTitle="@(SelectedResource != null ? $"{SelectedResource.ResourceType}: {GetResourceName(SelectedResource)}" : null)"
                         ShowDetails="@(SelectedResource is not null)"
                         OnDismiss="@(() => ClearSelectedResourceAsync(causedByUserAction: true))"


### PR DESCRIPTION
# A11Y - Fix options under 'Type filter' button are not accessible by keyboard

To solve problem #3173, the `FluentPopover` is moved outside the `FluentToolbar`.

The web component `fluent-toolbar` changes all sub-elements with `tabindex="-1"`, except the one it's on. 
And that it overloads the passage from one element to another via the arrows.

Using the **FluentPopover**, the default `tabindex` are retained and the user can press `[Enter]` to open the menu, `[Tab]` to navigate from one item to another, `[Space]` to select or deselect it and finally `[Esc]` to close the menu.

## Before
![Before](https://github.com/dotnet/aspire/assets/8350694/7949bd1d-c2cd-4c4f-9b54-2fda183d014c)

## After
![After](https://github.com/dotnet/aspire/assets/8350694/fbebcdb4-c319-4b25-ba02-8af566cf0380)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4243)