### PR TITLE
CI: Disable workload tests on Windows for internal builds

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -37,11 +37,12 @@ steps:
               "${{ parameters.buildScript }} -testnobuild -test -configuration ${{ parameters.buildConfig }} /bl:${{ parameters.repoLogPath }}/tests.binlog $(_OfficialBuildIdArgs)"
       displayName: Run non-helix tests
 
-    - script: ${{ parameters.buildScript }}
-              /p:Configuration=${{ parameters.buildConfig }}
-              /bl:${{ parameters.repoLogPath }}/WorkloadInstallForTesting.binlog
-              -projects $(Build.SourcesDirectory)/tests/workloads.proj
-      displayName: Install sdk+workload for testing
+    - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+      - script: ${{ parameters.buildScript }}
+                /p:Configuration=${{ parameters.buildConfig }}
+                /bl:${{ parameters.repoLogPath }}/WorkloadInstallForTesting.binlog
+                -projects $(Build.SourcesDirectory)/tests/workloads.proj
+        displayName: Install sdk+workload for testing
 
     # Helix captures code coverage information and, once tests are complete, the code coverage information is
     # downloaded to <repo root>/artifacts/helixresults folder.

--- a/tests/helix/send-to-helix-ci.proj
+++ b/tests/helix/send-to-helix-ci.proj
@@ -4,7 +4,8 @@
       <TestCategory Include="basictests" />
       <!-- no docker on windows -->
       <TestCategory Condition="'$(OS)' != 'Windows_NT'" Include="endtoendtests" />
-      <TestCategory Include="workloadtests" />
+      <!-- build broken on windows for internal pipeline -->
+      <TestCategory Condition="'$(OS)' != 'Windows_NT' or '$(SYSTEM_TEAMPROJECT)' != 'internal'" Include="workloadtests" />
 
       <AdditionalProperties Condition="'$(Configuration)' != ''" Include="Configuration=$(Configuration)" />
       <_ProjectsToBuild Include="send-to-helix-inner.proj"


### PR DESCRIPTION
Disable the workload tests on Windows for internal builds.

Issue: https://github.com/dotnet/aspire/issues/4246

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4248)