### PR TITLE
[tests] Fix installing workload for tests on Windows in the internal pipeline

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -73,9 +73,9 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.WorkloadTesting.Internal" Version="9.0.0-preview.3.24158.8">
+    <Dependency Name="Microsoft.NET.Runtime.WorkloadTesting.Internal" Version="9.0.0-preview.5.24272.3">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>54d318d6da76e409d4e865220d9923283d55a06d</Sha>
+      <Sha>b83186a969946f61c71ad0da034936fac9947752</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.OpenApi" Version="8.0.2">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-aspnetcore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,6 +52,6 @@
     <MicrosoftEntityFrameworkCoreDesignPackageVersion>8.0.5</MicrosoftEntityFrameworkCoreDesignPackageVersion>
     <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>8.0.5</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
     <MicrosoftEntityFrameworkCoreToolsPackageVersion>8.0.5</MicrosoftEntityFrameworkCoreToolsPackageVersion>
-    <MicrosoftNETRuntimeWorkloadTestingInternalVersion>9.0.0-preview.4.24208.7</MicrosoftNETRuntimeWorkloadTestingInternalVersion>
+    <MicrosoftNETRuntimeWorkloadTestingInternalVersion>9.0.0-preview.5.24272.3</MicrosoftNETRuntimeWorkloadTestingInternalVersion>
   </PropertyGroup>
 </Project>

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -37,12 +37,12 @@ steps:
               "${{ parameters.buildScript }} -testnobuild -test -configuration ${{ parameters.buildConfig }} /bl:${{ parameters.repoLogPath }}/tests.binlog $(_OfficialBuildIdArgs)"
       displayName: Run non-helix tests
 
-    - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-      - script: ${{ parameters.buildScript }}
-                /p:Configuration=${{ parameters.buildConfig }}
-                /bl:${{ parameters.repoLogPath }}/WorkloadInstallForTesting.binlog
-                -projects $(Build.SourcesDirectory)/tests/workloads.proj
-        displayName: Install sdk+workload for testing
+    - script: ${{ parameters.buildScript }}
+              /p:Configuration=${{ parameters.buildConfig }}
+              $(_OfficialBuildIdArgs)
+              /bl:${{ parameters.repoLogPath }}/WorkloadInstallForTesting.binlog
+              -projects $(Build.SourcesDirectory)/tests/workloads.proj
+      displayName: Install sdk+workload for testing
 
     # Helix captures code coverage information and, once tests are complete, the code coverage information is
     # downloaded to <repo root>/artifacts/helixresults folder.

--- a/tests/helix/send-to-helix-ci.proj
+++ b/tests/helix/send-to-helix-ci.proj
@@ -4,8 +4,7 @@
       <TestCategory Include="basictests" />
       <!-- no docker on windows -->
       <TestCategory Condition="'$(OS)' != 'Windows_NT'" Include="endtoendtests" />
-      <!-- build broken on windows for internal pipeline -->
-      <TestCategory Condition="'$(OS)' != 'Windows_NT' or '$(SYSTEM_TEAMPROJECT)' != 'internal'" Include="workloadtests" />
+      <TestCategory Include="workloadtests" />
 
       <AdditionalProperties Condition="'$(Configuration)' != ''" Include="Configuration=$(Configuration)" />
       <_ProjectsToBuild Include="send-to-helix-inner.proj"


### PR DESCRIPTION
The installation of the sdk+workload for testing failed on Windows in the internal pipeline with:

```
##[error].packages\microsoft.net.runtime.workloadtesting.internal\9.0.0-preview.4.24208.7\Sdk\WorkloadTesting.Core.targets(201,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Restoring packages failed with exit code: 1. Output:
  Determining projects to restore...
D:\a\_work\1\s\artifacts\obj\workload-q3zh33t1.fms\surfuxtl.vly\restore\Restore.csproj : error NU1102: Unable to find package Microsoft.NET.Sdk.Aspire.Manifest-8.0.100 with version (= 8.1.0-ci)
D:\a\_work\1\s\artifacts\obj\workload-q3zh33t1.fms\surfuxtl.vly\restore\Restore.csproj : error NU1102:   - Found 786 version(s) in dotnet8 [ Nearest version: 8.1.0-preview.1.24178.6 ]
D:\a\_work\1\s\artifacts\obj\workload-q3zh33t1.fms\surfuxtl.vly\restore\Restore.csproj : error NU1102:   - Found 8 version(s) in dotnet-public [ Nearest version: 8.0.0-preview.7.24251.11 ]
D:\a\_work\1\s\artifacts\obj\workload-q3zh33t1.fms\surfuxtl.vly\restore\Restore.csproj : error NU1102:   - Found 1 version(s) in nuget-local [ Nearest version: 8.1.0-preview.1.24270.2 ]
D:\a\_work\1\s\artifacts\obj\workload-q3zh33t1.fms\surfuxtl.vly\restore\Restore.csproj : error NU1102:   - Found 0 version(s) in dotnet9-transport
D:\a\_work\1\s\artifacts\obj\workload-q3zh33t1.fms\surfuxtl.vly\restore\Restore.csproj : error NU1102:   - Found 0 version(s) in dotnet-eng
D:\a\_work\1\s\artifacts\obj\workload-q3zh33t1.fms\surfuxtl.vly\restore\Restore.csproj : error NU1102:   - Versions from dotnet-libraries were not considered
```

This is because on the internal pipeline the version is like `8.1.0-preview.1.24270.2` instead of `8.1.0-ci`, so the generated nugets use that version. But the workload install step did not pass the `OfficialBuildId` which caused the build to get the `8.1.0-ci` version instead, causing the failure.

Once that is fixed an issue (https://github.com/dotnet/runtime/pull/102533) was hit in the workload task for which the nuget is being updated here.
Fixes https://github.com/dotnet/aspire/issues/4246 .
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4259)