### PR TITLE
Improve error handling in DistributedApplicationFactory

### DIFF
--- a/src/Aspire.Hosting.Testing/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Testing/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 Aspire.Hosting.Testing.DistributedApplicationFactory
 Aspire.Hosting.Testing.DistributedApplicationFactory.CreateHttpClient(string! resourceName, string? endpointName = null) -> System.Net.Http.HttpClient!
 Aspire.Hosting.Testing.DistributedApplicationFactory.DistributedApplicationFactory(System.Type! entryPoint) -> void
+Aspire.Hosting.Testing.DistributedApplicationFactory.DistributedApplicationFactory(System.Type! entryPoint, string![]! args) -> void
 Aspire.Hosting.Testing.DistributedApplicationFactory.GetConnectionString(string! resourceName) -> System.Threading.Tasks.ValueTask<string?>
 Aspire.Hosting.Testing.DistributedApplicationFactory.GetEndpoint(string! resourceName, string? endpointName = null) -> System.Uri!
 Aspire.Hosting.Testing.DistributedApplicationFactory.StartAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
@@ -20,7 +21,9 @@ Aspire.Hosting.Testing.IDistributedApplicationTestingBuilder.Services.get -> Mic
 static Aspire.Hosting.Testing.DistributedApplicationHostingTestingExtensions.CreateHttpClient(this Aspire.Hosting.DistributedApplication! app, string! resourceName, string? endpointName = null) -> System.Net.Http.HttpClient!
 static Aspire.Hosting.Testing.DistributedApplicationHostingTestingExtensions.GetConnectionStringAsync(this Aspire.Hosting.DistributedApplication! app, string! resourceName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<string?>
 static Aspire.Hosting.Testing.DistributedApplicationHostingTestingExtensions.GetEndpoint(this Aspire.Hosting.DistributedApplication! app, string! resourceName, string? endpointName = null) -> System.Uri!
+static Aspire.Hosting.Testing.DistributedApplicationTestingBuilder.CreateAsync(System.Type! entryPoint, string![]! args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Aspire.Hosting.Testing.IDistributedApplicationTestingBuilder!>!
 static Aspire.Hosting.Testing.DistributedApplicationTestingBuilder.CreateAsync(System.Type! entryPoint, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Aspire.Hosting.Testing.IDistributedApplicationTestingBuilder!>!
+static Aspire.Hosting.Testing.DistributedApplicationTestingBuilder.CreateAsync<TEntryPoint>(string![]! args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Aspire.Hosting.Testing.IDistributedApplicationTestingBuilder!>!
 static Aspire.Hosting.Testing.DistributedApplicationTestingBuilder.CreateAsync<TEntryPoint>(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Aspire.Hosting.Testing.IDistributedApplicationTestingBuilder!>!
 virtual Aspire.Hosting.Testing.DistributedApplicationFactory.Dispose() -> void
 virtual Aspire.Hosting.Testing.DistributedApplicationFactory.DisposeAsync() -> System.Threading.Tasks.ValueTask

--- a/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationFixtureOfT.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/DistributedApplicationFixtureOfT.cs
@@ -6,14 +6,16 @@ namespace Aspire.Hosting.Testing.Tests;
 
 public class DistributedApplicationFixture<TEntryPoint> : DistributedApplicationFactory, IAsyncLifetime where TEntryPoint : class
 {
-    public DistributedApplicationFixture()
-        : base(typeof(TEntryPoint))
+    public DistributedApplicationFixture(string[] args)
+        : base(typeof(TEntryPoint), args)
     {
         if (Environment.GetEnvironmentVariable("BUILD_BUILDID") != null)
         {
             throw new SkipException("These tests can only run in local environments.");
         }
     }
+
+    public DistributedApplicationFixture() : this([]) { }
 
     protected override void OnBuilderCreating(DistributedApplicationOptions applicationOptions, HostApplicationBuilderSettings hostOptions)
     {

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -78,6 +78,72 @@ public class TestingBuilderTests
         Assert.Throws<InvalidOperationException>(() => app.CreateHttpClient("mywebapp1"));
     }
 
+    // Tests that DistributedApplicationTestingBuilder throws exceptions at the right times when the app crashes.
+    [LocalOnlyTheory]
+    [InlineData(true, "before-build")]
+    [InlineData(true, "after-build")]
+    [InlineData(true, "after-start")]
+    [InlineData(true, "after-shutdown")]
+    [InlineData(false, "before-build")]
+    [InlineData(false, "after-build")]
+    [InlineData(false, "after-start")]
+    [InlineData(false, "after-shutdown")]
+    public async Task CrashTests(bool genericEntryPoint, string crashArg)
+    {
+        var timeout = TimeSpan.FromMinutes(5);
+        using var cts = new CancellationTokenSource(timeout);
+        DistributedApplication? app = null;
+
+        IDistributedApplicationTestingBuilder appHost;
+        if (crashArg == "before-build")
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            genericEntryPoint ? DistributedApplicationTestingBuilder.CreateAsync<Projects.TestingAppHost1_AppHost>([$"--crash-{crashArg}"], cts.Token).WaitAsync(cts.Token)
+                                : DistributedApplicationTestingBuilder.CreateAsync(typeof(Projects.TestingAppHost1_AppHost), [$"--crash-{crashArg}"], cts.Token).WaitAsync(cts.Token))
+                .ConfigureAwait(false);
+            Assert.Contains(crashArg, exception.Message);
+            return;
+        }
+        else
+        {
+            appHost = genericEntryPoint
+                ? await DistributedApplicationTestingBuilder.CreateAsync<Projects.TestingAppHost1_AppHost>([$"--crash-{crashArg}"], cts.Token).WaitAsync(cts.Token)
+            : await DistributedApplicationTestingBuilder.CreateAsync(typeof(Projects.TestingAppHost1_AppHost), [$"--crash-{crashArg}"], cts.Token).WaitAsync(cts.Token);
+        }
+
+        cts.CancelAfter(timeout);
+        app = await appHost.BuildAsync().WaitAsync(cts.Token).ConfigureAwait(false);
+
+        cts.CancelAfter(timeout);
+        if (crashArg == "after-build")
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync().WaitAsync(cts.Token));
+            Assert.Contains(crashArg, exception.Message);
+
+            // DisposeAsync should throw the same exception.
+            exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await app.DisposeAsync().AsTask().WaitAsync(cts.Token));
+            Assert.Contains(crashArg, exception.Message);
+
+            return;
+        }
+        else
+        {
+            await app.StartAsync().WaitAsync(cts.Token);
+        }
+
+        cts.CancelAfter(timeout);
+        if (crashArg is "after-shutdown" or "after-start")
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await app.DisposeAsync().AsTask().WaitAsync(cts.Token));
+            Assert.Contains(crashArg, exception.Message);
+            return;
+        }
+        else
+        {
+            await app.DisposeAsync().AsTask().WaitAsync(cts.Token);
+        }
+    }
+
     private sealed record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
     {
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryCrashTests.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Tests.Helpers;
+using Xunit;
+
+namespace Aspire.Hosting.Testing.Tests;
+
+// Tests that DistributedApplicationTestingBuilder throws exceptions at the right times when the app crashes.
+public class TestingFactoryCrashTests
+{
+    [LocalOnlyTheory]
+    [InlineData("before-build")]
+    [InlineData("after-build")]
+    [InlineData("after-start")]
+    [InlineData("after-shutdown")]
+    public async Task CrashTests(string crashArg)
+    {
+        var timeout = TimeSpan.FromMinutes(5);
+        using var cts = new CancellationTokenSource(timeout);
+
+        var factory = new DistributedApplicationFactory(typeof(Projects.TestingAppHost1_AppHost), [$"--crash-{crashArg}"]);
+
+        if (crashArg is "before-build" or "after-build")
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => factory.StartAsync().WaitAsync(cts.Token));
+            Assert.Contains(crashArg, exception.Message);
+            return;
+        }
+        else
+        {
+            await factory.StartAsync().WaitAsync(cts.Token);
+        }
+
+        if (crashArg is "after-start" or "after-shutdown")
+        {
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => factory.DisposeAsync().AsTask().WaitAsync(cts.Token));
+            Assert.Contains(crashArg, exception.Message);
+            return;
+        }
+        else
+        {
+            await factory.DisposeAsync().AsTask().WaitAsync(cts.Token);
+        }
+    }
+}

--- a/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
+++ b/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
@@ -1,10 +1,38 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Hosting;
+
 var builder = DistributedApplication.CreateBuilder(args);
+
 builder.AddRedis("redis1");
 builder.AddProject<Projects.TestingAppHost1_MyWebApp>("mywebapp1");
 builder.AddProject<Projects.TestingAppHost1_MyWorker>("myworker1")
     .WithEndpoint(name: "myendpoint1");
 builder.AddPostgres("postgres1");
-builder.Build().Run();
+
+if (args.Contains("--crash-before-build"))
+{
+    throw new InvalidOperationException("Crashing: before-build.");
+}
+
+var app = builder.Build();
+
+if (args.Contains("--crash-after-build"))
+{
+    throw new InvalidOperationException("Crashing: after-build.");
+}
+
+await app.StartAsync();
+
+if (args.Contains("--crash-after-start"))
+{
+    throw new InvalidOperationException("Crashing: after-start.");
+}
+
+await app.WaitForShutdownAsync();
+
+if (args.Contains("--crash-after-shutdown"))
+{
+    throw new InvalidOperationException("Crashing after-shutdown.");
+}


### PR DESCRIPTION
Fixes #4330

Please note the public API change to add `string[] args` to the test app builders.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4331)