### PR TITLE
Fix Aspire.Hosting.Azure.CognitiveServices package description and tags

### DIFF
--- a/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure openai ai</PackageTags>
+    <PackageTags>aspire hosting azure openai ai cognitiveservices cognitive services</PackageTags>
     <Description>Azure OpenAI resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureOpenAI_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
-    <Description>Azure Open AI resource types for .NET Aspire.</Description>
+    <PackageTags>aspire hosting azure openai ai</PackageTags>
+    <Description>Azure OpenAI resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureOpenAI_256x.png</PackageIconFullPath>
   </PropertyGroup>
 


### PR DESCRIPTION
Add "openai" and "ai" to package tags.
Fix spacing of "OpenAI" in description.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4345)