### PR TITLE
style: change finished ressource icon to success

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -19,8 +19,8 @@
     {
         <!-- process completed, which may not have been unexpected -->
         <FluentIcon Title="@string.Format(Loc[Columns.StateColumnResourceExited], Resource.ResourceType)"
-                    Icon="Icons.Filled.Size16.Warning"
-                    Color="Color.Warning"
+                    Icon="Icons.Regular.Size16.CheckmarkUnderlineCircle"
+                    Color="Color.Success"
                     Class="severity-icon" />
     }
 }


### PR DESCRIPTION
Related to #4127

Change finished executable succeed icon from warning to checkmark
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4365)