### PR TITLE
Remove Aspire.Hosting.Orleans dependency on Azure hosting

### DIFF
--- a/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
+++ b/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
+    <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR removes the dependency from `Aspire.Hosting.Azure` which added unwanted Azure dependencies when Orleans was used in a non-Azure deployment. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4373)