### PR TITLE
Add new DCP build context schema

### DIFF
--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -68,9 +68,26 @@ internal sealed class BuildContext
     [JsonPropertyName("args")]
     public List<EnvVar>? Args { get; set; }
 
+    // Optional build secret mounts to pass to the build command
+    [JsonPropertyName("secrets")]
+    public List<BuildContextSecret>? Secrets { get; set; }
+
     // Optional specific stage to use when building a multiple stage Dockerfile
     [JsonPropertyName("stage")]
     public string? Stage { get; set; }
+
+    // Optional additional tags to apply to the built image
+    [JsonPropertyName("tags")]
+    public List<string>? Tags { get; set; }
+}
+
+internal sealed class BuildContextSecret
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("source")]
+    public string? Source { get; set; }
 }
 
 internal static class VolumeMountType

--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -83,9 +83,11 @@ internal sealed class BuildContext
 
 internal sealed class BuildContextSecret
 {
+    // The ID of the secret (a secret can be used in a Dockerfile with `RUN --mount-type=secret,id=<id>,target=<targetpath>`)
     [JsonPropertyName("id")]
     public string? Id { get; set; }
 
+    // Path to secret file/folder that will be mounted as a build secret using --secret
     [JsonPropertyName("source")]
     public string? Source { get; set; }
 }


### PR DESCRIPTION
Adds the schema for the newly added "secrets" and "tags" DCP image build context properties.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4374)