### PR TITLE
Normalize `C#` as `csharp`, and add missing lang ids

### DIFF
--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -111,7 +111,7 @@ public static class AzureEventHubsExtensions
     /// <example>
     /// The following example creates an Azure Event Hubs resource that runs locally is an emulator and referencing that
     /// resource in a .NET project.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// var eventHub = builder.AddAzureEventHubs("eventhubns")

--- a/src/Aspire.Hosting.Azure/BicepResourceAnnotation.cs
+++ b/src/Aspire.Hosting.Azure/BicepResourceAnnotation.cs
@@ -21,7 +21,7 @@ namespace Aspire.Hosting.Azure;
 ///         resource to the application model. This type does not derive from <see cref="AzureBicepResource"/> but can be annotated with
 ///         <see cref="AzureBicepResourceAnnotation"/> by using the AzureSqlExtensions.AsAzureSqlDatabase() extension method.
 ///     </para>
-///     <code>
+///     <code lang="csharp">
 ///         var builder = DistributedApplication.CreateBuilder();
 ///         builder.AddAzureProvisioning();
 ///         var sql = builder.AddSqlServerServer("sql"); // This resource would not be deployable via Azure Provisioner.

--- a/src/Aspire.Hosting.Garnet/GarnetBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Garnet/GarnetBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class GarnetBuilderExtensions
     /// </summary>
     /// <example>
     /// Use in application host
-    /// <code>
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// var garnet = builder.AddGarnet("garnet");
@@ -32,7 +32,7 @@ public static class GarnetBuilderExtensions
     /// </example>
     /// <example>
     /// Use in Api with Aspire.StackExchange.Redis
-    /// <code>
+    /// <code lang="csharp">
     /// var builder = WebApplication.CreateBuilder(args);
     /// builder.AddRedisClient("garnet");
     ///
@@ -63,7 +63,7 @@ public static class GarnetBuilderExtensions
     /// </summary>
     /// <example>
     /// Use <see cref="WithPersistence(IResourceBuilder{GarnetResource}, TimeSpan?, long)"/> to adjust Garnet persistence configuration, e.g.:
-    /// <code>
+    /// <code lang="csharp">
     /// var cache = builder.AddGarnet("cache")
     ///                    .WithDataVolume()
     ///                    .WithPersistence(TimeSpan.FromSeconds(10), 5);
@@ -94,7 +94,7 @@ public static class GarnetBuilderExtensions
     /// </summary>
     /// <example>
     /// Use <see cref="WithPersistence(IResourceBuilder{GarnetResource}, TimeSpan?, long)"/> to adjust Garnet persistence configuration, e.g.:
-    /// <code>
+    /// <code lang="csharp">
     /// var garnet = builder.AddGarnet("garnet")
     ///                    .WithDataBindMount()
     ///                    .WithPersistence(TimeSpan.FromSeconds(10), 5);
@@ -125,7 +125,7 @@ public static class GarnetBuilderExtensions
     /// <example>
     /// Use with <see cref="WithDataBindMount(IResourceBuilder{GarnetResource}, string, bool)"/>
     /// or <see cref="WithDataVolume(IResourceBuilder{GarnetResource}, string?, bool)"/> to persist Garnet data across sessions with custom persistence configuration, e.g.:
-    /// <code>
+    /// <code lang="csharp">
     /// var cache = builder.AddGarnet("cache")
     ///                    .WithDataVolume()
     ///                    .WithPersistence(TimeSpan.FromSeconds(10), 5);

--- a/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class MilvusBuilderExtensions
     /// </summary>
     /// <example>
     /// Use in application host
-    /// <code>
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// var milvus = builder.AddMilvus("milvus");
@@ -69,7 +69,7 @@ public static class MilvusBuilderExtensions
     /// </summary>
     /// <example>
     /// Use in application host
-    /// <code>
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// var booksdb = builder.AddMilvus("milvus");
@@ -101,7 +101,7 @@ public static class MilvusBuilderExtensions
     /// </summary>
     /// <example>
     /// Use in application host with a Milvus resource
-    /// <code>
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// var milvus = builder.AddMilvus("milvus")

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -85,7 +85,7 @@ public static class RedisBuilderExtensions
     /// </summary>
     /// <remarks>
     /// Use <see cref="WithPersistence(IResourceBuilder{RedisResource}, TimeSpan?, long)"/> to adjust Redis persistence configuration, e.g.:
-    /// <code>
+    /// <code lang="csharp">
     /// var cache = builder.AddRedis("cache")
     ///                    .WithDataVolume()
     ///                    .WithPersistence(TimeSpan.FromSeconds(10), 5);
@@ -113,7 +113,7 @@ public static class RedisBuilderExtensions
     /// </summary>
     /// <remarks>
     /// Use <see cref="WithPersistence(IResourceBuilder{RedisResource}, TimeSpan?, long)"/> to adjust Redis persistence configuration, e.g.:
-    /// <code>
+    /// <code lang="csharp">
     /// var cache = builder.AddRedis("cache")
     ///                    .WithDataBindMount()
     ///                    .WithPersistence(TimeSpan.FromSeconds(10), 5);
@@ -142,7 +142,7 @@ public static class RedisBuilderExtensions
     /// <remarks>
     /// Use with <see cref="WithDataBindMount(IResourceBuilder{RedisResource}, string, bool)"/>
     /// or <see cref="WithDataVolume(IResourceBuilder{RedisResource}, string?, bool)"/> to persist Redis data across sessions with custom persistence configuration, e.g.:
-    /// <code>
+    /// <code lang="csharp">
     /// var cache = builder.AddRedis("cache")
     ///                    .WithDataVolume()
     ///                    .WithPersistence(TimeSpan.FromSeconds(10), 5);

--- a/src/Aspire.Hosting/ApplicationModel/ParameterDefault.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterDefault.cs
@@ -58,7 +58,7 @@ public abstract class ParameterDefault
 /// A generalized lower-bound formula for the number of possible outputs is to consider a string of the form:
 /// </para>
 ///
-/// <code>
+/// <code lang="csharp">
 /// {nonRequiredCharacters}{requiredCharacters}
 ///
 /// let a = MinLower, b = MinUpper, c = MinNumeric, d = MinSpecial
@@ -72,7 +72,7 @@ public abstract class ParameterDefault
 ///
 /// Putting it all together, the lower-bound bits of entropy calculation is:
 ///
-/// <code>
+/// <code lang="csharp">
 /// log base 2 [67^x * 23^a * 23^b * 10^c * 11^d * (a + b + c + d)! / (a! * b! * c! * d!)]
 /// </code>
 /// </remarks>

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -35,7 +35,7 @@ namespace Aspire.Hosting;
 /// <example>
 /// The following example shows creating a PostgreSQL server resource with a database and referencing that
 /// database in a .NET project.
-/// <code lang="C#">
+/// <code lang="csharp">
 /// var builder = DistributedApplication.CreateBuilder(args);
 /// var inventoryDatabase = builder.AddPostgres("mypostgres").AddDatabase("inventory");
 /// builder.AddProject&lt;Projects.InventoryService&gt;()
@@ -74,7 +74,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// <example>
     /// The following example is creating a Postgres server resource with a database and referencing that
     /// database in a .NET project.
-    /// <code>
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder();
     /// var inventoryDatabase = builder.AddPostgres("mypostgres").AddDatabase("inventory");
     /// builder.AddProject&lt;Projects.InventoryService&gt;()
@@ -106,7 +106,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// <example>
     /// The following example shows creating a Postgres server resource with a database and referencing that
     /// database in a .NET project.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     /// var inventoryDatabase = builder.AddPostgres("mypostgres").AddDatabase("inventory");
     /// builder.AddProject&lt;Projects.InventoryService&gt;()
@@ -117,7 +117,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// </example>
     /// <example>
     /// The following example is equivalent to the previous example except that it does not use top-level statements.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// public class Program
     /// {
     ///     public static void Main(string[] args)
@@ -164,7 +164,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// </remarks>
     /// <example>
     /// Override the container registry used by the distributed application.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// var options = new DistributedApplicationOptions
     /// {
     ///     Args = args; // Important for deployment tools

--- a/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
@@ -38,7 +38,7 @@ namespace Aspire.Hosting;
 /// later use.
 /// </para>
 /// 
-/// <code>
+/// <code lang="csharp">
 /// var builder = DistributedApplication.CreateBuilder(args);
 /// var cache = builder.AddRedis("cache");
 /// var inventoryDatabase = builder.AddPostgres("postgres").AddDatabase("inventory");
@@ -83,7 +83,7 @@ public interface IDistributedApplicationBuilder
     /// the <see cref="IResourceBuilder{T}.ApplicationBuilder"/>. In this case an extension method is used to generate a stable node name for RabbitMQ for local
     /// development runs.
     /// </para>
-    /// <code>
+    /// <code lang="csharp">
     /// private static IResourceBuilder&lt;RabbitMQServerResource&gt; RunWithStableNodeName(this IResourceBuilder&lt;RabbitMQServerResource&gt; builder)
     /// {
     ///     if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
@@ -131,7 +131,7 @@ public interface IDistributedApplicationBuilder
     /// constructs a resource derived from <see cref="IResource"/> and adds it to the application model using the <see cref="AddResource{T}(T)"/>
     /// method. Other extension methods (such as <see cref="ContainerResourceBuilderExtensions.WithImage{T}(IResourceBuilder{T}, string, string)"/>
     /// in this case) can be chained to configure the resource as desired.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// public static IResourceBuilder&lt;ContainerResource&gt; AddContainer(this IDistributedApplicationBuilder builder, string name, string image, string tag)
     /// {
     ///     var container = new ContainerResource(name);
@@ -181,7 +181,7 @@ public interface IDistributedApplicationBuilder
     /// <see cref="CreateResourceBuilder{T}(T)"/> method assists by allowing the creation of a <see cref="IResourceBuilder{T}"/> without adding
     /// another resource to the application model.
     /// </para>
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// public static IResourceBuilder&lt;IResourceWithConnectionString&gt; AddConnectionString(this IDistributedApplicationBuilder builder, string name, string? environmentVariableName = null)
     /// {
     ///     var parameterBuilder = builder.AddParameter(name, _ =>

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -44,7 +44,7 @@ public static class ProjectResourceBuilderExtensions
     /// </remarks>
     /// <example>
     /// Example of adding a project to the application model.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     /// 
     /// builder.AddProject&lt;Projects.InventoryService&gt;("inventoryservice");
@@ -76,7 +76,7 @@ public static class ProjectResourceBuilderExtensions
     /// </remarks>
     /// <example>
     /// Add a project to the app model via a project path.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     /// 
     /// builder.AddProject("inventoryservice", @"..\InventoryService\InventoryService.csproj");
@@ -124,7 +124,7 @@ public static class ProjectResourceBuilderExtensions
     /// </remarks>
     /// <example>
     /// Example of adding a project to the application model.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     /// 
     /// builder.AddProject&lt;Projects.InventoryService&gt;("inventoryservice", launchProfileName: "otherLaunchProfile");
@@ -157,7 +157,7 @@ public static class ProjectResourceBuilderExtensions
     /// </remarks>
     /// <example>
     /// Add a project to the app model via a project path.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     /// 
     /// builder.AddProject("inventoryservice", @"..\InventoryService\InventoryService.csproj", launchProfileName: "otherLaunchProfile");
@@ -374,7 +374,7 @@ public static class ProjectResourceBuilderExtensions
     /// </remarks>
     /// <example>
     /// Start multiple instances of the same service.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// builder.AddProject&lt;Projects.InventoryService&gt;("inventoryservice")
@@ -406,7 +406,7 @@ public static class ProjectResourceBuilderExtensions
     /// </remarks>
     /// <example>
     /// Disable forwarded headers for a project.
-    /// <code lang="C#">
+    /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
     /// builder.AddProject&lt;Projects.InventoryService&gt;("inventoryservice")


### PR DESCRIPTION
Throughout the .NET Aspire API docs there are places where we show examples, which is awesome! We need to however ensure that it consistently receives the appropriate syntax highlighting. In this PR:

- Normalize `lang="C#"` as `lang="csharp"`
- Add missing lang ids, `<code>` became `<code lang="csharp">`

Discovered when making other updates and reviewing API docs:

![image](https://github.com/dotnet/aspire/assets/7679720/31e9c7b7-7b8d-4eea-8192-6b0d407b0bb7)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4398)