### PR TITLE
Allow WithArgs to accept ReferenceExpressions

### DIFF
--- a/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
@@ -47,7 +47,7 @@ public static class ExecutableResourceBuilderExtensions
                           {
                               context.Args.AddRange(args);
                           }
-                      });        
+                      });
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
@@ -23,6 +23,20 @@ public static class ExecutableResourceBuilderExtensions
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<ExecutableResource> AddExecutable(this IDistributedApplicationBuilder builder, string name, string command, string workingDirectory, params string[]? args)
     {
+        return AddExecutable(builder, name, command, workingDirectory, (object[]?)args);
+    }
+
+    /// <summary>
+    /// Adds an executable resource to the application model.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="command">The executable path. This can be a fully qualified path or a executable to run from the shell/command line.</param>
+    /// <param name="workingDirectory">The working directory of the executable.</param>
+    /// <param name="args">The arguments to the executable.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<ExecutableResource> AddExecutable(this IDistributedApplicationBuilder builder, string name, string command, string workingDirectory, params object[]? args)
+    {
         workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, workingDirectory));
 
         var executable = new ExecutableResource(name, command, workingDirectory);
@@ -33,7 +47,7 @@ public static class ExecutableResourceBuilderExtensions
                           {
                               context.Args.AddRange(args);
                           }
-                      });
+                      });        
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -113,3 +113,5 @@ static Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject(this Aspire.Ho
 static Aspire.Hosting.ProjectResourceBuilderExtensions.AddProject<TProject>(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, System.Action<Aspire.Hosting.ProjectResourceOptions!>! configure) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.TerminalStates -> System.Collections.Generic.IReadOnlyList<string!>!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Waiting -> string!
+static Aspire.Hosting.ExecutableResourceBuilderExtensions.AddExecutable(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string! command, string! workingDirectory, params object![]? args) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ExecutableResource!>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithArgs<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, params object![]! args) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -168,6 +168,18 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Adds the arguments to be passed to a container resource when the container is started.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <param name="args">The arguments to be passed to the container when it is started.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<T> WithArgs<T>(this IResourceBuilder<T> builder, params object[] args) where T : IResourceWithArgs
+    {
+        return builder.WithArgs(context => context.Args.AddRange(args));
+    }
+
+    /// <summary>
     /// Adds a callback to be executed with a list of command-line arguments when a container resource is started.
     /// </summary>
     /// <typeparam name="T"></typeparam>


### PR DESCRIPTION
Update the `WithArgs` extension method to accept `object[]` rather than `string[]`.  In particular, this now allows for the use of reference expressions inside `WithArgs`
```cs
.WithArgs(
   "-p",
   resource.PrimaryEndpoint.Property(EndpointProperty.TargetPort)
);
```

Fixes #4237
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4415)