### PR TITLE
Update PgAdmin from tag 8.5 to 8.8.

### DIFF
--- a/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
@@ -10,5 +10,5 @@ internal static class PostgresContainerImageTags
     public const string Tag = "16.2";
     public const string PgAdminRegistry = "docker.io";
     public const string PgAdminImage = "dpage/pgadmin4";
-    public const string PgAdminTag = "8.5";
+    public const string PgAdminTag = "8.8";
 }


### PR DESCRIPTION
The current version of PgAdmin is outdated, resulting in a warning message when opening the PgAdmin dashboard:
![image](https://github.com/dotnet/aspire/assets/20819818/f5e0ec85-ebb5-49f6-b373-faea58c8c387)

This PR bumps the image tag from 8.5 to 8.8, which is the most recent version as of this PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4524)