### PR TITLE
Treat the first endpoint for each scheme as default

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -17,4 +17,18 @@ public class ProjectResource(string name) : Resource(name), IResourceWithEnviron
 
     // Track the https endpoint that was added as a default, and should be excluded from the port & kestrel environment
     internal EndpointAnnotation? DefaultHttpsEndpoint { get; set; }
+
+    internal bool IsDefaultEndpoint(EndpointAnnotation endpoint)
+    {
+        // Determine if the endpoint should be treated as the Default endpoint.
+        // Endpoints can come from 3 different sources (in this order):
+        // 1. Kestrel configuration
+        // 2. Default endpoints added by the framework
+        // 3. Explicitly added endpoints
+        // But wherever they come from, we treat the first one as Default (for each scheme).
+        // NOTE: the implementation is a bit inefficient as it iterates over the endpoints
+        // for each check, but it's not a performance critical path.
+        return endpoint == Annotations.OfType<EndpointAnnotation>().FirstOrDefault(
+            e => e.UriScheme == endpoint.UriScheme);
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ProjectResource.cs
@@ -17,18 +17,4 @@ public class ProjectResource(string name) : Resource(name), IResourceWithEnviron
 
     // Track the https endpoint that was added as a default, and should be excluded from the port & kestrel environment
     internal EndpointAnnotation? DefaultHttpsEndpoint { get; set; }
-
-    internal bool IsDefaultEndpoint(EndpointAnnotation endpoint)
-    {
-        // Determine if the endpoint should be treated as the Default endpoint.
-        // Endpoints can come from 3 different sources (in this order):
-        // 1. Kestrel configuration
-        // 2. Default endpoints added by the framework
-        // 3. Explicitly added endpoints
-        // But wherever they come from, we treat the first one as Default (for each scheme).
-        // NOTE: the implementation is a bit inefficient as it iterates over the endpoints
-        // for each check, but it's not a performance critical path.
-        return endpoint == Annotations.OfType<EndpointAnnotation>().FirstOrDefault(
-            e => e.UriScheme == endpoint.UriScheme);
-    }
 }

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -384,7 +384,12 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                     _ => PortAllocator.AllocatePort()
                 };
 
-                schemesEncountered.Add(endpoint.UriScheme);
+                // We only keep track of schemes for project resources, since we don't want
+                // a non-project scheme to affect what project endpoints are considered default.
+                if (resource is ProjectResource)
+                {
+                    schemesEncountered.Add(endpoint.UriScheme);
+                }
 
                 int? exposedPort = (endpoint.UriScheme, endpoint.Port, targetPort) switch
                 {

--- a/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
+++ b/src/Aspire.Hosting/Publishing/ManifestPublishingContext.cs
@@ -368,9 +368,9 @@ public sealed class ManifestPublishingContext(DistributedApplicationExecutionCon
                     // Container resources get their default listening port from the exposed port.
                     (ContainerResource, _, null, int port) => port,
 
-                    // Project resources get their default listening port from the deployment tool
-                    // ideally we would default to a known port but we don't know it at this point
-                    (ProjectResource, var scheme, null, _) when scheme is "http" or "https" => null,
+                    // Check whether the project view this endpoint as Default (for its scheme).
+                    // If so, we don't specify the target port, as it will get one from the deployment tool.
+                    (ProjectResource project, _, null, _) when project.IsDefaultEndpoint(endpoint) => null,
 
                     // Allocate a dynamic port
                     _ => PortAllocator.AllocatePort()

--- a/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
+++ b/tests/Aspire.Hosting.Tests/KestrelConfigTests.cs
@@ -216,7 +216,8 @@ public class KestrelConfigTests
                   "scheme": "http",
                   "protocol": "tcp",
                   "transport": "http",
-                  "port": 5017
+                  "port": 5017,
+                  "targetPort": 8000
                 },
                 "ExplicitNoProxyHttp": {
                   "scheme": "http",

--- a/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
+++ b/tests/Aspire.Hosting.Tests/WithEndpointTests.cs
@@ -452,12 +452,14 @@ public class WithEndpointTests
     }
 
     [Fact]
-    public async Task VerifyManifestProjectWithHttpEndpointDoesNotAllocatePort()
+    public async Task VerifyManifestProjectWithDefaultHttpEndpointsDoesNotAllocatePort()
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
         var project = builder.AddProject<TestProject>("proj")
-            .WithHttpEndpoint(name: "hp")
-            .WithHttpsEndpoint(name: "hps");
+            .WithHttpEndpoint(name: "hp")       // Won't get targetPort since it's the first http
+            .WithHttpEndpoint(name: "hp2")      // Will get a targetPort
+            .WithHttpsEndpoint(name: "hps")     // Won't get targetPort since it's the first https
+            .WithHttpsEndpoint(name: "hps2");   // Will get a targetPort
 
         var manifest = await ManifestUtils.GetManifest(project.Resource);
 
@@ -471,8 +473,8 @@ public class WithEndpointTests
                 "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
                 "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
                 "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
-                "HTTP_PORTS": "{proj.bindings.hp.targetPort}",
-                "HTTPS_PORTS": "{proj.bindings.hps.targetPort}"
+                "HTTP_PORTS": "{proj.bindings.hp.targetPort};{proj.bindings.hp2.targetPort}",
+                "HTTPS_PORTS": "{proj.bindings.hps.targetPort};{proj.bindings.hps2.targetPort}"
               },
               "bindings": {
                 "hp": {
@@ -480,10 +482,22 @@ public class WithEndpointTests
                   "protocol": "tcp",
                   "transport": "http"
                 },
+                "hp2": {
+                  "scheme": "http",
+                  "protocol": "tcp",
+                  "transport": "http",
+                  "targetPort": 8000
+                },
                 "hps": {
                   "scheme": "https",
                   "protocol": "tcp",
                   "transport": "http"
+                },
+                "hps2": {
+                  "scheme": "https",
+                  "protocol": "tcp",
+                  "transport": "http",
+                  "targetPort": 8001
                 }
               }
             }


### PR DESCRIPTION
The idea is that all non-default endpoints should get a target port allocate in the manifest. Only the default gets it omitted.

Fixes #3786.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4529)