### PR TITLE
Use CBL-Mariner minimal image for Dockerfile playground.

### DIFF
--- a/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
@@ -6,8 +6,7 @@ COPY . .
 RUN go build qots.go
 
 # Stage 2: Run the Go program
-ARG GO_VERSION
-FROM golang:${GO_VERSION}
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 WORKDIR /app
 RUN --mount=type=secret,id=SECRET_ASENV cp /run/secrets/SECRET_ASENV /app/SECRET_ASENV
 RUN --mount=type=secret,id=SECRET_ASFILE cp /run/secrets/SECRET_ASFILE /app/SECRET_ASFILE


### PR DESCRIPTION
Changes from using the golang image for runtime of the Go-based app in playground.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4531)