### PR TITLE
Fix compatibility with Autofac and LookupClient registration

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Dns/ServiceDiscoveryDnsServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Dns/ServiceDiscoveryDnsServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ public static class ServiceDiscoveryDnsServiceCollectionExtensions
     public static IServiceCollection AddDnsSrvServiceEndpointProvider(this IServiceCollection services, Action<DnsSrvServiceEndpointProviderOptions> configureOptions)
     {
         services.AddServiceDiscoveryCore();
-        services.TryAddSingleton<IDnsQuery, LookupClient>();
+        services.TryAddSingleton<IDnsQuery>(_ => new LookupClient());
         services.AddSingleton<IServiceEndpointProviderFactory, DnsSrvServiceEndpointProviderFactory>();
         var options = services.AddOptions<DnsSrvServiceEndpointProviderOptions>();
         options.Configure(o => configureOptions?.Invoke(o));


### PR DESCRIPTION
Fixes #4431 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4532)

Autofac has trouble choosing the right constructor when there are multiple constructors with the same number of parameters. This ensures that the correct constructor is used. See [here](https://github.com/autofac/Autofac/blob/ec4907fb6ea61015080b76bcd18cbcf63e43579e/src/Autofac/Core/Activators/Reflection/MostParametersConstructorSelector.cs#L70).