### PR TITLE
Don't show success status for FailedToStart state, use static helpers for determining resource state

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Aspire.Dashboard.Components.Controls;
+using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
@@ -171,7 +172,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         builder.Add(_noSelection);
 
         foreach (var resourceGroupsByApplicationName in _resourceByName
-            .Where(r => r.Value.State != ResourceStates.HiddenState)
+            .Where(r => !r.Value.IsHiddenState())
             .OrderBy(c => c.Value.Name)
             .GroupBy(r => r.Value.DisplayName, r => r.Value))
         {
@@ -208,12 +209,17 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             {
                 var resourceName = ResourceViewModel.GetResourceName(resource, _resourceByName);
 
-                return resource.State switch
+                if (resource.HasNoState())
                 {
-                    null or { Length: 0 } => $"{resourceName} ({Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsUnknownState)]})",
-                    ResourceStates.RunningState => resourceName,
-                    _ => $"{resourceName} ({resource.State})"
-                };
+                    return $"{resourceName} ({Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsUnknownState)]})";
+                }
+
+                if (resource.IsRunningState())
+                {
+                    return resourceName;
+                }
+
+                return $"{resourceName} ({resource.State})";
             }
         }
     }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
@@ -53,7 +54,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         _visibleResourceTypes = new(StringComparers.ResourceType);
     }
 
-    private bool Filter(ResourceViewModel resource) => _visibleResourceTypes.ContainsKey(resource.ResourceType) && (_filter.Length == 0 || resource.MatchesFilter(_filter)) && resource.State != ResourceStates.HiddenState;
+    private bool Filter(ResourceViewModel resource) => _visibleResourceTypes.ContainsKey(resource.ResourceType) && (_filter.Length == 0 || resource.MatchesFilter(_filter)) && !resource.IsHiddenState();
 
     protected Task OnResourceTypeVisibilityChangedAsync(string resourceType, bool isVisible)
     {
@@ -241,7 +242,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         var count = 0;
         foreach (var (_, item) in _resourceByName)
         {
-            if (item.State == ResourceStates.HiddenState)
+            if (item.IsHiddenState())
             {
                 continue;
             }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -8,7 +8,7 @@
 
 @if (Resource.IsStopped())
 {
-    if (Resource.TryGetExitCode(out int exitCode) && exitCode is not 0)
+    if (Resource.TryGetExitCode(out var exitCode) && exitCode is not 0)
     {
         <!-- process completed unexpectedly, hence the non-zero code. this is almost certainly an error, so warn users -->
         <FluentIcon Title="@string.Format(Loc[Columns.StateColumnResourceExitedUnexpectedly], Resource.ResourceType, exitCode)"
@@ -16,12 +16,19 @@
                     Color="Color.Error"
                     Class="severity-icon" />
     }
+    else if (Resource.IsFinishedState())
+    {
+        <FluentIcon Title="@string.Format(Loc[Columns.StateColumnResourceExited], Resource.ResourceType)"
+                    Icon="Icons.Regular.Size16.CheckmarkUnderlineCircle"
+                    Color="Color.Success"
+                    Class="severity-icon" />
+    }
     else
     {
         <!-- process completed, which may not have been unexpected -->
         <FluentIcon Title="@string.Format(Loc[Columns.StateColumnResourceExited], Resource.ResourceType)"
-                    Icon="Icons.Regular.Size16.CheckmarkUnderlineCircle"
-                    Color="Color.Success"
+                    Icon="Icons.Filled.Size16.Warning"
+                    Color="Color.Warning"
                     Class="severity-icon" />
     }
 }
@@ -31,7 +38,7 @@ else if (Resource.IsStartingOrBuilding())
                 Color="Color.Info"
                 Class="severity-icon" />
 }
-else if (Resource is { State: /* unknown */ null or { Length: 0 } })
+else if (Resource.HasNoState())
 {
     <FluentIcon Icon="Icons.Filled.Size16.Circle"
                 Color="Color.Neutral"
@@ -75,7 +82,7 @@ else
                 Class="severity-icon" />
 }
 
-@if (string.IsNullOrEmpty(Resource.State))
+@if (Resource.HasNoState())
 {
     <span>@Loc[Columns.UnknownStateLabel]</span>
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -1,11 +1,12 @@
-﻿@using Aspire.Dashboard.Model
+﻿@using Aspire.Dashboard.Extensions
+@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
 @using Humanizer
 
 @inject IStringLocalizer<Columns> Loc
 
-@if (Resource is { State: ResourceStates.ExitedState /* containers */ or ResourceStates.FinishedState /* executables */ or ResourceStates.FailedToStartState })
+@if (Resource.IsStopped())
 {
     if (Resource.TryGetExitCode(out int exitCode) && exitCode is not 0)
     {
@@ -24,7 +25,7 @@
                     Class="severity-icon" />
     }
 }
-else if (Resource is { State: ResourceStates.StartingState } or { State: ResourceStates.BuildingState })
+else if (Resource.IsStartingOrBuilding())
 {
     <FluentIcon Icon="Icons.Regular.Size16.CircleHint"
                 Color="Color.Info"

--- a/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+
+namespace Aspire.Dashboard.Extensions;
+
+public static class ResourceViewModelExtensions
+{
+    internal static KnownResourceState? GetKnownState(this ResourceViewModel resource)
+    {
+        if (Enum.TryParse(resource.State, out KnownResourceState knownState))
+        {
+            return knownState;
+        }
+
+        return null;
+    }
+
+    internal static bool IsHiddenState(this ResourceViewModel resource)
+    {
+        return resource.GetKnownState() == KnownResourceState.Hidden;
+    }
+
+    internal static bool IsRunningState(this ResourceViewModel resource)
+    {
+        return resource.GetKnownState() == KnownResourceState.Running;
+    }
+
+    internal static bool IsStopped(this ResourceViewModel resource)
+    {
+        return resource.GetKnownState() is KnownResourceState.Exited or KnownResourceState.Finished or KnownResourceState.FailedToStart;
+    }
+
+    internal static bool IsStartingOrBuilding(this ResourceViewModel resource)
+    {
+        return resource.GetKnownState() is KnownResourceState.Starting or KnownResourceState.Building;
+    }
+
+    internal static bool HasNoState(this ResourceViewModel resource) => string.IsNullOrEmpty(resource.State);
+}

--- a/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
@@ -27,6 +27,11 @@ public static class ResourceViewModelExtensions
         return resource.GetKnownState() == KnownResourceState.Running;
     }
 
+    internal static bool IsFinishedState(this ResourceViewModel resource)
+    {
+        return resource.GetKnownState() is KnownResourceState.Finished;
+    }
+
     internal static bool IsStopped(this ResourceViewModel resource)
     {
         return resource.GetKnownState() is KnownResourceState.Exited or KnownResourceState.Finished or KnownResourceState.FailedToStart;

--- a/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
@@ -5,32 +5,32 @@ using Aspire.Dashboard.Model;
 
 namespace Aspire.Dashboard.Extensions;
 
-public static class ResourceViewModelExtensions
+internal static class ResourceViewModelExtensions
 {
-    internal static bool IsHiddenState(this ResourceViewModel resource)
+    public static bool IsHiddenState(this ResourceViewModel resource)
     {
         return resource.KnownState == KnownResourceState.Hidden;
     }
 
-    internal static bool IsRunningState(this ResourceViewModel resource)
+    public static bool IsRunningState(this ResourceViewModel resource)
     {
         return resource.KnownState == KnownResourceState.Running;
     }
 
-    internal static bool IsFinishedState(this ResourceViewModel resource)
+    public static bool IsFinishedState(this ResourceViewModel resource)
     {
         return resource.KnownState is KnownResourceState.Finished;
     }
 
-    internal static bool IsStopped(this ResourceViewModel resource)
+    public static bool IsStopped(this ResourceViewModel resource)
     {
         return resource.KnownState is KnownResourceState.Exited or KnownResourceState.Finished or KnownResourceState.FailedToStart;
     }
 
-    internal static bool IsStartingOrBuilding(this ResourceViewModel resource)
+    public static bool IsStartingOrBuilding(this ResourceViewModel resource)
     {
         return resource.KnownState is KnownResourceState.Starting or KnownResourceState.Building;
     }
 
-    internal static bool HasNoState(this ResourceViewModel resource) => string.IsNullOrEmpty(resource.State);
+    public static bool HasNoState(this ResourceViewModel resource) => string.IsNullOrEmpty(resource.State);
 }

--- a/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
@@ -7,39 +7,29 @@ namespace Aspire.Dashboard.Extensions;
 
 public static class ResourceViewModelExtensions
 {
-    internal static KnownResourceState? GetKnownState(this ResourceViewModel resource)
-    {
-        if (Enum.TryParse(resource.State, out KnownResourceState knownState))
-        {
-            return knownState;
-        }
-
-        return null;
-    }
-
     internal static bool IsHiddenState(this ResourceViewModel resource)
     {
-        return resource.GetKnownState() == KnownResourceState.Hidden;
+        return resource.KnownState == KnownResourceState.Hidden;
     }
 
     internal static bool IsRunningState(this ResourceViewModel resource)
     {
-        return resource.GetKnownState() == KnownResourceState.Running;
+        return resource.KnownState == KnownResourceState.Running;
     }
 
     internal static bool IsFinishedState(this ResourceViewModel resource)
     {
-        return resource.GetKnownState() is KnownResourceState.Finished;
+        return resource.KnownState is KnownResourceState.Finished;
     }
 
     internal static bool IsStopped(this ResourceViewModel resource)
     {
-        return resource.GetKnownState() is KnownResourceState.Exited or KnownResourceState.Finished or KnownResourceState.FailedToStart;
+        return resource.KnownState is KnownResourceState.Exited or KnownResourceState.Finished or KnownResourceState.FailedToStart;
     }
 
     internal static bool IsStartingOrBuilding(this ResourceViewModel resource)
     {
-        return resource.GetKnownState() is KnownResourceState.Starting or KnownResourceState.Building;
+        return resource.KnownState is KnownResourceState.Starting or KnownResourceState.Building;
     }
 
     internal static bool HasNoState(this ResourceViewModel resource) => string.IsNullOrEmpty(resource.State);

--- a/src/Aspire.Dashboard/Model/KnownResourceState.cs
+++ b/src/Aspire.Dashboard/Model/KnownResourceState.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public enum KnownResourceState
+{
+    Finished,
+    Exited,
+    FailedToStart,
+    Starting,
+    Running,
+    Building,
+    Hidden
+}

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Aspire.Dashboard.Extensions;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Dashboard.Model;
@@ -35,7 +36,7 @@ public sealed class ResourceViewModel
         var count = 0;
         foreach (var (_, item) in allResources)
         {
-            if (item.State == ResourceStates.HiddenState)
+            if (item.IsHiddenState())
             {
                 continue;
             }
@@ -106,15 +107,4 @@ public sealed class UrlViewModel
         Url = url;
         IsInternal = isInternal;
     }
-}
-
-public static class ResourceStates
-{
-    public const string FinishedState = "Finished";
-    public const string ExitedState = "Exited";
-    public const string FailedToStartState = "FailedToStart";
-    public const string StartingState = "Starting";
-    public const string RunningState = "Running";
-    public const string BuildingState = "Building";
-    public const string HiddenState = "Hidden";
 }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -24,6 +24,7 @@ public sealed class ResourceViewModel
     public required ImmutableArray<UrlViewModel> Urls { get; init; }
     public required FrozenDictionary<string, Value> Properties { get; init; }
     public required ImmutableArray<CommandViewModel> Commands { get; init; }
+    public KnownResourceState? KnownState { get; init; }
 
     internal bool MatchesFilter(string filter)
     {

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -26,6 +26,7 @@ partial class Resource
             Environment = GetEnvironment(),
             Urls = GetUrls(),
             State = HasState ? State : null,
+            KnownState = HasState ? Enum.TryParse(State, out KnownResourceState knownState) ? knownState : null : null,
             StateStyle = HasStateStyle ? StateStyle : null,
             Commands = GetCommands()
         };

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -181,6 +181,7 @@ public sealed class ResourceEndpointHelpersTests
             Urls = urls,
             Properties = FrozenDictionary<string, Value>.Empty,
             State = null,
+            KnownState = null,
             StateStyle = null,
             Commands = []
         };

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -25,6 +25,7 @@ public class ResourceOutgoingPeerResolverTests
             Properties = FrozenDictionary<string, Value>.Empty,
             Urls = servicePort is null || servicePort is null ? [] : [new UrlViewModel(name, new($"http://{serviceAddress}:{servicePort}"), isInternal: false)],
             State = null,
+            KnownState = null,
             StateStyle = null,
             Commands = []
         };


### PR DESCRIPTION
Fix #4498 and fix #1406 

This PR converts the static class used to hold known resource states into an enum, adds static helper methods for determining state kind, and fixes #4498 by only showing success for `Finished` state.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4541)