### PR TITLE
Revert CSS fix from #4013

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -429,14 +429,3 @@ fluent-data-grid-cell.no-ellipsis {
 .endpoint-button::part(control) {
     padding: calc(((var(--design-unit) * 0.5) - var(--stroke-width)) * 1px) calc((var(--design-unit) - var(--stroke-width)) * 1px);
 }
-
-.column-header {
-    /*
-        fluent-data-grid-cells have a height of 100%, which should correspond to
-        the height of their parent fluent-data-grid-row.
-        On Safari only, this is not the case; height actually computes to the grid height.
-        We can force column headers to take the height of their parent by inheriting height
-        of their row.
-     */
-    height: inherit !important;
-}


### PR DESCRIPTION
As mentioned in #4018, the prior css issue has been fixed in fluentui-blazor. Therefore, the override we added can be removed.

![image](https://github.com/dotnet/aspire/assets/20359921/a842349f-540e-4ac8-9e53-da0fc78d6417)
still appears correct on Safari 😄 

fixes #4048 