### PR TITLE
Fix CredScan false positive.

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -20,6 +20,10 @@
     {
       "placeholder": "p@ssw0rd1",
       "_justification": "This is fake password, used in integration tests."
+    },
+    {
+      "placeholder": "thisIsAFakeSecret",
+      "_justification": "This isn't a real secret, it's used in one of the playground applications for testing purposes."
     }
   ]
 }

--- a/playground/withdockerfile/WithDockerfile.AppHost/appsettings.json
+++ b/playground/withdockerfile/WithDockerfile.AppHost/appsettings.json
@@ -8,6 +8,6 @@
     }
   },
   "Parameters": {
-    "secret": "opensesame"
+    "secret": "thisIsAFakeSecret"
   }
 }


### PR DESCRIPTION
Repo mirroring is broken currently because CredScan is flagging a false positive secret in the recent changes for FromDockerfile support. This PR fixes that by using a placeholder that is more clearly fake, as well as adding it to the suppressions file. All of the existing suppressions are mostly credentials, which is why I went with defining a new one instead of using an existing one.

cc: @mitchdenny @mmitche 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4548)