### PR TITLE
[tests] Make dependencies installation on helix more robust

### DIFF
--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -75,7 +75,7 @@
 
     <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="chmod +x $HELIX_WORKITEM_ROOT/.playwright/node/linux-x64/node" />
     <!-- wait for lock for 2mins -->
-    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="sudo apt-get -o DPkg::Lock::Timeout=120 install -y libgbm1 libxkbcommon0" />
+    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="sudo apt-get -o DPkg::Lock::Timeout=120 install -y libgbm1 libxkbcommon0 || exit 1" />
 
     <HelixPreCommand Condition="'$(OS)' == 'Windows_NT'" Include="set PLAYWRIGHT_BROWSERS_PATH=%HELIX_CORRELATION_PAYLOAD%\playwright-deps" />
     <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="export PLAYWRIGHT_BROWSERS_PATH=$HELIX_CORRELATION_PAYLOAD/playwright-deps" />

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -74,7 +74,8 @@
     <HelixCorrelationPayload Include="$(PlaywrightDependenciesDirectory)" Destination="playwright-deps" />
 
     <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="chmod +x $HELIX_WORKITEM_ROOT/.playwright/node/linux-x64/node" />
-    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="sudo apt-get install -y libgbm1 libxkbcommon0" />
+    <!-- wait for lock for 2mins -->
+    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="sudo apt-get -o DPkg::Lock::Timeout=120 install -y libgbm1 libxkbcommon0" />
 
     <HelixPreCommand Condition="'$(OS)' == 'Windows_NT'" Include="set PLAYWRIGHT_BROWSERS_PATH=%HELIX_CORRELATION_PAYLOAD%\playwright-deps" />
     <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="export PLAYWRIGHT_BROWSERS_PATH=$HELIX_CORRELATION_PAYLOAD/playwright-deps" />


### PR DESCRIPTION
- [tests] Wait for 2mins for dpkg lock when using apt-get
This is to handle:
```
+ sudo apt-get install -y libgbm1 libxkbcommon0
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 1655 (dpkg)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), is another process using it?
```
- Also, fail the run if `apt-get` fails

Fixes https://github.com/dotnet/aspire/issues/4487 .

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4557)