### PR TITLE
Fix src/Components/Directory.Build.props

### DIFF
--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -1,12 +1,10 @@
 <Project>
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
     <IsAotCompatible>true</IsAotCompatible>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-    <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>
-    <PackageValidationBaselineVersion Condition="'$(EnablePackageValidation)' == 'true' and '$(PackageValidationBaselineVersion)' == ''">$(BaselineVersionForPackageValidation)</PackageValidationBaselineVersion>
 
     <ComponentCommonPackageTags>aspire component cloud</ComponentCommonPackageTags>
     <ComponentCachePackageTags>$(ComponentCommonPackageTags) cache caching</ComponentCachePackageTags>


### PR DESCRIPTION
Ensure we import the src/Directory.Build.props file. Don't skip it, so we don't have to duplicate properties.

See https://github.com/dotnet/aspire/pull/4467/files#r1635638019
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4573)