### PR TITLE
Add new DCP binary unix file permissions entry

### DIFF
--- a/eng/dcppack/UnixFilePermissions.xml
+++ b/eng/dcppack/UnixFilePermissions.xml
@@ -1,4 +1,5 @@
 <FileList>
   <File Path="tools/dcp" Permission="755"/>
   <File Path="tools/ext/dcpctrl" Permission="755"/>
+  <File Path="tools/ext/bin/dcpproc" Permission="755"/>
 </FileList>


### PR DESCRIPTION
There's a new DCP binary responsible for cleaning up child processes if DCP happens to go away suddenly, but it needs an entry in UnixFilePermissions.xml for *nix workload installs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4577)