### PR TITLE
Fix structured logs filter field, which was erroneously filtering out all logs

### DIFF
--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -130,6 +130,11 @@ public class LogFilter
                     }
                     return input;
                 }
+            case nameof(OtlpLogEntry.Message):
+                {
+                    var func = ConditionToFuncString(Condition);
+                    return input.Where(x => func(x.Message, Value));
+                }
             default:
                 {
                     var func = ConditionToFuncString(Condition);

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -739,6 +739,7 @@ public class LogTests
 
         var applicationId = repository.GetApplications().First().InstanceId;
 
+        // Assert
         Assert.Empty(repository.GetLogs(new GetLogsContext
         {
             ApplicationServiceId = applicationId,
@@ -754,6 +755,5 @@ public class LogTests
             Count = 1,
             Filters = [new LogFilter { Condition = FilterCondition.Contains, Field = nameof(OtlpLogEntry.Message), Value = "message" }]
         }).Items);
-
     }
 }


### PR DESCRIPTION
This has been broken for a while. [this line](https://github.com/dotnet/aspire/blob/main/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs#L80) adds `Message` as a filter field for a new filter, but there is no special case for `Message`, while there are for two other properties of the class [here when applying the filter](https://github.com/dotnet/aspire/blob/faf26a8700c79ec435c2348d566caf4c1a4ebc13/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs#L116). `KnownMessageField` is `log.message`, so `GetFieldValue` returns null.

Fixes #4593

Before:
![Animation](https://github.com/dotnet/aspire/assets/20359921/a055435a-f77b-4687-8b4a-df6710271422)

After:
![Animation](https://github.com/dotnet/aspire/assets/20359921/2449e826-cb32-4ef5-be15-027b226e9e12)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4595)