### PR TITLE
Remove unnecessary DiagnosticListener code

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
@@ -317,7 +316,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         if (diagnosticListener.IsEnabled() && diagnosticListener.IsEnabled(BuilderConstructingEventName))
         {
-            Write(diagnosticListener, BuilderConstructingEventName, (appBuilderOptions, hostBuilderOptions));
+            diagnosticListener.Write(BuilderConstructingEventName, (appBuilderOptions, hostBuilderOptions));
         }
 
         return diagnosticListener;
@@ -329,7 +328,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         if (diagnosticListener.IsEnabled() && diagnosticListener.IsEnabled(BuilderConstructedEventName))
         {
-            Write(diagnosticListener, BuilderConstructedEventName, builder);
+            diagnosticListener.Write(BuilderConstructedEventName, builder);
         }
 
         return diagnosticListener;
@@ -341,7 +340,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         if (diagnosticListener.IsEnabled() && diagnosticListener.IsEnabled(ApplicationBuildingEventName))
         {
-            Write(diagnosticListener, ApplicationBuildingEventName, appBuilder);
+            diagnosticListener.Write(ApplicationBuildingEventName, appBuilder);
         }
 
         return diagnosticListener;
@@ -353,24 +352,9 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         if (diagnosticListener.IsEnabled() && diagnosticListener.IsEnabled(ApplicationBuiltEventName))
         {
-            Write(diagnosticListener, ApplicationBuiltEventName, app);
+            diagnosticListener.Write(ApplicationBuiltEventName, app);
         }
 
         return diagnosticListener;
-    }
-
-    // Remove when https://github.com/dotnet/runtime/pull/78532 is merged and consumed by the used SDK.
-#if NET7_0
-        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-            Justification = "DiagnosticSource is used here to pass objects in-memory to code using HostFactoryResolver. This won't require creating new generic types.")]
-#endif
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
-        Justification = "The values being passed into Write are being consumed by the application already.")]
-    private static void Write<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(
-        DiagnosticListener diagnosticSource,
-        string name,
-        T value)
-    {
-        diagnosticSource.Write(name, value);
     }
 }


### PR DESCRIPTION
This is not necessary since we aren't making Aspire.Hosting trimming compatible. Also, the existing suppressions aren't valid so it is better to just remove them until we need to make this library trimming compatible.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4616)