### PR TITLE
Add DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL to AppHost templates

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-apphost/Properties/launchSettings.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-apphost/Properties/launchSettings.json
@@ -10,8 +10,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21000",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22000"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:22000",
+        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:23000",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:24000"
       }
     },
     //#endif
@@ -24,7 +25,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19000",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20000"
+        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:20000",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:21000"
       }
     }
   }

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.AppHost/Properties/launchSettings.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/AspireApplication.1.AppHost/Properties/launchSettings.json
@@ -10,8 +10,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21000",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22000"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:22000",
+        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:23000",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:24000"
       }
     },
     //#endif
@@ -24,7 +25,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19000",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20000"
+        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:20000",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:21000"
       }
     }
   }

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.AppHost/Properties/launchSettings.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.AppHost/Properties/launchSettings.json
@@ -10,8 +10,9 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21000",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22000"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:22000",
+        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:23000",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:24000"
       }
     },
     //#endif
@@ -24,7 +25,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19000",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20000"
+        "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:20000",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:21000"
       }
     }
   }


### PR DESCRIPTION
The dashboard now supports receiving telemetry via OTLP/HTTP: https://github.com/dotnet/aspire/pull/4197

This PR adds `DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL` env var to AppHost template's launchSettings.json file.

Basically, the new env var enables the dashboard to support both OTLP protocols in parallel. If someone has issues with telemetry over gRPC then they can comment out `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` in launchSettings.json. The dashboard and app host will then tell resources to send telemetry over HTTP to the dashboard. In the future, this could be configured per-resource with an annotation to allow a mix.

* The env var is optional. If it is missing (such as older templates) then everything continues to work.
* `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` (the existing OTLP/gRPC configuration) is now optional. Either one of the OTLP endpoint env vars can be specified. Or both at the same time.
* The env var is passed by the AppHost to the dashboard. The dashboard uses it to expose an OTLP/HTTP endpoint.
* This dashboard OTLP/HTTP endpoint sits alongside the existing OTLP/gRPC endpoint.
* The app host continues to pass `DOTNET_DASHBOARD_OTLP_ENDPOINT_URL` to resources in OTEL env vars.
    * If it isn't configured then the app host uses `DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL`.
    * If both are configured then gRPC endpoint takes precedence.
    * In the future we may want to add annotation to control which is passed to a resource. This should be simple to do.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4619)