### PR TITLE
[ci] Check that dev-certs are installed on windows

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -41,7 +41,7 @@ steps:
         displayName: Install devcerts
 
     - ${{ if eq(parameters.isWindows, 'true') }}:
-      - script: dotnet dev-certs https --check
+      - script: dotnet dev-certs https --verbose
         displayName: Install devcerts
 
     - script: ${{ parameters.dotnetScript }} dotnet-coverage collect

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -41,7 +41,7 @@ steps:
         displayName: Install devcerts
 
     - ${{ if eq(parameters.isWindows, 'true') }}:
-      - script: dotnet dev-certs https --trust
+      - script: dotnet dev-certs https --check
         displayName: Install devcerts
 
     - script: ${{ parameters.dotnetScript }} dotnet-coverage collect

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -41,8 +41,8 @@ steps:
         displayName: Install devcerts
 
     - ${{ if eq(parameters.isWindows, 'true') }}:
-      - script: dotnet dev-certs https --verbose
-        displayName: Install devcerts
+      - script: dotnet dev-certs https --check --verbose
+        displayName: Check dev-certs are installed
 
     - script: ${{ parameters.dotnetScript }} dotnet-coverage collect
               --settings $(Build.SourcesDirectory)/eng/CodeCoverage.config

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -40,6 +40,10 @@ steps:
                 ./ubuntu-create-dotnet-devcert.sh
         displayName: Install devcerts
 
+    - ${{ if eq(parameters.isWindows, 'true') }}:
+      - script: dotnet dev-certs https --trust
+        displayName: Install devcerts
+
     - script: ${{ parameters.dotnetScript }} dotnet-coverage collect
               --settings $(Build.SourcesDirectory)/eng/CodeCoverage.config
               --output ${{ parameters.repoTestResultsPath }}/NonHelix.cobertura.xml


### PR DESCRIPTION
Prompted by tests failing on windows:
`Aspire.Dashboard.Tests.Integration.DashboardClientAuthTests.ConnectsToResourceService_ApiKey(useHttps: True)`
`Aspire.Dashboard.Tests.Integration.DashboardClientAuthTests.ConnectsToResourceService_Unsecured(useHttps: True)`

.. with ..

```
System.InvalidOperationException : Unable to configure HTTPS endpoint. No server certificate was specified, and the default developer certificate could not be found or is out of date.
To generate a developer certificate run 'dotnet dev-certs https'. To trust the certificate (Windows and macOS only) run 'dotnet dev-certs https --trust'.
For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.
```

This seems to have failed on a particular build machine. It's not clear why. So this PR adds a check to get more information in case the dev-certs are not installed, or not valid.

Co-authored by: @DamianEdwards 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4636)