### PR TITLE
Fix Orleans broadcast channel provider registration

### DIFF
--- a/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
+++ b/src/Aspire.Hosting.Orleans/OrleansServiceExtensions.cs
@@ -234,7 +234,7 @@ public static class OrleansServiceExtensions
         string name,
         IProviderConfiguration provider)
     {
-        orleansServiceBuilder.Streaming[name] = provider;
+        orleansServiceBuilder.BroadcastChannel[name] = provider;
         return orleansServiceBuilder;
     }
 


### PR DESCRIPTION
Broadcast channel provider configuration is added to the wrong section (Streaming vs BroadcastChannel)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4649)