### PR TITLE
Add zh-CN culture to dashboard

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -180,7 +180,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         // our language list comes from https://github.com/dotnet/arcade/blob/89008f339a79931cc49c739e9dbc1a27c608b379/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props#L22
         var supportedLanguages = new[]
         {
-            "en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant", "zh-CN" /* non-standard culture but is default in many Chinese browsers request. allowing the culture allows OS culture customization to flow through the dashboard */
+            "en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant", // Standard cultures for compliance.
+            "zh-CN" // Non-standard culture but it is the default in many Chinese browsers. Adding zh-CN allows OS culture customization to flow through the dashboard.
         };
 
         _app.UseRequestLocalization(new RequestLocalizationOptions()

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -180,7 +180,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         // our language list comes from https://github.com/dotnet/arcade/blob/89008f339a79931cc49c739e9dbc1a27c608b379/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props#L22
         var supportedLanguages = new[]
         {
-            "en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant"
+            "en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant", "zh-CN" /* non-standard culture but is default in many Chinese browsers request. allowing the culture allows OS culture customization to flow through the dashboard */
         };
 
         _app.UseRequestLocalization(new RequestLocalizationOptions()


### PR DESCRIPTION
Fixes #2530

As mentioned in the issue, the only thing we need to do is add zh-CN (the set culture by default for many chinese browsers) to the list of supported language locales. This allows culture customizations such as time formats to show up for users in the dashboard.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4652)