### PR TITLE
Expose IServiceProvider on DistributedApplicationExecutionContext.

### DIFF
--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -58,6 +58,8 @@ public class DistributedApplication : IHost, IAsyncDisposable
         ArgumentNullException.ThrowIfNull(host);
 
         _host = host;
+        var context = _host.Services.GetRequiredService<DistributedApplicationExecutionContext>();
+        context.ServiceProvider = _host.Services;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -58,8 +58,6 @@ public class DistributedApplication : IHost, IAsyncDisposable
         ArgumentNullException.ThrowIfNull(host);
 
         _host = host;
-        var context = _host.Services.GetRequiredService<DistributedApplicationExecutionContext>();
-        context.ServiceProvider = _host.Services;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -82,6 +82,11 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         ArgumentNullException.ThrowIfNull(args);
     }
 
+    // This is here because in the constructor of DistributedApplicationBuilder we inject
+    // DistributedApplicationExecutionContext. This is a class that is used to expose contextual
+    // values in various callbacks and is a central location to access useful services like IServiceProvider.
+    private readonly DistributedApplicationExecutionContextOptions _executionContextOptions;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DistributedApplicationBuilder"/> class with the specified options.
     /// </summary>
@@ -136,11 +141,13 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             ["AppHost:Directory"] = AppHostDirectory
         });
 
-        ExecutionContext = _innerBuilder.Configuration["Publishing:Publisher"] switch
+        _executionContextOptions = _innerBuilder.Configuration["Publishing:Publisher"] switch
         {
-            "manifest" => new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish),
-            _ => new DistributedApplicationExecutionContext(DistributedApplicationOperation.Run)
+            "manifest" => new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Publish),
+            _ => new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run)
         };
+
+        ExecutionContext = new DistributedApplicationExecutionContext(_executionContextOptions);
 
         // Core things
         _innerBuilder.Services.AddSingleton(sp => new DistributedApplicationModel(Resources));
@@ -278,6 +285,9 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             }
 
             var application = new DistributedApplication(_innerBuilder.Build());
+
+            _executionContextOptions.ServiceProvider = application.Services.GetRequiredService<IServiceProvider>();
+
             LogAppBuilt(application);
             return application;
         }

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -14,6 +14,17 @@ public class DistributedApplicationExecutionContext(DistributedApplicationOperat
     /// </summary>
     public DistributedApplicationOperation Operation { get; } = operation;
 
+    private IServiceProvider? _serviceProvider;
+
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> for the AppHost.
+    /// </summary>
+    public IServiceProvider ServiceProvider
+    {
+        get =>_serviceProvider ?? throw new InvalidOperationException("The ServiceProvider has not been set.");
+        internal set => _serviceProvider = value;
+    }
+
     /// <summary>
     /// Returns true if the current operation is publishing.
     /// </summary>

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContext.cs
@@ -6,23 +6,56 @@ namespace Aspire.Hosting;
 /// <summary>
 /// Exposes the global contextual information for this invocation of the AppHost.
 /// </summary>
-/// <param name="operation">The operation being performed in this invocation of the AppHost.</param>
-public class DistributedApplicationExecutionContext(DistributedApplicationOperation operation)
+public class DistributedApplicationExecutionContext
 {
+    /// <summary>
+    /// Constructs a <see cref="DistributedApplicationExecutionContext" /> without a callback to retrieve the <see cref="IServiceProvider" />.
+    /// </summary>
+    /// <param name="operation">The operation being performed in this invocation of the AppHost.</param>
+    /// <remarks>
+    /// This constructor is used for internal testing purposes.
+    /// </remarks>
+    public DistributedApplicationExecutionContext(DistributedApplicationOperation operation)
+    {
+        Operation = operation;
+    }
+
+    private readonly DistributedApplicationExecutionContextOptions? _options;
+
+    /// <summary>
+    /// Constructs a <see cref="DistributedApplicationExecutionContext" /> with a callback to retrieve the <see cref="IServiceProvider" />.
+    /// </summary>
+    /// <param name="options">Options for <see cref="DistributedApplicationExecutionContext"/>.</param>
+    public DistributedApplicationExecutionContext(DistributedApplicationExecutionContextOptions options) : this(options.Operation)
+    {
+        _options = options;
+    }
+
     /// <summary>
     /// The operation currently being performed by the AppHost.
     /// </summary>
-    public DistributedApplicationOperation Operation { get; } = operation;
-
-    private IServiceProvider? _serviceProvider;
+    public DistributedApplicationOperation Operation { get; }
 
     /// <summary>
     /// The <see cref="IServiceProvider"/> for the AppHost.
     /// </summary>
+    /// <exception cref="InvalidOperationException" accessor="get">Thrown when the <see cref="IServiceProvider"/> is not available.</exception>
     public IServiceProvider ServiceProvider
     {
-        get =>_serviceProvider ?? throw new InvalidOperationException("The ServiceProvider has not been set.");
-        internal set => _serviceProvider = value;
+        get
+        {
+            if (_options is not { } options)
+            {
+                throw new InvalidOperationException("IServiceProvider is not available because execution context was not constructed with DistributedApplicationExecutionContextOptions.");
+            }
+
+            if (options.ServiceProvider is not { } serviceProvider)
+            {
+                throw new InvalidOperationException("IServiceProvider is not available because the container has not yet been built.");
+            }
+
+            return serviceProvider;
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/DistributedApplicationExecutionContextOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationExecutionContextOptions.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Configuration options and references that need to be exposed to the <see cref="DistributedApplicationExecutionContext"/>.
+/// </summary>
+public class DistributedApplicationExecutionContextOptions(DistributedApplicationOperation operation)
+{
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> for the AppHost.
+    /// </summary>
+    public IServiceProvider? ServiceProvider { get; set; }
+
+    /// <summary>
+    /// The operation currently being performed by the AppHost.
+    /// </summary>
+    public DistributedApplicationOperation Operation { get; } = operation;
+}

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, string? targetState = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, System.Collections.Generic.IEnumerable<string!>! targetStates, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+Aspire.Hosting.DistributedApplicationExecutionContext.ServiceProvider.get -> System.IServiceProvider!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.FailedToStart -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Finished -> string!

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -2,7 +2,13 @@
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, string? targetState = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, System.Collections.Generic.IEnumerable<string!>! targetStates, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+Aspire.Hosting.DistributedApplicationExecutionContext.DistributedApplicationExecutionContext(Aspire.Hosting.DistributedApplicationExecutionContextOptions! options) -> void
 Aspire.Hosting.DistributedApplicationExecutionContext.ServiceProvider.get -> System.IServiceProvider!
+Aspire.Hosting.DistributedApplicationExecutionContextOptions
+Aspire.Hosting.DistributedApplicationExecutionContextOptions.DistributedApplicationExecutionContextOptions(Aspire.Hosting.DistributedApplicationOperation operation) -> void
+Aspire.Hosting.DistributedApplicationExecutionContextOptions.Operation.get -> Aspire.Hosting.DistributedApplicationOperation
+Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.get -> System.IServiceProvider?
+Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.set -> void
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.FailedToStart -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Finished -> string!

--- a/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/EnvironmentVariableEvaluator.cs
@@ -6,14 +6,22 @@ namespace Aspire.Hosting.Tests.Utils;
 public static class EnvironmentVariableEvaluator
 {
     public static async ValueTask<Dictionary<string, string>> GetEnvironmentVariablesAsync(IResource resource,
-        DistributedApplicationOperation applicationOperation = DistributedApplicationOperation.Run)
+        DistributedApplicationOperation applicationOperation = DistributedApplicationOperation.Run, IServiceProvider? serviceProvider = null)
     {
         var environmentVariables = new Dictionary<string, string>();
 
         if (resource.TryGetEnvironmentVariables(out var callbacks))
         {
             var config = new Dictionary<string, object>();
-            var executionContext = new DistributedApplicationExecutionContext(applicationOperation);
+            var executionContext = serviceProvider switch
+            {
+                { } => new DistributedApplicationExecutionContext(new DistributedApplicationExecutionContextOptions(applicationOperation)
+                {
+                    ServiceProvider = serviceProvider
+                }),
+                _ => new DistributedApplicationExecutionContext(applicationOperation)
+            };
+
             var context = new EnvironmentCallbackContext(executionContext, config);
 
             foreach (var callback in callbacks)


### PR DESCRIPTION
Experimenting with exposing `IServiceProvider` via `DistributedApplicationExecutionContext` with minimal API breaking changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4668)