### PR TITLE
[tests] Disable playwright tests on helix/linux

### DIFF
--- a/tests/Aspire.Workload.Tests/EmptyTemplateRunTests.cs
+++ b/tests/Aspire.Workload.Tests/EmptyTemplateRunTests.cs
@@ -17,6 +17,7 @@ public class EmptyTemplateRunTests : WorkloadTestsBase, IClassFixture<EmptyTempl
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(BuildEnvironment), nameof(BuildEnvironment.HasPlaywrightSupport))]
     public async Task ResourcesShowUpOnDashboad()
     {
         await using var context = await CreateNewBrowserContextAsync();

--- a/tests/Aspire.Workload.Tests/PerTestFrameworkTemplatesTests.cs
+++ b/tests/Aspire.Workload.Tests/PerTestFrameworkTemplatesTests.cs
@@ -50,9 +50,12 @@ public abstract partial class PerTestFrameworkTemplatesTests : WorkloadTestsBase
             buildEnvironment: BuildEnvironment.ForDefaultFramework);
 
         await project.BuildAsync(extraBuildArgs: [$"-c {config}"]).ConfigureAwait(false);
-        await using (var context = await CreateNewBrowserContextAsync())
+        if (BuildEnvironment.HasPlaywrightSupport)
         {
-            await AssertBasicTemplateAsync(context).ConfigureAwait(false);
+            await using (var context = await CreateNewBrowserContextAsync())
+            {
+                await AssertBasicTemplateAsync(context).ConfigureAwait(false);
+            }
         }
 
         // Add test project

--- a/tests/Aspire.Workload.Tests/StarterTemplateProjectNamesTests.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateProjectNamesTests.cs
@@ -40,7 +40,7 @@ public class StarterTemplateProjectNamesTests : WorkloadTestsBase
             BuildEnvironment.ForDefaultFramework,
             $"-t {testType}").ConfigureAwait(false);
 
-        await using var context = await CreateNewBrowserContextAsync();
+        await using var context = BuildEnvironment.HasPlaywrightSupport ? await CreateNewBrowserContextAsync() : null;
         _testOutput.WriteLine($"Checking the starter template project");
         await AssertStarterTemplateRunAsync(context, project, config, _testOutput).ConfigureAwait(false);
 

--- a/tests/Aspire.Workload.Tests/StarterTemplateRunTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateRunTestsBase.cs
@@ -22,6 +22,7 @@ public abstract class StarterTemplateRunTestsBase<T> : WorkloadTestsBase, IClass
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(BuildEnvironment), nameof(BuildEnvironment.HasPlaywrightSupport))]
     public async Task ResourcesShowUpOnDashboad()
     {
         await using var context = await CreateNewBrowserContextAsync();
@@ -34,6 +35,7 @@ public abstract class StarterTemplateRunTestsBase<T> : WorkloadTestsBase, IClass
     [Theory]
     [InlineData("http://")]
     [InlineData("https://")]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(BuildEnvironment), nameof(BuildEnvironment.HasPlaywrightSupport))]
     public async Task WebFrontendWorks(string urlPrefix)
     {
         await using var context = await CreateNewBrowserContextAsync();

--- a/tests/Aspire.Workload.Tests/TemplateTests.cs
+++ b/tests/Aspire.Workload.Tests/TemplateTests.cs
@@ -50,9 +50,12 @@ public class TemplateTests : WorkloadTestsBase
         await project.BuildAsync(extraBuildArgs: [$"-c {config}"]);
         await project.StartAppHostAsync(extraArgs: [$"-c {config}"]);
 
-        await using var context = await CreateNewBrowserContextAsync();
-        var page = await project.OpenDashboardPageAsync(context);
-        await CheckDashboardHasResourcesAsync(page, []);
+        if (BuildEnvironment.HasPlaywrightSupport)
+        {
+            await using var context = await CreateNewBrowserContextAsync();
+            var page = await project.OpenDashboardPageAsync(context);
+            await CheckDashboardHasResourcesAsync(page, []);
+        }
     }
 
     [Theory]
@@ -67,7 +70,7 @@ public class TemplateTests : WorkloadTestsBase
             _testOutput,
             buildEnvironment: BuildEnvironment.ForDefaultFramework);
 
-        await using var context = await CreateNewBrowserContextAsync();
+        await using var context = BuildEnvironment.HasPlaywrightSupport ? await CreateNewBrowserContextAsync() : null;
         await AssertStarterTemplateRunAsync(context, project, config, _testOutput);
     }
 
@@ -97,8 +100,11 @@ public class TemplateTests : WorkloadTestsBase
         testSpecificBuildEnvironment.EnvVars["ASPIRE_ALLOW_UNSECURED_TRANSPORT"] = "true";
         await project.StartAppHostAsync();
 
-        await using var context = await CreateNewBrowserContextAsync();
-        var page = await project.OpenDashboardPageAsync(context);
-        await CheckDashboardHasResourcesAsync(page, []).ConfigureAwait(false);
+        if (BuildEnvironment.HasPlaywrightSupport)
+        {
+            await using var context = await CreateNewBrowserContextAsync();
+            var page = await project.OpenDashboardPageAsync(context);
+            await CheckDashboardHasResourcesAsync(page, []).ConfigureAwait(false);
+        }
     }
 }

--- a/tests/Shared/WorkloadTesting/BuildEnvironment.cs
+++ b/tests/Shared/WorkloadTesting/BuildEnvironment.cs
@@ -25,6 +25,7 @@ public class BuildEnvironment
     public const TestTargetFramework        DefaultTargetFramework = TestTargetFramework.Net80;
     public static readonly string           TestDataPath = Path.Combine(AppContext.BaseDirectory, "data");
     public static readonly string           TestRootPath = Path.Combine(Path.GetTempPath(), "testroot");
+    public static bool                      HasPlaywrightSupport => !EnvironmentVariables.DisablePlaywrightTests;
 
     public static bool IsRunningOnHelix => Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null;
     public static bool IsRunningOnCIBuildMachine => Environment.GetEnvironmentVariable("BUILD_BUILDID") is not null;

--- a/tests/Shared/WorkloadTesting/EnvironmentVariables.cs
+++ b/tests/Shared/WorkloadTesting/EnvironmentVariables.cs
@@ -17,4 +17,5 @@ public static class EnvironmentVariables
     public static readonly string? TestAssetsPath            = Environment.GetEnvironmentVariable("TEST_ASSETS_PATH");
     public static readonly string? TestScenario              = Environment.GetEnvironmentVariable("TEST_SCENARIO");
     public static readonly string? BrowserPath               = Environment.GetEnvironmentVariable("BROWSER_PATH");
+    public static readonly bool    DisablePlaywrightTests    = Environment.GetEnvironmentVariable("DISABLE_PLAYWRIGHT_TESTS") is "true";
 }

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -74,8 +74,10 @@
     <HelixCorrelationPayload Include="$(PlaywrightDependenciesDirectory)" Destination="playwright-deps" />
 
     <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="chmod +x $HELIX_WORKITEM_ROOT/.playwright/node/linux-x64/node" />
-    <!-- wait for lock for 2mins -->
-    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="(sudo apt-get -o DPkg::Lock::Timeout=120 install -y libgbm1 libxkbcommon0 || (cat /var/lib/dkms/lttng-modules/2.13.8/build/make.log; exit 1)) || exit 1" />
+
+    <!-- Disable playwright tests on helix/linux. Issue: https://github.com/dotnet/aspire/issues/4623 -->
+    <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="export DISABLE_PLAYWRIGHT_TESTS=true" />
+    <!--<HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="(sudo apt-get -o DPkg::Lock::Timeout=120 install -y libgbm1 libxkbcommon0 || (cat /var/lib/dkms/lttng-modules/2.13.8/build/make.log; exit 1)) || exit 1" />-->
 
     <HelixPreCommand Condition="'$(OS)' == 'Windows_NT'" Include="set PLAYWRIGHT_BROWSERS_PATH=%HELIX_CORRELATION_PAYLOAD%\playwright-deps" />
     <HelixPreCommand Condition="'$(OS)' != 'Windows_NT'" Include="export PLAYWRIGHT_BROWSERS_PATH=$HELIX_CORRELATION_PAYLOAD/playwright-deps" />


### PR DESCRIPTION
Playwright dependency installation on helix/linux has been failing on some random helix agents. Until that gets fixed, this PR is disabling:

- tests that exclusively use playwright
- disable parts of tests that use playwright

To keep the test runs on CI consistent, these are always being disabled on Helix/Linux.

Issue: https://github.com/dotnet/aspire/issues/4623

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4694)