### PR TITLE
Use composite key from OTEL service name and instance id

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -25,7 +25,7 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
     private readonly InstrumentViewModel _instrumentViewModel = new InstrumentViewModel();
 
     [Parameter, EditorRequired]
-    public required string ApplicationId { get; set; }
+    public required ApplicationKey ApplicationKey { get; set; }
 
     [Parameter, EditorRequired]
     public required string MeterName { get; set; }
@@ -177,7 +177,7 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
 
         var instrument = TelemetryRepository.GetInstrument(new GetInstrumentRequest
         {
-            ApplicationServiceId = ApplicationId,
+            ApplicationKey = ApplicationKey,
             MeterName = MeterName,
             InstrumentName = InstrumentName,
             StartTime = startDate,
@@ -187,8 +187,8 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
         if (instrument == null)
         {
             Logger.LogDebug(
-                "Unable to find instrument. ApplicationServiceId: {ApplicationServiceId}, MeterName: {MeterName}, InstrumentName: {InstrumentName}",
-                ApplicationId,
+                "Unable to find instrument. ApplicationKey: {ApplicationKey}, MeterName: {MeterName}, InstrumentName: {InstrumentName}",
+                ApplicationKey,
                 MeterName,
                 InstrumentName);
         }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -2,7 +2,7 @@
 
 <FluentSelect @ref="_resourceSelectComponent"
               Items="Resources"
-              OptionValue="@(c => c!.Id?.InstanceId)"
+              OptionValue="@(c => c!.Name)"
               OptionDisabled="@(c => c!.Id?.Type is Otlp.Model.OtlpApplicationType.ReplicaSet)"
               SelectedOption="SelectedResource"
               SelectedOptionChanged="SelectedResourceChanged"

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -199,7 +199,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         {
             var id = isReplica
                 ? ResourceTypeDetails.CreateReplicaInstance(resource.Name, applicationName)
-                : ResourceTypeDetails.CreateSingleton(resource.Name);
+                : ResourceTypeDetails.CreateSingleton(resource.Name, applicationName);
 
             return new SelectViewModel<ResourceTypeDetails>
             {

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -51,7 +51,7 @@
                         @if (PageViewModel.SelectedApplication.Id?.InstanceId != null && PageViewModel.SelectedMeter != null && PageViewModel.SelectedInstrument != null)
                         {
                             <ChartContainer
-                                ApplicationId="@(PageViewModel.SelectedApplication.Id.InstanceId)"
+                                ApplicationKey="@(PageViewModel.SelectedApplication.Id.GetApplicationKey())"
                                 MeterName="@(PageViewModel.SelectedMeter.MeterName)"
                                 InstrumentName="@(PageViewModel.SelectedInstrument.Name)"
                                 Duration="PageViewModel.SelectedDuration.Id"

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -100,7 +100,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     protected override async Task OnParametersSetAsync()
     {
         await this.InitializeViewModelAsync();
-        TracesViewModel.ApplicationServiceId = PageViewModel.SelectedApplication.Id?.InstanceId;
+        TracesViewModel.ApplicationKey = PageViewModel.SelectedApplication.Id?.GetApplicationKey();
         UpdateSubscription();
     }
 
@@ -120,8 +120,8 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     {
         viewModel.SelectedDuration = _durations.SingleOrDefault(d => (int)d.Id.TotalMinutes == DurationMinutes) ?? _durations.Single(d => d.Id == s_defaultDuration);
         viewModel.SelectedApplication = _applications.GetApplication(Logger, ApplicationName, _selectApplication);
-        var selectedInstance = viewModel.SelectedApplication.Id?.InstanceId;
-        viewModel.Instruments = !string.IsNullOrEmpty(selectedInstance) ? TelemetryRepository.GetInstrumentsSummary(selectedInstance) : null;
+        var selectedInstance = viewModel.SelectedApplication.Id?.GetApplicationKey();
+        viewModel.Instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentsSummary(selectedInstance.Value) : null;
 
         viewModel.SelectedMeter = null;
         viewModel.SelectedInstrument = null;
@@ -134,7 +134,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
             {
                 viewModel.SelectedInstrument = TelemetryRepository.GetInstrument(new GetInstrumentRequest
                 {
-                    ApplicationServiceId = viewModel.SelectedApplication.Id?.InstanceId!,
+                    ApplicationKey = selectedInstance!.Value,
                     MeterName = MeterName,
                     InstrumentName = InstrumentName
                 });
@@ -232,17 +232,18 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
 
     private void UpdateSubscription()
     {
-        var selectedApplication = PageViewModel.SelectedApplication.Id;
+        var selectedApplicationKey = PageViewModel.SelectedApplication.Id?.GetApplicationKey();
+
         // Subscribe to updates.
-        if (_metricsSubscription is null || _metricsSubscription.ApplicationId != selectedApplication?.InstanceId)
+        if (_metricsSubscription is null || _metricsSubscription.ApplicationKey != selectedApplicationKey)
         {
             _metricsSubscription?.Dispose();
-            _metricsSubscription = TelemetryRepository.OnNewMetrics(selectedApplication?.InstanceId, SubscriptionType.Read, async () =>
+            _metricsSubscription = TelemetryRepository.OnNewMetrics(selectedApplicationKey, SubscriptionType.Read, async () =>
             {
-                if (!string.IsNullOrEmpty(selectedApplication?.InstanceId))
+                if (selectedApplicationKey != null)
                 {
                     // If there are more instruments than before then update the UI.
-                    var instruments = TelemetryRepository.GetInstrumentsSummary(selectedApplication.InstanceId);
+                    var instruments = TelemetryRepository.GetInstrumentsSummary(selectedApplicationKey.Value);
 
                     if (PageViewModel.Instruments is null || instruments.Count > PageViewModel.Instruments.Count)
                     {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -86,7 +86,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         // The workaround is to put the count inside a control and explicitly update and refresh the control.
         _totalItemsFooter.SetTotalItemCount(logs.TotalItemCount);
 
-        TelemetryRepository.MarkViewedErrorLogs(ViewModel.ApplicationServiceId);
+        TelemetryRepository.MarkViewedErrorLogs(ViewModel.ApplicationKey);
 
         return ValueTask.FromResult(GridItemsProviderResult.From(logs.Items, logs.TotalItemCount));
     }
@@ -162,10 +162,10 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     private void UpdateSubscription()
     {
         // Subscribe to updates.
-        if (_logsSubscription is null || _logsSubscription.ApplicationId != PageViewModel.SelectedApplication.Id?.InstanceId)
+        if (_logsSubscription is null || _logsSubscription.ApplicationKey != PageViewModel.SelectedApplication.Id?.GetApplicationKey())
         {
             _logsSubscription?.Dispose();
-            _logsSubscription = TelemetryRepository.OnNewLogs(PageViewModel.SelectedApplication.Id?.InstanceId, SubscriptionType.Read, async () =>
+            _logsSubscription = TelemetryRepository.OnNewLogs(PageViewModel.SelectedApplication.Id?.GetApplicationKey(), SubscriptionType.Read, async () =>
             {
                 ViewModel.ClearData();
                 await InvokeAsync(StateHasChanged);
@@ -206,7 +206,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
 
     private async Task OpenFilterAsync(LogFilter? entry)
     {
-        var logPropertyKeys = TelemetryRepository.GetLogPropertyKeys(PageViewModel.SelectedApplication.Id?.InstanceId);
+        var logPropertyKeys = TelemetryRepository.GetLogPropertyKeys(PageViewModel.SelectedApplication.Id?.GetApplicationKey());
 
         var title = entry is not null ? Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEditFilter)] : Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsAddFilter)];
         var parameters = new DialogParameters
@@ -336,7 +336,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     public void UpdateViewModelFromQuery(StructuredLogsPageViewModel viewModel)
     {
         PageViewModel.SelectedApplication = _applicationViewModels.GetApplication(Logger, ApplicationName, _allApplication);
-        ViewModel.ApplicationServiceId = PageViewModel.SelectedApplication.Id?.InstanceId;
+        ViewModel.ApplicationKey = PageViewModel.SelectedApplication.Id?.GetApplicationKey();
 
         if (LogLevelText is not null && Enum.TryParse<LogLevel>(LogLevelText, ignoreCase: true, out var logLevel))
         {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -201,10 +201,10 @@ public partial class TraceDetail : ComponentBase
                 _spanWaterfallViewModels = CreateSpanWaterfallViewModels(trace, new TraceDetailState(OutgoingPeerResolvers, _collapsedSpanIds));
                 _maxDepth = _spanWaterfallViewModels.Max(s => s.Depth);
 
-                if (_tracesSubscription is null || _tracesSubscription.ApplicationId != trace.FirstSpan.Source.InstanceId)
+                if (_tracesSubscription is null || _tracesSubscription.ApplicationKey != trace.FirstSpan.Source.ApplicationKey)
                 {
                     _tracesSubscription?.Dispose();
-                    _tracesSubscription = TelemetryRepository.OnNewTraces(trace.FirstSpan.Source.InstanceId, SubscriptionType.Read, () => InvokeAsync(() =>
+                    _tracesSubscription = TelemetryRepository.OnNewTraces(trace.FirstSpan.Source.ApplicationKey, SubscriptionType.Read, () => InvokeAsync(() =>
                     {
                         UpdateDetailViewData();
                         StateHasChanged();

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -101,7 +101,7 @@ public partial class Traces
     protected override void OnParametersSet()
     {
         _selectedApplication = _applicationViewModels.GetApplication(Logger, ApplicationName, _allApplication);
-        TracesViewModel.ApplicationServiceId = _selectedApplication.Id?.InstanceId;
+        TracesViewModel.ApplicationKey = _selectedApplication.Id?.GetApplicationKey();
         UpdateSubscription();
     }
 
@@ -123,11 +123,13 @@ public partial class Traces
 
     private void UpdateSubscription()
     {
+        var selectedApplicationKey = _selectedApplication.Id?.GetApplicationKey();
+
         // Subscribe to updates.
-        if (_tracesSubscription is null || _tracesSubscription.ApplicationId != _selectedApplication.Id?.InstanceId)
+        if (_tracesSubscription is null || _tracesSubscription.ApplicationKey != selectedApplicationKey)
         {
             _tracesSubscription?.Dispose();
-            _tracesSubscription = TelemetryRepository.OnNewTraces(_selectedApplication.Id?.InstanceId, SubscriptionType.Read, async () =>
+            _tracesSubscription = TelemetryRepository.OnNewTraces(selectedApplicationKey, SubscriptionType.Read, async () =>
             {
                 TracesViewModel.ClearData();
                 await InvokeAsync(StateHasChanged);

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
@@ -36,7 +36,7 @@ public partial class UnreadLogErrorsBadge
             return (null, 0);
         }
 
-        var application = TelemetryRepository.GetApplication(resource.Name);
+        var application = TelemetryRepository.GetApplicationByCompositeName(resource.Name);
         if (application is null)
         {
             return (null, 0);

--- a/src/Aspire.Dashboard/Model/Otlp/ApplicationsSelectHelpers.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/ApplicationsSelectHelpers.cs
@@ -54,7 +54,7 @@ public static class ApplicationsSelectHelpers
                 var app = replicas.Single();
                 selectViewModels.Add(new SelectViewModel<ResourceTypeDetails>
                 {
-                    Id = ResourceTypeDetails.CreateSingleton(app.InstanceId),
+                    Id = ResourceTypeDetails.CreateSingleton(app.InstanceId, applicationName),
                     Name = applicationName
                 });
 

--- a/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
+++ b/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
 
 namespace Aspire.Dashboard.Model;
 
@@ -20,14 +21,28 @@ public class ResourceTypeDetails
     public string? InstanceId { get; }
     public string? ReplicaSetName { get; }
 
+    public ApplicationKey GetApplicationKey()
+    {
+        if (ReplicaSetName == null)
+        {
+            throw new InvalidOperationException($"Can't get ApplicationKey from resource type details '{ToString()}' because {nameof(ReplicaSetName)} is null.");
+        }
+        if (InstanceId == null)
+        {
+            throw new InvalidOperationException($"Can't get ApplicationKey from resource type details '{ToString()}' because {nameof(InstanceId)} is null.");
+        }
+
+        return new ApplicationKey(ReplicaSetName, InstanceId);
+    }        
+
     public static ResourceTypeDetails CreateReplicaSet(string replicaSetName)
     {
         return new ResourceTypeDetails(OtlpApplicationType.ReplicaSet, instanceId: null, replicaSetName);
     }
 
-    public static ResourceTypeDetails CreateSingleton(string instanceId)
+    public static ResourceTypeDetails CreateSingleton(string instanceId, string replicaSetName)
     {
-        return new ResourceTypeDetails(OtlpApplicationType.Singleton, instanceId, replicaSetName: null);
+        return new ResourceTypeDetails(OtlpApplicationType.Singleton, instanceId, replicaSetName: replicaSetName);
     }
 
     public static ResourceTypeDetails CreateReplicaInstance(string instanceId, string replicaSetName)

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -58,6 +58,7 @@ public sealed class ResourceViewModel
     }
 }
 
+[DebuggerDisplay("CommandType = {CommandType}, DisplayName = {DisplayName}")]
 public sealed class CommandViewModel
 {
     public string CommandType { get; }
@@ -77,6 +78,7 @@ public sealed class CommandViewModel
     }
 }
 
+[DebuggerDisplay("Name = {Name}, Value = {Value}, FromSpec = {FromSpec}, IsValueMasked = {IsValueMasked}")]
 public sealed class EnvironmentVariableViewModel
 {
     public string Name { get; }
@@ -95,6 +97,7 @@ public sealed class EnvironmentVariableViewModel
     }
 }
 
+[DebuggerDisplay("Name = {Name}, Url = {Url}, IsInternal = {IsInternal}")]
 public sealed class UrlViewModel
 {
     public string Name { get; }

--- a/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
@@ -13,7 +13,7 @@ public class StructuredLogsViewModel
     private readonly List<LogFilter> _filters = new();
 
     private PagedResult<OtlpLogEntry>? _logs;
-    private string? _applicationServiceId;
+    private ApplicationKey? _applicationKey;
     private string _filterText = string.Empty;
     private int _logsStartIndex;
     private int? _logsCount;
@@ -24,7 +24,7 @@ public class StructuredLogsViewModel
         _telemetryRepository = telemetryRepository;
     }
 
-    public string? ApplicationServiceId { get => _applicationServiceId; set => SetValue(ref _applicationServiceId, value); }
+    public ApplicationKey? ApplicationKey { get => _applicationKey; set => SetValue(ref _applicationKey, value); }
     public string FilterText { get => _filterText; set => SetValue(ref _filterText, value); }
     public IReadOnlyList<LogFilter> Filters => _filters;
 
@@ -87,7 +87,7 @@ public class StructuredLogsViewModel
 
             logs = _telemetryRepository.GetLogs(new GetLogsContext
             {
-                ApplicationServiceId = ApplicationServiceId,
+                ApplicationKey = ApplicationKey,
                 StartIndex = StartIndex,
                 Count = Count,
                 Filters = filters

--- a/src/Aspire.Dashboard/Model/TracesViewModel.cs
+++ b/src/Aspire.Dashboard/Model/TracesViewModel.cs
@@ -11,7 +11,7 @@ public class TracesViewModel
     private readonly TelemetryRepository _telemetryRepository;
 
     private PagedResult<OtlpTrace>? _traces;
-    private string? _applicationServiceId;
+    private ApplicationKey? _applicationKey;
     private string _filterText = string.Empty;
     private int _startIndex;
     private int? _count;
@@ -21,7 +21,7 @@ public class TracesViewModel
         _telemetryRepository = telemetryRepository;
     }
 
-    public string? ApplicationServiceId { get => _applicationServiceId; set => SetValue(ref _applicationServiceId, value); }
+    public ApplicationKey? ApplicationKey { get => _applicationKey; set => SetValue(ref _applicationKey, value); }
     public string FilterText { get => _filterText; set => SetValue(ref _filterText, value); }
     public int StartIndex { get => _startIndex; set => SetValue(ref _startIndex, value); }
     public int? Count { get => _count; set => SetValue(ref _count, value); }
@@ -45,7 +45,7 @@ public class TracesViewModel
         {
             var result = _telemetryRepository.GetTraces(new GetTracesRequest
             {
-                ApplicationServiceId = ApplicationServiceId,
+                ApplicationKey = ApplicationKey,
                 FilterText = FilterText,
                 StartIndex = StartIndex,
                 Count = Count

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Metrics.V1;
@@ -15,9 +16,12 @@ public class OtlpApplication
 {
     public const string SERVICE_NAME = "service.name";
     public const string SERVICE_INSTANCE_ID = "service.instance.id";
+    public const string PROCESS_EXECUTABLE_NAME = "process.executable.name";
 
     public string ApplicationName { get; }
     public string InstanceId { get; }
+
+    public ApplicationKey ApplicationKey => new ApplicationKey(ApplicationName, InstanceId);
 
     private readonly ReaderWriterLockSlim _metricsLock = new();
     private readonly Dictionary<string, OtlpMeter> _meters = new();
@@ -28,7 +32,7 @@ public class OtlpApplication
 
     public KeyValuePair<string, string>[] Properties { get; }
 
-    public OtlpApplication(Resource resource, IReadOnlyDictionary<string, OtlpApplication> applications, ILogger logger, TelemetryLimitOptions options)
+    public OtlpApplication(string name, string instanceId, Resource resource, ILogger logger, TelemetryLimitOptions options)
     {
         var properties = new List<KeyValuePair<string, string>>();
         foreach (var attribute in resource.Attributes)
@@ -36,10 +40,8 @@ public class OtlpApplication
             switch (attribute.Key)
             {
                 case SERVICE_NAME:
-                    ApplicationName = attribute.Value.GetString();
-                    break;
                 case SERVICE_INSTANCE_ID:
-                    InstanceId = attribute.Value.GetString();
+                    // Values passed in via ctor and set to members. Don't add to properties collection.
                     break;
                 default:
                     properties.Add(new KeyValuePair<string, string>(attribute.Key, attribute.Value.GetString()));
@@ -48,18 +50,10 @@ public class OtlpApplication
             }
         }
         Properties = properties.ToArray();
-        if (string.IsNullOrEmpty(ApplicationName))
-        {
-            ApplicationName = "Unknown";
-        }
-        if (string.IsNullOrEmpty(InstanceId))
-        {
-            //
-            // NOTE: The service.instance.id value is a recommended attribute, but not required.
-            //       See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service-experimental
-            //
-            InstanceId = ApplicationName;
-        }
+
+        ApplicationName = name;
+        InstanceId = instanceId;
+
         _logger = logger;
         _options = options;
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -16,28 +16,42 @@ namespace Aspire.Dashboard.Otlp.Model;
 
 public static class OtlpHelpers
 {
-    public static string? GetServiceId(this Resource resource)
+    public static ApplicationKey GetApplicationKey(this Resource resource)
     {
         string? serviceName = null;
+        string? serviceInstanceId = null;
+        string? processExecutableName = null;
 
         for (var i = 0; i < resource.Attributes.Count; i++)
         {
             var attribute = resource.Attributes[i];
             if (attribute.Key == OtlpApplication.SERVICE_INSTANCE_ID)
             {
-                return attribute.Value.GetString();
+                serviceInstanceId = attribute.Value.GetString();
             }
             if (attribute.Key == OtlpApplication.SERVICE_NAME)
             {
                 serviceName = attribute.Value.GetString();
             }
+            if (attribute.Key == OtlpApplication.PROCESS_EXECUTABLE_NAME)
+            {
+                processExecutableName = attribute.Value.GetString();
+            }
         }
 
-        //
-        // NOTE: The service.instance.id value is a recommended attribute, but not required.
-        //       See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service-experimental
-        //
-        return serviceName;
+        // Fallback to unknown_service if service name isn't specified.
+        // https://github.com/open-telemetry/opentelemetry-specification/issues/3210
+        if (string.IsNullOrEmpty(serviceName))
+        {
+            serviceName = "unknown_service";
+            if (!string.IsNullOrEmpty(processExecutableName))
+            {
+                serviceName += ":" + processExecutableName;
+            }
+        }
+
+        // service.instance.id is recommended but not required.
+        return new ApplicationKey(serviceName, serviceInstanceId ?? serviceName);
     }
 
     public static string ToShortenedId(string id) => TruncateString(id, maxLength: 7);

--- a/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Otlp.Storage;
+
+public readonly record struct ApplicationKey(string Name, string InstanceId)
+{
+    public bool EqualsCompositeName(string name)
+    {
+        if (name == null)
+        {
+            return false;
+        }
+
+        // Composite name has the format "{Name}-{InstanceId}".
+        if (name.Length != Name.Length + InstanceId.Length + 1)
+        {
+            return false;
+        }
+
+        if (!name.AsSpan(0, Name.Length).Equals(Name, StringComparisons.ResourceName))
+        {
+            return false;
+        }
+        if (name[Name.Length] != '-')
+        {
+            return false;
+        }
+        if (!name.AsSpan(Name.Length + 1, InstanceId.Length).Equals(InstanceId, StringComparisons.ResourceName))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/GetInstrumentRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetInstrumentRequest.cs
@@ -6,7 +6,7 @@ namespace Aspire.Dashboard.Otlp.Storage;
 public sealed class GetInstrumentRequest
 {
     public required string InstrumentName { get; init; }
-    public required string ApplicationServiceId { get; init; }
+    public required ApplicationKey ApplicationKey { get; init; }
     public required string MeterName { get; init; }
     public DateTime? StartTime { get; init; }
     public DateTime? EndTime { get; init; }

--- a/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
@@ -7,7 +7,7 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public sealed class GetLogsContext
 {
-    public required string? ApplicationServiceId { get; init; }
+    public required ApplicationKey? ApplicationKey { get; init; }
     public required int StartIndex { get; init; }
     public required int? Count { get; init; }
     public required List<LogFilter> Filters { get; init; }

--- a/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
@@ -5,7 +5,7 @@ namespace Aspire.Dashboard.Otlp.Storage;
 
 public sealed class GetTracesRequest
 {
-    public required string? ApplicationServiceId { get; init; }
+    public required ApplicationKey? ApplicationKey { get; init; }
     public required int StartIndex { get; init; }
     public required int? Count { get; init; }
     public required string FilterText { get; init; }

--- a/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
@@ -16,14 +16,14 @@ public sealed class Subscription : IDisposable
 
     private DateTime? _lastExecute;
 
-    public string? ApplicationId { get; }
+    public ApplicationKey? ApplicationKey { get; }
     public SubscriptionType SubscriptionType { get; }
     public string Name { get; }
 
-    public Subscription(string name, string? applicationId, SubscriptionType subscriptionType, Func<Task> callback, Action unsubscribe, ExecutionContext? executionContext, TelemetryRepository telemetryRepository)
+    public Subscription(string name, ApplicationKey? applicationKey, SubscriptionType subscriptionType, Func<Task> callback, Action unsubscribe, ExecutionContext? executionContext, TelemetryRepository telemetryRepository)
     {
         Name = name;
-        ApplicationId = applicationId;
+        ApplicationKey = applicationKey;
         SubscriptionType = subscriptionType;
         _callback = callback;
         _unsubscribe = unsubscribe;

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -115,8 +115,8 @@ public sealed class ApplicationsSelectHelpersTests
 
         var appVMs = new List<SelectViewModel<ResourceTypeDetails>>
         {
-            new SelectViewModel<ResourceTypeDetails>() { Name = "test", Id = ResourceTypeDetails.CreateSingleton("test-abc") },
-            new SelectViewModel<ResourceTypeDetails>() { Name = "test", Id = ResourceTypeDetails.CreateSingleton("test-def") }
+            new SelectViewModel<ResourceTypeDetails>() { Name = "test", Id = ResourceTypeDetails.CreateSingleton("test-abc", "test") },
+            new SelectViewModel<ResourceTypeDetails>() { Name = "test", Id = ResourceTypeDetails.CreateSingleton("test-def", "test") }
         };
 
         var testSink = new TestSink();
@@ -131,15 +131,18 @@ public sealed class ApplicationsSelectHelpersTests
         Assert.Single(testSink.Writes);
     }
 
-    private static OtlpApplication CreateOtlpApplication(Dictionary<string, OtlpApplication> apps, string name, string instanceId)
+    private static OtlpApplication CreateOtlpApplication(string name, string instanceId)
     {
-        return new OtlpApplication(new Resource
+        var resource = new Resource
         {
             Attributes =
                 {
                     new KeyValue { Key = "service.name", Value = new AnyValue { StringValue = name } },
                     new KeyValue { Key = "service.instance.id", Value = new AnyValue { StringValue = instanceId } }
                 }
-        }, apps, NullLogger.Instance, new TelemetryLimitOptions());
+        };
+        var applicationKey = OtlpHelpers.GetApplicationKey(resource);
+
+        return new OtlpApplication(applicationKey.Name, applicationKey.InstanceId, resource, NullLogger.Instance, new TelemetryLimitOptions());
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -20,13 +20,11 @@ public sealed class ApplicationsSelectHelpersTests
     public void GetApplication_SameNameAsReplica_GetInstance()
     {
         // Arrange
-        var apps = new Dictionary<string, OtlpApplication>();
-
         var appVMs = ApplicationsSelectHelpers.CreateApplications(new List<OtlpApplication>
         {
-            CreateOtlpApplication(apps, name: "app", instanceId: "app"),
-            CreateOtlpApplication(apps, name: "app", instanceId: "app-abc"),
-            CreateOtlpApplication(apps, name: "singleton", instanceId: "singleton-abc")
+            CreateOtlpApplication(name: "app", instanceId: "app"),
+            CreateOtlpApplication(name: "app", instanceId: "app-abc"),
+            CreateOtlpApplication(name: "singleton", instanceId: "singleton-abc")
         });
 
         Assert.Collection(appVMs,
@@ -67,12 +65,10 @@ public sealed class ApplicationsSelectHelpersTests
     public void GetApplication_NameDifferentByCase_Merge()
     {
         // Arrange
-        var apps = new Dictionary<string, OtlpApplication>();
-
         var appVMs = ApplicationsSelectHelpers.CreateApplications(new List<OtlpApplication>
         {
-            CreateOtlpApplication(apps, name: "app", instanceId: "app"),
-            CreateOtlpApplication(apps, name: "APP", instanceId: "app-abc")
+            CreateOtlpApplication(name: "app", instanceId: "app"),
+            CreateOtlpApplication(name: "APP", instanceId: "app-abc")
         });
 
         Assert.Collection(appVMs,

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ApplicationKeyTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ApplicationKeyTests.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Storage;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
+
+public class ApplicationKeyTests
+{
+    [Theory]
+    [InlineData("name", "instanceid", "name-instanceid")]
+    [InlineData("name", "instanceid", "NAME-INSTANCEID")]
+    [InlineData("name", "752e1688-ca3c-45da-b48b-b2163296ac91", "name-752e1688-ca3c-45da-b48b-b2163296ac91")]
+    public void EqualsCompositeName_Success(string name, string instanceId, string compositeName)
+    {
+        // Arrange
+        var key = new ApplicationKey(name, instanceId);
+
+        // Act
+        var result = key.EqualsCompositeName(compositeName);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("name", "instanceid", null)]
+    [InlineData("name", "instanceid", "")]
+    [InlineData("name", "instanceid", "name")]
+    [InlineData("name", "instanceid", "instanceid")]
+    [InlineData("name", "instanceid", "name_instanceid")]
+    [InlineData("name", "instanceid", "instanceid-name")]
+    public void EqualsCompositeName_Failure(string name, string instanceId, string compositeName)
+    {
+        // Arrange
+        var key = new ApplicationKey(name, instanceId);
+
+        // Act
+        var result = key.EqualsCompositeName(compositeName);
+
+        // Assert
+        Assert.False(result);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ApplicationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ApplicationTests.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+using Google.Protobuf.Collections;
+using OpenTelemetry.Proto.Trace.V1;
+using Xunit;
+using static Aspire.Dashboard.Tests.TelemetryRepositoryTests.TestHelpers;
+
+namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
+
+public class ApplicationTests
+{
+    private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void GetApplicationByCompositeName()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "app2"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10)),
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(5), endTime: s_testTime.AddMinutes(10), parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(name: "app1"),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "2", spanId: "2-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10)),
+                            CreateSpan(traceId: "2", spanId: "2-2", startTime: s_testTime.AddMinutes(5), endTime: s_testTime.AddMinutes(10), parentSpanId: "2-1")
+                        }
+                    }
+                }
+            }
+        });
+
+        Assert.Equal(0, addContext.FailureCount);
+
+        // Act 1
+        var applications = repository.GetApplications();
+
+        // Assert 1
+        Assert.Collection(applications,
+            app =>
+            {
+                Assert.Equal("app1", app.ApplicationName);
+                Assert.Equal("TestId", app.InstanceId);
+            },
+            app =>
+            {
+                Assert.Equal("app2", app.ApplicationName);
+                Assert.Equal("TestId", app.InstanceId);
+            });
+
+        // Act 2
+        var app1 = repository.GetApplicationByCompositeName("app1-TestId");
+        var app2 = repository.GetApplicationByCompositeName("APP2-TESTID");
+        var notFound = repository.GetApplicationByCompositeName("APP2_TESTID");
+
+        // Assert 2
+        Assert.NotNull(app1);
+        Assert.Equal("app1", app1.ApplicationName);
+        Assert.Equal(applications[0], app1);
+
+        Assert.NotNull(app2);
+        Assert.Equal("app2", app2.ApplicationName);
+        Assert.Equal(applications[1], app2);
+
+        Assert.Null(notFound);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
@@ -64,7 +64,7 @@ public class MetricsTests
                 Assert.Equal("TestId", app.InstanceId);
             });
 
-        var instruments = repository.GetInstrumentsSummary(applications[0].InstanceId);
+        var instruments = repository.GetInstrumentsSummary(applications[0].ApplicationKey);
         Assert.Collection(instruments,
             instrument =>
             {
@@ -145,7 +145,7 @@ public class MetricsTests
 
         var instrument = repository.GetInstrument(new GetInstrumentRequest
         {
-            ApplicationServiceId = applications[0].InstanceId,
+            ApplicationKey = applications[0].ApplicationKey,
             InstrumentName = "test",
             MeterName = "test-meter",
             StartTime = DateTime.MinValue,
@@ -262,7 +262,7 @@ public class MetricsTests
 
         var instrument = repository.GetInstrument(new GetInstrumentRequest
         {
-            ApplicationServiceId = applications[0].InstanceId,
+            ApplicationKey = applications[0].ApplicationKey,
             InstrumentName = "test",
             MeterName = "test-meter",
             StartTime = s_testTime.AddMinutes(1),
@@ -339,7 +339,7 @@ public class MetricsTests
 
         var instrument = repository.GetInstrument(new GetInstrumentRequest
         {
-            ApplicationServiceId = applications[0].InstanceId,
+            ApplicationKey = applications[0].ApplicationKey,
             InstrumentName = "test",
             MeterName = "test-meter",
             StartTime = DateTime.MinValue,

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -71,7 +71,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = applications[0].InstanceId,
+            ApplicationKey = applications[0].ApplicationKey,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
@@ -143,7 +143,7 @@ public class TraceTests
 
         var traces1 = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = applications[0].InstanceId,
+            ApplicationKey = applications[0].ApplicationKey,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
@@ -186,7 +186,7 @@ public class TraceTests
 
         var traces2 = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = applications[0].InstanceId,
+            ApplicationKey = applications[0].ApplicationKey,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
@@ -242,7 +242,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = null,
+            ApplicationKey = null,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
@@ -310,7 +310,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = null,
+            ApplicationKey = null,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
@@ -367,7 +367,7 @@ public class TraceTests
 
         var traces1 = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = null,
+            ApplicationKey = null,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
@@ -382,7 +382,7 @@ public class TraceTests
 
         var traces2 = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = null,
+            ApplicationKey = null,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
@@ -449,7 +449,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = applications[0].InstanceId,
+            ApplicationKey = applications[0].ApplicationKey,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10
@@ -520,7 +520,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = applications[0].InstanceId,
+            ApplicationKey = applications[0].ApplicationKey,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/4217

The dashboard incorrectly assumes that each app instance has a unique instance id. That's true in Aspire land, but it isn't guaranteed when the standalone dashboard receives telemetry from 3rd party apps.

For example, someone might use the machine name as a common instance ID:

* Name = `App1`, Instance ID = `machine-name-1`
* Name = `App2`, Instance ID = `machine-name-1`

This PR changes dashboard to use `service.name` + `service.instance.id` as a composite key to identify apps. Allows for apps with different names to share an instance id.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4698)