### PR TITLE
Revert "Bump the fluentui group across 1 directory with 2 updates (#4645)"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,8 +101,8 @@
     <PackageVersion Include="Humanizer.Core" Version="2.14.1" />
     <PackageVersion Include="KubernetesClient" Version="14.0.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.8.1" />
-    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.8.0" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.7.2" />
+    <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.7.2" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1"/>
     <PackageVersion Include="MongoDB.Driver" Version="2.25.0" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />


### PR DESCRIPTION
The behavior in #4716 is seen after #4645 was merged. We should revert this package upgrade, ensure the issue is fixed in microsoft/fluentui-blazor, and then upgrade packages to that fixed version.

cc @vnbaaij 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4722)