### PR TITLE
[tests] Some Playwright related fixes

### DIFF
--- a/tests/Aspire.Workload.Tests/EmptyTemplateRunTests.cs
+++ b/tests/Aspire.Workload.Tests/EmptyTemplateRunTests.cs
@@ -17,7 +17,7 @@ public class EmptyTemplateRunTests : WorkloadTestsBase, IClassFixture<EmptyTempl
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(BuildEnvironment), nameof(BuildEnvironment.HasPlaywrightSupport))]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.HasPlaywrightSupport))]
     public async Task ResourcesShowUpOnDashboad()
     {
         await using var context = await CreateNewBrowserContextAsync();

--- a/tests/Aspire.Workload.Tests/EmptyTemplateRunTests.cs
+++ b/tests/Aspire.Workload.Tests/EmptyTemplateRunTests.cs
@@ -17,7 +17,7 @@ public class EmptyTemplateRunTests : WorkloadTestsBase, IClassFixture<EmptyTempl
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.HasPlaywrightSupport))]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.DoesNotHavePlaywrightSupport))]
     public async Task ResourcesShowUpOnDashboad()
     {
         await using var context = await CreateNewBrowserContextAsync();

--- a/tests/Aspire.Workload.Tests/PerTestFrameworkTemplatesTests.cs
+++ b/tests/Aspire.Workload.Tests/PerTestFrameworkTemplatesTests.cs
@@ -50,7 +50,7 @@ public abstract partial class PerTestFrameworkTemplatesTests : WorkloadTestsBase
             buildEnvironment: BuildEnvironment.ForDefaultFramework);
 
         await project.BuildAsync(extraBuildArgs: [$"-c {config}"]).ConfigureAwait(false);
-        if (BuildEnvironment.HasPlaywrightSupport)
+        if (PlaywrightProvider.HasPlaywrightSupport)
         {
             await using (var context = await CreateNewBrowserContextAsync())
             {

--- a/tests/Aspire.Workload.Tests/StarterTemplateProjectNamesTests.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateProjectNamesTests.cs
@@ -40,7 +40,7 @@ public class StarterTemplateProjectNamesTests : WorkloadTestsBase
             BuildEnvironment.ForDefaultFramework,
             $"-t {testType}").ConfigureAwait(false);
 
-        await using var context = BuildEnvironment.HasPlaywrightSupport ? await CreateNewBrowserContextAsync() : null;
+        await using var context = PlaywrightProvider.HasPlaywrightSupport ? await CreateNewBrowserContextAsync() : null;
         _testOutput.WriteLine($"Checking the starter template project");
         await AssertStarterTemplateRunAsync(context, project, config, _testOutput).ConfigureAwait(false);
 

--- a/tests/Aspire.Workload.Tests/StarterTemplateRunTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateRunTestsBase.cs
@@ -22,7 +22,7 @@ public abstract class StarterTemplateRunTestsBase<T> : WorkloadTestsBase, IClass
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(BuildEnvironment), nameof(BuildEnvironment.HasPlaywrightSupport))]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.HasPlaywrightSupport))]
     public async Task ResourcesShowUpOnDashboad()
     {
         await using var context = await CreateNewBrowserContextAsync();
@@ -35,7 +35,7 @@ public abstract class StarterTemplateRunTestsBase<T> : WorkloadTestsBase, IClass
     [Theory]
     [InlineData("http://")]
     [InlineData("https://")]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(BuildEnvironment), nameof(BuildEnvironment.HasPlaywrightSupport))]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.HasPlaywrightSupport))]
     public async Task WebFrontendWorks(string urlPrefix)
     {
         await using var context = await CreateNewBrowserContextAsync();

--- a/tests/Aspire.Workload.Tests/StarterTemplateRunTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateRunTestsBase.cs
@@ -22,7 +22,7 @@ public abstract class StarterTemplateRunTestsBase<T> : WorkloadTestsBase, IClass
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.HasPlaywrightSupport))]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.DoesNotHavePlaywrightSupport))]
     public async Task ResourcesShowUpOnDashboad()
     {
         await using var context = await CreateNewBrowserContextAsync();
@@ -35,7 +35,7 @@ public abstract class StarterTemplateRunTestsBase<T> : WorkloadTestsBase, IClass
     [Theory]
     [InlineData("http://")]
     [InlineData("https://")]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.HasPlaywrightSupport))]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.DoesNotHavePlaywrightSupport))]
     public async Task WebFrontendWorks(string urlPrefix)
     {
         await using var context = await CreateNewBrowserContextAsync();

--- a/tests/Aspire.Workload.Tests/TemplateTests.cs
+++ b/tests/Aspire.Workload.Tests/TemplateTests.cs
@@ -50,7 +50,7 @@ public class TemplateTests : WorkloadTestsBase
         await project.BuildAsync(extraBuildArgs: [$"-c {config}"]);
         await project.StartAppHostAsync(extraArgs: [$"-c {config}"]);
 
-        if (BuildEnvironment.HasPlaywrightSupport)
+        if (PlaywrightProvider.HasPlaywrightSupport)
         {
             await using var context = await CreateNewBrowserContextAsync();
             var page = await project.OpenDashboardPageAsync(context);
@@ -70,7 +70,7 @@ public class TemplateTests : WorkloadTestsBase
             _testOutput,
             buildEnvironment: BuildEnvironment.ForDefaultFramework);
 
-        await using var context = BuildEnvironment.HasPlaywrightSupport ? await CreateNewBrowserContextAsync() : null;
+        await using var context = PlaywrightProvider.HasPlaywrightSupport ? await CreateNewBrowserContextAsync() : null;
         await AssertStarterTemplateRunAsync(context, project, config, _testOutput);
     }
 
@@ -100,7 +100,7 @@ public class TemplateTests : WorkloadTestsBase
         testSpecificBuildEnvironment.EnvVars["ASPIRE_ALLOW_UNSECURED_TRANSPORT"] = "true";
         await project.StartAppHostAsync();
 
-        if (BuildEnvironment.HasPlaywrightSupport)
+        if (PlaywrightProvider.HasPlaywrightSupport)
         {
             await using var context = await CreateNewBrowserContextAsync();
             var page = await project.OpenDashboardPageAsync(context);

--- a/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
@@ -34,7 +34,7 @@ public class WorkloadTestsBase
     }
 
     public static Task<IBrowserContext> CreateNewBrowserContextAsync()
-        => BuildEnvironment.HasPlaywrightSupport
+        => PlaywrightProvider.HasPlaywrightSupport
                 ? Browser.Value.NewContextAsync(new BrowserNewContextOptions { IgnoreHTTPSErrors = true })
                 : throw new InvalidOperationException("Playwright is not available");
 

--- a/tests/Shared/Playwright/PlaywrightProvider.cs
+++ b/tests/Shared/Playwright/PlaywrightProvider.cs
@@ -11,6 +11,9 @@ public class PlaywrightProvider
     public const string BrowserPathEnvironmentVariableName = "BROWSER_PATH";
     private const string PlaywrightBrowsersPathEnvironmentVariableName = "PLAYWRIGHT_BROWSERS_PATH";
 
+    public static bool DoesNotHavePlaywrightSupport => Environment.GetEnvironmentVariable("DISABLE_PLAYWRIGHT_TESTS") is "true";
+    public static bool HasPlaywrightSupport => !DoesNotHavePlaywrightSupport;
+
     public static async Task<IBrowser> CreateBrowserAsync(BrowserTypeLaunchOptions? options = null)
     {
         var playwright = await Playwright.CreateAsync();

--- a/tests/Shared/WorkloadTesting/BuildEnvironment.cs
+++ b/tests/Shared/WorkloadTesting/BuildEnvironment.cs
@@ -25,7 +25,6 @@ public class BuildEnvironment
     public const TestTargetFramework        DefaultTargetFramework = TestTargetFramework.Net80;
     public static readonly string           TestDataPath = Path.Combine(AppContext.BaseDirectory, "data");
     public static readonly string           TestRootPath = Path.Combine(Path.GetTempPath(), "testroot");
-    public static bool                      HasPlaywrightSupport => !EnvironmentVariables.DisablePlaywrightTests;
 
     public static bool IsRunningOnHelix => Environment.GetEnvironmentVariable("HELIX_WORKITEM_ROOT") is not null;
     public static bool IsRunningOnCIBuildMachine => Environment.GetEnvironmentVariable("BUILD_BUILDID") is not null;

--- a/tests/Shared/WorkloadTesting/EnvironmentVariables.cs
+++ b/tests/Shared/WorkloadTesting/EnvironmentVariables.cs
@@ -17,5 +17,4 @@ public static class EnvironmentVariables
     public static readonly string? TestAssetsPath            = Environment.GetEnvironmentVariable("TEST_ASSETS_PATH");
     public static readonly string? TestScenario              = Environment.GetEnvironmentVariable("TEST_SCENARIO");
     public static readonly string? BrowserPath               = Environment.GetEnvironmentVariable(PlaywrightProvider.BrowserPathEnvironmentVariableName);
-    public static readonly bool    DisablePlaywrightTests    = Environment.GetEnvironmentVariable("DISABLE_PLAYWRIGHT_TESTS") is "true";
 }


### PR DESCRIPTION
PR #4694 incorrectly disabled playwright tests when they should have been running. This inverts the condition to correctly disable for the failing case.

Related: https://github.com/dotnet/aspire/issues/4623

- **[tests] Move HasPlaywrightSupport to PlaywrightProvider class**
- **Fix condition disabling playwright based tests**

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4726)