### PR TITLE
Configure Aspire Dashboard with key-per-file configuration provider (#4526)

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -89,6 +89,12 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             builder.Configuration.AddJsonFile(configFilePath, optional: false, reloadOnChange: true);
         }
 
+        // Allow for a user specified config directory on disk (e.g. for Docker secrets). Throw an error if the specified directory doesn't exist.
+        if (builder.Configuration[DashboardConfigNames.DashboardFileConfigDirectory.ConfigKey] is { Length: > 0 } fileConfigDirectory)
+        {
+            builder.Configuration.AddKeyPerFile(directoryPath: fileConfigDirectory, optional: false, reloadOnChange: true);
+        }
+
         var dashboardConfigSection = builder.Configuration.GetSection("Dashboard");
         builder.Services.AddOptions<DashboardOptions>()
             .Bind(dashboardConfigSection)

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -12,6 +12,7 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DashboardConfigFilePathName = new("DOTNET_DASHBOARD_CONFIG_FILE_PATH");
     public static readonly ConfigName ResourceServiceUrlName = new("DOTNET_RESOURCE_SERVICE_ENDPOINT_URL");
 
+    public static readonly ConfigName DashboardFileConfigDirectory = new("Dashboard:FileConfigDirectory", "DASHBOARD__FILECONFIGDIRECTORY");
     public static readonly ConfigName DashboardOtlpAuthModeName = new("Dashboard:Otlp:AuthMode", "DASHBOARD__OTLP__AUTHMODE");
     public static readonly ConfigName DashboardOtlpPrimaryApiKeyName = new("Dashboard:Otlp:PrimaryApiKey", "DASHBOARD__OTLP__PRIMARYAPIKEY");
     public static readonly ConfigName DashboardOtlpSecondaryApiKeyName = new("Dashboard:Otlp:SecondaryApiKey", "DASHBOARD__OTLP__SECONDARYAPIKEY");

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -5,6 +5,8 @@ using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Http;
 using Aspire.Hosting;
 using Google.Protobuf;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
@@ -63,6 +65,96 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
 
         // Assert
         Assert.Contains(configFilePath, ex.Message);
+    }
+
+    [Fact]
+    public async Task Configuration_FileConfigDirectoryDoesExist_Success()
+    {
+        // Arrange
+        const string frontendBrowserToken = "SomeSecretContent";
+        var fileConfigDirectory = Directory.CreateTempSubdirectory();
+        var browserTokenConfigFile = await CreateBrowserTokenConfigFileAsync(fileConfigDirectory, frontendBrowserToken);
+        try
+        {
+            var config = new ConfigurationManager()
+                .AddInMemoryCollection(new Dictionary<string, string?> { [DashboardConfigNames.DashboardFileConfigDirectory.ConfigKey] = fileConfigDirectory.FullName })
+                .Build();
+            WebApplicationBuilder? localBuilder = null;
+            Action<WebApplicationBuilder> webApplicationBuilderConfigAction = builder =>
+            {
+                builder.Configuration.AddConfiguration(config);
+                localBuilder = builder;
+            };
+
+            // Act
+            await using var dashboardWebApplication = new DashboardWebApplication(webApplicationBuilderConfigAction);
+
+            // Assert
+            Assert.NotNull(localBuilder);
+            Assert.Equal(frontendBrowserToken, localBuilder.Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey]);
+        }
+        finally
+        {
+            File.Delete(browserTokenConfigFile);
+        }
+    }
+
+    [Fact]
+    public async Task Configuration_FileConfigDirectoryReloadsChanges_Success()
+    {
+        // Arrange
+        const string initialFrontendBrowserToken = "InitialSecretContent";
+        const string changedFrontendBrowserToken = "NewSecretContent";
+        var fileConfigDirectory = Directory.CreateTempSubdirectory();
+        var browserTokenConfigFile = await CreateBrowserTokenConfigFileAsync(fileConfigDirectory, initialFrontendBrowserToken);
+        try
+        {
+            var config = new ConfigurationManager()
+                .AddInMemoryCollection(new Dictionary<string, string?> { [DashboardConfigNames.DashboardFileConfigDirectory.ConfigKey] = fileConfigDirectory.FullName })
+                .Build();
+            WebApplicationBuilder? localBuilder = null;
+            Action<WebApplicationBuilder> webApplicationBuilderConfigAction = builder =>
+            {
+                builder.Configuration.AddConfiguration(config);
+                localBuilder = builder;
+            };
+            await using var dashboardWebApplication = new DashboardWebApplication(webApplicationBuilderConfigAction);
+
+            // Act
+            // get the initial browser token to make sure nothing went wrong until here
+            var initialBrowserTokenProvidedByConfiguration = localBuilder?.Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey];
+
+            // update the browser token's config file and get the new value
+            await File.WriteAllTextAsync(browserTokenConfigFile, changedFrontendBrowserToken);
+            await Task.Delay(TimeSpan.FromMilliseconds(500)); // it takes some time before the file change is detected and propagated
+            var updatedBrowserTokenProvidedByConfiguration = localBuilder?.Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey];
+
+            // Assert
+            Assert.Equal(initialFrontendBrowserToken, initialBrowserTokenProvidedByConfiguration);
+            Assert.Equal(changedFrontendBrowserToken, updatedBrowserTokenProvidedByConfiguration);
+        }
+        finally
+        {
+            File.Delete(browserTokenConfigFile);
+        }
+    }
+
+    [Fact]
+    public async Task Configuration_FileConfigDirectoryDoesntExist_Error()
+    {
+        // Arrange & Act
+        var fileConfigDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var ex = await Assert.ThrowsAsync<DirectoryNotFoundException>(async () =>
+        {
+            await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
+                data =>
+                {
+                    data[DashboardConfigNames.DashboardFileConfigDirectory.ConfigKey] = fileConfigDirectory;
+                });
+        });
+
+        // Assert
+        Assert.Contains(fileConfigDirectory, ex.Message);
     }
 
     [Fact]
@@ -441,5 +533,13 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         // Check that the specified dynamic port of 0 is overridden with the actual port number.
         var ipEndPoint = endPointAccessor().EndPoint;
         Assert.NotEqual(0, ipEndPoint.Port);
+    }
+
+    private static async Task<string> CreateBrowserTokenConfigFileAsync(DirectoryInfo fileConfigDirectory, string browserToken)
+    {
+        var browserTokenConfigFile = Path.Combine(fileConfigDirectory.FullName, DashboardConfigNames.DashboardFrontendBrowserTokenName.EnvVarName);
+        await File.WriteAllTextAsync(browserTokenConfigFile, browserToken);
+
+        return browserTokenConfigFile;
     }
 }


### PR DESCRIPTION
This PR adds the [.NET key-per-file configuration provider](https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers#key-per-file-configuration-provider) to the Aspire Dashboard (see issue https://github.com/dotnet/aspire/issues/4526).

Thereby, one can use Docker secrets like this:

```yaml
services:
  aspire-dashboard:
    image: mcr.microsoft.com/dotnet/aspire-dashboard
    container_name: aspire-dashboard
    ports:
      - 4317:18889
      - 18888:18888
    environment:
      - Dashboard__FileConfigDirectory=/run/secrets
    secrets:
      - Dashboard__Frontend__BrowserToken
secrets:
  Dashboard__Frontend__BrowserToken:
    file: Dashboard__Frontend__BrowserToken.txt
```

Another PR for updating [the docs](https://github.com/dotnet/docs-aspire/blob/main/docs/fundamentals/dashboard/configuration.md) will follow.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4728)