### PR TITLE
[ci] Fix internal build

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -41,8 +41,8 @@ steps:
         displayName: Install devcerts
 
     - ${{ if eq(parameters.isWindows, 'true') }}:
-      - script: dotnet dev-certs https --check --verbose
-        displayName: Check dev-certs are installed
+      - script: dotnet dev-certs https --trust
+        displayName: Install dev-certs
 
     - script: ${{ parameters.dotnetScript }} dotnet-coverage collect
               --settings $(Build.SourcesDirectory)/eng/CodeCoverage.config

--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -41,7 +41,7 @@ steps:
         displayName: Install devcerts
 
     - ${{ if eq(parameters.isWindows, 'true') }}:
-      - script: dotnet dev-certs https --trust
+      - script: dotnet dev-certs https
         displayName: Install dev-certs
 
     - script: ${{ parameters.dotnetScript }} dotnet-coverage collect


### PR DESCRIPTION
[ci] Install dev-certs on windows

Remove the dev-certs check that we had added earlier to debug an issue. And instead always install it on Windows for build machines.

This is currently failing internal builds, and some PR ones.

```
dotnet dev-certs https --check --verbose

D:\a\_work\1\s\.dotnet
[1] Listing certificates from CurrentUser\My
[2] Found certificates: no certificates
[3] Checking certificates validity
[4] Valid certificates: no certificates
[5] Invalid certificates: no certificates
[6] Finished listing certificates.
No valid certificate found.
##[error]Cmd.exe exited with code '6'.
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4742)