### PR TITLE
Bump Polly to 8.4.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,9 @@ updates:
       Grpc:
         patterns:
           - "Grpc.*"
+      Polly:
+        patterns:
+          - "Polly.*"
     labels:
       - "area-codeflow"
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -112,8 +112,8 @@
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.23.40" />
-    <PackageVersion Include="Polly.Core" Version="8.4.0" />
-    <PackageVersion Include="Polly.Extensions" Version="8.4.0" />
+    <PackageVersion Include="Polly.Core" Version="8.4.1" />
+    <PackageVersion Include="Polly.Extensions" Version="8.4.1" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
     <PackageVersion Include="Qdrant.Client" Version="1.9.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0.0)" />


### PR DESCRIPTION
- Bump Polly to [8.4.1](https://github.com/App-vNext/Polly/releases/tag/8.4.1) to pick up bug fixes:
  - https://github.com/App-vNext/Polly/pull/2164
  - https://github.com/App-vNext/Polly/pull/2166
- Group Polly dependabot updates to avoid multiple PRs such as:
  - #4167
  - #4200

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4745)