### PR TITLE
Telemetry name improvements

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
+++ b/src/Aspire.Dashboard/Model/ResourceOutgoingPeerResolver.cs
@@ -102,7 +102,7 @@ public sealed class ResourceOutgoingPeerResolver : IOutgoingPeerResolver, IAsync
 
                     if (string.Equals(hostAndPort, value, StringComparison.OrdinalIgnoreCase))
                     {
-                        name = resource.Name;
+                        name = ResourceViewModel.GetResourceName(resource, resources);
                         return true;
                     }
                 }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -32,7 +31,7 @@ public sealed class ResourceViewModel
         return Name.Contains(filter, StringComparisons.UserTextSearch);
     }
 
-    public static string GetResourceName(ResourceViewModel resource, ConcurrentDictionary<string, ResourceViewModel> allResources)
+    public static string GetResourceName(ResourceViewModel resource, IDictionary<string, ResourceViewModel> allResources)
     {
         var count = 0;
         foreach (var (_, item) in allResources)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
@@ -192,7 +192,21 @@ public class OtlpApplication
                 count++;
                 if (count >= 2)
                 {
-                    return $"{item.ApplicationName}-{app.InstanceId}";
+                    var instanceId = app.InstanceId;
+
+                    // Convert long GUID into a shorter, more human friendly format.
+                    // Before: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+                    // After:  aaaaaaaa
+                    if (Guid.TryParse(instanceId, out var guid))
+                    {
+                        Span<char> chars = stackalloc char[32];
+                        var result = guid.TryFormat(chars, charsWritten: out _, format: "N");
+                        Debug.Assert(result, "Guid.TryFormat not successful.");
+
+                        instanceId = chars.Slice(0, 8).ToString();
+                    }
+
+                    return $"{item.ApplicationName}-{instanceId}";
                 }
             }
         }

--- a/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
@@ -3,8 +3,19 @@
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
-public readonly record struct ApplicationKey(string Name, string InstanceId)
+public readonly record struct ApplicationKey(string Name, string InstanceId) : IComparable<ApplicationKey>
 {
+    public int CompareTo(ApplicationKey other)
+    {
+        var c = string.Compare(Name, other.Name, StringComparisons.ResourceName);
+        if (c != 0)
+        {
+            return c;
+        }
+
+        return string.Compare(InstanceId, other.InstanceId, StringComparisons.ResourceName);
+    }
+
     public bool EqualsCompositeName(string name)
     {
         if (name == null)

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -56,7 +56,7 @@ public sealed class TelemetryRepository
         {
             applications.Add(kvp.Value);
         }
-        applications.Sort((a, b) => string.Compare(a.ApplicationName, b.ApplicationName, StringComparisons.ResourceName));
+        applications.Sort((a, b) => a.ApplicationKey.CompareTo(b.ApplicationKey));
         return applications;
     }
 

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -144,7 +144,7 @@ public class TraceTests
 
         var traces = repository.GetTraces(new GetTracesRequest
         {
-            ApplicationServiceId = applications[0].InstanceId,
+            ApplicationKey = applications[0].ApplicationKey,
             FilterText = string.Empty,
             StartIndex = 0,
             Count = 10


### PR DESCRIPTION
* Remove instance ID from uninstrumented peer names when not needed
* Shorten guid display to the first 8 characters. It's common for the instance ID to be a guid and this can make names in the UI look messy. A shortened name is more user friendly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4764)