### PR TITLE
DisableLocalAuth for AppConfig.

### DIFF
--- a/playground/cdk/CdkSample.AppHost/appConfig.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/appConfig.module.bicep
@@ -20,6 +20,7 @@ resource appConfigurationStore_xM7mBhesj 'Microsoft.AppConfiguration/configurati
     name: 'standard'
   }
   properties: {
+    disableLocalAuth: true
   }
 }
 

--- a/playground/cdk/CdkSample.AppHost/storage.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/storage.module.bicep
@@ -31,6 +31,7 @@ resource storageAccount_1XR3Um8QY 'Microsoft.Storage/storageAccounts@2022-09-01'
     networkAcls: {
       defaultAction: 'Allow'
     }
+    minimumTlsVersion: 'TLS1_2'
   }
 }
 

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -42,6 +42,7 @@ public static class AzureAppConfigurationExtensions
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             var store = new AppConfigurationStore(construct, name: name, skuName: "standard");
+            store.AssignProperty(x => x.DisableLocalAuth, "true");
             store.AddOutput("appConfigEndpoint", x => x.Endpoint);
             var appConfigurationDataOwnerRoleAssignemnt = store.AssignRole(RoleDefinition.AppConfigurationDataOwner);
             appConfigurationDataOwnerRoleAssignemnt.AssignProperty(x => x.PrincipalId, construct.PrincipalIdParameter);

--- a/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Azure/AzureBicepResourceTests.cs
@@ -456,6 +456,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 name: 'standard'
               }
               properties: {
+                disableLocalAuth: true
               }
             }
 


### PR DESCRIPTION
Following up on an issue raised by @mjrousos where we are leaving local auth enabled on the Azure AppConfig instances we create. This is unnecessary since we setup managed identity/service principal auth when we deploy.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4774)