### PR TITLE
Update resource endpoints to always display at least one endpoint inline

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -1,80 +1,83 @@
 ﻿@using Aspire.Dashboard.Model
 @namespace Aspire.Dashboard.Components
 
-@if (DisplayedEndpoints.Count == 1)
+@if (DisplayedEndpoints.Count > 0)
 {
-    var displayedEndpoint = DisplayedEndpoints[0];
-    if (displayedEndpoint.Url != null)
-    {
-        <a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Text</a>
-    }
-    else
-    {
-        @displayedEndpoint.Text
-    }
-}
-else
-{
-    <FluentOverflow Class="endpoint-overflow">
-        <ChildContent>
-            @for (var i = 0; i < DisplayedEndpoints.Count; i++)
+    <div style="display: grid; grid-template-columns: minmax(0px, max-content) minmax(min-content, auto)">
+        <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;">
+            @WriteEndpoint(DisplayedEndpoints[0])
+            @if (DisplayedEndpoints.Count > 1)
             {
-                var displayedEndpoint = DisplayedEndpoints[i];
-                var isLast = i == DisplayedEndpoints.Count - 1;
-
-                <FluentOverflowItem Data="displayedEndpoint">
-                    @if (displayedEndpoint.Url != null)
-                    {
-                        <a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Text</a>
-                    }
-                    else
-                    {
-                        @displayedEndpoint.Text
-                    }
-                    @if (!isLast)
-                    {
-                        <span>,</span>
-                    }
-                </FluentOverflowItem>
+                <span>,&nbsp;</span>
             }
-        </ChildContent>
-        <MoreButtonTemplate Context="overflow">
-            <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
-                @($"+{overflow.ItemsOverflow.Count()}")
-            </FluentButton>
-        </MoreButtonTemplate>
-        <OverflowTemplate Context="overflow">
-            @{
-                var items = overflow.ItemsOverflow.ToList();
-            }
-            <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200" AutoFocus="false">
-                <Header>
-                    Endpoints
-                </Header>
-                <Body>
-                    <div class="endpoint-popup">
-                        @foreach (var item in items)
+        </div>
+        <div>
+            @if (DisplayedEndpoints.Count > 1)
+            {
+                <FluentOverflow Class="endpoint-overflow">
+                    <ChildContent>
+                        @for (var i = 1; i < DisplayedEndpoints.Count; i++)
                         {
-                            var d = (DisplayedEndpoint)item.Data!;
-                            <div class="endpoint-link">
-                                @if (d.Url != null)
+                            var displayedEndpoint = DisplayedEndpoints[i];
+                            var isLast = i == DisplayedEndpoints.Count - 1;
+
+                            <FluentOverflowItem Data="displayedEndpoint">
+                                @WriteEndpoint(displayedEndpoint)
+
+                                @if (!isLast)
                                 {
-                                    <a href="@d.Url" target="_blank" title="@d.Text">@d.Text</a>
+                                    <span>,</span>
                                 }
-                                else
-                                {
-                                    <span title="@d.Text">@d.Text</span>
-                                }
-                            </div>
+                            </FluentOverflowItem>
                         }
-                    </div>
-                </Body>
-            </FluentPopover>
-        </OverflowTemplate>
-    </FluentOverflow>
+                    </ChildContent>
+                    <MoreButtonTemplate Context="overflow">
+                        <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
+                            @($"+{overflow.ItemsOverflow.Count()}")
+                        </FluentButton>
+                    </MoreButtonTemplate>
+                    <OverflowTemplate Context="overflow">
+                        @{
+                            var items = overflow.ItemsOverflow.ToList();
+                        }
+                        <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200" AutoFocus="false">
+                            <Header>
+                                Endpoints
+                            </Header>
+                            <Body>
+                                <div class="endpoint-popup">
+                                    @foreach (var item in items)
+                                    {
+                                        var d = (DisplayedEndpoint)item.Data!;
+                                        <div class="endpoint-link">
+                                            @WriteEndpoint(d)
+                                        </div>
+                                    }
+                                </div>
+                            </Body>
+                        </FluentPopover>
+                    </OverflowTemplate>
+                </FluentOverflow>
+            }
+        </div>
+    </div>
 }
 
 @if (!string.IsNullOrEmpty(AdditionalMessage))
 {
     <div>@AdditionalMessage</div>
+}
+
+@code {
+    RenderFragment WriteEndpoint(DisplayedEndpoint displayedEndpoint)
+    {
+        if (displayedEndpoint.Url != null)
+        {
+            return @<a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Text</a>;
+        }
+        else
+        {
+            return @<span title="@displayedEndpoint.Text">@displayedEndpoint.Text</span>;
+        }
+    }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -3,8 +3,8 @@
 
 @if (DisplayedEndpoints.Count > 0)
 {
-    <div style="display: grid; grid-template-columns: minmax(0px, max-content) minmax(min-content, auto)">
-        <div style="text-overflow: ellipsis; overflow: hidden; white-space: nowrap;">
+    <div class="endpoint-container">
+        <div class="endpoint-first">
             @WriteEndpoint(DisplayedEndpoints[0])
             @if (DisplayedEndpoints.Count > 1)
             {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
@@ -1,3 +1,19 @@
+::deep.endpoint-container {
+    display: grid;
+    /*
+        Two columns:
+        -The first endpoint. Max width is the width of the endpoint text, min width is nothing so the overflow button is always displayed.
+        -The endpoint overflow. Max width is all remaining space, min width is the overflow button.
+    */
+    grid-template-columns: minmax(0px, max-content) minmax(min-content, auto);
+}
+
+::deep.endpoint-first {
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
 ::deep.endpoint-list {
     margin: 0;
     padding: 0;

--- a/tests/Aspire.Workload.Tests/StarterTemplateRunTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/StarterTemplateRunTestsBase.cs
@@ -23,7 +23,7 @@ public abstract class StarterTemplateRunTestsBase<T> : WorkloadTestsBase, IClass
 
     [Fact]
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.DoesNotHavePlaywrightSupport))]
-    public async Task ResourcesShowUpOnDashboad()
+    public async Task ResourcesShowUpOnDashboard()
     {
         await using var context = await CreateNewBrowserContextAsync();
         await CheckDashboardHasResourcesAsync(

--- a/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
@@ -105,25 +105,23 @@ public class WorkloadTestsBase
                 int matchingEndpoints = 0;
                 var expectedEndpoints = expectedRow.Endpoints;
 
-                string[] endpointsFound =
+                var endpointsFound =
                     (await rowLoc.Locator("//div[@class='fluent-overflow-item']").AllAsync())
                         .Select(async e => await e.InnerTextAsync())
                         .Select(t => t.Result.Trim(','))
-                        .ToArray();
-                // FIXME: this could still return "+2"
-                if (endpointsFound.Length == 0)
-                {
-                    var cellText = await cellLocs[5].InnerTextAsync();
-                    endpointsFound = cellText.Trim().Split(',', StringSplitOptions.RemoveEmptyEntries);
-                }
-                if (expectedEndpoints.Length != endpointsFound.Length)
+                        .ToList();
+
+                var firstEndpoint = await rowLoc.Locator("//div[@class='endpoint-first']").InnerTextAsync();
+                endpointsFound.Insert(0, firstEndpoint.Trim().Trim(','));
+
+                if (expectedEndpoints.Length != endpointsFound.Count)
                 {
                     // _testOutput.WriteLine($"For resource '{resourceName}, found ")
                     // _testOutput.WriteLine($"-- expected: {expectedEndpoints.Length} found: {endpointsFound.Length}, expected: {string.Join(',', expectedEndpoints)} found: {string.Join(',', endpointsFound)} for {resourceName}");
                     continue;
                 }
 
-                AssertEqual(expectedEndpoints.Length, endpointsFound.Length, $"#endpoints for {resourceName}");
+                AssertEqual(expectedEndpoints.Length, endpointsFound.Count, $"#endpoints for {resourceName}");
 
                 // endpointsFound: ["foo", "https://localhost:7589/weatherforecast"]
                 foreach (var endpointFound in endpointsFound)
@@ -142,7 +140,7 @@ public class WorkloadTestsBase
                 // Check 'Source' column
                 AssertEqual(expectedRow.Source, await cellLocs[4].InnerTextAsync(), $"Source for {resourceName}");
 
-                foundRows.Add(expectedRow with { Endpoints = endpointsFound });
+                foundRows.Add(expectedRow with { Endpoints = endpointsFound.ToArray() });
                 foundNames.Add(resourceName);
             }
         }

--- a/tests/Shared/WorkloadTesting/BuildEnvironment.cs
+++ b/tests/Shared/WorkloadTesting/BuildEnvironment.cs
@@ -199,6 +199,10 @@ public class BuildEnvironment
                     }
                 }
             }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Error deleting '{TestRootPath}'.", ex);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/3550

Always attempt to show the first endpoint in the space available. Avoid the situation where you just see the more button.

If folks are happy with this change, then I'll move the inline CSS to classes.

**Before:**

![resource-endpoints-before](https://github.com/dotnet/aspire/assets/303201/dc5a23f8-08a3-45c2-badb-9c9445280c0f)

**After:**

![resource-endpoints-after](https://github.com/dotnet/aspire/assets/303201/1f590de5-2831-44de-99fd-18ef204c354b)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4797)