### PR TITLE
Order endpoints in resource details

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -363,17 +363,6 @@ public partial class Resources : ComponentBase, IAsyncDisposable
 
         additionalMessage = null;
 
-        // Make sure that endpoints have a consistent ordering. Show https first, then everything else.
-        return [.. GetEndpoints(resource)
-            .OrderByDescending(e => e.Url?.StartsWith("https") == true)
-            .ThenBy(e=> e.Url ?? e.Text)];
-    }
-
-    /// <summary>
-    /// A resource has services and endpoints. These can overlap. This method attempts to return a single list without duplicates.
-    /// </summary>
-    private static List<DisplayedEndpoint> GetEndpoints(ResourceViewModel resource)
-    {
         return ResourceEndpointHelpers.GetEndpoints(resource, includeInteralUrls: false);
     }
 

--- a/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
@@ -32,7 +32,7 @@ internal static class ResourceEndpointHelpers
         // Make sure that endpoints have a consistent ordering. Show https first, then everything else.
         var orderedEndpoints = endpoints
             .OrderByDescending(e => e.Url?.StartsWith("https") == true)
-            .ThenBy(e => e.Name)
+            .ThenBy(e => e.Name, StringComparers.EndpointAnnotationName)
             .ToList();
 
         return orderedEndpoints;

--- a/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
@@ -29,7 +29,13 @@ internal static class ResourceEndpointHelpers
             }
         }
 
-        return endpoints;
+        // Make sure that endpoints have a consistent ordering. Show https first, then everything else.
+        var orderedEndpoints = endpoints
+            .OrderByDescending(e => e.Url?.StartsWith("https") == true)
+            .ThenBy(e => e.Name)
+            .ToList();
+
+        return orderedEndpoints;
     }
 }
 

--- a/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
@@ -29,9 +29,14 @@ internal static class ResourceEndpointHelpers
             }
         }
 
-        // Make sure that endpoints have a consistent ordering. Show https first, then everything else.
+        // Make sure that endpoints have a consistent ordering.
+        // Order:
+        // - https
+        // - other urls
+        // - endpoint name
         var orderedEndpoints = endpoints
             .OrderByDescending(e => e.Url?.StartsWith("https") == true)
+            .ThenByDescending(e => e.Url != null)
             .ThenBy(e => e.Name, StringComparers.EndpointAnnotationName)
             .ToList();
 

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -174,15 +174,17 @@ public sealed class ResourceEndpointHelpersTests
         var endpoints = GetEndpoints(CreateResource([
             new("a", new("http://localhost:8080"), isInternal: false),
             new("C", new("http://localhost:8080"), isInternal: false),
-            new("B", new("http://localhost:8080"), isInternal: false),
+            new("D", new("tcp://localhost:8080"), isInternal: false),
+            new("B", new("tcp://localhost:8080"), isInternal: false),
             new("Z", new("https://localhost:8080"), isInternal: false)
         ]));
 
         Assert.Collection(endpoints,
             e => Assert.Equal("Z", e.Name),
             e => Assert.Equal("a", e.Name),
+            e => Assert.Equal("C", e.Name),
             e => Assert.Equal("B", e.Name),
-            e => Assert.Equal("C", e.Name));
+            e => Assert.Equal("D", e.Name));
     }
 
     private static ResourceViewModel CreateResource(ImmutableArray<UrlViewModel> urls)

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -168,6 +168,23 @@ public sealed class ResourceEndpointHelpersTests
             });
     }
 
+    [Fact]
+    public void GetEndpoints_OrderByName()
+    {
+        var endpoints = GetEndpoints(CreateResource([
+            new("a", new("http://localhost:8080"), isInternal: false),
+            new("C", new("http://localhost:8080"), isInternal: false),
+            new("B", new("http://localhost:8080"), isInternal: false),
+            new("Z", new("https://localhost:8080"), isInternal: false)
+        ]));
+
+        Assert.Collection(endpoints,
+            e => Assert.Equal("Z", e.Name),
+            e => Assert.Equal("a", e.Name),
+            e => Assert.Equal("B", e.Name),
+            e => Assert.Equal("C", e.Name));
+    }
+
     private static ResourceViewModel CreateResource(ImmutableArray<UrlViewModel> urls)
     {
         return new ResourceViewModel


### PR DESCRIPTION
I noticed endpoints in the resource details could be out of order. Centralize order logic to ensure data is displayed consistently.

![image](https://github.com/dotnet/aspire/assets/303201/c115994d-31c1-429a-82bb-683a33dce3a9)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4798)