### PR TITLE
Adds overload for AddSqlServerDbContext - Aspire.Microsoft.EntityFrameworkCore.SqlServer

### DIFF
--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/PublicAPI.Unshipped.txt
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-
+static Microsoft.Extensions.Hosting.AspireSqlServerEFCoreSqlClientExtensions.AddSqlServerDbContext<TContext>(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<Aspire.Microsoft.EntityFrameworkCore.SqlServer.MicrosoftEntityFrameworkCoreSqlServerSettings!>? configureSettings = null, System.Action<System.IServiceProvider, Microsoft.EntityFrameworkCore.DbContextOptionsBuilder!>? configureDbContextOptions = null) -> void


### PR DESCRIPTION
There was no overload for AddSqlServerDbContext in Aspire.Microsoft.EntityFrameworkCore.SqlServer where configureDbContextOptions has an IServiceProvider as delegate parameter.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4803)