### PR TITLE
Add span links to dashboard UI

### DIFF
--- a/playground/Stress/Stress.ApiService/TraceCreator.cs
+++ b/playground/Stress/Stress.ApiService/TraceCreator.cs
@@ -11,9 +11,13 @@ public class TraceCreator
 
     private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
 
+    private readonly List<Activity> _allActivities = new List<Activity>();
+
     public async Task CreateTraceAsync(int count, bool createChildren)
     {
-        for (var i = 0; i < count; i++)
+        var activityStack = new Stack<Activity>();
+
+        for (var i = 0; i < 10; i++)
         {
             if (i > 0)
             {
@@ -27,19 +31,39 @@ public class TraceCreator
                 continue;
             }
 
+            _allActivities.Add(activity);
+
             if (createChildren)
             {
                 await CreateChildActivityAsync(name);
             }
+
+            await Task.Delay(Random.Shared.Next(10, 50));
+        }
+
+        while (activityStack.Count > 0)
+        {
+            activityStack.Pop().Stop();
         }
     }
 
-    private static async Task CreateChildActivityAsync(string parentName)
+    private async Task CreateChildActivityAsync(string parentName)
     {
         if (Random.Shared.NextDouble() > 0.05)
         {
             var name = parentName + "-0";
-            using var activity = s_activitySource.StartActivity(name, ActivityKind.Client);
+
+            var links = CreateLinks();
+
+            using var activity = s_activitySource.StartActivity(ActivityKind.Client, name: name, links: links.DistinctBy(l => l.Context.SpanId));
+            if (activity == null)
+            {
+                return;
+            }
+
+            AddEvents(activity);
+
+            _allActivities.Add(activity);
 
             await Task.Delay(Random.Shared.Next(10, 50));
 
@@ -47,5 +71,56 @@ public class TraceCreator
 
             await Task.Delay(Random.Shared.Next(10, 50));
         }
+    }
+
+    private static void AddEvents(Activity activity)
+    {
+        var eventCount = Random.Shared.Next(0, 5);
+        for (var i = 0; i < eventCount; i++)
+        {
+            var activityTags = new ActivityTagsCollection();
+            var tagsCount = Random.Shared.Next(0, 3);
+            for (var j = 0; j < tagsCount; j++)
+            {
+                activityTags.Add($"key-{j}", "Value!");
+            }
+
+            activity.AddEvent(new ActivityEvent($"event-{i}", DateTimeOffset.UtcNow.AddMilliseconds(1), activityTags));
+        }
+    }
+
+    private ActivityLink[] CreateLinks()
+    {
+        var activityLinkCount = Random.Shared.Next(0, Math.Min(5, _allActivities.Count));
+        var links = new ActivityLink[activityLinkCount];
+        for (var i = 0; i < links.Length; i++)
+        {
+            // Randomly create some tags.
+            var activityTags = new ActivityTagsCollection();
+            var tagsCount = Random.Shared.Next(0, 3);
+            for (var j = 0; j < tagsCount; j++)
+            {
+                activityTags.Add($"key-{j}", "Value!");
+            }
+
+            // Create the activity link. There is a 50% chance the activity link goes to an activity
+            // that doesn't exist. This logic is here to ensure incomplete links are handled correctly.
+            ActivityContext activityContext;
+            if (Random.Shared.Next() % 2 == 0)
+            {
+                var a = _allActivities[Random.Shared.Next(0, _allActivities.Count)];
+                activityContext = a.Context;
+            }
+            else
+            {
+                activityContext = new ActivityContext(
+                    ActivityTraceId.CreateRandom(),
+                    ActivitySpanId.CreateRandom(),
+                    ActivityTraceFlags.None);
+            }
+            links[i] = new ActivityLink(activityContext, activityTags);
+        }
+
+        return links;
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
@@ -303,7 +303,7 @@ public abstract class ChartBase : ComponentBase
                 var key = new SpanKey(exemplar.TraceId, exemplar.SpanId);
                 if (!_currentCache.TryGetValue(key, out var span))
                 {
-                    span = GetSpan(exemplar.TraceId, exemplar.SpanId);
+                    span = TelemetryRepository.GetSpan(exemplar.TraceId, exemplar.SpanId);
                 }
                 if (span != null)
                 {
@@ -503,11 +503,6 @@ public abstract class ChartBase : ComponentBase
         _newCache = new Dictionary<SpanKey, OtlpSpan>();
 
         await OnChartUpdated(traces, xValues, exemplars, tickUpdate, inProgressDataTime);
-    }
-
-    protected OtlpSpan? GetSpan(string traceId, string spanId)
-    {
-        return MetricsHelpers.GetSpan(TelemetryRepository, traceId, spanId);
     }
 
     private DateTimeOffset GetCurrentDataTime()

--- a/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
@@ -199,6 +199,7 @@ public partial class PlotlyChart : ChartBase, IAsyncDisposable
         public void Dispose()
         {
             _cts.Cancel();
+            _cts.Dispose();
         }
 
         [JSInvokable]
@@ -207,7 +208,7 @@ public partial class PlotlyChart : ChartBase, IAsyncDisposable
             var available = await MetricsHelpers.WaitForSpanToBeAvailableAsync(
                 traceId,
                 spanId,
-                _plotlyChart.GetSpan,
+                _plotlyChart.TelemetryRepository.GetSpan,
                 _plotlyChart.DialogService,
                 _plotlyChart.InvokeAsync,
                 _plotlyChart.DialogsLoc,

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -1,8 +1,10 @@
 ﻿@using Aspire.Dashboard.Model
+@using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils
 @inject IStringLocalizer<ControlsStrings> Loc
+@inject IStringLocalizer<Dialogs> DialogsLoc
 
 <div class="span-details-layout">
     <FluentToolbar Orientation="Orientation.Horizontal">
@@ -91,8 +93,6 @@
                     <ExtraValueContent>
                         @if (context.Attributes.Length > 0)
                         {
-                            <div class="event-attributes-header">@Loc[nameof(ControlsStrings.TraceDetailAttributesHeader)]</div>
-
                             /* There's a weird bug where trying to render a nested FluentDataGrid here with a non-primitive
                                TItem leads to the click event not being raised *only in the value (not header) rows*. A
                                workaround is to use the attribute index as the item and query the attributes list for its
@@ -109,6 +109,74 @@
                     </ExtraValueContent>
                 </PropertyGrid>
             </FluentAccordionItem>
+            <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsLinksHeader)]" Expanded="true">
+                <div slot="end">
+                    <FluentBadge Appearance="Appearance.Neutral" Circular="true">
+                        @FilteredSpanLinks.Count()
+                    </FluentBadge>
+                </div>
+                <FluentDataGrid TGridItem="SpanLinkViewModel"
+                                Items="@FilteredSpanLinks"
+                                Style="width:100%"
+                                GenerateHeader="GenerateHeaderOption.Sticky"
+                                GridTemplateColumns="4fr 1fr">
+                    <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsSpanColumnHeader)]">
+                        @WriteSpanLink(context)
+                    </TemplateColumn>
+                    <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsDetailsColumnHeader)]">
+                        <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => OnViewDetailsAsync(context))">View</FluentButton>
+                    </TemplateColumn>
+                </FluentDataGrid>
+            </FluentAccordionItem>
+            <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsBacklinksHeader)]" Expanded="true">
+                <div slot="end">
+                    <FluentBadge Appearance="Appearance.Neutral" Circular="true">
+                        @FilteredSpanBacklinks.Count()
+                    </FluentBadge>
+                </div>
+                <FluentDataGrid TGridItem="SpanLinkViewModel"
+                                Items="@FilteredSpanBacklinks"
+                                Style="width:100%"
+                                GenerateHeader="GenerateHeaderOption.Sticky"
+                                GridTemplateColumns="4fr 1fr">
+                    <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsSpanColumnHeader)]">
+                        @WriteSpanLink(context)
+                    </TemplateColumn>
+                    <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsDetailsColumnHeader)]">
+                        <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => OnViewDetailsAsync(context))">View</FluentButton>
+                    </TemplateColumn>
+                </FluentDataGrid>
+            </FluentAccordionItem>
         </FluentAccordion>
     </div>
 </div>
+
+@code {
+    RenderFragment WriteSpanLink(SpanLinkViewModel context)
+    {
+        var content = context.Span != null
+            ? SpanWaterfallViewModel.GetTitle(context.Span, ViewModel.Applications)
+            : $"{Loc[nameof(ControlsStrings.SpanDetailsSpanPrefix)]}: {OtlpHelpers.ToShortenedId(context.SpanId)}";
+        var color = context.Span != null
+            ? ColorGenerator.Instance.GetColorHexByKey(OtlpApplication.GetResourceName(context.Span.Source, ViewModel.Applications))
+            : "transparent";
+
+        return @<div>
+            <div class="spanlink-container" style="height:32px;">
+            <span class="spanlink-text" title="@content" style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(color);">
+                    @content
+                </span>
+            </div>
+            @if (context.Attributes.Length > 0)
+            {
+                <PropertyGrid TItem="SpanPropertyViewModel"
+                              Items="@Queryable.AsQueryable(context.Attributes.Select(a => new SpanPropertyViewModel() { Name = a.Key, Value = a.Value }))"
+                              GridTemplateColumns="1fr 2fr"
+                              NameColumnValue="(vm) => vm.Name"
+                              ValueColumnValue="(vm) => vm.Value"
+                              IsNameSortable="false"
+                              IsValueSortable="false" />
+            }
+        </div>;
+    }
+}

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -124,7 +124,7 @@
                         @WriteSpanLink(context)
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsDetailsColumnHeader)]">
-                        <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => OnViewDetailsAsync(context))">View</FluentButton>
+                        <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => OnViewDetailsAsync(context))">@Loc[nameof(ControlsStrings.ViewAction)]</FluentButton>
                     </TemplateColumn>
                 </FluentDataGrid>
             </FluentAccordionItem>
@@ -143,7 +143,7 @@
                         @WriteSpanLink(context)
                     </TemplateColumn>
                     <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsDetailsColumnHeader)]">
-                        <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => OnViewDetailsAsync(context))">View</FluentButton>
+                        <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => OnViewDetailsAsync(context))">@Loc[nameof(ControlsStrings.ViewAction)]</FluentButton>
                     </TemplateColumn>
                 </FluentDataGrid>
             </FluentAccordionItem>

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -3,15 +3,26 @@
 
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components.Controls;
 
-public partial class SpanDetails
+public partial class SpanDetails : IDisposable
 {
     [Parameter, EditorRequired]
     public required SpanDetailsViewModel ViewModel { get; set; }
+
+    [Inject]
+    public required IDialogService DialogService { get; init; }
+
+    [Inject]
+    public required NavigationManager NavigationManager { get; init; }
+
+    [Inject]
+    public required TelemetryRepository TelemetryRepository { get; init; }
 
     private IQueryable<SpanPropertyViewModel> FilteredItems =>
         ViewModel.Properties.Where(ApplyFilter).AsQueryable();
@@ -27,8 +38,15 @@ public partial class SpanDetails
     private IQueryable<OtlpSpanEvent> FilteredSpanEvents =>
         ViewModel.Span.Events.Where(e => e.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase)).OrderBy(e => e.Time).AsQueryable();
 
+    private IQueryable<SpanLinkViewModel> FilteredSpanLinks =>
+        ViewModel.Links.Where(e => e.SpanId.Contains(_filter, StringComparison.CurrentCultureIgnoreCase)).AsQueryable();
+
+    private IQueryable<SpanLinkViewModel> FilteredSpanBacklinks =>
+        ViewModel.Backlinks.Where(e => e.SpanId.Contains(_filter, StringComparison.CurrentCultureIgnoreCase)).AsQueryable();
+
     private string _filter = "";
     private List<KeyValuePair<string, string>> _contextAttributes = null!;
+    private readonly CancellationTokenSource _cts = new();
 
     private readonly GridSort<SpanPropertyViewModel> _nameSort = GridSort<SpanPropertyViewModel>.ByAscending(vm => vm.Name);
     private readonly GridSort<SpanPropertyViewModel> _valueSort = GridSort<SpanPropertyViewModel>.ByAscending(vm => vm.Value);
@@ -57,5 +75,28 @@ public partial class SpanDetails
         {
             _contextAttributes.Add(new KeyValuePair<string, string>("TraceId", ViewModel.Span.TraceId));
         }
+    }
+
+    public async Task OnViewDetailsAsync(SpanLinkViewModel linkVM)
+    {
+        var available = await MetricsHelpers.WaitForSpanToBeAvailableAsync(
+            traceId: linkVM.TraceId,
+            spanId: linkVM.SpanId,
+            getSpan: TelemetryRepository.GetSpan,
+            DialogService,
+            InvokeAsync,
+            DialogsLoc,
+            _cts.Token).ConfigureAwait(false);
+
+        if (available)
+        {
+            NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(linkVM.TraceId, spanId: linkVM.SpanId));
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.css
@@ -18,8 +18,15 @@
     margin-bottom: 0;
 }
 
-::deep .event-attributes-header {
-    font-weight: bold;
-    margin: 5px 0;
+::deep .spanlink-container {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: calc((6 + (var(--design-unit) * var(--density))) * 1px);
+    align-items: center;
 }
 
+::deep .spanlink-text {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}

--- a/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor.cs
@@ -42,7 +42,7 @@ public partial class ExemplarsDialog : IDisposable
         var available = await MetricsHelpers.WaitForSpanToBeAvailableAsync(
             traceId: exemplar.TraceId,
             spanId: exemplar.SpanId,
-            getSpan: (traceId, spanId) => MetricsHelpers.GetSpan(TelemetryRepository, traceId, spanId),
+            getSpan: TelemetryRepository.GetSpan,
             DialogService,
             InvokeAsync,
             Loc,
@@ -79,6 +79,7 @@ public partial class ExemplarsDialog : IDisposable
 
     public void Dispose()
     {
+        _cts.Cancel();
         _cts.Dispose();
     }
 }

--- a/src/Aspire.Dashboard/Model/MetricsHelpers.cs
+++ b/src/Aspire.Dashboard/Model/MetricsHelpers.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using Aspire.Dashboard.Otlp.Model;
-using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.Extensions.Localization;
@@ -13,17 +12,6 @@ namespace Aspire.Dashboard.Model;
 
 public static class MetricsHelpers
 {
-    public static OtlpSpan? GetSpan(TelemetryRepository telemetryRepository, string traceId, string spanId)
-    {
-        var trace = telemetryRepository.GetTrace(traceId);
-        if (trace == null)
-        {
-            return null;
-        }
-
-        return trace.Spans.FirstOrDefault(s => s.SpanId == spanId);
-    }
-
     public static async Task<bool> WaitForSpanToBeAvailableAsync(
         string traceId,
         string spanId,

--- a/src/Aspire.Dashboard/Model/SpanDetailsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/SpanDetailsViewModel.cs
@@ -9,5 +9,8 @@ public sealed class SpanDetailsViewModel
 {
     public required OtlpSpan Span { get; init; }
     public required List<SpanPropertyViewModel> Properties { get; init; }
+    public required List<SpanLinkViewModel> Links { get; init; }
+    public required List<SpanLinkViewModel> Backlinks { get; init; }
     public required string Title { get; init; }
+    public required List<OtlpApplication> Applications { get; init; }
 }

--- a/src/Aspire.Dashboard/Model/SpanLinkViewModel.cs
+++ b/src/Aspire.Dashboard/Model/SpanLinkViewModel.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+
+namespace Aspire.Dashboard.Model;
+
+public sealed class SpanLinkViewModel
+{
+    public required string TraceId { get; init; }
+    public required string SpanId { get; init; }
+    public required KeyValuePair<string, string>[] Attributes { get; init; }
+    public required OtlpSpan? Span { get; init; }
+}

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -34,6 +34,8 @@ public class OtlpSpan
     public required string? State { get; init; }
     public required KeyValuePair<string, string>[] Attributes { get; init; }
     public required List<OtlpSpanEvent> Events { get; init; }
+    public required List<OtlpSpanLink> Links { get; init; }
+    public required List<OtlpSpanLink> BackLinks { get; init; }
 
     public OtlpScope Scope { get; }
     public TimeSpan Duration => EndTime - StartTime;
@@ -62,7 +64,9 @@ public class OtlpSpan
             StatusMessage = item.StatusMessage,
             State = item.State,
             Attributes = item.Attributes,
-            Events = item.Events
+            Events = item.Events,
+            Links = item.Links,
+            BackLinks = item.BackLinks,
         };
     }
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpanLink.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpanLink.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Dashboard.Otlp.Model;
+
+[DebuggerDisplay("TraceId = {TraceId}, SpanId = {SpanId}, SourceTraceId = {SourceTraceId}, SourceSpanId = {SourceSpanId}")]
+public class OtlpSpanLink
+{
+    public required string SourceTraceId { get; init; }
+    public required string SourceSpanId { get; init; }
+    public required string TraceState { get; init; }
+    public required string SpanId { get; init; }
+    public required string TraceId { get; init; }
+    public required KeyValuePair<string, string>[] Attributes { get; init; }
+}

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -4,6 +4,8 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Model;
 using Google.Protobuf.Collections;
@@ -38,10 +40,14 @@ public sealed class TelemetryRepository
     private readonly ReaderWriterLockSlim _tracesLock = new();
     private readonly Dictionary<string, OtlpScope> _traceScopes = new();
     private readonly CircularBuffer<OtlpTrace> _traces;
+    private readonly List<OtlpSpanLink> _spanLinks = new();
     private readonly DashboardOptions _dashboardOptions;
 
     public bool HasDisplayedMaxLogLimitMessage { get; set; }
     public bool HasDisplayedMaxTraceLimitMessage { get; set; }
+
+    // For testing.
+    internal List<OtlpSpanLink> SpanLinks => _spanLinks;
 
     public TelemetryRepository(ILoggerFactory loggerFactory, IOptions<DashboardOptions> dashboardOptions)
     {
@@ -50,6 +56,19 @@ public sealed class TelemetryRepository
 
         _logs = new(_dashboardOptions.TelemetryLimits.MaxLogCount);
         _traces = new(_dashboardOptions.TelemetryLimits.MaxTraceCount);
+        _traces.ItemRemovedForCapacity += TracesItemRemovedForCapacity;
+    }
+
+    private void TracesItemRemovedForCapacity(OtlpTrace trace)
+    {
+        // Remove links from central collection when the span is removed.
+        foreach (var span in trace.Spans)
+        {
+            foreach (var link in span.Links)
+            {
+                _spanLinks.Remove(link);
+            }
+        }
     }
 
     public List<OtlpApplication> GetApplications()
@@ -415,6 +434,20 @@ public sealed class TelemetryRepository
 
         try
         {
+            return GetTraceUnsynchronized(traceId);
+        }
+        finally
+        {
+            _tracesLock.ExitReadLock();
+        }
+    }
+
+    private OtlpTrace? GetTraceUnsynchronized(string traceId)
+    {
+        Debug.Assert(_tracesLock.IsReadLockHeld || _tracesLock.IsWriteLockHeld, $"Must get lock before calling {nameof(GetTraceUnsynchronized)}.");
+
+        try
+        {
             var results = _traces.Where(t => t.TraceId.StartsWith(traceId, StringComparison.Ordinal));
             var trace = results.SingleOrDefault();
             return trace is not null ? OtlpTrace.Clone(trace) : null;
@@ -422,6 +455,35 @@ public sealed class TelemetryRepository
         catch (Exception ex)
         {
             throw new InvalidOperationException($"Multiple traces found with trace id '{traceId}'.", ex);
+        }
+    }
+
+    private OtlpSpan? GetSpanUnsynchronized(string traceId, string spanId)
+    {
+        Debug.Assert(_tracesLock.IsReadLockHeld || _tracesLock.IsWriteLockHeld, $"Must get lock before calling {nameof(GetSpanUnsynchronized)}.");
+
+        var trace = GetTraceUnsynchronized(traceId);
+        if (trace != null)
+        {
+            foreach (var span in trace.Spans)
+            {
+                if (span.SpanId == spanId)
+                {
+                    return span;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public OtlpSpan? GetSpan(string traceId, string spanId)
+    {
+        _tracesLock.EnterReadLock();
+
+        try
+        {
+            return GetSpanUnsynchronized(traceId, spanId);
         }
         finally
         {
@@ -563,6 +625,25 @@ public sealed class TelemetryRepository
                         var newSpan = CreateSpan(application, span, trace, scope, _dashboardOptions.TelemetryLimits);
                         trace.AddSpan(newSpan);
 
+                        // The new span might be linked to by an existing span.
+                        // Check current links to see if a backlink should be created.
+                        foreach (var existingLink in _spanLinks)
+                        {
+                            if (existingLink.SpanId == newSpan.SpanId && existingLink.TraceId == newSpan.TraceId)
+                            {
+                                newSpan.BackLinks.Add(existingLink);
+                            }
+                        }
+
+                        // Add links to central collection. Add backlinks to existing spans.
+                        foreach (var link in newSpan.Links)
+                        {
+                            _spanLinks.Add(link);
+
+                            var linkedSpan = GetSpanUnsynchronized(link.TraceId, link.SpanId);
+                            linkedSpan?.BackLinks.Add(link);
+                        }
+
                         // Traces are sorted by the start time of the first span.
                         // We need to ensure traces are in the correct order if we're:
                         // 1. Adding a new trace.
@@ -627,6 +708,7 @@ public sealed class TelemetryRepository
                     }
 
                     AssertTraceOrder();
+                    AssertSpanLinks();
                 }
 
             }
@@ -669,6 +751,42 @@ public sealed class TelemetryRepository
         }
     }
 
+    [Conditional("DEBUG")]
+    private void AssertSpanLinks()
+    {
+        // Create a local copy of span links.
+        var currentSpanLinks = _spanLinks.ToList();
+
+        // Remove span links that match span links on spans.
+        // Throw an error if an expected span link doesn't exist.
+        foreach (var trace in _traces)
+        {
+            foreach (var span in trace.Spans)
+            {
+                foreach (var link in span.Links)
+                {
+                    if (!currentSpanLinks.Remove(link))
+                    {
+                        throw new InvalidOperationException($"Couldn't find expected link from span {span.SpanId} to span {link.SpanId}.");
+                    }
+                }
+            }
+        }
+
+        // Throw error if there are orphaned span links.
+        if (currentSpanLinks.Count > 0)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine(CultureInfo.InvariantCulture, $"There are {currentSpanLinks.Count} orphaned span links.");
+            foreach (var link in currentSpanLinks)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"\tSource span ID: {link.SourceSpanId}, Target span ID: {link.SpanId}");
+            }
+
+            throw new InvalidOperationException(sb.ToString());
+        }
+    }
+
     private static OtlpSpan CreateSpan(OtlpApplication application, Span span, OtlpTrace trace, OtlpScope scope, TelemetryLimitOptions options)
     {
         var id = span.SpanId?.ToHexString();
@@ -680,7 +798,7 @@ public sealed class TelemetryRepository
         var events = new List<OtlpSpanEvent>();
         foreach (var e in span.Events.OrderBy(e => e.TimeUnixNano))
         {
-            events.Add(new OtlpSpanEvent()
+            events.Add(new OtlpSpanEvent
             {
                 Name = e.Name,
                 Time = OtlpHelpers.UnixNanoSecondsToDateTime(e.TimeUnixNano),
@@ -691,6 +809,20 @@ public sealed class TelemetryRepository
             {
                 break;
             }
+        }
+
+        var links = new List<OtlpSpanLink>();
+        foreach (var e in span.Links)
+        {
+            links.Add(new OtlpSpanLink
+            {
+                SourceSpanId = id,
+                SourceTraceId = trace.TraceId,
+                TraceState = e.TraceState,
+                SpanId = e.SpanId.ToHexString(),
+                TraceId = e.TraceId.ToHexString(),
+                Attributes = e.Attributes.ToKeyValuePairs(options)
+            });
         }
 
         var newSpan = new OtlpSpan(application, trace, scope)
@@ -705,7 +837,9 @@ public sealed class TelemetryRepository
             StatusMessage = span.Status?.Message,
             Attributes = span.Attributes.ToKeyValuePairs(options),
             State = span.TraceState,
-            Events = events
+            Events = events,
+            Links = links,
+            BackLinks = new()
         };
         return newSpan;
     }

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -502,11 +502,29 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Backlinks.
+        /// </summary>
+        public static string SpanDetailsBacklinksHeader {
+            get {
+                return ResourceManager.GetString("SpanDetailsBacklinksHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Context.
         /// </summary>
         public static string SpanDetailsContextHeader {
             get {
                 return ResourceManager.GetString("SpanDetailsContextHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Details.
+        /// </summary>
+        public static string SpanDetailsDetailsColumnHeader {
+            get {
+                return ResourceManager.GetString("SpanDetailsDetailsColumnHeader", resourceCulture);
             }
         }
         
@@ -525,6 +543,15 @@ namespace Aspire.Dashboard.Resources {
         public static string SpanDetailsEventsHeader {
             get {
                 return ResourceManager.GetString("SpanDetailsEventsHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Links.
+        /// </summary>
+        public static string SpanDetailsLinksHeader {
+            get {
+                return ResourceManager.GetString("SpanDetailsLinksHeader", resourceCulture);
             }
         }
         
@@ -549,9 +576,27 @@ namespace Aspire.Dashboard.Resources {
         /// <summary>
         ///   Looks up a localized string similar to Span.
         /// </summary>
+        public static string SpanDetailsSpanColumnHeader {
+            get {
+                return ResourceManager.GetString("SpanDetailsSpanColumnHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Span.
+        /// </summary>
         public static string SpanDetailsSpanHeader {
             get {
                 return ResourceManager.GetString("SpanDetailsSpanHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Span.
+        /// </summary>
+        public static string SpanDetailsSpanPrefix {
+            get {
+                return ResourceManager.GetString("SpanDetailsSpanPrefix", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -341,4 +341,19 @@
   <data name="PlotlyChartTrace" xml:space="preserve">
     <value>Trace</value>
   </data>
+  <data name="SpanDetailsLinksHeader" xml:space="preserve">
+    <value>Links</value>
+  </data>
+  <data name="SpanDetailsSpanPrefix" xml:space="preserve">
+    <value>Span</value>
+  </data>
+  <data name="SpanDetailsSpanColumnHeader" xml:space="preserve">
+    <value>Span</value>
+  </data>
+  <data name="SpanDetailsDetailsColumnHeader" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="SpanDetailsBacklinksHeader" xml:space="preserve">
+    <value>Backlinks</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -247,9 +247,19 @@
         <target state="translated">Vybrat aplikaci</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">Události</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">Prostředek &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">Prostředek</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">Rozpětí</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -247,9 +247,19 @@
         <target state="translated">Anwendung auswählen</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">Ereignisse</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">Ressource &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">Ressource</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">Span</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -247,9 +247,19 @@
         <target state="translated">Seleccionar una aplicación</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">Eventos</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">Recurso &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">Recurso</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">Span</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -247,9 +247,19 @@
         <target state="translated">Sélectionner une application</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">Événements</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">Ressource &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">Ressource</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">Étendue</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -247,9 +247,19 @@
         <target state="translated">Seleziona un'applicazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">Eventi</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">Risorsa &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">Risorsa</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">Span</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -247,9 +247,19 @@
         <target state="translated">アプリケーションを選択する</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">イベント</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">リソース &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">リソース</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">スパン</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -247,9 +247,19 @@
         <target state="translated">애플리케이션 선택</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">이벤트</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">리소스 &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">리소스</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">범위</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -247,9 +247,19 @@
         <target state="translated">Wybierz aplikację</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">Zdarzenia</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">Zasób &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">Zasób</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">Zakres</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -247,9 +247,19 @@
         <target state="translated">Selecionar um aplicativo</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">Eventos</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">Recurso &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">Recurso</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">Extensão</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -247,9 +247,19 @@
         <target state="translated">Выберите приложение</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">События</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">Ресурс &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">Ресурс</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">Диапазон</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -247,9 +247,19 @@
         <target state="translated">Uygulama seçin</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">Etkinlikler</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">Kaynak &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">Kaynak</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">Yayılma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -247,9 +247,19 @@
         <target state="translated">选择应用程序</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">事件</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">资源 &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">资源</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">范围</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -247,9 +247,19 @@
         <target state="translated">選取應用程式</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsBacklinksHeader">
+        <source>Backlinks</source>
+        <target state="new">Backlinks</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsContextHeader">
         <source>Context</source>
         <target state="new">Context</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsDetailsColumnHeader">
+        <source>Details</source>
+        <target state="new">Details</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsDuration">
@@ -262,6 +272,11 @@
         <target state="translated">事件</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsLinksHeader">
+        <source>Links</source>
+        <target state="new">Links</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsResource">
         <source>Resource &lt;strong&gt;{0}&lt;/strong&gt;</source>
         <target state="translated">資源 &lt;strong&gt;{0}&lt;/strong&gt;</target>
@@ -272,9 +287,19 @@
         <target state="translated">資源</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpanDetailsSpanColumnHeader">
+        <source>Span</source>
+        <target state="new">Span</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpanDetailsSpanHeader">
         <source>Span</source>
         <target state="translated">跨時</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SpanDetailsSpanPrefix">
+        <source>Span</source>
+        <target state="new">Span</target>
         <note />
       </trans-unit>
       <trans-unit id="SpanDetailsStartTime">

--- a/src/Shared/CircularBuffer.cs
+++ b/src/Shared/CircularBuffer.cs
@@ -20,6 +20,8 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
     internal int _start;
     internal int _end;
 
+    public event Action<T>? ItemRemovedForCapacity;
+
     public CircularBuffer(int capacity) : this(new List<T>(), capacity, start: 0, end: 0)
     {
     }
@@ -81,7 +83,12 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
             if (index == 0)
             {
                 // When full, the item inserted at 0 is always the "last" in the buffer and is removed.
+                ItemRemovedForCapacity?.Invoke(item);
                 return;
+            }
+            else
+            {
+                ItemRemovedForCapacity?.Invoke(this[0]);
             }
 
             var internalIndex = InternalIndex(index);
@@ -105,6 +112,10 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
                     data.Slice(0, _end).CopyTo(data.Slice(1));
                 }
                 data[0] = overflowItem;
+            }
+            else if (internalIndex < _end && _end < _buffer.Count - 1)
+            {
+                data.Slice(internalIndex, _end - internalIndex).CopyTo(data.Slice(_end));
             }
             else
             {
@@ -181,6 +192,8 @@ internal sealed class CircularBuffer<T> : IList<T>, ICollection<T>, IEnumerable<
     {
         if (IsFull)
         {
+            ItemRemovedForCapacity?.Invoke(this[0]);
+
             _buffer[_end] = item;
             Increment(ref _end);
             _start = _end;

--- a/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
+++ b/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
@@ -590,4 +590,37 @@ public class CircularBufferTests
         b.RemoveAt(0);
         Assert.Empty(b);
     }
+
+    [Fact]
+    public void Insert_BeforeEnd_EndInMiddle()
+    {
+        var values = new List<string>
+        {
+            "10",
+            "12",
+            "0",
+            "2",
+            "2",
+            "4",
+            "4",
+            "6",
+            "6",
+            "8",
+        };
+
+        var buffer = new CircularBuffer<string>(values, capacity: 10, start: 2, end: 2);
+        buffer.Insert(9, "11");
+
+        Assert.Collection(buffer,
+            i => Assert.Equal("2", i),
+            i => Assert.Equal("2", i),
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("4", i),
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("6", i),
+            i => Assert.Equal("8", i),
+            i => Assert.Equal("10", i),
+            i => Assert.Equal("11", i),
+            i => Assert.Equal("12", i));
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TestHelpers.cs
@@ -143,7 +143,7 @@ internal static class TestHelpers
         return e;
     }
 
-    public static Span CreateSpan(string traceId, string spanId, DateTime startTime, DateTime endTime, string? parentSpanId = null, List<Span.Types.Event>? events = null, IEnumerable<KeyValuePair<string, string>>? attributes = null)
+    public static Span CreateSpan(string traceId, string spanId, DateTime startTime, DateTime endTime, string? parentSpanId = null, List<Span.Types.Event>? events = null, List<Span.Types.Link>? links = null, IEnumerable<KeyValuePair<string, string>>? attributes = null)
     {
         var span = new Span
         {
@@ -157,6 +157,10 @@ internal static class TestHelpers
         if (events != null)
         {
             span.Events.AddRange(events);
+        }
+        if (links != null)
+        {
+            span.Links.AddRange(links);
         }
         if (attributes != null)
         {

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Text;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
+using Google.Protobuf;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Trace.V1;
@@ -412,6 +414,114 @@ public class TraceTests
     }
 
     [Fact]
+    public void AddTraces_SpanLinks_ReturnData()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        // Act
+        repository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), links: new List<Span.Types.Link>
+                            {
+                                new Span.Types.Link
+                                {
+                                    TraceId = ByteString.CopyFrom(Encoding.UTF8.GetBytes("1")),
+                                    SpanId = ByteString.CopyFrom(Encoding.UTF8.GetBytes("1-1")),
+                                    Attributes =
+                                    {
+                                        new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "Value!" } }
+                                    }
+                                },
+                                new Span.Types.Link
+                                {
+                                    TraceId = ByteString.CopyFrom(Encoding.UTF8.GetBytes("2")),
+                                    SpanId = ByteString.CopyFrom(Encoding.UTF8.GetBytes("2-1")),
+                                    Attributes =
+                                    {
+                                        new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "Value!" } }
+                                    }
+                                }
+                            })
+                        }
+                    }
+                }
+            }
+        });
+
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ApplicationKey = null,
+            FilterText = string.Empty,
+            StartIndex = 0,
+            Count = 10
+        });
+        Assert.Collection(traces.PagedResult.Items,
+            trace =>
+            {
+                AssertId("1", trace.TraceId);
+                AssertId("1-1", trace.FirstSpan.SpanId);
+                Assert.Collection(trace.FirstSpan.Links,
+                    l =>
+                    {
+                        AssertId("1", l.TraceId);
+                        AssertId("1-1", l.SpanId);
+                        Assert.Collection(l.Attributes,
+                            a =>
+                            {
+                                Assert.Equal("key2", a.Key);
+                                Assert.Equal("Value!", a.Value);
+                            });
+                    },
+                    l =>
+                    {
+                        AssertId("2", l.TraceId);
+                        AssertId("2-1", l.SpanId);
+                        Assert.Collection(l.Attributes,
+                            a =>
+                            {
+                                Assert.Equal("key1", a.Key);
+                                Assert.Equal("Value!", a.Value);
+                            });
+                    });
+            });
+
+        Assert.Collection(repository.SpanLinks,
+            l =>
+            {
+                AssertId("1", l.TraceId);
+                AssertId("1-1", l.SpanId);
+                Assert.Collection(l.Attributes,
+                    a =>
+                    {
+                        Assert.Equal("key2", a.Key);
+                        Assert.Equal("Value!", a.Value);
+                    });
+            },
+            l =>
+            {
+                AssertId("2", l.TraceId);
+                AssertId("2-1", l.SpanId);
+                Assert.Collection(l.Attributes,
+                    a =>
+                    {
+                        Assert.Equal("key1", a.Key);
+                        Assert.Equal("Value!", a.Value);
+                    });
+            });
+    }
+
+    [Fact]
     public void GetTraces_ReturnCopies()
     {
         // Arrange
@@ -564,22 +674,73 @@ public class TraceTests
     }
 
     [Fact]
+    public void AddTraces_Links_BacklinksPopulated()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        // Act
+        AddTrace(repository, "1", s_testTime);
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ApplicationKey = null,
+            FilterText = string.Empty,
+            StartIndex = 0,
+            Count = 10
+        });
+
+        // Assert
+        var trace = Assert.Single(traces.PagedResult.Items);
+
+        Assert.Collection(trace.Spans,
+            s =>
+            {
+                var link = Assert.Single(s.Links);
+                AssertId("1-2", link.SpanId);
+                AssertId("1-1", link.SourceSpanId);
+
+                var backLink = Assert.Single(s.BackLinks);
+                AssertId("1-1", backLink.SpanId);
+                AssertId("1-2", backLink.SourceSpanId);
+            },
+            s =>
+            {
+                var link = Assert.Single(s.Links);
+                AssertId("1-1", link.SpanId);
+                AssertId("1-2", link.SourceSpanId);
+
+                var backLink = Assert.Single(s.BackLinks);
+                AssertId("1-2", backLink.SpanId);
+                AssertId("1-1", backLink.SourceSpanId);
+            });
+    }
+
+    [Fact]
     public void AddTraces_ExceedLimit_FirstInFirstOut()
     {
         // Arrange
-        var repository = CreateRepository(maxTraceCount: 10);
+        const int MaxTraceCount = 10;
+        var repository = CreateRepository(maxTraceCount: MaxTraceCount);
 
         var testTime = s_testTime.AddDays(1);
 
         // Act
         for (var i = 0; i < 2000; i++)
         {
-            var traceId = (i + 1).ToString(CultureInfo.InvariantCulture);
+            var traceNumber = i + 1;
+            var traceId = traceNumber.ToString(CultureInfo.InvariantCulture);
 
             // Insert traces out of order to stress the circular buffer type.
             var startTime = testTime.AddMinutes(i + (i % 2 == 0 ? -5 : 0));
 
-            AddTrace(repository, traceId, startTime);
+            try
+            {
+                AddTrace(repository, traceId, startTime);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException($"Error adding trace number {i}.", ex);
+            }
         }
 
         // Assert
@@ -602,18 +763,39 @@ public class TraceTests
         // Most recent traces are returned.
         var first = GetStringId(traces.PagedResult.Items.First().TraceId);
         var last = GetStringId(traces.PagedResult.Items.Last().TraceId);
-        Assert.Equal("1984", first);
+        Assert.Equal("1988", first);
         Assert.Equal("2000", last);
 
         // Traces returned are ordered by start time.
         var actualOrder = traces.PagedResult.Items.Select(t => t.TraceId).ToList();
         var expectedOrder = traces.PagedResult.Items.OrderBy(t => t.FirstSpan.StartTime).Select(t => t.TraceId).ToList();
         Assert.Equal(expectedOrder, actualOrder);
+
+        Assert.Equal(MaxTraceCount * 2, repository.SpanLinks.Count);
     }
 
     private static void AddTrace(TelemetryRepository repository, string traceId, DateTime startTime)
     {
         var addContext = new AddContext();
+
+        var link1 = new Span.Types.Link
+        {
+            TraceId = ByteString.CopyFrom(Encoding.UTF8.GetBytes(traceId)),
+            SpanId = ByteString.CopyFrom(Encoding.UTF8.GetBytes($"{traceId}-2")),
+            Attributes =
+            {
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "Value!" } }
+            }
+        };
+        var link2 = new Span.Types.Link
+        {
+            TraceId = ByteString.CopyFrom(Encoding.UTF8.GetBytes(traceId)),
+            SpanId = ByteString.CopyFrom(Encoding.UTF8.GetBytes($"{traceId}-1")),
+            Attributes =
+            {
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "Value!" } }
+            }
+        };
 
         repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
         {
@@ -627,8 +809,14 @@ public class TraceTests
                         Scope = CreateScope(),
                         Spans =
                         {
-                            CreateSpan(traceId: traceId, spanId: $"{traceId}-2", startTime: startTime.AddMinutes(5), endTime: startTime.AddMinutes(1), parentSpanId: $"{traceId}-1"),
-                            CreateSpan(traceId: traceId, spanId: $"{traceId}-1", startTime: startTime.AddMinutes(1), endTime: startTime.AddMinutes(10))
+                            CreateSpan(traceId: traceId, spanId: $"{traceId}-2", startTime: startTime.AddMinutes(5), endTime: startTime.AddMinutes(1), parentSpanId: $"{traceId}-1", links: new List<Span.Types.Link>
+                            {
+                                link2
+                            }),
+                            CreateSpan(traceId: traceId, spanId: $"{traceId}-1", startTime: startTime.AddMinutes(1), endTime: startTime.AddMinutes(10), links: new List<Span.Types.Link>
+                            {
+                                link1
+                            })
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/2577

* Displays list of span links for a span.
* Dashboard attempts to link the link IDs to in-memory span. If it is present then a summary of the span is displayed, otherwise the span id is displayed.
* Displays attributes in a grid if present.
* View button takes you to the trace/span if available. If not available, then the "loading" dialog from metrics exemplar is shown.

~PR doesn't include showing backlinks, but they could be added in the future. Backlinks are trickier:~
Backlinks done.

~Ready for review but shouldn't be merged until metrics exemplar is merged and the base branch is changed to main. The PR reuses functionality that was added for metrics exemplars.~
Metrics exemplars merged.

**Span with two links, one with attributes:**

![image](https://github.com/dotnet/aspire/assets/303201/85dfb8e3-5c41-4d75-8cd1-bbb7e8182c29)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4805)