### PR TITLE
Insert the "Select a Resource" option in console logs after sort

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -169,7 +169,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     private void UpdateResourcesList()
     {
         var builder = ImmutableList.CreateBuilder<SelectViewModel<ResourceTypeDetails>>();
-        builder.Add(_noSelection);
 
         foreach (var resourceGroupsByApplicationName in _resourceByName
             .Where(r => !r.Value.IsHiddenState())
@@ -193,6 +192,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
         builder.Sort((r1, r2) => StringComparers.ResourceName.Compare(r1.Name, r2.Name));
 
+        builder.Insert(0, _noSelection);
         _resources = builder.ToImmutableList();
 
         SelectViewModel<ResourceTypeDetails> ToOption(ResourceViewModel resource, bool isReplica, string applicationName)


### PR DESCRIPTION
When sorting was added to `UpdateResourcesList`, the call occurred after the _noSelection item was added to the collection. So, we can just insert it into the beginning of the collection after sort.

Fixes #4767 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4815)