### PR TITLE
Update project template package versions to latest

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/Aspire.Tests.1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/Aspire.Tests.1.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="MSTest" Version="3.1.1" />
+    <PackageReference Include="MSTest" Version="3.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/Aspire.Tests.1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/Aspire.Tests.1.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/Aspire.Tests.1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/Aspire.Tests.1.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="NUnit" Version="4.0.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.0.1" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Tests/Aspire-StarterApplication.1.Tests.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/Aspire-StarterApplication.1.Tests/Aspire-StarterApplication.1.Tests.csproj
@@ -15,14 +15,14 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" Condition=" $(TestFramework) == 'xUnit.net' " />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" Condition=" $(TestFramework) != 'MSTest' " />
-    <PackageReference Include="MSTest" Version="3.1.1" Condition=" $(TestFramework) == 'MSTest' " />
-    <PackageReference Include="NUnit" Version="4.0.1" Condition=" $(TestFramework) == 'NUnit' " />
-    <PackageReference Include="NUnit.Analyzers" Version="4.0.1" Condition=" $(TestFramework) == 'NUnit' " />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" Condition=" $(TestFramework) == 'xUnit.net' " />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" Condition=" $(TestFramework) != 'MSTest' " />
+    <PackageReference Include="MSTest" Version="3.4.3" Condition=" $(TestFramework) == 'MSTest' " />
+    <PackageReference Include="NUnit" Version="4.1.0" Condition=" $(TestFramework) == 'NUnit' " />
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0" Condition=" $(TestFramework) == 'NUnit' " />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" Condition=" $(TestFramework) == 'NUnit' " />
-    <PackageReference Include="xunit" Version="2.5.3" Condition=" $(TestFramework) == 'xUnit.net' " />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" Condition=" $(TestFramework) == 'xUnit.net' " />
+    <PackageReference Include="xunit" Version="2.9.0" Condition=" $(TestFramework) == 'xUnit.net' " />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" Condition=" $(TestFramework) == 'xUnit.net' " />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/Aspire.Tests.1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/Aspire.Tests.1.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/Aspire.Tests.1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/Aspire.Tests.1.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Testing" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
-
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />


### PR DESCRIPTION
Fix #3975

Dependabot does not understand or update project templates, perhaps because it sees the directory.packages.props or uses the .sln. Nor does `dotnet outdated` work (at least not easily) because the projects cannot load successfully as they are (they pick up the checked in build props and targets, etc which are not intended for them)

So we need to remember to periodically update them by hand until we write an elaborate script to make `dotnet outdated` work.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4816)