### PR TITLE
Fix WithDockerfileTests container start failures.

### DIFF
--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -16,7 +16,7 @@ namespace Aspire.Hosting.Containers.Tests;
 
 public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
 {
-    [Fact(Skip = "https://github.com/dotnet/aspire/issues/4828")]
+    [Fact]
     [RequiresDocker]
     public async Task WithBuildSecretPopulatesSecretFilesCorrectly()
     {
@@ -53,7 +53,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         await app.StopAsync();
     }
 
-    [Fact(Skip = "https://github.com/dotnet/aspire/issues/4828")]
+    [Fact]
     [RequiresDocker]
     public async Task WithDockerfileLaunchesContainerSuccessfully()
     {
@@ -87,7 +87,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         await app.StopAsync();
     }
 
-    [Fact(Skip = "https://github.com/dotnet/aspire/issues/4828")]
+    [Fact]
     [RequiresDocker]
     public async Task AddDockerfileLaunchesContainerSuccessfully()
     {
@@ -398,7 +398,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         Assert.Equal(expectedManifest, manifest.ToString());
     }
 
-    [Fact(Skip = "https://github.com/dotnet/aspire/issues/4828")]
+    [Fact]
     [RequiresDocker]
     public async Task WithDockerfileWithParameterLaunchesContainerSuccessfully()
     {
@@ -469,7 +469,7 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         await app.StopAsync();
     }
 
-    [Fact(Skip = "https://github.com/dotnet/aspire/issues/4828")]
+    [Fact]
     [RequiresDocker]
     public async Task AddDockerfileWithParameterLaunchesContainerSuccessfully()
     {
@@ -822,28 +822,33 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     private const string DefaultMessage = "aspire!";
 
     private const string HelloWorldDockerfile = $$"""
-        FROM mcr.microsoft.com/k8se/quickstart:latest AS builder
+        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS builder
         ARG MESSAGE=aspire!
-        RUN echo !!!CACHEBUSTER!!! > /app/static/cachebuster.txt
-        RUN echo ${MESSAGE} > /app/static/aspire.html
+        RUN mkdir -p /usr/share/nginx/html
+        RUN echo !!!CACHEBUSTER!!! > /usr/share/nginx/html/cachebuster.txt
+        RUN echo ${MESSAGE} > /usr/share/nginx/html/aspire.html
 
-        FROM mcr.microsoft.com/k8se/quickstart:latest AS runner
+        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS runner
         ARG MESSAGE
-        COPY --from=builder /app/static/cachebuster.txt /app/static
-        COPY --from=builder /app/static/aspire.html /app/static
+        RUN mkdir -p /usr/share/nginx/html
+        COPY --from=builder /usr/share/nginx/html/cachebuster.txt /usr/share/nginx/html
+        COPY --from=builder /usr/share/nginx/html/aspire.html /usr/share/nginx/html
         """;
 
     private const string HelloWorldDockerfileWithSecrets = $$"""
-        FROM mcr.microsoft.com/k8se/quickstart:latest AS builder
+        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS builder
         ARG MESSAGE=aspire!
-        RUN echo !!!CACHEBUSTER!!! > /app/static/cachebuster.txt
-        RUN echo ${MESSAGE} > /app/static/aspire.html
+        RUN mkdir -p /usr/share/nginx/html
+        RUN echo !!!CACHEBUSTER!!! > /usr/share/nginx/html/cachebuster.txt
+        RUN echo ${MESSAGE} > /usr/share/nginx/html/aspire.html
 
-        FROM mcr.microsoft.com/k8se/quickstart:latest AS runner
+        FROM mcr.microsoft.com/cbl-mariner/base/nginx:1.22 AS runner
         ARG MESSAGE
-        COPY --from=builder /app/static/cachebuster.txt /app/static
-        COPY --from=builder /app/static/aspire.html /app/static
-        RUN --mount=type=secret,id=FILE_SECRET cp /run/secrets/FILE_SECRET /app/static/FILE_SECRET.txt
-        RUN --mount=type=secret,id=ENV_SECRET cp /run/secrets/ENV_SECRET /app/static/ENV_SECRET.txt
+        RUN mkdir -p /usr/share/nginx/html
+        COPY --from=builder /usr/share/nginx/html/cachebuster.txt /usr/share/nginx/html
+        COPY --from=builder /usr/share/nginx/html/aspire.html /usr/share/nginx/html
+        RUN --mount=type=secret,id=FILE_SECRET cp /run/secrets/FILE_SECRET /usr/share/nginx/html/FILE_SECRET.txt
+        RUN --mount=type=secret,id=ENV_SECRET cp /run/secrets/ENV_SECRET /usr/share/nginx/html/ENV_SECRET.txt
+        RUN chmod -R 777 /usr/share/nginx/html
         """;
 }


### PR DESCRIPTION
This PR fixes #4792.

The issue was that the team that owns that image on MCR significantly changed the way it works (it just runs an executable rather than a web server that can service static content by the looks of it). To address this I changed to using the Mariner-based Nginx image also hosted on mcr.microsoft.com (because supply chain issues).

This resulted in a few necessary changes to the Dockerfile setups. Should all be unblocked now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4832)