### PR TITLE
Add DotnetWatchAnnotation to configure dotnet watch startup command

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/DotnetWatchAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DotnetWatchAnnotation.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents an annotation for the dotnet watch command.
+/// </summary>
+/// <param name="enableHotReload"></param>
+public sealed class DotnetWatchAnnotation(bool enableHotReload) : IResourceAnnotation
+{
+    /// <summary>
+    /// If set, the dotnet watch command will be called without the --no-hot-reload argument
+    /// </summary>
+    /// <remarks>In some cases, hot reloads might not be sufficient</remarks>
+    public bool EnableHotReload { get; } = enableHotReload;
+}

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1046,7 +1046,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                         projectMetadata.ProjectPath
                     ];
 
-                    if (dwa.EnableHotReload)
+                    if (!dwa.EnableHotReload)
                     {
                         exeSpec.Args.Add("--no-hot-reload");
                     }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1036,23 +1036,29 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             else
             {
                 exeSpec.ExecutionType = ExecutionType.Process;
-                if (configuration.GetBool("DOTNET_WATCH") is not true)
+                if (project.TryGetLastAnnotation<DotnetWatchAnnotation>(out var dwa))
                 {
-                    exeSpec.Args = [
+                    exeSpec.Args =
+                    [
+                        "watch",
+                        "--non-interactive",
+                        "--project",
+                        projectMetadata.ProjectPath
+                    ];
+
+                    if (dwa.EnableHotReload)
+                    {
+                        exeSpec.Args.Add("--no-hot-reload");
+                    }
+                }
+                else
+                {
+                    exeSpec.Args =
+                    [
                         "run",
                         "--no-build",
                         "--project",
                         projectMetadata.ProjectPath,
-                    ];
-                }
-                else
-                {
-                    exeSpec.Args = [
-                        "watch",
-                        "--non-interactive",
-                        "--no-hot-reload",
-                        "--project",
-                        projectMetadata.ProjectPath
                     ];
                 }
 

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -52,9 +52,9 @@ public static class ProjectResourceBuilderExtensions
     /// Example of adding a project to the application model.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
-    /// 
+    ///
     /// builder.AddProject&lt;Projects.InventoryService&gt;("inventoryservice");
-    /// 
+    ///
     /// builder.Build().Run();
     /// </code>
     /// </example>
@@ -64,7 +64,7 @@ public static class ProjectResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a .NET project to the application model. 
+    /// Adds a .NET project to the application model.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used for service discovery when referenced in a dependency.</param>
@@ -82,9 +82,9 @@ public static class ProjectResourceBuilderExtensions
     /// Add a project to the app model via a project path.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
-    /// 
+    ///
     /// builder.AddProject("inventoryservice", @"..\InventoryService\InventoryService.csproj");
-    /// 
+    ///
     /// builder.Build().Run();
     /// </code>
     /// </example>
@@ -125,9 +125,9 @@ public static class ProjectResourceBuilderExtensions
     /// Example of adding a project to the application model.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
-    /// 
+    ///
     /// builder.AddProject&lt;Projects.InventoryService&gt;("inventoryservice", launchProfileName: "otherLaunchProfile");
-    /// 
+    ///
     /// builder.Build().Run();
     /// </code>
     /// </example>
@@ -160,9 +160,9 @@ public static class ProjectResourceBuilderExtensions
     /// Add a project to the app model via a project path.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
-    /// 
+    ///
     /// builder.AddProject("inventoryservice", @"..\InventoryService\InventoryService.csproj", launchProfileName: "otherLaunchProfile");
-    /// 
+    ///
     /// builder.Build().Run();
     /// </code>
     /// </example>
@@ -205,9 +205,9 @@ public static class ProjectResourceBuilderExtensions
     /// Example of adding a project to the application model.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
-    /// 
+    ///
     /// builder.AddProject&lt;Projects.InventoryService&gt;("inventoryservice", options => { options.LaunchProfileName = "otherLaunchProfile"; });
-    /// 
+    ///
     /// builder.Build().Run();
     /// </code>
     /// </example>
@@ -241,9 +241,9 @@ public static class ProjectResourceBuilderExtensions
     /// Add a project to the app model via a project path.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
-    /// 
+    ///
     /// builder.AddProject("inventoryservice", @"..\InventoryService\InventoryService.csproj", options => { options.LaunchProfileName = "otherLaunchProfile"; });
-    /// 
+    ///
     /// builder.Build().Run();
     /// </code>
     /// </example>
@@ -295,6 +295,11 @@ public static class ProjectResourceBuilderExtensions
                     context.EnvironmentVariables[AspNetCoreForwardedHeadersEnabledVariableName] = "true";
                 }
             });
+        }
+
+        if (builder.ApplicationBuilder.Configuration.GetBool("DOTNET_WATCH") is true)
+        {
+            builder.WithAnnotation(new DotnetWatchAnnotation(false));
         }
 
         if (options.ExcludeLaunchProfile)

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Aspire.Hosting.ApplicationModel.DotnetWatchAnnotation
+Aspire.Hosting.ApplicationModel.DotnetWatchAnnotation.DotnetWatchAnnotation(bool enableHotReload) -> void
+Aspire.Hosting.ApplicationModel.DotnetWatchAnnotation.EnableHotReload.get -> bool
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, string? targetState = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, System.Collections.Generic.IEnumerable<string!>! targetStates, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!

--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -192,6 +192,25 @@ public class ProjectResourceTests
     }
 
     [Fact]
+    public void DotnetWatchConfigurationAddsAnnotationToProject()
+    {
+        var appBuilder = CreateBuilder(operation: DistributedApplicationOperation.Run);
+
+        appBuilder.Configuration["DOTNET_WATCH"] = "1";
+
+        appBuilder.AddProject<Projects.ServiceA>("projectName");
+        using var app = appBuilder.Build();
+
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var projectResources = appModel.GetProjectResources();
+
+        var resource = Assert.Single(projectResources);
+
+        Assert.Contains(resource.Annotations, a => a is DotnetWatchAnnotation { EnableHotReload: false });
+    }
+
+    [Fact]
     public void WithLaunchProfile_ApplicationUrlTrailingSemiColon_Ignore()
     {
         var appBuilder = CreateBuilder(operation: DistributedApplicationOperation.Run);


### PR DESCRIPTION
Added a new annotation which can be used to configure the `dotnet watch` command, mainly the -no-hot-reload argument.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4846)