### PR TITLE
Remove dependency on dockerhub in Hosting.Redis.Tests

### DIFF
--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -17,7 +17,7 @@ public class RedisFunctionalTests
     [RequiresDocker]
     public async Task VerifyRedisResource()
     {
-        var builder = TestDistributedApplicationBuilder.Create();
+        var builder = CreateDistributedApplicationBuilder();
 
         var redis = builder.AddRedis("redis");
 
@@ -55,7 +55,7 @@ public class RedisFunctionalTests
     {
         // Use a volume to do a snapshot save
 
-        var builder1 = TestDistributedApplicationBuilder.Create();
+        var builder1 = CreateDistributedApplicationBuilder();
         var redis1 = builder1.AddRedis("redis");
 
         // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
@@ -96,7 +96,7 @@ public class RedisFunctionalTests
             await app.StopAsync();
         }
 
-        var builder2 = TestDistributedApplicationBuilder.Create();
+        var builder2 = CreateDistributedApplicationBuilder();
         var redis2 = builder2.AddRedis("redis").WithDataVolume(volumeName);
 
         using (var app = builder2.Build())
@@ -145,7 +145,7 @@ public class RedisFunctionalTests
 
         // Use a bind mount to do a snapshot save
 
-        var builder1 = TestDistributedApplicationBuilder.Create();
+        var builder1 = CreateDistributedApplicationBuilder();
         var redis1 = builder1.AddRedis("redis").WithDataBindMount(bindMountPath);
 
         using (var app = builder1.Build())
@@ -181,7 +181,7 @@ public class RedisFunctionalTests
             await app.StopAsync();
         }
 
-        var builder2 = TestDistributedApplicationBuilder.Create();
+        var builder2 = CreateDistributedApplicationBuilder();
         var redis2 = builder2.AddRedis("redis").WithDataBindMount(bindMountPath);
 
         using (var app = builder2.Build())
@@ -229,7 +229,7 @@ public class RedisFunctionalTests
     {
         // Checks that without enabling Redis Persistence the tests fail
 
-        var builder1 = TestDistributedApplicationBuilder.Create();
+        var builder1 = CreateDistributedApplicationBuilder();
         var redis1 = builder1.AddRedis("redis");
 
         using (var app = builder1.Build())
@@ -260,7 +260,7 @@ public class RedisFunctionalTests
             await app.StopAsync();
         }
 
-        var builder2 = TestDistributedApplicationBuilder.Create();
+        var builder2 = CreateDistributedApplicationBuilder();
         var redis2 = builder2.AddRedis("redis");
 
         using (var app = builder2.Build())
@@ -292,4 +292,7 @@ public class RedisFunctionalTests
             await app.StopAsync();
         }
     }
+
+    private static TestDistributedApplicationBuilder CreateDistributedApplicationBuilder() =>
+        TestDistributedApplicationBuilder.CreateWithTestContainerRegistry();
 }

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -45,6 +45,9 @@ public sealed class TestDistributedApplicationBuilder : IDistributedApplicationB
         return new TestDistributedApplicationBuilder(configureOptions);
     }
 
+    public static TestDistributedApplicationBuilder CreateWithTestContainerRegistry() =>
+        Create(o => o.ContainerRegistryOverride = "netaspireci.azurecr.io");
+
     private TestDistributedApplicationBuilder(Action<DistributedApplicationOptions> configureOptions)
     {
         var appAssembly = typeof(TestDistributedApplicationBuilder).Assembly;

--- a/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
@@ -34,7 +34,7 @@ public sealed class RedisContainerFixture : IAsyncLifetime
     public static async Task<RedisContainer> CreateContainerAsync()
     {
         var container = new RedisBuilder()
-            .WithImage($"{RedisContainerImageTags.Image}:{RedisContainerImageTags.Tag}")
+            .WithImage($"netaspireci.azurecr.io/{RedisContainerImageTags.Image}:{RedisContainerImageTags.Tag}")
             .Build();
         await container.StartAsync();
 


### PR DESCRIPTION
Since our tests are being rate limited in CI, we need to move off of pulling from dockerhub. This is the first step. Other tests will follow.

Contributes to #4786
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4847)