### PR TITLE
Remove dependency on dockerhub in tests

### DIFF
--- a/src/Aspire.Hosting.Valkey/ValkeyContainerImageTags.cs
+++ b/src/Aspire.Hosting.Valkey/ValkeyContainerImageTags.cs
@@ -5,7 +5,7 @@ namespace Aspire.Hosting.Valkey;
 
 internal static class ValkeyContainerImageTags
 {
-    public const string Registry = "valkey";
-    public const string Image = "valkey";
+    public const string Registry = "docker.io";
+    public const string Image = "valkey/valkey";
     public const string Tag = "7.2";
 }

--- a/tests/Aspire.Components.Common.Tests/TestConstants.cs
+++ b/tests/Aspire.Components.Common.Tests/TestConstants.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Components.Common.Tests;
+
+public static class TestConstants
+{
+    public const string AspireTestContainerRegistry = "netaspireci.azurecr.io";
+}

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Garnet;
 using Aspire.Hosting.MongoDB;
 using Aspire.Hosting.MySql;
@@ -549,7 +550,7 @@ public class ManifestGenerationTests
                 "mysql": {
                   "type": "container.v0",
                   "connectionString": "Server={mysql.bindings.tcp.host};Port={mysql.bindings.tcp.port};User ID=root;Password={mysql-password.value}",
-                  "image": "{{MySqlContainerImageTags.Registry}}/{{MySqlContainerImageTags.Image}}:{{MySqlContainerImageTags.Tag}}",
+                  "image": "{{TestConstants.AspireTestContainerRegistry}}/{{MySqlContainerImageTags.Image}}:{{MySqlContainerImageTags.Tag}}",
                   "env": {
                     "MYSQL_ROOT_PASSWORD": "{mysql-password.value}",
                     "MYSQL_DATABASE": "mysqldb"
@@ -570,7 +571,7 @@ public class ManifestGenerationTests
                 "redis": {
                   "type": "container.v0",
                   "connectionString": "{redis.bindings.tcp.host}:{redis.bindings.tcp.port}",
-                  "image": "{{RedisContainerImageTags.Registry}}/{{RedisContainerImageTags.Image}}:{{RedisContainerImageTags.Tag}}",
+                  "image": "{{TestConstants.AspireTestContainerRegistry}}/{{RedisContainerImageTags.Image}}:{{RedisContainerImageTags.Tag}}",
                   "bindings": {
                     "tcp": {
                       "scheme": "tcp",
@@ -596,7 +597,7 @@ public class ManifestGenerationTests
                 "valkey": {
                   "type": "container.v0",
                   "connectionString": "{valkey.bindings.tcp.host}:{valkey.bindings.tcp.port}",
-                  "image": "{{ValkeyContainerImageTags.Registry}}/{{ValkeyContainerImageTags.Image}}:{{ValkeyContainerImageTags.Tag}}",
+                  "image": "{{TestConstants.AspireTestContainerRegistry}}/{{ValkeyContainerImageTags.Image}}:{{ValkeyContainerImageTags.Tag}}",
                   "bindings": {
                     "tcp": {
                       "scheme": "tcp",
@@ -609,7 +610,7 @@ public class ManifestGenerationTests
                 "postgres": {
                   "type": "container.v0",
                   "connectionString": "Host={postgres.bindings.tcp.host};Port={postgres.bindings.tcp.port};Username=postgres;Password={postgres-password.value}",
-                  "image": "{{PostgresContainerImageTags.Registry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
+                  "image": "{{TestConstants.AspireTestContainerRegistry}}/{{PostgresContainerImageTags.Image}}:{{PostgresContainerImageTags.Tag}}",
                   "env": {
                     "POSTGRES_HOST_AUTH_METHOD": "scram-sha-256",
                     "POSTGRES_INITDB_ARGS": "--auth-host=scram-sha-256 --auth-local=scram-sha-256",
@@ -633,7 +634,7 @@ public class ManifestGenerationTests
                 "rabbitmq": {
                   "type": "container.v0",
                   "connectionString": "amqp://guest:{rabbitmq-password.value}@{rabbitmq.bindings.tcp.host}:{rabbitmq.bindings.tcp.port}",
-                  "image": "{{RabbitMQContainerImageTags.Registry}}/{{RabbitMQContainerImageTags.Image}}:{{RabbitMQContainerImageTags.Tag}}",
+                  "image": "{{TestConstants.AspireTestContainerRegistry}}/{{RabbitMQContainerImageTags.Image}}:{{RabbitMQContainerImageTags.Tag}}",
                   "env": {
                     "RABBITMQ_DEFAULT_USER": "guest",
                     "RABBITMQ_DEFAULT_PASS": "{rabbitmq-password.value}"
@@ -650,7 +651,7 @@ public class ManifestGenerationTests
                 "mongodb": {
                   "type": "container.v0",
                   "connectionString": "mongodb://{mongodb.bindings.tcp.host}:{mongodb.bindings.tcp.port}",
-                  "image": "{{MongoDBContainerImageTags.Registry}}/{{MongoDBContainerImageTags.Image}}:{{MongoDBContainerImageTags.Tag}}",
+                  "image": "{{TestConstants.AspireTestContainerRegistry}}/{{MongoDBContainerImageTags.Image}}:{{MongoDBContainerImageTags.Tag}}",
                   "bindings": {
                     "tcp": {
                       "scheme": "tcp",
@@ -687,7 +688,7 @@ public class ManifestGenerationTests
                 "kafka": {
                   "type": "container.v0",
                   "connectionString": "{kafka.bindings.tcp.host}:{kafka.bindings.tcp.port}",
-                  "image": "{{KafkaContainerImageTags.Registry}}/{{KafkaContainerImageTags.Image}}:{{KafkaContainerImageTags.Tag}}",
+                  "image": "{{TestConstants.AspireTestContainerRegistry}}/{{KafkaContainerImageTags.Image}}:{{KafkaContainerImageTags.Tag}}",
                   "env": {
                     "KAFKA_LISTENERS": "PLAINTEXT://localhost:29092,CONTROLLER://localhost:29093,PLAINTEXT_HOST://0.0.0.0:9092,PLAINTEXT_INTERNAL://0.0.0.0:9093",
                     "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP": "CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT",
@@ -737,7 +738,7 @@ public class ManifestGenerationTests
                 "milvus": {
                   "type": "container.v0",
                   "connectionString": "Endpoint={milvus.bindings.grpc.url};Key={milvusApiKey.value}",
-                  "image": "docker.io/milvusdb/milvus:2.3-latest",
+                  "image": "{{TestConstants.AspireTestContainerRegistry}}/milvusdb/milvus:2.3-latest",
                   "args": [
                     "milvus",
                     "run",

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Dashboard;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,7 +47,7 @@ public sealed class TestDistributedApplicationBuilder : IDistributedApplicationB
     }
 
     public static TestDistributedApplicationBuilder CreateWithTestContainerRegistry() =>
-        Create(o => o.ContainerRegistryOverride = "netaspireci.azurecr.io");
+        Create(o => o.ContainerRegistryOverride = TestConstants.AspireTestContainerRegistry);
 
     private TestDistributedApplicationBuilder(Action<DistributedApplicationOptions> configureOptions)
     {

--- a/tests/Aspire.Milvus.Client.Tests/MilvusContainerFixture.cs
+++ b/tests/Aspire.Milvus.Client.Tests/MilvusContainerFixture.cs
@@ -20,7 +20,7 @@ public sealed class MilvusContainerFixture : IAsyncLifetime
         if (RequiresDockerAttribute.IsSupported)
         {
             Container = new MilvusBuilder()
-                .WithImage($"{MilvusContainerImageTags.Image}:{MilvusContainerImageTags.Tag}")
+                .WithImage($"{TestConstants.AspireTestContainerRegistry}/{MilvusContainerImageTags.Image}:{MilvusContainerImageTags.Tag}")
                 .Build();
             await Container.StartAsync();
         }

--- a/tests/Aspire.MongoDB.Driver.Tests/MongoDbContainerFixture.cs
+++ b/tests/Aspire.MongoDB.Driver.Tests/MongoDbContainerFixture.cs
@@ -22,7 +22,7 @@ public sealed class MongoDbContainerFixture : IAsyncLifetime
             // testcontainers uses mongo:mongo by default,
             // resetting that for tests
             Container = new MongoDbBuilder()
-                .WithImage($"{MongoDBContainerImageTags.Image}:{MongoDBContainerImageTags.Tag}")
+                .WithImage($"{TestConstants.AspireTestContainerRegistry}/{MongoDBContainerImageTags.Image}:{MongoDBContainerImageTags.Tag}")
                 .WithUsername(null)
                 .WithPassword(null)
                 .Build();

--- a/tests/Aspire.MySqlConnector.Tests/MySqlContainerFixture.cs
+++ b/tests/Aspire.MySqlConnector.Tests/MySqlContainerFixture.cs
@@ -20,7 +20,7 @@ public sealed class MySqlContainerFixture : IAsyncLifetime
         if (RequiresDockerAttribute.IsSupported)
         {
             Container = new MySqlBuilder()
-                .WithImage($"{MySqlContainerImageTags.Image}:{MySqlContainerImageTags.Tag}")
+                .WithImage($"{TestConstants.AspireTestContainerRegistry}/{MySqlContainerImageTags.Image}:{MySqlContainerImageTags.Tag}")
                 .Build();
             await Container.StartAsync();
         }

--- a/tests/Aspire.NATS.Net.Tests/NatsContainerFixture.cs
+++ b/tests/Aspire.NATS.Net.Tests/NatsContainerFixture.cs
@@ -20,7 +20,7 @@ public sealed class NatsContainerFixture : IAsyncLifetime
         if (RequiresDockerAttribute.IsSupported)
         {
             Container = new NatsBuilder()
-                .WithImage($"{NatsContainerImageTags.Image}:{NatsContainerImageTags.Tag}")
+                .WithImage($"{TestConstants.AspireTestContainerRegistry}/{NatsContainerImageTags.Image}:{NatsContainerImageTags.Tag}")
                 .Build();
             await Container.StartAsync();
         }

--- a/tests/Aspire.Npgsql.Tests/PostgreSQLContainerFixture.cs
+++ b/tests/Aspire.Npgsql.Tests/PostgreSQLContainerFixture.cs
@@ -20,7 +20,7 @@ public sealed class PostgreSQLContainerFixture : IAsyncLifetime
         if (RequiresDockerAttribute.IsSupported)
         {
             Container = new PostgreSqlBuilder()
-                .WithImage($"{PostgresContainerImageTags.Image}:{PostgresContainerImageTags.Tag}")
+                .WithImage($"{TestConstants.AspireTestContainerRegistry}/{PostgresContainerImageTags.Image}:{PostgresContainerImageTags.Tag}")
                 .Build();
             await Container.StartAsync();
         }

--- a/tests/Aspire.RabbitMQ.Client.Tests/RabbitMQContainerFixture.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/RabbitMQContainerFixture.cs
@@ -34,7 +34,7 @@ public sealed class RabbitMQContainerFixture : IAsyncLifetime
     public static async Task<RabbitMqContainer> CreateContainerAsync()
     {
         var container = new RabbitMqBuilder()
-            .WithImage($"{RabbitMQContainerImageTags.Image}:{RabbitMQContainerImageTags.Tag}")
+            .WithImage($"{TestConstants.AspireTestContainerRegistry}/{RabbitMQContainerImageTags.Image}:{RabbitMQContainerImageTags.Tag}")
             .Build();
         await container.StartAsync();
 

--- a/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
+++ b/tests/Aspire.StackExchange.Redis.Tests/RedisContainerFixture.cs
@@ -34,7 +34,7 @@ public sealed class RedisContainerFixture : IAsyncLifetime
     public static async Task<RedisContainer> CreateContainerAsync()
     {
         var container = new RedisBuilder()
-            .WithImage($"netaspireci.azurecr.io/{RedisContainerImageTags.Image}:{RedisContainerImageTags.Tag}")
+            .WithImage($"{TestConstants.AspireTestContainerRegistry}/{RedisContainerImageTags.Image}:{RedisContainerImageTags.Tag}")
             .Build();
         await container.StartAsync();
 

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -10,6 +10,8 @@ using Microsoft.Extensions.DependencyInjection;
 
 public class TestProgram : IDisposable
 {
+    private const string AspireTestContainerRegistry = "netaspireci.azurecr.io";
+
     private TestProgram(
         string[] args,
         string assemblyName,
@@ -91,13 +93,15 @@ public class TestProgram : IDisposable
             {
                 var mysqlDbName = "mysqldb";
                 var mysql = AppBuilder.AddMySql("mysql")
+                    .WithImageRegistry(AspireTestContainerRegistry)
                     .WithEnvironment("MYSQL_DATABASE", mysqlDbName)
                     .AddDatabase(mysqlDbName);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(mysql);
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.redis))
             {
-                var redis = AppBuilder.AddRedis("redis");
+                var redis = AppBuilder.AddRedis("redis")
+                    .WithImageRegistry(AspireTestContainerRegistry);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(redis);
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.garnet))
@@ -107,26 +111,30 @@ public class TestProgram : IDisposable
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.valkey))
             {
-                var valkey = AppBuilder.AddValkey("valkey");
+                var valkey = AppBuilder.AddValkey("valkey")
+                    .WithImageRegistry(AspireTestContainerRegistry);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(valkey);
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.postgres) || !resourcesToSkip.HasFlag(TestResourceNames.efnpgsql))
             {
                 var postgresDbName = "postgresdb";
                 var postgres = AppBuilder.AddPostgres("postgres")
+                    .WithImageRegistry(AspireTestContainerRegistry)
                     .WithEnvironment("POSTGRES_DB", postgresDbName)
                     .AddDatabase(postgresDbName);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(postgres);
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.rabbitmq))
             {
-                var rabbitmq = AppBuilder.AddRabbitMQ("rabbitmq");
+                var rabbitmq = AppBuilder.AddRabbitMQ("rabbitmq")
+                    .WithImageRegistry(AspireTestContainerRegistry);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(rabbitmq);
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.mongodb))
             {
                 var mongoDbName = "mymongodb";
                 var mongodb = AppBuilder.AddMongoDB("mongodb")
+                    .WithImageRegistry(AspireTestContainerRegistry)
                     .AddDatabase(mongoDbName);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(mongodb);
             }
@@ -139,7 +147,8 @@ public class TestProgram : IDisposable
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.kafka))
             {
-                var kafka = AppBuilder.AddKafka("kafka");
+                var kafka = AppBuilder.AddKafka("kafka")
+                    .WithImageRegistry(AspireTestContainerRegistry);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(kafka);
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.cosmos) || !resourcesToSkip.HasFlag(TestResourceNames.efcosmos))
@@ -159,7 +168,8 @@ public class TestProgram : IDisposable
 
                 var milvusApiKey = builder.AddParameter("milvusApiKey");
 
-                var milvus = AppBuilder.AddMilvus("milvus", milvusApiKey);
+                var milvus = AppBuilder.AddMilvus("milvus", milvusApiKey)
+                    .WithImageRegistry(AspireTestContainerRegistry);
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(milvus);
             }
         }


### PR DESCRIPTION
Move the rest of the tests that pull a docker container from docker.io to pull it from Aspire's container registry.

Fix #4786
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4848)