### PR TITLE
Update .NET SDK to 8.0.303

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "8.0.200",
+    "version": "8.0.303",
     "rollForward": "major",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "8.0.200"
+    "dotnet": "8.0.303"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24359.3",


### PR DESCRIPTION
Updating so we use the latest SDK in our CI tests, for example the template tests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4858)