### PR TITLE
Add en-GB to supported Dashboard cultures

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -188,7 +188,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         var supportedLanguages = new[]
         {
             "en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant", // Standard cultures for compliance.
-            "zh-CN" // Non-standard culture but it is the default in many Chinese browsers. Adding zh-CN allows OS culture customization to flow through the dashboard.
+            "zh-CN", // Non-standard culture but it is the default in many Chinese browsers. Adding zh-CN allows OS culture customization to flow through the dashboard.
+            "en-GB", // Support UK DateTime formatting (24-hour clock, dd/MM/yyyy)
         };
 
         _app.UseRequestLocalization(new RequestLocalizationOptions()


### PR DESCRIPTION
Support `en-GB` in the dashboard so dates and times are formatted appropriately for users in the UK.

I haven't added a test as I wasn't sure where to add such a test - if you'd like one, just point me in the right direction.

### Before

![before](https://github.com/user-attachments/assets/9e6d82e0-9012-4f58-b722-48d8851ad674)

```html
<fluent-data-grid-cell cell-id="c12" cell-type="default" grid-column="4" class="col-justify-start " style="height: 46px; align-content: center; grid-column: 4;" title="7/13/2024 11:16:29 AM" aria-label="7/13/2024 11:16:29 AM" b-w6qdxfylwy="" tabindex="-1" role="gridcell">
  <!--!-->
  11:16:29 AM
</fluent-data-grid-cell>
```

### After

![after](https://github.com/user-attachments/assets/aa5e381b-f5ae-43fa-a16b-bb19ff060bd7)

```html
<fluent-data-grid-cell cell-id="c133" cell-type="default" grid-column="4" class="col-justify-start " style="height: 46px; align-content: center; grid-column: 4;" title="13/07/2024 11:47:05" aria-label="13/07/2024 11:47:05" b-w6qdxfylwy="" tabindex="-1" role="gridcell">
  <!--!-->
  11:47:05
</fluent-data-grid-cell>
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4882)