### PR TITLE
Remove static SHA1 field from ImageNameGenerator

### DIFF
--- a/src/Aspire.Hosting/Utils/ImageNameGenerator.cs
+++ b/src/Aspire.Hosting/Utils/ImageNameGenerator.cs
@@ -9,12 +9,10 @@ namespace Aspire.Hosting.Utils;
 
 internal static class ImageNameGenerator
 {
-    private static readonly SHA1 s_sha1 = SHA1.Create();
-
     public static string GenerateImageName<T>(this IResourceBuilder<T> builder) where T: IResource
     {
         var bytes = Encoding.UTF8.GetBytes(builder.ApplicationBuilder.AppHostDirectory);
-        var hash = s_sha1.ComputeHash(bytes);
+        var hash = SHA1.HashData(bytes);
         var hex = Convert.ToHexString(hash).ToLower();
         return $"{builder.Resource.Name}-image-{hex}";
     }


### PR DESCRIPTION
This removes the static `s_sha` from `ImageNameGenerator` in favor of using the static one-shot.

The primary motivator for this is that instances of `HashAlgorithm` (which `SHA1` derives from) are not thread safe. Having a static instance of a HashAlgorithm is usually incorrect. In this case, if `GenerateImageName` were called concurrently from multiple threads, this could lead to exceptions or silent data corruption (producing the wrong hash). 

Since .NET 5 there have been static APIs for producing hashes. They are thread safe and internally they do not allocate - the only thing they allocate is the return value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4885)