### PR TITLE
Create hover tokens for grid row hover effect

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -6,7 +6,8 @@
                 ResizableColumns="true"
                 Style="width:100%"
                 GenerateHeader="GenerateHeaderOption.Sticky"
-                GridTemplateColumns="@GridTemplateColumns">
+                GridTemplateColumns="@GridTemplateColumns"
+                ShowHover="true">
     <TemplateColumn Title="@(NameColumnTitle ?? Loc[nameof(ControlsStrings.NameColumnHeader)])" Class="nameColumn" SortBy="@NameSort" Sortable="@IsNameSortable">
         <GridValue Value="@NameColumnValue(context)" HighlightText="@HighlightText" />
     </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -47,7 +47,8 @@
                                 ResizableColumns="true"
                                 Style="width:100%"
                                 GenerateHeader="GenerateHeaderOption.Sticky"
-                                GridTemplateColumns="1fr 1.5fr">
+                                GridTemplateColumns="1fr 1.5fr"
+                                ShowHover="true">
                     <TemplateColumn Title="@ControlStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Class="nameColumn">
                         <GridValue Value="@(context.KnownProperty?.DisplayName ?? context.Key)" ToolTip="@context.Key" />
                     </TemplateColumn>
@@ -66,7 +67,8 @@
                                 ResizableColumns="true"
                                 Style="width:100%"
                                 GenerateHeader="GenerateHeaderOption.Sticky"
-                                GridTemplateColumns="1fr 1.5fr">
+                                GridTemplateColumns="1fr 1.5fr"
+                                ShowHover="true">
                     <TemplateColumn Title="@ControlStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Class="nameColumn">
                         <GridValue Value="@context.Name" />
                     </TemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -74,7 +74,7 @@
                     @{
                     var gridTemplateColumns = HasResourcesWithCommands ? "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr 1fr" : "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr";
                     }
-                    <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading">
+                    <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading" ShowHover="true">
                         <ChildContent>
                             <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" Tooltip="true" TooltipText="@(c => c.ResourceType)"/>
                             <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c))" >

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -104,7 +104,7 @@
                 <Summary>
                     <div class="logs-summary-layout">
                         <div class="logs-grid-container continuous-scroll-overflow">
-                            <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr">
+                            <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr" ShowHover="true">
                                 <ChildContent>
                                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.Application))">
                                         <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Application)));">

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -59,7 +59,7 @@
                         </div>
                     </DetailsTitleTemplate>
                     <Summary>
-                        <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="4fr 12fr 85px">
+                        <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="4fr 12fr 85px" ShowHover="true">
                             <TemplateColumn Title="Name">
                                 <div class="col-long-content" title="@context.GetTooltip(_applications)" @onclick="() => OnShowPropertiesAsync(context, null)">
                                     @{

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -21,10 +21,6 @@
     display: inline !important;
 }
 
-::deep .trace-view-grid fluent-data-grid-row[row-type="default"]:hover {
-    background-color: var(--neutral-fill-hover);
-}
-
 ::deep .trace-view-grid fluent-data-grid-row[row-type="default"] {
     cursor: pointer;
 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -21,7 +21,7 @@
     display: inline !important;
 }
 
-::deep .trace-view-grid fluent-data-grid-row[row-type="default"] {
+::deep fluent-data-grid.trace-view-grid fluent-data-grid-row[row-type="default"]:hover {
     cursor: pointer;
 }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -31,7 +31,7 @@
         </ToolbarSection>
         <MainSection>
             <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
-                <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr">
+                <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr" ShowHover="true">
                     <ChildContent>
                         <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
                             @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -84,6 +84,17 @@ fluent-toolbar[orientation=horizontal] {
     color-scheme: dark;
 }
 
+/*
+    Override the `cursor: pointer` in the default styles from fluentui-blazor since
+    we don't have selection implemented and the pointer doesn't really make sense.
+    The `fluent-data-grid-row[role='row']` part added to the beginning is a bit of
+    a hack to get the specificity higher than the default style to avoid using
+    `!important` just in case there's a reason to to override further later.
+*/
+fluent-data-grid-row[role='row'].hover:not([row-type='header'],[row-type='sticky-header']):hover {
+    cursor: auto;
+}
+
 [data-theme="light"] {
     color-scheme: light;
 }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -51,6 +51,13 @@ fluent-toolbar[orientation=horizontal] {
     --messagebar-info-border-color: #d1d1d1;
 
     --layout-toolbar-padding: calc(var(--design-unit) * 1.5px);
+
+    /*
+        --neutral-layer-2 is the background for the body of most of the site so
+        we can default the datagrid hover color to that and just override it as
+        necessary elsewhere (e.g. in the details view)
+    */
+    --datagrid-hover-color: var(--neutral-layer-2-hover);
 }
 
 [data-theme="dark"] {
@@ -338,6 +345,24 @@ fluent-switch.table-switch::part(label) {
      width: 160px;
 }
 
+/*
+    If ShowHover is enabled on a FluentDataGrid, we need to tweak the way anchors and buttons
+    are colored when a row is hovered
+*/
+fluent-data-grid-row[row-type=default].hover:hover fluent-anchor[appearance=lightweight]::part(control):not(:hover),
+fluent-data-grid-row[row-type=default].hover:hover fluent-anchor[appearance=stealth]::part(control):not(:hover),
+fluent-data-grid-row[row-type=default].hover:hover fluent-button[appearance=lightweight]::part(control):not(:hover),
+fluent-data-grid-row[row-type=default].hover:hover fluent-button[appearance=stealth]::part(control):not(:hover) {
+    background-color: var(--datagrid-hover-color);
+}
+
+fluent-data-grid-row[row-type=default].hover:hover fluent-anchor[appearance=lightweight]::part(control):hover,
+fluent-data-grid-row[row-type=default].hover:hover fluent-anchor[appearance=stealth]::part(control):hover,
+fluent-data-grid-row[row-type=default].hover:hover fluent-button[appearance=lightweight]::part(control):hover,
+fluent-data-grid-row[row-type=default].hover:hover fluent-button[appearance=stealth]::part(control):hover {
+    background-color: var(--fill-color);
+}
+
 .property-grid-container {
     grid-area: main;
     overflow: auto;
@@ -352,8 +377,12 @@ fluent-switch.table-switch::part(label) {
     --fill-color: var(--neutral-layer-1);
 }
 
+.property-grid-container fluent-accordion fluent-data-grid {
+    --datagrid-hover-color: var(--neutral-layer-1-hover);
+}
+
 /* Under the current light theme, --neutral-layer-1 is too white, so we'll
-   use something that's halfway between --neutral-layer-2 and --neutral-layer1.
+   use something that's halfway between --neutral-layer-2 and --neutral-layer-1.
 */
 [data-theme="light"] .property-grid-container fluent-accordion {
     --fill-color: var(--neutral-fill-rest);
@@ -385,13 +414,13 @@ fluent-switch.table-switch::part(label) {
     border-bottom: none;
 }
 
-.property-grid-container fluent-accordion fluent-data-grid fluent-button[appearance=stealth]:not(:hover)::part(control),
-.property-grid-container fluent-accordion fluent-data-grid fluent-button[appearance=lightweight]:not(:hover)::part(control) {
+.property-grid-container fluent-accordion fluent-data-grid-row fluent-button[appearance=stealth]::part(control):not(:hover),
+.property-grid-container fluent-accordion fluent-data-grid-row fluent-button[appearance=lightweight]::part(control):not(:hover) {
     background-color: var(--fill-color);
 }
 
-.property-grid-container fluent-accordion fluent-data-grid fluent-button[appearance=stealth]:hover::part(control),
-.property-grid-container fluent-accordion fluent-data-grid fluent-button[appearance=lightweight]:hover::part(control) {
+.property-grid-container fluent-accordion fluent-data-grid-row:not([row-type=default]) fluent-button[appearance=stealth]::part(control):hover,
+.property-grid-container fluent-accordion fluent-data-grid-row:not([row-type=default]) fluent-button[appearance=lightweight]::part(control):hover {
     background-color: var(--neutral-fill-stealth-hover-on-neutral-fill-layer-rest);
 }
 

--- a/src/Aspire.Dashboard/wwwroot/js/app-theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-theme.js
@@ -201,6 +201,12 @@ function isDark(color) {
     return color.relativeLuminance <= darknessLuminanceTarget;
 }
 
+/**
+ * Creates additional design tokens that are used to define the hover colors for the neutral layers
+ * used in the site theme (neutral-layer-1 and neutral-layer-2, specifically). Unlike other -hover
+ * variants, these are not created by the design system by default so we need to create them ourselves.
+ * This is a lightly tweaked variant of other hover recipes used in the design system.
+ */
 function createAdditionalDesignTokens() {
     const neutralLayer1HoverLightDelta = DesignToken.create({ name: 'neutral-layer-1-hover-light-delta', cssCustomPropertyName: null }).withDefault(3);
     const neutralLayer1HoverDarkDelta = DesignToken.create({ name: 'neutral-layer-1-hover-dark-delta', cssCustomPropertyName: null }).withDefault(2);

--- a/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
@@ -61,7 +61,7 @@ public class WorkloadTestsBase
             await Task.Delay(500);
 
             // _testOutput.WriteLine($"Checking for rows again");
-            ILocator rowsLocator = dashboardPage.Locator("//fluent-data-grid-row[@class='resource-row']");
+            ILocator rowsLocator = dashboardPage.Locator("//fluent-data-grid-row[@class='hover resource-row']");
             var allRows = await rowsLocator.AllAsync();
             // _testOutput.WriteLine($"found rows#: {allRows.Count}");
             if (allRows.Count == 0)


### PR DESCRIPTION
Finally got around to taking a stab at #2281 to create hover tokens for the neutral-layer-1/neutral-layer-2 colors we use as our primary background colors from the current styles provided by the designers. Those tokens are not automatically provided by Fluent so we need to create them ourselves.

- Creates hover tokens for neutral-layer-1/neutral-layer-2 that we use as primary background colors for the current styles provided by the designers. Those tokens aren't automatically provided by Fluent like other -hover variants so we need to create them ourselves
- The above tokens are created as generically as possible so that we can tweak them as we want. E.g. if we decide that the layer 2 light color is too light/dark, we can change the `neutralLayer2HoverLightDelta` up/down by 1 to move it to the next value in the color palette.
- Ties the new tokens into the `FluentDataGrid`'s `ShowHover` functionality.
- Tweaks some of the hover effects on buttons in the grids to make them make a little more sense when the row is hovered

![grid-hover-colors](https://github.com/user-attachments/assets/45eceff7-be2d-4e59-aeda-69c85b301bbe)

I gave a look at all of the pages as I went through this, but I'm sure I missed some things that don't look quite right with this change. Will try to give it another pass tomorrow, but wanted to get the PR out for others eyes as well.



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4892)