### PR TITLE
Update runtime, aspnetcore, and extensions versions in a single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,18 +29,11 @@ updates:
       AspNetCoreHealthChecks:
         patterns:
           - "AspNetCore.HealthChecks.*"
-      AspNetCore:
-        patterns:
-          - "Microsoft.AspNetCore.*"
-          - "Microsoft.Extensions.Features"
       AWS:
         patterns:
           - "AWS.*"
           - "AWSSDK.*"
           - "OpenTelemetry.*.AWS"
-      MicrosoftExtensions:
-        patterns:
-          - "Microsoft.Extensions.*"
       EntityFrameworkCore:
         patterns:
           - "Microsoft.EntityFrameworkCore.*"
@@ -50,6 +43,10 @@ updates:
       OpenTelemetry:
         patterns:
           - "OpenTelemetry.*"
+      NetPlatform:
+        patterns:
+          - "Microsoft.AspNetCore.*"
+          - "Microsoft.Extensions.*"
       Npgsql:
         patterns:
           - "Npgsql.*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,9 @@ updates:
       OpenTelemetry:
         patterns:
           - "OpenTelemetry.*"
+      Orleans:
+        patterns:
+          - "Microsoft.Orleans*"
       NetPlatform:
         patterns:
           - "Microsoft.AspNetCore.*"


### PR DESCRIPTION
That way we don't get conflicting PRs like

* https://github.com/dotnet/aspire/pull/4897
* https://github.com/dotnet/aspire/pull/4898
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4911)