### PR TITLE
Add producer-consumer telemetry example to stress app

### DIFF
--- a/playground/Stress/Stress.ApiService/ProducerConsumer.cs
+++ b/playground/Stress/Stress.ApiService/ProducerConsumer.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Threading.Channels;
+
+namespace Stress.ApiService;
+
+public class Data
+{
+    public required int Id { get; init; }
+    public required Activity? Producer { get; init; }
+    public required string Message { get; init; }
+}
+
+public class ProducerConsumer
+{
+    public const string ActivitySourceName = "ProducerConsumer";
+
+    private readonly Channel<Data> _channel = Channel.CreateUnbounded<Data>();
+
+    private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
+
+    public async Task ProduceAndConsumeAsync(int count)
+    {
+        var consumerTask = Task.Run(async () =>
+        {
+            using var appActivity = s_activitySource.StartActivity("ConsumerApp", ActivityKind.Internal);
+
+            await foreach (var item in _channel.Reader.ReadAllAsync())
+            {
+                var links = new List<ActivityLink>();
+                if (item.Producer != null)
+                {
+                    links.Add(new ActivityLink(new ActivityContext(item.Producer.TraceId, item.Producer.SpanId, ActivityTraceFlags.None)));
+                }
+
+                using var activity = s_activitySource.StartActivity($"Consume {item.Id}", ActivityKind.Consumer, parentId: null, links: links);
+
+                await Task.Delay(Random.Shared.Next(10, 50));
+            }
+        });
+
+        using var appActivity = s_activitySource.StartActivity("ProducerApp", ActivityKind.Internal);
+
+        for (var i = 0; i < count; i++)
+        {
+            var id = i + 1;
+
+            Data data;
+            using (var activity = s_activitySource.StartActivity($"Produce {id}", ActivityKind.Producer))
+            {
+                await Task.Delay(Random.Shared.Next(10, 50));
+
+                data = new Data
+                {
+                    Id = id,
+                    Producer = activity,
+                    Message = $"Message {id}"
+                };
+            }
+
+            await _channel.Writer.WriteAsync(data);
+        }
+        _channel.Writer.Complete();
+
+        await consumerTask;
+    }
+}

--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -11,7 +11,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 
 builder.Services.AddOpenTelemetry()
-    .WithTracing(tracing => tracing.AddSource(TraceCreator.ActivitySourceName));
+    .WithTracing(tracing => tracing.AddSource(TraceCreator.ActivitySourceName, ProducerConsumer.ActivitySourceName));
 
 var app = builder.Build();
 
@@ -117,6 +117,15 @@ app.MapGet("/many-logs", (ILoggerFactory loggerFactory, CancellationToken cancel
             yield return message;
         }
     }
+});
+
+app.MapGet("/producer-consumer", async () =>
+{
+    var producerConsumer = new ProducerConsumer();
+
+    await producerConsumer.ProduceAndConsumeAsync(count: 5);
+
+    return "Produced and consumed";
 });
 
 app.Run();


### PR DESCRIPTION
Example of linked spans in a producer/consumer app.

Good for testing and demoing linked spans.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4927)