### PR TITLE
Revert change to always display first endpoint

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -1,66 +1,56 @@
 ﻿@using Aspire.Dashboard.Model
 @namespace Aspire.Dashboard.Components
 
-@if (DisplayedEndpoints.Count > 0)
+@if (DisplayedEndpoints.Count == 1)
 {
-    <div class="endpoint-container">
-        <div class="endpoint-first">
-            @WriteEndpoint(DisplayedEndpoints[0])
-            @if (DisplayedEndpoints.Count > 1)
+    @WriteEndpoint(DisplayedEndpoints[0])
+}
+else if (DisplayedEndpoints.Count > 1)
+{
+    <FluentOverflow Class="endpoint-overflow">
+        <ChildContent>
+            @for (var i = 0; i < DisplayedEndpoints.Count; i++)
             {
-                <span>,&nbsp;</span>
+                var displayedEndpoint = DisplayedEndpoints[i];
+                var isLast = i == DisplayedEndpoints.Count - 1;
+
+                <FluentOverflowItem Data="displayedEndpoint">
+                    @WriteEndpoint(displayedEndpoint)
+
+                    @if (!isLast)
+                    {
+                        <span>,</span>
+                    }
+                </FluentOverflowItem>
             }
-        </div>
-        <div>
-            @if (DisplayedEndpoints.Count > 1)
-            {
-                <FluentOverflow Class="endpoint-overflow">
-                    <ChildContent>
-                        @for (var i = 1; i < DisplayedEndpoints.Count; i++)
+        </ChildContent>
+        <MoreButtonTemplate Context="overflow">
+            <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
+                @($"+{overflow.ItemsOverflow.Count()}")
+            </FluentButton>
+        </MoreButtonTemplate>
+        <OverflowTemplate Context="overflow">
+            @{
+                var items = overflow.ItemsOverflow.ToList();
+            }
+            <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200" AutoFocus="false">
+                <Header>
+                    @Loc[Resources.Columns.EndpointsColumnDisplayOverflowTitle]
+                </Header>
+                <Body>
+                    <div class="endpoint-popup">
+                        @foreach (var item in items)
                         {
-                            var displayedEndpoint = DisplayedEndpoints[i];
-                            var isLast = i == DisplayedEndpoints.Count - 1;
-
-                            <FluentOverflowItem Data="displayedEndpoint">
-                                @WriteEndpoint(displayedEndpoint)
-
-                                @if (!isLast)
-                                {
-                                    <span>,</span>
-                                }
-                            </FluentOverflowItem>
+                            var d = (DisplayedEndpoint)item.Data!;
+                            <div class="endpoint-link">
+                                @WriteEndpoint(d)
+                            </div>
                         }
-                    </ChildContent>
-                    <MoreButtonTemplate Context="overflow">
-                        <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
-                            @($"+{overflow.ItemsOverflow.Count()}")
-                        </FluentButton>
-                    </MoreButtonTemplate>
-                    <OverflowTemplate Context="overflow">
-                        @{
-                            var items = overflow.ItemsOverflow.ToList();
-                        }
-                        <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200" AutoFocus="false">
-                            <Header>
-                                @Loc[Resources.Columns.EndpointsColumnDisplayOverflowTitle]
-                            </Header>
-                            <Body>
-                                <div class="endpoint-popup">
-                                    @foreach (var item in items)
-                                    {
-                                        var d = (DisplayedEndpoint)item.Data!;
-                                        <div class="endpoint-link">
-                                            @WriteEndpoint(d)
-                                        </div>
-                                    }
-                                </div>
-                            </Body>
-                        </FluentPopover>
-                    </OverflowTemplate>
-                </FluentOverflow>
-            }
-        </div>
-    </div>
+                    </div>
+                </Body>
+            </FluentPopover>
+        </OverflowTemplate>
+    </FluentOverflow>
 }
 
 @if (!string.IsNullOrEmpty(AdditionalMessage))

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.css
@@ -1,19 +1,3 @@
-::deep.endpoint-container {
-    display: grid;
-    /*
-        Two columns:
-        -The first endpoint. Max width is the width of the endpoint text, min width is nothing so the overflow button is always displayed.
-        -The endpoint overflow. Max width is all remaining space, min width is the overflow button.
-    */
-    grid-template-columns: minmax(0px, max-content) minmax(min-content, auto);
-}
-
-::deep.endpoint-first {
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-}
-
 ::deep.endpoint-list {
     margin: 0;
     padding: 0;

--- a/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
@@ -111,9 +111,6 @@ public class WorkloadTestsBase
                         .Select(t => t.Result.Trim(','))
                         .ToList();
 
-                var firstEndpoint = await rowLoc.Locator("//div[@class='endpoint-first']").InnerTextAsync();
-                endpointsFound.Insert(0, firstEndpoint.Trim().Trim(','));
-
                 if (expectedEndpoints.Length != endpointsFound.Count)
                 {
                     // _testOutput.WriteLine($"For resource '{resourceName}, found ")


### PR DESCRIPTION
Revert #4797

This change doesn't work if there is more than one overflow endpoint.

I still think we want this as an improvement. Request to add it as a feature to FluentOverflow: https://github.com/microsoft/fluentui-blazor/issues/2391
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4935)