### PR TITLE
Limit number of console log messages retained in dashboard process

### DIFF
--- a/src/Aspire.Dashboard/Authentication/OpenIdConnect/AuthorizationPolicyBuilderExtensions.cs
+++ b/src/Aspire.Dashboard/Authentication/OpenIdConnect/AuthorizationPolicyBuilderExtensions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Authorization;
-using OpenIdConnectOptions = Aspire.Dashboard.Configuration.OpenIdConnectOptions;
+using Aspire.Dashboard.Configuration;
 
 namespace Aspire.Dashboard.Authentication.OpenIdConnect;
 

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -73,10 +73,7 @@ public sealed partial class LogViewer
             {
                 // Keep track of the base line number to ensure that we can calculate the line number of each log entry.
                 // This becomes important when the total number of log entries exceeds the limit and is truncated.
-                if (ViewModel.LogEntries.BaseLineNumber is null)
-                {
-                    ViewModel.LogEntries.BaseLineNumber = lineNumber;
-                }
+                ViewModel.LogEntries.BaseLineNumber ??= lineNumber;
 
                 ViewModel.LogEntries.InsertSorted(logParser.CreateLogEntry(content, isErrorOutput));
             }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Components.Resize;
-using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
@@ -16,7 +15,6 @@ using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
-using Microsoft.Extensions.Options;
 
 namespace Aspire.Dashboard.Components.Pages;
 
@@ -39,9 +37,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     [Inject]
     public required DimensionManager DimensionManager { get; init; }
-
-    [Inject]
-    public required IOptionsMonitor<DashboardOptions> Options { get; init; }
 
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; init; }
@@ -183,8 +178,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     {
         if (firstRender)
         {
-            LogViewerViewModel.LogEntries.MaximumEntryCount = Options.CurrentValue.Frontend.MaxConsoleLogCount;
-
             // Let anyone waiting know that the render is complete, so we have access to the underlying log viewer.
             _whenDomReady.SetResult();
         }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Layout;
 using Aspire.Dashboard.Components.Resize;
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
@@ -15,6 +16,7 @@ using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Dashboard.Components.Pages;
 
@@ -37,6 +39,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     [Inject]
     public required DimensionManager DimensionManager { get; init; }
+
+    [Inject]
+    public required IOptionsMonitor<DashboardOptions> Options { get; init; }
 
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; init; }
@@ -178,6 +183,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     {
         if (firstRender)
         {
+            LogViewerViewModel.LogEntries.MaximumEntryCount = Options.CurrentValue.Frontend.ConsoleLogHistoryLimit;
+
             // Let anyone waiting know that the render is complete, so we have access to the underlying log viewer.
             _whenDomReady.SetResult();
         }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -120,7 +120,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             {
                 await foreach (var changes in subscription.WithCancellation(_resourceSubscriptionCancellation.Token).ConfigureAwait(false))
                 {
-                    // TODO: This could be updated to be more efficent.
+                    // TODO: This could be updated to be more efficient.
                     // It should apply on the resource changes in a batch and then update the UI.
                     foreach (var (changeType, resource) in changes)
                     {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -183,7 +183,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     {
         if (firstRender)
         {
-            LogViewerViewModel.LogEntries.MaximumEntryCount = Options.CurrentValue.Frontend.ConsoleLogHistoryLimit;
+            LogViewerViewModel.LogEntries.MaximumEntryCount = Options.CurrentValue.Frontend.MaxConsoleLogCount;
 
             // Let anyone waiting know that the render is complete, so we have access to the underlying log viewer.
             _whenDomReady.SetResult();

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -131,6 +131,16 @@ public sealed class FrontendOptions
     public string? EndpointUrls { get; set; }
     public FrontendAuthMode? AuthMode { get; set; }
     public string? BrowserToken { get; set; }
+
+    /// <summary>
+    /// Gets and sets an optional limit on the number of log messages to be retained in the viewer.
+    /// </summary>
+    /// <remarks>
+    /// When non-null, the viewer will retain at most this number of log messages. When the limit is reached, the oldest messages will be removed.
+    /// Defaults to 10,000, which matches the default used in the app host's circular buffer, on the publish side.
+    /// </remarks>
+    public int ConsoleLogHistoryLimit { get; set; } = 10_000;
+
     public OpenIdConnectOptions OpenIdConnect { get; set; } = new();
 
     public byte[]? GetBrowserTokenBytes() => _browserTokenBytes;

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -139,7 +139,7 @@ public sealed class FrontendOptions
     /// When non-null, the viewer will retain at most this number of log messages. When the limit is reached, the oldest messages will be removed.
     /// Defaults to 10,000, which matches the default used in the app host's circular buffer, on the publish side.
     /// </remarks>
-    public int ConsoleLogHistoryLimit { get; set; } = 10_000;
+    public int MaxConsoleLogCount { get; set; } = 10_000;
 
     public OpenIdConnectOptions OpenIdConnect { get; set; } = new();
 

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -133,10 +133,10 @@ public sealed class FrontendOptions
     public string? BrowserToken { get; set; }
 
     /// <summary>
-    /// Gets and sets an optional limit on the number of log messages to be retained in the viewer.
+    /// Gets and sets an optional limit on the number of console log messages to be retained in the viewer.
     /// </summary>
     /// <remarks>
-    /// When non-null, the viewer will retain at most this number of log messages. When the limit is reached, the oldest messages will be removed.
+    /// The viewer will retain at most this number of log messages. When the limit is reached, the oldest messages will be removed.
     /// Defaults to 10,000, which matches the default used in the app host's circular buffer, on the publish side.
     /// </remarks>
     public int MaxConsoleLogCount { get; set; } = 10_000;

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -55,9 +55,9 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
                 break;
         }
 
-        if (options.Frontend.ConsoleLogHistoryLimit <= 0)
+        if (options.Frontend.MaxConsoleLogCount <= 0)
         {
-            errorMessages.Add("ConsoleLogHistoryLimit must be greater than zero.");
+            errorMessages.Add("MaxConsoleLogCount must be greater than zero.");
         }
 
         if (!options.Otlp.TryParseOptions(out var otlpParseErrorMessage))

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -55,6 +55,11 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
                 break;
         }
 
+        if (options.Frontend.ConsoleLogHistoryLimit <= 0)
+        {
+            errorMessages.Add("ConsoleLogHistoryLimit must be greater than zero.");
+        }
+
         if (!options.Otlp.TryParseOptions(out var otlpParseErrorMessage))
         {
             errorMessages.Add(otlpParseErrorMessage);

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -57,7 +57,7 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
 
         if (options.Frontend.MaxConsoleLogCount <= 0)
         {
-            errorMessages.Add("MaxConsoleLogCount must be greater than zero.");
+            errorMessages.Add($"{DashboardConfigNames.DashboardFrontendMaxConsoleLogCountName.ConfigKey} must be greater than zero.");
         }
 
         if (!options.Otlp.TryParseOptions(out var otlpParseErrorMessage))

--- a/src/Aspire.Dashboard/ConsoleLogs/LogEntries.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogEntries.cs
@@ -30,7 +30,7 @@ public sealed class LogEntries
 
                 if (current.Id == logEntry.ParentId && logEntry.LineIndex - 1 == current.LineIndex)
                 {
-                    InsertLogEntry(_logEntries, rowIndex + 1, logEntry);
+                    InsertAt(rowIndex + 1);
                     return;
                 }
             }
@@ -47,7 +47,7 @@ public sealed class LogEntries
 
                 if (currentTimestamp != null && currentTimestamp <= logEntry.Timestamp)
                 {
-                    InsertLogEntry(_logEntries, rowIndex + 1, logEntry);
+                    InsertAt(rowIndex + 1);
                     return;
                 }
             }
@@ -55,9 +55,9 @@ public sealed class LogEntries
 
         // If we didn't find a place to insert then append it to the end. This happens with the first entry, but
         // could also happen if the logs don't have recognized timestamps.
-        InsertLogEntry(_logEntries, _logEntries.Count, logEntry);
+        InsertAt(_logEntries.Count);
 
-        void InsertLogEntry(List<LogEntry> logEntries, int index, LogEntry logEntry)
+        void InsertAt(int index)
         {
             // Set the line number of the log entry.
             if (index == 0)
@@ -67,23 +67,23 @@ public sealed class LogEntries
             }
             else
             {
-                logEntry.LineNumber = logEntries[index - 1].LineNumber + 1;
+                logEntry.LineNumber = _logEntries[index - 1].LineNumber + 1;
             }
 
             // Trim old log messages if we have a maximum and we're over it.
-            if (MaximumEntryCount is not (null or 0) && logEntries.Count >= MaximumEntryCount && index is not 0)
+            if (MaximumEntryCount is not (null or 0) && _logEntries.Count >= MaximumEntryCount && index is not 0)
             {
-                logEntries.RemoveAt(0);
+                _logEntries.RemoveAt(0);
                 index--;
             }
 
             // Insert the entry.
-            logEntries.Insert(index, logEntry);
+            _logEntries.Insert(index, logEntry);
 
             // If a log entry isn't inserted at the end then update the line numbers of all subsequent entries.
-            for (var i = index + 1; i < logEntries.Count; i++)
+            for (var i = index + 1; i < _logEntries.Count; i++)
             {
-                logEntries[i].LineNumber++;
+                _logEntries[i].LineNumber++;
             }
         }
     }

--- a/src/Aspire.Dashboard/ConsoleLogs/LogEntries.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogEntries.cs
@@ -12,6 +12,8 @@ public sealed class LogEntries
 
     public int? BaseLineNumber { get; set; }
 
+    public int? MaximumEntryCount { get; set; }
+
     public void Clear() => _logEntries.Clear();
 
     public IList<LogEntry> GetEntries() => _logEntries;
@@ -68,6 +70,14 @@ public sealed class LogEntries
                 logEntry.LineNumber = logEntries[index - 1].LineNumber + 1;
             }
 
+            // Trim old log messages if we have a maximum and we're over it.
+            if (MaximumEntryCount is not (null or 0) && logEntries.Count >= MaximumEntryCount && index is not 0)
+            {
+                logEntries.RemoveAt(0);
+                index--;
+            }
+
+            // Insert the entry.
             logEntries.Insert(index, logEntry);
 
             // If a log entry isn't inserted at the end then update the line numbers of all subsequent entries.

--- a/src/Aspire.Dashboard/ConsoleLogs/LogEntries.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/LogEntries.cs
@@ -3,16 +3,15 @@
 
 using System.Diagnostics;
 using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Storage;
 
 namespace Aspire.Dashboard.ConsoleLogs;
 
-public sealed class LogEntries
+public sealed class LogEntries(int maximumEntryCount)
 {
-    private readonly List<LogEntry> _logEntries = new();
+    private readonly CircularBuffer<LogEntry> _logEntries = new(maximumEntryCount);
 
     public int? BaseLineNumber { get; set; }
-
-    public int? MaximumEntryCount { get; set; }
 
     public void Clear() => _logEntries.Clear();
 
@@ -68,13 +67,6 @@ public sealed class LogEntries
             else
             {
                 logEntry.LineNumber = _logEntries[index - 1].LineNumber + 1;
-            }
-
-            // Trim old log messages if we have a maximum and we're over it.
-            if (MaximumEntryCount is not (null or 0) && _logEntries.Count >= MaximumEntryCount && index is not 0)
-            {
-                _logEntries.RemoveAt(0);
-                index--;
             }
 
             // Insert the entry.

--- a/src/Aspire.Dashboard/Model/LogViewerViewModel.cs
+++ b/src/Aspire.Dashboard/Model/LogViewerViewModel.cs
@@ -9,5 +9,4 @@ public class LogViewerViewModel
 {
     public LogEntries LogEntries { get; } = new();
     public string? ResourceName { get; set; }
-
 }

--- a/src/Aspire.Dashboard/Model/LogViewerViewModel.cs
+++ b/src/Aspire.Dashboard/Model/LogViewerViewModel.cs
@@ -1,12 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.ConsoleLogs;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Dashboard.Model;
 
-public class LogViewerViewModel
+public class LogViewerViewModel(IOptions<DashboardOptions> options)
 {
-    public LogEntries LogEntries { get; } = new();
+    public LogEntries LogEntries { get; } = new(options.Value.Frontend.MaxConsoleLogCount);
     public string? ResourceName { get; set; }
 }

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -63,6 +63,10 @@ Set `Dashboard:Frontend:AuthMode` to `OpenIdConnect`, then add the following con
 - `Dashboard:Frontend:OpenIdConnect:RequiredClaimType` specifies the (optional) claim that be present for authorized users. Defaults to empty.
 - `Dashboard:Frontend:OpenIdConnect:RequiredClaimValue` specifies the (optional) value of the required claim. Only used if `Dashboard:Frontend:OpenIdConnect:RequireClaimType` is also specified. Defaults to empty.
 
+#### Memory limits
+
+- `Dashboard:Frontend:ConsoleLogHistoryLimit` specifies the (optional) maximum number of console log messages to keep in memory. Defaults to 10,000. When the limit is reached, the oldest messages are removed.
+
 ### OTLP authentication
 
 The OTLP endpoint can be secured with [client certificate](https://learn.microsoft.com/aspnet/core/security/authentication/certauth) or API key authentication.

--- a/src/Aspire.Dashboard/README.md
+++ b/src/Aspire.Dashboard/README.md
@@ -65,7 +65,7 @@ Set `Dashboard:Frontend:AuthMode` to `OpenIdConnect`, then add the following con
 
 #### Memory limits
 
-- `Dashboard:Frontend:ConsoleLogHistoryLimit` specifies the (optional) maximum number of console log messages to keep in memory. Defaults to 10,000. When the limit is reached, the oldest messages are removed.
+- `Dashboard:Frontend:MaxConsoleLogCount` specifies the (optional) maximum number of console log messages to keep in memory. Defaults to 10,000. When the limit is reached, the oldest messages are removed.
 
 ### OTLP authentication
 

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -17,6 +17,7 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DashboardOtlpSecondaryApiKeyName = new("Dashboard:Otlp:SecondaryApiKey", "DASHBOARD__OTLP__SECONDARYAPIKEY");
     public static readonly ConfigName DashboardFrontendAuthModeName = new("Dashboard:Frontend:AuthMode", "DASHBOARD__FRONTEND__AUTHMODE");
     public static readonly ConfigName DashboardFrontendBrowserTokenName = new("Dashboard:Frontend:BrowserToken", "DASHBOARD__FRONTEND__BROWSERTOKEN");
+    public static readonly ConfigName DashboardFrontendMaxConsoleLogCountName = new("Dashboard:Frontend:MaxConsoleLogCount", "DASHBOARD__FRONTEND__MAXCONSOLELOGCOUNT");
     public static readonly ConfigName ResourceServiceClientAuthModeName = new("Dashboard:ResourceServiceClient:AuthMode", "DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE");
     public static readonly ConfigName ResourceServiceClientApiKeyName = new("Dashboard:ResourceServiceClient:ApiKey", "DASHBOARD__RESOURCESERVICECLIENT__APIKEY");
 }

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
@@ -31,4 +31,44 @@ public class LogEntriesTests
             l => Assert.Equal("2", l.Content),
             l => Assert.Equal("3", l.Content));
     }
+
+    [Fact]
+    public void InsertSorted_TrimsToMaximumEntryCount_Ordered()
+    {
+        // Arrange
+        var logEntries = new LogEntries { MaximumEntryCount = 2, BaseLineNumber = 1 };
+
+        var timestamp = DateTimeOffset.UtcNow;
+
+        // Act
+        logEntries.InsertSorted(new LogEntry { Timestamp = timestamp.AddSeconds(1), Content = "1" });
+        logEntries.InsertSorted(new LogEntry { Timestamp = timestamp.AddSeconds(2), Content = "2" });
+        logEntries.InsertSorted(new LogEntry { Timestamp = timestamp.AddSeconds(3), Content = "3" });
+
+        // Assert
+        var entries = logEntries.GetEntries();
+        Assert.Collection(entries,
+            l => Assert.Equal("2", l.Content),
+            l => Assert.Equal("3", l.Content));
+    }
+
+    [Fact]
+    public void InsertSorted_TrimsToMaximumEntryCount_OutOfOrder()
+    {
+        // Arrange
+        var logEntries = new LogEntries { MaximumEntryCount = 2, BaseLineNumber = 1 };
+
+        var timestamp = DateTimeOffset.UtcNow;
+
+        // Act
+        logEntries.InsertSorted(new LogEntry { Timestamp = timestamp.AddSeconds(1), Content = "1" });
+        logEntries.InsertSorted(new LogEntry { Timestamp = timestamp.AddSeconds(3), Content = "3" });
+        logEntries.InsertSorted(new LogEntry { Timestamp = timestamp.AddSeconds(2), Content = "2" });
+
+        // Assert
+        var entries = logEntries.GetEntries();
+        Assert.Collection(entries,
+            l => Assert.Equal("2", l.Content),
+            l => Assert.Equal("3", l.Content));
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/LogEntriesTests.cs
@@ -13,7 +13,7 @@ public class LogEntriesTests
     public void InsertSorted_OutOfOrderWithSameTimestamp_ReturnInOrder()
     {
         // Arrange
-        var logEntries = new LogEntries();
+        var logEntries = new LogEntries(maximumEntryCount: int.MaxValue);
 
         var timestamp = new DateTimeOffset(2024, 6, 25, 15, 59, 0, TimeSpan.Zero);
 
@@ -36,7 +36,7 @@ public class LogEntriesTests
     public void InsertSorted_TrimsToMaximumEntryCount_Ordered()
     {
         // Arrange
-        var logEntries = new LogEntries { MaximumEntryCount = 2, BaseLineNumber = 1 };
+        var logEntries = new LogEntries(maximumEntryCount: 2) { BaseLineNumber = 1 };
 
         var timestamp = DateTimeOffset.UtcNow;
 
@@ -56,7 +56,7 @@ public class LogEntriesTests
     public void InsertSorted_TrimsToMaximumEntryCount_OutOfOrder()
     {
         // Arrange
-        var logEntries = new LogEntries { MaximumEntryCount = 2, BaseLineNumber = 1 };
+        var logEntries = new LogEntries(maximumEntryCount: 2) { BaseLineNumber = 1 };
 
         var timestamp = DateTimeOffset.UtcNow;
 

--- a/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
@@ -77,15 +77,15 @@ public sealed class DashboardOptionsTests
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
-    public void FrontendOptions_ConsoleLogHistoryLimit(int limit)
+    public void FrontendOptions_MaxConsoleLogCount(int limit)
     {
         var options = GetValidOptions();
-        options.Frontend.ConsoleLogHistoryLimit = limit;
+        options.Frontend.MaxConsoleLogCount = limit;
 
         var result = new ValidateDashboardOptions().Validate(null, options);
 
         Assert.False(result.Succeeded);
-        Assert.Equal("ConsoleLogHistoryLimit must be greater than zero.", result.FailureMessage);
+        Assert.Equal("MaxConsoleLogCount must be greater than zero.", result.FailureMessage);
     }
 
     #endregion

--- a/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
@@ -85,7 +85,7 @@ public sealed class DashboardOptionsTests
         var result = new ValidateDashboardOptions().Validate(null, options);
 
         Assert.False(result.Succeeded);
-        Assert.Equal("MaxConsoleLogCount must be greater than zero.", result.FailureMessage);
+        Assert.Equal($"{DashboardConfigNames.DashboardFrontendMaxConsoleLogCountName.ConfigKey} must be greater than zero.", result.FailureMessage);
     }
 
     #endregion

--- a/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
@@ -74,6 +74,20 @@ public sealed class DashboardOptionsTests
         Assert.Equal("Failed to parse frontend endpoint URLs 'http://localhost:5000;invalid'.", result.FailureMessage);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void FrontendOptions_ConsoleLogHistoryLimit(int limit)
+    {
+        var options = GetValidOptions();
+        options.Frontend.ConsoleLogHistoryLimit = limit;
+
+        var result = new ValidateDashboardOptions().Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal("ConsoleLogHistoryLimit must be greater than zero.", result.FailureMessage);
+    }
+
     #endregion
 
     #region Resource service client options


### PR DESCRIPTION
Fixes #4849

Defaults limit to 10,000, matching the limit used in the AppHost.

Value may be controlled via configuration. For example, given:

```json
{
  "DetailedErrors": true,
  "Dashboard": {
    "Frontend": {
      "MaxConsoleLogCount": 5
    }
  }
}
```

Only five rows are visible (no scrollbar here):

![bounded-console-logs](https://github.com/user-attachments/assets/56ddd526-5c3e-4574-aa0e-cb6c37676c93)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4936)