### PR TITLE
Don't display browser tooltip for error icon

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
@@ -12,14 +12,15 @@
     @if (_hasErrorInfo)
     {
         var iconId = Guid.NewGuid().ToString();
-
         @*
-            We don't want a browser tooltip to display when hovering over the error icon.
-            Use alt instead of title for screen readers. Also, the column has a title set
-            so add a whitespace title to prevent a browser tooltip from displaying.
+        * We don't want a browser tooltip to display when hovering over the error icon.
+        * Use alt instead of title for screen readers. Also, the column has a title set
+        * so add a whitespace title to prevent a browser tooltip from displaying.
         *@
+        var title = " ";
+
         <FluentIcon alt="@Loc[nameof(Columns.LogMessageColumnExceptionDetailsTitle)]"
-                    title="@Loc[nameof(Columns.LogMessageColumnExceptionDetailsTitle)].ToString()"
+                    title="@title"
                     Style="flex-shrink: 0"
                     Id="@iconId"
                     Icon="Icons.Filled.Size16.DocumentError"


### PR DESCRIPTION
The error icon shows a popup so we don't want to show a browser icon from `title`.

The browser tooltip was hidden but in came back in https://github.com/dotnet/aspire/pull/2344. I'm guessing this was unintentional since the comment wasn't removed. cc @adamint 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4939)