### PR TITLE
Fix Aspire.Hosting.Tests build on VS

### DIFF
--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -43,8 +43,6 @@
     <ProjectReference Include="..\..\src\Components\Aspire.Npgsql\Aspire.Npgsql.csproj" IsAspireProjectResource="false" />
     <ProjectReference Include="..\..\src\Components\Aspire.Oracle.EntityFrameworkCore\Aspire.Oracle.EntityFrameworkCore.csproj" IsAspireProjectResource="false" />
 
-    <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
-
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
 


### PR DESCRIPTION
When building only the `Aspire.Hosting.Tests` in VS, it would fail with
errors about `ActiveIssue` not being found. This is because the project
was being compiled with none of the dependencies from
`Aspire.Components.Common.Tests` getting used in the
`Aspire.Hosting.Tests` build.

Building the solution worked fine though.

The problem seems to be a duplicate project reference to
`Aspire.Components.Common.Tests`:

```
<ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" IsAspireProjectResource="false" />

<ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
```

Removing the second reference fixes the issue. I'm not sure *why* this
broke VS though.

Note that this works perfectly find on command line, whether building the whole solution or just the tests project on Windows, and macOS.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4951)