### PR TITLE
Fix line numbers in console

### DIFF
--- a/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
@@ -381,8 +381,7 @@ internal sealed class DashboardClient : IDashboardClient
                         {
                             foreach (var channel in _outgoingChannels)
                             {
-                                // Channel is unbound so TryWrite always succeeds.
-                                channel.Writer.TryWrite(changes);
+                                channel.Writer.TryWriteWithAssert(changes);
                             }
                         }
                     }
@@ -487,8 +486,7 @@ internal sealed class DashboardClient : IDashboardClient
                         logLines[i] = new ResourceLogLine(response.LogLines[i].LineNumber, response.LogLines[i].Text, response.LogLines[i].IsStdErr);
                     }
 
-                    // Channel is unbound so TryWrite always succeeds.
-                    channel.Writer.TryWrite(logLines);
+                    channel.Writer.TryWriteWithAssert(logLines);
                 }
             }
             finally

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -123,7 +123,7 @@ public class ResourceNotificationService
         var channel = Channel.CreateUnbounded<ResourceEvent>();
 
         void WriteToChannel(ResourceEvent resourceEvent) =>
-            channel.Writer.TryWrite(resourceEvent);
+            channel.Writer.TryWriteWithAssert(resourceEvent);
 
         OnResourceUpdated += WriteToChannel;
 

--- a/src/Shared/ChannelExtensions.cs
+++ b/src/Shared/ChannelExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Aspire.Dashboard.Otlp.Storage;
@@ -64,5 +65,15 @@ internal static class ChannelExtensions
                 break;
             }
         }
+    }
+
+    /// <summary>
+    /// Write value with TryWrite then assert in debug that it was successful.
+    /// This method should only be used to write to unbound channels where TryWrite should never fail.
+    /// </summary>
+    public static void TryWriteWithAssert<T>(this ChannelWriter<T> writer, T value)
+    {
+        var write = writer.TryWrite(value);
+        Debug.Assert(write, "Channel is unbound so TryWrite always succeeds.");
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestKubernetesService.cs
@@ -19,9 +19,10 @@ internal sealed class TestKubernetesService : IKubernetesService
     public const int StartOfAutoPortRange = 52000;
 
     public ConcurrentQueue<CustomResource> CreatedResources { get; } = [];
+    public Action<CustomResource>? ActionCreatedResource { get; set; }
 
     private readonly List<Channel<(WatchEventType, CustomResource)>> _watchChannels = [];
-    private int _nextPort = StartOfAutoPortRange; 
+    private int _nextPort = StartOfAutoPortRange;
 
     public Task<T> GetAsync<T>(string name, string? namespaceParameter = null, CancellationToken _ = default) where T : CustomResource
     {
@@ -57,6 +58,8 @@ internal sealed class TestKubernetesService : IKubernetesService
             svc.Status.EffectiveAddress = svc.Spec.Address ?? "localhost";
             svc.Status.EffectivePort = svc.Spec.Port ?? Interlocked.Increment(ref _nextPort);
         }
+
+        ActionCreatedResource?.Invoke(res);
 
         lock (CreatedResources)
         {


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspire/issues/4893

Storing line number state in logger doesn't work because they're reused between watches. This PR moves tracking the log number up a level to `ResourceLogSource`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4955)