### PR TITLE
Fix resources title position

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.css
@@ -1,4 +1,4 @@
-﻿::deep.content-layout {
+::deep.content-layout {
     height: 100%;
     width: 100%;
     display: grid;
@@ -13,6 +13,7 @@
 
 ::deep .title-toolbar-inline {
     padding-left: 0px;
+    padding-top: 0px;
 }
 
 ::deep .title-toolbar-inline > h1 {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -1,7 +1,3 @@
-::deep fluent-toolbar > h1 {
-    padding-left: calc(var(--design-unit) * 1.5px);
-}
-
 ::deep .unread-logs-errors-link {
     vertical-align: middle;
     --unread-logs-badge-color: #ffffff;


### PR DESCRIPTION
Resources title position was slightly different to other pages:
![resources-title](https://github.com/user-attachments/assets/df2e2d89-2308-4caa-a5f0-21bbbbdb11ec)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4978)