### PR TITLE
make policheck nearly clean

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -32,6 +32,10 @@
     {
       "file": "\\tests\\Shared\\TestCertificates\\testCert.pfx",
       "_justification": "Legitimate UT certificate file with private key, from dotnet/aspnetcore"
+    },
+    {
+      "file": "\\playground\\keycloak\\realms\\weathershop-realm.json",
+      "_justification": "Bogus secret used in test sample data"
     }
   ]
 }

--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -32,10 +32,6 @@
     {
       "file": "\\tests\\Shared\\TestCertificates\\testCert.pfx",
       "_justification": "Legitimate UT certificate file with private key, from dotnet/aspnetcore"
-    },
-    {
-      "file": "\\playground\\keycloak\\realms\\weathershop-realm.json",
-      "_justification": "Bogus secret used in test sample data"
     }
   ]
 }

--- a/.config/PoliCheckExclusions.xml
+++ b/.config/PoliCheckExclusions.xml
@@ -1,3 +1,4 @@
 <PoliCheckExclusions>
-
+  <!-- https://eng.ms/docs/experiences-devices/customer-success-engineering/global/language-as-a-service/validationservices/policheck-for-microsoft/policheckclient/features/features#false-positive-management -->
+  <Exclusion Type="FileName">plotly-2.32.0.min.js</Exclusion>
 </PoliCheckExclusions>

--- a/playground/AzureSearchEndToEnd/AzureSearch.ApiService/Program.cs
+++ b/playground/AzureSearchEndToEnd/AzureSearch.ApiService/Program.cs
@@ -125,7 +125,7 @@ static async Task RunQueriesAsync(ILogger logger, SearchClient searchClient, Can
     options = new SearchOptions();
     options.SearchFields.Add("HotelName");
 
-    //Adding details to select, because "Location" is not supported yet when deserialize search result to "Hotel"
+    // Adding details to select, because "Location" is not supported yet when deserializing search result to "Hotel"
     options.Select.Add("HotelId");
     options.Select.Add("HotelName");
     options.Select.Add("Description");

--- a/playground/AzureSearchEndToEnd/AzureSearch.ApiService/hotels.json
+++ b/playground/AzureSearchEndToEnd/AzureSearch.ApiService/hotels.json
@@ -192,7 +192,7 @@
     },
     {
         "HotelId": "10",
-        "HotelName": "Country Home",
+        "HotelName": "Super Home",
         "Description": "Save up to 50% off traditional hotels. Free WiFi, great location near downtown, full kitchen, washer & dryer, 24\/7 support, bowling alley, fitness center and more.",
         "Description_fr": "Économisez jusqu'à 50% sur les hôtels traditionnels. WiFi gratuit, très bien situé près du centre-ville, cuisine complète, laveuse & sécheuse, support 24\/7, bowling, centre de fitness et plus encore.",
         "Category": "Extended-Stay",
@@ -5219,7 +5219,7 @@
     {
         "HotelId": "31",
         "HotelName": "Athens Residence Hotel",
-        "Description": "All of the suites feature full-sized kitchens stocked with cookware, separate living and sleeping areas and sofa beds. Some of the larger rooms have fireplaces. Experience real country hospitality in the heart of bustling Nashville. The most vibrant music scene in the world is just outside your front door.",
+        "Description": "All of the suites feature full-sized kitchens stocked with cookware, separate living and sleeping areas and sofa beds. Some of the larger rooms have fireplaces. Experience real hospitality in the heart of bustling Nashville. The most vibrant music scene in the world is just outside your front door.",
         "Description_fr": "Toutes les suites disposent d'une cuisine pleine grandeur équipée d'ustensiles de cuisine, de coins salon et chambre séparés et de canapés-lits. Certaines des plus grandes chambres ont des cheminées. Découvrez la véritable hospitalité campagnarde au cœur de la ville animée de Nashville. La scène musicale la plus vibrante du monde est juste devant votre porte.",
         "Category": "Extended-Stay",
         "Tags": [
@@ -9091,7 +9091,7 @@
     {
         "HotelId": "48",
         "HotelName": "Nordick's B & B",
-        "Description": "Only 90 miles (about 2 hours) from the nation's capital and nearby most everything the historic valley has to offer. Hiking? Wine Tasting? Exploring the caverns? It's all nearby and we have specially priced packages to help make our B&B your home base for fun while visiting the valley.",
+        "Description": "Only 90 miles (about 2 hours) from the nation's center and nearby most everything the historic valley has to offer. Hiking? Wine Tasting? Exploring the caverns? It's all nearby and we have specially priced packages to help make our B&B your home base for fun while visiting the valley.",
         "Description_fr": "Seulement 90 milles (environ 2 heures) de la capitale de la nation et à proximité la plupart tout que la vallée historique a à offrir. Randonnée? Dégustation? Vous explorez les cavernes? C'est tout près et nous avons des forfaits à prix spécial pour aider à rendre notre B&B votre base pour le plaisir en visitant la vallée.",
         "Category": "Boutique",
         "Tags": [


### PR DESCRIPTION
* plotly is full of geopolitical terms that are assumed fine in context and it's not something we control anyway
* country and capital are fine in context so removed them where they were arbitrary strings
* tested locally with policheck.exe.

this makes us 98% clean which makes it easy to eyeball violations.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/4992)