### PR TITLE
View details with row click

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -26,11 +26,13 @@
     }
     @if (EnableMasking)
     {
-        <FluentButton Appearance="Appearance.Lightweight"
-                      IconEnd="@(IsMasked ? _unmaskIcon : _maskIcon)"
-                      Title="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])"
-                      OnClick="ToggleMaskStateAsync"
-                      aria-label="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])" />
+        <div @onclick:stopPropagation="true">
+            <FluentButton Appearance="Appearance.Lightweight"
+                          IconEnd="@(IsMasked ? _unmaskIcon : _maskIcon)"
+                          Title="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])"
+                          OnClick="ToggleMaskStateAsync"
+                          aria-label="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])" />
+        </div>
     }
 
     @{
@@ -42,13 +44,15 @@
         ];
     }
 
-    <FluentButton Appearance="Appearance.Lightweight"
-                  Id="@_anchorId"
-                  Class="defaultHidden"
-                  Style="float: right; flex-shrink: 0"
-                  AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(ValueToCopy ?? Value, PreCopyToolTip, PostCopyToolTip, uncapturedAttributes)">
-        <FluentIcon Class="copy-icon" Style="display:inline;" Icon="Icons.Regular.Size16.Copy" />
-        <FluentIcon Class="checkmark-icon" Style="display:none;" Icon="Icons.Regular.Size16.Checkmark" />
-    </FluentButton>
+    <div @onclick:stopPropagation="true">
+        <FluentButton Appearance="Appearance.Lightweight"
+                      Id="@_anchorId"
+                      Class="defaultHidden"
+                      Style="float: right; flex-shrink: 0"
+                      AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(ValueToCopy ?? Value, PreCopyToolTip, PostCopyToolTip, uncapturedAttributes)">
+            <FluentIcon Class="copy-icon" Style="display:inline;" Icon="Icons.Regular.Size16.Copy" />
+            <FluentIcon Class="checkmark-icon" Style="display:none;" Icon="Icons.Regular.Size16.Checkmark" />
+        </FluentButton>
+    </div>
     <FluentTooltip @ref="_tooltipComponent" Anchor="@_anchorId" Position="TooltipPosition.Top" HideTooltipOnCursorLeave="true">@PreCopyToolTip</FluentTooltip>
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -29,19 +29,18 @@
                               IconEnd="@(new Icons.Regular.Size24.Filter())"
                               @onclick="() => _isTypeFilterVisible = !_isTypeFilterVisible"
                               Title="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])"
-                              aria-label="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])"/>
+                              aria-label="@(AreAllTypesVisible is true ? Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFilterAllVisible)] : Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeFiltered)])" />
             }
             else
             {
                 <div>
                     <h5>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</h5>
 
-                    <SelectResourceTypes
-                        AllResourceTypes="_allResourceTypes"
-                        VisibleResourceTypes="_visibleResourceTypes"
-                        OnAllResourceTypesCheckedChanged="@(b => AreAllTypesVisible = b)"
-                        AreAllTypesVisible="@(() => AreAllTypesVisible)"
-                        OnResourceTypeVisibilityChangedAsync="@OnResourceTypeVisibilityChangedAsync" />
+                    <SelectResourceTypes AllResourceTypes="_allResourceTypes"
+                                         VisibleResourceTypes="_visibleResourceTypes"
+                                         OnAllResourceTypesCheckedChanged="@(b => AreAllTypesVisible = b)"
+                                         AreAllTypesVisible="@(() => AreAllTypesVisible)"
+                                         OnResourceTypeVisibilityChangedAsync="@OnResourceTypeVisibilityChangedAsync" />
                 </div>
             }
 
@@ -50,19 +49,18 @@
                           @bind-Value="_filter"
                           slot="end"
                           Label="@(ViewportInformation.IsDesktop ? null : ControlsStringsLoc[nameof(ControlsStrings.FilterPlaceholder)].Value)"
-                          @bind-Value:after="HandleSearchFilterChangedAsync"/>
+                          @bind-Value:after="HandleSearchFilterChangedAsync" />
         </ToolbarSection>
 
         <MainSection>
             <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true">
                 <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
                 <Body>
-                    <SelectResourceTypes
-                        AllResourceTypes="_allResourceTypes"
-                        VisibleResourceTypes="_visibleResourceTypes"
-                        OnAllResourceTypesCheckedChanged="@(b => AreAllTypesVisible = b)"
-                        AreAllTypesVisible="@(() => AreAllTypesVisible)"
-                        OnResourceTypeVisibilityChangedAsync="@OnResourceTypeVisibilityChangedAsync" />
+                    <SelectResourceTypes AllResourceTypes="_allResourceTypes"
+                                         VisibleResourceTypes="_visibleResourceTypes"
+                                         OnAllResourceTypesCheckedChanged="@(b => AreAllTypesVisible = b)"
+                                         AreAllTypesVisible="@(() => AreAllTypesVisible)"
+                                         OnResourceTypeVisibilityChangedAsync="@OnResourceTypeVisibilityChangedAsync" />
                 </Body>
             </FluentPopover>
 
@@ -73,16 +71,27 @@
                                 ViewKey="ResourcesList">
                 <Summary>
                     @{
-                    var gridTemplateColumns = HasResourcesWithCommands ? "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr 1fr" : "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr";
+                        var gridTemplateColumns = HasResourcesWithCommands ? "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr 1fr" : "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr";
                     }
-                    <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading" ShowHover="true" TGridItem="ResourceViewModel" OnRowClick="ResourceClick">
+                    <FluentDataGrid Virtualize="true"
+                                    GenerateHeader="GenerateHeaderOption.Sticky"
+                                    ItemSize="46"
+                                    Items="@FilteredResources"
+                                    ResizableColumns="true"
+                                    GridTemplateColumns="@gridTemplateColumns"
+                                    RowClass="GetRowClass"
+                                    Loading="_isLoading"
+                                    ShowHover="true"
+                                    TGridItem="ResourceViewModel"
+                                    OnRowClick="@(r => r.ExecuteOnDefault(d => ShowResourceDetailsAsync(d, buttonId: null)))"
+                                    Class="enable-row-click">
                         <ChildContent>
-                            <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" Tooltip="true" TooltipText="@(c => c.ResourceType)"/>
-                            <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c))" >
+                            <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" Tooltip="true" TooltipText="@(c => c.ResourceType)" />
+                            <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c))">
                                 <ResourceNameDisplay Resource="context" FilterText="@_filter" FormatName="GetResourceName" />
                             </TemplateColumn>
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort" Tooltip="true" TooltipText="@(c => c.State.Humanize())">
-                                <StateColumnDisplay Resource="@context" UnviewedErrorCounts ="@_applicationUnviewedErrorCounts" />
+                                <StateColumnDisplay Resource="@context" UnviewedErrorCounts="@_applicationUnviewedErrorCounts" />
                             </TemplateColumn>
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" TooltipText="@(context => context.CreationTimeStamp != null ? FormatHelpers.FormatDateTime(TimeProvider, context.CreationTimeStamp.Value, MillisecondsDisplay.None, CultureInfo.CurrentCulture) : null)" Tooltip="true">
                                 <StartTimeColumnDisplay Resource="@context" />
@@ -90,23 +99,21 @@
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetSourceColumnValueAndTooltip(ctx)?.Tooltip)">
                                 @if (GetSourceColumnValueAndTooltip(context) is { } columnDisplay)
                                 {
-                                <SourceColumnDisplay Resource="context" FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip" />
+                                    <SourceColumnDisplay Resource="context" FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip" />
                                 }
                             </TemplateColumn>
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEndpointsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetEndpointsTooltip(ctx))">
-                                <div @onclick:stopPropagation="true">
-                                    <EndpointsColumnDisplay Resource="context"
-                                                            HasMultipleReplicas="HasMultipleReplicas(context)"
-                                                            DisplayedEndpoints="@GetDisplayedEndpoints(context, out var additionalMessage)"
-                                                            AdditionalMessage="@additionalMessage" />
-                                </div>
+                                <EndpointsColumnDisplay Resource="context"
+                                                        HasMultipleReplicas="HasMultipleReplicas(context)"
+                                                        DisplayedEndpoints="@GetDisplayedEndpoints(context, out var additionalMessage)"
+                                                        AdditionalMessage="@additionalMessage" />
                             </TemplateColumn>
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesLogsColumnHeader)]" Class="no-ellipsis">
-                                <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(resource: context.Name)">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
+                                <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(resource: context.Name)" @onclick:stopPropagation="true">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
                             </TemplateColumn>
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesDetailsColumnHeader)]" Sortable="false" Class="no-ellipsis">
                                 @{
-                                var id = $"details-button-{context.Uid}";
+                                    var id = $"details-button-{context.Uid}";
                                 }
                                 <div @onclick:stopPropagation="true">
                                     <FluentButton Appearance="Appearance.Lightweight"
@@ -117,10 +124,12 @@
                             </TemplateColumn>
                             @if (HasResourcesWithCommands)
                             {
-                            <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesCommandsColumnHeader)]">
-                                <ResourceCommands Commands="@context.Commands"
-                                                  CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)" />
-                            </TemplateColumn>
+                                <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesCommandsColumnHeader)]">
+                                    <div @onclick:stopPropagation="true">
+                                        <ResourceCommands Commands="@context.Commands"
+                                                          CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)" />
+                                    </div>
+                                </TemplateColumn>
                             }
                         </ChildContent>
                         <EmptyContent>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -94,11 +94,12 @@
                                 }
                             </TemplateColumn>
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEndpointsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetEndpointsTooltip(ctx))">
-                                <EndpointsColumnDisplay
-                                    Resource="context"
-                                    HasMultipleReplicas="HasMultipleReplicas(context)"
-                                    DisplayedEndpoints="@GetDisplayedEndpoints(context, out var additionalMessage)"
-                                    AdditionalMessage="@additionalMessage" />
+                                <div @onclick:stopPropagation="true">
+                                    <EndpointsColumnDisplay Resource="context"
+                                                            HasMultipleReplicas="HasMultipleReplicas(context)"
+                                                            DisplayedEndpoints="@GetDisplayedEndpoints(context, out var additionalMessage)"
+                                                            AdditionalMessage="@additionalMessage" />
+                                </div>
                             </TemplateColumn>
                             <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesLogsColumnHeader)]" Class="no-ellipsis">
                                 <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(resource: context.Name)">@ControlsStringsLoc[ControlsStrings.ViewAction]</FluentAnchor>
@@ -107,10 +108,12 @@
                                 @{
                                 var id = $"details-button-{context.Uid}";
                                 }
-                                <FluentButton Appearance="Appearance.Lightweight"
-                                              Id="@id"
-                                              Title="@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]"
-                                              OnClick="@(() => ShowResourceDetailsAsync(context, id))">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
+                                <div @onclick:stopPropagation="true">
+                                    <FluentButton Appearance="Appearance.Lightweight"
+                                                  Id="@id"
+                                                  Title="@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]"
+                                                  OnClick="@(() => ShowResourceDetailsAsync(context, id))">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
+                                </div>
                             </TemplateColumn>
                             @if (HasResourcesWithCommands)
                             {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -1,5 +1,6 @@
 ﻿@page "/"
 @using Aspire.Dashboard.Components.ResourcesGridColumns
+@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils
 @using System.Globalization
@@ -74,7 +75,7 @@
                     @{
                     var gridTemplateColumns = HasResourcesWithCommands ? "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr 1fr" : "1fr 1.5fr 1.25fr 1.5fr 2.5fr 2.5fr 1fr 1fr";
                     }
-                    <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading" ShowHover="true">
+                    <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" Items="@FilteredResources" ResizableColumns="true" GridTemplateColumns="@gridTemplateColumns" RowClass="GetRowClass" Loading="_isLoading" ShowHover="true" TGridItem="ResourceViewModel" OnRowClick="ResourceClick">
                         <ChildContent>
                             <PropertyColumn Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" Tooltip="true" TooltipText="@(c => c.ResourceType)"/>
                             <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c))" >

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -223,7 +223,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         return false;
     }
 
-    private async Task ShowResourceDetailsAsync(ResourceViewModel resource, string buttonId)
+    private async Task ShowResourceDetailsAsync(ResourceViewModel resource, string? buttonId)
     {
         _elementIdBeforeDetailsViewOpened = buttonId;
 
@@ -380,6 +380,12 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         additionalMessage = null;
 
         return ResourceEndpointHelpers.GetEndpoints(resource, includeInteralUrls: false);
+    }
+
+    public async Task ResourceClick(FluentDataGridRow<ResourceViewModel> row)
+    {
+        var resource = row.Item!;
+        await ShowResourceDetailsAsync(resource, buttonId: null);
     }
 
     public async ValueTask DisposeAsync()

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -382,12 +382,6 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         return ResourceEndpointHelpers.GetEndpoints(resource, includeInteralUrls: false);
     }
 
-    public async Task ResourceClick(FluentDataGridRow<ResourceViewModel> row)
-    {
-        var resource = row.Item!;
-        await ShowResourceDetailsAsync(resource, buttonId: null);
-    }
-
     public async ValueTask DisposeAsync()
     {
         _watchTaskCancellationTokenSource.Cancel();

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -17,11 +17,10 @@
 <PageTitle><ApplicationName ResourceName="@nameof(Dashboard.Resources.StructuredLogs.StructuredLogsPageTitle)" Loc="@Loc" /></PageTitle>
 
 <div class="page-content-container">
-    <AspirePageContentLayout
-        @ref="@_contentLayout"
-        AddNewlineOnToolbar="true"
-        ShouldShowFooter="@(SelectedLogEntry is null)"
-        IsSummaryDetailsViewOpen="@(SelectedLogEntry is not null)">
+    <AspirePageContentLayout @ref="@_contentLayout"
+                             AddNewlineOnToolbar="true"
+                             ShouldShowFooter="@(SelectedLogEntry is null)"
+                             IsSummaryDetailsViewOpen="@(SelectedLogEntry is not null)">
         <PageTitleSection>
             <h1 class="page-header">@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsHeader)]</h1>
         </PageTitleSection>
@@ -41,7 +40,7 @@
             {
                 <div title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsMinimumLogFilter)]" slot="end" style="display: flex;align-items: center;">
                     <span>@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevels)]</span>
-                    <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical"/>
+                    <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
 
                     <LogLevelSelect IncludeLabel="false"
                                     @bind-LogLevel="@PageViewModel.SelectedLogLevel"
@@ -78,22 +77,21 @@
             else
             {
                 <FluentButton slot="end" Appearance="Appearance.Stealth" aria-label="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsAddFilter)]" OnClick="() => OpenFilterAsync(null)">
-                    <FluentIcon Class="align-text-bottom" Value="@(new Icons.Regular.Size16.Filter())"/> @Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsAddFilter)]
+                    <FluentIcon Class="align-text-bottom" Value="@(new Icons.Regular.Size16.Filter())" /> @Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsAddFilter)]
                 </FluentButton>
             }
         </ToolbarSection>
 
         <MainSection>
-            <SummaryDetailsView
-                ShowDetails="@(SelectedLogEntry is not null)"
-                OnDismiss="@(() => ClearSelectedLogEntryAsync(causedByUserAction: true))"
-                ViewKey="StructuredLogsList"
-                SelectedValue="@SelectedLogEntry">
+            <SummaryDetailsView ShowDetails="@(SelectedLogEntry is not null)"
+                                OnDismiss="@(() => ClearSelectedLogEntryAsync(causedByUserAction: true))"
+                                ViewKey="StructuredLogsList"
+                                SelectedValue="@SelectedLogEntry">
                 <DetailsTitleTemplate>
                     @{
                         var eventName = OtlpHelpers.GetValue(context!.LogEntry.Attributes, "event.name")
-                                        ?? OtlpHelpers.GetValue(context!.LogEntry.Attributes, "logrecord.event.name")
-                                        ?? Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails)];
+                        ?? OtlpHelpers.GetValue(context!.LogEntry.Attributes, "logrecord.event.name")
+                        ?? Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsEntryDetails)];
                     }
 
                     <div class="pane-details-title" title="@($"{eventName} ({context!.LogEntry.Scope.ScopeName})")">
@@ -104,7 +102,17 @@
                 <Summary>
                     <div class="logs-summary-layout">
                         <div class="logs-grid-container continuous-scroll-overflow">
-                            <FluentDataGrid Virtualize="true" RowClass="@GetRowClass" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpLogEntry" GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr" ShowHover="true">
+                            <FluentDataGrid Virtualize="true"
+                                            RowClass="@GetRowClass"
+                                            GenerateHeader="GenerateHeaderOption.Sticky"
+                                            ItemSize="46"
+                                            ResizableColumns="true"
+                                            ItemsProvider="@GetData"
+                                            TGridItem="OtlpLogEntry"
+                                            GridTemplateColumns="1fr 1fr 1fr 5fr 0.8fr 0.8fr"
+                                            ShowHover="true"
+                                            OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))"
+                                            Class="enable-row-click">
                                 <ChildContent>
                                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.Application))">
                                         <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Application)));">
@@ -123,7 +131,7 @@
                                     <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsTraceColumnHeader)]">
                                         @if (!string.IsNullOrEmpty(context.TraceId))
                                         {
-                                            <a href="@DashboardUrls.TraceDetailUrl(context.TraceId)" class="long-inner-content">
+                                            <a href="@DashboardUrls.TraceDetailUrl(context.TraceId)" class="long-inner-content" @onclick:stopPropagation="true">
                                                 @OtlpHelpers.ToShortenedId(context.TraceId)
                                             </a>
                                         }
@@ -132,7 +140,9 @@
                                         @{
                                             var id = $"details-button-{context.InternalId}";
                                         }
-                                        <FluentButton Id="@id" Appearance="Appearance.Lightweight" OnClick="@(() => OnShowPropertiesAsync(context, id))">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
+                                        <div @onclick:stopPropagation="true">
+                                            <FluentButton Id="@id" Appearance="Appearance.Lightweight" OnClick="@(() => OnShowPropertiesAsync(context, id))">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
+                                        </div>
                                     </TemplateColumn>
                                 </ChildContent>
                                 <EmptyContent>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -214,7 +214,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         }
     }
 
-    private async Task OnShowPropertiesAsync(OtlpLogEntry entry, string buttonId)
+    private async Task OnShowPropertiesAsync(OtlpLogEntry entry, string? buttonId)
     {
         _elementIdBeforeDetailsViewOpened = buttonId;
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -13,10 +13,9 @@
 <div class="page-content-container">
     @if (_trace is { } trace)
     {
-        <AspirePageContentLayout
-            AddNewlineOnToolbar="true"
-            MobileToolbarButtonText="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailMobileToolbarButtonText)]"
-            IsSummaryDetailsViewOpen="@(SelectedSpan is not null)">
+        <AspirePageContentLayout AddNewlineOnToolbar="true"
+                                 MobileToolbarButtonText="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailMobileToolbarButtonText)]"
+                                 IsSummaryDetailsViewOpen="@(SelectedSpan is not null)">
             <PageTitleSection>
                 <div class="page-header">
                     <h1 style="display:inline-block">@GetResourceName(trace.FirstSpan.Source): @trace.FirstSpan.Name</h1>
@@ -46,96 +45,105 @@
                 <FluentAnchor slot="end" Appearance="Appearance.Lightweight" Href="@DashboardUrls.StructuredLogsUrl(traceId: trace.TraceId)">@ControlStringsLoc[nameof(ControlsStrings.ViewLogsLink)]</FluentAnchor>
             </ToolbarSection>
             <MainSection>
-                <SummaryDetailsView
-                    ShowDetails="SelectedSpan is not null"
-                    OnDismiss="@(() => ClearSelectedSpanAsync(causedByUserAction: true))"
-                    ViewKey="TraceDetail"
-                    SelectedValue="@SelectedSpan">
+                <SummaryDetailsView ShowDetails="SelectedSpan is not null"
+                                    OnDismiss="@(() => ClearSelectedSpanAsync(causedByUserAction: true))"
+                                    ViewKey="TraceDetail"
+                                    SelectedValue="@SelectedSpan">
                     <DetailsTitleTemplate>
-                        @{ var shortedSpanId = OtlpHelpers.ToShortenedId(context!.Span.SpanId); }
+                        @{
+                            var shortedSpanId = OtlpHelpers.ToShortenedId(context!.Span.SpanId);
+                        }
                         <div class="pane-details-title" title="@($"{context!.Title} ({shortedSpanId})")">
                             @context!.Title
                             <span class="pane-details-subtext">@shortedSpanId</span>
                         </div>
                     </DetailsTitleTemplate>
                     <Summary>
-                        <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" Class="trace-view-grid" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="SpanWaterfallViewModel" RowClass="@GetRowClass" GridTemplateColumns="4fr 12fr 85px" ShowHover="true">
+                        <FluentDataGrid Virtualize="true"
+                                        GenerateHeader="GenerateHeaderOption.Sticky"
+                                        Class="trace-view-grid enable-row-click"
+                                        ResizableColumns="true"
+                                        ItemsProvider="@GetData"
+                                        TGridItem="SpanWaterfallViewModel"
+                                        RowClass="@GetRowClass"
+                                        GridTemplateColumns="4fr 12fr 85px"
+                                        ShowHover="true"
+                                        OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))">
                             <TemplateColumn Title="Name">
-                                <div class="col-long-content" title="@context.GetTooltip(_applications)" @onclick="() => OnShowPropertiesAsync(context, null)">
+                                <div class="col-long-content" title="@context.GetTooltip(_applications)">
                                     @{
-                                    var isServerOrConsumer = context.Span.Kind == OtlpSpanKind.Server || context.Span.Kind == OtlpSpanKind.Consumer;
-                                    // Indent the span name based on the depth of the span.
-                                    var marginLeft = (context.Depth - 1) * 15;
+                                        var isServerOrConsumer = context.Span.Kind == OtlpSpanKind.Server || context.Span.Kind == OtlpSpanKind.Consumer;
+                                        // Indent the span name based on the depth of the span.
+                                        var marginLeft = (context.Depth - 1) * 15;
 
-                                    // We want to have consistent margin for both client and server spans.
-                                    string spanNameContainerStyle;
-                                    if (!isServerOrConsumer)
-                                    {
-                                    // Client span has 19px extra content:
-                                    // - 5px extra margin-left
-                                    // - 5px border
-                                    // - 9px padding-left
-                                    spanNameContainerStyle = $"margin-left: 5px; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
-                                    }
-                                    else
-                                    {
-                                    // Span with icon has 19px extra content:
-                                    // - 16px icon
-                                    // - 3px padding-left
-                                    spanNameContainerStyle = string.Empty;
-                                    }
+                                        // We want to have consistent margin for both client and server spans.
+                                        string spanNameContainerStyle;
+                                        if (!isServerOrConsumer)
+                                        {
+                                            // Client span has 19px extra content:
+                                            // - 5px extra margin-left
+                                            // - 5px border
+                                            // - 9px padding-left
+                                            spanNameContainerStyle = $"margin-left: 5px; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
+                                        }
+                                        else
+                                        {
+                                            // Span with icon has 19px extra content:
+                                            // - 16px icon
+                                            // - 3px padding-left
+                                            spanNameContainerStyle = string.Empty;
+                                        }
                                     }
 
                                     <span style="margin-left: @(marginLeft)px;">
-                                    <span class="span-collapse-symbol" @onclick="() => OnToggleCollapse(context)" @onclick:stopPropagation="true">
-                                        @if (context.Children.Count > 0)
-                                        {
-                                        @(context.IsCollapsed ? '+' : '-')
-                                        }
-                                    </span>
-                                    <span class="span-name-container" style="@spanNameContainerStyle">
-                                        @if (isServerOrConsumer)
-                                        {
-                                        <FluentIcon Class="span-kind-icon"
-                                                    Color="Color.Custom"
-                                                    CustomColor="@ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))"
-                                                    Value="@GetSpanIcon(context.Span)" />
-                                        }
+                                        <span class="span-collapse-symbol" @onclick="() => OnToggleCollapse(context)" @onclick:stopPropagation="true">
+                                            @if (context.Children.Count > 0)
+                                            {
+                                                @(context.IsCollapsed ? '+' : '-')
+                                            }
+                                        </span>
+                                        <span class="span-name-container" style="@spanNameContainerStyle">
+                                            @if (isServerOrConsumer)
+                                            {
+                                                <FluentIcon Class="span-kind-icon"
+                                                            Color="Color.Custom"
+                                                            CustomColor="@ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))"
+                                                            Value="@GetSpanIcon(context.Span)" />
+                                            }
 
-                                        @if (context.IsError)
-                                        {
-                                        <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
-                                        }
-                                        @GetResourceName(context.Span.Source)
-                                        @if (context.HasUninstrumentedPeer)
-                                        {
-                                        <span class="uninstrumented-peer">
-                                                @{
-                                            Icon icon;
-                                            if (context.Span.Attributes.HasKey("db.system"))
+                                            @if (context.IsError)
                                             {
-                                            icon = new Icons.Filled.Size16.Database();
+                                                <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
                                             }
-                                            else if (context.Span.Attributes.HasKey("messaging.system"))
+                                            @GetResourceName(context.Span.Source)
+                                            @if (context.HasUninstrumentedPeer)
                                             {
-                                            icon = new Icons.Filled.Size16.Mail();
+                                                <span class="uninstrumented-peer">
+                                                    @{
+                                                        Icon icon;
+                                                        if (context.Span.Attributes.HasKey("db.system"))
+                                                        {
+                                                            icon = new Icons.Filled.Size16.Database();
+                                                        }
+                                                        else if (context.Span.Attributes.HasKey("messaging.system"))
+                                                        {
+                                                            icon = new Icons.Filled.Size16.Mail();
+                                                        }
+                                                        else
+                                                        {
+                                                            // Everything else.
+                                                            icon = new Icons.Filled.Size16.ArrowCircleRight();
+                                                        }
+                                                    }
+                                                    <FluentIcon Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")"
+                                                                Value="icon"
+                                                                Class="uninstrumented-peer-icon" />
+                                                    @context.UninstrumentedPeer
+                                                </span>
                                             }
-                                            else
-                                            {
-                                            // Everything else.
-                                            icon = new Icons.Filled.Size16.ArrowCircleRight();
-                                            }
-                                            }
-                                            <FluentIcon
-                                                Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")"
-                                                Value="icon"
-                                                Class="uninstrumented-peer-icon" />
-                                            @context.UninstrumentedPeer
-                                            </span>
-                                        }
-                                        <span class="span-row-name">@SpanWaterfallViewModel.GetDisplaySummary(context.Span)</span>
+                                            <span class="span-row-name">@SpanWaterfallViewModel.GetDisplaySummary(context.Span)</span>
+                                        </span>
                                     </span>
-                                </span>
                                 </div>
                             </TemplateColumn>
                             <TemplateColumn>
@@ -158,7 +166,7 @@
                                     </div>
                                 </HeaderCellItemTemplate>
                                 <ChildContent>
-                                    <div class="ticks" @onclick="() => OnShowPropertiesAsync(context, null)">
+                                    <div class="ticks">
                                         <div class="span-container" style="grid-template-columns: @context.LeftOffset.ToString("F2", CultureInfo.InvariantCulture)% @context.Width.ToString("F2", CultureInfo.InvariantCulture)% min-content;">
                                             <div class="span-bar" style="grid-column: 2; background: @ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source));"></div>
                                             <div class="span-bar-label @(context.LabelIsRight ? "span-bar-label-right" : "span-bar-label-left")">
@@ -176,14 +184,15 @@
                             </TemplateColumn>
                             <TemplateColumn Title="@ControlStringsLoc[nameof(ControlsStrings.DetailsColumnHeader)]" Class="no-ellipsis">
                                 @{
-                                var id = context.Span.SpanId;
+                                    var id = context.Span.SpanId;
                                 }
 
-                                <FluentButton
-                                    Id="@id"
-                                    Style="margin-left: 7px;"
-                                    Title="@ControlStringsLoc[nameof(ControlsStrings.ViewAction)]"
-                                    Appearance="Appearance.Lightweight" OnClick="@(() => OnShowPropertiesAsync(context, id))">@ControlStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
+                                <div @onclick:stopPropagation="true">
+                                    <FluentButton Id="@id"
+                                                  Style="margin-left: 7px;"
+                                                  Title="@ControlStringsLoc[nameof(ControlsStrings.ViewAction)]"
+                                                  Appearance="Appearance.Lightweight" OnClick="@(() => OnShowPropertiesAsync(context, id))">@ControlStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentButton>
+                                </div>
                             </TemplateColumn>
                         </FluentDataGrid>
                     </Summary>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -21,10 +21,6 @@
     display: inline !important;
 }
 
-::deep fluent-data-grid.trace-view-grid fluent-data-grid-row[row-type="default"]:hover {
-    cursor: pointer;
-}
-
 ::deep .trace-view-grid fluent-data-grid-row[row-type="header"] {
     background: var(--fill-color);
     border-bottom: calc(var(--stroke-width) * 1px) solid var(--neutral-stroke-divider-rest);

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -31,7 +31,16 @@
         </ToolbarSection>
         <MainSection>
             <div class="datagrid-overflow-area continuous-scroll-overflow" tabindex="-1">
-                <FluentDataGrid Virtualize="true" GenerateHeader="GenerateHeaderOption.Sticky" ItemSize="46" ResizableColumns="true" ItemsProvider="@GetData" TGridItem="OtlpTrace" GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr" ShowHover="true">
+                <FluentDataGrid Virtualize="true"
+                                GenerateHeader="GenerateHeaderOption.Sticky"
+                                ItemSize="46"
+                                ResizableColumns="true"
+                                ItemsProvider="@GetData"
+                                TGridItem="OtlpTrace"
+                                GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr"
+                                ShowHover="true"
+                                OnRowClick="@(r => r.ExecuteOnDefault(d => NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(d.TraceId))))"
+                                Class="enable-row-click">
                     <ChildContent>
                         <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
                             @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)
@@ -45,32 +54,32 @@
                                 <ChildContent>
                                     @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Min(s => s.StartTime)))
                                     {
-                                    <FluentOverflowItem>
-                                        <span class="trace-tag trace-service-tag" title="@(GetSpansTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(item.Key)));">
-                                            @if (item.Any(s => s.Status == OtlpSpanStatusCode.Error))
-                                            {
-                                            <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
-                                            }
-                                            @GetResourceName(item.Key) (@item.Count())
-                                        </span>
-                                    </FluentOverflowItem>
+                                        <FluentOverflowItem>
+                                            <span class="trace-tag trace-service-tag" title="@(GetSpansTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(item.Key)));">
+                                                @if (item.Any(s => s.Status == OtlpSpanStatusCode.Error))
+                                                {
+                                                    <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
+                                                }
+                                                @GetResourceName(item.Key) (@item.Count())
+                                            </span>
+                                        </FluentOverflowItem>
                                     }
                                 </ChildContent>
                                 <MoreButtonTemplate Context="overflow">
-                                <span class="trace-tag">
-                                    @($"+{overflow.ItemsOverflow.Count()}")
-                                </span>
+                                    <span class="trace-tag">
+                                        @($"+{overflow.ItemsOverflow.Count()}")
+                                    </span>
                                 </MoreButtonTemplate>
                                 <OverflowTemplate Context="overflow">
                                     @{
-                                    var items = overflow.ItemsOverflow.ToList();
+                                        var items = overflow.ItemsOverflow.ToList();
                                     }
                                     <FluentTooltip UseTooltipService="false" Anchor="@overflow.IdMoreButton">
                                         @foreach (var item in items)
                                         {
-                                        <div style="margin-top: 8px; margin-bottom: 8px;">
-                                            @item.ChildContent
-                                        </div>
+                                            <div style="margin-top: 8px; margin-bottom: 8px;">
+                                                @item.ChildContent
+                                            </div>
                                         }
                                     </FluentTooltip>
                                 </OverflowTemplate>
@@ -84,7 +93,7 @@
                                                         Min="0"
                                                         Max="@Convert.ToInt32(TracesViewModel.MaxDuration.TotalMilliseconds)"
                                                         Value="@Convert.ToInt32(context.Duration.TotalMilliseconds)"
-                                                        aria-label="@ControlsStringsLoc[nameof(ControlsStrings.DurationColumnHeader)]"/>
+                                                        aria-label="@ControlsStringsLoc[nameof(ControlsStrings.DurationColumnHeader)]" />
                                     <span class="trace-duration">
                                         @DurationFormatter.FormatDuration(context.Duration)
                                     </span>
@@ -97,7 +106,7 @@
                         </TemplateColumn>
 
                         <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.DetailsColumnHeader)]" Class="no-ellipsis">
-                            <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.TraceDetailUrl(context.TraceId)">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
+                            <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.TraceDetailUrl(context.TraceId)" @onclick:stopPropagation="true">@ControlsStringsLoc[nameof(ControlsStrings.ViewAction)]</FluentAnchor>
                         </TemplateColumn>
                     </ChildContent>
                     <EmptyContent>
@@ -107,7 +116,7 @@
             </div>
         </MainSection>
         <FooterSection>
-            <TotalItemsFooter @ref="_totalItemsFooter"/>
+            <TotalItemsFooter @ref="_totalItemsFooter" />
         </FooterSection>
     </AspirePageContentLayout>
 </div>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -26,30 +26,34 @@ else if (DisplayedEndpoints.Count > 1)
             }
         </ChildContent>
         <MoreButtonTemplate Context="overflow">
-            <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
-                @($"+{overflow.ItemsOverflow.Count()}")
-            </FluentButton>
+            <div @onclick:stopPropagation="true" style="display:inherit;">
+                <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
+                    @($"+{overflow.ItemsOverflow.Count()}")
+                </FluentButton>
+            </div>
         </MoreButtonTemplate>
         <OverflowTemplate Context="overflow">
             @{
                 var items = overflow.ItemsOverflow.ToList();
             }
-            <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200" AutoFocus="false">
-                <Header>
-                    @Loc[Resources.Columns.EndpointsColumnDisplayOverflowTitle]
-                </Header>
-                <Body>
-                    <div class="endpoint-popup">
-                        @foreach (var item in items)
-                        {
-                            var d = (DisplayedEndpoint)item.Data!;
-                            <div class="endpoint-link">
-                                @WriteEndpoint(d)
-                            </div>
-                        }
-                    </div>
-                </Body>
-            </FluentPopover>
+            <div @onclick:stopPropagation="true">
+                <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200" AutoFocus="false">
+                    <Header>
+                        @Loc[Resources.Columns.EndpointsColumnDisplayOverflowTitle]
+                    </Header>
+                    <Body>
+                        <div class="endpoint-popup">
+                            @foreach (var item in items)
+                            {
+                                var d = (DisplayedEndpoint)item.Data!;
+                                <div class="endpoint-link">
+                                    @WriteEndpoint(d)
+                                </div>
+                            }
+                        </div>
+                    </Body>
+                </FluentPopover>
+            </div>
         </OverflowTemplate>
     </FluentOverflow>
 }
@@ -64,7 +68,7 @@ else if (DisplayedEndpoints.Count > 1)
     {
         if (displayedEndpoint.Url != null)
         {
-            return @<a href="@displayedEndpoint.Url" target="_blank">@displayedEndpoint.Text</a>;
+            return @<a href="@displayedEndpoint.Url" target="_blank" @onclick:stopPropagation="true">@displayedEndpoint.Text</a>;
         }
         else
         {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor
@@ -8,7 +8,8 @@
     <FluentAnchor aria-label="@(_unviewedCount == 1 ? nameof(Columns.UnreadLogErrorsBadgeOneErrorLog) : string.Format(Loc[nameof(Columns.UnreadLogErrorsBadgeErrorLogs)], _unviewedCount))"
                   Href="@GetResourceErrorStructuredLogsUrl()"
                   Appearance="Appearance.Stealth"
-                  Class="unread-logs-errors-link">
+                  Class="unread-logs-errors-link"
+                  @onclick:stopPropagation="true">
         <FluentBadge
             Appearance="Appearance.Accent"
             Circular="true"

--- a/src/Aspire.Dashboard/Components/_Imports.razor
+++ b/src/Aspire.Dashboard/Components/_Imports.razor
@@ -1,6 +1,7 @@
 ﻿@using System.Net.Http
 @using System.Net.Http.Json
 @using Aspire.Dashboard.Authentication
+@using Aspire.Dashboard.Extensions
 @using Microsoft.AspNetCore.Authentication.OpenIdConnect
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization

--- a/src/Aspire.Dashboard/Extensions/ComponentExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ComponentExtensions.cs
@@ -9,6 +9,7 @@ internal static class ComponentExtensions
 {
     public static async Task ExecuteOnDefault<T>(this FluentDataGridRow<T> row, Func<T, Task> call)
     {
+        // Don't trigger on header rows.
         if (row.RowType == DataGridRowType.Default)
         {
             await call(row.Item!).ConfigureAwait(false);
@@ -17,6 +18,7 @@ internal static class ComponentExtensions
 
     public static void ExecuteOnDefault<T>(this FluentDataGridRow<T> row, Action<T> call)
     {
+        // Don't trigger on header rows.
         if (row.RowType == DataGridRowType.Default)
         {
             call(row.Item!);

--- a/src/Aspire.Dashboard/Extensions/ComponentExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ComponentExtensions.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.FluentUI.AspNetCore.Components;
+
+namespace Aspire.Dashboard.Extensions;
+
+internal static class ComponentExtensions
+{
+    public static async Task ExecuteOnDefault<T>(this FluentDataGridRow<T> row, Func<T, Task> call)
+    {
+        if (row.RowType == DataGridRowType.Default)
+        {
+            await call(row.Item!).ConfigureAwait(false);
+        }
+    }
+
+    public static void ExecuteOnDefault<T>(this FluentDataGridRow<T> row, Action<T> call)
+    {
+        if (row.RowType == DataGridRowType.Default)
+        {
+            call(row.Item!);
+        }
+    }
+}

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -95,6 +95,10 @@ fluent-data-grid-row[role='row'].hover:not([row-type='header'],[row-type='sticky
     cursor: auto;
 }
 
+.enable-row-click fluent-data-grid-row[role='row'].hover:not([row-type='header'],[row-type='sticky-header']):hover {
+    cursor: pointer;
+}
+
 [data-theme="light"] {
     color-scheme: light;
 }


### PR DESCRIPTION
Use new OnRowClick feature in FluentUI to show details on pages:

* Resources
* Structured logs
* Traces
* Trace detail (already had row click, moves feature to row instead of cell)

Clickable UI on rows takes precedent. For example, clicking on a resource endpoint URL will launch a new browser to that URL. It doesn't open the detail view.

Changes:

* Add OnRowClick to data grids
* Add `@onclick:stopPropagation="true"` where required. Clicking on UI will bubble the event up until it stops. That means clicking on the `View` button triggers the button action and the row click action. The fix is to tell Blazor to stop propagating the event with the `stopPropagation` attribute.
* Re-enable pointer on grids with row click events

Demo:
![row-click](https://github.com/user-attachments/assets/6aa91ec3-cf47-4fc4-abd5-f9ba91bd2449)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5000)