### PR TITLE
Add settings file support

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/SettingsFileAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/SettingsFileAnnotation.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+[DebuggerDisplay("Type = {GetType().Name,nq}, SettingsFileOptions = {SettingsFileOptions}")]
+internal sealed class SettingsFileAnnotation : IResourceAnnotation
+{
+    public SettingsFileAnnotation(SettingsFileOptions settingsFileOptions)
+    {
+        ArgumentNullException.ThrowIfNull(settingsFileOptions);
+
+        SettingsFileOptions = settingsFileOptions;
+    }
+
+    public SettingsFileOptions SettingsFileOptions { get; }
+}

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dashboard;
+using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -259,6 +260,21 @@ public static class ProjectResourceBuilderExtensions
         return builder.AddResource(project)
                       .WithAnnotation(new ProjectMetadata(projectPath))
                       .WithProjectDefaults(options);
+    }
+
+    /// <summary>
+    /// Adds a settings file to the project resource, to optionally persist settings that are normally set via environment variables.
+    /// The settings file can be generated with or without also launching the project.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="settingsFileOptions"></param>
+    /// <returns></returns>
+    public static IResourceBuilder<ProjectResource> WithSettingsFile(this IResourceBuilder<ProjectResource> builder, SettingsFileOptions settingsFileOptions)
+    {
+        builder.WithAnnotation(new SettingsFileAnnotation(settingsFileOptions));
+
+        builder.ApplicationBuilder.Services.TryAddLifecycleHook<SettingsFileWriterHook>();
+        return builder;
     }
 
     private static IResourceBuilder<ProjectResource> WithProjectDefaults(this IResourceBuilder<ProjectResource> builder, ProjectResourceOptions options)

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -263,11 +263,30 @@ public static class ProjectResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Adds a .NET project to the application model, just generating a settings file for the project.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
+    /// <param name="name">The name of the resource. This name will be used for service discovery when referenced in a dependency.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// This overload of the <see cref="AddProject(IDistributedApplicationBuilder, string, string)"/> method adds a project to the application
+    /// model where Aspire only generates a settings file for the project, not otherwise trying to build or run it. This is useful for projects
+    /// that you wish to always launch manually, but have them connect to Aspire services and OTEL.
+    /// </para>
+    public static IResourceBuilder<ProjectResource> AddSettingsOnlyProject(this IDistributedApplicationBuilder builder, string name,
+        string settingsFilePath, SettingsFileType settingsFileType)
+    {
+        return builder.AddProject(name, "")
+            .WithSettingsFile(settingsFilePath, settingsFileType, onlyGenerateSettings:true);
+    }
+
+    /// <summary>
     /// Adds a settings file to the project resource, to optionally persist settings that are normally set via environment variables.
     /// The settings file can be generated with or without also launching the project.
     /// </summary>
-    /// <param name="builder"></param>
-    /// <param name="settingsFileOptions"></param>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
+    /// <param name="settingsFileOptions">The options to use for settings file generation.</param>
     /// <returns></returns>
     public static IResourceBuilder<ProjectResource> WithSettingsFile(this IResourceBuilder<ProjectResource> builder, SettingsFileOptions settingsFileOptions)
     {
@@ -275,6 +294,19 @@ public static class ProjectResourceBuilderExtensions
 
         builder.ApplicationBuilder.Services.TryAddLifecycleHook<SettingsFileWriterHook>();
         return builder;
+    }
+
+    /// <summary>
+    /// Adds a settings file to the project resource, to optionally persist settings that are normally set via environment variables.
+    /// The settings file can be generated with or without also launching the project.
+    /// </summary>
+    /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
+    /// <param name="settingsFilePath">The path to settings file, absolute or relative to app host directory.</param>
+    /// <param name="settingsFileType">The settings file type, C# code (for use with IConfigurationBuilder.AddInMemoryCollection) or JSON (for use with IConfigurationBuilder.AddJsonFile).</param>
+    /// <param name="onlyGenerateSettings">Indicate whether to skip build/running this resource, only generating settings.</param>
+    public static IResourceBuilder<ProjectResource> WithSettingsFile(this IResourceBuilder<ProjectResource> builder, string settingsFilePath, SettingsFileType settingsFileType, bool onlyGenerateSettings)
+    {
+        return builder.WithSettingsFile(new SettingsFileOptions(settingsFilePath, settingsFileType, onlyGenerateSettings));
     }
 
     private static IResourceBuilder<ProjectResource> WithProjectDefaults(this IResourceBuilder<ProjectResource> builder, ProjectResourceOptions options)

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -2,6 +2,18 @@
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, string? targetState = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, System.Collections.Generic.IEnumerable<string!>! targetStates, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+Aspire.Hosting.SettingsFileOptions
+Aspire.Hosting.SettingsFileOptions.OnlyGenerateSettings.get -> bool
+Aspire.Hosting.SettingsFileOptions.OnlyGenerateSettings.set -> void
+Aspire.Hosting.SettingsFileOptions.SettingsFileOptions() -> void
+Aspire.Hosting.SettingsFileOptions.SettingsFileOptions(string? settingsFilePath, Aspire.Hosting.SettingsFileType settingsFileType, bool onlyGenerateSettings) -> void
+Aspire.Hosting.SettingsFileOptions.SettingsFilePath.get -> string?
+Aspire.Hosting.SettingsFileOptions.SettingsFilePath.set -> void
+Aspire.Hosting.SettingsFileOptions.SettingsFileType.get -> Aspire.Hosting.SettingsFileType
+Aspire.Hosting.SettingsFileOptions.SettingsFileType.set -> void
+Aspire.Hosting.SettingsFileType
+Aspire.Hosting.SettingsFileType.CSharp = 0 -> Aspire.Hosting.SettingsFileType
+Aspire.Hosting.SettingsFileType.Json = 1 -> Aspire.Hosting.SettingsFileType
 static Aspire.Hosting.ProjectResourceBuilderExtensions.WithEndpointsInEnvironment(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, System.Func<Aspire.Hosting.ApplicationModel.EndpointAnnotation!, bool>! filter) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
 Aspire.Hosting.DistributedApplicationExecutionContext.DistributedApplicationExecutionContext(Aspire.Hosting.DistributedApplicationExecutionContextOptions! options) -> void
 Aspire.Hosting.DistributedApplicationExecutionContext.ServiceProvider.get -> System.IServiceProvider!
@@ -10,6 +22,7 @@ Aspire.Hosting.DistributedApplicationExecutionContextOptions.DistributedApplicat
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.Operation.get -> Aspire.Hosting.DistributedApplicationOperation
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.get -> System.IServiceProvider?
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.set -> void
+static Aspire.Hosting.ProjectResourceBuilderExtensions.WithSettingsFile(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, Aspire.Hosting.SettingsFileOptions! settingsFileOptions) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.FailedToStart -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Finished -> string!

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -2,18 +2,20 @@
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, string? targetState = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, System.Collections.Generic.IEnumerable<string!>! targetStates, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+Aspire.Hosting.ProjectResourceOptions.SettingsFileOptions.get -> Aspire.Hosting.SettingsFileOptions?
+Aspire.Hosting.ProjectResourceOptions.SettingsFileOptions.set -> void
 Aspire.Hosting.SettingsFileOptions
 Aspire.Hosting.SettingsFileOptions.OnlyGenerateSettings.get -> bool
 Aspire.Hosting.SettingsFileOptions.OnlyGenerateSettings.set -> void
-Aspire.Hosting.SettingsFileOptions.SettingsFileOptions() -> void
-Aspire.Hosting.SettingsFileOptions.SettingsFileOptions(string? settingsFilePath, Aspire.Hosting.SettingsFileType settingsFileType, bool onlyGenerateSettings) -> void
-Aspire.Hosting.SettingsFileOptions.SettingsFilePath.get -> string?
+Aspire.Hosting.SettingsFileOptions.SettingsFileOptions(string! settingsFilePath, Aspire.Hosting.SettingsFileType settingsFileType, bool onlyGenerateSettings) -> void
+Aspire.Hosting.SettingsFileOptions.SettingsFilePath.get -> string!
 Aspire.Hosting.SettingsFileOptions.SettingsFilePath.set -> void
 Aspire.Hosting.SettingsFileOptions.SettingsFileType.get -> Aspire.Hosting.SettingsFileType
 Aspire.Hosting.SettingsFileOptions.SettingsFileType.set -> void
 Aspire.Hosting.SettingsFileType
 Aspire.Hosting.SettingsFileType.CSharp = 0 -> Aspire.Hosting.SettingsFileType
 Aspire.Hosting.SettingsFileType.Json = 1 -> Aspire.Hosting.SettingsFileType
+static Aspire.Hosting.ProjectResourceBuilderExtensions.AddSettingsOnlyProject(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string! settingsFilePath, Aspire.Hosting.SettingsFileType settingsFileType) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
 static Aspire.Hosting.ProjectResourceBuilderExtensions.WithEndpointsInEnvironment(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, System.Func<Aspire.Hosting.ApplicationModel.EndpointAnnotation!, bool>! filter) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
 Aspire.Hosting.DistributedApplicationExecutionContext.DistributedApplicationExecutionContext(Aspire.Hosting.DistributedApplicationExecutionContextOptions! options) -> void
 Aspire.Hosting.DistributedApplicationExecutionContext.ServiceProvider.get -> System.IServiceProvider!
@@ -23,6 +25,7 @@ Aspire.Hosting.DistributedApplicationExecutionContextOptions.Operation.get -> As
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.get -> System.IServiceProvider?
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.set -> void
 static Aspire.Hosting.ProjectResourceBuilderExtensions.WithSettingsFile(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, Aspire.Hosting.SettingsFileOptions! settingsFileOptions) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
+static Aspire.Hosting.ProjectResourceBuilderExtensions.WithSettingsFile(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, string! settingsFilePath, Aspire.Hosting.SettingsFileType settingsFileType, bool onlyGenerateSettings) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.FailedToStart -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Finished -> string!

--- a/src/Aspire.Hosting/SettingsFileOptions.cs
+++ b/src/Aspire.Hosting/SettingsFileOptions.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Type of setting file
+/// </summary>
+public enum SettingsFileType
+{
+    /// <summary>
+    /// Write out the settings as a C# Dictionary, in a format that can passed to IConfigurationBuilder.AddInMemoryCollection as shown here:
+    /// https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration.memoryconfigurationbuilderextensions.addinmemorycollection?view=net-8.0
+    /// </summary>
+    CSharp,
+    /// <summary>
+    /// Write out the settings in a Json format like used by appsettings.json, a format that can be passed to IConfigurationBuilder.AddJsonFile 
+    /// </summary>
+    Json,
+}
+
+/// <summary>
+/// Control generation of a settings file, persisting the same settings passed via launch environment variables.
+/// A settings file allows the option of launching outside of AppHost, while still running with the right settings
+/// to connect to other Aspire services and OTEL.
+/// </summary>
+public class SettingsFileOptions
+{
+    /// <summary>
+    /// Control generation of a settings file, persisting the same settings passed via launch environment variables.
+    /// A settings file allows the option of launching outside of AppHost, while still running with the right settings
+    /// to connect to other Aspire services and OTEL.
+    /// </summary>
+    /// <param name="settingsFilePath">The path to settings file, absolute or relative to app host directory.</param>
+    /// <param name="settingsFileType">The settings file type, C# code (for use with IConfigurationBuilder.AddInMemoryCollection) or JSON (for use with IConfigurationBuilder.AddJsonFile).</param>
+    /// <param name="onlyGenerateSettings">Indicate whether to skip build/running this resource, only generating settings.</param>
+    public SettingsFileOptions(string? settingsFilePath, SettingsFileType settingsFileType, bool onlyGenerateSettings)
+    {
+        SettingsFilePath = settingsFilePath;
+        SettingsFileType = settingsFileType;
+        OnlyGenerateSettings = onlyGenerateSettings;
+    }
+
+    /// <summary>
+    /// Path, including file name, for the settings file to be generated. If the not an absolute path then it should be
+    /// relative to the app host directory.
+    /// </summary>
+    public string? SettingsFilePath { get; set; }
+
+    /// <summary>
+    /// Setting file type, C# code (for use with IConfigurationBuilder.AddInMemoryCollection) or JSON (for use with IConfigurationBuilder.AddJsonFile)
+    /// </summary>
+    public SettingsFileType SettingsFileType { get; set; }
+
+    /// <summary>
+    /// If true, then only generate the settings file, not attempting to build or launch the project resource.
+    /// If false, then generate the settings file in addition to building and launch the project resource. This
+    /// is useful for projects that you want AppHost to manage, but also want the option of launching them
+    /// directly and still being able to connect to AppHost managed services and the dashboard.
+    /// </summary>
+    public bool OnlyGenerateSettings { get; set; }
+}

--- a/src/Aspire.Hosting/SettingsFileOptions.cs
+++ b/src/Aspire.Hosting/SettingsFileOptions.cs
@@ -34,7 +34,7 @@ public class SettingsFileOptions
     /// <param name="settingsFilePath">The path to settings file, absolute or relative to app host directory.</param>
     /// <param name="settingsFileType">The settings file type, C# code (for use with IConfigurationBuilder.AddInMemoryCollection) or JSON (for use with IConfigurationBuilder.AddJsonFile).</param>
     /// <param name="onlyGenerateSettings">Indicate whether to skip build/running this resource, only generating settings.</param>
-    public SettingsFileOptions(string? settingsFilePath, SettingsFileType settingsFileType, bool onlyGenerateSettings)
+    public SettingsFileOptions(string settingsFilePath, SettingsFileType settingsFileType, bool onlyGenerateSettings)
     {
         SettingsFilePath = settingsFilePath;
         SettingsFileType = settingsFileType;
@@ -45,7 +45,7 @@ public class SettingsFileOptions
     /// Path, including file name, for the settings file to be generated. If the not an absolute path then it should be
     /// relative to the app host directory.
     /// </summary>
-    public string? SettingsFilePath { get; set; }
+    public string SettingsFilePath { get; set; }
 
     /// <summary>
     /// Setting file type, C# code (for use with IConfigurationBuilder.AddInMemoryCollection) or JSON (for use with IConfigurationBuilder.AddJsonFile)

--- a/src/Aspire.Hosting/SettingsFileWriterHook.cs
+++ b/src/Aspire.Hosting/SettingsFileWriterHook.cs
@@ -1,0 +1,183 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Lifecycle;
+
+namespace Aspire.Hosting;
+
+internal sealed class SettingsFileWriterHook : IDistributedApplicationLifecycleHook
+{
+    public async Task AfterEndpointsAllocatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
+    {
+        var projectResources = appModel.Resources.OfType<ProjectResource>();
+
+        foreach (var projectResource in projectResources)
+        {
+            if (projectResource.TryGetLastAnnotation<SettingsFileAnnotation>(out var settingsFileAnnotation))
+            {
+                var settingsFileOptions = settingsFileAnnotation.SettingsFileOptions;
+
+                var config = new Dictionary<string, object>();
+                DistributedApplicationExecutionContext? executionContext = null; // TODO: How to get this?
+                var context = new EnvironmentCallbackContext(executionContext!, config, cancellationToken)
+                {
+                    //Logger = resourceLogger
+                };
+
+                if (projectResource.TryGetEnvironmentVariables(out var envVarAnnotations))
+                {
+                    foreach (var ann in envVarAnnotations)
+                    {
+                        await ann.Callback(context).ConfigureAwait(false);
+                    }
+                }
+
+                List<Setting> settings = new List<Setting>();
+                foreach (var c in config)
+                {
+                    try
+                    {
+                        var value = c.Value switch
+                        {
+                            string s => s,
+                            //IValueProvider valueProvider => await GetValue(c.Key, valueProvider, resourceLogger, isContainer: false, cancellationToken).ConfigureAwait(false),
+                            null => null,
+                            _ => throw new InvalidOperationException($"Unexpected value for environment variable \"{c.Key}\".")
+                        };
+
+                        if (value is not null)
+                        {
+                            settings.Add(new Setting(c.Key, value));
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        //resourceLogger.LogCritical("Failed to apply configuration value '{ConfigKey}'. A dependency may have failed to start.", c.Key);
+                        //_logger.LogDebug(ex, "Failed to apply configuration value '{ConfigKey}'. A dependency may have failed to start.", c.Key);
+                        //failedToApplyConfiguration = true;
+                    }
+                }
+
+                if (settingsFileOptions.SettingsFileType == SettingsFileType.CSharp)
+                {
+                    WriteCSharpSettings(settings, settingsFileOptions.SettingsFilePath!);
+                }
+                else
+                {
+                    //WriteJsonSettings(projectResource.EnvironmentVariables, settingsFileOptions.SettingsFilePath!);
+                }
+            }
+        }
+    }
+
+    static void WriteCSharpSettings(List<Setting> settings, string settingsPath)
+    {
+        var prefixesToRemove = new List<string>
+        {
+            "ASPNETCORE_",
+            "DOTNET_",
+        };
+
+        // Get the subset of variables that are provided by Aspire and sort them
+        List<Setting> transformedSettings = new List<Setting>();
+        foreach (var setting in settings)
+        {
+            string variableName = setting.Name;
+            string value = setting.Value;
+
+            // Normalize the key, matching the logic here:
+            // https://github.dev/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+            variableName = variableName.Replace("__", ":");
+
+            // For defined prefixes, add the variable with the prefix removed, matching the logic
+            // in EnvironmentVariablesConfigurationProvider.cs. Also add the variable with the
+            // prefix intact, which matches the normal HostApplicationBuilder behavior, where
+            // there's an EnvironmentVariablesConfigurationProvider added with and another one
+            // without the prefix set.
+            foreach (var prefix in prefixesToRemove)
+            {
+                if (variableName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    transformedSettings.Add(new Setting(variableName, value));
+                    variableName = variableName.Substring(prefix.Length);
+                    break;
+                }
+            }
+
+            transformedSettings.Add(new Setting(variableName, value));
+        }
+
+        transformedSettings.Sort();
+
+        // TODO: Should we add a UTF-8 BOM or escape non-ASCII characters in setting values?
+        using (var file = new StreamWriter(settingsPath))
+        {
+            EnsureFileIsReadable(settingsPath);
+
+            file.Write("""
+                    // This file is generated from the Aspire AppHost project. Rerun the Aspire AppHost
+                    // to regenerate it.
+                    
+                    public static class AspireAppSettings
+                    {
+                        public static readonly Dictionary<string, string> Settings =
+                            new Dictionary<string, string>
+                            {
+
+                    """);
+
+            foreach (Setting setting in transformedSettings)
+            {
+                var value = setting.Value;
+                string escapedValue;
+                if (value.Contains('"') || value.Contains('\\'))
+                {
+                    escapedValue = "@\"" + value.Replace("\"", "\"\"") + "\"";
+                }
+                else
+                {
+                    escapedValue = "\"" + value + "\"";
+                }
+
+                file.WriteLine($"""            ["{setting.Name}"] = {escapedValue},""");
+            }
+
+            file.Write("""
+                            };
+                    }
+                    """);
+        }
+    }
+
+    private static void EnsureFileIsReadable(string filePath)
+    {
+        // Need to grant read access to the config file on unix like systems.
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(filePath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        }
+    }
+
+    private class Setting(string name, string value) : IComparable<Setting>
+    {
+        public string Name { get; } = name;
+        public string Value { get; } = value;
+
+        public string GetCSharpEscapedValue()
+        {
+            // If the string contains a quote or escape sequence, use a verbatim string literal, where "" is used for "
+            if (Value.Contains('"') || Value.Contains('\\'))
+            {
+                return "@\"" + Value.Replace("\"", "\"\"") + "\"";
+            }
+            else
+            {
+                return "\"" + Value + "\"";
+            }
+        }
+
+        public int CompareTo(Setting? other) =>
+            other is null ? 1 : Name.CompareTo(other.Name);
+    }
+}


### PR DESCRIPTION
Add support for optionally generating a settings file.
See motivation and API details here: https://github.com/dotnet/aspire/issues/5015 

Note that this PR is a work in progress, not yet complete.
For one thing, I'll need some help on how to best get the context (DistributedApplicationExecutionContext or otherwise) to provide to EnvironmentCallbackContext).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5016)