### PR TITLE
Update StructuredLogs to use LogFilter fields

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -129,14 +129,14 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         {
             ViewModel.AddFilter(new LogFilter
             {
-                Field = "TraceId", Condition = FilterCondition.Equals, Value = TraceId
+                Field = LogFilter.KnownTraceIdField, Condition = FilterCondition.Equals, Value = TraceId
             });
         }
         if (!string.IsNullOrEmpty(SpanId))
         {
             ViewModel.AddFilter(new LogFilter
             {
-                Field = "SpanId", Condition = FilterCondition.Equals, Value = SpanId
+                Field = LogFilter.KnownSpanIdField, Condition = FilterCondition.Equals, Value = SpanId
             });
         }
 


### PR DESCRIPTION
This should address #4005

Locally I had a similar issue where the 'View logs' button did not work on either the Trace or Span level. 
Once on the Structured logs page, selecting the correct field from the 'Edit filter' dialog would show 'log.traceid' and 'log.spanid' in the address bar.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5023)