### PR TITLE
Add IResourceWithServiceDiscovery interface to PythonProjectResource.

### DIFF
--- a/src/Aspire.Hosting.Python/PythonProjectResource.cs
+++ b/src/Aspire.Hosting.Python/PythonProjectResource.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.Python;
 /// <param name="executablePath">The path to the executable used to run the python project.</param>
 /// <param name="projectDirectory">The path to the directory containing the python project.</param>
 public class PythonProjectResource(string name, string executablePath, string projectDirectory)
-    : ExecutableResource(name, executablePath, projectDirectory)
+    : ExecutableResource(name, executablePath, projectDirectory), IResourceWithServiceDiscovery
 {
 
 }


### PR DESCRIPTION
Fixes #5019 

We were just missing the marker interface. This will result in the service discovery variables be populated with `WithRefrence(...)` is used. It also unlocks `WithEnvironment(string, EndpointReference)` which is arguably more useful in these polyglot scenarios.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5024)