### PR TITLE
[release/8.1] Update StructuredLogs to use LogFilter fields

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -129,14 +129,14 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         {
             ViewModel.AddFilter(new LogFilter
             {
-                Field = "TraceId", Condition = FilterCondition.Equals, Value = TraceId
+                Field = LogFilter.KnownTraceIdField, Condition = FilterCondition.Equals, Value = TraceId
             });
         }
         if (!string.IsNullOrEmpty(SpanId))
         {
             ViewModel.AddFilter(new LogFilter
             {
-                Field = "SpanId", Condition = FilterCondition.Equals, Value = SpanId
+                Field = LogFilter.KnownSpanIdField, Condition = FilterCondition.Equals, Value = SpanId
             });
         }
 


### PR DESCRIPTION
Backport https://github.com/dotnet/aspire/pull/5023

## Customer Impact

The view logs buttons in the trace/span views are broken. Clicking them will always say that no logs are available instead of showing the filtered logs for the trace/span.

## Testing

Manual. Launch TestShop, add item to the cart, go to trace, then click view logs.

## Risk

Low.

## Regression?



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5026)