### PR TITLE
[Dashboard] Fix the ellipsis cut off in FluentOverflow

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -25,9 +25,9 @@ else if (DisplayedEndpoints.Count > 1)
             }
         </ChildContent>
         <MoreButtonTemplate Context="overflow">
-            <FluentButton Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
+            <FluentBadge role="button" tabindex="0" Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
                 @($"+{overflow.ItemsOverflow.Count()}")
-            </FluentButton>
+            </FluentBadge>
         </MoreButtonTemplate>
         <OverflowTemplate Context="overflow">
             @{

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -467,8 +467,8 @@ fluent-data-grid-cell.no-ellipsis {
     overflow-x: visible !important;
 }
 
-.endpoint-overflow .fluent-overflow-more {
-    display: flex;
+.endpoint-button::part(control) {
+    padding: 2px 8px !important;
 }
 
 .endpoint-button {


### PR DESCRIPTION
# [Dashboard] Fix the ellipsis cut off in FluentOverflow

In the dashboard, the ellipsis cut off in `FluentOverflow`.
See this issue: https://github.com/microsoft/fluentui-blazor/issues/2427

## Before
![Before](https://github.com/user-attachments/assets/f74ce8f1-d715-4568-a12c-c2c84b925af1)

## After
![After](https://github.com/user-attachments/assets/d5acbbe1-2e9c-48f4-b774-dcaac6dfaf19)

## Code
The problem seems to be related to this `flex` style applied to the **FluentButton**.
Strange, but I think that with `flex' the JavaScript code cannot calculate the initial element widths correctly.

```css
.endpoint-overflow .fluent-overflow-more {
    display: flex;
}
```

I found this solution, replacing the **FluentButton** by a **FluentBadge**.

```xml
<MoreButtonTemplate Context="overflow">
    <FluentBadge role="button" tabindex="0" Appearance="Appearance.Accent" OnClick="() => _popoverVisible = !_popoverVisible" Class="endpoint-button">
        @($"+{overflow.ItemsOverflow.Count()}")
    </FluentBadge>
</MoreButtonTemplate>
```

And using this style to get the same look and feel.

```css
/*
.endpoint-overflow .fluent-overflow-more {
    display: flex;
}
*/

.endpoint-button::part(control) {
    padding: 2px 8px !important;
}
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5030)