### PR TITLE
Avoid dispose race on metrics page

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
@@ -1,6 +1,5 @@
 ﻿@namespace Aspire.Dashboard.Components.Controls
 
-@implements IAsyncDisposable
 @using Aspire.Dashboard.Extensions
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
@@ -270,7 +270,11 @@ public partial class MetricTable : ChartBase
     protected override async ValueTask DisposeAsync(bool disposing)
     {
         await base.DisposeAsync(disposing);
-        await JSInteropHelpers.SafeDisposeAsync(_jsModule);
+
+        if (disposing)
+        {
+            await JSInteropHelpers.SafeDisposeAsync(_jsModule);
+        }
     }
 
     public abstract record MetricViewBase

--- a/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
@@ -175,8 +175,11 @@ public partial class PlotlyChart : ChartBase
     {
         await base.DisposeAsync(disposing);
 
-        _chartInteropReference?.Dispose();
-        await JSInteropHelpers.SafeDisposeAsync(_jsModule);
+        if (disposing)
+        {
+            _chartInteropReference?.Dispose();
+            await JSInteropHelpers.SafeDisposeAsync(_jsModule);
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
@@ -17,7 +17,7 @@ using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components;
 
-public partial class PlotlyChart : ChartBase, IAsyncDisposable
+public partial class PlotlyChart : ChartBase
 {
     [Inject]
     public required IJSRuntime JS { get; init; }
@@ -45,7 +45,7 @@ public partial class PlotlyChart : ChartBase, IAsyncDisposable
                 """;
     }
 
-    protected override async Task OnChartUpdated(List<ChartTrace> traces, List<DateTimeOffset> xValues, List<ChartExemplar> exemplars, bool tickUpdate, DateTimeOffset inProgressDataTime)
+    protected override async Task OnChartUpdatedAsync(List<ChartTrace> traces, List<DateTimeOffset> xValues, List<ChartExemplar> exemplars, bool tickUpdate, DateTimeOffset inProgressDataTime, CancellationToken cancellationToken)
     {
         Debug.Assert(_jsModule != null, "The module should be initialized before chart data is sent to control.");
 
@@ -171,35 +171,24 @@ public partial class PlotlyChart : ChartBase, IAsyncDisposable
     // The first data is used to initialize the chart. The module needs to be ready first.
     protected override bool ReadyForData() => _jsModule != null;
 
-    public async ValueTask DisposeAsync()
+    protected override async ValueTask DisposeAsync(bool disposing)
     {
-        if (_chartInteropReference != null)
-        {
-            _chartInteropReference.Value.Dispose();
-            _chartInteropReference.Dispose();
-        }
+        await base.DisposeAsync(disposing);
 
+        _chartInteropReference?.Dispose();
         await JSInteropHelpers.SafeDisposeAsync(_jsModule);
     }
 
     /// <summary>
     /// Handle user clicking on a trace point in the browser.
     /// </summary>
-    private sealed class ChartInterop : IDisposable
+    private sealed class ChartInterop
     {
         private readonly PlotlyChart _plotlyChart;
-        private readonly CancellationTokenSource _cts;
 
         public ChartInterop(PlotlyChart plotlyChart)
         {
             _plotlyChart = plotlyChart;
-            _cts = new CancellationTokenSource();
-        }
-
-        public void Dispose()
-        {
-            _cts.Cancel();
-            _cts.Dispose();
         }
 
         [JSInvokable]
@@ -212,7 +201,7 @@ public partial class PlotlyChart : ChartBase, IAsyncDisposable
                 _plotlyChart.DialogService,
                 _plotlyChart.InvokeAsync,
                 _plotlyChart.DialogsLoc,
-                _cts.Token).ConfigureAwait(false);
+                _plotlyChart.CancellationToken).ConfigureAwait(false);
 
             if (available)
             {

--- a/src/Aspire.Dashboard/wwwroot/js/app-metrics.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-metrics.js
@@ -5,6 +5,7 @@ export function initializeChart(id, traces, exemplarTrace, rangeStartTime, range
 
     var chartContainerDiv = document.getElementById(id);
     if (!chartContainerDiv) {
+        console.log(`Couldn't find container '${id}' when initializing chart.`);
         return;
     }
 
@@ -129,10 +130,15 @@ export function initializeChart(id, traces, exemplarTrace, rangeStartTime, range
 export function updateChart(id, traces, exemplarTrace, rangeStartTime, rangeEndTime) {
     var chartContainerDiv = document.getElementById(id);
     if (!chartContainerDiv) {
+        console.log(`Couldn't find container '${id}' when updating chart.`);
         return;
     }
 
     var chartDiv = chartContainerDiv.firstChild;
+    if (!chartDiv) {
+        console.log(`Couldn't find div inside container '${id}' when updating chart. Chart may not have been successfully initialized.`);
+        return;
+    }
 
     var themeColors = getThemeColors();
 

--- a/src/Aspire.Dashboard/wwwroot/js/app-metrics.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-metrics.js
@@ -4,6 +4,9 @@ export function initializeChart(id, traces, exemplarTrace, rangeStartTime, range
     registerLocale(serverLocale);
 
     var chartContainerDiv = document.getElementById(id);
+    if (!chartContainerDiv) {
+        return;
+    }
 
     // Reusing a div can create issues with chart lines appearing beyond the end range.
     // Workaround this issue by replacing the chart div. Ensures we start from a new state.
@@ -125,6 +128,10 @@ export function initializeChart(id, traces, exemplarTrace, rangeStartTime, range
 
 export function updateChart(id, traces, exemplarTrace, rangeStartTime, rangeEndTime) {
     var chartContainerDiv = document.getElementById(id);
+    if (!chartContainerDiv) {
+        return;
+    }
+
     var chartDiv = chartContainerDiv.firstChild;
 
     var themeColors = getThemeColors();


### PR DESCRIPTION
I noticed an ODE on the metrics page. I think this change to centralize cancellation, not run data updates after dispose and ignore ODE makes it more robust.

Also perhaps helps with https://github.com/dotnet/aspire/issues/5027. I couldn't repo the error, but added some extra safety checks when rendering metrics.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5031)