### PR TITLE
[tests] Work around sqlserver 2022-latest latest image breaking with testcontainers

### DIFF
--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
@@ -22,7 +22,7 @@ public sealed class SqlServerContainerFixture : IAsyncLifetime
         {
             Container = new MsSqlBuilder()
                             .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}:{SqlServerContainerImageTags.Tag}")
-                            .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("/opt/mssql-tools18/bin/sqlcmd", "-C", "-Q", "SELECT 1;"))
+                            .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("/opt/mssql-tools18/bin/sqlcmd", "-C", "-Q", "SELECT 1;")) // https://github.com/dotnet/aspire/issues/5057
                             .Build();
             await Container.StartAsync();
         }

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Components.Common.Tests;
 using Aspire.Hosting;
+using DotNet.Testcontainers.Builders;
 using Testcontainers.MsSql;
 using Xunit;
 
@@ -21,6 +22,7 @@ public sealed class SqlServerContainerFixture : IAsyncLifetime
         {
             Container = new MsSqlBuilder()
                             .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}:{SqlServerContainerImageTags.Tag}")
+                            .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("/opt/mssql-tools18/bin/sqlcmd", "-C", "-Q", "SELECT 1;"))
                             .Build();
             await Container.StartAsync();
         }


### PR DESCRIPTION
[tests] Workaround sqlserver 2022-latest latest image failing

.. with testcontainers because the path `/opt/mssql-tools/bin/sqlcmd`
changed to `/opt/mssql-tools18/bin/sqlcmd`. But this hardcoded path is
being used in testcontainers, causing it to fail.

https://github.com/testcontainers/testcontainers-dotnet/issues/1220
https://github.com/microsoft/mssql-docker/issues/892

Issue: https://github.com/dotnet/aspire/issues/5057

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5058)