### PR TITLE
Use digest for sqlserver and fix tests

### DIFF
--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -27,7 +27,8 @@ public static class SqlServerBuilderExtensions
         var sqlServer = new SqlServerServerResource(name, passwordParameter);
         return builder.AddResource(sqlServer)
                       .WithEndpoint(port: port, targetPort: 1433, name: SqlServerServerResource.PrimaryEndpointName)
-                      .WithImage(SqlServerContainerImageTags.Image, SqlServerContainerImageTags.Tag)
+                      .WithImage(SqlServerContainerImageTags.Image)
+                      .WithImageSHA256(SqlServerContainerImageTags.Digest)
                       .WithImageRegistry(SqlServerContainerImageTags.Registry)
                       .WithEnvironment("ACCEPT_EULA", "Y")
                       .WithEnvironment(context =>

--- a/src/Aspire.Hosting.SqlServer/SqlServerContainerImageTags.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerContainerImageTags.cs
@@ -8,5 +8,5 @@ internal static class SqlServerContainerImageTags
     public const string Registry = "mcr.microsoft.com";
     public const string Image = "mssql/server";
     // Tracking tag: 2022-latest. NOTE: latest  digest fails the tests. We need to investigate.
-    public const string Digest = "sha256:c4369c38385eba011c10906dc8892425831275bb035d5ce69656da8e29de50d8";
+    public const string Digest = "c4369c38385eba011c10906dc8892425831275bb035d5ce69656da8e29de50d8";
 }

--- a/src/Aspire.Hosting.SqlServer/SqlServerContainerImageTags.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerContainerImageTags.cs
@@ -7,5 +7,6 @@ internal static class SqlServerContainerImageTags
 {
     public const string Registry = "mcr.microsoft.com";
     public const string Image = "mssql/server";
-    public const string Tag = "2022-latest";
+    // Tracking tag: 2022-latest. NOTE: latest  digest fails the tests. We need to investigate.
+    public const string Digest = "sha256:c4369c38385eba011c10906dc8892425831275bb035d5ce69656da8e29de50d8";
 }

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -504,7 +504,7 @@ public class ManifestGenerationTests
                 "sqlserver": {
                   "type": "container.v0",
                   "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver-password.value};TrustServerCertificate=true",
-                  "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}@{{SqlServerContainerImageTags.Digest}}",
+                  "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}@sha256:{{SqlServerContainerImageTags.Digest}}",
                   "env": {
                     "ACCEPT_EULA": "Y",
                     "MSSQL_SA_PASSWORD": "{sqlserver-password.value}"

--- a/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ManifestGenerationTests.cs
@@ -504,7 +504,7 @@ public class ManifestGenerationTests
                 "sqlserver": {
                   "type": "container.v0",
                   "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver-password.value};TrustServerCertificate=true",
-                  "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}:{{SqlServerContainerImageTags.Tag}}",
+                  "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}@{{SqlServerContainerImageTags.Digest}}",
                   "env": {
                     "ACCEPT_EULA": "Y",
                     "MSSQL_SA_PASSWORD": "{sqlserver-password.value}"

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -55,7 +55,7 @@ public class AddSqlServerTests
         Assert.Equal("tcp", endpoint.UriScheme);
 
         var containerAnnotation = Assert.Single(containerResource.Annotations.OfType<ContainerImageAnnotation>());
-        Assert.Equal(SqlServerContainerImageTags.Tag, containerAnnotation.Tag);
+        Assert.Equal(SqlServerContainerImageTags.Digest, containerAnnotation.SHA256);
         Assert.Equal(SqlServerContainerImageTags.Image, containerAnnotation.Image);
         Assert.Equal(SqlServerContainerImageTags.Registry, containerAnnotation.Registry);
 
@@ -135,7 +135,7 @@ public class AddSqlServerTests
             {
               "type": "container.v0",
               "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver-password.value};TrustServerCertificate=true",
-              "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}:{{SqlServerContainerImageTags.Tag}}",
+              "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}@{{SqlServerContainerImageTags.Digest}}",
               "env": {
                 "ACCEPT_EULA": "Y",
                 "MSSQL_SA_PASSWORD": "{sqlserver-password.value}"
@@ -175,7 +175,7 @@ public class AddSqlServerTests
             {
               "type": "container.v0",
               "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true",
-              "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}:{{SqlServerContainerImageTags.Tag}}",
+              "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}@{{SqlServerContainerImageTags.Digest}}",
               "env": {
                 "ACCEPT_EULA": "Y",
                 "MSSQL_SA_PASSWORD": "{pass.value}"

--- a/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.Tests/SqlServer/AddSqlServerTests.cs
@@ -135,7 +135,7 @@ public class AddSqlServerTests
             {
               "type": "container.v0",
               "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver-password.value};TrustServerCertificate=true",
-              "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}@{{SqlServerContainerImageTags.Digest}}",
+              "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}@sha256:{{SqlServerContainerImageTags.Digest}}",
               "env": {
                 "ACCEPT_EULA": "Y",
                 "MSSQL_SA_PASSWORD": "{sqlserver-password.value}"
@@ -175,7 +175,7 @@ public class AddSqlServerTests
             {
               "type": "container.v0",
               "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true",
-              "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}@{{SqlServerContainerImageTags.Digest}}",
+              "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}@sha256:{{SqlServerContainerImageTags.Digest}}",
               "env": {
                 "ACCEPT_EULA": "Y",
                 "MSSQL_SA_PASSWORD": "{pass.value}"

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
@@ -20,7 +20,7 @@ public sealed class SqlServerContainerFixture : IAsyncLifetime
         if (RequiresDockerAttribute.IsSupported)
         {
             Container = new MsSqlBuilder()
-                            .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}:{SqlServerContainerImageTags.Tag}")
+                            .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}@{SqlServerContainerImageTags.Digest}")
                             .Build();
             await Container.StartAsync();
         }

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
@@ -20,7 +20,7 @@ public sealed class SqlServerContainerFixture : IAsyncLifetime
         if (RequiresDockerAttribute.IsSupported)
         {
             Container = new MsSqlBuilder()
-                            .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}@{SqlServerContainerImageTags.Digest}")
+                            .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}@sha256:{SqlServerContainerImageTags.Digest}")
                             .Build();
             await Container.StartAsync();
         }


### PR DESCRIPTION
An update to mssql/server image tag `2022-latest` broke our tests as we can no longer communicate with the container. Chatting offline with our experts from the dotnet-docker repo, they suggested we should instead depend on digests as opposed to tags, to be able to guarantee determinism, and then just make sure we update these digests in a frequent basis to ensure we get fixes for them. This PR is switching just the sqlserver hosting component to use digest instead and it also does that for the tests so that they pass again, but we will likely want to make an overhaul pass to all of our hosting components to similarly depend on digests as opposed to tags.

cc: @mitchdenny @radical @eerhardt 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5059)