### PR TITLE
Add support for multiple ANSI arguments to AnsiParser

### DIFF
--- a/playground/Stress/Stress.ApiService/ConsoleStresser.cs
+++ b/playground/Stress/Stress.ApiService/ConsoleStresser.cs
@@ -109,6 +109,24 @@ public static class ConsoleStresser
         Console.WriteLine("\u001b[1mThis text is bold using ANSI escape codes.\u001b[0m");
         Console.WriteLine("\u001b[4mThis text is underlined using ANSI escape codes.\u001b[0m");
         Console.WriteLine("\u001b[31;1;4mThis text is red, bold, and underlined.\u001b[0m");
+        Console.WriteLine("\u001b[31;3;4mThis text is red, italic and underlined.\u001b[0m");
+        Console.WriteLine("\u001b[31;42;3;4mThis text is red, green background, italic and underlined.\u001b[0m");
+
+        Console.WriteLine();
+        Console.WriteLine("\u001b[38;5;221mThis text is a 256 text color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[48;5;95mThis text is a 256 bakground color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;221m\u001b[48;5;95mThis text is a 256 text and bakground color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;243mThis text is a 256 gray text color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[48;5;243mThis text is a 256 gray background color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;1mThis text is a 256 red color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;9mThis text is a 256 bright red color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[48;5;1mThis text is a 256 red background color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[48;5;9mThis text is a 256 bright red background color using ANSI escape codes.\u001b[0m");
+
+        Console.WriteLine();
+        Console.WriteLine("\u001b[38;5;321mThis text is a 256 text color using invalid color value.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;100This text is a 256 text color using unfinished escape sequence (m here to finish the sequence late).\u001b[0m");
+        Console.WriteLine("\u001b[38;5;100This text is a 256 text color using unfinished escape sequence.\u001b[0m");
 
         Console.WriteLine();
         Console.WriteLine("HTML:");

--- a/playground/Stress/Stress.ApiService/ConsoleStresser.cs
+++ b/playground/Stress/Stress.ApiService/ConsoleStresser.cs
@@ -110,23 +110,31 @@ public static class ConsoleStresser
         Console.WriteLine("\u001b[4mThis text is underlined using ANSI escape codes.\u001b[0m");
         Console.WriteLine("\u001b[31;1;4mThis text is red, bold, and underlined.\u001b[0m");
         Console.WriteLine("\u001b[31;3;4mThis text is red, italic and underlined.\u001b[0m");
+        Console.WriteLine("\u001b[31;3;4;9mThis text is red, italic and strikethrough.\u001b[0m");
         Console.WriteLine("\u001b[31;42;3;4mThis text is red, green background, italic and underlined.\u001b[0m");
 
         Console.WriteLine();
-        Console.WriteLine("\u001b[38;5;221mThis text is a 256 text color using ANSI escape codes.\u001b[0m");
-        Console.WriteLine("\u001b[48;5;95mThis text is a 256 bakground color using ANSI escape codes.\u001b[0m");
-        Console.WriteLine("\u001b[38;5;221m\u001b[48;5;95mThis text is a 256 text and bakground color using ANSI escape codes.\u001b[0m");
-        Console.WriteLine("\u001b[38;5;243mThis text is a 256 gray text color using ANSI escape codes.\u001b[0m");
-        Console.WriteLine("\u001b[48;5;243mThis text is a 256 gray background color using ANSI escape codes.\u001b[0m");
-        Console.WriteLine("\u001b[38;5;1mThis text is a 256 red color using ANSI escape codes.\u001b[0m");
-        Console.WriteLine("\u001b[38;5;9mThis text is a 256 bright red color using ANSI escape codes.\u001b[0m");
-        Console.WriteLine("\u001b[48;5;1mThis text is a 256 red background color using ANSI escape codes.\u001b[0m");
-        Console.WriteLine("\u001b[48;5;9mThis text is a 256 bright red background color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;221mThis text is a Xterm text color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[48;5;95mThis text is a Xterm bakground color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;221m\u001b[48;5;95mThis text is a Xterm text and bakground color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;243mThis text is a Xterm gray text color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[48;5;243mThis text is a Xterm gray background color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;1mThis text is a Xterm red color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;9mThis text is a Xterm bright red color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[48;5;1mThis text is a Xterm red background color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[48;5;9mThis text is a Xterm bright red background color using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[3;38;5;9mThis text is a Xterm bright red color and italic using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[4;38;5;9mThis text is a Xterm bright red color and underlined using ANSI escape codes.\u001b[0m");
+        Console.WriteLine("\u001b[9;38;5;9mThis text is a Xterm bright red color and strikethrough using ANSI escape codes.\u001b[0m");
 
         Console.WriteLine();
-        Console.WriteLine("\u001b[38;5;321mThis text is a 256 text color using invalid color value.\u001b[0m");
-        Console.WriteLine("\u001b[38;5;100This text is a 256 text color using unfinished escape sequence (m here to finish the sequence late).\u001b[0m");
-        Console.WriteLine("\u001b[38;5;100This text is a 256 text color using unfinished escape sequence.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;321mThis text is a Xterm text color using invalid color value.\u001b[0m");
+        Console.WriteLine("\u001b[38;5;100This text is a Xterm text color using unfinished escape sequence (m here to finish the sequence late).\u001b[0m");
+        Console.WriteLine("\u001b[38;5;100This text is a Xterm text color using unfinished escape sequence.\u001b[0m");
+
+        Console.WriteLine();
+        Console.WriteLine("A link in escape sequence: \u001b]8;;https://example.com\u001b\\The link text\u001b]8;;\u001b\\");
+        Console.WriteLine("A link with formatted link text in escape sequnce: \u001b]8;;https://example.com\u001b\\The \u001b[38;5;100mlink\u001b[0m formatted text\u001b]8;;\u001b\\");
 
         Console.WriteLine();
         Console.WriteLine("HTML:");

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -218,3 +218,7 @@
 ::deep .ansi-italic {
     font-style: italic;
 }
+
+::deep .ansi-strikethrough {
+    text-decoration: line-through;
+}

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.css
@@ -210,3 +210,11 @@
 ::deep .ansi-bg-yellow {
     background-color: var(--console-theme-yellow);
 }
+
+::deep .ansi-underline {
+    text-decoration: underline;
+}
+
+::deep .ansi-italic {
+    font-style: italic;
+}

--- a/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/AnsiParser.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Aspire.Dashboard.ConsoleLogs;
@@ -9,11 +8,16 @@ namespace Aspire.Dashboard.ConsoleLogs;
 public class AnsiParser
 {
     private const char EscapeChar = '\x1B';
+    private const char ParametersSeparatorChar = ';';
     private const int ResetCode = 0;
     private const int IncreasedIntensityCode = 1;
+    private const int ItalicCode = 3;
+    private const int UnderlineCode = 4;
     private const int NormalIntensityCode = 22;
     private const int DefaultForegroundCode = 39;
     private const int DefaultBackgroundCode = 49;
+    private const int Ansi256ForegroundSequenceCode = 38;
+    private const int Ansi256BackgroundSequenceCode = 48;
 
     public static ConversionResult ConvertToHtml(string? text, ParserState? priorResidualState = null)
     {
@@ -34,7 +38,7 @@ public class AnsiParser
 
         for (var i = 0; i < span.Length; i++)
         {
-            if (IsControlSequence(span, i, out var parameter))
+            if (IsControlSequence(span[i..], ref i, out var parameters))
             {
                 // If we have a control sequence, but have found some text already,
                 // we need to write out the new styles (if applicable) and that text
@@ -51,9 +55,8 @@ public class AnsiParser
                     textLength = 0;
                 }
 
-                ProcessParameter(ref newState, parameter);
+                ProcessParameters(ref newState, parameters);
 
-                i += (parameter >= 10) ? 4 : 3;
                 continue;
             }
 
@@ -101,59 +104,124 @@ public class AnsiParser
         return new(outputBuilder.ToString(), currentState);
     }
 
-    private static void ProcessParameter(ref ParserState newState, int parameter)
+    private static void ProcessParameters(ref ParserState newState, int[] parameters)
     {
-        if (TryGetForegroundColor(parameter, out var color))
+        // If 256 color format parameters
+        if (parameters is [int colorSequence, int colorType, int colorValue]
+            && colorSequence is Ansi256ForegroundSequenceCode or Ansi256BackgroundSequenceCode
+            && colorType is 5
+            && colorValue is >= 0 and < 256)
         {
-            newState.ForegroundColor = color;
+            if (colorSequence == Ansi256ForegroundSequenceCode)
+            {
+                newState.Ansi256ForegroundColorCode = colorValue;
+                return;
+            }
+            else if (colorSequence == Ansi256BackgroundSequenceCode)
+            {
+                newState.Ansi256BackgroundColorCode = colorValue;
+                return;
+            }
         }
-        else if (TryGetBackgroundColor(parameter, out color))
+
+        foreach (var parameter in parameters)
         {
-            newState.BackgroundColor = color;
-        }
-        else if (parameter == DefaultBackgroundCode)
-        {
-            newState.BackgroundColor = null;
-        }
-        else if (parameter == DefaultForegroundCode)
-        {
-            newState.ForegroundColor = null;
-        }
-        else if (parameter == NormalIntensityCode)
-        {
-            newState.Bright = false;
-        }
-        else if (parameter == ResetCode)
-        {
-            newState = default;
-        }
-        else if (parameter == IncreasedIntensityCode)
-        {
-            newState.Bright = true;
+            if (TryGetForegroundColor(parameter, out var color))
+            {
+                newState.ForegroundColor = color;
+            }
+            else if (TryGetBackgroundColor(parameter, out color))
+            {
+                newState.BackgroundColor = color;
+            }
+            else if (parameter == DefaultBackgroundCode)
+            {
+                newState.BackgroundColor = null;
+            }
+            else if (parameter == DefaultForegroundCode)
+            {
+                newState.ForegroundColor = null;
+            }
+            else if (parameter == NormalIntensityCode)
+            {
+                newState.Bright = false;
+            }
+            else if (parameter == ResetCode)
+            {
+                newState = default;
+            }
+            else if (parameter == IncreasedIntensityCode)
+            {
+                newState.Bright = true;
+            }
+            else if (parameter == UnderlineCode)
+            {
+                newState.Underline = true;
+            }
+            else if (parameter == ItalicCode)
+            {
+                newState.Italic = true;
+            }
         }
     }
 
-    private static bool IsControlSequence(ReadOnlySpan<char> span, int position, out int parameter)
+    private static bool IsControlSequence(ReadOnlySpan<char> span, ref int position, out int[] parameters)
     {
-        // If we're at \x1B[ and the span is at least long enough for a single digit parameter
-        if (span[position] == EscapeChar && span.Length >= position + 4 && span[position + 1] == '[')
+        // If we're at \x1B[
+        if (span.Length <= 2 || (span[0] != EscapeChar || span[1] != '['))
         {
-            // If we've got a single digit parameter and the closing m
-            if (span[position + 3] == 'm' && IsDigit(span[position + 2]))
+            parameters = [];
+            return false;
+        }
+
+        // Find the index of the next 'm' character
+        var paramsEndPosition = span.IndexOf('m');
+        if (paramsEndPosition == -1)
+        {
+            // No end of escape with 'm' code, cannot parse params.
+            parameters = [];
+            return false;
+        }
+
+        // Find the index of the next escape character
+        var nextEscapePosition = span[1..].IndexOf(EscapeChar);
+        if (nextEscapePosition != -1 && nextEscapePosition < paramsEndPosition)
+        {
+            // Current sequence is not finished before the next escape sequence starts.
+            parameters = [];
+            return false;
+        }
+
+        // Save where current parameter start location
+        var currentParamStartPosition = 2;
+
+        // List to store all parameters
+        List<int> ret = new(2);
+
+        for (var i = currentParamStartPosition; i <= paramsEndPosition; i++)
+        {
+            if (span[i] == ParametersSeparatorChar || i == paramsEndPosition)
             {
-                parameter = span[position + 2] - '0';
-                return true;
-            }
-            // If we've got a two digit parameter and the closing m
-            else if (span.Length >= position + 5 && span[position + 4] == 'm' && IsDigit(span[position + 2]) && IsDigit(span[position + 3]))
-            {
-                parameter = (span[position + 2] - '0') * 10 + (span[position + 3] - '0');
-                return true;
+                // Try to parse the parameter
+                if (int.TryParse(
+                    span[currentParamStartPosition..i],
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var parameterValue))
+                {
+                    // Add the parameter to the list
+                    ret.Add(parameterValue);
+                }
+
+                // Move current parameter start to the next character
+                currentParamStartPosition = i + 1;
             }
         }
 
-        parameter = -1;
-        return false;
+        // Advance the position in the span to the end of the control sequence
+        position += paramsEndPosition;
+        parameters = [.. ret];
+
+        return true;
     }
 
     private static string ProcessStateChange(ParserState currentState, ParserState newState)
@@ -164,22 +232,57 @@ public class AnsiParser
             closeSpanIfNeeded += "</span>";
         }
 
-        if (newState.ForegroundColor.HasValue && newState.BackgroundColor.HasValue)
+        var classes = new List<string>(2);
+        var styles = new List<string>(2);
+
+        if (newState.ForegroundColor.HasValue)
         {
-            return closeSpanIfNeeded + $"<span class=\"{GetForegroundColorClass(newState)} {GetBackgroundColorClass(newState)}\">";
+            classes.Add(GetForegroundColorClass(newState)!);
         }
-        else if (newState.ForegroundColor.HasValue)
+
+        if (newState.BackgroundColor.HasValue)
         {
-            return closeSpanIfNeeded + $"<span class=\"{GetForegroundColorClass(newState)}\">";
+            classes.Add(GetBackgroundColorClass(newState)!);
         }
-        else if (newState.BackgroundColor.HasValue)
+
+        if (newState.Underline)
         {
-            return closeSpanIfNeeded + $"<span class=\"{GetBackgroundColorClass(newState)}\">";
+            classes.Add("ansi-underline");
         }
-        else
+        if (newState.Italic)
         {
-            return closeSpanIfNeeded;
+            classes.Add("ansi-italic");
         }
+
+        if (newState.Ansi256ForegroundColorCode.HasValue)
+        {
+            var colorValue = newState.Ansi256ForegroundColorCode.Value;
+            if (TryGetXtermRgbHexColor(colorValue, out var rgbForegroundHex))
+            {
+                styles.Add($"color: {rgbForegroundHex}");
+            }
+        }
+
+        if (newState.Ansi256BackgroundColorCode.HasValue)
+        {
+            var colorValue = newState.Ansi256BackgroundColorCode.Value;
+            if (TryGetXtermRgbHexColor(colorValue, out var rgbBackgroundHex))
+            {
+                styles.Add($"background-color: {rgbBackgroundHex}");
+            }
+        }
+
+        if (classes.Count > 0)
+        {
+            return closeSpanIfNeeded + $"<span class=\"{string.Join(" ", classes)}\">";
+        }
+
+        if (styles.Count > 0)
+        {
+            return closeSpanIfNeeded + $"<span style=\"{string.Join(";", styles)}\">";
+        }
+
+        return closeSpanIfNeeded;
     }
 
     private static string? GetForegroundColorClass(ParserState state)
@@ -213,9 +316,6 @@ public class AnsiParser
             _ => ""
         };
     }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsDigit(char c) => (uint)(c - '0') <= ('9' - '0');
 
     private static bool TryGetForegroundColor(int number, out ConsoleColor? color)
     {
@@ -251,11 +351,281 @@ public class AnsiParser
         return color != null || number == 49;
     }
 
+    private static bool TryGetXtermRgbHexColor(int number, out string? rgbHex)
+    {
+        rgbHex = number switch
+        {
+            0 => "#000000",
+            1 => "#800000",
+            2 => "#008000",
+            3 => "#808000",
+            4 => "#000080",
+            5 => "#800080",
+            6 => "#008080",
+            7 => "#c0c0c0",
+            8 => "#808080",
+            9 => "#ff0000",
+            10 => "#00ff00",
+            11 => "#ffff00",
+            12 => "#0000ff",
+            13 => "#ff00ff",
+            14 => "#00ffff",
+            15 => "#ffffff",
+            16 => "#000000",
+            17 => "#00005f",
+            18 => "#000087",
+            19 => "#0000af",
+            20 => "#0000d7",
+            21 => "#0000ff",
+            22 => "#005f00",
+            23 => "#005f5f",
+            24 => "#005f87",
+            25 => "#005faf",
+            26 => "#005fd7",
+            27 => "#005fff",
+            28 => "#008700",
+            29 => "#00875f",
+            30 => "#008787",
+            31 => "#0087af",
+            32 => "#0087d7",
+            33 => "#0087ff",
+            34 => "#00af00",
+            35 => "#00af5f",
+            36 => "#00af87",
+            37 => "#00afaf",
+            38 => "#00afd7",
+            39 => "#00afff",
+            40 => "#00d700",
+            41 => "#00d75f",
+            42 => "#00d787",
+            43 => "#00d7af",
+            44 => "#00d7d7",
+            45 => "#00d7ff",
+            46 => "#00ff00",
+            47 => "#00ff5f",
+            48 => "#00ff87",
+            49 => "#00ffaf",
+            50 => "#00ffd7",
+            51 => "#00ffff",
+            52 => "#5f0000",
+            53 => "#5f005f",
+            54 => "#5f0087",
+            55 => "#5f00af",
+            56 => "#5f00d7",
+            57 => "#5f00ff",
+            58 => "#5f5f00",
+            59 => "#5f5f5f",
+            60 => "#5f5f87",
+            61 => "#5f5faf",
+            62 => "#5f5fd7",
+            63 => "#5f5fff",
+            64 => "#5f8700",
+            65 => "#5f875f",
+            66 => "#5f8787",
+            67 => "#5f87af",
+            68 => "#5f87d7",
+            69 => "#5f87ff",
+            70 => "#5faf00",
+            71 => "#5faf5f",
+            72 => "#5faf87",
+            73 => "#5fafaf",
+            74 => "#5fafd7",
+            75 => "#5fafff",
+            76 => "#5fd700",
+            77 => "#5fd75f",
+            78 => "#5fd787",
+            79 => "#5fd7af",
+            80 => "#5fd7d7",
+            81 => "#5fd7ff",
+            82 => "#5fff00",
+            83 => "#5fff5f",
+            84 => "#5fff87",
+            85 => "#5fffaf",
+            86 => "#5fffd7",
+            87 => "#5fffff",
+            88 => "#870000",
+            89 => "#87005f",
+            90 => "#870087",
+            91 => "#8700af",
+            92 => "#8700d7",
+            93 => "#8700ff",
+            94 => "#875f00",
+            95 => "#875f5f",
+            96 => "#875f87",
+            97 => "#875faf",
+            98 => "#875fd7",
+            99 => "#875fff",
+            100 => "#878700",
+            101 => "#87875f",
+            102 => "#878787",
+            103 => "#8787af",
+            104 => "#8787d7",
+            105 => "#8787ff",
+            106 => "#87af00",
+            107 => "#87af5f",
+            108 => "#87af87",
+            109 => "#87afaf",
+            110 => "#87afd7",
+            111 => "#87afff",
+            112 => "#87d700",
+            113 => "#87d75f",
+            114 => "#87d787",
+            115 => "#87d7af",
+            116 => "#87d7d7",
+            117 => "#87d7ff",
+            118 => "#87ff00",
+            119 => "#87ff5f",
+            120 => "#87ff87",
+            121 => "#87ffaf",
+            122 => "#87ffd7",
+            123 => "#87ffff",
+            124 => "#af0000",
+            125 => "#af005f",
+            126 => "#af0087",
+            127 => "#af00af",
+            128 => "#af00d7",
+            129 => "#af00ff",
+            130 => "#af5f00",
+            131 => "#af5f5f",
+            132 => "#af5f87",
+            133 => "#af5faf",
+            134 => "#af5fd7",
+            135 => "#af5fff",
+            136 => "#af8700",
+            137 => "#af875f",
+            138 => "#af8787",
+            139 => "#af87af",
+            140 => "#af87d7",
+            141 => "#af87ff",
+            142 => "#afaf00",
+            143 => "#afaf5f",
+            144 => "#afaf87",
+            145 => "#afafaf",
+            146 => "#afafd7",
+            147 => "#afafff",
+            148 => "#afd700",
+            149 => "#afd75f",
+            150 => "#afd787",
+            151 => "#afd7af",
+            152 => "#afd7d7",
+            153 => "#afd7ff",
+            154 => "#afff00",
+            155 => "#afff5f",
+            156 => "#afff87",
+            157 => "#afffaf",
+            158 => "#afffd7",
+            159 => "#afffff",
+            160 => "#d70000",
+            161 => "#d7005f",
+            162 => "#d70087",
+            163 => "#d700af",
+            164 => "#d700d7",
+            165 => "#d700ff",
+            166 => "#d75f00",
+            167 => "#d75f5f",
+            168 => "#d75f87",
+            169 => "#d75faf",
+            170 => "#d75fd7",
+            171 => "#d75fff",
+            172 => "#d78700",
+            173 => "#d7875f",
+            174 => "#d78787",
+            175 => "#d787af",
+            176 => "#d787d7",
+            177 => "#d787ff",
+            178 => "#d7af00",
+            179 => "#d7af5f",
+            180 => "#d7af87",
+            181 => "#d7afaf",
+            182 => "#d7afd7",
+            183 => "#d7afff",
+            184 => "#d7d700",
+            185 => "#d7d75f",
+            186 => "#d7d787",
+            187 => "#d7d7af",
+            188 => "#d7d7d7",
+            189 => "#d7d7ff",
+            190 => "#d7ff00",
+            191 => "#d7ff5f",
+            192 => "#d7ff87",
+            193 => "#d7ffaf",
+            194 => "#d7ffd7",
+            195 => "#d7ffff",
+            196 => "#ff0000",
+            197 => "#ff005f",
+            198 => "#ff0087",
+            199 => "#ff00af",
+            200 => "#ff00d7",
+            201 => "#ff00ff",
+            202 => "#ff5f00",
+            203 => "#ff5f5f",
+            204 => "#ff5f87",
+            205 => "#ff5faf",
+            206 => "#ff5fd7",
+            207 => "#ff5fff",
+            208 => "#ff8700",
+            209 => "#ff875f",
+            210 => "#ff8787",
+            211 => "#ff87af",
+            212 => "#ff87d7",
+            213 => "#ff87ff",
+            214 => "#ffaf00",
+            215 => "#ffaf5f",
+            216 => "#ffaf87",
+            217 => "#ffafaf",
+            218 => "#ffafd7",
+            219 => "#ffafff",
+            220 => "#ffd700",
+            221 => "#ffd75f",
+            222 => "#ffd787",
+            223 => "#ffd7af",
+            224 => "#ffd7d7",
+            225 => "#ffd7ff",
+            226 => "#ffff00",
+            227 => "#ffff5f",
+            228 => "#ffff87",
+            229 => "#ffffaf",
+            230 => "#ffffd7",
+            231 => "#ffffff",
+            232 => "#080808",
+            233 => "#121212",
+            234 => "#1c1c1c",
+            235 => "#262626",
+            236 => "#303030",
+            237 => "#3a3a3a",
+            238 => "#444444",
+            239 => "#4e4e4e",
+            240 => "#585858",
+            241 => "#626262",
+            242 => "#6c6c6c",
+            243 => "#767676",
+            244 => "#808080",
+            245 => "#8a8a8a",
+            246 => "#949494",
+            247 => "#9e9e9e",
+            248 => "#a8a8a8",
+            249 => "#b2b2b2",
+            250 => "#bcbcbc",
+            251 => "#c6c6c6",
+            252 => "#d0d0d0",
+            253 => "#dadada",
+            254 => "#e4e4e4",
+            255 => "#eeeeee",
+            _ => null
+        };
+
+        return rgbHex != null;
+    }
+
     public record struct ParserState
     {
         public ConsoleColor? ForegroundColor { get; set; }
         public ConsoleColor? BackgroundColor { get; set; }
+        public int? Ansi256ForegroundColorCode { get; set; }
+        public int? Ansi256BackgroundColorCode { get; set; }
         public bool Bright { get; set; }
+        public bool Underline { get; set; }
+        public bool Italic { get; set; }
     }
 
     public readonly record struct ConversionResult(string? ConvertedText, ParserState ResidualState);

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/AnsiParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/AnsiParserTests.cs
@@ -231,7 +231,7 @@ public class AnsiParserTests
     [InlineData("\x1B[38;5;231mtext", "<span style=\"color: #ffffff\">text</span>")]
     [InlineData("\x1B[38;5;255mtext", "<span style=\"color: #eeeeee\">text</span>")]
     [InlineData("\x1B[38;5;0mtext", "<span style=\"color: #000000\">text</span>")]
-    public void ConvertToHtml_HandlesForegroundAnsi256ColorCode(string input, string expectedOutput)
+    public void ConvertToHtml_HandlesForegroundXtermColorCode(string input, string expectedOutput)
     {
         var result = AnsiParser.ConvertToHtml(input);
 
@@ -245,7 +245,28 @@ public class AnsiParserTests
     [InlineData("\x1B[48;5;231mtext", "<span style=\"background-color: #ffffff\">text</span>")]
     [InlineData("\x1B[48;5;255mtext", "<span style=\"background-color: #eeeeee\">text</span>")]
     [InlineData("\x1B[48;5;0mtext", "<span style=\"background-color: #000000\">text</span>")]
-    public void ConvertToHtml_HandlesBackgroundAnsi256ColorCode(string input, string expectedOutput)
+    public void ConvertToHtml_HandlesBackgroundXtermColorCode(string input, string expectedOutput)
+    {
+        var result = AnsiParser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+    }
+
+    [Theory]
+    [InlineData("\x1B[4;38;5;100mtext", "<span class=\"ansi-underline\" style=\"color: #878700\">text</span>")]
+    [InlineData("\x1B[4;9;38;5;100mtext", "<span class=\"ansi-underline ansi-strikethrough\" style=\"color: #878700\">text</span>")]
+    public void ConvertToHtml_HandlesCombinedXtermColorAndModes(string input, string expectedOutput)
+    {
+        var result = AnsiParser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+    }
+
+    [Theory]
+    [InlineData("\x1B[3mtext", "<span class=\"ansi-italic\">text</span>")]
+    [InlineData("\x1B[4mtext", "<span class=\"ansi-underline\">text</span>")]
+    [InlineData("\x1B[9mtext", "<span class=\"ansi-strikethrough\">text</span>")]
+    public void ConvertToHtml_HandlesModes(string input, string expectedOutput)
     {
         var result = AnsiParser.ConvertToHtml(input);
 

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/AnsiParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/AnsiParserTests.cs
@@ -213,4 +213,52 @@ public class AnsiParserTests
         Assert.Equal(expectedOutput, result.ConvertedText);
         Assert.Equal(expectedResidualState, result.ResidualState);
     }
+
+    [Fact]
+    public void ConvertToHtml_HandlesMultipleParameterInSingleEscape()
+    {
+        var input = "\x1B[31;42;3;4mThis text is red, italic and underlined.";
+        var expectedOutput = "<span class=\"ansi-fg-red ansi-bg-green ansi-underline ansi-italic\">This text is red, italic and underlined.</span>";
+        var result = AnsiParser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+    }
+
+    [Theory]
+    [InlineData("\x1B[38;5;100mtext", "<span style=\"color: #878700\">text</span>")]
+    [InlineData("\x1B[38;5;200mtext", "<span style=\"color: #ff00d7\">text</span>")]
+    [InlineData("\x1B[38;5;245mtext", "<span style=\"color: #8a8a8a\">text</span>")]
+    [InlineData("\x1B[38;5;231mtext", "<span style=\"color: #ffffff\">text</span>")]
+    [InlineData("\x1B[38;5;255mtext", "<span style=\"color: #eeeeee\">text</span>")]
+    [InlineData("\x1B[38;5;0mtext", "<span style=\"color: #000000\">text</span>")]
+    public void ConvertToHtml_HandlesForegroundAnsi256ColorCode(string input, string expectedOutput)
+    {
+        var result = AnsiParser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+    }
+
+    [Theory]
+    [InlineData("\x1B[48;5;100mtext", "<span style=\"background-color: #878700\">text</span>")]
+    [InlineData("\x1B[48;5;200mtext", "<span style=\"background-color: #ff00d7\">text</span>")]
+    [InlineData("\x1B[48;5;245mtext", "<span style=\"background-color: #8a8a8a\">text</span>")]
+    [InlineData("\x1B[48;5;231mtext", "<span style=\"background-color: #ffffff\">text</span>")]
+    [InlineData("\x1B[48;5;255mtext", "<span style=\"background-color: #eeeeee\">text</span>")]
+    [InlineData("\x1B[48;5;0mtext", "<span style=\"background-color: #000000\">text</span>")]
+    public void ConvertToHtml_HandlesBackgroundAnsi256ColorCode(string input, string expectedOutput)
+    {
+        var result = AnsiParser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+    }
+
+    [Fact]
+    public void ConvertToHtml_HandlesInvalidAnsi256ColorCode()
+    {
+        var input = "\x1B[38;5;300mInvalid color\x1B[0m";
+        var expectedOutput = "Invalid color";
+        var result = AnsiParser.ConvertToHtml(input);
+
+        Assert.Equal(expectedOutput, result.ConvertedText);
+    }
 }


### PR DESCRIPTION
Solves #2838

- Adds support for multiple ANSI arguments in one escape sequence
- Adds support for Xterm colors (256)
- Adds support for italic, underline and strikethrough
- Adds support to handle hyperlinks ([OSC 8](https://github.com/Alhadis/OSC8-Adoption/blob/master/README.md))
  Removes the label and only keeps the actual URL
  `\x1B]8;;http://example.com\x1B\\This is a link\x1B]8;;\x1B\\` -> `http://example.com` 

In RabbitMQ logs
![image](https://github.com/user-attachments/assets/a6c40f82-841f-46f8-a103-121d6701824f)

In ConsoleStresser
![image](https://github.com/user-attachments/assets/71f5cf22-fbc9-4c6b-853c-ccf40bdb0c7c)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5081)