### PR TITLE
DRAFT: Pubsub eventing model in app model.

### DIFF
--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -345,13 +345,11 @@ public class DistributedApplication : IHost, IAsyncDisposable
 
         try
         {
-            var lifecycleHooks = _host.Services.GetServices<IDistributedApplicationLifecycleHook>();
+            var lifecycleEventPublisher = _host.Services.GetRequiredService<ILifecycleEventPublisher>();
             var appModel = _host.Services.GetRequiredService<DistributedApplicationModel>();
 
-            foreach (var lifecycleHook in lifecycleHooks)
-            {
-                await lifecycleHook.BeforeStartAsync(appModel, cancellationToken).ConfigureAwait(false);
-            }
+            var beforeStartEvent = new BeforeStartLifecycleEvent(appModel);
+            await lifecycleEventPublisher.PublishAsync(beforeStartEvent, cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -203,6 +203,21 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                     );
                 }
 
+                // Lifecycle event pub/sub.
+                _innerBuilder.Services.AddSingleton<ILifecycleEventPublisher, LifecycleEventPublisher>();
+
+                // ... replace direct calls to BeforeStartAync(...);
+                _innerBuilder.Services.AddSingleton<ILifecycleEventDispatcher<BeforeStartLifecycleEvent>, BeforeStartLifecycleEventHandler>();
+                _innerBuilder.Services.AddSingleton<ILifecycleEventSubscriber<BeforeStartLifecycleEvent>, LegacyBeforeStartLifecycleHookSubscriber>();
+
+                // ... replace direct calls to AfterEndpointsAllocatedAync(...);
+                _innerBuilder.Services.AddSingleton<ILifecycleEventDispatcher<AfterEndpointsAllocatedLifecycleEvent>, AfterEndpointsAllocatedLifecycleEventHandler>();
+                _innerBuilder.Services.AddSingleton<ILifecycleEventSubscriber<AfterEndpointsAllocatedLifecycleEvent>, LegacyAfterEndpointsAllocatedLifecycleHookSubscriber>();
+
+                // ... replace direct calls to AfterResourcesCreatedAync(...);
+                _innerBuilder.Services.AddSingleton<ILifecycleEventDispatcher<AfterResourcesCreatedLifecycleEvent>, AfterResourcesCreatedLifecycleEventHandler>();
+                _innerBuilder.Services.AddSingleton<ILifecycleEventSubscriber<AfterResourcesCreatedLifecycleEvent>, LegacyAfterResourcesCreatedLifecycleHookSubscriber>();
+
                 _innerBuilder.Services.AddOptions<TransportOptions>().ValidateOnStart().PostConfigure(MapTransportOptionsFromCustomKeys);
                 _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<TransportOptions>, TransportOptionsValidator>());
                 _innerBuilder.Services.AddSingleton<DashboardServiceHost>();

--- a/src/Aspire.Hosting/Lifecycle/AfterEndpointsAllocatedLifecycleEvent.cs
+++ b/src/Aspire.Hosting/Lifecycle/AfterEndpointsAllocatedLifecycleEvent.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Lifecycle;
+
+/// <summary>
+/// TODO:
+/// </summary>
+/// <param name="model"></param>
+public class AfterEndpointsAllocatedLifecycleEvent(DistributedApplicationModel model) : ILifecycleEvent
+{
+    /// <summary>
+    /// TODO:
+    /// </summary>
+    public DistributedApplicationModel Model { get; } = model;
+}

--- a/src/Aspire.Hosting/Lifecycle/AfterEndpointsAllocatedLifecycleEventHandler.cs
+++ b/src/Aspire.Hosting/Lifecycle/AfterEndpointsAllocatedLifecycleEventHandler.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Lifecycle;
+
+internal class AfterEndpointsAllocatedLifecycleEventHandler(IEnumerable<ILifecycleEventSubscriber<AfterEndpointsAllocatedLifecycleEvent>> subscribers) : ILifecycleEventDispatcher<AfterEndpointsAllocatedLifecycleEvent>
+{
+    public async Task DispatchAsync(AfterEndpointsAllocatedLifecycleEvent lifecycleEvent, CancellationToken cancellationToken)
+    {
+        foreach (var subscriber in subscribers)
+        {
+            await subscriber.HandleAsync(lifecycleEvent, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Aspire.Hosting/Lifecycle/AfterResourcesCreatedLifecycleEvent.cs
+++ b/src/Aspire.Hosting/Lifecycle/AfterResourcesCreatedLifecycleEvent.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Lifecycle;
+
+/// <summary>
+/// TODO:
+/// </summary>
+public class AfterResourcesCreatedLifecycleEvent(DistributedApplicationModel model) : ILifecycleEvent
+{
+    /// <summary>
+    /// TODO:
+    /// </summary>
+    public DistributedApplicationModel Model { get; } = model;
+}

--- a/src/Aspire.Hosting/Lifecycle/AfterResourcesCreatedLifecycleEventHandler.cs
+++ b/src/Aspire.Hosting/Lifecycle/AfterResourcesCreatedLifecycleEventHandler.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Lifecycle;
+
+internal class AfterResourcesCreatedLifecycleEventHandler(IEnumerable<ILifecycleEventSubscriber<AfterResourcesCreatedLifecycleEvent>> subscribers) : ILifecycleEventDispatcher<AfterResourcesCreatedLifecycleEvent>
+{
+    public async Task DispatchAsync(AfterResourcesCreatedLifecycleEvent lifecycleEvent, CancellationToken cancellationToken)
+    {
+        foreach (var subscriber in subscribers)
+        {
+            await subscriber.HandleAsync(lifecycleEvent, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Aspire.Hosting/Lifecycle/BeforeStartLifecycleEvent.cs
+++ b/src/Aspire.Hosting/Lifecycle/BeforeStartLifecycleEvent.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Lifecycle;
+
+/// <summary>
+/// TODO:
+/// </summary>
+public class BeforeStartLifecycleEvent(DistributedApplicationModel model) : ILifecycleEvent
+{
+    /// <summary>
+    /// TODO:
+    /// </summary>
+    public DistributedApplicationModel Model { get; } = model;
+}

--- a/src/Aspire.Hosting/Lifecycle/BeforeStartLifecycleEventHandler.cs
+++ b/src/Aspire.Hosting/Lifecycle/BeforeStartLifecycleEventHandler.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Lifecycle;
+
+internal class BeforeStartLifecycleEventHandler(IEnumerable<ILifecycleEventSubscriber<BeforeStartLifecycleEvent>> subscribers) : ILifecycleEventDispatcher<BeforeStartLifecycleEvent>
+{
+    public async Task DispatchAsync(BeforeStartLifecycleEvent lifecycleEvent, CancellationToken cancellationToken)
+    {
+        foreach (var subscriber in subscribers)
+        {
+            await subscriber.HandleAsync(lifecycleEvent, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Aspire.Hosting/Lifecycle/ILifecycleEventPublisher.cs
+++ b/src/Aspire.Hosting/Lifecycle/ILifecycleEventPublisher.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Aspire.Hosting.Lifecycle;
+
+/// <summary>
+/// TODO:
+/// </summary>
+public interface ILifecycleEventDispatcher<TLifecycleEvent> where TLifecycleEvent : ILifecycleEvent
+{
+    /// <summary>
+    /// TODO:
+    /// </summary>
+    /// <param name="lifecycleEvent"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task DispatchAsync(TLifecycleEvent lifecycleEvent, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// TODO:
+/// </summary>
+public interface ILifecycleEventPublisher
+{
+    /// <summary>
+    /// TODO:
+    /// </summary>
+    /// <typeparam name="TLifecycleEvent"></typeparam>
+    /// <param name="lifecycleEvent"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task PublishAsync<TLifecycleEvent>(TLifecycleEvent lifecycleEvent, CancellationToken cancellationToken) where TLifecycleEvent : class, ILifecycleEvent;
+}
+
+/// <summary>
+/// TODO:
+/// </summary>
+public interface ILifecycleEvent
+{
+}
+
+/// <summary>
+/// TODO:
+/// </summary>
+/// <typeparam name="TLifecycleEvent"></typeparam>
+public interface ILifecycleEventSubscriber<TLifecycleEvent> where TLifecycleEvent : class, ILifecycleEvent
+{
+    /// <summary>
+    /// TODO:
+    /// </summary>
+    /// <param name="lifecycleEvent"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task HandleAsync(TLifecycleEvent lifecycleEvent, CancellationToken cancellationToken);
+}
+
+internal class LifecycleEventPublisher(IServiceProvider serviceProvider) : ILifecycleEventPublisher
+{
+    private readonly Dictionary<Type, Func<ILifecycleEvent, CancellationToken, Task>> _lifecycleEventHandlerDispatcherCallbacks = new();
+
+    public Task PublishAsync<TLifecycleEvent>(TLifecycleEvent lifecycleEvent, CancellationToken cancellationToken) where TLifecycleEvent : class, ILifecycleEvent
+    {
+        Func<ILifecycleEvent, CancellationToken, Task>? dispatcherCallback;
+
+        if (!_lifecycleEventHandlerDispatcherCallbacks.TryGetValue(typeof(TLifecycleEvent), out dispatcherCallback))
+        {
+            var dispatcher = serviceProvider.GetRequiredService<ILifecycleEventDispatcher<TLifecycleEvent>>();
+
+            dispatcherCallback = async (ILifecycleEvent lifecycleEvent, CancellationToken cancellationToken) =>
+            {
+                await dispatcher.DispatchAsync((TLifecycleEvent)lifecycleEvent, cancellationToken).ConfigureAwait(false);
+            };
+        }
+
+        return dispatcherCallback.Invoke(lifecycleEvent, cancellationToken);
+    }
+}

--- a/src/Aspire.Hosting/Lifecycle/LegacyAfterEndpointsAllocatedLifecycleHookSubscriber.cs
+++ b/src/Aspire.Hosting/Lifecycle/LegacyAfterEndpointsAllocatedLifecycleHookSubscriber.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Lifecycle;
+
+internal class LegacyAfterEndpointsAllocatedLifecycleHookSubscriber(IEnumerable<IDistributedApplicationLifecycleHook> lifecycleHooks) : ILifecycleEventSubscriber<AfterEndpointsAllocatedLifecycleEvent>
+{
+    public async Task HandleAsync(AfterEndpointsAllocatedLifecycleEvent lifecycleEvent, CancellationToken cancellationToken)
+    {
+        foreach (var lifecycleHook in lifecycleHooks)
+        {
+            await lifecycleHook.AfterEndpointsAllocatedAsync(lifecycleEvent.Model, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Aspire.Hosting/Lifecycle/LegacyAfterResourcesCreatedLifecycleHookSubscriber.cs
+++ b/src/Aspire.Hosting/Lifecycle/LegacyAfterResourcesCreatedLifecycleHookSubscriber.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Lifecycle;
+
+internal class LegacyAfterResourcesCreatedLifecycleHookSubscriber(IEnumerable<IDistributedApplicationLifecycleHook> lifecycleHooks) : ILifecycleEventSubscriber<AfterResourcesCreatedLifecycleEvent>
+{
+    public async Task HandleAsync(AfterResourcesCreatedLifecycleEvent lifecycleEvent, CancellationToken cancellationToken)
+    {
+        foreach (var lifecycleHook in lifecycleHooks)
+        {
+            await lifecycleHook.AfterResourcesCreatedAsync(lifecycleEvent.Model, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Aspire.Hosting/Lifecycle/LegacyBeforeStartLifecycleHookSubscriber.cs
+++ b/src/Aspire.Hosting/Lifecycle/LegacyBeforeStartLifecycleHookSubscriber.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Lifecycle;
+
+internal class LegacyBeforeStartLifecycleHookSubscriber(IEnumerable<IDistributedApplicationLifecycleHook> lifecycleHooks) : ILifecycleEventSubscriber<BeforeStartLifecycleEvent>
+{
+    public async Task HandleAsync(BeforeStartLifecycleEvent lifecycleEvent, CancellationToken cancellationToken)
+    {
+        foreach (var lifecycleHook in lifecycleHooks)
+        {
+            await lifecycleHook.BeforeStartAsync(lifecycleEvent.Model, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -1,4 +1,20 @@
 #nullable enable
+Aspire.Hosting.Lifecycle.AfterEndpointsAllocatedLifecycleEvent
+Aspire.Hosting.Lifecycle.AfterEndpointsAllocatedLifecycleEvent.AfterEndpointsAllocatedLifecycleEvent(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model) -> void
+Aspire.Hosting.Lifecycle.AfterEndpointsAllocatedLifecycleEvent.Model.get -> Aspire.Hosting.ApplicationModel.DistributedApplicationModel!
+Aspire.Hosting.Lifecycle.AfterResourcesCreatedLifecycleEvent
+Aspire.Hosting.Lifecycle.AfterResourcesCreatedLifecycleEvent.AfterResourcesCreatedLifecycleEvent(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model) -> void
+Aspire.Hosting.Lifecycle.AfterResourcesCreatedLifecycleEvent.Model.get -> Aspire.Hosting.ApplicationModel.DistributedApplicationModel!
+Aspire.Hosting.Lifecycle.BeforeStartLifecycleEvent
+Aspire.Hosting.Lifecycle.BeforeStartLifecycleEvent.BeforeStartLifecycleEvent(Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model) -> void
+Aspire.Hosting.Lifecycle.BeforeStartLifecycleEvent.Model.get -> Aspire.Hosting.ApplicationModel.DistributedApplicationModel!
+Aspire.Hosting.Lifecycle.ILifecycleEvent
+Aspire.Hosting.Lifecycle.ILifecycleEventDispatcher<TLifecycleEvent>
+Aspire.Hosting.Lifecycle.ILifecycleEventDispatcher<TLifecycleEvent>.DispatchAsync(TLifecycleEvent lifecycleEvent, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Aspire.Hosting.Lifecycle.ILifecycleEventPublisher
+Aspire.Hosting.Lifecycle.ILifecycleEventPublisher.PublishAsync<TLifecycleEvent>(TLifecycleEvent! lifecycleEvent, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Aspire.Hosting.Lifecycle.ILifecycleEventSubscriber<TLifecycleEvent>
+Aspire.Hosting.Lifecycle.ILifecycleEventSubscriber<TLifecycleEvent>.HandleAsync(TLifecycleEvent! lifecycleEvent, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 static Aspire.Hosting.ApplicationModel.ResourceExtensions.GetEnvironmentVariableValuesAsync(this Aspire.Hosting.ApplicationModel.IResourceWithEnvironment! resource, Aspire.Hosting.DistributedApplicationOperation applicationOperation = Aspire.Hosting.DistributedApplicationOperation.Run) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.Dictionary<string!, string!>!>
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, string? targetState = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!


### PR DESCRIPTION
This is a spike on introducing a pub/sub eventing model in the app model. At the moment I've built some infrastructure and used it to bridge the existing lifecycle hook subscriber infrastructure (so lifecycle hooks are just implemented on top of this new model).

Some explanatory notes:

1. Events all implement `ILifecycleEvent`. This allows for some generic constraints in various places to support resolution of event subscribers based on the event type they subscribe to.
2. There is a single "publisher" API ... `ILifecycleEventPublisher`. The purpose of the implementor of this is to take an event and make sure it finds its way to all the subscribers.
3. Dispatchers (e.g. `AfterEndpointsAllocatedEventDispatcher` which implements `ILifechcleEventDispatcher<TLifecycleEvent>`. This is provided by the code that defines an event type. The purpose of this type is to allow some processing of subscribers before sending the event to them. For example if you want to route an event to a specific subscriber because that subscriber is explicitly wired to dispatch events for a particular resource then this optimization can happen here. I'm not 100% on this abstraction yet other than I think we'll need something like it.
4. ILifecycleEventSubscriber<TLifecycleEvent>; implemented by subscribers to events and injected into DI.

Here is the way someone would start publishing a new event:

1. Define a class that implements `ILifecycleEvent`.
2. Define a "handler" that implements `ILifecycleEventDispatcher<T>` and register it to DI - add any custom processing logic to `DispatchAsync(...)`.
3. Define a custom subscriber interface that derives from `ILifecycleEventSubscriber<T>` and adds any additional properties. For example if you wanted a subscriber model that worked per-resource you would expose a resource property on this subscriber which is then implemented by the subscribers concrete implementation. The dispatcher logic could then query that and make sure that the event is routed to the right place without having to call every single subscriber.

We could probably optimize this a bit by having some base implementations of these boilerplate bits.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5104)