### PR TITLE
[tests] Use test container registry for RabbitMQ testcontainer

### DIFF
--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using Aspire.Components.Common.Tests;
+using Aspire.Hosting.RabbitMQ;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -27,7 +28,9 @@ public class AspireRabbitMQLoggingTests
     [RequiresDocker]
     public async Task EndToEndLoggingTest()
     {
-        await using var rabbitMqContainer = new RabbitMqBuilder().Build();
+        await using var rabbitMqContainer = new RabbitMqBuilder()
+            .WithImage($"{TestConstants.AspireTestContainerRegistry}/{RabbitMQContainerImageTags.Image}:{RabbitMQContainerImageTags.Tag}")
+            .Build();
         await rabbitMqContainer.StartAsync();
 
         var builder = Host.CreateEmptyApplicationBuilder(null);


### PR DESCRIPTION
.. instead of the default from `docker.com`.

```
  Failed Aspire.RabbitMQ.Client.Tests.AspireRabbitMQLoggingTests.EndToEndLoggingTest [6 s]
  Error Message:
   Docker.DotNet.DockerApiException : Docker API responded with status code=InternalServerError, response={"message":"toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"}

  Stack Trace:
     at Docker.DotNet.DockerClient.HandleIfErrorResponseAsync(HttpStatusCode statusCode, HttpResponseMessage response)
   at Docker.DotNet.DockerClient.MakeRequestForRawResponseAsync(HttpMethod method, String path, IQueryString queryString, IRequestContent body, IDictionary`2 headers, CancellationToken token)
   at Docker.DotNet.Models.StreamUtil.MonitorResponseForMessagesAsync[T](Task`1 responseTask, DockerClient client, CancellationToken cancel, IProgress`1 progress)
   at DotNet.Testcontainers.Clients.DockerImageOperations.CreateAsync(IImage image, IDockerRegistryAuthenticationConfiguration dockerRegistryAuthConfig, CancellationToken ct) in /_/src/Testcontainers/Clients/DockerImageOperations.cs:line 74
   at DotNet.Testcontainers.Clients.TestcontainersClient.PullImageAsync(IImage image, CancellationToken ct) in /_/src/Testcontainers/Clients/TestcontainersClient.cs:line 375
   at DotNet.Testcontainers.Clients.TestcontainersClient.RunAsync(IContainerConfiguration configuration, CancellationToken ct) in /_/src/Testcontainers/Clients/TestcontainersClient.cs:line 303
   at DotNet.Testcontainers.Containers.DockerContainer.UnsafeCreateAsync(CancellationToken ct) in /_/src/Testcontainers/Containers/DockerContainer.cs:line 413
   at DotNet.Testcontainers.Containers.DockerContainer.StartAsync(CancellationToken ct) in /_/src/Testcontainers/Containers/DockerContainer.cs:line 277
   at Aspire.RabbitMQ.Client.Tests.AspireRabbitMQLoggingTests.EndToEndLoggingTest() in /_/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs:line 31
   at Aspire.RabbitMQ.Client.Tests.AspireRabbitMQLoggingTests.EndToEndLoggingTest() in /_/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs:line 65
--- End of stack trace from previous location ---
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5114)