### PR TITLE
Redirect to homepage if login page is requested when token auth is not enabled

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(MicrosoftAspNetCoreOpenApiPackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.OutputCaching.StackExchangeRedis" Version="$(MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreTestHostPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftExtensionsCachingStackExchangeRedisPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion)" />
@@ -147,6 +148,7 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="$(MicrosoftExtensionsDiagnosticsTestingPackageVersion)" />
     <PackageVersion Include="Microsoft.NET.Runtime.WorkloadTesting.Internal" Version="$(MicrosoftNETRuntimeWorkloadTestingInternalVersion)" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.45.0" />
+    <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageVersion Include="Testcontainers.MongoDb" Version="$(TestcontainersPackageVersion)" />
     <PackageVersion Include="Testcontainers.MsSql" Version="$(TestcontainersPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -148,7 +148,6 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="$(MicrosoftExtensionsDiagnosticsTestingPackageVersion)" />
     <PackageVersion Include="Microsoft.NET.Runtime.WorkloadTesting.Internal" Version="$(MicrosoftNETRuntimeWorkloadTestingInternalVersion)" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.45.0" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageVersion Include="Testcontainers.MongoDb" Version="$(TestcontainersPackageVersion)" />
     <PackageVersion Include="Testcontainers.MsSql" Version="$(TestcontainersPackageVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -49,6 +49,7 @@
     <MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>8.0.7</MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>
     <MicrosoftAspNetCoreOpenApiPackageVersion>8.0.7</MicrosoftAspNetCoreOpenApiPackageVersion>
     <MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion>8.0.7</MicrosoftAspNetCoreOutputCachingStackExchangeRedisPackageVersion>
+    <MicrosoftAspNetCoreTestHostPackageVersion>8.0.7</MicrosoftAspNetCoreTestHostPackageVersion>
     <MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>8.0.7</MicrosoftExtensionsCachingStackExchangeRedisPackageVersion>
     <MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>8.0.7</MicrosoftExtensionsDiagnosticsHealthChecksEntityFrameworkCorePackageVersion>
     <MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>8.0.7</MicrosoftExtensionsDiagnosticsHealthChecksPackageVersion>

--- a/playground/TestShop/AppHost/Properties/launchSettings.json
+++ b/playground/TestShop/AppHost/Properties/launchSettings.json
@@ -26,7 +26,9 @@
         "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16032",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17031",
         "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "Dashboard:Frontend:AuthMode": "Unsecured",
+        "DASHBOARD__FRONTEND__AUTHMODE": "Unsecured"
       }
     },
     "generate-manifest": {

--- a/playground/TestShop/AppHost/Properties/launchSettings.json
+++ b/playground/TestShop/AppHost/Properties/launchSettings.json
@@ -26,9 +26,7 @@
         "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16032",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17031",
         "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
-        "Dashboard:Frontend:AuthMode": "Unsecured",
-        "DASHBOARD__FRONTEND__AUTHMODE": "Unsecured"
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     },
     "generate-manifest": {

--- a/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
+++ b/src/Aspire.Dashboard/Model/ValidateTokenMiddleware.cs
@@ -65,6 +65,7 @@ internal sealed class ValidateTokenMiddleware
 
         await _next(context).ConfigureAwait(false);
     }
+
     private static void RedirectAfterValidation(HttpContext context)
     {
         if (context.Request.Query.TryGetValue("returnUrl", out var returnUrl))

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Grpc.Tools" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
-    <PackageReference Include="NSubstitute" />
 
     <ProjectReference Include="..\..\src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
 

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -15,6 +15,8 @@
   <ItemGroup>
     <PackageReference Include="Grpc.Tools" />
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="NSubstitute" />
 
     <ProjectReference Include="..\..\src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
 

--- a/tests/Aspire.Dashboard.Tests/Middleware/ValidateTokenMiddlewareTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Middleware/ValidateTokenMiddlewareTests.cs
@@ -25,7 +25,7 @@ public class ValidateTokenMiddlewareTests
     }
 
     [Fact]
-    public async Task ValidateToken_NotBrowserTokenAuth_RedirectedToHomepage_ReturnUrl()
+    public async Task ValidateToken_NotBrowserTokenAuth_RedirectedToReturnUrl()
     {
         using var host = await SetUpHostAsync(FrontendAuthMode.Unsecured, string.Empty);
         var response = await host.GetTestClient().GetAsync("/login?t=test&returnUrl=/test");
@@ -57,7 +57,7 @@ public class ValidateTokenMiddlewareTests
     }
 
     [Fact]
-    public async Task ValidateToken_BrowserTokenAuth_RightToken_RedirectsToHome_WithReturnUrl()
+    public async Task ValidateToken_BrowserTokenAuth_RightToken_RedirectsToReturnUrl()
     {
         using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token");
         var response = await host.GetTestClient().GetAsync("/login?t=token&returnUrl=/test");

--- a/tests/Aspire.Dashboard.Tests/Middleware/ValidateTokenMiddlewareTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Middleware/ValidateTokenMiddlewareTests.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Middleware;
+
+public class ValidateTokenMiddlewareTests
+{
+    [Fact]
+    public async Task ValidateToken_NotBrowserTokenAuth_RedirectedToHomepage()
+    {
+        using var host = await SetUpHostAsync(FrontendAuthMode.Unsecured, string.Empty);
+        var response = await host.GetTestClient().GetAsync("/login?t=test");
+        Assert.Equal("/", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task ValidateToken_NotBrowserTokenAuth_RedirectedToHomepage_ReturnUrl()
+    {
+        using var host = await SetUpHostAsync(FrontendAuthMode.Unsecured, string.Empty);
+        var response = await host.GetTestClient().GetAsync("/login?t=test&returnUrl=/test");
+        Assert.Equal("/test", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task ValidateToken_BrowserTokenAuth_WrongToken_RedirectsToLogin()
+    {
+        using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token");
+        var response = await host.GetTestClient().GetAsync("/login?t=wrong");
+        Assert.Equal("/login", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task ValidateToken_BrowserTokenAuth_WrongToken_RedirectsToLogin_WithReturnUrl()
+    {
+        using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token");
+        var response = await host.GetTestClient().GetAsync("/login?t=wrong&returnUrl=/test");
+        Assert.Equal("/login?returnUrl=%2ftest", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task ValidateToken_BrowserTokenAuth_RightToken_RedirectsToHome()
+    {
+        using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token");
+        var response = await host.GetTestClient().GetAsync("/login?t=token");
+        Assert.Equal("/", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task ValidateToken_BrowserTokenAuth_RightToken_RedirectsToHome_WithReturnUrl()
+    {
+        using var host = await SetUpHostAsync(FrontendAuthMode.BrowserToken, "token");
+        var response = await host.GetTestClient().GetAsync("/login?t=token&returnUrl=/test");
+        Assert.Equal("/test", response.Headers.Location?.OriginalString);
+    }
+
+    private static async Task<IHost> SetUpHostAsync(FrontendAuthMode authMode, string expectedToken)
+    {
+        return await new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddRouting();
+                        services.AddAuthentication().AddCookie();
+                        services.AddSingleton(GetOptionsMonitorMock(authMode, expectedToken));
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseMiddleware<ValidateTokenMiddleware>();
+                    });
+            })
+            .StartAsync();
+    }
+
+    private static IOptionsMonitor<DashboardOptions> GetOptionsMonitorMock(FrontendAuthMode authMode, string expectedToken)
+    {
+        var options = new DashboardOptions
+        {
+            Frontend = new FrontendOptions
+            {
+                AuthMode = authMode,
+                BrowserToken = expectedToken,
+                EndpointUrls = "http://localhost" // required for TryParseOptions
+            }
+        };
+
+        Assert.True(options.Frontend.TryParseOptions(out _));
+
+        var optionsMonitor = Substitute.For<IOptionsMonitor<DashboardOptions>>();
+        optionsMonitor.CurrentValue.Returns(options);
+
+        return optionsMonitor;
+    }
+}


### PR DESCRIPTION
Looping in a wider range of reviewers because this is modifying a sensitive code path. Fixes #3775 by redirecting if the requested path equals `/login` and auth mode is not `token`, including when the token query parameter (`t`) is not included in the URL.

demo, token auth NOT enabled:

https://github.com/user-attachments/assets/5ff07fa4-85d8-43d6-a7fb-9099a22bfe1a

demo, token auth enabled (login page still shows and works as normal)

https://github.com/user-attachments/assets/48c1e978-70d5-48e1-bb39-8ad447d70e3c


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5123)