### PR TITLE
Fix up first column unit on trace detail

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -141,8 +141,9 @@
                             <TemplateColumn>
                                 <HeaderCellItemTemplate>
                                     <div class="ticks">
+                                        @* First column starts at 0. We don't want to display the smallest unit (0μs) because that looks odd. Use the unit from the next column *@
                                         <div class="tick" style="grid-column: 1;"></div>
-                                        <span class="tick-label" style="grid-column: 1;">@DurationFormatter.FormatDuration(TimeSpan.Zero)</span>
+                                        <span class="tick-label" style="grid-column: 1;">@($"0{DurationFormatter.GetUnit(trace.Duration / 4)}")</span>
 
                                         <div class="tick" style="grid-column: 2;"></div>
                                         <span class="tick-label" style="grid-column: 2;">@DurationFormatter.FormatDuration(trace.Duration / 4)</span>

--- a/src/Aspire.Dashboard/Otlp/Model/DurationFormatter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/DurationFormatter.cs
@@ -1,10 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace Aspire.Dashboard.Otlp.Model;
 
 public static class DurationFormatter
 {
+    [DebuggerDisplay("Unit = {Unit}, Ticks = {Ticks}, IsDecimal = {IsDecimal}")]
     private sealed class UnitStep
     {
         public required string Unit { get; init; }

--- a/src/Aspire.Dashboard/Otlp/Model/DurationFormatter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/DurationFormatter.cs
@@ -28,12 +28,6 @@ public static class DurationFormatter
         var ofPrevious = primaryUnit.Ticks / secondaryUnit.Ticks;
         var ticks = (double)duration.Ticks;
 
-        // Special case time 0 to not display any unit, as "0μs" looks quirky
-        if (ticks == 0)
-        {
-            return "0";
-        }
-
         if (primaryUnit.IsDecimal)
         {
             // If the unit is decimal based, display as a decimal
@@ -46,6 +40,16 @@ public static class DurationFormatter
         var secondaryUnitString = $"{secondaryValue}{secondaryUnit.Unit}";
 
         return secondaryValue == 0 ? primaryUnitString : $"{primaryUnitString} {secondaryUnitString}";
+    }
+
+    public static string GetUnit(TimeSpan duration)
+    {
+        var (primaryUnit, secondaryUnit) = ResolveUnits(duration.Ticks);
+        if (primaryUnit.IsDecimal)
+        {
+            return primaryUnit.Unit;
+        }
+        return secondaryUnit.Unit;
     }
 
     private static (UnitStep, UnitStep) ResolveUnits(long ticks)

--- a/tests/Aspire.Dashboard.Tests/DurationFormatterTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DurationFormatterTests.cs
@@ -9,6 +9,20 @@ namespace Aspire.Dashboard.Tests;
 
 public class DurationFormatterTests
 {
+    [Theory]
+    [InlineData(0, "μs")]
+    [InlineData(1, "μs")]
+    [InlineData(1_000, "μs")]
+    [InlineData(1_000_000, "ms")]
+    [InlineData(1_000_000_000, "s")]
+    [InlineData(1_000_000_000_000, "h")]
+    [InlineData(1_000_000_000_000_000, "h")]
+    [InlineData(1_000_000_000_000_000_000, "h")]
+    public void GetUnit(long ticks, string unit)
+    {
+        Assert.Equal(unit, DurationFormatter.GetUnit(TimeSpan.FromTicks(ticks)));
+    }
+
     [Fact]
     public void KeepsMicrosecondsTheSame()
     {

--- a/tests/Aspire.Dashboard.Tests/DurationFormatterTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DurationFormatterTests.cs
@@ -82,6 +82,6 @@ public class DurationFormatterTests
     public void DisplaysTimesOf0()
     {
         var input = 0;
-        Assert.Equal("0", DurationFormatter.FormatDuration(TimeSpan.FromTicks(input)));
+        Assert.Equal("0μs", DurationFormatter.FormatDuration(TimeSpan.FromTicks(input)));
     }
 }


### PR DESCRIPTION
The first column always has a value of zero. Originally it displayed the smallest unit: `0μs`. That looked odd.

A [later update](https://github.com/dotnet/aspire/pull/4183) removed the unit so it just displayed zero: `0`. Better but not perfect.

This PR uses the unit from the next column. So, if the next unit is `ms` then the first column is `0ms`. If the next unit is `s` then the first column is `0s`.

![image](https://github.com/user-attachments/assets/b09d1cb1-2dfd-414b-8526-c576bd923fa7)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5133)