### PR TITLE
Add support for all cultures corresponding to localizations we have

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -67,6 +67,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
     public IReadOnlyList<string> ValidationFailures => _validationFailures;
 
+    // our localization list comes from https://github.com/dotnet/arcade/blob/89008f339a79931cc49c739e9dbc1a27c608b379/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props#L22
     internal static HashSet<string> LocalizedCultures { get; } = new(StringComparer.OrdinalIgnoreCase)
     {
         "en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant", // Standard cultures for compliance.
@@ -202,8 +203,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         var supportedCultures = GetSupportedCultures();
 
         _app.UseRequestLocalization(new RequestLocalizationOptions()
-            .AddSupportedCultures([.. supportedCultures])
-            .AddSupportedUICultures([.. supportedCultures]));
+            .AddSupportedCultures(supportedCultures)
+            .AddSupportedUICultures(supportedCultures));
 
         WriteVersion(_logger);
 
@@ -334,17 +335,16 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
     }
 
-    internal static List<string> GetSupportedCultures()
+    internal static string[] GetSupportedCultures()
     {
-        // our localization list comes from https://github.com/dotnet/arcade/blob/89008f339a79931cc49c739e9dbc1a27c608b379/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props#L22
         var supportedCultures = CultureInfo.GetCultures(CultureTypes.AllCultures)
-            .Where(culture => LocalizedCultures.Contains(culture.Name) || LocalizedCultures.Contains(culture.TwoLetterISOLanguageName))
+            .Where(culture => LocalizedCultures.Contains(culture.TwoLetterISOLanguageName) || LocalizedCultures.Contains(culture.Name))
             .Select(culture => culture.Name)
             .ToList();
 
         // Non-standard culture but it is the default in many Chinese browsers. Adding zh-CN allows OS culture customization to flow through the dashboard.
         supportedCultures.Add("zh-CN");
-        return supportedCultures;
+        return supportedCultures.ToArray();
     }
 
     private ILogger<DashboardWebApplication> GetLogger()

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -194,18 +194,23 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
         _logger = GetLogger();
 
-        // this needs to be explicitly enumerated for each supported language
-        // our language list comes from https://github.com/dotnet/arcade/blob/89008f339a79931cc49c739e9dbc1a27c608b379/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props#L22
-        var supportedLanguages = new[]
+        // our localization list comes from https://github.com/dotnet/arcade/blob/89008f339a79931cc49c739e9dbc1a27c608b379/src/Microsoft.DotNet.XliffTasks/build/Microsoft.DotNet.XliffTasks.props#L22
+        var localizedLanguages = new[]
         {
             "en", "cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant", // Standard cultures for compliance.
-            "zh-CN", // Non-standard culture but it is the default in many Chinese browsers. Adding zh-CN allows OS culture customization to flow through the dashboard.
-            "en-GB", // Support UK DateTime formatting (24-hour clock, dd/MM/yyyy)
-        };
+        }.ToHashSet();
+
+        var supportedCultures = CultureInfo.GetCultures(CultureTypes.AllCultures)
+            .Where(culture => localizedLanguages.Contains(culture.Name) || localizedLanguages.Contains(culture.TwoLetterISOLanguageName))
+            .Select(culture => culture.Name)
+            .ToList();
+
+        // Non-standard culture but it is the default in many Chinese browsers. Adding zh-CN allows OS culture customization to flow through the dashboard.
+        supportedCultures.Add("zh-CN");
 
         _app.UseRequestLocalization(new RequestLocalizationOptions()
-            .AddSupportedCultures(supportedLanguages)
-            .AddSupportedUICultures(supportedLanguages));
+            .AddSupportedCultures([.. supportedCultures])
+            .AddSupportedUICultures([.. supportedCultures]));
 
         WriteVersion(_logger);
 

--- a/tests/Aspire.Dashboard.Tests/GlobalizationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/GlobalizationTests.cs
@@ -10,14 +10,18 @@ public class GlobalizationTests
     [Fact]
     public void GetSupportedCultures_IncludesPopularCultures()
     {
+        // Act
         var supportedCultures = DashboardWebApplication.GetSupportedCultures();
 
+        // Assert
         foreach (var localizedCulture in DashboardWebApplication.LocalizedCultures)
         {
             Assert.Contains(localizedCulture, supportedCultures);
         }
 
+        // A few cultures we expect to be available
         Assert.Contains("en-GB", supportedCultures);
         Assert.Contains("fr-CA", supportedCultures);
+        Assert.Contains("zh-CN", supportedCultures);
     }
 }

--- a/tests/Aspire.Dashboard.Tests/GlobalizationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/GlobalizationTests.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Dashboard.Tests;
+
+public class GlobalizationTests
+{
+    [Fact]
+    public void GetSupportedCultures_IncludesPopularCultures()
+    {
+        var supportedCultures = DashboardWebApplication.GetSupportedCultures();
+
+        foreach (var localizedCulture in DashboardWebApplication.LocalizedCultures)
+        {
+            Assert.Contains(localizedCulture, supportedCultures);
+        }
+
+        Assert.Contains("en-GB", supportedCultures);
+        Assert.Contains("fr-CA", supportedCultures);
+    }
+}


### PR DESCRIPTION
I looked into this and it appears that, since we must explicitly enumerate the cultures we support, we can simply enable support for all cultures that we have language translations for. 

For some cultures, we localize into a specific locale - ie, pt-BR, but some are a language code - ie, fr. We can enumerate through all cultures in `CultureInfo` and filter out cultures whose language code we support.

Example (showing en-GB and en):
<img width="172" alt="image" src="https://github.com/user-attachments/assets/ab8ba5b6-488e-4012-9c68-fa9824767a96">
(en)

<img width="176" alt="image" src="https://github.com/user-attachments/assets/36c7b95c-8a40-4c87-82f7-dc92ffc0ab20">
(en-GB)

Hopefully, this solves #4884 once and for all
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5143)