### PR TITLE
Support filtering telemetry to all instances of a resource

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartBase.cs
@@ -518,7 +518,7 @@ public abstract class ChartBase : ComponentBase, IAsyncDisposable
         return TimeProvider.GetUtcNow().Subtract(TimeSpan.FromSeconds(1)); // Compensate for delay in receiving metrics from services.
     }
 
-    private string GetDisplayedUnit(OtlpInstrument instrument)
+    private string GetDisplayedUnit(OtlpInstrumentSummary instrument)
     {
         return InstrumentUnitResolver.ResolveDisplayedUnit(instrument, titleCase: true, pluralize: true);
     }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor
@@ -13,8 +13,8 @@ else
 {
     <div class="metrics-chart">
         <div class="metrics-chart-header">
-            <h3>@_instrument.Name</h3>
-            <p>@_instrument.Description</p>
+            <h3>@_instrument.Summary.Name</h3>
+            <p>@_instrument.Summary.Description</p>
         </div>
         <FluentTabs ActiveTabId="@($"tab-{ActiveView}")" OnTabChange="@OnTabChangeAsync">
             <FluentTab LabelClass="tab-label"

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -13,7 +13,7 @@ namespace Aspire.Dashboard.Components;
 
 public partial class ChartContainer : ComponentBase, IAsyncDisposable
 {
-    private OtlpInstrument? _instrument;
+    private OtlpInstrumentData? _instrument;
     private PeriodicTimer? _tickTimer;
     private Task? _tickTask;
     private IDisposable? _themeChangedSubscription;
@@ -103,12 +103,12 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
         await UpdateInstrumentDataAsync(_instrument);
     }
 
-    private async Task UpdateInstrumentDataAsync(OtlpInstrument instrument)
+    private async Task UpdateInstrumentDataAsync(OtlpInstrumentData instrument)
     {
-        var matchedDimensions = instrument.Dimensions.Values.Where(MatchDimension).ToList();
+        var matchedDimensions = instrument.Dimensions.Where(MatchDimension).ToList();
 
         // Only update data in plotly
-        await _instrumentViewModel.UpdateDataAsync(instrument, matchedDimensions);
+        await _instrumentViewModel.UpdateDataAsync(instrument.Summary, matchedDimensions);
     }
 
     private bool MatchDimension(DimensionScope dimension)
@@ -168,7 +168,7 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
         await UpdateInstrumentDataAsync(_instrument);
     }
 
-    private OtlpInstrument? GetInstrument()
+    private OtlpInstrumentData? GetInstrument()
     {
         var endDate = DateTime.UtcNow;
         // Get more data than is being displayed. Histogram graph uses some historical data to calculate bucket counts.

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -79,7 +79,7 @@
             </FluentDataGrid>
         </div>
     }
-    @if (Instrument.Type == OtlpInstrumentType.Histogram)
+    @if (Instrument.Summary.Type == OtlpInstrumentType.Histogram)
     {
         <div class="metrics-filters-section">
             <h5>@Loc[nameof(ControlsStrings.ChartContainerOptionsHeader)]</h5>
@@ -92,14 +92,3 @@
         </div>
     }
 </div>
-
-@code {
-    [Parameter, EditorRequired]
-    public required OtlpInstrument Instrument { get; set; }
-
-    [Parameter, EditorRequired]
-    public required InstrumentViewModel InstrumentViewModel { get; set; }
-
-    [Parameter, EditorRequired]
-    public required List<DimensionFilterViewModel> DimensionFilters { get; set; }
-}

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor.cs
@@ -1,10 +1,23 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Microsoft.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components;
 
 public partial class ChartFilters
 {
+    [Parameter, EditorRequired]
+    public required OtlpInstrumentData Instrument { get; set; }
+
+    [Parameter, EditorRequired]
+    public required InstrumentViewModel InstrumentViewModel { get; set; }
+
+    [Parameter, EditorRequired]
+    public required List<DimensionFilterViewModel> DimensionFilters { get; set; }
+
     public bool ShowCounts { get; set; }
 
     protected override void OnInitialized()

--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor.cs
@@ -22,7 +22,7 @@ public partial class MetricTable : ChartBase
     private string _unitColumnHeader = string.Empty;
     private IJSObjectReference? _jsModule;
 
-    private OtlpInstrument? _instrument;
+    private OtlpInstrumentSummary? _instrument;
     private bool _showCount;
     private DateTimeOffset? _lastUpdate;
 

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -11,7 +11,7 @@
               Items="Resources"
               Id="@_selectId"
               OptionValue="@(c => c!.Name)"
-              OptionDisabled="@(c => c!.Id?.Type is Otlp.Model.OtlpApplicationType.ResourceGrouping)"
+              OptionDisabled="@(c => !CanSelectGrouping && c!.Id?.Type is Otlp.Model.OtlpApplicationType.ResourceGrouping)"
               SelectedOption="SelectedResource"
               SelectedOptionChanged="SelectedResourceChanged"
               ValueChanged="ValuedChanged"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -29,6 +29,9 @@ public partial class ResourceSelect
     [Parameter]
     public string? AriaLabel { get; set; }
 
+    [Parameter]
+    public bool CanSelectGrouping { get; set; }
+
     [Inject]
     public required IJSRuntime JS { get; init; }
 

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -24,7 +24,8 @@
             <ResourceSelect Resources="_applicationViewModels"
                             AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"
                             @bind-SelectedResource="PageViewModel.SelectedApplication"
-                            @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync"/>
+                            @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync"
+                            CanSelectGrouping="true" />
             <FluentIcon slot="end" Icon="Icons.Regular.Size20.Clock" Style="margin-right:5px;"/>
             <FluentSelect slot="end" TOption="SelectViewModel<TimeSpan>"
                           Items="@_durations"
@@ -56,10 +57,11 @@
                         <Panel2>
                             <div>
                                 <div class="metrics-content">
-                                    @if (PageViewModel.SelectedApplication.Id?.InstanceId != null && PageViewModel.SelectedMeter != null && PageViewModel.SelectedInstrument != null)
+                                    @if (PageViewModel.SelectedApplication.Id?.ReplicaSetName != null && PageViewModel.SelectedMeter != null && PageViewModel.SelectedInstrument != null)
                                     {
                                         <ChartContainer
-                                            ApplicationKey="@(PageViewModel.SelectedApplication.Id.GetApplicationKey())"                                            MeterName="@(PageViewModel.SelectedMeter.MeterName)"
+                                            ApplicationKey="@(PageViewModel.SelectedApplication.Id.GetApplicationKey())"
+                                            MeterName="@(PageViewModel.SelectedMeter.MeterName)"
                                             InstrumentName="@(PageViewModel.SelectedInstrument.Name)"
                                             Duration="PageViewModel.SelectedDuration.Id"
                                             ActiveView="@(PageViewModel.SelectedViewKind ?? MetricViewKind.Graph)"
@@ -69,7 +71,7 @@
                                     else if (PageViewModel.SelectedMeter != null)
                                     {
                                         <h3>@PageViewModel.SelectedMeter.MeterName</h3>
-                                        <FluentDataGrid Style="max-width:1100px;" Items="@PageViewModel.Instruments.Where(i => i.Parent == PageViewModel.SelectedMeter).OrderBy(i => i.Name).AsQueryable()" GridTemplateColumns="3fr 5fr" TGridItem="OtlpInstrument">
+                                        <FluentDataGrid Style="max-width:1100px;" Items="@PageViewModel.Instruments.Where(i => i.Parent == PageViewModel.SelectedMeter).OrderBy(i => i.Name).AsQueryable()" GridTemplateColumns="3fr 5fr" TGridItem="OtlpInstrumentSummary">
                                             <ChildContent>
                                                 <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Metrics.MetricsInsturementNameGridNameColumnHeader)]">
                                                     <FluentAnchor Href="@DashboardUrls.MetricsUrl(resource: PageViewModel.SelectedApplication.Name, meter: context.Parent.MeterName, instrument: context.Name)" Appearance="Appearance.Lightweight">

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -117,9 +117,9 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     public void UpdateViewModelFromQuery(MetricsViewModel viewModel)
     {
         viewModel.SelectedDuration = _durations.SingleOrDefault(d => (int)d.Id.TotalMinutes == DurationMinutes) ?? _durations.Single(d => d.Id == s_defaultDuration);
-        viewModel.SelectedApplication = _applicationViewModels.GetApplication(Logger, ApplicationName, _selectApplication);
+        viewModel.SelectedApplication = _applicationViewModels.GetApplication(Logger, ApplicationName, canSelectGrouping: true, _selectApplication);
         var selectedInstance = viewModel.SelectedApplication.Id?.GetApplicationKey();
-        viewModel.Instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentsSummary(selectedInstance.Value) : null;
+        viewModel.Instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentsSummaries(selectedInstance.Value) : null;
 
         viewModel.SelectedMeter = null;
         viewModel.SelectedInstrument = null;
@@ -130,12 +130,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
             viewModel.SelectedMeter = viewModel.Instruments.FirstOrDefault(i => i.Parent.MeterName == MeterName)?.Parent;
             if (viewModel.SelectedMeter != null && !string.IsNullOrEmpty(InstrumentName))
             {
-                viewModel.SelectedInstrument = TelemetryRepository.GetInstrument(new GetInstrumentRequest
-                {
-                    ApplicationKey = selectedInstance!.Value,
-                    MeterName = MeterName,
-                    InstrumentName = InstrumentName
-                });
+                viewModel.SelectedInstrument = viewModel.Instruments.FirstOrDefault(i => i.Parent.MeterName == MeterName && i.Name == InstrumentName);
             }
         }
     }
@@ -156,7 +151,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
             PageViewModel.SelectedInstrument != null)
         {
             var selectedInstance = PageViewModel.SelectedApplication.Id?.GetApplicationKey();
-            var instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentsSummary(selectedInstance.Value) : null;
+            var instruments = selectedInstance != null ? TelemetryRepository.GetInstrumentsSummaries(selectedInstance.Value) : null;
 
             if (instruments == null || ShouldClearSelectedMetrics(instruments))
             {
@@ -168,7 +163,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
         return this.AfterViewModelChangedAsync(_contentLayout, isChangeInToolbar: true);
     }
 
-    private bool ShouldClearSelectedMetrics(List<OtlpInstrument> instruments)
+    private bool ShouldClearSelectedMetrics(List<OtlpInstrumentSummary> instruments)
     {
         if (PageViewModel.SelectedMeter != null && !instruments.Any(i => i.Parent.MeterName == PageViewModel.SelectedMeter.MeterName))
         {
@@ -191,10 +186,10 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
     {
         public FluentTreeItem? SelectedTreeItem { get; set; }
         public OtlpMeter? SelectedMeter { get; set; }
-        public OtlpInstrument? SelectedInstrument { get; set; }
+        public OtlpInstrumentSummary? SelectedInstrument { get; set; }
         public required SelectViewModel<ResourceTypeDetails> SelectedApplication { get; set; }
         public SelectViewModel<TimeSpan> SelectedDuration { get; set; } = null!;
-        public List<OtlpInstrument>? Instruments { get; set; }
+        public List<OtlpInstrumentSummary>? Instruments { get; set; }
         public required MetricViewKind? SelectedViewKind { get; set; }
     }
 
@@ -220,7 +215,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
             PageViewModel.SelectedMeter = meter;
             PageViewModel.SelectedInstrument = null;
         }
-        else if (PageViewModel.SelectedTreeItem?.Data is OtlpInstrument instrument)
+        else if (PageViewModel.SelectedTreeItem?.Data is OtlpInstrumentSummary instrument)
         {
             PageViewModel.SelectedMeter = instrument.Parent;
             PageViewModel.SelectedInstrument = instrument;
@@ -269,7 +264,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
                 if (selectedApplicationKey != null)
                 {
                     // If there are more instruments than before then update the UI.
-                    var instruments = TelemetryRepository.GetInstrumentsSummary(selectedApplicationKey.Value);
+                    var instruments = TelemetryRepository.GetInstrumentsSummaries(selectedApplicationKey.Value);
 
                     if (PageViewModel.Instruments is null || instruments.Count > PageViewModel.Instruments.Count)
                     {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -28,7 +28,8 @@
             <ResourceSelect Resources="_applicationViewModels"
                             AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"
                             @bind-SelectedResource="PageViewModel.SelectedApplication"
-                            @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync" />
+                            @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync"
+                            CanSelectGrouping="true" />
             <FluentSearch @bind-Value="_filter"
                           @oninput="HandleFilter"
                           @bind-Value:after="HandleAfterFilterBindAsync"

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -396,7 +396,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
 
     public void UpdateViewModelFromQuery(StructuredLogsPageViewModel viewModel)
     {
-        viewModel.SelectedApplication = _applicationViewModels.GetApplication(Logger, ApplicationName, _allApplication);
+        viewModel.SelectedApplication = _applicationViewModels.GetApplication(Logger, ApplicationName, canSelectGrouping: true, _allApplication);
         ViewModel.ApplicationKey = PageViewModel.SelectedApplication.Id?.GetApplicationKey();
 
         if (LogLevelText is not null && Enum.TryParse<LogLevel>(LogLevelText, ignoreCase: true, out var logLevel))

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -21,7 +21,8 @@
             <ResourceSelect Resources="_applicationViewModels"
                             AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"
                             @bind-SelectedResource="PageViewModel.SelectedApplication"
-                            @bind-SelectedResource:after="HandleSelectedApplicationChanged" />
+                            @bind-SelectedResource:after="HandleSelectedApplicationChanged"
+                            CanSelectGrouping="true" />
             <FluentSearch @bind-Value="_filter"
                           @oninput="HandleFilter"
                           @bind-Value:after="HandleAfterFilterBindAsync"

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -242,7 +242,7 @@ public partial class Traces : IPageWithSessionAndUrlState<TracesPageViewModel, T
 
     public void UpdateViewModelFromQuery(TracesPageViewModel viewModel)
     {
-        viewModel.SelectedApplication = _applicationViewModels.GetApplication(Logger, ApplicationName, _allApplication);
+        viewModel.SelectedApplication = _applicationViewModels.GetApplication(Logger, ApplicationName, canSelectGrouping: true, _allApplication);
         TracesViewModel.ApplicationKey = PageViewModel.SelectedApplication.Id?.GetApplicationKey();
     }
 

--- a/src/Aspire.Dashboard/Model/DefaultInstrumentUnitResolver.cs
+++ b/src/Aspire.Dashboard/Model/DefaultInstrumentUnitResolver.cs
@@ -11,7 +11,7 @@ namespace Aspire.Dashboard.Model;
 
 public sealed class DefaultInstrumentUnitResolver(IStringLocalizer<ControlsStrings> loc) : IInstrumentUnitResolver
 {
-    public string ResolveDisplayedUnit(OtlpInstrument instrument, bool titleCase, bool pluralize)
+    public string ResolveDisplayedUnit(OtlpInstrumentSummary instrument, bool titleCase, bool pluralize)
     {
         if (!string.IsNullOrEmpty(instrument.Unit))
         {

--- a/src/Aspire.Dashboard/Model/ExemplarsDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ExemplarsDialogViewModel.cs
@@ -10,5 +10,5 @@ public sealed class ExemplarsDialogViewModel
 {
     public required List<ChartExemplar> Exemplars { get; init; }
     public required List<OtlpApplication> Applications { get; init; }
-    public required OtlpInstrument Instrument { get; init; }
+    public required OtlpInstrumentSummary Instrument { get; init; }
 }

--- a/src/Aspire.Dashboard/Model/IInstrumentUnitResolver.cs
+++ b/src/Aspire.Dashboard/Model/IInstrumentUnitResolver.cs
@@ -7,5 +7,5 @@ namespace Aspire.Dashboard.Model;
 
 public interface IInstrumentUnitResolver
 {
-    string ResolveDisplayedUnit(OtlpInstrument instrument, bool titleCase, bool pluralize);
+    string ResolveDisplayedUnit(OtlpInstrumentSummary instrument, bool titleCase, bool pluralize);
 }

--- a/src/Aspire.Dashboard/Model/InstrumentViewModel.cs
+++ b/src/Aspire.Dashboard/Model/InstrumentViewModel.cs
@@ -8,14 +8,14 @@ namespace Aspire.Dashboard.Model;
 
 public class InstrumentViewModel
 {
-    public OtlpInstrument? Instrument { get; private set; }
+    public OtlpInstrumentSummary? Instrument { get; private set; }
     public List<DimensionScope>? MatchedDimensions { get; private set; }
 
     public List<Func<Task>> DataUpdateSubscriptions { get; } = [];
     public string? Theme { get; set; }
     public bool ShowCount { get; set; }
 
-    public async Task UpdateDataAsync(OtlpInstrument instrument, List<DimensionScope> matchedDimensions)
+    public async Task UpdateDataAsync(OtlpInstrumentSummary instrument, List<DimensionScope> matchedDimensions)
     {
         Instrument = instrument;
         MatchedDimensions = matchedDimensions;

--- a/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
+++ b/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
@@ -27,10 +27,6 @@ public class ResourceTypeDetails
         {
             throw new InvalidOperationException($"Can't get ApplicationKey from resource type details '{ToString()}' because {nameof(ReplicaSetName)} is null.");
         }
-        if (InstanceId == null)
-        {
-            throw new InvalidOperationException($"Can't get ApplicationKey from resource type details '{ToString()}' because {nameof(InstanceId)} is null.");
-        }
 
         return new ApplicationKey(ReplicaSetName, InstanceId);
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
@@ -92,11 +92,14 @@ public class OtlpApplication
                         {
                             _instruments.Add(instrumentKey, instrument = new OtlpInstrument
                             {
-                                Name = metric.Name,
-                                Description = metric.Description,
-                                Unit = metric.Unit,
-                                Type = MapMetricType(metric.DataCase),
-                                Parent = GetMeter(sm.Scope),
+                                Summary = new OtlpInstrumentSummary
+                                {
+                                    Name = metric.Name,
+                                    Description = metric.Description,
+                                    Unit = metric.Unit,
+                                    Type = MapMetricType(metric.DataCase),
+                                    Parent = GetMeter(sm.Scope)
+                                },
                                 Options = _options
                             });
                         }
@@ -156,16 +159,16 @@ public class OtlpApplication
         }
     }
 
-    public List<OtlpInstrument> GetInstrumentsSummary()
+    public List<OtlpInstrumentSummary> GetInstrumentsSummary()
     {
         _metricsLock.EnterReadLock();
 
         try
         {
-            var instruments = new List<OtlpInstrument>(_instruments.Count);
+            var instruments = new List<OtlpInstrumentSummary>(_instruments.Count);
             foreach (var instrument in _instruments)
             {
-                instruments.Add(OtlpInstrument.Clone(instrument.Value, cloneData: false, valuesStart: null, valuesEnd: null));
+                instruments.Add(instrument.Value.Summary);
             }
             return instruments;
         }

--- a/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/ApplicationKey.cs
@@ -3,7 +3,7 @@
 
 namespace Aspire.Dashboard.Otlp.Storage;
 
-public readonly record struct ApplicationKey(string Name, string InstanceId) : IComparable<ApplicationKey>
+public readonly record struct ApplicationKey(string Name, string? InstanceId) : IComparable<ApplicationKey>
 {
     public int CompareTo(ApplicationKey other)
     {
@@ -23,23 +23,32 @@ public readonly record struct ApplicationKey(string Name, string InstanceId) : I
             return false;
         }
 
-        // Composite name has the format "{Name}-{InstanceId}".
-        if (name.Length != Name.Length + InstanceId.Length + 1)
+        if (InstanceId != null)
         {
-            return false;
-        }
+            // Composite name has the format "{Name}-{InstanceId}".
+            if (name.Length != Name.Length + InstanceId.Length + 1)
+            {
+                return false;
+            }
 
-        if (!name.AsSpan(0, Name.Length).Equals(Name, StringComparisons.ResourceName))
-        {
-            return false;
+            if (!name.AsSpan(0, Name.Length).Equals(Name, StringComparisons.ResourceName))
+            {
+                return false;
+            }
+            if (name[Name.Length] != '-')
+            {
+                return false;
+            }
+            if (!name.AsSpan(Name.Length + 1, InstanceId.Length).Equals(InstanceId, StringComparisons.ResourceName))
+            {
+                return false;
+            }
         }
-        if (name[Name.Length] != '-')
+        else
         {
-            return false;
-        }
-        if (!name.AsSpan(Name.Length + 1, InstanceId.Length).Equals(InstanceId, StringComparisons.ResourceName))
-        {
-            return false;
+            // InstanceId is null so just match on name.
+            // This is used to match all instances of an app with the matching name.
+            return string.Equals(Name, name, StringComparisons.ResourceName);
         }
 
         return true;

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Text;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Proto.Logs.V1;
@@ -73,12 +74,23 @@ public sealed class TelemetryRepository
 
     public List<OtlpApplication> GetApplications()
     {
-        var applications = new List<OtlpApplication>();
-        foreach (var kvp in _applications)
+        return GetApplicationsCore(name: null);
+    }
+
+    public List<OtlpApplication> GetApplicationsByName(string name)
+    {
+        return GetApplicationsCore(name);
+    }
+
+    private List<OtlpApplication> GetApplicationsCore(string? name)
+    {
+        IEnumerable<OtlpApplication> results = _applications.Values;
+        if (name != null)
         {
-            applications.Add(kvp.Value);
+            results = results.Where(a => string.Equals(a.ApplicationKey.Name, name, StringComparisons.ResourceName));
         }
-        applications.Sort((a, b) => a.ApplicationKey.CompareTo(b.ApplicationKey));
+
+        var applications = results.OrderBy(a => a.ApplicationKey).ToList();
         return applications;
     }
 
@@ -97,8 +109,23 @@ public sealed class TelemetryRepository
 
     public OtlpApplication? GetApplication(ApplicationKey key)
     {
+        if (key.InstanceId == null)
+        {
+            throw new InvalidOperationException($"{nameof(ApplicationKey)} must have an instance ID.");
+        }
+
         _applications.TryGetValue(key, out var application);
         return application;
+    }
+
+    public List<OtlpApplication> GetApplications(ApplicationKey key)
+    {
+        if (key.InstanceId == null)
+        {
+            return GetApplicationsByName(key.Name);
+        }
+
+        return [GetApplication(key)];
     }
 
     public Dictionary<OtlpApplication, int> GetApplicationUnviewedErrorLogsCount()
@@ -131,15 +158,14 @@ public sealed class TelemetryRepository
                 }
                 return;
             }
-            var application = GetApplication(key.Value);
-            if (application is not null)
+            var applications = GetApplications(key.Value);
+            foreach (var application in applications)
             {
                 // Mark one application logs as viewed.
                 if (_applicationUnviewedErrorLogs.Remove(application))
                 {
                     RaiseSubscriptionChanged(_logSubscriptions);
                 }
-                return;
             }
         }
         finally
@@ -176,7 +202,7 @@ public sealed class TelemetryRepository
             var application = _applications.GetOrAdd(key, _ =>
             {
                 newApplication = true;
-                return new OtlpApplication(key.Name, key.InstanceId, resource, _logger, _dashboardOptions.TelemetryLimits);
+                return new OtlpApplication(key.Name, key.InstanceId!, resource, _logger, _dashboardOptions.TelemetryLimits);
             });
             return (application, newApplication);
         }
@@ -344,10 +370,15 @@ public sealed class TelemetryRepository
 
     public PagedResult<OtlpLogEntry> GetLogs(GetLogsContext context)
     {
-        OtlpApplication? application = null;
-        if (context.ApplicationKey != null && !_applications.TryGetValue(context.ApplicationKey.Value, out application))
+        List<OtlpApplication>? applications = null;
+        if (context.ApplicationKey is { } key)
         {
-            return PagedResult<OtlpLogEntry>.Empty;
+            applications = GetApplications(key);
+
+            if (applications.Count == 0)
+            {
+                return PagedResult<OtlpLogEntry>.Empty;
+            }
         }
 
         _logsLock.EnterReadLock();
@@ -355,9 +386,9 @@ public sealed class TelemetryRepository
         try
         {
             var results = _logs.AsEnumerable();
-            if (application != null)
+            if (applications?.Count > 0)
             {
-                results = results.Where(l => l.Application == application);
+                results = results.Where(l => MatchApplications(l.Application, applications));
             }
 
             foreach (var filter in context.Filters)
@@ -373,16 +404,34 @@ public sealed class TelemetryRepository
         }
     }
 
+    private static bool MatchApplications(OtlpApplication application, List<OtlpApplication> applications)
+    {
+        for (var i = 0; i < applications.Count; i++)
+        {
+            if (application == applications[i])
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public List<string> GetLogPropertyKeys(ApplicationKey? applicationKey)
     {
+        List<OtlpApplication>? applications = null;
+        if (applicationKey != null)
+        {
+            applications = GetApplications(applicationKey.Value);
+        }
+
         _logsLock.EnterReadLock();
 
         try
         {
             var applicationKeys = _logPropertyKeys.AsEnumerable();
-            if (applicationKey != null)
+            if (applications?.Count > 0)
             {
-                applicationKeys = applicationKeys.Where(keys => keys.Application.ApplicationKey == applicationKey);
+                applicationKeys = applicationKeys.Where(keys => MatchApplications(keys.Application, applications));
             }
 
             var keys = applicationKeys.Select(keys => keys.PropertyKey).Distinct();
@@ -396,14 +445,39 @@ public sealed class TelemetryRepository
 
     public GetTracesResponse GetTraces(GetTracesRequest context)
     {
+        List<OtlpApplication>? applications = null;
+        if (context.ApplicationKey is { } key)
+        {
+            applications = GetApplications(key);
+
+            if (applications.Count == 0)
+            {
+                return new GetTracesResponse
+                {
+                    PagedResult = PagedResult<OtlpTrace>.Empty,
+                    MaxDuration = TimeSpan.Zero
+                };
+            }
+        }
+
         _tracesLock.EnterReadLock();
 
         try
         {
             var results = _traces.AsEnumerable();
-            if (context.ApplicationKey != null)
+            if (applications?.Count > 0)
             {
-                results = results.Where(t => HasApplication(t, context.ApplicationKey.Value));
+                results = results.Where(t =>
+                {
+                    for (var i = 0; i < applications.Count; i++)
+                    {
+                        if (HasApplication(t, applications[i].ApplicationKey))
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
             }
             if (!string.IsNullOrWhiteSpace(context.FilterText))
             {
@@ -844,23 +918,79 @@ public sealed class TelemetryRepository
         return newSpan;
     }
 
-    public List<OtlpInstrument> GetInstrumentsSummary(ApplicationKey key)
+    public List<OtlpInstrumentSummary> GetInstrumentsSummaries(ApplicationKey key)
     {
-        if (!_applications.TryGetValue(key, out var application))
+        var applications = GetApplications(key);
+        if (applications.Count == 0)
         {
-            return new List<OtlpInstrument>();
+            return new List<OtlpInstrumentSummary>();
+        }
+        else if (applications.Count == 1)
+        {
+            return applications[0].GetInstrumentsSummary();
+        }
+        else
+        {
+            var allApplicationSummaries = applications
+                .SelectMany(a => a.GetInstrumentsSummary())
+                .DistinctBy(s => s.GetKey())
+                .ToList();
+
+            return allApplicationSummaries;
         }
 
-        return application.GetInstrumentsSummary();
     }
 
-    public OtlpInstrument? GetInstrument(GetInstrumentRequest request)
+    public OtlpInstrumentData? GetInstrument(GetInstrumentRequest request)
     {
-        if (!_applications.TryGetValue(request.ApplicationKey, out var application))
+        var applications = GetApplications(request.ApplicationKey);
+        var instruments = applications
+            .Select(a => a.GetInstrument(request.MeterName, request.InstrumentName, request.StartTime, request.EndTime))
+            .OfType<OtlpInstrument>()
+            .ToList();
+
+        if (instruments.Count == 0)
         {
             return null;
         }
+        else if (instruments.Count == 1)
+        {
+            var instrument = instruments[0];
+            return new OtlpInstrumentData
+            {
+                Summary = instrument.Summary,
+                KnownAttributeValues = instrument.KnownAttributeValues,
+                Dimensions = instrument.Dimensions.Values.ToList()
+            };
+        }
+        else
+        {
+            var allDimensions = new List<DimensionScope>();
+            var allKnownAttributes = new Dictionary<string, List<string>>();
 
-        return application.GetInstrument(request.MeterName, request.InstrumentName, request.StartTime, request.EndTime);
+            foreach (var instrument in instruments)
+            {
+                allDimensions.AddRange(instrument.Dimensions.Values);
+
+                foreach (var knownAttributeValues in instrument.KnownAttributeValues)
+                {
+                    if (allKnownAttributes.TryGetValue(knownAttributeValues.Key, out var values))
+                    {
+                        allKnownAttributes[knownAttributeValues.Key] = values.Union(knownAttributeValues.Value).ToList();
+                    }
+                    else
+                    {
+                        allKnownAttributes[knownAttributeValues.Key] = knownAttributeValues.Value.ToList();
+                    }
+                }
+            }
+
+            return new OtlpInstrumentData
+            {
+                Summary = instruments[0].Summary,
+                Dimensions = allDimensions,
+                KnownAttributeValues = allKnownAttributes
+            };
+        }
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -52,15 +52,18 @@ public class PlotlyChartTests : TestContext
         var options = new TelemetryLimitOptions();
         var instrument = new OtlpInstrument
         {
-            Name = "Name-<b>Bold</b>",
-            Unit = "Unit-<b>Bold</b>",
-            Options = options,
-            Description = "Description-<b>Bold</b>",
-            Parent = new OtlpMeter(new InstrumentationScope
+            Summary = new OtlpInstrumentSummary
             {
-                Name = "Parent-Name-<b>Bold</b>"
-            }, options),
-            Type = OtlpInstrumentType.Sum
+                Name = "Name-<b>Bold</b>",
+                Unit = "Unit-<b>Bold</b>",
+                Description = "Description-<b>Bold</b>",
+                Parent = new OtlpMeter(new InstrumentationScope
+                {
+                    Name = "Parent-Name-<b>Bold</b>"
+                }, options),
+                Type = OtlpInstrumentType.Sum
+            },
+            Options = options,
         };
 
         var model = new InstrumentViewModel();
@@ -72,7 +75,7 @@ public class PlotlyChartTests : TestContext
             TimeUnixNano = long.MaxValue
         }, options);
 
-        await model.UpdateDataAsync(instrument, [dimension]);
+        await model.UpdateDataAsync(instrument.Summary, [dimension]);
 
         // Act
         var cut = RenderComponent<PlotlyChart>(builder =>

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestInstrumentUnitResolver.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestInstrumentUnitResolver.cs
@@ -8,7 +8,7 @@ namespace Aspire.Dashboard.Components.Tests.Shared;
 
 public sealed class TestInstrumentUnitResolver : IInstrumentUnitResolver
 {
-    public string ResolveDisplayedUnit(OtlpInstrument instrument, bool titleCase, bool pluralize)
+    public string ResolveDisplayedUnit(OtlpInstrumentSummary instrument, bool titleCase, bool pluralize)
     {
         return instrument.Unit;
     }

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -54,7 +54,7 @@ public sealed class ApplicationsSelectHelpersTests
             });
 
         // Act
-        var app = appVMs.GetApplication(NullLogger.Instance, "app-app-abc", null!);
+        var app = appVMs.GetApplication(NullLogger.Instance, "app-app-abc", canSelectGrouping: false, null!);
 
         // Assert
         Assert.Equal("app-abc", app.Id!.InstanceId);
@@ -95,7 +95,7 @@ public sealed class ApplicationsSelectHelpersTests
         var factory = LoggerFactory.Create(b => b.AddProvider(new TestLoggerProvider(testSink)));
 
         // Act
-        var app = appVMs.GetApplication(factory.CreateLogger("Test"), "app-app", null!);
+        var app = appVMs.GetApplication(factory.CreateLogger("Test"), "app-app", canSelectGrouping: false, null!);
 
         // Assert
         Assert.Equal("app", app.Id!.InstanceId);
@@ -119,12 +119,87 @@ public sealed class ApplicationsSelectHelpersTests
         var factory = LoggerFactory.Create(b => b.AddProvider(new TestLoggerProvider(testSink)));
 
         // Act
-        var app = appVMs.GetApplication(factory.CreateLogger("Test"), "test", null!);
+        var app = appVMs.GetApplication(factory.CreateLogger("Test"), "test", canSelectGrouping: false, null!);
 
         // Assert
         Assert.Equal("test-abc", app.Id!.InstanceId);
         Assert.Equal(OtlpApplicationType.Singleton, app.Id!.Type);
         Assert.Single(testSink.Writes);
+    }
+
+    [Fact]
+    public void GetApplication_SelectGroup_NotEnabled_ReturnNull()
+    {
+        // Arrange
+        var appVMs = ApplicationsSelectHelpers.CreateApplications(new List<OtlpApplication>
+        {
+            CreateOtlpApplication(name: "app", instanceId: "123"),
+            CreateOtlpApplication(name: "app", instanceId: "456")
+        });
+
+        Assert.Collection(appVMs,
+            app =>
+            {
+                Assert.Equal("app", app.Name);
+                Assert.Equal(OtlpApplicationType.ResourceGrouping, app.Id!.Type);
+                Assert.Null(app.Id!.InstanceId);
+            },
+            app =>
+            {
+                Assert.Equal("app-123", app.Name);
+                Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
+                Assert.Equal("123", app.Id!.InstanceId);
+            },
+            app =>
+            {
+                Assert.Equal("app-456", app.Name);
+                Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
+                Assert.Equal("456", app.Id!.InstanceId);
+            });
+
+        // Act
+        var app = appVMs.GetApplication(NullLogger.Instance, "app", canSelectGrouping: false, null!);
+
+        // Assert
+        Assert.Null(app);
+    }
+
+    [Fact]
+    public void GetApplication_SelectGroup_Enabled_ReturnGroup()
+    {
+        // Arrange
+        var appVMs = ApplicationsSelectHelpers.CreateApplications(new List<OtlpApplication>
+        {
+            CreateOtlpApplication(name: "app", instanceId: "123"),
+            CreateOtlpApplication(name: "app", instanceId: "456")
+        });
+
+        Assert.Collection(appVMs,
+            app =>
+            {
+                Assert.Equal("app", app.Name);
+                Assert.Equal(OtlpApplicationType.ResourceGrouping, app.Id!.Type);
+                Assert.Null(app.Id!.InstanceId);
+            },
+            app =>
+            {
+                Assert.Equal("app-123", app.Name);
+                Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
+                Assert.Equal("123", app.Id!.InstanceId);
+            },
+            app =>
+            {
+                Assert.Equal("app-456", app.Name);
+                Assert.Equal(OtlpApplicationType.Instance, app.Id!.Type);
+                Assert.Equal("456", app.Id!.InstanceId);
+            });
+
+        // Act
+        var app = appVMs.GetApplication(NullLogger.Instance, "app", canSelectGrouping: true, null!);
+
+        // Assert
+        Assert.Equal("app", app.Name);
+        Assert.Equal(OtlpApplicationType.ResourceGrouping, app.Id!.Type);
     }
 
     private static OtlpApplication CreateOtlpApplication(string name, string instanceId)
@@ -139,6 +214,6 @@ public sealed class ApplicationsSelectHelpersTests
         };
         var applicationKey = OtlpHelpers.GetApplicationKey(resource);
 
-        return new OtlpApplication(applicationKey.Name, applicationKey.InstanceId, resource, NullLogger.Instance, new TelemetryLimitOptions());
+        return new OtlpApplication(applicationKey.Name, applicationKey.InstanceId!, resource, NullLogger.Instance, new TelemetryLimitOptions());
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ApplicationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/ApplicationTests.cs
@@ -55,6 +55,44 @@ public class ApplicationTests
     }
 
     [Fact]
+    public void GetApplications_WithNameAndNoKey()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        AddResource(repository, "app2");
+        AddResource(repository, "app1", instanceId: "123");
+        AddResource(repository, "app1", instanceId: "456");
+
+        // Act 1
+        var applications1 = repository.GetApplications(new ApplicationKey("app1", InstanceId: null));
+
+        // Assert 1
+        Assert.Collection(applications1,
+            app =>
+            {
+                Assert.Equal("app1", app.ApplicationName);
+                Assert.Equal("123", app.InstanceId);
+            },
+            app =>
+            {
+                Assert.Equal("app1", app.ApplicationName);
+                Assert.Equal("456", app.InstanceId);
+            });
+
+        // Act 2
+        var applications2 = repository.GetApplications(new ApplicationKey("app2", InstanceId: null));
+
+        // Assert 2
+        Assert.Collection(applications2,
+            app =>
+            {
+                Assert.Equal("app2", app.ApplicationName);
+                Assert.Equal("TestId", app.InstanceId);
+            });
+    }
+
+    [Fact]
     public void GetApplications_Order()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -855,4 +855,93 @@ public class LogTests
                     });
             });
     }
+
+    [Fact]
+    public void GetLogs_MultipleInstances()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        // Act
+        var addContext = new AddContext();
+        repository.AddLogs(addContext, new RepeatedField<ResourceLogs>()
+        {
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app1", instanceId: "123"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord(time: s_testTime.AddMinutes(1), message: "message-1", attributes: [KeyValuePair.Create("key-1", "value-1")]) }
+                    }
+                }
+            },
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app1", instanceId: "456"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord(time: s_testTime.AddMinutes(2), message: "message-2", attributes: [KeyValuePair.Create("key-2", "value-2")]) }
+                    }
+                }
+            },
+            new ResourceLogs
+            {
+                Resource = CreateResource(name: "app2"),
+                ScopeLogs =
+                {
+                    new ScopeLogs
+                    {
+                        Scope = CreateScope("TestLogger"),
+                        LogRecords = { CreateLogRecord(time: s_testTime.AddMinutes(3)) }
+                    }
+                }
+            }
+        });
+
+        // Assert
+        Assert.Equal(0, addContext.FailureCount);
+
+        var appKey = new ApplicationKey("app1", InstanceId: null);
+        var logs = repository.GetLogs(new GetLogsContext
+        {
+            ApplicationKey = appKey,
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        });
+        Assert.Collection(logs.Items,
+            app =>
+            {
+                Assert.Equal("message-1", app.Message);
+                Assert.Equal("TestLogger", app.Scope.ScopeName);
+                Assert.Collection(app.Attributes,
+                    p =>
+                    {
+                        Assert.Equal("key-1", p.Key);
+                        Assert.Equal("value-1", p.Value);
+                    });
+            },
+            app =>
+            {
+                Assert.Equal("message-2", app.Message);
+                Assert.Equal("TestLogger", app.Scope.ScopeName);
+                Assert.Collection(app.Attributes,
+                    p =>
+                    {
+                        Assert.Equal("key-2", p.Key);
+                        Assert.Equal("value-2", p.Value);
+                    });
+            });
+
+        var propertyKeys = repository.GetLogPropertyKeys(appKey)!;
+        Assert.Collection(propertyKeys,
+            s => Assert.Equal("key-1", s),
+            s => Assert.Equal("key-2", s));
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
@@ -67,7 +67,7 @@ public class MetricsTests
                 Assert.Equal("TestId", app.InstanceId);
             });
 
-        var instruments = repository.GetInstrumentsSummary(applications[0].ApplicationKey);
+        var instruments = repository.GetInstrumentsSummaries(applications[0].ApplicationKey);
         Assert.Collection(instruments,
             instrument =>
             {
@@ -75,8 +75,6 @@ public class MetricsTests
                 Assert.Equal("Test metric description", instrument.Description);
                 Assert.Equal("widget", instrument.Unit);
                 Assert.Equal("test-meter", instrument.Parent.MeterName);
-                Assert.Empty(instrument.Dimensions);
-                Assert.Empty(instrument.KnownAttributeValues);
             },
             instrument =>
             {
@@ -84,8 +82,6 @@ public class MetricsTests
                 Assert.Equal("Test metric description", instrument.Description);
                 Assert.Equal("widget", instrument.Unit);
                 Assert.Equal("test-meter", instrument.Parent.MeterName);
-                Assert.Empty(instrument.Dimensions);
-                Assert.Empty(instrument.KnownAttributeValues);
             },
             instrument =>
             {
@@ -93,8 +89,6 @@ public class MetricsTests
                 Assert.Equal("Test metric description", instrument.Description);
                 Assert.Equal("widget", instrument.Unit);
                 Assert.Equal("test-meter2", instrument.Parent.MeterName);
-                Assert.Empty(instrument.Dimensions);
-                Assert.Empty(instrument.KnownAttributeValues);
             });
     }
 
@@ -155,7 +149,7 @@ public class MetricsTests
             EndTime = DateTime.MaxValue
         })!;
 
-        Assert.Collection(instrument.Parent.Attributes,
+        Assert.Collection(instrument.Summary.Parent.Attributes,
             p =>
             {
                 Assert.Equal("Meter_Key0", p.Key);
@@ -182,9 +176,9 @@ public class MetricsTests
                 Assert.Equal("0123456789012345", p.Value);
             });
 
-        var dimensionAttributes = instrument.Dimensions.Single().Key;
+        var dimensionAttributes = instrument.Dimensions.Single().Attributes;
 
-        Assert.Collection(MemoryMarshal.ToEnumerable(dimensionAttributes),
+        Assert.Collection(dimensionAttributes,
             p =>
             {
                 Assert.Equal("Meter_Key0", p.Key);
@@ -271,16 +265,16 @@ public class MetricsTests
             EndTime = DateTime.MaxValue
         })!;
 
-        Assert.Collection(instrument.Parent.Attributes,
+        Assert.Collection(instrument.Summary.Parent.Attributes,
             p =>
             {
                 Assert.Equal("Meter_Key0", p.Key);
                 Assert.Equal("01234", p.Value);
             });
 
-        var dimensionAttributes = instrument.Dimensions.Single().Key;
+        var dimensionAttributes = instrument.Dimensions.Single().Attributes;
 
-        Assert.Collection(MemoryMarshal.ToEnumerable(dimensionAttributes),
+        Assert.Collection(dimensionAttributes,
             p =>
             {
                 Assert.Equal("Meter_Key0", p.Key);
@@ -359,7 +353,7 @@ public class MetricsTests
                 Assert.Equal("TestId", app.InstanceId);
             });
 
-        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        var instrumentData = repository.GetInstrument(new GetInstrumentRequest
         {
             ApplicationKey = applications[0].ApplicationKey,
             InstrumentName = "test",
@@ -368,13 +362,13 @@ public class MetricsTests
             EndTime = s_testTime.AddMinutes(1.5),
         });
 
-        Assert.NotNull(instrument);
-        Assert.Equal("test", instrument.Name);
-        Assert.Equal("Test metric description", instrument.Description);
-        Assert.Equal("widget", instrument.Unit);
-        Assert.Equal("test-meter", instrument.Parent.MeterName);
+        Assert.NotNull(instrumentData);
+        Assert.Equal("test", instrumentData.Summary.Name);
+        Assert.Equal("Test metric description", instrumentData.Summary.Description);
+        Assert.Equal("widget", instrumentData.Summary.Unit);
+        Assert.Equal("test-meter", instrumentData.Summary.Parent.MeterName);
 
-        Assert.Collection(instrument.KnownAttributeValues.OrderBy(kvp => kvp.Key),
+        Assert.Collection(instrumentData.KnownAttributeValues.OrderBy(kvp => kvp.Key),
             e =>
             {
                 Assert.Equal("key1", e.Key);
@@ -386,15 +380,18 @@ public class MetricsTests
                 Assert.Equal(new[] { "", "value1" }, e.Value);
             });
 
-        Assert.Equal(4, instrument.Dimensions.Count);
+        Assert.Equal(4, instrumentData.Dimensions.Count);
 
-        AssertDimensionValues(instrument.Dimensions, Array.Empty<KeyValuePair<string, string>>(), valueCount: 1);
-        var dimension = instrument.Dimensions[Array.Empty<KeyValuePair<string, string>>()];
+        var dimension = instrumentData.Dimensions.Single(d => d.Attributes.Length == 0);
         var exemplar = Assert.Single(dimension.Values[0].Exemplars);
 
         Assert.Equal("key1", exemplar.Attributes[0].Key);
         Assert.Equal("value1", exemplar.Attributes[0].Value);
 
+        var instrument = applications.Single().GetInstrument("test-meter", "test", s_testTime.AddMinutes(1), s_testTime.AddMinutes(1.5));
+        Assert.NotNull(instrument);
+
+        AssertDimensionValues(instrument.Dimensions, Array.Empty<KeyValuePair<string, string>>(), valueCount: 1);
         AssertDimensionValues(instrument.Dimensions, new KeyValuePair<string, string>[] { KeyValuePair.Create("key1", "value1") }, valueCount: 1);
         AssertDimensionValues(instrument.Dimensions, new KeyValuePair<string, string>[] { KeyValuePair.Create("key1", "value2") }, valueCount: 1);
         AssertDimensionValues(instrument.Dimensions, new KeyValuePair<string, string>[] { KeyValuePair.Create("key1", "value1"), KeyValuePair.Create("key2", "value1") }, valueCount: 1);
@@ -472,14 +469,14 @@ public class MetricsTests
             EndTime = DateTime.MaxValue
         })!;
 
-        Assert.Equal("test", instrument.Name);
-        Assert.Equal("Test metric description", instrument.Description);
-        Assert.Equal("widget", instrument.Unit);
-        Assert.Equal("test-meter", instrument.Parent.MeterName);
+        Assert.Equal("test", instrument.Summary.Name);
+        Assert.Equal("Test metric description", instrument.Summary.Description);
+        Assert.Equal("widget", instrument.Summary.Unit);
+        Assert.Equal("test-meter", instrument.Summary.Parent.MeterName);
 
         // Only the last 3 values should be kept.
         var dimension = Assert.Single(instrument.Dimensions);
-        Assert.Collection(dimension.Value.Values,
+        Assert.Collection(dimension.Values,
             m =>
             {
                 Assert.Equal(s_testTime.AddMinutes(2), m.Start);
@@ -498,6 +495,125 @@ public class MetricsTests
                 Assert.Equal(s_testTime.AddMinutes(5), m.End);
                 Assert.Equal(5, ((MetricValue<long>)m).Value);
             });
+    }
+
+    [Fact]
+    public void GetMetrics_MultipleInstances()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        // Act
+        var addContext = new AddContext();
+        repository.AddMetrics(addContext, new RepeatedField<ResourceMetrics>()
+        {
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "app1", instanceId: "123"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test1", value: 1, startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key-1", "value-1")]),
+                            CreateSumMetric(metricName: "test1", value: 2, startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key-1", "value-2")])
+                        }
+                    }
+                }
+            },
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "app1", instanceId: "456"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test1", value: 3, startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key-1", "value-3")]),
+                            CreateSumMetric(metricName: "test2", value: 4, startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key-1", "value-4")])
+                        }
+                    }
+                }
+            },
+            new ResourceMetrics
+            {
+                Resource = CreateResource(name: "app2"),
+                ScopeMetrics =
+                {
+                    new ScopeMetrics
+                    {
+                        Scope = CreateScope(name: "test-meter"),
+                        Metrics =
+                        {
+                            CreateSumMetric(metricName: "test1", value: 5, startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key-1", "value-5")]),
+                            CreateSumMetric(metricName: "test3", value: 6, startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key-1", "value-6")])
+                        }
+                    }
+                }
+            }
+        });
+
+        // Assert
+        Assert.Equal(0, addContext.FailureCount);
+
+        var appKey = new ApplicationKey("app1", InstanceId: null);
+        var instruments = repository.GetInstrumentsSummaries(appKey);
+        Assert.Collection(instruments,
+            instrument =>
+            {
+                Assert.Equal("test1", instrument.Name);
+                Assert.Equal("Test metric description", instrument.Description);
+                Assert.Equal("widget", instrument.Unit);
+                Assert.Equal("test-meter", instrument.Parent.MeterName);
+            },
+            instrument =>
+            {
+                Assert.Equal("test2", instrument.Name);
+                Assert.Equal("Test metric description", instrument.Description);
+                Assert.Equal("widget", instrument.Unit);
+                Assert.Equal("test-meter", instrument.Parent.MeterName);
+            });
+
+        var instrument = repository.GetInstrument(new GetInstrumentRequest
+        {
+            ApplicationKey = appKey,
+            InstrumentName = "test1",
+            MeterName = "test-meter",
+            StartTime = s_testTime,
+            EndTime = s_testTime.AddMinutes(20)
+        });
+
+        Assert.NotNull(instrument);
+        Assert.Equal("test1", instrument.Summary.Name);
+
+        Assert.Collection(instrument.Dimensions.OrderBy(d => d.Name),
+            d =>
+            {
+                Assert.Equal(KeyValuePair.Create("key-1", "value-1"), d.Attributes.Single());
+                Assert.Equal(1, ((MetricValue<long>)d.Values.Single()).Value);
+            },
+            d =>
+            {
+                Assert.Equal(KeyValuePair.Create("key-1", "value-2"), d.Attributes.Single());
+                Assert.Equal(2, ((MetricValue<long>)d.Values.Single()).Value);
+            },
+            d =>
+            {
+                Assert.Equal(KeyValuePair.Create("key-1", "value-3"), d.Attributes.Single());
+                Assert.Equal(3, ((MetricValue<long>)d.Values.Single()).Value);
+            });
+
+        var knownValues = Assert.Single(instrument.KnownAttributeValues);
+        Assert.Equal("key-1", knownValues.Key);
+
+        Assert.Collection(knownValues.Value.Order(),
+            v => Assert.Equal("value-1", v),
+            v => Assert.Equal("value-2", v),
+            v => Assert.Equal("value-3", v));
     }
 
     private static void AssertDimensionValues(Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> dimensions, ReadOnlyMemory<KeyValuePair<string, string>> key, int valueCount)


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/5137

Aspire supports collecting data from multiple instances of an app, e.g. `CatalogService-123` and `CatalogService-456`. When this happens, the resource selector shows instances grouped together. Selecting an instance shows telemetry for only that instance.

This PR adds support for showing telemetry across all instances of an app. In the resource selector on telemetry pages it enables the group option, e.g. `CatalogService (application)`. Now you can filter telemetry to an instance of an app or view all instances at once.

The new behavior is straight forward on structured logs and tracing pages. They show items for all instances. The metrics page is more complicated. Selecting `CatalogService (application)` will show all the meters/instruments across instances. Selecting an instrument then shows data from all instances in the graph. In histogram graphs, the percentiles are calculated using data from all instances. In counter graphs, counts are added together from all instances. For example, if `consoto.login.count` is 10 in one instance, and 20 in another, the graph will display 30.

Demo:
![resource-filter-all-logs](https://github.com/user-attachments/assets/1fc6f47e-cabf-4a58-b402-340a54ceee09)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5150)