### PR TITLE
Move tooltip position in login to top for a11y

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Login.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor
@@ -32,7 +32,7 @@
                 <div class="token-entry-footer">
                     <a href="@NavigationManager.Uri" id="helpLink">@Loc[nameof(Dashboard.Resources.Login.WhereIsMyTokenLinkText)]</a>
                     <FluentButton Appearance="Appearance.Accent" Type="ButtonType.Submit">@Loc[nameof(Dashboard.Resources.Login.LogInButtonText)]</FluentButton>
-                    <FluentTooltip Anchor="helpLink" Position="TooltipPosition.Bottom" MaxWidth="650px">
+                    <FluentTooltip Anchor="helpLink" MaxWidth="650px">
                         <div class="token-help-container">
                             <div>
                                 <a href="/img/TokenExample.png" target="_blank">


### PR DESCRIPTION
We are not able to have a 'preferred' positioning for the login help tooltip, so we should put at top so it is not cut off, even if it looks slightly worse.

Longer-term @vnbaaij we should add a preferred positioning option for tooltips.

Fixes #4171 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5151)