### PR TITLE
Correct the path of the TestShop.AppHost

### DIFF
--- a/playground/TestShop/TestShop.sln
+++ b/playground/TestShop/TestShop.sln
@@ -13,11 +13,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceDefaults", "ServiceD
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyFrontend", "MyFrontend\MyFrontend.csproj", "{A92E2CCE-5B2B-461E-80AA-1669FE2EEF2E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppHost", "AppHost\AppHost.csproj", "{96FDD139-88F1-46DC-8487-4D5D7F1E5A8D}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrderProcessor", "OrderProcessor\OrderProcessor.csproj", "{7926680B-CE02-4AE8-AED2-E95678309289}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CatalogModel", "CatalogModel\CatalogModel.csproj", "{AAD6BF29-5FB9-4CA5-8B84-4863B27D5228}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestShop.AppHost", "TestShop.AppHost\TestShop.AppHost.csproj", "{764C4B11-4457-4ACE-81EE-B22398FAD45F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,10 +45,6 @@ Global
 		{A92E2CCE-5B2B-461E-80AA-1669FE2EEF2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A92E2CCE-5B2B-461E-80AA-1669FE2EEF2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A92E2CCE-5B2B-461E-80AA-1669FE2EEF2E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{96FDD139-88F1-46DC-8487-4D5D7F1E5A8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{96FDD139-88F1-46DC-8487-4D5D7F1E5A8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{96FDD139-88F1-46DC-8487-4D5D7F1E5A8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{96FDD139-88F1-46DC-8487-4D5D7F1E5A8D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7926680B-CE02-4AE8-AED2-E95678309289}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7926680B-CE02-4AE8-AED2-E95678309289}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7926680B-CE02-4AE8-AED2-E95678309289}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -57,6 +53,10 @@ Global
 		{AAD6BF29-5FB9-4CA5-8B84-4863B27D5228}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AAD6BF29-5FB9-4CA5-8B84-4863B27D5228}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AAD6BF29-5FB9-4CA5-8B84-4863B27D5228}.Release|Any CPU.Build.0 = Release|Any CPU
+		{764C4B11-4457-4ACE-81EE-B22398FAD45F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{764C4B11-4457-4ACE-81EE-B22398FAD45F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{764C4B11-4457-4ACE-81EE-B22398FAD45F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{764C4B11-4457-4ACE-81EE-B22398FAD45F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I was working on https://github.com/dotnet/docs-aspire/issues/1407, so I pulled latest from `main` and spun up the TestShop solution. Visual Studio was complaining that it couldn't find the AppHost, and it was right - it's the wrong path. This PR corrects the path of the TestShop.AppHost.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5155)