### PR TITLE
Fix configuration binding

### DIFF
--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -26,7 +26,7 @@ public sealed class ResourceServiceClientOptions
 
     public string? Url { get; set; }
     public ResourceClientAuthMode? AuthMode { get; set; }
-    public ResourceServiceClientCertificateOptions ClientCertificates { get; set; } = new();
+    public ResourceServiceClientCertificateOptions ClientCertificate { get; set; } = new();
     public string? ApiKey { get; set; }
 
     public Uri? GetUri() => _parsedUrl;

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -110,17 +110,17 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
                         case DashboardClientCertificateSource.File:
                             if (string.IsNullOrEmpty(options.ResourceServiceClient.ClientCertificate.FilePath))
                             {
-                                errorMessages.Add("Dashboard:ResourceServiceClient:ClientCertificate:Source is \"File\", but no Dashboard:ResourceServiceClient:ClientCertificate:FilePath is configured.");
+                                errorMessages.Add($"{DashboardConfigNames.ResourceServiceClientCertificateSourceName.ConfigKey} is \"File\", but no {DashboardConfigNames.ResourceServiceClientCertificateFilePathName.ConfigKey} is configured.");
                             }
                             break;
                         case DashboardClientCertificateSource.KeyStore:
                             if (string.IsNullOrEmpty(options.ResourceServiceClient.ClientCertificate.Subject))
                             {
-                                errorMessages.Add("Dashboard:ResourceServiceClient:ClientCertificate:Source is \"KeyStore\", but no Dashboard:ResourceServiceClient:ClientCertificate:Subject is configured.");
+                                errorMessages.Add($"{DashboardConfigNames.ResourceServiceClientCertificateSourceName.ConfigKey} is \"KeyStore\", but no {DashboardConfigNames.ResourceServiceClientCertificateSubjectName.ConfigKey} is configured.");
                             }
                             break;
                         case null:
-                            errorMessages.Add($"The resource service client is configured to use certificates, but no certificate source is specified. Specify Dashboard:ResourceServiceClient:ClientCertificate:Source. Possible values: {string.Join(", ", typeof(DashboardClientCertificateSource).GetEnumNames())}");
+                            errorMessages.Add($"The resource service client is configured to use certificates, but no certificate source is specified. Specify {DashboardConfigNames.ResourceServiceClientCertificateSourceName.ConfigKey}. Possible values: {string.Join(", ", typeof(DashboardClientCertificateSource).GetEnumNames())}");
                             break;
                         default:
                             errorMessages.Add($"Unexpected resource service client certificate source: {options.ResourceServiceClient.ClientCertificate.Source}");

--- a/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/ValidateDashboardOptions.cs
@@ -105,16 +105,16 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
                     }
                     break;
                 case ResourceClientAuthMode.Certificate:
-                    switch (options.ResourceServiceClient.ClientCertificates.Source)
+                    switch (options.ResourceServiceClient.ClientCertificate.Source)
                     {
                         case DashboardClientCertificateSource.File:
-                            if (string.IsNullOrEmpty(options.ResourceServiceClient.ClientCertificates.FilePath))
+                            if (string.IsNullOrEmpty(options.ResourceServiceClient.ClientCertificate.FilePath))
                             {
                                 errorMessages.Add("Dashboard:ResourceServiceClient:ClientCertificate:Source is \"File\", but no Dashboard:ResourceServiceClient:ClientCertificate:FilePath is configured.");
                             }
                             break;
                         case DashboardClientCertificateSource.KeyStore:
-                            if (string.IsNullOrEmpty(options.ResourceServiceClient.ClientCertificates.Subject))
+                            if (string.IsNullOrEmpty(options.ResourceServiceClient.ClientCertificate.Subject))
                             {
                                 errorMessages.Add("Dashboard:ResourceServiceClient:ClientCertificate:Source is \"KeyStore\", but no Dashboard:ResourceServiceClient:ClientCertificate:Subject is configured.");
                             }
@@ -123,7 +123,7 @@ public sealed class ValidateDashboardOptions : IValidateOptions<DashboardOptions
                             errorMessages.Add($"The resource service client is configured to use certificates, but no certificate source is specified. Specify Dashboard:ResourceServiceClient:ClientCertificate:Source. Possible values: {string.Join(", ", typeof(DashboardClientCertificateSource).GetEnumNames())}");
                             break;
                         default:
-                            errorMessages.Add($"Unexpected resource service client certificate source: {options.ResourceServiceClient.ClientCertificates.Source}");
+                            errorMessages.Add($"Unexpected resource service client certificate source: {options.ResourceServiceClient.ClientCertificate.Source}");
                             break;
                     }
                     break;

--- a/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
@@ -115,7 +115,7 @@ internal sealed class DashboardClient : IDashboardClient
             if (authMode == ResourceClientAuthMode.Certificate)
             {
                 // Auth hasn't been suppressed, so configure it.
-                var certificates = _dashboardOptions.ResourceServiceClient.ClientCertificates.Source switch
+                var certificates = _dashboardOptions.ResourceServiceClient.ClientCertificate.Source switch
                 {
                     DashboardClientCertificateSource.File => GetFileCertificate(),
                     DashboardClientCertificateSource.KeyStore => GetKeyStoreCertificate(),
@@ -162,11 +162,11 @@ internal sealed class DashboardClient : IDashboardClient
             X509CertificateCollection GetFileCertificate()
             {
                 Debug.Assert(
-                    _dashboardOptions.ResourceServiceClient.ClientCertificates.FilePath != null,
+                    _dashboardOptions.ResourceServiceClient.ClientCertificate.FilePath != null,
                     "FilePath is validated as not null when configuration is loaded.");
 
-                var filePath = _dashboardOptions.ResourceServiceClient.ClientCertificates.FilePath;
-                var password = _dashboardOptions.ResourceServiceClient.ClientCertificates.Password;
+                var filePath = _dashboardOptions.ResourceServiceClient.ClientCertificate.FilePath;
+                var password = _dashboardOptions.ResourceServiceClient.ClientCertificate.Password;
 
                 return [new X509Certificate2(filePath, password)];
             }
@@ -174,12 +174,12 @@ internal sealed class DashboardClient : IDashboardClient
             X509CertificateCollection GetKeyStoreCertificate()
             {
                 Debug.Assert(
-                    _dashboardOptions.ResourceServiceClient.ClientCertificates.Subject != null,
+                    _dashboardOptions.ResourceServiceClient.ClientCertificate.Subject != null,
                     "Subject is validated as not null when configuration is loaded.");
 
-                var subject = _dashboardOptions.ResourceServiceClient.ClientCertificates.Subject;
-                var storeName = _dashboardOptions.ResourceServiceClient.ClientCertificates.Store ?? "My";
-                var location = _dashboardOptions.ResourceServiceClient.ClientCertificates.Location ?? StoreLocation.CurrentUser;
+                var subject = _dashboardOptions.ResourceServiceClient.ClientCertificate.Subject;
+                var storeName = _dashboardOptions.ResourceServiceClient.ClientCertificate.Store ?? "My";
+                var location = _dashboardOptions.ResourceServiceClient.ClientCertificate.Location ?? StoreLocation.CurrentUser;
 
                 using var store = new X509Store(storeName: storeName, storeLocation: location);
 

--- a/src/Shared/DashboardConfigNames.cs
+++ b/src/Shared/DashboardConfigNames.cs
@@ -19,6 +19,9 @@ internal static class DashboardConfigNames
     public static readonly ConfigName DashboardFrontendBrowserTokenName = new("Dashboard:Frontend:BrowserToken", "DASHBOARD__FRONTEND__BROWSERTOKEN");
     public static readonly ConfigName DashboardFrontendMaxConsoleLogCountName = new("Dashboard:Frontend:MaxConsoleLogCount", "DASHBOARD__FRONTEND__MAXCONSOLELOGCOUNT");
     public static readonly ConfigName ResourceServiceClientAuthModeName = new("Dashboard:ResourceServiceClient:AuthMode", "DASHBOARD__RESOURCESERVICECLIENT__AUTHMODE");
+    public static readonly ConfigName ResourceServiceClientCertificateSourceName = new("Dashboard:ResourceServiceClient:ClientCertificate:Source", "DASHBOARD__RESOURCESERVICECLIENT__CLIENTCERTIFICATE__SOURCE");
+    public static readonly ConfigName ResourceServiceClientCertificateFilePathName = new("Dashboard:ResourceServiceClient:ClientCertificate:FilePath", "DASHBOARD__RESOURCESERVICECLIENT__CLIENTCERTIFICATE__FILEPATH");
+    public static readonly ConfigName ResourceServiceClientCertificateSubjectName = new("Dashboard:ResourceServiceClient:ClientCertificate:Subject", "DASHBOARD__RESOURCESERVICECLIENT__CLIENTCERTIFICATE__SUBJECT");
     public static readonly ConfigName ResourceServiceClientApiKeyName = new("Dashboard:ResourceServiceClient:ApiKey", "DASHBOARD__RESOURCESERVICECLIENT__APIKEY");
 }
 

--- a/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
@@ -130,7 +130,7 @@ public sealed class DashboardOptionsTests
         var result = new ValidateDashboardOptions().Validate(null, options);
 
         Assert.False(result.Succeeded);
-        Assert.Equal("Dashboard:ResourceServiceClient:ClientCertificate:Source is \"File\", but no Dashboard:ResourceServiceClient:ClientCertificate:FilePath is configured.", result.FailureMessage);
+        Assert.Equal($"{DashboardConfigNames.ResourceServiceClientCertificateSourceName.ConfigKey} is \"File\", but no {DashboardConfigNames.ResourceServiceClientCertificateFilePathName.ConfigKey} is configured.", result.FailureMessage);
     }
 
     [Fact]
@@ -145,7 +145,7 @@ public sealed class DashboardOptionsTests
         var result = new ValidateDashboardOptions().Validate(null, options);
 
         Assert.False(result.Succeeded);
-        Assert.Equal("Dashboard:ResourceServiceClient:ClientCertificate:Source is \"KeyStore\", but no Dashboard:ResourceServiceClient:ClientCertificate:Subject is configured.", result.FailureMessage);
+        Assert.Equal($"{DashboardConfigNames.ResourceServiceClientCertificateSourceName.ConfigKey} is \"KeyStore\", but no {DashboardConfigNames.ResourceServiceClientCertificateSubjectName.ConfigKey} is configured.", result.FailureMessage);
     }
 
     [Fact]
@@ -159,7 +159,7 @@ public sealed class DashboardOptionsTests
         var result = new ValidateDashboardOptions().Validate(null, options);
 
         Assert.False(result.Succeeded);
-        Assert.Equal($"The resource service client is configured to use certificates, but no certificate source is specified. Specify Dashboard:ResourceServiceClient:ClientCertificate:Source. Possible values: {string.Join(", ", typeof(DashboardClientCertificateSource).GetEnumNames())}", result.FailureMessage);
+        Assert.Equal($"The resource service client is configured to use certificates, but no certificate source is specified. Specify {DashboardConfigNames.ResourceServiceClientCertificateSourceName.ConfigKey}. Possible values: {string.Join(", ", typeof(DashboardClientCertificateSource).GetEnumNames())}", result.FailureMessage);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/DashboardOptionsTests.cs
@@ -124,8 +124,8 @@ public sealed class DashboardOptionsTests
         var options = GetValidOptions();
         options.ResourceServiceClient.Url = "http://localhost";
         options.ResourceServiceClient.AuthMode = ResourceClientAuthMode.Certificate;
-        options.ResourceServiceClient.ClientCertificates.Source = DashboardClientCertificateSource.File;
-        options.ResourceServiceClient.ClientCertificates.FilePath = "";
+        options.ResourceServiceClient.ClientCertificate.Source = DashboardClientCertificateSource.File;
+        options.ResourceServiceClient.ClientCertificate.FilePath = "";
 
         var result = new ValidateDashboardOptions().Validate(null, options);
 
@@ -139,8 +139,8 @@ public sealed class DashboardOptionsTests
         var options = GetValidOptions();
         options.ResourceServiceClient.Url = "http://localhost";
         options.ResourceServiceClient.AuthMode = ResourceClientAuthMode.Certificate;
-        options.ResourceServiceClient.ClientCertificates.Source = DashboardClientCertificateSource.KeyStore;
-        options.ResourceServiceClient.ClientCertificates.Subject = "";
+        options.ResourceServiceClient.ClientCertificate.Source = DashboardClientCertificateSource.KeyStore;
+        options.ResourceServiceClient.ClientCertificate.Subject = "";
 
         var result = new ValidateDashboardOptions().Validate(null, options);
 
@@ -154,7 +154,7 @@ public sealed class DashboardOptionsTests
         var options = GetValidOptions();
         options.ResourceServiceClient.Url = "http://localhost";
         options.ResourceServiceClient.AuthMode = ResourceClientAuthMode.Certificate;
-        options.ResourceServiceClient.ClientCertificates.Source = null;
+        options.ResourceServiceClient.ClientCertificate.Source = null;
 
         var result = new ValidateDashboardOptions().Validate(null, options);
 
@@ -168,12 +168,12 @@ public sealed class DashboardOptionsTests
         var options = GetValidOptions();
         options.ResourceServiceClient.Url = "http://localhost";
         options.ResourceServiceClient.AuthMode = ResourceClientAuthMode.Certificate;
-        options.ResourceServiceClient.ClientCertificates.Source = (DashboardClientCertificateSource)int.MaxValue;
+        options.ResourceServiceClient.ClientCertificate.Source = (DashboardClientCertificateSource)int.MaxValue;
 
         var result = new ValidateDashboardOptions().Validate(null, options);
 
         Assert.False(result.Succeeded);
-        Assert.Equal($"Unexpected resource service client certificate source: {options.ResourceServiceClient.ClientCertificates.Source}", result.FailureMessage);
+        Assert.Equal($"Unexpected resource service client certificate source: {options.ResourceServiceClient.ClientCertificate.Source}", result.FailureMessage);
     }
 
     [Fact]

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -285,6 +285,25 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task Configuration_ResourceClientCertificates()
+    {
+        // Arrange & Act
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
+            additionalConfiguration: data =>
+            {
+                data[DashboardConfigNames.ResourceServiceClientAuthModeName.ConfigKey] = nameof(ResourceClientAuthMode.Certificate);
+                data[DashboardConfigNames.ResourceServiceClientCertificateSourceName.ConfigKey] = nameof(DashboardClientCertificateSource.KeyStore);
+                data[DashboardConfigNames.ResourceServiceClientCertificateSubjectName.ConfigKey] = "MySubject";
+            });
+
+        // Assert
+        Assert.Equal(ResourceClientAuthMode.Certificate, app.DashboardOptionsMonitor.CurrentValue.ResourceServiceClient.AuthMode);
+        Assert.Equal(DashboardClientCertificateSource.KeyStore, app.DashboardOptionsMonitor.CurrentValue.ResourceServiceClient.ClientCertificate.Source);
+        Assert.Equal("MySubject", app.DashboardOptionsMonitor.CurrentValue.ResourceServiceClient.ClientCertificate.Subject);
+        Assert.Empty(app.ValidationFailures);
+    }
+
+    [Fact]
     public async Task LogOutput_DynamicPort_PortResolvedInLogs()
     {
         // Arrange


### PR DESCRIPTION
The dashboard supports the use of client certificates for authorization to the resource service. This requires a custom resource server, and we're not aware of any that use this feature.

Throughout the Aspire documentation, we advertise values like `Dashboard:ResourceServiceClient:ClientCertificate:Source` to configure certificates, however these values will not bind to the documented configuration values. The CLR property was `ClientCertificates` (plural), not the documented `ClientCertificate` (singular).

This change makes the dashboard respect the documented configuration names.

We don't have any automated tests here yet. We have manual test instructions in https://github.com/dotnet/aspire/issues/4626 for vendors to use, which assume this fix has been applied.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5173)