### PR TITLE
[tests] Fix some flaky tests in Aspire.Hosting.Azure.Tests

### DIFF
--- a/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
@@ -195,7 +195,8 @@ public class SchemaTests
     {
         _ = testCaseName;
 
-        var builder = TestDistributedApplicationBuilder.Create(["--publisher", "manifest", "--output-path", "not-used.json"]);
+        string manifestDir = Directory.CreateTempSubdirectory(testCaseName).FullName;
+        var builder = TestDistributedApplicationBuilder.Create(["--publisher", "manifest", "--output-path", Path.Combine(manifestDir, "not-used.json")]);
         builder.Services.AddKeyedSingleton<IDistributedApplicationPublisher, JsonDocumentManifestPublisher>("manifest");
         configurator(builder);
 

--- a/tests/Aspire.Hosting.Tests/Utils/ManifestUtils.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/ManifestUtils.cs
@@ -67,19 +67,20 @@ public sealed class ManifestUtils
 
     public static async Task<(JsonNode ManifestNode, string BicepText)> GetManifestWithBicep(IResource resource)
     {
-        var manifestNode = await GetManifest(resource);
+        string manifestDir = Directory.CreateTempSubdirectory(resource.Name).FullName;
+        var manifestNode = await GetManifest(resource, manifestDir);
 
         if (!manifestNode.AsObject().TryGetPropertyValue("path", out var pathNode))
         {
             throw new ArgumentException("Specified resource does not contain a path property.", nameof(resource));
         }
 
-        if (pathNode?.ToString() is not { } path || !File.Exists(path))
+        if (pathNode?.ToString() is not { } path || !File.Exists(Path.Combine(manifestDir, path)))
         {
             throw new ArgumentException("Path node in resource is null, empty, or does not exist.", nameof(resource));
         }
 
-        var bicepText = await File.ReadAllTextAsync(path);
+        var bicepText = await File.ReadAllTextAsync(Path.Combine(manifestDir, path));
         return (manifestNode, bicepText);
     }
 }


### PR DESCRIPTION
Some tests generate `.module.bicep` files in the tests' `bindir`. Some such tests running in parallel can interfere with others getting the incorrect content.

- For example, one test writes `postgres.module.bicep`, and before it can read it back, it gets overwritten by a different test with slightly different contents, thus breaking the first test.
- this can also result in errors like `System.IO.IOException: The process cannot access the file '/mnt/vss/_work/1/s/artifacts/bin/Aspire.Hosting.Azure.Tests/Release/net8.0/postgres.module.bicep' because it is being used by another process.`

Fixes: https://github.com/dotnet/aspire/issues/5174
Fixes: https://github.com/dotnet/aspire/issues/5113

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5187)