### PR TITLE
WIP: Supporting multiple construct config callbacks on Bicep resources

### DIFF
--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresResource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Azure.Provisioning.PostgreSql;
 
 namespace Aspire.Hosting.Azure;
 
@@ -11,7 +12,9 @@ namespace Aspire.Hosting.Azure;
 /// <param name="innerResource"><see cref="PostgresServerResource"/> that this resource wraps.</param>
 /// <param name="configureConstruct">Callback to configure construct.</param>
 public class AzurePostgresResource(PostgresServerResource innerResource, Action<ResourceModuleConstruct> configureConstruct) :
-    AzureConstructResource(innerResource.Name, configureConstruct),
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    AzureConstructResource<AzurePostgresResource, PostgreSqlFlexibleServer>(innerResource.Name, configureConstruct),
+#pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     IResourceWithConnectionString
 {
     /// <summary>

--- a/src/Aspire.Hosting.Azure.PostgreSQL/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-
+static Aspire.Hosting.AzurePostgresExtensions.ConfigureAzurePostgreFlexibleServer(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.PostgresServerResource!>! builder, System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzurePostgresResource!>!, Aspire.Hosting.ResourceModuleConstruct!, Azure.Provisioning.PostgreSql.PostgreSqlFlexibleServer!>! configureResource) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.PostgresServerResource!>!

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -213,3 +213,30 @@ public class ResourceModuleConstruct : Infrastructure
     /// </summary>
     public Parameter PrincipalNameParameter => new Parameter("principalName");
 }
+
+/// <summary>
+/// 
+/// </summary>
+/// <typeparam name="TResource"></typeparam>
+/// <typeparam name="TAzureResource"></typeparam>
+/// <param name="name"></param>
+/// <param name="configureConstruct"></param>
+public class AzureConstructResource<TResource, TAzureResource>(string name, Action<ResourceModuleConstruct> configureConstruct) :
+    AzureConstructResource(name, configureConstruct)
+    where TResource : IResource
+    where TAzureResource : global::Azure.Provisioning.Resource
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public List<Action<IResourceBuilder<TResource>, ResourceModuleConstruct, TAzureResource>> ResourceConfigurations { get; } = [];
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="configuration"></param>
+    public void AddResourceConfiguration(Action<IResourceBuilder<TResource>, ResourceModuleConstruct, TAzureResource> configuration)
+    {
+        ResourceConfigurations.Add(configuration);
+    }
+}

--- a/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
@@ -1,2 +1,6 @@
 #nullable enable
+Aspire.Hosting.AzureConstructResource<TResource, TAzureResource>
+Aspire.Hosting.AzureConstructResource<TResource, TAzureResource>.AddResourceConfiguration(System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>!, Aspire.Hosting.ResourceModuleConstruct!, TAzureResource!>! configuration) -> void
+Aspire.Hosting.AzureConstructResource<TResource, TAzureResource>.AzureConstructResource(string! name, System.Action<Aspire.Hosting.ResourceModuleConstruct!>! configureConstruct) -> void
+Aspire.Hosting.AzureConstructResource<TResource, TAzureResource>.ResourceConfigurations.get -> System.Collections.Generic.List<System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<TResource>!, Aspire.Hosting.ResourceModuleConstruct!, TAzureResource!>!>!
 static Aspire.Hosting.AzureConstructResourceExtensions.ConfigureConstruct<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, System.Action<Aspire.Hosting.ResourceModuleConstruct!>! configure) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!


### PR DESCRIPTION
This PR introduces a new type which Azure hosted resources can inherit from that allows multiple callbacks to be provides for the "configure construct" stage of the resource provisioning. By having this in place, we can tackle #5127.

Initial prototype here focuses on just the Azure PG resource, but would need to be expanded to any resources deployable via the CDK.

Presently, the PR only contains the minimal amount of code required to get it compiling and to write a test (so, no doc comments).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5196)