### PR TITLE
[ci] Bump dcp-dependency check timeout to 3 minutes on the build machine

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -52,6 +52,8 @@ steps:
         DOCKER_BUILDKIT: 1
         # Disable on Linux - https://github.com/dotnet/aspire/issues/4623
         DISABLE_PLAYWRIGHT_TESTS: ${{ ne(parameters.isWindows, 'true') }}
+        # https://github.com/dotnet/aspire/issues/5195#issuecomment-2271687822
+        DOTNET_ASPIRE_DEPENDENCY_CHECK_TIMEOUT: 180
 
       displayName: Run non-helix tests
 


### PR DESCRIPTION
Prompted by https://github.com/dotnet/aspire/issues/5195 showing
frequent dcp-info timeouts. Based on
https://github.com/dotnet/aspire/issues/5195#issuecomment-2271687822 ,
bump the timeout to 3 minutes from the default 25 seconds.

Issue: https://github.com/dotnet/aspire/issues/5195

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5204)