### PR TITLE
Fix TestBuilderTests flakyness

### DIFF
--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -3,11 +3,11 @@
 
 using System.Net.Http.Json;
 using Aspire.Components.Common.Tests;
+using Aspire.Hosting.Tests.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Aspire.Hosting.Tests.Utils;
 
 namespace Aspire.Hosting.Testing.Tests;
 
@@ -67,7 +67,7 @@ public class TestingBuilderTests
         await app.StartAsync();
 
         // Wait for the application to be ready
-        await app.WaitForText("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
         var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
         var result1 = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast");
@@ -119,7 +119,7 @@ public class TestingBuilderTests
         Assert.Equal("https", profileName);
 
         // Wait for the application to be ready
-        await app.WaitForText("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
         // Explicitly get the HTTPS endpoint - this is only available on the "https" launch profile.
         var httpClient = app.CreateHttpClient("mywebapp1", "https");

--- a/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingBuilderTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
+using Aspire.Hosting.Tests.Utils;
 
 namespace Aspire.Hosting.Testing.Tests;
 
@@ -65,6 +66,9 @@ public class TestingBuilderTests
         await using var app = await appHost.BuildAsync();
         await app.StartAsync();
 
+        // Wait for the application to be ready
+        await app.WaitForText("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+
         var httpClient = app.CreateHttpClientWithResilience("mywebapp1");
         var result1 = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast");
         Assert.NotNull(result1);
@@ -113,6 +117,9 @@ public class TestingBuilderTests
         var config = app.Services.GetRequiredService<IConfiguration>();
         var profileName = config["AppHost:DefaultLaunchProfileName"];
         Assert.Equal("https", profileName);
+
+        // Wait for the application to be ready
+        await app.WaitForText("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
         // Explicitly get the HTTPS endpoint - this is only available on the "https" launch profile.
         var httpClient = app.CreateHttpClient("mywebapp1", "https");

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -3,6 +3,7 @@
 
 using System.Net.Http.Json;
 using Aspire.Components.Common.Tests;
+using Aspire.Hosting.Tests.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -46,6 +47,9 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
         // Wait for resource to start.
         var rns = _app.Services.GetRequiredService<ResourceNotificationService>();
         await rns.WaitForResourceAsync("mywebapp1").WaitAsync(TimeSpan.FromSeconds(60));
+
+        // Wait for the application to be ready
+        await _app.WaitForText("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
         var httpClient = _app.CreateHttpClientWithResilience("mywebapp1");
         var result1 = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast");

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -49,7 +49,7 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
         await rns.WaitForResourceAsync("mywebapp1").WaitAsync(TimeSpan.FromSeconds(60));
 
         // Wait for the application to be ready
-        await _app.WaitForText("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
+        await _app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
         var httpClient = _app.CreateHttpClientWithResilience("mywebapp1");
         var result1 = await httpClient.GetFromJsonAsync<WeatherForecast[]>("/weatherforecast");

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -11,6 +11,7 @@ using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Testing;
 using Aspire.Hosting.Testing.Tests;
 using Aspire.Hosting.Tests.Helpers;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using k8s.Models;
 using Microsoft.Extensions.DependencyInjection;
@@ -755,6 +756,9 @@ public class DistributedApplicationTests
 
         using var app = builder.Build();
         await app.StartAsync();
+
+        // Wait for the application to be ready
+        await app.WaitForTextAsync("Application started.").WaitAsync(TimeSpan.FromMinutes(1));
 
         // Wait until the service itself starts.
         using var clientA = app.CreateHttpClient(servicea.Resource.Name, "http");

--- a/tests/Aspire.Hosting.Tests/Utils/LoggerNotificationExtensions.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/LoggerNotificationExtensions.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using IResource = Aspire.Hosting.ApplicationModel.IResource;
+using ResourceLoggerService = Aspire.Hosting.ApplicationModel.ResourceLoggerService;
+using ResourceNotificationService = Aspire.Hosting.ApplicationModel.ResourceNotificationService;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Aspire.Hosting.Tests.Utils;
+
+public static class LoggerNotificationExtensions
+{
+    /// <summary>
+    /// Waits for the specified text to be logged.
+    /// </summary>
+    /// <param name="app">The <see cref="DistributedApplication" /> instance to watch.</param>
+    /// <param name="logText">The text to wait for.</param>
+    /// <param name="resource">An optional <see cref="IResource"/> instance to filter the logs for.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    public static Task WaitForText(this DistributedApplication app, string logText, IResource? resource = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentException.ThrowIfNullOrEmpty(logText);
+
+        return WaitForText(app, [logText], resource, cancellationToken);
+    }
+
+    /// <summary>
+    /// Waits for the specified text to be logged.
+    /// </summary>
+    /// <param name="app">The <see cref="DistributedApplication" /> instance to watch.</param>
+    /// <param name="logTexts">Any text to wait for.</param>
+    /// <param name="resource">An optional <see cref="IResource"/> instance to filter the logs for.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    public static Task WaitForText(this DistributedApplication app, IEnumerable<string> logTexts, IResource? resource = null, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(logTexts);
+
+        var hostApplicationLifetime = app.Services.GetRequiredService<IHostApplicationLifetime>();
+
+        using var watchCts = CancellationTokenSource.CreateLinkedTokenSource(hostApplicationLifetime.ApplicationStopping, cancellationToken);
+        var watchToken = watchCts.Token;
+
+        var tcs = new TaskCompletionSource();
+
+        _ = Task.Run(() => WatchNotifications(app, resource, logTexts, tcs, watchToken), watchToken);
+
+        return tcs.Task;
+    }
+
+    private static async Task WatchNotifications(DistributedApplication app, IResource? resource, IEnumerable<string> logTexts, TaskCompletionSource tcs, CancellationToken cancellationToken)
+    {
+        var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+        var resourceLoggerService = app.Services.GetRequiredService<ResourceLoggerService>();
+
+        var loggingResourceIds = new HashSet<string>();
+        var logWatchTasks = new List<Task>();
+
+        await foreach (var resourceEvent in resourceNotificationService.WatchAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (resource != null && resourceEvent.Resource != resource)
+            {
+                continue;
+            }
+
+            var resourceId = resourceEvent.ResourceId;
+
+            if (loggingResourceIds.Add(resourceId))
+            {
+                // Start watching the logs for this resource ID
+                logWatchTasks.Add(WatchResourceLogs(tcs, resourceId, logTexts, resourceLoggerService, cancellationToken));
+            }
+        }
+
+        await Task.WhenAny(logWatchTasks).ConfigureAwait(false);
+    }
+
+    private static async Task WatchResourceLogs(TaskCompletionSource tcs, string resourceId, IEnumerable<string> logTexts, ResourceLoggerService resourceLoggerService, CancellationToken cancellationToken)
+    {
+        await foreach (var logEvent in resourceLoggerService.WatchAsync(resourceId).WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            foreach (var line in logEvent)
+            {
+                foreach (var log in logTexts)
+                {
+                    if (line.Content.Contains(log))
+                    {
+                        tcs.SetResult();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes

```
Aspire.Hosting.Testing.Tests.TestingBuilderTests.HttpClientGetTest(genericEntryPoint: True) [FAIL]
Aspire.Hosting.Testing.Tests.TestingBuilderTests.HttpClientGetTest(genericEntryPoint: False) [FAIL]
Aspire.Hosting.Testing.Tests.TestingBuilderTests.SelectsFirstLaunchProfile(genericEntryPoint: True) [FAIL]
Aspire.Hosting.Testing.Tests.TestingBuilderTests.SelectsFirstLaunchProfile(genericEntryPoint: False) [FAIL]
Aspire.Hosting.Testing.Tests.TestingFactoryTests.HttpClientGetTest [FAIL]
```

Fixed the tests on local Linux box. Was failing consistently before.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5216)