### PR TITLE
Aspire.Hosting.Testing: Improve error message when loading

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Properties/launchSettings.json
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Properties/launchSettings.json
@@ -11,7 +11,7 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
       }
     },
     "http": {

--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -212,8 +212,16 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         }
 
         using var stream = File.OpenRead(launchSettingsFilePath);
-        var settings = JsonSerializer.Deserialize(stream, LaunchSettingsSerializerContext.Default.LaunchSettings);
-        return settings;
+        try
+        {
+            var settings = JsonSerializer.Deserialize(stream, LaunchSettingsSerializerContext.Default.LaunchSettings);
+            return settings;
+        }
+        catch (JsonException ex)
+        {
+            var message = $"Failed to get effective launch profile for project '{appHostPath}'. There is malformed JSON in the project's launch settings file at '{launchSettingsFilePath}'.";
+            throw new DistributedApplicationException(message, ex);
+        }
     }
 
     private void OnBuilderCreatedCore(DistributedApplicationBuilder applicationBuilder)


### PR DESCRIPTION
.. launchsettings fails. This matches the code in
`DistributedApplicationFactory.GetLaunchSettings`.

- **[playground] Fix CosmosEndToEnd.AppHost's launchsettings.json - trailing comma**

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5218)