### PR TITLE
Allow NoWarn on ProjectReference to supress ASPIRE004

### DIFF
--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.targets
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.targets
@@ -171,7 +171,7 @@ namespace Projects%3B
     </GetNonExecutableReferences>
 
     <Warning Code="ASPIRE004"
-             Condition="'@(_AspireNonExecutableProjectResource)' != ''"
+             Condition="'@(_AspireNonExecutableProjectResource)' != '' AND (%(_AspireNonExecutableProjectResource.NoWarn)!='ASPIRE004')"
              Text="'%(_AspireNonExecutableProjectResource.OriginalItemSpec)' is referenced by an Aspire Host project, but it is not an executable. Did you mean to set IsAspireProjectResource=&quot;false&quot;?" />
   </Target>
 


### PR DESCRIPTION
## Description

Allow the suppression of the `ASPIRE004` error message per `ProjectReference` using the `NoWarn` property.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5230)