### PR TITLE
Remove obsolete, pre-GA, DCP-related annotations

### DIFF
--- a/src/Aspire.Hosting/Dcp/Model/Executable.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Executable.cs
@@ -113,10 +113,6 @@ internal static class ExecutableState
 
 internal sealed class Executable : CustomResource<ExecutableSpec, ExecutableStatus>
 {
-    [Obsolete] public const string CSharpProjectPathAnnotation = "csharp-project-path";
-    [Obsolete] public const string CSharpLaunchProfileAnnotation = "csharp-launch-profile";
-    [Obsolete] public const string CSharpDisableLaunchProfileAnnotation = "csharp-disable-launch-profile";
-
     public const string LaunchConfigurationsAnnotation = "executable.usvc-dev.developer.microsoft.com/launch-configurations";
 
     [JsonConstructor]


### PR DESCRIPTION
## Description

(as the title says). These annotation names are not used anywhere anymore.

Fixes # (issue) https://github.com/dotnet/aspire/issues/3345

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5242)