### PR TITLE
Use key as text visualizer title in property grids

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -66,7 +66,7 @@
 
             <FluentMenuItem
                 Disabled="@(Value is null)"
-                AdditionalAttributes="@FluentUIExtensions.GetOpenTextVisualizerAdditionalAttributes(Value!, ValueDescription)">
+                AdditionalAttributes="@FluentUIExtensions.GetOpenTextVisualizerAdditionalAttributes(Value!, !string.IsNullOrEmpty(TextVisualizerTitle) ? TextVisualizerTitle : ValueDescription)">
                 <span slot="start">
                     <FluentIcon Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Open" Slot="start"/>
                 </span>

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
@@ -17,6 +17,9 @@ public partial class GridValue
     [Parameter, EditorRequired]
     public required string ValueDescription { get; set; }
 
+    [Parameter]
+    public string? TextVisualizerTitle { get; set; }
+
     /// <summary>
     /// Content to include, if any, after the Value string
     /// </summary>

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -19,7 +19,8 @@
             ValueDescription="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])"
             Value="@ValueColumnValue(context)" HighlightText="@HighlightText"
             EnableMasking="@EnableValueMasking" IsMasked="@GetIsItemMasked(context)"
-            IsMaskedChanged="(newValue) => OnIsMaskedChanged(context, newValue)"/>
+            IsMaskedChanged="(newValue) => OnIsMaskedChanged(context, newValue)"
+            TextVisualizerTitle="@NameColumnValue(context)"/>
         @ExtraValueContent(context)
     </TemplateColumn>
 </FluentDataGrid>

--- a/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/TextVisualizerDialog.razor
@@ -7,14 +7,14 @@
 @implements IDialogContentComponent<Aspire.Dashboard.Model.TextVisualizerDialogViewModel>
 
 <FluentDialogHeader ShowDismiss="true">
-    <FluentStack VerticalAlignment="VerticalAlignment.Center">
-        <FluentIcon Value="@(new Icons.Regular.Size24.SlideSearch())" />
-        <FluentLabel Typo="Typography.PaneHeader">
+    <div class="visualizer-title-grid">
+        <FluentIcon Value="@(new Icons.Regular.Size24.SlideSearch())" Style="grid-area: dialog-icon; align-self: center;" />
+        <FluentLabel Typo="Typography.PaneHeader" Class="col-long-content" Style="grid-area: dialog-title;">
             @Content.Description
         </FluentLabel>
 
-        <div style="margin-left: auto">
-            <FluentMenuButton id="@_openSelectFormatButtonId" slot="end"
+        <div Style="grid-area: dialog-format;">
+            <FluentMenuButton id="@_openSelectFormatButtonId"
                               ButtonAppearance="Appearance.Stealth"
                               IconEnd="@(new Icons.Regular.Size24.SlideTextEdit())"
                               Text="@(_currentValue ?? Loc[nameof(Dialogs.TextVisualizerSelectFormatType)])"
@@ -26,7 +26,7 @@
                 }
             </FluentMenuButton>
         </div>
-    </FluentStack>
+    </div>
 </FluentDialogHeader>
 
 <FluentDialogBody>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -1,3 +1,10 @@
+.visualizer-title-grid {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas: "dialog-icon dialog-title dialog-format";
+    grid-column-gap: 8px;
+}
+
 fluent-toolbar fluent-switch,
 fluent-toolbar p {
     margin-inline-end: 15px;


### PR DESCRIPTION
## Description

Improvement to https://github.com/dotnet/aspire/pull/5018. The text visualizer is commonly launched for property values. Rather than always show "Value" as the visualizer dialog title, show the property key.

When viewing the text visualizer for this property:
![image](https://github.com/user-attachments/assets/172dd5e5-f325-438d-8e37-94c5ef96ee34)

Before:
![image](https://github.com/user-attachments/assets/c3a1b93e-1db0-4680-9f28-7315d9b706bb)

After:
![image](https://github.com/user-attachments/assets/8c87d03c-4988-413e-8771-2ca4846d1924)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5259)