### PR TITLE
playground.BrowserTelemetry: avoid using npm on ci/windows

### DIFF
--- a/playground/BrowserTelemetry/BrowserTelemetry.Web/BrowserTelemetry.Web.csproj
+++ b/playground/BrowserTelemetry/BrowserTelemetry.Web/BrowserTelemetry.Web.csproj
@@ -4,13 +4,15 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Issue: https://github.com/dotnet/dnceng/issues/3091 -->
+    <NpmAvailable Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(OS)' != 'Windows_NT'">true</NpmAvailable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
   </ItemGroup>
 
-  <Target Name="NpmInstall" Inputs="package.json" Outputs="node_modules/.install-stamp">
+  <Target Name="NpmInstall" Inputs="package.json" Outputs="node_modules/.install-stamp" Condition="'$(NpmAvailable)' == 'true'">
     <!--
         Use npm install or npm ci depending on RestorePackagesWithLockFile value.
         Uncomment the following lines if you want to use this feature:
@@ -30,7 +32,7 @@
       2. Run npm run build before building the .NET project.
       MSBuild runs NpmInstall before this task because of the DependsOnTargets attribute.
    -->
-  <Target Name="NpmRunBuild" DependsOnTargets="NpmInstall" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Debug' ">
+  <Target Name="NpmRunBuild" DependsOnTargets="NpmInstall" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Debug' and '$(NpmAvailable)' == 'true' ">
     <Exec Command="npm run build" />
   </Target>
 

--- a/playground/BrowserTelemetry/BrowserTelemetry.Web/BrowserTelemetry.Web.csproj
+++ b/playground/BrowserTelemetry/BrowserTelemetry.Web/BrowserTelemetry.Web.csproj
@@ -5,14 +5,14 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- Issue: https://github.com/dotnet/dnceng/issues/3091 -->
-    <NpmAvailable Condition="'$(ContinuousIntegrationBuild)' != 'true' and '$(OS)' != 'Windows_NT'">true</NpmAvailable>
+    <NpmUnavailable Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OS)' == 'Windows_NT'">true</NpmUnavailable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
   </ItemGroup>
 
-  <Target Name="NpmInstall" Inputs="package.json" Outputs="node_modules/.install-stamp" Condition="'$(NpmAvailable)' == 'true'">
+  <Target Name="NpmInstall" Inputs="package.json" Outputs="node_modules/.install-stamp" Condition="'$(NpmUnavailable)' != 'true'">
     <!--
         Use npm install or npm ci depending on RestorePackagesWithLockFile value.
         Uncomment the following lines if you want to use this feature:
@@ -32,7 +32,7 @@
       2. Run npm run build before building the .NET project.
       MSBuild runs NpmInstall before this task because of the DependsOnTargets attribute.
    -->
-  <Target Name="NpmRunBuild" DependsOnTargets="NpmInstall" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Debug' and '$(NpmAvailable)' == 'true' ">
+  <Target Name="NpmRunBuild" DependsOnTargets="NpmInstall" BeforeTargets="BeforeBuild" Condition="'$(Configuration)' == 'Debug' and '$(NpmUnavailable)' != 'true' ">
     <Exec Command="npm run build" />
   </Target>
 


### PR DESCRIPTION
## Description

Using npm on build machines is blocked by https://github.com/dotnet/dnceng/issues/3091 .

Fixes https://github.com/dotnet/aspire/issues/5268

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
