### PR TITLE
[tests] Try to fix random failures on playground tests build

### DIFF
--- a/playground/AzureSearchEndToEnd/AzureSearch.AppHost/Program.cs
+++ b/playground/AzureSearchEndToEnd/AzureSearch.AppHost/Program.cs
@@ -9,11 +9,14 @@ builder.AddProject<Projects.AzureSearch_ApiService>("api")
        .WithExternalHttpEndpoints()
        .WithReference(azureSearch);
 
+#if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
-// in the artifacts dir).
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
 
 builder.Build().Run();

--- a/playground/BrowserTelemetry/BrowserTelemetry.AppHost/Program.cs
+++ b/playground/BrowserTelemetry/BrowserTelemetry.AppHost/Program.cs
@@ -6,11 +6,14 @@ var builder = DistributedApplication.CreateBuilder(args);
 builder.AddProject<Projects.BrowserTelemetry_Web>("web")
     .WithExternalHttpEndpoints();
 
+#if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
-// in the artifacts dir).
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
 
 builder.Build().Run();

--- a/playground/Directory.Build.targets
+++ b/playground/Directory.Build.targets
@@ -1,6 +1,12 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
+  <PropertyGroup>
+    <!-- Skip dashboard when building outside the repo, like on helix. Or when
+         building on CI -->
+    <SkipDashboardProjectReference Condition="'$(SkipDashboardProjectReference)' == '' and ('$(RepoRoot)' == '' or '$(ContinuousIntegrationBuild)' == 'true')">true</SkipDashboardProjectReference>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(IsAspireHost)' == 'true' and '$(SkipDashboardProjectReference)' != 'true'">
     <ProjectReference Include="$(RepoRoot)src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
   </ItemGroup>

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/Program.cs
@@ -15,11 +15,14 @@ builder.AddProject<Projects.OpenAIEndToEnd_WebStory>("webstory")
        .WithReference(openai)
        .WithEnvironment("OpenAI__DeploymentName", deploymentAndModelName);
 
+#if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
-// in the artifacts dir).
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
 
 builder.Build().Run();

--- a/playground/OracleEndToEnd/OracleEndToEnd.AppHost/Program.cs
+++ b/playground/OracleEndToEnd/OracleEndToEnd.AppHost/Program.cs
@@ -10,11 +10,14 @@ var pdb = oracle.AddDatabase("FREEPDB1");
 builder.AddProject<Projects.OracleEndToEnd_ApiService>("api")
        .WithReference(pdb);
 
+#if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
-// in the artifacts dir).
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
 
 builder.Build().Run();

--- a/playground/bicep/BicepSample.AppHost/Program.cs
+++ b/playground/bicep/BicepSample.AppHost/Program.cs
@@ -79,11 +79,14 @@ builder.AddProject<Projects.BicepSample_ApiService>("api")
        .WithEnvironment("bicepValue0", bicep1.GetOutput("val0"))
        .WithEnvironment("bicepValue1", bicep1.GetOutput("val1"));
 
+#if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
-// in the artifacts dir).
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
 
 builder.Build().Run();

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -102,11 +102,14 @@ builder.AddProject<Projects.CdkSample_ApiService>("api")
     .WithReference(search)
     .WithReference(appInsights);
 
+#if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
-// in the artifacts dir).
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
 
 builder.Build().Run();

--- a/playground/dapr/Dapr.AppHost/Program.cs
+++ b/playground/dapr/Dapr.AppHost/Program.cs
@@ -12,12 +12,15 @@ builder.AddProject<Projects.DaprServiceB>("serviceb")
        .WithDaprSidecar()
        .WithReference(pubSub);
 
+#if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging
 // of the dashboard. It is not required in end developer code. Comment out this code
-// to test end developer dashboard launch experience. Refer to Directory.Build.props
-// for the path to the dashboard binary (defaults to the Aspire.Dashboard bin output
-// in the artifacts dir).
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
 builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
 
 using var app = builder.Build();
 

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -29,14 +29,14 @@
     <AspireProjectOrPackageReference Include="Aspire.Hosting.NodeJs" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Testing" />
 
-    <ProjectReference Include="$(PlaygroundSourceDir)CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)ProxylessEndToEnd/ProxylessEndToEnd.AppHost/ProxylessEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)Qdrant/Qdrant.AppHost/Qdrant.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)TestShop/TestShop.AppHost/TestShop.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)mongo/Mongo.AppHost/Mongo.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)nats/Nats.AppHost/Nats.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)seq/Seq.AppHost/Seq.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)ProxylessEndToEnd/ProxylessEndToEnd.AppHost/ProxylessEndToEnd.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)Qdrant/Qdrant.AppHost/Qdrant.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)TestShop/TestShop.AppHost/TestShop.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)mongo/Mongo.AppHost/Mongo.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)nats/Nats.AppHost/Nats.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)seq/Seq.AppHost/Seq.AppHost.csproj" />
 
     <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />


### PR DESCRIPTION
`Aspire.Playground.Tests` build failed sometimes with errors like:

`Could not copy "D:\a\_work\1\s\artifacts\obj\CatalogModel\Release\net8.0\CatalogModel.dll" to "D:\a\_work\1\s\artifacts\bin\CatalogModel\Release\net8.0\CatalogModel.dll". Beginning retry 1 in 1000ms. The process cannot access the file 'D:\a\_work\1\s\artifacts\bin\CatalogModel\Release\net8.0\CatalogModel.dll' because it is being used by another process. The file is locked by: "Pdb2Pdb (1628)"`

The errors are not limited to this file, but can be one from any of the
playground projects.

Given:

1. `Aspire.Playgroud.Tests` references various playground AppHost projects
   directly with `AdditionalProperties="SkipDashboardProjectReference=true"`.
2. `Aspire.sln` also references these playground projects.

My thinking is that msbuild ends up treating these projects like
`TestShop/CatalogModel/CatalogModel.csproj` as two different project
instances:

1. One with `SkipDashboardProjectReference=true` (from
   `Aspire.Playground.Tests`)
2. One without that property, when building the reference directly from
   `Aspire.sln`.

This patch avoids that entirely by defaulting to
`SkipDashboardProjectReference=true` on CI, and on helix.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5271)