### PR TITLE
Use test container registry with Oracle

### DIFF
--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleContainerFixture.cs
@@ -30,9 +30,9 @@ public sealed class OracleContainerFixture : IAsyncLifetime
             Container = new OracleBuilder()
                 .WithPortBinding(1521, true)
                 .WithHostname("localhost")
+                .WithImage($"{TestConstants.AspireTestContainerRegistry}/gvenzl/oracle-xe:21.3.0-slim-faststart")
                 .WithWaitStrategy(Wait
                     .ForUnixContainer()
-                    .UntilMessageIsLogged("Pluggable database XEPDB1 opened read write")
                     .UntilMessageIsLogged("Completed: ALTER DATABASE OPEN")
                 ).Build();
 


### PR DESCRIPTION
TestContainer is using docker.io with Oracle. This uses the image from our test registry.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5272)