### PR TITLE
[ci] Disable failing Aspire.Playground.Tests

### DIFF
--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -6,6 +6,9 @@
     <!-- Set this explicitly so the project can build without arcade -->
     <IsTestProject>true</IsTestProject>
 
+    <!-- Disabling these tests - blocked on https://github.com/dotnet/aspire/pull/5251 -->
+    <SkipTests>true</SkipTests>
+
     <!-- no docker support on helix/windows yet -->
     <RunTestsOnHelix Condition="'$(OS)' != 'Windows_NT'">true</RunTestsOnHelix>
     <SkipTests Condition="'$(OS)' == 'Windows_NT'">true</SkipTests>
@@ -29,6 +32,15 @@
     <AspireProjectOrPackageReference Include="Aspire.Hosting.NodeJs" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Testing" />
 
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
+
+    <Using Include="Aspire.Hosting.Testing" />
+  </ItemGroup>
+
+  <!-- disable the build on CI . Blocked on https://github.com/dotnet/aspire/pull/5271 -->
+  <ItemGroup Condition="'$(ContinuousIntegrationBuild)' != 'true'">
     <ProjectReference Include="$(PlaygroundSourceDir)CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
     <ProjectReference Include="$(PlaygroundSourceDir)ProxylessEndToEnd/ProxylessEndToEnd.AppHost/ProxylessEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
     <ProjectReference Include="$(PlaygroundSourceDir)Qdrant/Qdrant.AppHost/Qdrant.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
@@ -37,12 +49,6 @@
     <ProjectReference Include="$(PlaygroundSourceDir)mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
     <ProjectReference Include="$(PlaygroundSourceDir)nats/Nats.AppHost/Nats.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
     <ProjectReference Include="$(PlaygroundSourceDir)seq/Seq.AppHost/Seq.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-
-    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
-
-    <Using Include="Aspire.Hosting.Testing" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ArchiveTests)' == 'true'" Label="Prepare archive dir for helix">

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -8,10 +8,11 @@
 
     <!-- Disabling these tests - blocked on https://github.com/dotnet/aspire/pull/5251 -->
     <SkipTests>true</SkipTests>
+    <RunTestsOnHelix>false</RunTestsOnHelix>
 
     <!-- no docker support on helix/windows yet -->
-    <RunTestsOnHelix Condition="'$(OS)' != 'Windows_NT'">true</RunTestsOnHelix>
-    <SkipTests Condition="'$(OS)' == 'Windows_NT'">true</SkipTests>
+    <!--<RunTestsOnHelix Condition="'$(OS)' != 'Windows_NT'">true</RunTestsOnHelix>-->
+    <!--<SkipTests Condition="'$(OS)' == 'Windows_NT'">true</SkipTests>-->
 
     <DeployOutsideOfRepoSupportFilesRelativeDir>staging-archive\</DeployOutsideOfRepoSupportFilesRelativeDir>
 

--- a/tests/helix/send-to-helix-ci.proj
+++ b/tests/helix/send-to-helix-ci.proj
@@ -6,7 +6,8 @@
       <TestCategory Condition="'$(OS)' != 'Windows_NT'" Include="endtoendtests" />
       <TestCategory Include="workloadtests" />
       <!-- no docker on windows -->
-      <TestCategory Condition="'$(OS)' != 'Windows_NT'" Include="buildonhelixtests" />
+      <!-- Issue: https://github.com/dotnet/aspire/pull/5271, and https://github.com/dotnet/aspire/pull/5251 -->
+      <!--<TestCategory Condition="'$(OS)' != 'Windows_NT'" Include="buildonhelixtests" />-->
 
       <AdditionalProperties Condition="'$(Configuration)' != ''" Include="Configuration=$(Configuration)" />
       <_ProjectsToBuild Include="send-to-helix-inner.proj"


### PR DESCRIPTION
There are two failures hitting CI right now:

1. `Could not copy "D:\a\_work\1\s\artifacts\obj\CatalogModel\Release\net8.0\CatalogModel.dll" to "D:\a\_work\1\s\artifacts\bin\CatalogModel\Release\net8.0\CatalogModel.dll". Beginning retry 1 in 1000ms. The process cannot access the file 'D:\a\_work\1\s\artifacts\bin\CatalogModel\Release\net8.0\CatalogModel.dll' because it is being used by another process. The file is locked by: "Pdb2Pdb (1628)"`

    - Exceptions like this when building playground apps.
    - Waiting on https://github.com/dotnet/aspire/pull/5271 which might
      be a fix.

2. Individual playground tests failing
    - Waiting on https://github.com/dotnet/aspire/pull/5251

This PR disable the tests completely to get the CI in a better state,
and can be re-enabled once the aforementioned issues are fixed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5273)