### PR TITLE
Traces UI update to add color and move timestamp

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -37,16 +37,15 @@
                                 ResizableColumns="true"
                                 ItemsProvider="@GetData"
                                 TGridItem="OtlpTrace"
-                                GridTemplateColumns="0.8fr 2fr 3fr 0.8fr 0.5fr"
+                                GridTemplateColumns="2fr 3fr 0.8fr 0.8fr 0.5fr"
                                 ShowHover="true"
                                 OnRowClick="@(r => r.ExecuteOnDefault(d => NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(d.TraceId))))"
                                 Class="enable-row-click">
                     <ChildContent>
-                        <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
-                            @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)
-                        </TemplateColumn>
                         <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Tooltip="true" TooltipText="@(trace => GetNameTooltip(trace))">
-                            <span><FluentHighlighter HighlightedText="@(TracesViewModel.FilterText)" Text="@(context.FullName)" /></span>
+                            <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName((context.RootSpan ?? context.FirstSpan).Source)));">
+                                <FluentHighlighter HighlightedText="@(TracesViewModel.FilterText)" Text="@(context.FullName)" />
+                            </span>
                             <span class="trace-id">@OtlpHelpers.ToShortenedId(context.TraceId)</span>
                         </TemplateColumn>
                         <TemplateColumn Title="@Loc[nameof(Dashboard.Resources.Traces.TracesSpansColumnHeader)]">
@@ -84,6 +83,9 @@
                                     </FluentTooltip>
                                 </OverflowTemplate>
                             </FluentOverflow>
+                        </TemplateColumn>
+                        <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
+                            @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)
                         </TemplateColumn>
                         <TemplateColumn Title="@ControlsStringsLoc[nameof(ControlsStrings.DurationColumnHeader)]">
                             <div class="duration-container">


### PR DESCRIPTION
## Description

Minor changes to trace page:

* Change column order so name is first
* Timestamp is moved next to duration
* Add color bar to name

These changes move the most important information to the first column and makes the traces page more consistent with the structured logs page. It bugged me that timestamp column position on the two telemetry pages was different.

![image](https://github.com/user-attachments/assets/eef1dc74-fc30-4912-930a-173ddcade444)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5286)