### PR TITLE
[tests] Add tests for more Playground apps

### DIFF
--- a/playground/Directory.Build.targets
+++ b/playground/Directory.Build.targets
@@ -1,12 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
-  <PropertyGroup>
-    <!-- Skip dashboard when building outside the repo, like on helix. Or when
-         building on CI -->
-    <SkipDashboardProjectReference Condition="'$(SkipDashboardProjectReference)' == '' and ('$(RepoRoot)' == '' or '$(ContinuousIntegrationBuild)' == 'true')">true</SkipDashboardProjectReference>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(IsAspireHost)' == 'true' and '$(SkipDashboardProjectReference)' != 'true'">
     <ProjectReference Include="$(RepoRoot)src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
   </ItemGroup>
@@ -17,4 +11,8 @@
   <PropertyGroup Condition="'$(SkipDashboardProjectReference)' == 'true'">
     <DefineConstants>SKIP_DASHBOARD_REFERENCE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Update="@(ProjectReference)" AdditionalProperties="SkipDashboardProjectReference=$(SkipDashboardProjectReference)" />
+  </ItemGroup>
 </Project>

--- a/playground/Directory.Build.targets
+++ b/playground/Directory.Build.targets
@@ -1,6 +1,12 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
+  <PropertyGroup>
+    <!-- Skip dashboard when building outside the repo, like on helix. Or when
+         building on CI -->
+    <SkipDashboardProjectReference Condition="'$(SkipDashboardProjectReference)' == '' and ('$(RepoRoot)' == '' or '$(ContinuousIntegrationBuild)' == 'true')">true</SkipDashboardProjectReference>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(IsAspireHost)' == 'true' and '$(SkipDashboardProjectReference)' != 'true'">
     <ProjectReference Include="$(RepoRoot)src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
   </ItemGroup>
@@ -11,8 +17,4 @@
   <PropertyGroup Condition="'$(SkipDashboardProjectReference)' == 'true'">
     <DefineConstants>SKIP_DASHBOARD_REFERENCE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Update="@(ProjectReference)" AdditionalProperties="SkipDashboardProjectReference=$(SkipDashboardProjectReference)" />
-  </ItemGroup>
 </Project>

--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -6,11 +6,14 @@ var catalogDb = builder.AddPostgres("postgres")
                        .AddDatabase("catalogdb");
 
 var basketCache = builder.AddRedis("basketcache")
-                         .WithDataVolume()
-                         .WithRedisCommander(c =>
-                         {
-                             c.WithHostPort(33801);
-                         });
+                         .WithDataVolume();
+
+#if !SKIP_DASHBOARD_REFERENCE
+basketCache.WithRedisCommander(c =>
+                     {
+                         c.WithHostPort(33801);
+                     });
+#endif
 
 var catalogService = builder.AddProject<Projects.CatalogService>("catalogservice")
                             .WithReference(catalogDb)

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -166,6 +166,8 @@ public class AppHostTests
     {
         IList<TestEndpoints> candidates =
         [
+            new TestEndpoints("MilvusPlayground.AppHost",
+                resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/create", "/search"] } }),
             new TestEndpoints("CosmosEndToEnd.AppHost",
                 resourceEndpoints: new() { { "api", ["/alive", "/health", "/", "/ef"] } },
                 waitForTexts: [

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -34,22 +34,22 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
 
-    <ProjectReference Include="$(PlaygroundSourceDir)CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)ParameterEndToEnd/ParameterEndToEnd.AppHost/ParameterEndToEnd.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)PostgresEndToEnd/PostgresEndToEnd.AppHost/PostgresEndToEnd.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)ProxylessEndToEnd/ProxylessEndToEnd.AppHost/ProxylessEndToEnd.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)Qdrant/Qdrant.AppHost/Qdrant.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)SqlServerEndToEnd/SqlServerEndToEnd.AppHost/SqlServerEndToEnd.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)TestShop/TestShop.AppHost/TestShop.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)keycloak/Keycloak.AppHost/Keycloak.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)milvus/MilvusPlayground.AppHost/MilvusPlayground.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)ParameterEndToEnd/ParameterEndToEnd.AppHost/ParameterEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)PostgresEndToEnd/PostgresEndToEnd.AppHost/PostgresEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)ProxylessEndToEnd/ProxylessEndToEnd.AppHost/ProxylessEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)Qdrant/Qdrant.AppHost/Qdrant.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)SqlServerEndToEnd/SqlServerEndToEnd.AppHost/SqlServerEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)TestShop/TestShop.AppHost/TestShop.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)keycloak/Keycloak.AppHost/Keycloak.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)milvus/MilvusPlayground.AppHost/MilvusPlayground.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
 
     <!-- Issue: https://github.com/dotnet/aspire/issues/5274 -->
-    <!--<ProjectReference Include="$(PlaygroundSourceDir)mongo/Mongo.AppHost/Mongo.AppHost.csproj" />-->
+    <!--<ProjectReference Include="$(PlaygroundSourceDir)mongo/Mongo.AppHost/Mongo.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />-->
 
-    <ProjectReference Include="$(PlaygroundSourceDir)mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)nats/Nats.AppHost/Nats.AppHost.csproj" />
-    <ProjectReference Include="$(PlaygroundSourceDir)seq/Seq.AppHost/Seq.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)nats/Nats.AppHost/Nats.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)seq/Seq.AppHost/Seq.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
 
     <Using Include="Aspire.Hosting.Testing" />
   </ItemGroup>

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -42,6 +42,7 @@
     <ProjectReference Include="$(PlaygroundSourceDir)SqlServerEndToEnd/SqlServerEndToEnd.AppHost/SqlServerEndToEnd.AppHost.csproj" />
     <ProjectReference Include="$(PlaygroundSourceDir)TestShop/TestShop.AppHost/TestShop.AppHost.csproj" />
     <ProjectReference Include="$(PlaygroundSourceDir)keycloak/Keycloak.AppHost/Keycloak.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)milvus/MilvusPlayground.AppHost/MilvusPlayground.AppHost.csproj" />
 
     <!-- Issue: https://github.com/dotnet/aspire/issues/5274 -->
     <!--<ProjectReference Include="$(PlaygroundSourceDir)mongo/Mongo.AppHost/Mongo.AppHost.csproj" />-->

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -34,22 +34,22 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
 
-    <ProjectReference Include="$(PlaygroundSourceDir)CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)ParameterEndToEnd/ParameterEndToEnd.AppHost/ParameterEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)PostgresEndToEnd/PostgresEndToEnd.AppHost/PostgresEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)ProxylessEndToEnd/ProxylessEndToEnd.AppHost/ProxylessEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)Qdrant/Qdrant.AppHost/Qdrant.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)SqlServerEndToEnd/SqlServerEndToEnd.AppHost/SqlServerEndToEnd.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)TestShop/TestShop.AppHost/TestShop.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)keycloak/Keycloak.AppHost/Keycloak.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)milvus/MilvusPlayground.AppHost/MilvusPlayground.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)CosmosEndToEnd/CosmosEndToEnd.AppHost/CosmosEndToEnd.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)ParameterEndToEnd/ParameterEndToEnd.AppHost/ParameterEndToEnd.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)PostgresEndToEnd/PostgresEndToEnd.AppHost/PostgresEndToEnd.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)ProxylessEndToEnd/ProxylessEndToEnd.AppHost/ProxylessEndToEnd.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)Qdrant/Qdrant.AppHost/Qdrant.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)SqlServerEndToEnd/SqlServerEndToEnd.AppHost/SqlServerEndToEnd.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)TestShop/TestShop.AppHost/TestShop.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)keycloak/Keycloak.AppHost/Keycloak.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)milvus/MilvusPlayground.AppHost/MilvusPlayground.AppHost.csproj" />
 
     <!-- Issue: https://github.com/dotnet/aspire/issues/5274 -->
-    <!--<ProjectReference Include="$(PlaygroundSourceDir)mongo/Mongo.AppHost/Mongo.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />-->
+    <!--<ProjectReference Include="$(PlaygroundSourceDir)mongo/Mongo.AppHost/Mongo.AppHost.csproj" />-->
 
-    <ProjectReference Include="$(PlaygroundSourceDir)mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)nats/Nats.AppHost/Nats.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
-    <ProjectReference Include="$(PlaygroundSourceDir)seq/Seq.AppHost/Seq.AppHost.csproj" AdditionalProperties="SkipDashboardProjectReference=true" />
+    <ProjectReference Include="$(PlaygroundSourceDir)mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)nats/Nats.AppHost/Nats.AppHost.csproj" />
+    <ProjectReference Include="$(PlaygroundSourceDir)seq/Seq.AppHost/Seq.AppHost.csproj" />
 
     <Using Include="Aspire.Hosting.Testing" />
   </ItemGroup>

--- a/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
+++ b/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
@@ -46,9 +46,9 @@ internal static class DistributedApplicationTestFactory
             {
                 logging.AddXunit(testOutput);
             }
-            logging.SetMinimumLevel(LogLevel.Trace);
-            logging.AddFilter("Aspire", LogLevel.Trace);
-            logging.AddFilter(builder.Environment.ApplicationName, LogLevel.Trace);
+            logging.SetMinimumLevel(LogLevel.Debug);
+            logging.AddFilter("Aspire", LogLevel.Debug);
+            logging.AddFilter(builder.Environment.ApplicationName, LogLevel.Debug);
         });
 
         return builder;


### PR DESCRIPTION
- Add `milvus` playground app to the tests.
- Skip the redis commander in `TestShop` for tests, as it requires connecting to other containers which is not supported on our CI yet. And we don't really connect, and check the web app.
- Reduce log level to `debug` from `trace`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5294)