### PR TITLE
Improve support for non-primitive OTEL values

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -108,6 +108,8 @@ public static class OtlpHelpers
 
     private static JsonNode? ConvertAnyValue(AnyValue value)
     {
+        // Recursively convert AnyValue types to JsonNode types to produce more idiomatic JSON.
+        // Recursing over incoming values is safe because Protobuf serializer imposes a safe limit on recursive messages.
         return value.ValueCase switch
         {
             AnyValue.ValueOneofCase.StringValue => JsonValue.Create(value.StringValue),

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -18,6 +18,7 @@ namespace Aspire.Dashboard.Otlp.Model;
 
 public static class OtlpHelpers
 {
+    // Reduce size of JSON data by not indenting. Dashboard UI supports formatting JSON values when they're displayed.
     private static readonly JsonSerializerOptions s_jsonSerializerOptions = new JsonSerializerOptions
     {
         WriteIndented = false

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpHelpersTests.cs
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+using Google.Protobuf;
+using OpenTelemetry.Proto.Common.V1;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.TelemetryRepositoryTests;
+
+public class OtlpHelpersTests
+{
+    [Fact]
+    public void GetString_StringValue()
+    {
+        // Arrange
+        var anyValue = new AnyValue { StringValue = "string!" };
+
+        // Act
+        var s = OtlpHelpers.GetString(anyValue);
+
+        // Assert
+        Assert.Equal("string!", s);
+    }
+
+    [Fact]
+    public void GetString_BytesValue()
+    {
+        // Arrange
+        var anyValue = new AnyValue
+        {
+            BytesValue = ByteString.CopyFromUtf8("Hello world")
+        };
+
+        // Act
+        var s = OtlpHelpers.GetString(anyValue);
+
+        // Assert
+        Assert.Equal("48656c6c6f20776f726c64", s);
+    }
+
+    [Fact]
+    public void GetString_NoneValue()
+    {
+        // Arrange
+        var anyValue = new AnyValue();
+
+        // Act
+        var s = OtlpHelpers.GetString(anyValue);
+
+        // Assert
+        Assert.Equal("", s);
+    }
+
+    [Fact]
+    public void GetString_ArrayValue()
+    {
+        // Arrange
+        var anyValue = new AnyValue
+        {
+            ArrayValue = new ArrayValue
+            {
+                Values =
+                {
+                    new AnyValue { BoolValue = true },
+                    new AnyValue()
+                }
+            }
+        };
+
+        // Act
+        var s = OtlpHelpers.GetString(anyValue);
+
+        // Assert
+        Assert.Equal("[true,null]", s);
+    }
+
+    [Fact]
+    public void GetString_KeyValues()
+    {
+        // Arrange
+        var anyValue = new AnyValue
+        {
+            KvlistValue = new KeyValueList
+            {
+                Values =
+                {
+                    new KeyValue
+                    {
+                        Key = "prop1",
+                        Value = new AnyValue
+                        {
+                            ArrayValue = new ArrayValue
+                            {
+                                Values =
+                                {
+                                    new AnyValue { StringValue = "string!" },
+                                    new AnyValue { DoubleValue = 1.1d },
+                                    new AnyValue { IntValue = 1 }
+                                }
+                            }
+                        }
+                    },
+                    new KeyValue
+                    {
+                        Key = "prop2",
+                        Value = new AnyValue
+                        {
+                            BytesValue = ByteString.CopyFromUtf8("Hello world")
+                        }
+                    },
+                    new KeyValue
+                    {
+                        Key = "prop3",
+                        Value = new AnyValue
+                        {
+                            KvlistValue = new KeyValueList
+                            {
+                                Values =
+                                {
+                                    new KeyValue
+                                    {
+                                        Key = "nestedProp1",
+                                        Value = new AnyValue { StringValue = "nested!" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        // Act
+        var s = OtlpHelpers.GetString(anyValue);
+
+        // Assert
+        Assert.Equal(@"{""prop1"":[""string!"",1.1,1],""prop2"":""48656c6c6f20776f726c64"",""prop3"":{""nestedProp1"":""nested!""}}", s);
+    }
+}


### PR DESCRIPTION
## Description

OTLP data such as attributes on telemetry can be complex data. Realistically, almost everyone uses strings or other primitive types for attributes, but we should handle complex data.

Internally the dashboard stores attributes as strings, so we need a good conversion process when converting incoming values to strings.

This PR:

* Improves how complex data, such as objects and arrays, are serialized to JSON
* Adds tests around creating strings from OTLP values

Example of a simple array with a boolean:

* Before: `{ "arrayValue": { "values": [ { "boolValue": true } ] } }`
* After: `[true]`

Fixes https://github.com/dotnet/aspire/issues/4506

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5296)