### PR TITLE
Populate dashpages from configuration

### DIFF
--- a/spelling.dic
+++ b/spelling.dic
@@ -18,6 +18,7 @@ consolelogs
 cors
 csproj
 dashpage
+dashpages
 dbug
 dcpctrl
 dockerfile

--- a/src/Aspire.Dashboard/Components/Controls/Chart/DashpageCharts.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/DashpageCharts.razor
@@ -38,7 +38,7 @@
     public required OtlpMeter SelectedMeter { get; set; }
 
     [Parameter, EditorRequired]
-    public required Metrics.DashpageDefinition SelectedDashpage { get; set; }
+    public required DashpageDefinition SelectedDashpage { get; set; }
 
     [Parameter, EditorRequired]
     public required List<OtlpInstrument> Instruments { get; set; }

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -3,6 +3,7 @@
 @page "/metrics/resource/{applicationName}/meter/{meterName}"
 @page "/metrics/resource/{applicationName}/meter/{meterName}/instrument/{instrumentName}"
 
+@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Model.Otlp
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Otlp.Model
@@ -56,7 +57,7 @@
                         <Panel1>
                             <FluentTreeView Class="metrics-tree" @bind-CurrentSelected="PageViewModel.SelectedTreeItem" @bind-CurrentSelected:after="HandleSelectedTreeItemChangedAsync">
                                 <ChildContent>
-                                    @if (PageViewModel.Dashpages.Count is not 0)
+                                    @if (PageViewModel.Dashpages.Length is not 0)
                                     {
                                         <FluentTreeItem Text="@Loc[Aspire.Dashboard.Resources.Metrics.DashpagesSectionName]" title="@Loc[Aspire.Dashboard.Resources.Metrics.DashpagesSectionName]" InitiallyExpanded="true">
                                             @foreach (DashpageDefinition dashpage in PageViewModel.Dashpages)

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -29,6 +29,7 @@ using Microsoft.AspNetCore.Server.Kestrel;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -218,6 +219,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Services.AddScoped<ISessionStorage, SessionBrowserStorage>();
 
         builder.Services.AddScoped<DimensionManager>();
+
+        builder.Services.AddSingleton<IFileProvider>(new PhysicalFileProvider(Directory.GetCurrentDirectory()));
+        builder.Services.AddSingleton<IDashpagePersistence, DashpageJsonFilePersistence>();
 
         builder.Services.AddLocalization();
 

--- a/src/Aspire.Dashboard/Model/DashpageModels.cs
+++ b/src/Aspire.Dashboard/Model/DashpageModels.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.FileProviders;
+using static Aspire.Dashboard.Components.Pages.Metrics;
+
+namespace Aspire.Dashboard.Model;
+
+/// <summary>
+/// Data about a dashpage.
+/// </summary>
+public sealed class DashpageDefinition
+{
+    /// <summary>
+    /// Gets the unique name of this dashpage.
+    /// </summary>
+    /// <remarks>
+    /// Also used as a display name.
+    /// </remarks>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the relative priority of this dashpage, controlling ordering of dashpages in UI.
+    /// </summary>
+    /// <remarks>
+    /// Higher priorities appear higher in lists.
+    /// When priorities are equal, dashpages are ordered by name.
+    /// </remarks>
+    [JsonPropertyName("priority")]
+    public int Priority { get; init; }
+
+    [JsonPropertyName("charts")]
+    public required List<DashpageChartDefinition> Charts { get; init; }
+}
+
+/// <summary>
+/// Data about a chart on a dashpage.
+/// </summary>
+public sealed class DashpageChartDefinition
+{
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    [JsonPropertyName("instrument")]
+    public required string InstrumentName { get; init; }
+
+    [JsonPropertyName("required")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool IsRequired { get; init; }
+
+    [JsonPropertyName("resource")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ResourceName { get; init; }
+
+    [JsonPropertyName("kind")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public MetricViewKind DefaultViewKind { get; init; } = MetricViewKind.Graph;
+}
+
+public interface IDashpagePersistence
+{
+    Task<ImmutableArray<DashpageDefinition>> GetDashpagesAsync(CancellationToken token);
+}
+
+public sealed class DashpageJsonFilePersistence(IFileProvider fileProvider) : IDashpagePersistence
+{
+    private static readonly JsonSerializerOptions s_options = new() { ReadCommentHandling = JsonCommentHandling.Skip };
+
+    // Cache file to prevent re-reading on every request.
+    // In case of an exception, no caching is done.
+    private ImmutableArray<DashpageDefinition> _dashpages;
+
+    public async Task<ImmutableArray<DashpageDefinition>> GetDashpagesAsync(CancellationToken token)
+    {
+        if (_dashpages.IsDefault)
+        {
+            var fileInfo = fileProvider.GetFileInfo("dashpages.json");
+
+            if (fileInfo.Exists == false)
+            {
+                _dashpages = [];
+            }
+            else
+            {
+                using Stream stream = fileInfo.CreateReadStream();
+
+                using StreamReader reader = new(stream, Encoding.UTF8, leaveOpen: true);
+
+                var json = await reader.ReadToEndAsync(token).ConfigureAwait(false);
+
+                _dashpages = Deserialize(json);
+            }
+        }
+
+        return _dashpages;
+    }
+
+    internal static ImmutableArray<DashpageDefinition> Deserialize(string json)
+    {
+        return JsonSerializer.Deserialize<ImmutableArray<DashpageDefinition>>(json, s_options);
+    }
+}

--- a/src/Aspire.Dashboard/dashpages.json
+++ b/src/Aspire.Dashboard/dashpages.json
@@ -1,0 +1,38 @@
+[
+  /* Comments are ignored */
+  {
+    "name": ".NET",
+    "priority": 99,
+    "charts": [
+      {
+        "title": "Exception count",
+        "instrument": "process.runtime.dotnet.exceptions.count",
+        "required": false, // default
+        "resource": null, // default
+        "kind": "Graph" // upper case
+      },
+      {
+        "title": "Assembly count",
+        "instrument": "process.runtime.dotnet.assemblies.count",
+        "kind": "table" // lower case
+      },
+      {
+        "title": "Thread Pool Completion",
+        "instrument": "process.runtime.dotnet.thread_pool.completed_items.count",
+        "required": true // non-default
+      }
+    ]
+  },
+  {
+    "name": "Envoy",
+    "priority": 99,
+    "charts": [
+      {
+        "title": "Connection count",
+        "instrument": "envoy.connection.count",
+        "required": true, // non-default
+        "resource": "envoy" // non-default
+      }
+    ]
+  }
+]

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -16,7 +16,7 @@ namespace Aspire.Dashboard.Components.Tests.Controls;
 [UseCulture("en-US")]
 public class PlotlyChartTests : TestContext
 {
-    private static string GetContainerHtml(string divId) => $"""<div id="{divId}" class="plotly-chart-container" style="width:650px; height:450px;"></div>""";
+    private static string GetContainerHtml(string divId) => $"""<div id="{divId}" class="plotly-chart-container"></div>""";
 
     [Fact]
     public void Render_NoInstrument_NoPlotlyInvocations()

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/MetricsSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/MetricsSetupHelpers.cs
@@ -14,6 +14,7 @@ using Aspire.Dashboard.Model.BrowserStorage;
 using Aspire.Dashboard.Otlp.Storage;
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Microsoft.FluentUI.AspNetCore.Components;
 
@@ -81,6 +82,7 @@ internal static class MetricsSetupHelpers
         context.Services.AddSingleton<LibraryConfiguration>();
         context.Services.AddSingleton<IKeyCodeService, KeyCodeService>();
         context.Services.AddSingleton<IEffectiveThemeResolver, TestEffectiveThemeResolver>();
+        context.Services.AddSingleton<IDashpagePersistence, TestDashpagePersistence>();
         context.Services.AddSingleton<ThemeManager>();
     }
 

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashpagePersistence.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashpagePersistence.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Aspire.Dashboard.Model;
+
+namespace Aspire.Dashboard.Components.Tests.Shared;
+
+public sealed class TestDashpagePersistence : IDashpagePersistence
+{
+    public Task<ImmutableArray<DashpageDefinition>> GetDashpagesAsync(CancellationToken token)
+    {
+        return Task.FromResult<ImmutableArray<DashpageDefinition>>([]);
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/DashpageJsonFilePersistenceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashpageJsonFilePersistenceTests.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Xunit;
+using static Aspire.Dashboard.Components.Pages.Metrics;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class DashpageJsonFilePersistenceTests
+{
+    [Fact]
+    public void Deserialize()
+    {
+        // Start with JSON, convert to object model, back to JSON, and compare with original.
+        var json = """
+            [
+                /* Comments are ignored */
+                {
+                    "name": ".NET",
+                    "priority": 99,
+                    "charts": [
+                        {
+                            "title": "Exception count",
+                            "instrument": "process.runtime.dotnet.exceptions.count",
+                            "required": false, // default
+                            "resource": null,  // default
+                            "kind": "Graph"    // upper case
+                        },
+                        {
+                            "title": "Assembly count",
+                            "instrument": "process.runtime.dotnet.assemblies.count",
+                            "kind": "table"    // lower case
+                        },
+                        {
+                            "title": "Thread Pool Completion",
+                            "instrument": "process.runtime.dotnet.thread_pool.completed_items.count",
+                            "required": true   // non-default
+                        }
+                    ]
+                },
+                {
+                    "name": "Envoy",
+                    "priority": 99,
+                    "charts": [
+                        {
+                            "title": "Connection count",
+                            "instrument": "envoy.connection.count",
+                            "required": true,   // non-default
+                            "resource": "envoy" // non-default
+                        }
+                    ]
+                }
+            ]
+            """;
+
+        var dashpages = DashpageJsonFilePersistence.Deserialize(json);
+
+        Assert.Collection(dashpages,
+            dashpage =>
+            {
+                Assert.Equal(".NET", dashpage.Name);
+                Assert.Equal(99, dashpage.Priority);
+                Assert.Collection(dashpage.Charts,
+                    chart =>
+                    {
+                        Assert.Equal("Exception count", chart.Title);
+                        Assert.Equal("process.runtime.dotnet.exceptions.count", chart.InstrumentName);
+                        Assert.False(chart.IsRequired);
+                        Assert.Null(chart.ResourceName);
+                        Assert.Equal(MetricViewKind.Graph, chart.DefaultViewKind);
+                    },
+                    chart =>
+                    {
+                        Assert.Equal("Assembly count", chart.Title);
+                        Assert.Equal("process.runtime.dotnet.assemblies.count", chart.InstrumentName);
+                        Assert.False(chart.IsRequired);
+                        Assert.Null(chart.ResourceName);
+                        Assert.Equal(MetricViewKind.Table, chart.DefaultViewKind);
+                    },
+                    chart =>
+                    {
+                        Assert.Equal("Thread Pool Completion", chart.Title);
+                        Assert.Equal("process.runtime.dotnet.thread_pool.completed_items.count", chart.InstrumentName);
+                        Assert.True(chart.IsRequired);
+                        Assert.Null(chart.ResourceName);
+                        Assert.Equal(MetricViewKind.Graph, chart.DefaultViewKind);
+                    });
+            },
+            dashpage =>
+            {
+                Assert.Equal("Envoy", dashpage.Name);
+                Assert.Equal(99, dashpage.Priority);
+                Assert.Collection(dashpage.Charts,
+                    chart =>
+                    {
+                        Assert.Equal("Connection count", chart.Title);
+                        Assert.Equal("envoy.connection.count", chart.InstrumentName);
+                        Assert.True(chart.IsRequired);
+                        Assert.Equal("envoy", chart.ResourceName);
+                        Assert.Equal(MetricViewKind.Graph, chart.DefaultViewKind);
+                    });
+            });
+    }
+}


### PR DESCRIPTION
Fixes #5289

This change causes the dashboard to look for a file named `dashpages.json` in the current directory. If found, it's parsed to provide the set of dashpages shown on the metrics page.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected. (this is a PR to a feature branch)
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No (not yet, we will doc dashpages entirely before the feature branch merges)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5302)