### PR TITLE
[tests] Add waitForTexts for Milvus playground app test

### DIFF
--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -167,7 +167,10 @@ public class AppHostTests
         IList<TestEndpoints> candidates =
         [
             new TestEndpoints("MilvusPlayground.AppHost",
-                resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/create", "/search"] } }),
+                resourceEndpoints: new() { { "apiservice", ["/alive", "/health", "/create", "/search"] } },
+                waitForTexts: [
+                    new ("milvus", "Milvus Proxy successfully initialized and ready to serve"),
+                ]),
             new TestEndpoints("CosmosEndToEnd.AppHost",
                 resourceEndpoints: new() { { "api", ["/alive", "/health", "/", "/ef"] } },
                 waitForTexts: [


### PR DESCRIPTION
## Description

Fixes random failures with the test due to sending the requests too early, for Milvus playground app test.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5306)