### PR TITLE
[tests] DockerUtils.AttemptDeleteDockerVolume - allow throwing on failures

### DIFF
--- a/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
@@ -86,8 +86,8 @@ public class ElasticsearchFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(elasticsearch1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // if the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 elasticsearch1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Kafka.Tests/KafkaFunctionalTests.cs
@@ -94,8 +94,8 @@ public class KafkaFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(kafka1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // if the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 kafka1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -105,8 +105,8 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(milvus1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // if the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 milvus1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -87,8 +87,8 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(mongodb1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // if the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 mongodb1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -99,8 +99,8 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(mysql1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // If the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 mysql1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
@@ -85,8 +85,8 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(nats1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // if the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 nats1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -98,8 +98,8 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(postgres1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // If the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 postgres1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/QdrantFunctionalTests.cs
@@ -106,8 +106,8 @@ public class QdrantFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(qdrant1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // if the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 qdrant1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -71,8 +71,8 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(rabbitMQ1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // if the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 rabbitMQ1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -62,6 +62,8 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
         // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
         var volumeName = VolumeNameGenerator.CreateVolumeName(redis1, nameof(WithDataVolumeShouldPersistStateBetweenUsages));
         redis1.WithDataVolume(volumeName);
+        // if the volume already exists (because of a crashing previous run), delete it
+        DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
 
         using (var app = builder1.Build())
         {

--- a/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/SqlServerFunctionalTests.cs
@@ -102,8 +102,8 @@ public class SqlServerFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(sqlserver1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // If the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 sqlserver1.WithDataVolume(volumeName);
             }
             else

--- a/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Valkey.Tests/ValkeyFunctionalTests.cs
@@ -74,8 +74,8 @@ public class ValkeyFunctionalTests(ITestOutputHelper testOutputHelper)
                 // Use a deterministic volume name to prevent them from exhausting the machines if deletion fails
                 volumeName = VolumeNameGenerator.CreateVolumeName(valkey1, nameof(WithDataShouldPersistStateBetweenUsages));
 
-                // if the volume already exists (because of a crashing previous run), try to delete it
-                DockerUtils.AttemptDeleteDockerVolume(volumeName);
+                // if the volume already exists (because of a crashing previous run), delete it
+                DockerUtils.AttemptDeleteDockerVolume(volumeName, throwOnFailure: true);
                 valkey1.WithDataVolume(volumeName);
             }
             else


### PR DESCRIPTION
.. failures. This is useful when expecting to create a fresh new volume,
and this would cause an exception to be thrown if a volume with the same
name could not be deleted.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5315)