### PR TITLE
[tests] Misc fixes for playground tests

### DIFF
--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -3,7 +3,6 @@
 
 using System.Net;
 using System.Text;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;
@@ -312,11 +311,8 @@ public class AppHostTests
     }
 }
 
-public class TestEndpoints : IXunitSerializable
+public class TestEndpoints
 {
-    // Required for deserialization
-    public TestEndpoints() { }
-
     public TestEndpoints(string appHost, Dictionary<string, List<string>> resourceEndpoints, List<ReadyStateText>? waitForTexts = null)
     {
         AppHost = appHost;
@@ -324,29 +320,13 @@ public class TestEndpoints : IXunitSerializable
         WaitForTexts = waitForTexts;
     }
 
-    public string? AppHost { get; set; }
+    public string AppHost { get; set; }
 
     public List<ResourceWait>? WaitForResources { get; set; }
 
     public List<ReadyStateText>? WaitForTexts { get; set; }
 
     public Dictionary<string, List<string>>? ResourceEndpoints { get; set; }
-
-    public void Deserialize(IXunitSerializationInfo info)
-    {
-        AppHost = info.GetValue<string>(nameof(AppHost));
-        WaitForResources = JsonSerializer.Deserialize<List<ResourceWait>>(info.GetValue<string>(nameof(WaitForResources)));
-        WaitForTexts = JsonSerializer.Deserialize<List<ReadyStateText>>(info.GetValue<string>(nameof(WaitForTexts)));
-        ResourceEndpoints = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(info.GetValue<string>(nameof(ResourceEndpoints)));
-    }
-
-    public void Serialize(IXunitSerializationInfo info)
-    {
-        info.AddValue(nameof(AppHost), AppHost);
-        info.AddValue(nameof(WaitForResources), JsonSerializer.Serialize(WaitForResources));
-        info.AddValue(nameof(WaitForTexts), JsonSerializer.Serialize(WaitForTexts));
-        info.AddValue(nameof(ResourceEndpoints), JsonSerializer.Serialize(ResourceEndpoints));
-    }
 
     public override string? ToString() => $"{AppHost} ({ResourceEndpoints?.Count ?? 0} resources)";
 

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -28,7 +28,7 @@ public class AppHostTests
     }
 
     [Theory]
-    [MemberData(nameof(AppHostAssemblies))]
+    [MemberData(nameof(AppHostAssembliesWithNoTestEndpoints))]
     public async Task AppHostRunsCleanly(string appHostPath)
     {
         var appHost = await DistributedApplicationTestFactory.CreateAsync(appHostPath, _testOutput);
@@ -142,7 +142,7 @@ public class AppHostTests
         await app.StopAsync();
     }
 
-    public static TheoryData<string> AppHostAssemblies()
+    public static TheoryData<string> AppHostAssembliesWithNoTestEndpoints()
     {
         var appHostAssemblies = GetPlaygroundAppHostAssemblyPaths();
 
@@ -158,6 +158,7 @@ public class AppHostTests
             var appHostName = Path.GetFileNameWithoutExtension(asm);
             if (appHostsWithTestEndpoints.Contains(appHostName))
             {
+                // Skipping this as it will be tested by TestEndpointsReturnOk
                 continue;
             }
 

--- a/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
+++ b/tests/Aspire.Playground.Tests/Aspire.Playground.Tests.csproj
@@ -46,7 +46,8 @@
     <ProjectReference Include="$(PlaygroundSourceDir)milvus/MilvusPlayground.AppHost/MilvusPlayground.AppHost.csproj" />
 
     <!-- Issue: https://github.com/dotnet/aspire/issues/5274 -->
-    <!--<ProjectReference Include="$(PlaygroundSourceDir)mongo/Mongo.AppHost/Mongo.AppHost.csproj" />-->
+    <!-- Only `dotnet run` startup checked -->
+    <ProjectReference Include="$(PlaygroundSourceDir)mongo/Mongo.AppHost/Mongo.AppHost.csproj" />
 
     <ProjectReference Include="$(PlaygroundSourceDir)mysql/MySqlDb.AppHost/MySqlDb.AppHost.csproj" />
     <ProjectReference Include="$(PlaygroundSourceDir)nats/Nats.AppHost/Nats.AppHost.csproj" />

--- a/tests/helix/send-to-helix-buildonhelixtests.targets
+++ b/tests/helix/send-to-helix-buildonhelixtests.targets
@@ -27,6 +27,10 @@
     <ItemGroup>
       <_TestRunCommandArguments Remove="@(_TestRunCommandArguments)" />
 
+      <_TestBlameArguments Remove="@(_TestBlameArguments)" />
+      <_TestBlameArguments Include="--blame-crash" />
+      <_TestBlameArguments Include="--blame-crash-dump-type full" />
+
       <!-- Using `dotnet test` for the project directly here -->
       <_TestRunCommandArguments Include="dotnet test -s .runsettings --results-directory $(_HelixLogsPath)" />
       <_TestRunCommandArguments Include="@(_TestBlameArguments, ' ')" />


### PR DESCRIPTION
- Run AppHostRunsCleanly only for apphosts that don't have TestEndpoints defined
- Run AppHostRunsCleanly only for apphosts that don't have TestEndpoints defined
- cleanup TestEndpoints - serialization not required
- add Mongo which can get sanity checked by AppHostRunsCleanly, even though the TestEndpoints for it are blocked

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5318)