### PR TITLE
[tests] Hosting.RabbitMQ: Adding waitFor, and xunit logging for client

### DIFF
--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -153,7 +153,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
                     using (var host = hb.Build())
                     {
                         await host.StartAsync();
-                        await app.WaitForTextAsync($"Time to start RabbitMQ:", resourceName: "rabbitMQ").WaitAsync(TimeSpan.FromMinutes(1));
+                        await app.WaitForTextAsync($"Time to start RabbitMQ:", resourceName: rabbitMQ2.Resource.Name).WaitAsync(TimeSpan.FromMinutes(1));
 
                         var connection = host.Services.GetRequiredService<IConnection>();
 

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -96,7 +96,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
                     using (var host = hb.Build())
                     {
                         await host.StartAsync();
-                        await app.WaitForTextAsync($"Time to start RabbitMQ:", resourceName: "rabbitMQ").WaitAsync(TimeSpan.FromMinutes(1));
+                        await app.WaitForTextAsync($"Time to start RabbitMQ:", resourceName: rabbitMQ1.Resource.Name).WaitAsync(TimeSpan.FromMinutes(1));
 
                         var connection = host.Services.GetRequiredService<IConnection>();
 

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -16,6 +16,8 @@ namespace Aspire.Hosting.RabbitMQ.Tests;
 
 public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
 {
+    private const string RabbitMQReadyText = "Time to start RabbitMQ:";
+
     [Fact]
     [RequiresDocker]
     public async Task VerifyRabbitMQResource()
@@ -96,7 +98,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
                     using (var host = hb.Build())
                     {
                         await host.StartAsync();
-                        await app.WaitForTextAsync($"Time to start RabbitMQ:", resourceName: rabbitMQ1.Resource.Name).WaitAsync(TimeSpan.FromMinutes(1));
+                        await app.WaitForTextAsync(RabbitMQReadyText, resourceName: rabbitMQ1.Resource.Name).WaitAsync(TimeSpan.FromMinutes(1));
 
                         var connection = host.Services.GetRequiredService<IConnection>();
 
@@ -153,7 +155,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
                     using (var host = hb.Build())
                     {
                         await host.StartAsync();
-                        await app.WaitForTextAsync($"Time to start RabbitMQ:", resourceName: rabbitMQ2.Resource.Name).WaitAsync(TimeSpan.FromMinutes(1));
+                        await app.WaitForTextAsync(RabbitMQReadyText, resourceName: rabbitMQ2.Resource.Name).WaitAsync(TimeSpan.FromMinutes(1));
 
                         var connection = host.Services.GetRequiredService<IConnection>();
 


### PR DESCRIPTION
## Description

This avoids timeouts from the client when the resources take time to start up.
For example: 
```
fail: RabbitMQ.Client[3]
      Unexpected connection closure: AMQP close-reason, initiated by Library, code=0, text='End of stream', classId=0, methodId=0, exception=System.IO.EndOfStreamException: Reached the end of the stream. Possible authentication failure.
         at RabbitMQ.Client.Impl.InboundFrame.ReadFrom(Stream reader, Byte[] frameHeaderBuffer, ArrayPool`1 pool, UInt32 maxMessageSize)
         at RabbitMQ.Client.Impl.SocketFrameHandler.ReadFrame()
         at RabbitMQ.Client.Framing.Impl.Connection.MainLoopIteration()
         at RabbitMQ.Client.Framing.Impl.Connection.MainLoop()
```

Also, log messages from the client side to xunit.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5321)