### PR TITLE
DRAFT: WaitFor with healthcheck awareness

### DIFF
--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -34,7 +34,8 @@ builder.AddProject<Projects.MyFrontend>("frontend")
        .WithReference(catalogService);
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor", launchProfileName: "OrderProcessor")
-       .WithReference(messaging);
+       .WithReference(messaging)
+       .WaitFor(messaging);
 
 builder.AddProject<Projects.ApiGateway>("apigateway")
        .WithReference(basketService)

--- a/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
+++ b/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
+    <ProjectReference Include="..\Components\Aspire.RabbitMQ.Client\Aspire.RabbitMQ.Client.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -50,17 +50,12 @@ public static class RabbitMQBuilderExtensions
                               })
                               .WithAnnotation(new HealthCheckAnnotation($"RabbitMQ.Client_{name}")); // HACK! Hard coded string.
 
-        // When the resource is started, we update the apphost connection string configuration with the connection string
-        // so that subsequent healthchecks can use it.
         builder.Eventing.Subscribe<ResourceCreatedEvent>(resource, async (e, ct) =>
         {
             var connectionString = await resource.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false);
             builder.Configuration[$"ConnectionStrings:{name}"] = connectionString;
         });
 
-        // We take over the connection factory to make sure we are grabbing the URI from the connection string
-        // after the endpoint has been allocated since it isn't available when the client is first injected
-        // into the DI container.
         builder.AddKeyedRabbitMQClient(name, configureConnectionFactory: f =>
         {
             var connectionString = builder.Configuration.GetConnectionString(name);

--- a/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
+++ b/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting\Aspire.Hosting.csproj" />
+    <ProjectReference Include="..\Components\Aspire.StackExchange.Redis\Aspire.StackExchange.Redis.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting/ApplicationModel/HealthCheckAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HealthCheckAnnotation.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// An annotation that indicates the name of a health check associated with this resource.
+/// </summary>
+/// <param name="name">The name of the healthcheck registration.</param>
+public class HealthCheckAnnotation(string name) : IResourceAnnotation
+{
+    /// <summary>
+    /// The name of the health check registration.
+    /// </summary>
+    public string Name { get; } = name;
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCreatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCreatedEvent.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Eventing;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Event raised when a resource is created.
+/// </summary>
+/// <param name="resource">The resource that has been created.</param>
+/// <param name="services">The <see cref="IServiceProvider"/> for the app host.</param>
+/// <remarks>
+/// This event is raised whenever a resource is created by the underlying orchestrator. This may be DCP, or a cloud
+/// service provider. It is the responsibility of the orchestrator to raise this event. Resources that are not managed
+/// by an orchestrator may also have an event raised if the resource extension has logic to raise the event.
+/// </remarks>
+public class ResourceCreatedEvent(IResource resource, IServiceProvider services) : IDistributedApplicationResourceEvent
+{
+    /// <summary>
+    /// The resource that has been created.
+    /// </summary>
+    public IResource Resource { get; } = resource;
+
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> for the app host.
+    /// </summary>
+    public IServiceProvider Services { get; } = services;
+}

--- a/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
@@ -7,17 +7,18 @@ namespace Aspire.Hosting.ApplicationModel;
 /// TODO
 /// </summary>
 /// <param name="dependency">TODO</param>
-/// <param name="waitTask">TODO</param>
-public class WaitAnnotation(IResource dependency, Func<CancellationToken, Task> waitTask) : IResourceAnnotation
+/// <param name="callback">TODO</param>
+public class WaitAnnotation(IResource dependency, Func<WaitContext, CancellationToken, Task> callback) : IResourceAnnotation
 {
     /// <summary>
     /// TODO
     /// </summary>
+    /// <param name="context">TODO</param>
     /// <param name="cancellationToken">TODO</param>
     /// <returns>TODO</returns>
-    public async Task WaitAsync(CancellationToken cancellationToken)
+    public async Task WaitAsync(WaitContext context, CancellationToken cancellationToken)
     {
-        await waitTask(cancellationToken).ConfigureAwait(false);
+        await callback(context, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/WaitAnnotation.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// TODO
+/// </summary>
+/// <param name="dependency">TODO</param>
+/// <param name="waitTask">TODO</param>
+public class WaitAnnotation(IResource dependency, Func<CancellationToken, Task> waitTask) : IResourceAnnotation
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    /// <param name="cancellationToken">TODO</param>
+    /// <returns>TODO</returns>
+    public async Task WaitAsync(CancellationToken cancellationToken)
+    {
+        await waitTask(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public IResource Dependency { get; } = dependency;
+}

--- a/src/Aspire.Hosting/ApplicationModel/WaitContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/WaitContext.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Passed the callback on a <see cref="WaitAnnotation"/> to allow access to the dependency injection container.
+/// </summary>
+/// <param name="logger">TODO</param>
+/// <param name="serviceProvider">TODO</param>
+public class WaitContext(ILogger logger, IServiceProvider serviceProvider)
+{
+    /// <summary>
+    /// TODO:
+    /// </summary>
+    public ILogger Logger { get; } = logger;
+
+    /// <summary>
+    /// The <see cref="IServiceProvider"/> for the application host.
+    /// </summary>
+    public IServiceProvider Services { get; } = serviceProvider;
+}

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1277,6 +1277,9 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         }
 
         await createResource().ConfigureAwait(false);
+
+        var resourceCreatedEvent = new ResourceCreatedEvent(er.ModelResource, serviceProvider);
+        await eventing.PublishAsync(resourceCreatedEvent, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task<string?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, bool isContainer, CancellationToken cancellationToken)
@@ -1590,6 +1593,9 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         }
 
         await kubernetesService.CreateAsync(dcpContainerResource, cancellationToken).ConfigureAwait(false);
+
+        var resourceCreatedEvent = new ResourceCreatedEvent(cr.ModelResource, serviceProvider);
+        await eventing.PublishAsync(resourceCreatedEvent, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task ApplyBuildArgumentsAsync(Container dcpContainerResource, IResource modelContainerResource, CancellationToken cancellationToken)

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -198,7 +198,7 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// built using the <see cref="IDistributedApplicationBuilder.Build"/> method.
     /// </para>
     /// <para>
-    /// To add services to the dependency injection container developers should use the <see cref="IDistributedApplicationBuilder.Services"/>
+    /// To add services to the dependency injection container developers should use the <see cref="IHostApplicationBuilder.Services"/>
     /// property to access the <see cref="IServiceCollection"/> instance.
     /// </para>
     /// </remarks>

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -12,6 +12,7 @@ using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -69,6 +70,17 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
     /// <inheritdoc />
     public IDistributedApplicationEventing Eventing { get; } = new DistributedApplicationEventing();
+
+    IConfigurationManager IHostApplicationBuilder.Configuration => _innerBuilder.Configuration;
+
+    /// <inheritdoc />
+    public ILoggingBuilder Logging => _innerBuilder.Logging;
+
+    /// <inheritdoc />
+    public IMetricsBuilder Metrics => _innerBuilder.Metrics;
+
+    /// <inheritdoc />
+    public IDictionary<object, object> Properties => ((IHostApplicationBuilder)_innerBuilder).Properties;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DistributedApplicationBuilder"/> class with the specified options.
@@ -373,5 +385,11 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         }
 
         return diagnosticListener;
+    }
+
+    /// <inheritdoc />
+    public void ConfigureContainer<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory, Action<TContainerBuilder>? configure = null) where TContainerBuilder : notnull
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -390,6 +390,6 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
     /// <inheritdoc />
     public void ConfigureContainer<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory, Action<TContainerBuilder>? configure = null) where TContainerBuilder : notnull
     {
-        throw new NotImplementedException();
+        _innerBuilder.ConfigureContainer(factory, configure);
     }
 }

--- a/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/IDistributedApplicationBuilder.cs
@@ -5,8 +5,6 @@ using System.Reflection;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Aspire.Hosting;
@@ -50,11 +48,8 @@ namespace Aspire.Hosting;
 /// builder.Build().Run();
 /// </code>
 /// </example>
-public interface IDistributedApplicationBuilder
+public interface IDistributedApplicationBuilder : IHostApplicationBuilder
 {
-    /// <inheritdoc cref="HostApplicationBuilder.Configuration" />
-    public ConfigurationManager Configuration { get; }
-
     /// <summary>
     /// Directory of the project where the app host is located. Defaults to the content root if there's no project.
     /// </summary>
@@ -64,12 +59,6 @@ public interface IDistributedApplicationBuilder
     /// Assembly of the app host project.
     /// </summary>
     public Assembly? AppHostAssembly { get; }
-
-    /// <inheritdoc cref="HostApplicationBuilder.Environment" />
-    public IHostEnvironment Environment { get; }
-
-    /// <inheritdoc cref="HostApplicationBuilder.Services" />
-    public IServiceCollection Services { get; }
 
     /// <summary>
     /// Eventing infrastructure for AppHost lifecycle.

--- a/src/Aspire.Hosting/PublicAPI.Shipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Shipped.txt
@@ -372,12 +372,9 @@ Aspire.Hosting.IDistributedApplicationBuilder
 Aspire.Hosting.IDistributedApplicationBuilder.AddResource<T>(T resource) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 Aspire.Hosting.IDistributedApplicationBuilder.AppHostDirectory.get -> string!
 Aspire.Hosting.IDistributedApplicationBuilder.Build() -> Aspire.Hosting.DistributedApplication!
-Aspire.Hosting.IDistributedApplicationBuilder.Configuration.get -> Microsoft.Extensions.Configuration.ConfigurationManager!
 Aspire.Hosting.IDistributedApplicationBuilder.CreateResourceBuilder<T>(T resource) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
-Aspire.Hosting.IDistributedApplicationBuilder.Environment.get -> Microsoft.Extensions.Hosting.IHostEnvironment!
 Aspire.Hosting.IDistributedApplicationBuilder.ExecutionContext.get -> Aspire.Hosting.DistributedApplicationExecutionContext!
 Aspire.Hosting.IDistributedApplicationBuilder.Resources.get -> Aspire.Hosting.ApplicationModel.IResourceCollection!
-Aspire.Hosting.IDistributedApplicationBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 Aspire.Hosting.IProjectMetadata
 Aspire.Hosting.IProjectMetadata.ProjectPath.get -> string!
 Aspire.Hosting.IResourceWithServiceDiscovery

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -14,8 +14,12 @@ Aspire.Hosting.ApplicationModel.BeforeStartEvent.Services.get -> System.IService
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
 Aspire.Hosting.ApplicationModel.WaitAnnotation
 Aspire.Hosting.ApplicationModel.WaitAnnotation.Dependency.get -> Aspire.Hosting.ApplicationModel.IResource!
-Aspire.Hosting.ApplicationModel.WaitAnnotation.WaitAnnotation(Aspire.Hosting.ApplicationModel.IResource! dependency, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! waitTask) -> void
-Aspire.Hosting.ApplicationModel.WaitAnnotation.WaitAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Aspire.Hosting.ApplicationModel.WaitAnnotation.WaitAnnotation(Aspire.Hosting.ApplicationModel.IResource! dependency, System.Func<Aspire.Hosting.ApplicationModel.WaitContext!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! callback) -> void
+Aspire.Hosting.ApplicationModel.WaitAnnotation.WaitAsync(Aspire.Hosting.ApplicationModel.WaitContext! context, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Aspire.Hosting.ApplicationModel.WaitContext
+Aspire.Hosting.ApplicationModel.WaitContext.Logger.get -> Microsoft.Extensions.Logging.ILogger!
+Aspire.Hosting.ApplicationModel.WaitContext.Services.get -> System.IServiceProvider!
+Aspire.Hosting.ApplicationModel.WaitContext.WaitContext(Microsoft.Extensions.Logging.ILogger! logger, System.IServiceProvider! serviceProvider) -> void
 Aspire.Hosting.DistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eventing.IDistributedApplicationEventing!
 Aspire.Hosting.Eventing.DistributedApplicationEventing
 Aspire.Hosting.Eventing.DistributedApplicationEventing.DistributedApplicationEventing() -> void
@@ -49,7 +53,7 @@ Aspire.Hosting.DistributedApplicationExecutionContextOptions.DistributedApplicat
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.Operation.get -> Aspire.Hosting.DistributedApplicationOperation
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.get -> System.IServiceProvider?
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.set -> void
-static Aspire.Hosting.ResourceBuilderExtensions.WaitFor<T>(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WaitFor<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.FailedToStart -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Finished -> string!

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -11,6 +11,10 @@ Aspire.Hosting.ApplicationModel.BeforeStartEvent
 Aspire.Hosting.ApplicationModel.BeforeStartEvent.BeforeStartEvent(System.IServiceProvider! services, Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model) -> void
 Aspire.Hosting.ApplicationModel.BeforeStartEvent.Model.get -> Aspire.Hosting.ApplicationModel.DistributedApplicationModel!
 Aspire.Hosting.ApplicationModel.BeforeStartEvent.Services.get -> System.IServiceProvider!
+Aspire.Hosting.ApplicationModel.ResourceCreatedEvent
+Aspire.Hosting.ApplicationModel.ResourceCreatedEvent.Resource.get -> Aspire.Hosting.ApplicationModel.IResource!
+Aspire.Hosting.ApplicationModel.ResourceCreatedEvent.ResourceCreatedEvent(Aspire.Hosting.ApplicationModel.IResource! resource, System.IServiceProvider! services) -> void
+Aspire.Hosting.ApplicationModel.ResourceCreatedEvent.Services.get -> System.IServiceProvider!
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
 Aspire.Hosting.ApplicationModel.WaitAnnotation
 Aspire.Hosting.ApplicationModel.WaitAnnotation.Dependency.get -> Aspire.Hosting.ApplicationModel.IResource!

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -11,6 +11,9 @@ Aspire.Hosting.ApplicationModel.BeforeStartEvent
 Aspire.Hosting.ApplicationModel.BeforeStartEvent.BeforeStartEvent(System.IServiceProvider! services, Aspire.Hosting.ApplicationModel.DistributedApplicationModel! model) -> void
 Aspire.Hosting.ApplicationModel.BeforeStartEvent.Model.get -> Aspire.Hosting.ApplicationModel.DistributedApplicationModel!
 Aspire.Hosting.ApplicationModel.BeforeStartEvent.Services.get -> System.IServiceProvider!
+Aspire.Hosting.ApplicationModel.HealthCheckAnnotation
+Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.HealthCheckAnnotation(string! name) -> void
+Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.Name.get -> string!
 Aspire.Hosting.ApplicationModel.ResourceCreatedEvent
 Aspire.Hosting.ApplicationModel.ResourceCreatedEvent.Resource.get -> Aspire.Hosting.ApplicationModel.IResource!
 Aspire.Hosting.ApplicationModel.ResourceCreatedEvent.ResourceCreatedEvent(Aspire.Hosting.ApplicationModel.IResource! resource, System.IServiceProvider! services) -> void
@@ -24,7 +27,11 @@ Aspire.Hosting.ApplicationModel.WaitContext
 Aspire.Hosting.ApplicationModel.WaitContext.Logger.get -> Microsoft.Extensions.Logging.ILogger!
 Aspire.Hosting.ApplicationModel.WaitContext.Services.get -> System.IServiceProvider!
 Aspire.Hosting.ApplicationModel.WaitContext.WaitContext(Microsoft.Extensions.Logging.ILogger! logger, System.IServiceProvider! serviceProvider) -> void
+Aspire.Hosting.DistributedApplicationBuilder.ConfigureContainer<TContainerBuilder>(Microsoft.Extensions.DependencyInjection.IServiceProviderFactory<TContainerBuilder>! factory, System.Action<TContainerBuilder>? configure = null) -> void
 Aspire.Hosting.DistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eventing.IDistributedApplicationEventing!
+Aspire.Hosting.DistributedApplicationBuilder.Logging.get -> Microsoft.Extensions.Logging.ILoggingBuilder!
+Aspire.Hosting.DistributedApplicationBuilder.Metrics.get -> Microsoft.Extensions.Diagnostics.Metrics.IMetricsBuilder!
+Aspire.Hosting.DistributedApplicationBuilder.Properties.get -> System.Collections.Generic.IDictionary<object!, object!>!
 Aspire.Hosting.Eventing.DistributedApplicationEventing
 Aspire.Hosting.Eventing.DistributedApplicationEventing.DistributedApplicationEventing() -> void
 Aspire.Hosting.Eventing.DistributedApplicationEventing.PublishAsync<T>(T event, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -12,6 +12,10 @@ Aspire.Hosting.ApplicationModel.BeforeStartEvent.BeforeStartEvent(System.IServic
 Aspire.Hosting.ApplicationModel.BeforeStartEvent.Model.get -> Aspire.Hosting.ApplicationModel.DistributedApplicationModel!
 Aspire.Hosting.ApplicationModel.BeforeStartEvent.Services.get -> System.IServiceProvider!
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
+Aspire.Hosting.ApplicationModel.WaitAnnotation
+Aspire.Hosting.ApplicationModel.WaitAnnotation.Dependency.get -> Aspire.Hosting.ApplicationModel.IResource!
+Aspire.Hosting.ApplicationModel.WaitAnnotation.WaitAnnotation(Aspire.Hosting.ApplicationModel.IResource! dependency, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! waitTask) -> void
+Aspire.Hosting.ApplicationModel.WaitAnnotation.WaitAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Aspire.Hosting.DistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eventing.IDistributedApplicationEventing!
 Aspire.Hosting.Eventing.DistributedApplicationEventing
 Aspire.Hosting.Eventing.DistributedApplicationEventing.DistributedApplicationEventing() -> void
@@ -45,6 +49,7 @@ Aspire.Hosting.DistributedApplicationExecutionContextOptions.DistributedApplicat
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.Operation.get -> Aspire.Hosting.DistributedApplicationOperation
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.get -> System.IServiceProvider?
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.set -> void
+static Aspire.Hosting.ResourceBuilderExtensions.WaitFor<T>(Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.FailedToStart -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Finished -> string!

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Net.Sockets;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Publishing;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting;
 
@@ -557,12 +558,13 @@ public static class ResourceBuilderExtensions
     /// <param name="builder">The resource builder for the resource.</param>
     /// <param name="dependency">The resource builder of the dependency.</param>
     /// <returns>The resource builder for the resource.</returns>
-    public static IResourceBuilder<T> WaitFor<T>(IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency) where T: IResource
+    public static IResourceBuilder<T> WaitFor<T>(this IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency) where T: IResource
     {
-        var annotation = new WaitAnnotation(dependency.Resource, async (ct) =>
+        var annotation = new WaitAnnotation(dependency.Resource, async (context, ct) =>
         {
             await Task.Delay(1000, ct).ConfigureAwait(false);
         });
-        return builder;
+
+        return builder.WithAnnotation(annotation);
     }
 }

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -549,4 +549,20 @@ public static class ResourceBuilderExtensions
     {
         return builder.WithAnnotation(ManifestPublishingCallbackAnnotation.Ignore);
     }
+
+    /// <summary>
+    /// Wait for another resource to be healthy before starting another resource.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder for the resource.</param>
+    /// <param name="dependency">The resource builder of the dependency.</param>
+    /// <returns>The resource builder for the resource.</returns>
+    public static IResourceBuilder<T> WaitFor<T>(IResourceBuilder<T> builder, IResourceBuilder<IResource> dependency) where T: IResource
+    {
+        var annotation = new WaitAnnotation(dependency.Resource, async (ct) =>
+        {
+            await Task.Delay(1000, ct).ConfigureAwait(false);
+        });
+        return builder;
+    }
 }

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -10,6 +10,7 @@ using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
@@ -115,6 +116,14 @@ public sealed class TestDistributedApplicationBuilder : IDistributedApplicationB
 
     public IDistributedApplicationEventing Eventing => _innerBuilder.Eventing;
 
+    IConfigurationManager IHostApplicationBuilder.Configuration => _innerBuilder.Configuration;
+
+    public ILoggingBuilder Logging => throw new NotImplementedException();
+
+    public IMetricsBuilder Metrics => throw new NotImplementedException();
+
+    public IDictionary<object, object> Properties => _innerBuilder.Properties;
+
     public IResourceBuilder<T> AddResource<T>(T resource) where T : IResource => _innerBuilder.AddResource(resource);
 
     [MemberNotNull(nameof(_app))]
@@ -145,6 +154,11 @@ public sealed class TestDistributedApplicationBuilder : IDistributedApplicationB
 
             _app?.Dispose();
         }
+    }
+
+    public void ConfigureContainer<TContainerBuilder>(IServiceProviderFactory<TContainerBuilder> factory, Action<TContainerBuilder>? configure = null) where TContainerBuilder : notnull
+    {
+        _innerBuilder.ConfigureContainer(factory, configure);
     }
 
     private sealed class BuilderInterceptor : IObserver<DiagnosticListener>


### PR DESCRIPTION
## Description

This PR introduces a new `WaitFor` extension method that waits for a resource to start before allowing another resource to start. I'll attempt to summarize the approach here.

1. We introduce a new per-resource event that uses the eventing system called `ResourceCreatedEvent`: https://github.com/dotnet/aspire/pull/5322/files#diff-16f56cefe5f85117e6b36030d12f71ddfc60230018b25de447f352e3d3031185R18
2. We introduce a `WaitAnnotation` that is used by the various orchestrators to wait for a resource to be properly initialized. I've only tested this out with local containers so far but I believe I can adapt this for the AzureProvisioner as well. The annotation just represents a callback which we await ... the implementation will often just be a `TaskCompletionSource.Task` that we await.
3. Where a resource has health checks registered, we wait for those healthchecks to become healthy. We introduce a `HealthCheckAnnotation` which captures the name of the health check we should wait for, and inside the resource created event handler that we register we use the health check service to poll this health check. This decouples the waitfor implementation from the underlying health check logic.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: TODO
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5322)