### PR TITLE
Allow env var with no name in dashboard

### DIFF
--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -31,7 +31,11 @@ var basketService = builder.AddProject("basketservice", @"..\BasketService\Baske
 builder.AddProject<Projects.MyFrontend>("frontend")
        .WithExternalHttpEndpoints()
        .WithReference(basketService)
-       .WithReference(catalogService);
+       .WithReference(catalogService)
+       .WithEnvironment(c =>
+       {
+           c.EnvironmentVariables[""] = "hi";
+       });
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor", launchProfileName: "OrderProcessor")
        .WithReference(messaging);

--- a/playground/TestShop/TestShop.AppHost/Program.cs
+++ b/playground/TestShop/TestShop.AppHost/Program.cs
@@ -31,11 +31,7 @@ var basketService = builder.AddProject("basketservice", @"..\BasketService\Baske
 builder.AddProject<Projects.MyFrontend>("frontend")
        .WithExternalHttpEndpoints()
        .WithReference(basketService)
-       .WithReference(catalogService)
-       .WithEnvironment(c =>
-       {
-           c.EnvironmentVariables[""] = "hi";
-       });
+       .WithReference(catalogService);
 
 builder.AddProject<Projects.OrderProcessor>("orderprocessor", launchProfileName: "OrderProcessor")
        .WithReference(messaging);

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -89,7 +89,7 @@ public sealed class EnvironmentVariableViewModel
     public EnvironmentVariableViewModel(string name, string? value, bool fromSpec)
     {
         // Name should always have a value, but somehow an empty/whitespace name can reach this point.
-        // Better to allow Aspire to run with an env var with no name than break when loading resources.
+        // Better to allow the dashboard to run with an env var with no name than break when loading resources.
         // https://github.com/dotnet/aspire/issues/5309
         Name = name;
         Value = value;

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -88,8 +88,9 @@ public sealed class EnvironmentVariableViewModel
 
     public EnvironmentVariableViewModel(string name, string? value, bool fromSpec)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(name);
-
+        // Name should always have a value, but somehow an empty/whitespace name can reach this point.
+        // Better to allow Aspire to run with an env var with no name than break when loading resources.
+        // https://github.com/dotnet/aspire/issues/5309
         Name = name;
         Value = value;
         FromSpec = fromSpec;

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -15,21 +15,28 @@ partial class Resource
     /// </summary>
     public ResourceViewModel ToViewModel()
     {
-        return new()
+        try
         {
-            Name = ValidateNotNull(Name),
-            ResourceType = ValidateNotNull(ResourceType),
-            DisplayName = ValidateNotNull(DisplayName),
-            Uid = ValidateNotNull(Uid),
-            CreationTimeStamp = ValidateNotNull(CreatedAt).ToDateTime(),
-            Properties = Properties.ToFrozenDictionary(property => ValidateNotNull(property.Name), property => ValidateNotNull(property.Value), StringComparers.ResourcePropertyName),
-            Environment = GetEnvironment(),
-            Urls = GetUrls(),
-            State = HasState ? State : null,
-            KnownState = HasState ? Enum.TryParse(State, out KnownResourceState knownState) ? knownState : null : null,
-            StateStyle = HasStateStyle ? StateStyle : null,
-            Commands = GetCommands()
-        };
+            return new()
+            {
+                Name = ValidateNotNull(Name),
+                ResourceType = ValidateNotNull(ResourceType),
+                DisplayName = ValidateNotNull(DisplayName),
+                Uid = ValidateNotNull(Uid),
+                CreationTimeStamp = ValidateNotNull(CreatedAt).ToDateTime(),
+                Properties = Properties.ToFrozenDictionary(property => ValidateNotNull(property.Name), property => ValidateNotNull(property.Value), StringComparers.ResourcePropertyName),
+                Environment = GetEnvironment(),
+                Urls = GetUrls(),
+                State = HasState ? State : null,
+                KnownState = HasState ? Enum.TryParse(State, out KnownResourceState knownState) ? knownState : null : null,
+                StateStyle = HasStateStyle ? StateStyle : null,
+                Commands = GetCommands()
+            };
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($@"Error converting resource ""{Name}"" to {nameof(ResourceViewModel)}.", ex);
+        }
 
         ImmutableArray<EnvironmentVariableViewModel> GetEnvironment()
         {

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.ResourceService.Proto.V1;
+using Google.Protobuf.WellKnownTypes;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class ResourceViewModelTests
+{
+    private static readonly DateTime s_dateTime = new DateTime(2000, 12, 30, 23, 59, 59, DateTimeKind.Utc);
+
+    [Fact]
+    public void ToViewModel_EmptyEnvVarName_Success()
+    {
+        // Arrange
+        var resource = new Resource
+        {
+            Name = "TestName-abc",
+            DisplayName = "TestName",
+            CreatedAt = Timestamp.FromDateTime(s_dateTime),
+            Environment =
+            {
+                new EnvironmentVariable { Name = string.Empty, Value = "Value!" }
+            }
+        };
+
+        // Act
+        var vm = resource.ToViewModel();
+
+        // Assert
+        Assert.Collection(resource.Environment,
+            e =>
+            {
+                Assert.Empty(e.Name);
+                Assert.Equal("Value!", e.Value);
+            });
+    }
+
+    [Fact]
+    public void ToViewModel_MissingRequiredData_FailWithFriendlyError()
+    {
+        // Arrange
+        var resource = new Resource
+        {
+            Name = "TestName-abc"
+        };
+
+        // Act
+        var ex = Assert.Throws<InvalidOperationException>(resource.ToViewModel);
+
+        // Assert
+        Assert.Equal(@"Error converting resource ""TestName-abc"" to ResourceViewModel.", ex.Message);
+        Assert.NotNull(ex.InnerException);
+    }
+}


### PR DESCRIPTION
## Description

The dashboard was crashing because a user had an env var on their machine with no name.

This PR changes the dashboard to allow env var with no name in dashboard. Not ideal, but better than crashing, or losing data.

Fixes https://github.com/dotnet/aspire/issues/5309

Can reproduce empty env var via:

```cs
builder.AddProject<Projects.MyFrontend>("frontend")
       .WithExternalHttpEndpoints()
       .WithReference(basketService)
       .WithReference(catalogService)
       .WithEnvironment(c =>
       {
           c.EnvironmentVariables[""] = "hi";
       });
```

Note that resource is created by DCP but fails to start. I'm going to create a follow up issue to validate env vars set by the model always have a key. That way the host fails with a good error message before the DCP or dashboard start. Note that still doesn't stop an empty name env var from the OS.

**Update:** https://github.com/dotnet/aspire/issues/5324

![image](https://github.com/user-attachments/assets/a4ccf690-7f43-452a-89d4-1f2a946a358f)


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
