### PR TITLE
Fix build break in Linux

### DIFF
--- a/playground/BrowserTelemetry/BrowserTelemetry.Web/webpack.config.js
+++ b/playground/BrowserTelemetry/BrowserTelemetry.Web/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = {
-    entry: './scripts/index.js',
+    entry: './Scripts/index.js',
     output: {
         filename: 'bundle.js',
         path: path.resolve(__dirname, 'wwwroot/scripts'),


### PR DESCRIPTION
## Description

Building playground apps are broken in Linux due to a case-sensitive reference.

cc: @JamesNK

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5327)