### PR TITLE
Filter dashpages to show only available ones

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -59,12 +59,17 @@
                                 <ChildContent>
                                     @if (PageViewModel.Dashpages.Length is not 0)
                                     {
-                                        <FluentTreeItem Text="@Loc[Aspire.Dashboard.Resources.Metrics.DashpagesSectionName]" title="@Loc[Aspire.Dashboard.Resources.Metrics.DashpagesSectionName]" InitiallyExpanded="true">
-                                            @foreach (DashpageDefinition dashpage in PageViewModel.Dashpages)
-                                            {
-                                                <FluentTreeItem @key="dashpage" Class="nested" Text="@dashpage.Name" Data="@dashpage" title="@dashpage.Name" InitiallySelected="@(dashpage.Name == PageViewModel.SelectedDashpage?.Name)"/>
-                                            }
-                                        </FluentTreeItem>
+                                        var filteredDashpages = PageViewModel.Dashpages.Where(PageViewModel.IsDashpageAvailable).ToList();
+
+                                        if (filteredDashpages.Count is not 0)
+                                        {
+                                            <FluentTreeItem Text="@Loc[Aspire.Dashboard.Resources.Metrics.DashpagesSectionName]" title="@Loc[Aspire.Dashboard.Resources.Metrics.DashpagesSectionName]" InitiallyExpanded="true">
+                                                @foreach (DashpageDefinition dashpage in filteredDashpages)
+                                                {
+                                                    <FluentTreeItem @key="dashpage" Class="nested" Text="@dashpage.Name" Data="@dashpage" title="@dashpage.Name" InitiallySelected="@(dashpage.Name == PageViewModel.SelectedDashpage?.Name)"/>
+                                                }
+                                            </FluentTreeItem>
+                                        }
                                     }
                                     @foreach ((var meter, var instruments) in PageViewModel.Instruments.GroupBy(i => i.Parent).OrderBy(g => g.Key.MeterName))
                                     {

--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -16,6 +16,8 @@ internal static class StringComparers
     public static StringComparer UrlPath => StringComparer.OrdinalIgnoreCase;
     public static StringComparer UrlHost => StringComparer.OrdinalIgnoreCase;
     public static StringComparer Attribute => StringComparer.Ordinal;
+    public static StringComparer OtlpInstrumentName => StringComparer.OrdinalIgnoreCase;
+    public static StringComparer OtlpApplicationName => StringComparer.OrdinalIgnoreCase;
 }
 
 internal static class StringComparisons
@@ -31,4 +33,7 @@ internal static class StringComparisons
     public static StringComparison EnvironmentVariableName => StringComparison.InvariantCultureIgnoreCase;
     public static StringComparison UrlPath => StringComparison.OrdinalIgnoreCase;
     public static StringComparison UrlHost => StringComparison.OrdinalIgnoreCase;
+    public static StringComparison Attribute => StringComparison.Ordinal;
+    public static StringComparison OtlpInstrumentName => StringComparison.OrdinalIgnoreCase;
+    public static StringComparison OtlpApplicationName => StringComparison.OrdinalIgnoreCase;
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/MetricsViewModelTests.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Xunit;
+using static Aspire.Dashboard.Components.Pages.Metrics;
+
+namespace Aspire.Dashboard.Components.Tests.Pages;
+
+public sealed class MetricsViewModelTests
+{
+    [Fact]
+    public void IsDashpageAvailable()
+    {
+        OtlpInstrument instrument = new()
+        {
+            Name = "present-instrument",
+            Description = "",
+            Options = null!,
+            Parent = null!,
+            Type = OtlpInstrumentType.Histogram,
+            Unit = null!
+        };
+
+        MetricsViewModel vm = new()
+        {
+            Dashpages = [],
+            SelectedDuration = null!,
+            SelectedViewKind = MetricViewKind.Graph,
+            SelectedApplication = new() { Id = ResourceTypeDetails.CreateSingleton("my-instance", "my-replica-set"), Name = "" },
+            Instruments = [instrument],
+            ApplicationNames = ["present-application"],
+        };
+
+        Assert.True(vm.IsDashpageAvailable(new() { Name = "", Charts = [new() { InstrumentName = "present-instrument", Title = "" }] }));
+        Assert.True(vm.IsDashpageAvailable(new() { Name = "", Charts = [new() { InstrumentName = "present-instrument", Title = "", ResourceName = "present-application" }] }));
+        Assert.False(vm.IsDashpageAvailable(new() { Name = "", Charts = [new() { InstrumentName = "present-instrument", Title = "", ResourceName = "absent-application" }] }));
+        Assert.True(vm.IsDashpageAvailable(new() { Name = "", Charts = [new() { InstrumentName = "present-instrument", Title = "" }, new() { InstrumentName = "absent-instrument", Title = "" }] }));
+        Assert.False(vm.IsDashpageAvailable(new() { Name = "", Charts = [new() { InstrumentName = "absent-instrument", Title = "" }] }));
+        Assert.False(vm.IsDashpageAvailable(new() { Name = "", Charts = [new() { InstrumentName = "absent-instrument", Title = "" }, new() { InstrumentName = "absent-instrument", Title = "" }] }));
+        Assert.False(vm.IsDashpageAvailable(new() { Name = "", Charts = [new() { InstrumentName = "present-instrument", Title = "" }, new() { InstrumentName = "absent-instrument", Title = "", IsRequired = true }] }));
+    }
+}


### PR DESCRIPTION
Fixes #5295

The list of available dashpages in the Metrics UI is dynamic, depending on the selected resource.

A dashpage will only be shown if:

- metrics are available for at least one chart, and
- all required metrics are available
- all required resources are available

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected. **This is a feature branch.**
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No (though dashpages will be documented when the feature branch merges)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5337)