### PR TITLE
[tests] Fix AddPostgresTests.WithPgwebProducesValidBookmarkFiles

### DIFF
--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -510,13 +510,12 @@ public class AddPostgresTests
 
         await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
 
-        var bookMarkFiles = Directory
-            .GetFiles(volume.Source!);
+        var bookMarkFiles = Directory.GetFiles(volume.Source!).OrderBy(f => f).ToArray();
 
         Assert.Collection(bookMarkFiles,
             filePath =>
             {
-                Assert.Equal(".toml", Path.GetExtension(filePath)) ;
+                Assert.Equal(".toml", Path.GetExtension(filePath));
             },
             filePath =>
             {


### PR DESCRIPTION
This test can fail because the order of the bookmark files returned by
`Directory.GetFiles()` can be different:

```
Aspire.Hosting.PostgreSQL.Tests.AddPostgresTests.WithPgwebProducesValidBookmarkFiles(containerHost: "host.docker.internal") [FAIL]
  Assert.Collection() Failure
  Collection: ["host = \"host2\"\nport = 5002\nuser = \"postgres\""..., "host = \"host.docker.internal\"\nport = 5001\nuser"...]
  Error during comparison of item at index 0
  Inner exception: Assert.Equal() Failure
                                ↓ (pos 12)
          Expected: host = "host.docker.internal"\nport = 5001\nuser = "pos···
          Actual:   host = "host2"\nport = 5002\nuser = "postgres"\npassword···
                                ↑ (pos 12)
  Stack Trace:
    /_/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs(537,0): at Aspire.Hosting.PostgreSQL.Tests.AddPostgresTests.<>c__DisplayClass16_0.<WithPgwebProducesValidBookmarkFiles>b__7(String content)
    /_/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs(534,0): at Aspire.Hosting.PostgreSQL.Tests.AddPostgresTests.WithPgwebProducesValidBookmarkFiles(String containerHost)
    --- End of stack trace from previous location ---
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5352)