### PR TITLE
[tests] Aspire.Playground.Tests: bump request timeout

### DIFF
--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -115,8 +115,8 @@ public class AppHostTests
                     .ConfigureHttpClient(client => client.Timeout = Timeout.InfiniteTimeSpan)
                     .AddStandardResilienceHandler(resilience =>
                     {
-                        resilience.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(120);
-                        resilience.AttemptTimeout.Timeout = TimeSpan.FromSeconds(60);
+                        resilience.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(4);
+                        resilience.AttemptTimeout.Timeout = TimeSpan.FromSeconds(90);
                         resilience.Retry.MaxRetryAttempts = 30;
                         resilience.CircuitBreaker.SamplingDuration = resilience.AttemptTimeout.Timeout * 2;
                     });


### PR DESCRIPTION
.. for calling endpoints. This was prompted by Cosmos `/ef` calls
failing because the `ApiService` using efcore has timeout of 65 seconds,
and does not get enough attempts to wait for the db to become available.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5365)