### PR TITLE
ElasticSearchInstrumentationEndToEnd: Increase timeout for RemoteExecutor

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -5,6 +5,8 @@
   "retryOnRules": [
     { "testAssembly": { "regex": "Aspire.EndToEnd.*" }, "failureMessage": { "regex": "App run failed" } },
     { "testAssembly": { "regex": "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.*" } },
-    { "testAssembly": { "regex": "Aspire.Microsoft.EntityFrameworkCore.SqlServer.*" } }
+    { "testAssembly": { "regex": "Aspire.Microsoft.EntityFrameworkCore.SqlServer.*" } },
+    { "testName": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Tests.ConformanceTests.HealthCheckReportsExpectedStatus" } },
+    { "testAssembly": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Test" }, "failureMessage": { "contains": "RemoteExecutionException : Half-way through waiting for remote process." } }
   ]
 }

--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -3,10 +3,7 @@
   "defaultOnFailure": "fail",
   "localRerunCount": 1,
   "retryOnRules": [
-    { "testAssembly": { "regex": "Aspire.EndToEnd.*" }, "failureMessage": { "regex": "App run failed" } },
-    { "testAssembly": { "regex": "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.*" } },
-    { "testAssembly": { "regex": "Aspire.Microsoft.EntityFrameworkCore.SqlServer.*" } },
     { "testName": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Tests.ConformanceTests.HealthCheckReportsExpectedStatus" } },
-    { "testAssembly": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Test" }, "failureMessage": { "contains": "RemoteExecutionException : Half-way through waiting for remote process." } }
+    { "testAssembly": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Tests" }, "failureMessage": { "contains": "RemoteExecutionException : Half-way through waiting for remote process." } }
   ]
 }

--- a/tests/Aspire.Elastic.Clients.Elasticsearch.Tests/AspireElasticClientExtensionsTest.cs
+++ b/tests/Aspire.Elastic.Clients.Elasticsearch.Tests/AspireElasticClientExtensionsTest.cs
@@ -163,7 +163,7 @@ public class AspireElasticClientExtensionsTest : IClassFixture<ElasticsearchCont
             var activity = activityList[0];
             Assert.Equal("ping", activity.OperationName);
             Assert.Contains(activity.Tags, kvp => kvp.Key == "db.system" && kvp.Value == "elasticsearch");
-        }, DefaultConnectionString).Dispose();
+        }, DefaultConnectionString, new RemoteInvokeOptions { TimeOut = 120_000 }).Dispose();
     }
 
     private static HostApplicationBuilder CreateBuilder(string connectionString)


### PR DESCRIPTION
.. from 60s to 120s. This has been failing frequently on CI with:

```
Aspire.Elastic.Clients.Elasticsearch.Tests.AspireElasticClientExtensionsTest.ElasticsearchInstrumentationEndToEnd [FAIL]
  Microsoft.DotNet.RemoteExecutor.RemoteExecutionException : Half-way through waiting for remote process.
  Timed out at 8/20/2024 6:22:40 PM after 60000ms waiting for remote process.
  	Process ID: 29680
  	Handle: 11984
  	Name: dotnet
  	MainModule: /datadisks/disk1/work/B7250A1D/p/dotnet-cli/dotnet
  	StartTime: 8/20/2024 6:21:39 PM
  	TotalProcessorTime: 00:00:00.7300000

  Stack Trace:
    /_/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeHandle.cs(225,0): at Microsoft.DotNet.RemoteExecutor.RemoteInvokeHandle.Dispose(Boolean disposing)
    /_/src/Microsoft.DotNet.RemoteExecutor/src/RemoteInvokeHandle.cs(55,0): at Microsoft.DotNet.RemoteExecutor.RemoteInvokeHandle.Dispose()
    /_/tests/Aspire.Elastic.Clients.Elasticsearch.Tests/AspireElasticClientExtensionsTest.cs(145,0): at Aspire.Elastic.Clients.Elasticsearch.Tests.AspireElasticClientExtensionsTest.ElasticsearchInstrumentationEndToEnd()
       at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
       at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```
- **ElasticSearchInstrumentationEndToEnd: Increase timeout for RemoteExectuor**
- **Add some helix retries for Aspire.Elastic.Clients.Elasticsearch.Tests**
- Also, drop old helix retry conditions which were for https://github.com/dotnet/aspire/issues/2850, but the issue has since been fixed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5366)