### PR TITLE
Fix credscan warning in ElasticsearchPublicApiTests.cs

### DIFF
--- a/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchPublicApiTests.cs
@@ -74,7 +74,7 @@ public class ElasticsearchPublicApiTests
     public void CtorElasticsearchResourceShouldThrowWhenNameIsNull()
     {
         var builder = new DistributedApplicationBuilder([]);
-        builder.Configuration["Parameters:Password"] = "p@ssw0rd";
+        builder.Configuration["Parameters:Password"] = "p@ssw0rd1";
         var password = builder.AddParameter("Password");
         const string name = null!;
 


### PR DESCRIPTION
## Description

Use a placeholder password in the tests. Fixes internal builds.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5381)