### PR TITLE
Fix regression not showing pointer cursor on trace detail

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -65,7 +65,7 @@
                     <Summary>
                         <FluentDataGrid Virtualize="true"
                                         GenerateHeader="GenerateHeaderOption.Sticky"
-                                        Class="trace-view-grid"
+                                        Class="trace-view-grid enable-row-click"
                                         ResizableColumns="true"
                                         ItemsProvider="@GetData"
                                         TGridItem="SpanWaterfallViewModel"

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -102,7 +102,6 @@
     font-size: 12px;
     color: var(--foreground-subtext-rest);
     padding: 0 0.5em;
-    cursor: pointer;
     height: min-content;
 }
 


### PR DESCRIPTION
## Description

Regression from the recent large UI refactor. Trace detail grid didn't display a pointer cursor.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5385)