### PR TITLE
Fix blob items clashing with each other during stable builds

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -26,9 +26,15 @@
   </ItemGroup>
 
   <Target Name="_PublishBlobItems">
+    <!-- 
+      For blob items for the Dashboard, we want to make sure that the version we get back is not stable, even when the repo is producing stable versions.
+      This is because we want to be able to re-spin the build if necessary without hitting issues of blob items clashing with each other. For this reason,
+      We will pass SuppressFinalPackageVersion as true when fetching the package version so that we get back a version with a prerelease suffix.
+    -->
     <MSBuild Projects="$(RepoRoot)src\Microsoft.NET.Sdk.Aspire\Microsoft.NET.Sdk.Aspire.csproj"
         Targets="ReturnPackageVersion"
-        SkipNonexistentProjects="false">
+        SkipNonexistentProjects="false"
+        AdditionalProperties="SuppressFinalPackageVersion=true">
       <Output TaskParameter="TargetOutputs" PropertyName="_PackageVersion" />
     </MSBuild>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -32,9 +32,9 @@
       We will pass SuppressFinalPackageVersion as true when fetching the package version so that we get back a version with a prerelease suffix.
     -->
     <MSBuild Projects="$(RepoRoot)src\Microsoft.NET.Sdk.Aspire\Microsoft.NET.Sdk.Aspire.csproj"
-        Targets="ReturnPackageVersion"
-        SkipNonexistentProjects="false"
-        AdditionalProperties="SuppressFinalPackageVersion=true">
+      Targets="ReturnPackageVersion"
+      SkipNonexistentProjects="false"
+      Properties="SuppressFinalPackageVersion=true">
       <Output TaskParameter="TargetOutputs" PropertyName="_PackageVersion" />
     </MSBuild>
 


### PR DESCRIPTION
## Description

Once we stabilize builds, we typically hit issues whenever we need to re-spin a new build given the previous build would have already published blobs using stable versioning as the new build will try to push again and these builds would clash. This change is making it so that the version we use for the blobs we publish won't go stable even when the rest of the repo is producing stable packages. This version is only used for these blobs, so no risk this affecting other things. cc: @radical 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5387)