### PR TITLE
Fix Secure Supply Chain Analysis warning - avoid using external registry for golang in playgrounds

### DIFF
--- a/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
+++ b/playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build the Go program
-ARG GO_VERSION=1.16
-FROM golang:${GO_VERSION} AS builder
+ARG GO_VERSION=1.23
+FROM mcr.microsoft.com/oss/go/microsoft/golang:${GO_VERSION} AS builder
 WORKDIR /app
 COPY . .
 RUN go build qots.go


### PR DESCRIPTION
## Description

Changes the `golang` image to be referenced from `mcr.microsoft.com/oss/go/microsoft/golang` instead of `golang`. This PR also updates the tag being used to `1.23` which is the latest.

Fixes the warning: `Discovered a reference to an image from an
unapproved registry that violates the security policies and standards
for containers within Microsoft. Reference to image 'golang:1.16' on
line 2 of
playground/withdockerfile/WithDockerfile.AppHost/qots/Dockerfile`.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5392)