### PR TITLE
Update package tags for "integration" and "library" terms

### DIFF
--- a/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
+++ b/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <!-- This library needs more bake time until it can ship stable. -->
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PackageTags>aspire hosting aws</PackageTags>
+    <PackageTags>aspire integration hosting aws</PackageTags>
     <Description>Add support for provisioning AWS application resources and configuring the AWS SDK for .NET.</Description>
     <!-- This package hasn't shipped stable, so package validation runs against previously shipped version of it. -->
     <PackageValidationBaselineVersion>8.0.1-preview.8.24267.1</PackageValidationBaselineVersion>

--- a/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
+++ b/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <!-- This library needs more bake time until it can ship stable. -->
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PackageTags>aspire resource integration hosting aws</PackageTags>
+    <PackageTags>aspire integration hosting aws</PackageTags>
     <Description>Add support for provisioning AWS application resources and configuring the AWS SDK for .NET.</Description>
     <!-- This package hasn't shipped stable, so package validation runs against previously shipped version of it. -->
     <PackageValidationBaselineVersion>8.0.1-preview.8.24267.1</PackageValidationBaselineVersion>

--- a/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
+++ b/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <!-- This library needs more bake time until it can ship stable. -->
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PackageTags>aspire integration hosting aws</PackageTags>
+    <PackageTags>aspire resource integration hosting aws</PackageTags>
     <Description>Add support for provisioning AWS application resources and configuring the AWS SDK for .NET.</Description>
     <!-- This package hasn't shipped stable, so package validation runs against previously shipped version of it. -->
     <PackageValidationBaselineVersion>8.0.1-preview.8.24267.1</PackageValidationBaselineVersion>

--- a/src/Aspire.Hosting.Azure.AppConfiguration/Aspire.Hosting.Azure.AppConfiguration.csproj
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/Aspire.Hosting.Azure.AppConfiguration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure AppConfiguration resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureAppConfig_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.AppConfiguration/Aspire.Hosting.Azure.AppConfiguration.csproj
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/Aspire.Hosting.Azure.AppConfiguration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure AppConfiguration resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureAppConfig_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.AppConfiguration/Aspire.Hosting.Azure.AppConfiguration.csproj
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/Aspire.Hosting.Azure.AppConfiguration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure AppConfiguration resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureAppConfig_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Application Insights resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureAppInsights_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure Application Insights resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureAppInsights_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/Aspire.Hosting.Azure.ApplicationInsights.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Application Insights resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureAppInsights_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure openai ai cognitiveservices cognitive services</PackageTags>
+    <PackageTags>aspire integration hosting azure openai ai cognitiveservices cognitive services</PackageTags>
     <Description>Azure OpenAI resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureOpenAI_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure openai ai cognitiveservices cognitive services</PackageTags>
+    <PackageTags>aspire integration hosting azure openai ai cognitiveservices cognitive services</PackageTags>
     <Description>Azure OpenAI resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureOpenAI_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/Aspire.Hosting.Azure.CognitiveServices.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure openai ai cognitiveservices cognitive services</PackageTags>
+    <PackageTags>aspire resource integration hosting azure openai ai cognitiveservices cognitive services</PackageTags>
     <Description>Azure OpenAI resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureOpenAI_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
+++ b/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Cosmos DB resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureCosmosDB_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
+++ b/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Cosmos DB resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureCosmosDB_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
+++ b/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure Cosmos DB resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureCosmosDB_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
+++ b/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure eventhubs</PackageTags>
+    <PackageTags>aspire resource integration hosting azure eventhubs</PackageTags>
     <Description>Azure Event Hubs resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureEventHubs_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
+++ b/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure eventhubs</PackageTags>
+    <PackageTags>aspire integration hosting azure eventhubs</PackageTags>
     <Description>Azure Event Hubs resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureEventHubs_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
+++ b/src/Aspire.Hosting.Azure.EventHubs/Aspire.Hosting.Azure.EventHubs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure eventhubs</PackageTags>
+    <PackageTags>aspire integration hosting azure eventhubs</PackageTags>
     <Description>Azure Event Hubs resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureEventHubs_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
+++ b/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureKeyVault_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
+++ b/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureKeyVault_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
+++ b/src/Aspire.Hosting.Azure.KeyVault/Aspire.Hosting.Azure.KeyVault.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureKeyVault_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure Log Anlytics resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureLogAnalytics_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Log Anlytics resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureLogAnalytics_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/Aspire.Hosting.Azure.OperationalInsights.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Log Anlytics resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureLogAnalytics_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure PostgreSql Flexible Server resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzurePostgreSQL_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure PostgreSql Flexible Server resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzurePostgreSQL_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/Aspire.Hosting.Azure.PostgreSQL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure PostgreSql Flexible Server resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzurePostgreSQL_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
+++ b/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Redis resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureCacheRedis_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
+++ b/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Redis resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureCacheRedis_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
+++ b/src/Aspire.Hosting.Azure.Redis/Aspire.Hosting.Azure.Redis.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure Redis resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureCacheRedis_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Search/Aspire.Hosting.Azure.Search.csproj
+++ b/src/Aspire.Hosting.Azure.Search/Aspire.Hosting.Azure.Search.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure AI Search resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSearch_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Search/Aspire.Hosting.Azure.Search.csproj
+++ b/src/Aspire.Hosting.Azure.Search/Aspire.Hosting.Azure.Search.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure AI Search resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSearch_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Search/Aspire.Hosting.Azure.Search.csproj
+++ b/src/Aspire.Hosting.Azure.Search/Aspire.Hosting.Azure.Search.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure AI Search resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSearch_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
+++ b/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Service Bus resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureServiceBus_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
+++ b/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure Service Bus resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureServiceBus_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
+++ b/src/Aspire.Hosting.Azure.ServiceBus/Aspire.Hosting.Azure.ServiceBus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Service Bus resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureServiceBus_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.SignalR/Aspire.Hosting.Azure.SignalR.csproj
+++ b/src/Aspire.Hosting.Azure.SignalR/Aspire.Hosting.Azure.SignalR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure SignalR resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSignalR_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.SignalR/Aspire.Hosting.Azure.SignalR.csproj
+++ b/src/Aspire.Hosting.Azure.SignalR/Aspire.Hosting.Azure.SignalR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure SignalR resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSignalR_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.SignalR/Aspire.Hosting.Azure.SignalR.csproj
+++ b/src/Aspire.Hosting.Azure.SignalR/Aspire.Hosting.Azure.SignalR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure SignalR resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSignalR_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
+++ b/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure SQL Database resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSqlServer_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
+++ b/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure SQL Database resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSqlServer_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
+++ b/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure SQL Database resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureSqlServer_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Storage resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureStorageContainer_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure Storage resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureStorageContainer_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
+++ b/src/Aspire.Hosting.Azure.Storage/Aspire.Hosting.Azure.Storage.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure Storage resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureStorageContainer_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
+++ b/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure webpubsub pubsub websocket</PackageTags>
+    <PackageTags>aspire integration hosting azure webpubsub pubsub websocket</PackageTags>
     <Description>Azure WebPubSub resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureWebPubSub_256x.png</PackageIconFullPath>
     <!-- This library can't ship stable until Azure.Provisioning.WebPubSub ships stable. -->

--- a/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
+++ b/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure webpubsub pubsub websocket</PackageTags>
+    <PackageTags>aspire integration hosting azure webpubsub pubsub websocket</PackageTags>
     <Description>Azure WebPubSub resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureWebPubSub_256x.png</PackageIconFullPath>
     <!-- This library can't ship stable until Azure.Provisioning.WebPubSub ships stable. -->

--- a/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
+++ b/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure webpubsub pubsub websocket</PackageTags>
+    <PackageTags>aspire resource integration hosting azure webpubsub pubsub websocket</PackageTags>
     <Description>Azure WebPubSub resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureWebPubSub_256x.png</PackageIconFullPath>
     <!-- This library can't ship stable until Azure.Provisioning.WebPubSub ships stable. -->

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting azure</PackageTags>
+    <PackageTags>aspire resource integration hosting azure</PackageTags>
     <Description>Azure resource types for .NET Aspire.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting azure</PackageTags>
+    <PackageTags>aspire hosting azure</PackageTags>
     <Description>Azure resource types for .NET Aspire.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting azure</PackageTags>
+    <PackageTags>aspire integration hosting azure</PackageTags>
     <Description>Azure resource types for .NET Aspire.</Description>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageIconFullPath>$(SharedDir)Azure_256x.png</PackageIconFullPath>

--- a/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
+++ b/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting dapr</PackageTags>
+    <PackageTags>aspire integration hosting dapr</PackageTags>
     <Description>Dapr support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
+++ b/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting dapr</PackageTags>
+    <PackageTags>aspire integration hosting dapr</PackageTags>
     <Description>Dapr support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
+++ b/src/Aspire.Hosting.Dapr/Aspire.Hosting.Dapr.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting dapr</PackageTags>
+    <PackageTags>aspire resource integration hosting dapr</PackageTags>
     <Description>Dapr support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
+++ b/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PackageTags>aspire resource integration hosting elasticsearch</PackageTags>
+    <PackageTags>aspire integration hosting elasticsearch</PackageTags>
     <Description>Elasticsearch support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Elastic_logo.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
+++ b/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PackageTags>aspire hosting elasticsearch</PackageTags>
+    <PackageTags>aspire integration hosting elasticsearch</PackageTags>
     <Description>Elasticsearch support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Elastic_logo.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
+++ b/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PackageTags>aspire integration hosting elasticsearch</PackageTags>
+    <PackageTags>aspire resource integration hosting elasticsearch</PackageTags>
     <Description>Elasticsearch support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Elastic_logo.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Garnet/Aspire.Hosting.Garnet.csproj
+++ b/src/Aspire.Hosting.Garnet/Aspire.Hosting.Garnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting garnet</PackageTags>
+    <PackageTags>aspire resource integration hosting garnet</PackageTags>
     <Description>Garnet® support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)garnet-cube-red_white-rgb.png</PackageIconFullPath>
     <!-- Disable package validation as this package hasn't shipped yet. -->

--- a/src/Aspire.Hosting.Garnet/Aspire.Hosting.Garnet.csproj
+++ b/src/Aspire.Hosting.Garnet/Aspire.Hosting.Garnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting garnet</PackageTags>
+    <PackageTags>aspire integration hosting garnet</PackageTags>
     <Description>Garnet® support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)garnet-cube-red_white-rgb.png</PackageIconFullPath>
     <!-- Disable package validation as this package hasn't shipped yet. -->

--- a/src/Aspire.Hosting.Garnet/Aspire.Hosting.Garnet.csproj
+++ b/src/Aspire.Hosting.Garnet/Aspire.Hosting.Garnet.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting garnet</PackageTags>
+    <PackageTags>aspire integration hosting garnet</PackageTags>
     <Description>Garnet® support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)garnet-cube-red_white-rgb.png</PackageIconFullPath>
     <!-- Disable package validation as this package hasn't shipped yet. -->

--- a/src/Aspire.Hosting.Kafka/Aspire.Hosting.Kafka.csproj
+++ b/src/Aspire.Hosting.Kafka/Aspire.Hosting.Kafka.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting kafka</PackageTags>
+    <PackageTags>aspire integration hosting kafka</PackageTags>
     <Description>Kafka support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Kafka/Aspire.Hosting.Kafka.csproj
+++ b/src/Aspire.Hosting.Kafka/Aspire.Hosting.Kafka.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting kafka</PackageTags>
+    <PackageTags>aspire resource integration hosting kafka</PackageTags>
     <Description>Kafka support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Kafka/Aspire.Hosting.Kafka.csproj
+++ b/src/Aspire.Hosting.Kafka/Aspire.Hosting.Kafka.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting kafka</PackageTags>
+    <PackageTags>aspire integration hosting kafka</PackageTags>
     <Description>Kafka support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
+++ b/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PackageTags>aspire resource integration hosting keycloak</PackageTags>
+    <PackageTags>aspire integration hosting keycloak</PackageTags>
     <Description>Keycloak support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
+++ b/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PackageTags>aspire hosting keycloak</PackageTags>
+    <PackageTags>aspire integration hosting keycloak</PackageTags>
     <Description>Keycloak support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
+++ b/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
     <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    <PackageTags>aspire integration hosting keycloak</PackageTags>
+    <PackageTags>aspire resource integration hosting keycloak</PackageTags>
     <Description>Keycloak support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
+++ b/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting milvus database vector search</PackageTags>
+    <PackageTags>aspire integration hosting milvus database vector search</PackageTags>
     <Description>Milvus vector database support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Milvus_256x.png</PackageIconFullPath>
     <!-- Disable package validation as this package hasn't shipped yet. -->

--- a/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
+++ b/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting milvus database vector search</PackageTags>
+    <PackageTags>aspire integration hosting milvus database vector search</PackageTags>
     <Description>Milvus vector database support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Milvus_256x.png</PackageIconFullPath>
     <!-- Disable package validation as this package hasn't shipped yet. -->

--- a/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
+++ b/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting milvus database vector search</PackageTags>
+    <PackageTags>aspire resource integration hosting milvus database vector search</PackageTags>
     <Description>Milvus vector database support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Milvus_256x.png</PackageIconFullPath>
     <!-- Disable package validation as this package hasn't shipped yet. -->

--- a/src/Aspire.Hosting.MongoDB/Aspire.Hosting.MongoDB.csproj
+++ b/src/Aspire.Hosting.MongoDB/Aspire.Hosting.MongoDB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting MongoDB</PackageTags>
+    <PackageTags>aspire integration hosting MongoDB</PackageTags>
     <PackageIconFullPath>$(SharedDir)MongoDB_300px.png</PackageIconFullPath>
     <Description>MongoDB support for .NET Aspire.</Description>
   </PropertyGroup>

--- a/src/Aspire.Hosting.MongoDB/Aspire.Hosting.MongoDB.csproj
+++ b/src/Aspire.Hosting.MongoDB/Aspire.Hosting.MongoDB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting MongoDB</PackageTags>
+    <PackageTags>aspire integration hosting MongoDB</PackageTags>
     <PackageIconFullPath>$(SharedDir)MongoDB_300px.png</PackageIconFullPath>
     <Description>MongoDB support for .NET Aspire.</Description>
   </PropertyGroup>

--- a/src/Aspire.Hosting.MongoDB/Aspire.Hosting.MongoDB.csproj
+++ b/src/Aspire.Hosting.MongoDB/Aspire.Hosting.MongoDB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting MongoDB</PackageTags>
+    <PackageTags>aspire resource integration hosting MongoDB</PackageTags>
     <PackageIconFullPath>$(SharedDir)MongoDB_300px.png</PackageIconFullPath>
     <Description>MongoDB support for .NET Aspire.</Description>
   </PropertyGroup>

--- a/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
+++ b/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting MySQL</PackageTags>
+    <PackageTags>aspire resource integration hosting MySQL</PackageTags>
     <Description>MySQL support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)MySQL_logo.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
+++ b/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting MySQL</PackageTags>
+    <PackageTags>aspire integration hosting MySQL</PackageTags>
     <Description>MySQL support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)MySQL_logo.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
+++ b/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting MySQL</PackageTags>
+    <PackageTags>aspire integration hosting MySQL</PackageTags>
     <Description>MySQL support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)MySQL_logo.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Nats/Aspire.Hosting.Nats.csproj
+++ b/src/Aspire.Hosting.Nats/Aspire.Hosting.Nats.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting NATS</PackageTags>
+    <PackageTags>aspire integration hosting NATS</PackageTags>
     <Description>NATS support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)nats-icon.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Nats/Aspire.Hosting.Nats.csproj
+++ b/src/Aspire.Hosting.Nats/Aspire.Hosting.Nats.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting NATS</PackageTags>
+    <PackageTags>aspire integration hosting NATS</PackageTags>
     <Description>NATS support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)nats-icon.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Nats/Aspire.Hosting.Nats.csproj
+++ b/src/Aspire.Hosting.Nats/Aspire.Hosting.Nats.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting NATS</PackageTags>
+    <PackageTags>aspire resource integration hosting NATS</PackageTags>
     <Description>NATS support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)nats-icon.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.NodeJs/Aspire.Hosting.NodeJs.csproj
+++ b/src/Aspire.Hosting.NodeJs/Aspire.Hosting.NodeJs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting Node Nodejs</PackageTags>
+    <PackageTags>aspire integration hosting Node Nodejs</PackageTags>
     <Description>Node.js support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.NodeJs/Aspire.Hosting.NodeJs.csproj
+++ b/src/Aspire.Hosting.NodeJs/Aspire.Hosting.NodeJs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting Node Nodejs</PackageTags>
+    <PackageTags>aspire integration hosting Node Nodejs</PackageTags>
     <Description>Node.js support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.NodeJs/Aspire.Hosting.NodeJs.csproj
+++ b/src/Aspire.Hosting.NodeJs/Aspire.Hosting.NodeJs.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting Node Nodejs</PackageTags>
+    <PackageTags>aspire resource integration hosting Node Nodejs</PackageTags>
     <Description>Node.js support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Oracle/Aspire.Hosting.Oracle.csproj
+++ b/src/Aspire.Hosting.Oracle/Aspire.Hosting.Oracle.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting oracle sql</PackageTags>
+    <PackageTags>aspire resource integration hosting oracle sql</PackageTags>
     <Description>Oracle Database support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Oracle/Aspire.Hosting.Oracle.csproj
+++ b/src/Aspire.Hosting.Oracle/Aspire.Hosting.Oracle.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting oracle sql</PackageTags>
+    <PackageTags>aspire integration hosting oracle sql</PackageTags>
     <Description>Oracle Database support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Oracle/Aspire.Hosting.Oracle.csproj
+++ b/src/Aspire.Hosting.Oracle/Aspire.Hosting.Oracle.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting oracle sql</PackageTags>
+    <PackageTags>aspire integration hosting oracle sql</PackageTags>
     <Description>Oracle Database support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
+++ b/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting orleans</PackageTags>
+    <PackageTags>aspire resource integration hosting orleans</PackageTags>
     <Description>Orleans support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
+++ b/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting orleans</PackageTags>
+    <PackageTags>aspire integration hosting orleans</PackageTags>
     <Description>Orleans support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
+++ b/src/Aspire.Hosting.Orleans/Aspire.Hosting.Orleans.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting orleans</PackageTags>
+    <PackageTags>aspire integration hosting orleans</PackageTags>
     <Description>Orleans support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting postgresql postgres npgsql sql</PackageTags>
+    <PackageTags>aspire integration hosting postgresql postgres npgsql sql</PackageTags>
     <Description>PostgreSQL® support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)PostgreSQL_logo.3colors.540x557.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting postgresql postgres npgsql sql</PackageTags>
+    <PackageTags>aspire resource integration hosting postgresql postgres npgsql sql</PackageTags>
     <Description>PostgreSQL® support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)PostgreSQL_logo.3colors.540x557.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
+++ b/src/Aspire.Hosting.PostgreSQL/Aspire.Hosting.PostgreSQL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting postgresql postgres npgsql sql</PackageTags>
+    <PackageTags>aspire integration hosting postgresql postgres npgsql sql</PackageTags>
     <Description>PostgreSQL® support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)PostgreSQL_logo.3colors.540x557.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
+++ b/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting python</PackageTags>
+    <PackageTags>aspire resource integration hosting python</PackageTags>
     <Description>Python support for .NET Aspire.</Description>
     <MinCodeCoverage>80</MinCodeCoverage>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
+++ b/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting python</PackageTags>
+    <PackageTags>aspire integration hosting python</PackageTags>
     <Description>Python support for .NET Aspire.</Description>
     <MinCodeCoverage>80</MinCodeCoverage>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
+++ b/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting python</PackageTags>
+    <PackageTags>aspire integration hosting python</PackageTags>
     <Description>Python support for .NET Aspire.</Description>
     <MinCodeCoverage>80</MinCodeCoverage>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Qdrant/Aspire.Hosting.Qdrant.csproj
+++ b/src/Aspire.Hosting.Qdrant/Aspire.Hosting.Qdrant.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting qdrant</PackageTags>
+    <PackageTags>aspire integration hosting qdrant</PackageTags>
     <Description>Qdrant vector database support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)QdrantLogo_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Qdrant/Aspire.Hosting.Qdrant.csproj
+++ b/src/Aspire.Hosting.Qdrant/Aspire.Hosting.Qdrant.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting qdrant</PackageTags>
+    <PackageTags>aspire resource integration hosting qdrant</PackageTags>
     <Description>Qdrant vector database support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)QdrantLogo_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Qdrant/Aspire.Hosting.Qdrant.csproj
+++ b/src/Aspire.Hosting.Qdrant/Aspire.Hosting.Qdrant.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting qdrant</PackageTags>
+    <PackageTags>aspire integration hosting qdrant</PackageTags>
     <Description>Qdrant vector database support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)QdrantLogo_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
+++ b/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting rabbitmq</PackageTags>
+    <PackageTags>aspire integration hosting rabbitmq</PackageTags>
     <Description>RabbitMQ support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
+++ b/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting rabbitmq</PackageTags>
+    <PackageTags>aspire integration hosting rabbitmq</PackageTags>
     <Description>RabbitMQ support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
+++ b/src/Aspire.Hosting.RabbitMQ/Aspire.Hosting.RabbitMQ.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting rabbitmq</PackageTags>
+    <PackageTags>aspire resource integration hosting rabbitmq</PackageTags>
     <Description>RabbitMQ support for .NET Aspire.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
+++ b/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting redis</PackageTags>
+    <PackageTags>aspire integration hosting redis</PackageTags>
     <Description>Redis® support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)redis-cube-red_white-rgb.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
+++ b/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting redis</PackageTags>
+    <PackageTags>aspire integration hosting redis</PackageTags>
     <Description>Redis® support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)redis-cube-red_white-rgb.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
+++ b/src/Aspire.Hosting.Redis/Aspire.Hosting.Redis.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting redis</PackageTags>
+    <PackageTags>aspire resource integration hosting redis</PackageTags>
     <Description>Redis® support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)redis-cube-red_white-rgb.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
+++ b/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(SharedDir)Workload.targets" />
 
   <PropertyGroup>
-    <PackageTags>aspire integration hosting sdk</PackageTags>
+    <PackageTags>aspire hosting sdk</PackageTags>
     <Description>.NET Aspire Hosting SDK. Enabled via &lt;IsAspireHost&gt;true&lt;/IsAspireHost&gt;.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
+++ b/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(SharedDir)Workload.targets" />
 
   <PropertyGroup>
-    <PackageTags>aspire hosting sdk</PackageTags>
+    <PackageTags>aspire integration hosting sdk</PackageTags>
     <Description>.NET Aspire Hosting SDK. Enabled via &lt;IsAspireHost&gt;true&lt;/IsAspireHost&gt;.</Description>
   </PropertyGroup>
 

--- a/src/Aspire.Hosting.Seq/Aspire.Hosting.Seq.csproj
+++ b/src/Aspire.Hosting.Seq/Aspire.Hosting.Seq.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting Seq</PackageTags>
+    <PackageTags>aspire integration hosting Seq</PackageTags>
     <Description>Seq support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Seq_logo.275x147.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Seq/Aspire.Hosting.Seq.csproj
+++ b/src/Aspire.Hosting.Seq/Aspire.Hosting.Seq.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting Seq</PackageTags>
+    <PackageTags>aspire resource integration hosting Seq</PackageTags>
     <Description>Seq support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Seq_logo.275x147.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Seq/Aspire.Hosting.Seq.csproj
+++ b/src/Aspire.Hosting.Seq/Aspire.Hosting.Seq.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting Seq</PackageTags>
+    <PackageTags>aspire integration hosting Seq</PackageTags>
     <Description>Seq support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Seq_logo.275x147.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.SqlServer/Aspire.Hosting.SqlServer.csproj
+++ b/src/Aspire.Hosting.SqlServer/Aspire.Hosting.SqlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting sqlserver sql</PackageTags>
+    <PackageTags>aspire integration hosting sqlserver sql</PackageTags>
     <Description>Microsoft SQL Server support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)SQL_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.SqlServer/Aspire.Hosting.SqlServer.csproj
+++ b/src/Aspire.Hosting.SqlServer/Aspire.Hosting.SqlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting sqlserver sql</PackageTags>
+    <PackageTags>aspire resource integration hosting sqlserver sql</PackageTags>
     <Description>Microsoft SQL Server support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)SQL_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.SqlServer/Aspire.Hosting.SqlServer.csproj
+++ b/src/Aspire.Hosting.SqlServer/Aspire.Hosting.SqlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting sqlserver sql</PackageTags>
+    <PackageTags>aspire integration hosting sqlserver sql</PackageTags>
     <Description>Microsoft SQL Server support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)SQL_256x.png</PackageIconFullPath>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Valkey/Aspire.Hosting.Valkey.csproj
+++ b/src/Aspire.Hosting.Valkey/Aspire.Hosting.Valkey.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire resource integration hosting valkey</PackageTags>
+    <PackageTags>aspire integration hosting valkey</PackageTags>
     <Description>Valkey® support for .NET Aspire.</Description>
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>

--- a/src/Aspire.Hosting.Valkey/Aspire.Hosting.Valkey.csproj
+++ b/src/Aspire.Hosting.Valkey/Aspire.Hosting.Valkey.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire integration hosting valkey</PackageTags>
+    <PackageTags>aspire resource integration hosting valkey</PackageTags>
     <Description>Valkey® support for .NET Aspire.</Description>
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>

--- a/src/Aspire.Hosting.Valkey/Aspire.Hosting.Valkey.csproj
+++ b/src/Aspire.Hosting.Valkey/Aspire.Hosting.Valkey.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <PackageTags>aspire hosting valkey</PackageTags>
+    <PackageTags>aspire integration hosting valkey</PackageTags>
     <Description>Valkey® support for .NET Aspire.</Description>
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>

--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -6,7 +6,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
 
-    <ComponentCommonPackageTags>aspire integration client component cloud</ComponentCommonPackageTags>
+    <ComponentCommonPackageTags>aspire client integration component cloud</ComponentCommonPackageTags>
     <ComponentCachePackageTags>$(ComponentCommonPackageTags) cache caching</ComponentCachePackageTags>
     <ComponentDatabasePackageTags>$(ComponentCommonPackageTags) data database</ComponentDatabasePackageTags>
     <ComponentEfCorePackageTags>$(ComponentDatabasePackageTags) ef efcore entityframework entityframeworkcore entity-framework-core o/rm</ComponentEfCorePackageTags>

--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -6,7 +6,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
 
-    <ComponentCommonPackageTags>aspire component cloud</ComponentCommonPackageTags>
+    <ComponentCommonPackageTags>aspire integration library component cloud</ComponentCommonPackageTags>
     <ComponentCachePackageTags>$(ComponentCommonPackageTags) cache caching</ComponentCachePackageTags>
     <ComponentDatabasePackageTags>$(ComponentCommonPackageTags) data database</ComponentDatabasePackageTags>
     <ComponentEfCorePackageTags>$(ComponentDatabasePackageTags) ef efcore entityframework entityframeworkcore entity-framework-core o/rm</ComponentEfCorePackageTags>

--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -6,7 +6,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
 
-    <ComponentCommonPackageTags>aspire client integration component cloud</ComponentCommonPackageTags>
+    <ComponentCommonPackageTags>aspire integration client component cloud</ComponentCommonPackageTags>
     <ComponentCachePackageTags>$(ComponentCommonPackageTags) cache caching</ComponentCachePackageTags>
     <ComponentDatabasePackageTags>$(ComponentCommonPackageTags) data database</ComponentDatabasePackageTags>
     <ComponentEfCorePackageTags>$(ComponentDatabasePackageTags) ef efcore entityframework entityframeworkcore entity-framework-core o/rm</ComponentEfCorePackageTags>

--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -6,7 +6,7 @@
     <IsAotCompatible>true</IsAotCompatible>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
 
-    <ComponentCommonPackageTags>aspire integration library component cloud</ComponentCommonPackageTags>
+    <ComponentCommonPackageTags>aspire integration client component cloud</ComponentCommonPackageTags>
     <ComponentCachePackageTags>$(ComponentCommonPackageTags) cache caching</ComponentCachePackageTags>
     <ComponentDatabasePackageTags>$(ComponentCommonPackageTags) data database</ComponentDatabasePackageTags>
     <ComponentEfCorePackageTags>$(ComponentDatabasePackageTags) ef efcore entityframework entityframeworkcore entity-framework-core o/rm</ComponentEfCorePackageTags>


### PR DESCRIPTION
Updates the package tags to use the "integration" term. The previously termed "component" packages have "library" added also, so we have "integration hosting" packages and "integration library" packages. The "component" tag isn't being removed as yet as the Visual Studio "Add Aspire package" experience still relies on it.