### PR TITLE
Fix issue where replacement text is not getting evaluated when pack

### DIFF
--- a/eng/ReplaceText.targets
+++ b/eng/ReplaceText.targets
@@ -34,7 +34,7 @@
   that use the processed file but preserve all other metadata.
   -->
   <Target Name="GenerateTextReplacementFiles"
-    BeforeTargets="Build;AssignTargetPaths"
+    BeforeTargets="Build;AssignTargetPaths;_GetPackageFiles"
     DependsOnTargets="_GatherTextReplacementFiles;_ProcessTextReplacementFiles"
     Condition="@(None->AnyHaveMetadataValue('PerformTextReplacement', 'True'))"
     >

--- a/eng/ReplaceText.targets
+++ b/eng/ReplaceText.targets
@@ -34,7 +34,7 @@
   that use the processed file but preserve all other metadata.
   -->
   <Target Name="GenerateTextReplacementFiles"
-    BeforeTargets="Build;AssignTargetPaths;_GetPackageFiles"
+    BeforeTargets="Build;AssignTargetPaths"
     DependsOnTargets="_GatherTextReplacementFiles;_ProcessTextReplacementFiles"
     Condition="@(None->AnyHaveMetadataValue('PerformTextReplacement', 'True'))"
     >

--- a/eng/dcppack/Common.projitems
+++ b/eng/dcppack/Common.projitems
@@ -53,7 +53,7 @@
       <_DcpFilesToCopy Include="$(NuGetPackageRoot)microsoft.developercontrolplane.$(DcpPlatform)/$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)\tools\**\*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(_DcpFilesToCopy)" DestinationFolder="$(IntermediateOutputPath)\tools" />
+    <Copy SourceFiles="@(_DcpFilesToCopy)" DestinationFolder="$(IntermediateOutputPath)\tools\%(RecursiveDir)" />
   </Target>
 
   <Target Name="GetDCPBinaryLocation" Returns="$(DCPBinariesLocation)">

--- a/eng/dcppack/Common.projitems
+++ b/eng/dcppack/Common.projitems
@@ -48,9 +48,17 @@
 
   <Target Name="Build" />
 
-  <Target Name="GetDCPBinaryLocation" Returns="$(DCPBinariesLocation)" DependsOnTargets="Restore">
+  <Target Name="_CopyDCPBinaryToIntermediateDir" AfterTargets="Build">
+    <ItemGroup>
+      <_DcpFilesToCopy Include="$(NuGetPackageRoot)microsoft.developercontrolplane.$(DcpPlatform)/$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)\tools\**\*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_DcpFilesToCopy)" DestinationFolder="$(IntermediateOutputPath)\tools" />
+  </Target>
+
+  <Target Name="GetDCPBinaryLocation" Returns="$(DCPBinariesLocation)">
     <PropertyGroup>
-      <DCPBinariesLocation>$(NuGetPackageRoot)microsoft.developercontrolplane.$(DcpPlatform)/$(MicrosoftDeveloperControlPlanedarwinamd64PackageVersion)/tools</DCPBinariesLocation>
+      <DCPBinariesLocation>$(IntermediateOutputPath)/tools</DCPBinariesLocation>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
## Description

During our build, we currently are running Pack again after running tests (which is wrong and fixing it is tracked by #5404). Because of that, and due to a recent change that caused a new Restore operation to be called when sending our tests to Helix, the build is now trying to re-run pack one the package that was restored during test runs, but it is doing so by passing `/p:Restore=false /p:Build=false`. Currently, our ReplacementText targets only run if you are running the Build target as well, but if you run Pack and skip the Build, then the replacement targets won't run, meaning the new generated package won't have the placeholders replaced, which is what is causing #5396 to happen. This change is making it so that our Replacement targets also are hooked into the Pack target even when Build gets skipped which will workaround the issue. The ultimate fix will be to not try to re-pack the projects after testing, which will be tracked by #5404.

Fixes # https://github.com/dotnet/aspire/issues/5396

cc: @eerhardt @radical 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5411)