### PR TITLE
[ci] Internal build: build packages, and workload nugets only once

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -21,14 +21,41 @@ parameters:
     default: false
 
 steps:
-  - script: ${{ parameters.buildScript }}
-            -restore -build
-            -pack
-            -configuration ${{ parameters.buildConfig }}
-            /p:ArchiveTests=true
-            /bl:${{ parameters.repoLogPath }}/build.binlog
-            $(_OfficialBuildIdArgs)
-    displayName: Build
+  # Internal pipeline: Build with pack+sign+archive
+  - ${{ if ne(parameters.runAsPublic, 'true') }}:
+    - script: ${{ parameters.buildScript }}
+              -restore -build
+              -pack
+              -sign $(_SignArgs)
+              -publish $(_PublishArgs)
+              -configuration ${{ parameters.buildConfig }}
+              /p:ArchiveTests=true
+              /bl:${{ parameters.repoLogPath }}/build.binlog
+              $(_OfficialBuildIdArgs)
+      displayName: Build
+
+  # Public pipeline - helix tests
+  - ${{ if eq(parameters.runAsPublic, 'true') }}:
+    - script: ${{ parameters.buildScript }}
+              -restore -build
+              -configuration ${{ parameters.buildConfig }}
+              -pack
+              /p:ArchiveTests=${{ lower(eq(parameters.runHelixTests, 'true')) }}
+              /bl:${{ parameters.repoLogPath }}/build.binlog
+              $(_OfficialBuildIdArgs)
+      displayName: Build
+
+  # Run on windows, either for internal pipeline, or for public+non-helix-tests job
+  - ${{ if and(eq(parameters.isWindows, 'true'), or(ne(parameters.runAsPublic, 'true'), ne(parameters.runHelixTests, 'true'))) }}:
+    - script: ${{ parameters.buildScript }}
+        -restore -build
+        -sign $(_SignArgs)
+        -publish $(_PublishArgs)
+        -configuration $(_BuildConfig)
+        /bl:${{ parameters.repoLogPath }}/build-workloads.binlog
+        -projects eng\workloads\workloads.csproj
+        $(_InternalBuildArgs)
+      displayName: Build Workloads
 
   - ${{ if or(ne(parameters.runAsPublic, 'true'), ne(parameters.runHelixTests, 'true')) }}:
     - ${{ if ne(parameters.isWindows, 'true') }}:
@@ -124,27 +151,6 @@ steps:
 
   # Run on windows, for internal pipeline, or public+non-helix-tests job
   - ${{ if and(eq(parameters.isWindows, 'true'), or(ne(parameters.runAsPublic, 'true'), ne(parameters.runHelixTests, 'true'))) }}:
-    - script: ${{ parameters.buildScript }}
-              -pack
-              -sign $(_SignArgs)
-              -publish $(_PublishArgs)
-              -configuration ${{ parameters.buildConfig }}
-              /bl:${{ parameters.repoLogPath }}/pack.binlog
-              /p:Restore=false /p:Build=false
-              $(_OfficialBuildIdArgs)
-      displayName: Pack, Sign, and Publish
-
-    - script: ${{ parameters.buildScript }}
-        -restore -build
-        -pack
-        -sign $(_SignArgs)
-        -publish $(_PublishArgs)
-        -configuration $(_BuildConfig)
-        /bl:${{ parameters.repoLogPath }}/build-workloads.binlog
-        -projects eng\workloads\workloads.csproj
-        $(_InternalBuildArgs)
-      displayName: Build Workloads
-
     - ${{ if eq(parameters.runAsPublic, 'true') }}:
       - task: PublishPipelineArtifact@1
         displayName: Publish VSDrop MSIs

--- a/tests/Shared/Aspire.Workload.Testing.targets
+++ b/tests/Shared/Aspire.Workload.Testing.targets
@@ -111,10 +111,15 @@
       <UnexpectedPackages Include="@(AllPackages)" Exclude="@(ExpectedPackagePaths)" />
 
       <!-- Ignore these packages which are part of the workload. Existence of these would get checked
-            by the workload installation targets. And their names don't correspond to project names. -->
+           by the workload installation targets. -->
+      <UnexpectedPackages Remove="@(UnexpectedPackages)" Condition="$([System.String]::Copy('%(UnexpectedPackages.FileName)').StartsWith('Aspire.Hosting.Sdk.'))" />
+      <UnexpectedPackages Remove="@(UnexpectedPackages)" Condition="$([System.String]::Copy('%(UnexpectedPackages.FileName)').StartsWith('Aspire.ProjectTemplates.'))" />
       <UnexpectedPackages Remove="@(UnexpectedPackages)" Condition="$([System.String]::Copy('%(UnexpectedPackages.FileName)').StartsWith('Microsoft.NET.Sdk.Aspire.Manifest-'))" />
-      <UnexpectedPackages Remove="@(UnexpectedPackages)" Condition="$([System.String]::Copy('%(UnexpectedPackages.FileName)').StartsWith('Aspire.Hosting.Orchestration.'))" />
+
+      <!-- Exclude the packages with arch-specific nugets -->
       <UnexpectedPackages Remove="@(UnexpectedPackages)" Condition="$([System.String]::Copy('%(UnexpectedPackages.FileName)').StartsWith('Aspire.Dashboard.Sdk.'))" />
+      <UnexpectedPackages Remove="@(UnexpectedPackages)" Condition="$([System.String]::Copy('%(UnexpectedPackages.FileName)').StartsWith('Aspire.Hosting.Orchestration.'))" />
+
     </ItemGroup>
 
     <Warning Text="Found some unexpected packages in '$(ArtifactsShippingPackagesDir)', which might mean that the list of expected packages is incorrect: @(UnexpectedPackages -> '%(FileName)%(Extension)', ', '). Use %24(SkipPackageCheckForWorkloadTesting)='true' to skip this."


### PR DESCRIPTION
This ensures that for the internal pipeline the tests are run against the final packages produced, instead of building packages twice - once for testing, and then for publishing.

- And track change in final packages being built before the workload tests are run

Fixes https://github.com/dotnet/aspire/issues/5404

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5417)