### PR TITLE
Give theme cookie an expiration

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/js/app-theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-theme.js
@@ -35,7 +35,7 @@ export function updateTheme(specifiedTheme) {
  * @returns {string}
  */
 export function getThemeCookieValue() {
-    return getCookieValue(currentThemeCookieName) ?? themeSettingSystem;
+    return getCookieValue(currentThemeCookieName);
 }
 
 export function getCurrentTheme() {
@@ -263,6 +263,12 @@ function initializeTheme() {
     const effectiveTheme = getEffectiveTheme(themeCookieValue);
 
     applyTheme(effectiveTheme);
+
+    // If a theme cookie has been set then set it again on page load.
+    // This updates the cookie expiration date and creates a sliding expiration.
+    if (themeCookieValue) {
+        setThemeCookie(themeCookieValue);
+    }
 }
 
 createAdditionalDesignTokens();

--- a/src/Aspire.Dashboard/wwwroot/js/app-theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-theme.js
@@ -10,7 +10,6 @@ import {
 } from "/_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.lib.module.js";
 
 const currentThemeCookieName = "currentTheme";
-const themeSettingSystem = "System";
 const themeSettingDark = "Dark";
 const themeSettingLight = "Light";
 const darkThemeLuminance = 0.19;
@@ -31,7 +30,7 @@ export function updateTheme(specifiedTheme) {
 }
 
 /**
- * Returns the value of the currentTheme cookie, or System if the cookie is not set.
+ * Returns the value of the currentTheme cookie.
  * @returns {string}
  */
 export function getThemeCookieValue() {
@@ -61,10 +60,15 @@ function getSystemTheme() {
  * @param {string} theme
  */
 function setThemeCookie(theme) {
-    // Cookie will expire after 1 year. Using a much larger value won't have an impact because
-    // Chrome limits expiration to 400 days: https://developer.chrome.com/blog/cookie-max-age-expires
-    // The cookie is reset when the dashboard loads to creating a sliding expiration.
-    document.cookie = `${currentThemeCookieName}=${theme}; expires=${new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 365).toGMTString()}`;
+    if (theme == themeSettingDark || theme == themeSettingLight) {
+        // Cookie will expire after 1 year. Using a much larger value won't have an impact because
+        // Chrome limits expiration to 400 days: https://developer.chrome.com/blog/cookie-max-age-expires
+        // The cookie is reset when the dashboard loads to creating a sliding expiration.
+        document.cookie = `${currentThemeCookieName}=${theme}; Path=/; expires=${new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 365).toGMTString()}`;
+    } else {
+        // Delete cookie for other values (e.g. System)
+        document.cookie = `${currentThemeCookieName}=; Path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;`;
+    }
 }
 
 /**

--- a/src/Aspire.Dashboard/wwwroot/js/app-theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-theme.js
@@ -63,7 +63,7 @@ function getSystemTheme() {
 function setThemeCookie(theme) {
     // Cookie will expire after 1 year. Using a much larger value won't have an impact because
     // Chrome limits expiration to 400 days: https://developer.chrome.com/blog/cookie-max-age-expires
-    // If we want the cookie to persist longer then we'll need to reset it when the dashboard launches.
+    // The cookie is reset when the dashboard loads to creating a sliding expiration.
     document.cookie = `${currentThemeCookieName}=${theme}; expires=${new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 365).toGMTString()}`;
 }
 

--- a/src/Aspire.Dashboard/wwwroot/js/app-theme.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app-theme.js
@@ -61,7 +61,10 @@ function getSystemTheme() {
  * @param {string} theme
  */
 function setThemeCookie(theme) {
-    document.cookie = `${currentThemeCookieName}=${theme}`;
+    // Cookie will expire after 1 year. Using a much larger value won't have an impact because
+    // Chrome limits expiration to 400 days: https://developer.chrome.com/blog/cookie-max-age-expires
+    // If we want the cookie to persist longer then we'll need to reset it when the dashboard launches.
+    document.cookie = `${currentThemeCookieName}=${theme}; expires=${new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 365).toGMTString()}`;
 }
 
 /**


### PR DESCRIPTION
## Description

I noticed that Aspire dashboard sometimes lost the theme. The reason is the theme cookie had a session lifetime. Once all browsers are closed the cookie is cleared and the dashboard forgets the configured theme.

This PR:

* Gives the cookie a 1 year expiration
* If the theme cookie is present when the dashboard loads, it is set again to create a sliding expiration (i.e. cookie expires 1 year after the dashboard was last loaded)
* Specifies a path when working with the cookie to be explicit about where it is set
* Deletes the cookie if "System" is selected in the UI. No point having a cookie set and updating it if it is the default value.

![image](https://github.com/user-attachments/assets/2f877cf0-78b6-4ea2-bc5a-6ad7acc781af)

Fixes https://github.com/dotnet/aspire/issues/5430

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5429)