### PR TITLE
GridColumnManager improvements

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/GridColumnManager.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/GridColumnManager.cs
@@ -1,54 +1,57 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Model;
 
 namespace Aspire.Dashboard.Components;
 
-public class GridColumnManager
+public class GridColumnManager(IEnumerable<GridColumn> columns, DimensionManager dimensionManager)
 {
-    private readonly GridColumn[] _columns;
-    private readonly DimensionManager _dimensionManager;
+    private readonly Dictionary<string, GridColumn> _columnById
+        = columns.ToDictionary(c => c.Name, StringComparers.GridColumn);
 
-    public GridColumnManager(GridColumn[] columns, DimensionManager dimensionManager)
+    /// <summary>
+    /// Gets whether the column is known, visible, and has a width for the current viewport.
+    /// </summary>
+    public bool IsColumnVisible(string columnName)
     {
-        if (columns.DistinctBy(c => c.Name, StringComparers.GridColumn).Count() != columns.Length)
-        {
-            throw new InvalidOperationException("There are duplicate columns");
-        }
-
-        _columns = columns;
-        _dimensionManager = dimensionManager;
+        return _columnById.TryGetValue(columnName, out var column) // Is a known column.
+            && GetColumnWidth(column) is not null                  // Has width for current viewport.
+            && column.IsVisible?.Invoke() is null or true;         // Is visible.
     }
 
-    public bool IsColumnVisible(string columnId)
+    /// <summary>
+    /// Gets a string that can be used as the value for the grid-template-columns CSS property.
+    /// For example, <c>1fr 2fr 1fr</c>.
+    /// </summary>
+    /// <returns></returns>
+    public string GetGridTemplateColumns()
     {
-        return GetColumnWidth(_columns.First(column => column.Name == columnId)) is not null;
+        StringBuilder sb = new();
+
+        foreach (var (_, column) in _columnById)
+        {
+            if (column.IsVisible?.Invoke() is null or true &&
+                GetColumnWidth(column) is string width)
+            {
+                if (sb.Length > 0)
+                {
+                    sb.Append(' ');
+                }
+
+                sb.Append(width);
+            }
+        }
+
+        return sb.ToString();
     }
 
     private string? GetColumnWidth(GridColumn column)
     {
-        if (column.IsVisible is not null && !column.IsVisible())
-        {
-            return null;
-        }
-
-        if (_dimensionManager.ViewportInformation.IsDesktop)
-        {
-            return column.DesktopWidth;
-        }
-
-        return column.MobileWidth;
-    }
-
-    public string GetGridTemplateColumns()
-    {
-        var visibleColumns = _columns
-            .Select(GetColumnWidth)
-            .Where(s => s is not null)
-            .Select(s => s!);
-
-        return string.Join(" ", visibleColumns);
+        return dimensionManager.ViewportInformation.IsDesktop
+            ? column.DesktopWidth
+            : column.MobileWidth;
     }
 }


### PR DESCRIPTION
The previous code had two issues that are addressed here:

- Inconsistent use of string comparers for column names.
- O(N) scan through the column collection for lookups.

This PR uses a dictionary for columns, which ensures consistent comparer use, and gives O(1) lookup.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No, covered by existing tests
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5433)