### PR TITLE
[tests] Increase efcore timeout for cosmos in CosmosEndToEnd

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.ApiService/Program.cs
@@ -9,7 +9,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 builder.AddAzureCosmosClient("cosmos");
-builder.AddCosmosDbContext<TestCosmosContext>("cosmos", "ef");
+builder.AddCosmosDbContext<TestCosmosContext>("cosmos", "ef", configureDbContextOptions =>
+{
+    configureDbContextOptions.RequestTimeout = TimeSpan.FromSeconds(120);
+});
 
 var app = builder.Build();
 


### PR DESCRIPTION
.. playground app.

The `/ef` request times out after 65 seconds, which is the default timeout for efcore cosmos requests. Bumping this to 120 seconds makes the test run more stable.

Fixes issue: https://github.com/dotnet/aspire/issues/5415

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5464)