### PR TITLE
Fixing unintended formatting changes

### DIFF
--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.targets
@@ -1,11 +1,9 @@
 <Project>
 
   <!--
-  A property-based workload cannot import props files (except AutoImport.props, which has very tight
-  limitations.
+  A property-based workload cannot import props files (except AutoImport.props, which has very tight limitations.
   Instead, we copy everything from Aspire.Hosting.AppHost.props into these targets.
-  This means they cannot be overridden in the csproj, and may cause ordering issues, particularly
-  StaticWebAssets.
+  This means they cannot be overridden in the csproj, and may cause ordering issues, particularly StaticWebAssets.
   -->
 
   <ItemGroup>
@@ -15,45 +13,34 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- Aspire hosting projects aren't publishable right now until
-    https://github.com/dotnet/aspire/issues/147 is good -->
+    <!-- Aspire hosting projects aren't publishable right now until https://github.com/dotnet/aspire/issues/147 is good -->
     <IsPublishable Condition="'$(IsPublishable)' == ''">false</IsPublishable>
     <IsPackable Condition="'$(IsPackable)' == ''">false</IsPackable>
   </PropertyGroup>
 
   <!--
-  Default AppHost ProjectReference items to not be referenced in the AppHost, unless it is
-  IsAspireProjectResource=false.
+  Default AppHost ProjectReference items to not be referenced in the AppHost, unless it is IsAspireProjectResource=false.
   This defaulting needs to happen in the SDK targets so this metadata affects NuGet Restore.
   -->
   <ItemGroup Condition="'$(IsAspireHost)' == 'true'">
-
+    
     <ProjectReference Update="@(ProjectReference)">
       <IsAspireProjectResource Condition="'%(IsAspireProjectResource)' != 'false'">true</IsAspireProjectResource>
 
-      <ReferenceOutputAssembly
-        Condition="'%(ReferenceOutputAssembly)' == '' and '%(IsAspireProjectResource)' == 'true'">
-        false</ReferenceOutputAssembly>
-      <SkipGetTargetFrameworkProperties
-        Condition="'%(SkipGetTargetFrameworkProperties)' == '' and '%(IsAspireProjectResource)' == 'true'">
-        true</SkipGetTargetFrameworkProperties>
-      <ExcludeAssets Condition="'%(ExcludeAssets)' == '' and '%(IsAspireProjectResource)' == 'true'">
-        all</ExcludeAssets>
+      <ReferenceOutputAssembly Condition="'%(ReferenceOutputAssembly)' == '' and '%(IsAspireProjectResource)' == 'true'">false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties Condition="'%(SkipGetTargetFrameworkProperties)' == '' and '%(IsAspireProjectResource)' == 'true'">true</SkipGetTargetFrameworkProperties>
+      <ExcludeAssets Condition="'%(ExcludeAssets)' == '' and '%(IsAspireProjectResource)' == 'true'">all</ExcludeAssets>
       <Private Condition="'%(Private)' == '' and '%(IsAspireProjectResource)' == 'true'">false</Private>
     </ProjectReference>
 
   </ItemGroup>
 
-  <Target Name="__WarnOnAspireCapabilityMissing" BeforeTargets="PrepareForBuild"
-    Condition="!@(ProjectCapability->AnyHaveMetadataValue('Identity', 'Aspire'))">
-    <Warning Code="ASPIRE002"
-      Text="$(MSBuildProjectName) is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting.AppHost PackageReference?" />
+  <Target Name="__WarnOnAspireCapabilityMissing" BeforeTargets="PrepareForBuild" Condition="!@(ProjectCapability->AnyHaveMetadataValue('Identity', 'Aspire'))">
+    <Warning Code="ASPIRE002" Text="$(MSBuildProjectName) is an Aspire AppHost project but necessary dependencies aren't present. Are you missing an Aspire.Hosting.AppHost PackageReference?" />
   </Target>
 
-  <Target Name="__WarnOnMininumVsVersionMissing" BeforeTargets="PrepareForBuild"
-    Condition="'$(BuildingInsideVisualStudio)' == 'true' and $([MSBuild]::VersionLessThan('$(MSBuildVersion)', '17.10.0'))">
-    <Warning Code="ASPIRE003"
-      Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that requires Visual Studio version 17.10 or above to work correctly. You are using version $(MSBuildVersion)." />
+  <Target Name="__WarnOnMininumVsVersionMissing" BeforeTargets="PrepareForBuild" Condition="'$(BuildingInsideVisualStudio)' == 'true' and $([MSBuild]::VersionLessThan('$(MSBuildVersion)', '17.10.0'))">
+    <Warning Code="ASPIRE003" Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that requires Visual Studio version 17.10 or above to work correctly. You are using version $(MSBuildVersion)." />
   </Target>
 
   <!-- This target extracts the version of Aspire.Hosting.AppHost referenced by the project, and adds
@@ -65,8 +52,7 @@
     <!-- First, we assume project is not using Central Package Management, and we try to extract the version
          from PackageReference Items. -->
     <ItemGroup>
-      <_AppHostPackageReference Include="@(PackageReference)" Condition="'%(Identity)' ==
-  'Aspire.Hosting.AppHost'" />
+      <_AppHostPackageReference Include="@(PackageReference)" Condition="'%(Identity)' == 'Aspire.Hosting.AppHost'" />
     </ItemGroup>
 
     <!-- Extract the Version metadata -->
@@ -78,8 +64,7 @@
          and we try to extract the PackageVersion Items. -->
     <ItemGroup Condition="'$(_AppHostVersion)' == ''">
       <_AppHostPackageReference />
-      <_AppHostPackageReference Include="@(PackageVersion)" Condition="'%(Identity)' ==
-  'Aspire.Hosting.AppHost'" />
+      <_AppHostPackageReference Include="@(PackageVersion)" Condition="'%(Identity)' == 'Aspire.Hosting.AppHost'" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(_AppHostVersion)' == ''">
@@ -96,10 +81,8 @@
 
     <!-- Now that we have the version, we add the package references -->
     <ItemGroup>
-      <PackageReference Include="Aspire.Dashboard.Sdk.$(NETCoreSdkRuntimeIdentifier)"
-  Version="$(_AppHostVersion)" IsImplicitlyDefined="true" />
-      <PackageReference Include="Aspire.Hosting.Orchestration.$(NETCoreSdkRuntimeIdentifier)"
-  Version="$(_AppHostVersion)" IsImplicitlyDefined="true" />
+      <PackageReference Include="Aspire.Dashboard.Sdk.$(NETCoreSdkRuntimeIdentifier)" Version="$(_AppHostVersion)" IsImplicitlyDefined="true" />
+      <PackageReference Include="Aspire.Hosting.Orchestration.$(NETCoreSdkRuntimeIdentifier)" Version="$(_AppHostVersion)" IsImplicitlyDefined="true" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Description

When making the workload changes, I ran the xml formatter on the SDK.targets file to format tabs/spaces and indentation correctly, but it looks like that made some formatting changes that introduced bugs like adding newlines to property values, which would then break conditions when doing string comparisons. Thanks a lot @eerhardt for debugging and finding this out. The changes in this PR revert all the formatting changes made in that PR, which means the net difference since 8.1 will be the addition of the new target.

Fixes #5436 

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5471)