### PR TITLE
Support multiple applicationUrl endpoints for the same scheme

### DIFF
--- a/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ProjectResourceTests.cs
@@ -411,6 +411,35 @@ public class ProjectResourceTests
     }
 
     [Fact]
+    public async Task ProjectWithMultipleLaunchProfileAppUrlsGetsAllUrls()
+    {
+        var appBuilder = CreateBuilder(operation: DistributedApplicationOperation.Run);
+
+        var builder = appBuilder.AddProject<TestProjectWithManyAppUrlsInLaunchSettings>("projectName");
+
+        // Need to allocated all the endpoints we get from the launch profile applicationUrl
+        var index = 0;
+        foreach (var q in new[] { "http", "http2", "https", "https2", "https3" })
+        {
+            builder.WithEndpoint(q, e =>
+            {
+                e.AllocatedEndpoint = new(e, "localhost", e.Port!.Value, targetPortExpression: $"p{index++}");
+            });
+        }
+
+        using var app = appBuilder.Build();
+        var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+        var projectResources = appModel.GetProjectResources();
+        var resource = Assert.Single(projectResources);
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("https://localhost:p2;http://localhost:p0;http://localhost:p1;https://localhost:p3;https://localhost:p4", config["ASPNETCORE_URLS"]);
+
+        // The first https port is the one that should be used for ASPNETCORE_HTTPS_PORT
+        Assert.Equal("7144", config["ASPNETCORE_HTTPS_PORT"]);
+    }
+
+    [Fact]
     public void DisabledForwardedHeadersAddsAnnotationToProject()
     {
         var appBuilder = CreateBuilder();
@@ -610,6 +639,27 @@ public class ProjectResourceTests
                     CommandLineArgs = "arg1 arg2",
                     LaunchBrowser = true,
                     ApplicationUrl = "http://localhost:5031",
+                    EnvironmentVariables = new()
+                    {
+                        ["ASPNETCORE_ENVIRONMENT"] = "Development"
+                    }
+                }
+            };
+        }
+    }
+
+    private sealed class TestProjectWithManyAppUrlsInLaunchSettings : BaseProjectWithProfileAndConfig
+    {
+        public TestProjectWithManyAppUrlsInLaunchSettings()
+        {
+            Profiles = new()
+            {
+                ["https"] = new()
+                {
+                    CommandName = "Project",
+                    CommandLineArgs = "arg1 arg2",
+                    LaunchBrowser = true,
+                    ApplicationUrl = "https://localhost:7144;http://localhost:5193;http://localhost:5194;https://localhost:7145;https://localhost:7146",
                     EnvironmentVariables = new()
                     {
                         ["ASPNETCORE_ENVIRONMENT"] = "Development"


### PR DESCRIPTION
## Description

See https://github.com/dotnet/aspire/discussions/5338.

We add support for multiple `applicationUrl` endpoints for the same scheme. e.g.
```json
"applicationUrl": "https://localhost:p2;http://localhost:p0;http://localhost:p1;https://localhost:p3;https://localhost:p4"
```

Fixes #5338

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5481)