### PR TITLE
fix broken param name docs

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationHostingTestingExtensions.cs
@@ -16,9 +16,9 @@ public static class DistributedApplicationHostingTestingExtensions
     /// <summary>
     /// Creates an <see cref="HttpClient"/> configured to communicate with the specified resource.
     /// </summary>
-    /// <param resourceName="app">The application.</param>
-    /// <param resourceName="resourceName">The resourceName of the resource.</param>
-    /// <param resourceName="endpointName">The resourceName of the endpoint on the resource to communicate with.</param>
+    /// <param name="app">The application.</param>
+    /// <param name="resourceName">The resourceName of the resource.</param>
+    /// <param name="endpointName">The resourceName of the endpoint on the resource to communicate with.</param>
     /// <returns>The <see cref="HttpClient"/>.</returns>
     public static HttpClient CreateHttpClient(this DistributedApplication app, string resourceName, string? endpointName = default)
     {


### PR DESCRIPTION
A few `param` docs were broken using `resourceName` instead of `name`: `<param resourceName="app">`

my guess is a greedy rename refactor broke them
    
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5484)