### PR TITLE
Fix dashboard auth when unsecured

### DIFF
--- a/src/Aspire.Dashboard/Authentication/FrontendCompositeAuthenticationHandler.cs
+++ b/src/Aspire.Dashboard/Authentication/FrontendCompositeAuthenticationHandler.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Aspire.Dashboard.Authentication.Connection;
 using Aspire.Dashboard.Configuration;
@@ -27,13 +26,6 @@ public sealed class FrontendCompositeAuthenticationHandler(
                 new AuthenticationProperties(
                     items: new Dictionary<string, string?>(),
                     parameters: new Dictionary<string, object?> { [AspirePolicyEvaluator.SuppressChallengeKey] = true }));
-        }
-
-        var scheme = GetRelevantAuthenticationScheme();
-        if (scheme == null)
-        {
-            var id = new ClaimsIdentity([new Claim(OtlpAuthorization.OtlpClaimName, bool.FalseString)]);
-            return AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(id), Scheme.Name));
         }
 
         result = await Context.AuthenticateAsync().ConfigureAwait(false);

--- a/src/Aspire.Dashboard/Authentication/UnsecuredAuthenticationHandler.cs
+++ b/src/Aspire.Dashboard/Authentication/UnsecuredAuthenticationHandler.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard.Authentication;
+
+public class UnsecuredAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public UnsecuredAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder) : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var id = new ClaimsIdentity(
+            [new Claim(ClaimTypes.NameIdentifier, "Local"), new Claim(FrontendAuthorizationDefaults.UnsecuredClaimName, bool.TrueString)],
+            FrontendAuthenticationDefaults.AuthenticationSchemeUnsecured);
+
+        return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(new ClaimsPrincipal(id), Scheme.Name)));
+    }
+}

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -770,6 +770,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             }
         });
 
+        // ASP.NET Core authentication needs to have the correct default scheme for the configured frontend auth.
+        // This is required for ASP.NET Core/SignalR/Blazor to flow the authenticated user from the request and into the dashboard app.
         static string ConfigureDefaultAuthScheme(DashboardOptions dashboardOptions)
         {
             return dashboardOptions.Frontend.AuthMode switch

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -21,6 +21,7 @@ using Aspire.Dashboard.Otlp.Grpc;
 using Aspire.Dashboard.Otlp.Http;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Hosting;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Certificate;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -607,7 +608,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     private static void ConfigureAuthentication(WebApplicationBuilder builder, DashboardOptions dashboardOptions)
     {
         var authentication = builder.Services
-            .AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+            .AddAuthentication(o => o.DefaultScheme = ConfigureDefaultAuthScheme(dashboardOptions))
             .AddScheme<FrontendCompositeAuthenticationHandlerOptions, FrontendCompositeAuthenticationHandler>(FrontendCompositeAuthenticationDefaults.AuthenticationScheme, o => { })
             .AddScheme<OtlpCompositeAuthenticationHandlerOptions, OtlpCompositeAuthenticationHandler>(OtlpCompositeAuthenticationDefaults.AuthenticationScheme, o => { })
             .AddScheme<OtlpApiKeyAuthenticationHandlerOptions, OtlpApiKeyAuthenticationHandler>(OtlpApiKeyAuthenticationDefaults.AuthenticationScheme, o => { })
@@ -728,6 +729,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                     options.Cookie.Name = DashboardAuthCookieName;
                 });
                 break;
+            case FrontendAuthMode.Unsecured:
+                authentication.AddScheme<AuthenticationSchemeOptions, UnsecuredAuthenticationHandler>(FrontendAuthenticationDefaults.AuthenticationSchemeUnsecured, o => { });
+                break;
         }
 
         builder.Services.AddAuthorization(options =>
@@ -758,13 +762,22 @@ public sealed class DashboardWebApplication : IAsyncDisposable
                     options.AddPolicy(
                         name: FrontendAuthorizationDefaults.PolicyName,
                         policy: new AuthorizationPolicyBuilder(FrontendCompositeAuthenticationDefaults.AuthenticationScheme)
-                            .RequireClaim(OtlpAuthorization.OtlpClaimName, [bool.FalseString])
+                            .RequireClaim(FrontendAuthorizationDefaults.UnsecuredClaimName)
                             .Build());
                     break;
                 default:
                     throw new NotSupportedException($"Unexpected {nameof(FrontendAuthMode)} enum member: {dashboardOptions.Frontend.AuthMode}");
             }
         });
+
+        static string ConfigureDefaultAuthScheme(DashboardOptions dashboardOptions)
+        {
+            return dashboardOptions.Frontend.AuthMode switch
+            {
+                FrontendAuthMode.Unsecured => FrontendAuthenticationDefaults.AuthenticationSchemeUnsecured,
+                _ => CookieAuthenticationDefaults.AuthenticationScheme
+            };
+        }
     }
 
     public int Run()
@@ -804,10 +817,12 @@ public static class FrontendAuthorizationDefaults
 {
     public const string PolicyName = "Frontend";
     public const string BrowserTokenClaimName = "BrowserTokenClaim";
+    public const string UnsecuredClaimName = "UnsecuredTokenClaim";
 }
 
 public static class FrontendAuthenticationDefaults
 {
     public const string AuthenticationSchemeOpenIdConnect = "FrontendOpenIdConnect";
     public const string AuthenticationSchemeBrowserToken = "FrontendBrowserToken";
+    public const string AuthenticationSchemeUnsecured = "FrontendUnsecured";
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -17,7 +17,6 @@ public class AppBarTests : PlaywrightTestsBase
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/4851")]
     public async Task AppBar_Change_Theme()
     {
         // Arrange

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/PlaywrightFixture.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/PlaywrightFixture.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Workload.Tests;
@@ -13,6 +13,9 @@ public class PlaywrightFixture : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
+        // Default timeout of 5000 ms could time out on slow CI servers.
+        Assertions.SetDefaultExpectTimeout(15_000);
+
         PlaywrightProvider.DetectAndSetInstalledPlaywrightDependenciesPath();
         Browser = await PlaywrightProvider.CreateBrowserAsync();
     }


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/5490
Fixes https://github.com/dotnet/aspire/issues/4851

Changes to auth caused the dashboard's unsecured mode to fail. I don't exactly understand what is going on, but I think that:

1. Request would come into ASP.NET Core and the `HttpContext.User` would be set with a claim **<- good**
2. The request user is set as Blazor's auth state **<- good**
3. Blazor Server circuit is created and uses SignalR user as new auth state. SignalR user is a default unauthenticated principal. I'm not sure why it's different from the HttpContext's user. **<- bad**
4. `AuthorizeRouteView` in dashboard sees unauthorized user and displays message in browser.

I fixed this by making an auth scheme handler just for unsecured mode and made it the default auth scheme if dashboard is configured to be unsecured. My guess is the SignalR was attempting to run the default auth scheme (cookies) when it gets its user and was failing because cookies isn't used in unsecured mode.

I'm not sure how to test this simply. It might require a playwright test 😬

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5499)