### PR TITLE
[tests] Wait for Kafka playground to be ready before waiting for messages

### DIFF
--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -29,7 +29,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
         await app.StopAsync();
     }
 
-    [Fact(Skip = "https://github.com/dotnet/aspire/issues/5489")]
+    [Fact]
     public async Task KafkaTest()
     {
         var appHostPath = Directory.GetFiles(AppContext.BaseDirectory, "KafkaBasic.AppHost.dll").Single();
@@ -39,6 +39,10 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
         await app.StartAsync();
         await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(2));
 
+        // Wait for the producer to start sending messages
+        await app.WaitForTextAsync("Hello, World! 10").WaitAsync(TimeSpan.FromMinutes(5));
+
+        // Wait for the consumer to receive some messages
         await WaitForAllTextAsync(app,
             [
                 "Hello, World! 343",

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -40,7 +40,7 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
         await app.WaitForResources().WaitAsync(TimeSpan.FromMinutes(2));
 
         // Wait for the producer to start sending messages
-        await app.WaitForTextAsync("Hello, World! 10").WaitAsync(TimeSpan.FromMinutes(5));
+        await app.WaitForTextAsync("Hello, World!").WaitAsync(TimeSpan.FromMinutes(5));
 
         // Wait for the consumer to receive some messages
         await WaitForAllTextAsync(app,


### PR DESCRIPTION
The initial startup of the services can take some time to
get ready, and if a docker image needs to be pulled down too then that
increases the wait time.

Fixes https://github.com/dotnet/aspire/issues/5489

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5503)