### PR TITLE
Fix issues around metrics with unit rates

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -20,6 +20,11 @@ var app = builder.Build();
 
 app.Lifetime.ApplicationStarted.Register(ConsoleStresser.Stress);
 
+app.Lifetime.ApplicationStarted.Register(() =>
+{
+    _ = app.Services.GetRequiredService<TestMetrics>();
+});
+
 app.MapGet("/", () => "Hello world");
 
 app.MapGet("/write-console", () =>

--- a/src/Aspire.Dashboard/Model/DefaultInstrumentUnitResolver.cs
+++ b/src/Aspire.Dashboard/Model/DefaultInstrumentUnitResolver.cs
@@ -15,15 +15,19 @@ public sealed class DefaultInstrumentUnitResolver(IStringLocalizer<ControlsStrin
     {
         if (!string.IsNullOrEmpty(instrument.Unit))
         {
-            var unit = OtlpUnits.GetUnit(instrument.Unit.TrimStart('{').TrimEnd('}'));
-            if (pluralize)
+            var (unit, isRateUnit) = OtlpUnits.GetUnit(instrument.Unit.TrimStart('{').TrimEnd('}'));
+
+            // Don't pluralize rate units, e.g. We want "Bytes per second", not "Bytes per seconds".
+            if (pluralize && !isRateUnit)
             {
                 unit = unit.Pluralize();
             }
+
             if (titleCase)
             {
                 unit = unit.Titleize();
             }
+
             return unit;
         }
 

--- a/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Resources;
+using Microsoft.Extensions.Localization;
+using OpenTelemetry.Proto.Common.V1;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class DefaultInstrumentUnitResolverTests
+{
+    [Theory]
+    [InlineData("By/s", "instrument_name", "Bytes Per Second")]
+    [InlineData("connection", "instrument_name", "Connections")]
+    [InlineData("{connection}", "instrument_name", "Connections")]
+    [InlineData("", "instrument_name", "Localized:PlotlyChartValue")]
+    [InlineData("", "instrument_name.count", "Localized:PlotlyChartCount")]
+    [InlineData("", "instrument_name.length", "Localized:PlotlyChartLength")]
+    public void ResolveDisplayedUnit(string unit, string name, string expected)
+    {
+        // Arrange
+        var localizer = new TestStringLocalizer<ControlsStrings>();
+        var resolver = new DefaultInstrumentUnitResolver(localizer);
+
+        var otlpInstrumentSummary = new OtlpInstrumentSummary
+        {
+            Description = "Description!",
+            Name = name,
+            Parent = new OtlpMeter(new InstrumentationScope { Name = "meter_name" }, new TelemetryLimitOptions()),
+            Type = OtlpInstrumentType.Gauge,
+            Unit = unit
+        };
+
+        // Act
+        var result = resolver.ResolveDisplayedUnit(otlpInstrumentSummary, titleCase: true, pluralize: true);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    private sealed class TestStringLocalizer<T> : IStringLocalizer<T>
+    {
+        public LocalizedString this[string name] => new LocalizedString(name, $"Localized:{name}");
+        public LocalizedString this[string name, params object[] arguments] => new LocalizedString(name, $"Localized:{name}");
+
+        public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) => [];
+    }
+}


### PR DESCRIPTION
## Description

Unit rate display in metrics has some issues. This PR:

* Adds space between per and unit, e.g. `per second`
* Doesn't pluralize rate unit
* Adds tests

After:
![image](https://github.com/user-attachments/assets/f16105b5-5b42-44f9-8f04-b68dbcae053d)

Fixes https://github.com/dotnet/aspire/issues/5496

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5506)