### PR TITLE
Add browser token authentication Playwright tests

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Login.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Login.razor
@@ -31,7 +31,7 @@
                 </div>
                 <div class="token-entry-footer">
                     <a href="@NavigationManager.Uri" id="helpLink">@Loc[nameof(Dashboard.Resources.Login.WhereIsMyTokenLinkText)]</a>
-                    <FluentButton Appearance="Appearance.Accent" Type="ButtonType.Submit">@Loc[nameof(Dashboard.Resources.Login.LogInButtonText)]</FluentButton>
+                    <FluentButton Appearance="Appearance.Accent" Name="submit-token" Type="ButtonType.Submit">@Loc[nameof(Dashboard.Resources.Login.LogInButtonText)]</FluentButton>
                     <FluentTooltip Anchor="helpLink" MaxWidth="650px">
                         <div class="token-help-container">
                             <div>

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/AppBarTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Resources;
+using Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
 using Aspire.Workload.Tests;
 using Microsoft.Playwright;
 using Xunit;
@@ -9,10 +10,10 @@ using Xunit;
 namespace Aspire.Dashboard.Tests.Integration.Playwright;
 
 [ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.DoesNotHavePlaywrightSupport))]
-public class AppBarTests : PlaywrightTestsBase
+public class AppBarTests : PlaywrightTestsBase<DashboardServerFixture>
 {
-    public AppBarTests(DashboardServerFixture dashboardServerFixture, PlaywrightFixture playwrightFixture)
-        : base(dashboardServerFixture, playwrightFixture)
+    public AppBarTests(DashboardServerFixture dashboardServerFixture)
+        : base(dashboardServerFixture)
     {
     }
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/BrowserTokenAuthenticationTests.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
+using Aspire.Hosting;
+using Aspire.Workload.Tests;
+using Microsoft.Playwright;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Integration.Playwright;
+
+[ActiveIssue("https://github.com/dotnet/aspire/issues/4623", typeof(PlaywrightProvider), nameof(PlaywrightProvider.DoesNotHavePlaywrightSupport))]
+public class BrowserTokenAuthenticationTests : PlaywrightTestsBase<BrowserTokenAuthenticationTests.BrowserTokenDashboardServerFixture>
+{
+    public class BrowserTokenDashboardServerFixture : DashboardServerFixture
+    {
+        public BrowserTokenDashboardServerFixture()
+        {
+            Configuration[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = nameof(FrontendAuthMode.BrowserToken);
+            Configuration[DashboardConfigNames.DashboardFrontendBrowserTokenName.ConfigKey] = "VALID_TOKEN";
+        }
+    }
+
+    public BrowserTokenAuthenticationTests(BrowserTokenDashboardServerFixture dashboardServerFixture)
+        : base(dashboardServerFixture)
+    {
+    }
+
+    [Fact]
+    public async Task BrowserToken_LoginPage_Success_RedirectToResources()
+    {
+        // Arrange
+        await RunTestAsync(async page =>
+        {
+            // Act
+            var response = await page.GotoAsync("/");
+            var uri = new Uri(response!.Url);
+
+            Assert.Equal("/login?returnUrl=%2F", uri.PathAndQuery);
+
+            var tokenTextBox = page.GetByRole(AriaRole.Textbox);
+            await tokenTextBox.FillAsync("VALID_TOKEN");
+
+            var submitButton = page.GetByRole(AriaRole.Button);
+            await submitButton.ClickAsync();
+
+            // Assert
+            await Assertions
+                .Expect(page.GetByText(MockDashboardClient.TestResource1.DisplayName))
+                .ToBeVisibleAsync();
+        });
+    }
+
+    [Fact]
+    public async Task BrowserToken_LoginPage_Failure_DisplayFailureMessage()
+    {
+        // Arrange
+        await RunTestAsync(async page =>
+        {
+            // Act
+            var response = await page.GotoAsync("/");
+            var uri = new Uri(response!.Url);
+
+            Assert.Equal("/login?returnUrl=%2F", uri.PathAndQuery);
+
+            var tokenTextBox = page.GetByRole(AriaRole.Textbox);
+            await tokenTextBox.FillAsync("INVALID_TOKEN");
+
+            var submitButton = page.GetByRole(AriaRole.Button);
+            await submitButton.ClickAsync();
+
+            // Assert
+            await Assertions
+                .Expect(page.GetByText("Invalid token"))
+                .ToBeVisibleAsync();
+        });
+    }
+
+    [Fact]
+    public async Task BrowserToken_QueryStringToken_Success_RestrictToResources()
+    {
+        // Arrange
+        await RunTestAsync(async page =>
+        {
+            // Act
+            await page.GotoAsync("/login?t=VALID_TOKEN");
+
+            // Assert
+            await Assertions
+                .Expect(page.GetByText(MockDashboardClient.TestResource1.DisplayName))
+                .ToBeVisibleAsync();
+        });
+    }
+
+    [Fact]
+    public async Task BrowserToken_QueryStringToken_Failure_DisplayLoginPage()
+    {
+        // Arrange
+        await RunTestAsync(async page =>
+        {
+            // Act
+            await page.GotoAsync("/login?t=INVALID_TOKEN");
+
+            var submitButton = page.GetByRole(AriaRole.Button);
+            var name = await submitButton.GetAttributeAsync("name");
+
+            // Assert
+            Assert.Equal("submit-token", name);
+        });
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using Aspire.Dashboard.Model;
 using Google.Protobuf.WellKnownTypes;
 
-namespace Aspire.Dashboard.Tests.Integration.Playwright;
+namespace Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
 
 public sealed class MockDashboardClient : IDashboardClient
 {
@@ -18,7 +18,7 @@ public sealed class MockDashboardClient : IDashboardClient
         CreationTimeStamp = DateTime.Now,
         Environment = ImmutableArray<EnvironmentVariableViewModel>.Empty,
         ResourceType = KnownResourceTypes.Project,
-        Properties = new []
+        Properties = new[]
         {
             new KeyValuePair<string, Value>(KnownProperties.Project.Path, new Value()
             {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/PlaywrightFixture.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/PlaywrightFixture.cs
@@ -5,7 +5,7 @@ using Aspire.Workload.Tests;
 using Microsoft.Playwright;
 using Xunit;
 
-namespace Aspire.Dashboard.Tests.Integration.Playwright;
+namespace Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
 
 public class PlaywrightFixture : IAsyncLifetime
 {

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/PlaywrightTestsBase.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/PlaywrightTestsBase.cs
@@ -1,22 +1,23 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Playwright;
 using Xunit;
 
-namespace Aspire.Dashboard.Tests.Integration.Playwright;
+namespace Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
 
-public class PlaywrightTestsBase : IClassFixture<DashboardServerFixture>, IClassFixture<PlaywrightFixture>, IAsyncDisposable
+public class PlaywrightTestsBase<TDashboardServerFixture> : IClassFixture<TDashboardServerFixture>, IAsyncDisposable
+    where TDashboardServerFixture : DashboardServerFixture
 {
     public DashboardServerFixture DashboardServerFixture { get; }
     public PlaywrightFixture PlaywrightFixture { get; }
 
     private IBrowserContext? _context;
 
-    public PlaywrightTestsBase(DashboardServerFixture dashboardServerFixture, PlaywrightFixture playwrightFixture)
+    public PlaywrightTestsBase(DashboardServerFixture dashboardServerFixture)
     {
         DashboardServerFixture = dashboardServerFixture;
-        PlaywrightFixture = playwrightFixture;
+        PlaywrightFixture = dashboardServerFixture.PlaywrightFixture;
     }
 
     public async Task RunTestAsync(Func<IPage, Task> test)


### PR DESCRIPTION
## Description

Adds playwright tests to end-to-end test that validation works correctly.

Fixes https://github.com/dotnet/aspire/issues/5512

Note: Builds on top of https://github.com/dotnet/aspire/pull/5499. Can be reviewed now but should merge after https://github.com/dotnet/aspire/pull/5499.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5514)