### PR TITLE
Support displaying different resource properties

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -10,7 +10,7 @@
 <div class="span-details-layout">
     <FluentToolbar Orientation="Orientation.Horizontal">
         <div>
-            @((MarkupString)string.Format(ControlsStrings.SpanDetailsResource, ViewModel.Span.Source.ApplicationName))
+            @((MarkupString)string.Format(ControlsStrings.SpanDetailsResource, ViewModel.Span.Source.Application.ApplicationName))
         </div>
         <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <div>

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor
@@ -7,7 +7,7 @@
 <div class="structured-log-details-layout">
     <FluentToolbar Orientation="Orientation.Horizontal">
         <div>
-            @((MarkupString)string.Format(ControlsStrings.StructuredLogsDetailsResource, ViewModel.LogEntry.Application.ApplicationName))
+            @((MarkupString)string.Format(ControlsStrings.StructuredLogsDetailsResource, ViewModel.LogEntry.ApplicationView.Application.ApplicationName))
         </div>
         <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
         <div title="@FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, ViewModel.LogEntry.TimeStamp, MillisecondsDisplay.Full)">

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -28,7 +28,7 @@ public partial class StructuredLogDetails
             .Where(ApplyFilter).AsQueryable();
 
     private IQueryable<LogEntryPropertyViewModel> FilteredResourceItems =>
-        ViewModel.LogEntry.Application.AllProperties().Select(p => new LogEntryPropertyViewModel { Name = p.Key, Value = p.Value })
+        ViewModel.LogEntry.ApplicationView.AllProperties().Select(p => new LogEntryPropertyViewModel { Name = p.Key, Value = p.Value })
             .Where(ApplyFilter).AsQueryable();
 
     private string _filter = "";

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -8,7 +8,6 @@ using System.Text;
 using Aspire.Dashboard.Extensions;
 
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
@@ -31,7 +30,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
 
     private Subscription? _logsSubscription;
     private IList<GridColumn>? _gridColumns;
-    private Dictionary<OtlpApplication, int>? _applicationUnviewedErrorCounts;
+    private Dictionary<ApplicationKey, int>? _applicationUnviewedErrorCounts;
 
     [Inject]
     public required IDashboardClient DashboardClient { get; init; }
@@ -224,7 +223,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         }
     }
 
-    private bool ApplicationErrorCountsChanged(Dictionary<OtlpApplication, int> newApplicationUnviewedErrorCounts)
+    private bool ApplicationErrorCountsChanged(Dictionary<ApplicationKey, int> newApplicationUnviewedErrorCounts)
     {
         if (_applicationUnviewedErrorCounts == null || _applicationUnviewedErrorCounts.Count != newApplicationUnviewedErrorCounts.Count)
         {

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -119,8 +119,8 @@
                                                 OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))"
                                                 Class="enable-row-click">
                                     <ChildContent>
-                                        <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.Application))">
-                                            <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Application)));">
+                                        <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.ApplicationView))">
+                                            <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.ApplicationView)));">
                                                 @GetResourceName(context.ApplicationView)
                                             </span>
                                         </AspireTemplateColumn>

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -121,7 +121,7 @@
                                     <ChildContent>
                                         <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.Application))">
                                             <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Application)));">
-                                                @GetResourceName(context.Application)
+                                                @GetResourceName(context.ApplicationView)
                                             </span>
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@LogLevelColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsLevelColumnHeader)]">

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -344,7 +344,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         await this.AfterViewModelChangedAsync(_contentLayout, true);
     }
 
-    private string GetResourceName(OtlpApplication app) => OtlpApplication.GetResourceName(app, _applications);
+    private string GetResourceName(OtlpApplicationView app) => OtlpApplication.GetResourceName(app.Application, _applications);
 
     private string GetRowClass(OtlpLogEntry entry)
     {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -349,7 +349,7 @@ public partial class TraceDetail : ComponentBase
         _elementIdBeforeDetailsViewOpened = null;
     }
 
-    private string GetResourceName(OtlpApplication app) => OtlpApplication.GetResourceName(app, _applications);
+    private string GetResourceName(OtlpApplicationView app) => OtlpApplication.GetResourceName(app, _applications);
 
     public void Dispose()
     {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -59,7 +59,7 @@
                             <AspireTemplateColumn ColumnId="@SpansColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Traces.TracesSpansColumnHeader)]">
                                 <FluentOverflow>
                                     <ChildContent>
-                                        @foreach (var item in context.Spans.GroupBy(s => s.Source).OrderBy(g => g.Min(s => s.StartTime)))
+                                        @foreach (var item in context.Spans.GroupBy(s => s.Source.Application).OrderBy(g => g.Min(s => s.StartTime)))
                                         {
                                             <FluentOverflowItem>
                                                 <span class="trace-tag trace-service-tag" title="@(GetSpansTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(item.Key)));">

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -228,6 +228,7 @@ public partial class Traces : IPageWithSessionAndUrlState<TracesPageViewModel, T
     }
 
     private string GetResourceName(OtlpApplication app) => OtlpApplication.GetResourceName(app, _applications);
+    private string GetResourceName(OtlpApplicationView app) => OtlpApplication.GetResourceName(app, _applications);
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -1,6 +1,7 @@
 ﻿@using Aspire.Dashboard.Extensions
 @using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Otlp.Model
+@using Aspire.Dashboard.Otlp.Storage
 @using Aspire.Dashboard.Resources
 @using Humanizer
 
@@ -99,5 +100,5 @@ else
 
 
     [Parameter, EditorRequired]
-    public required Dictionary<OtlpApplication, int>? UnviewedErrorCounts { get; set; }
+    public required Dictionary<ApplicationKey, int>? UnviewedErrorCounts { get; set; }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
-using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
@@ -17,7 +16,7 @@ public partial class UnreadLogErrorsBadge
     [Parameter, EditorRequired]
     public required ResourceViewModel Resource { get; set; }
     [Parameter, EditorRequired]
-    public required Dictionary<OtlpApplication, int>? UnviewedErrorCounts { get; set; }
+    public required Dictionary<ApplicationKey, int>? UnviewedErrorCounts { get; set; }
 
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
@@ -42,7 +41,7 @@ public partial class UnreadLogErrorsBadge
             return (null, 0);
         }
 
-        if (!UnviewedErrorCounts.TryGetValue(application, out var count) || count == 0)
+        if (!UnviewedErrorCounts.TryGetValue(application.ApplicationKey, out var count) || count == 0)
         {
             return (null, 0);
         }

--- a/src/Aspire.Dashboard/Extensions/FluentUIExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/FluentUIExtensions.cs
@@ -10,7 +10,7 @@ internal static class FluentUIExtensions
         // No onclick attribute is added here. The CSP restricts inline scripts, including onclick.
         // Instead, a click event listener is added to the document and clicking the button is bubbled up to the event.
         // The document click listener looks for a button element and these attributes.
-        var attributes = new Dictionary<string, object>(StringComparers.Attribute)
+        var attributes = new Dictionary<string, object>(StringComparers.HtmlAttribute)
         {
             { "data-text", text ?? string.Empty },
             { "data-precopy", precopy ?? string.Empty },
@@ -28,7 +28,7 @@ internal static class FluentUIExtensions
 
     public static Dictionary<string, object> GetOpenTextVisualizerAdditionalAttributes(string textValue, string textValueDescription, params (string Attribute, object Value)[] additionalAttributes)
     {
-        var attributes = new Dictionary<string, object>(StringComparers.Attribute)
+        var attributes = new Dictionary<string, object>(StringComparers.HtmlAttribute)
         {
             { "data-text", textValue },
             { "data-textvisualizer-description", textValueDescription }

--- a/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/LogFilter.cs
@@ -102,7 +102,7 @@ public class LogFilter : IEquatable<LogFilter>
         return Field switch
         {
             KnownMessageField => x.Message,
-            KnownApplicationField => x.Application.ApplicationName,
+            KnownApplicationField => x.ApplicationView.Application.ApplicationName,
             KnownTraceIdField => x.TraceId,
             KnownSpanIdField => x.SpanId,
             KnownOriginalFormatField => x.OriginalFormat,

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplicationView.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplicationView.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Aspire.Dashboard.Otlp.Storage;
+using Google.Protobuf.Collections;
+using OpenTelemetry.Proto.Common.V1;
+
+namespace Aspire.Dashboard.Otlp.Model;
+
+[DebuggerDisplay("Application = {Application}, Properties = {Properties.Count}")]
+public class OtlpApplicationView
+{
+    public ApplicationKey ApplicationKey => Application.ApplicationKey;
+    public OtlpApplication Application { get; }
+    public KeyValuePair<string, string>[] Properties { get; }
+
+    public OtlpApplicationView(OtlpApplication application, RepeatedField<KeyValue> attributes)
+    {
+        Application = application;
+
+        List<KeyValuePair<string, string>>? properties = null;
+        foreach (var attribute in attributes)
+        {
+            switch (attribute.Key)
+            {
+                case OtlpApplication.SERVICE_NAME:
+                case OtlpApplication.SERVICE_INSTANCE_ID:
+                    // Values passed in via ctor and set to members. Don't add to properties collection.
+                    break;
+                default:
+                    properties ??= [];
+                    properties.Add(new KeyValuePair<string, string>(attribute.Key, attribute.Value.GetString()));
+                    break;
+
+            }
+        }
+
+        if (properties != null)
+        {
+            // Sort so keys are in a consistent order for equality check.
+            properties.Sort((p1, p2) => string.Compare(p1.Key, p2.Key, StringComparisons.OtlpAttribute));
+            Properties = properties.ToArray();
+        }
+        else
+        {
+            Properties = [];
+        }
+    }
+
+    public Dictionary<string, string> AllProperties()
+    {
+        var props = new Dictionary<string, string>(StringComparers.OtlpAttribute)
+        {
+            { OtlpApplication.SERVICE_NAME, Application.ApplicationName },
+            { OtlpApplication.SERVICE_INSTANCE_ID, Application.InstanceId }
+        };
+
+        foreach (var kv in Properties)
+        {
+            props.TryAdd(kv.Key, kv.Value);
+        }
+
+        return props;
+    }
+}

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -19,11 +19,11 @@ public class OtlpLogEntry
     public string TraceId { get; }
     public string ParentId { get; }
     public string? OriginalFormat { get; }
-    public OtlpApplication Application { get; }
+    public OtlpApplicationView ApplicationView { get; }
     public OtlpScope Scope { get; }
     public Guid InternalId { get; }
 
-    public OtlpLogEntry(LogRecord record, OtlpApplication logApp, OtlpScope scope, TelemetryLimitOptions options)
+    public OtlpLogEntry(LogRecord record, OtlpApplicationView logApp, OtlpScope scope, TelemetryLimitOptions options)
     {
         string? originalFormat = null;
         string? parentId = null;
@@ -55,7 +55,7 @@ public class OtlpLogEntry
         SpanId = record.SpanId.ToHexString();
         TraceId = record.TraceId.ToHexString();
         ParentId = parentId ?? string.Empty;
-        Application = logApp;
+        ApplicationView = logApp;
         Scope = scope;
         InternalId = Guid.NewGuid();
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -21,7 +21,7 @@ public class OtlpSpan
 
     public string TraceId => Trace.TraceId;
     public OtlpTrace Trace { get; }
-    public OtlpApplication Source { get; }
+    public OtlpApplicationView Source { get; }
 
     public required string SpanId { get; init; }
     public required string? ParentSpanId { get; init; }
@@ -43,9 +43,9 @@ public class OtlpSpan
     public IEnumerable<OtlpSpan> GetChildSpans() => Trace.Spans.Where(s => s.ParentSpanId == SpanId);
     public OtlpSpan? GetParentSpan() => string.IsNullOrEmpty(ParentSpanId) ? null : Trace.Spans.Where(s => s.SpanId == ParentSpanId).FirstOrDefault();
 
-    public OtlpSpan(OtlpApplication application, OtlpTrace trace, OtlpScope scope)
+    public OtlpSpan(OtlpApplicationView applicationView, OtlpTrace trace, OtlpScope scope)
     {
-        Source = application;
+        Source = applicationView;
         Trace = trace;
         Scope = scope;
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -91,7 +91,7 @@ public class OtlpTrace
 
         static string BuildFullName(OtlpSpan existingSpan)
         {
-            return $"{existingSpan.Source.ApplicationName}: {existingSpan.Name}";
+            return $"{existingSpan.Source.Application.ApplicationName}: {existingSpan.Name}";
         }
     }
 

--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -19,8 +19,9 @@ internal static class StringComparers
     public static StringComparer EnvironmentVariableName => StringComparer.InvariantCultureIgnoreCase;
     public static StringComparer UrlPath => StringComparer.OrdinalIgnoreCase;
     public static StringComparer UrlHost => StringComparer.OrdinalIgnoreCase;
-    public static StringComparer Attribute => StringComparer.Ordinal;
+    public static StringComparer HtmlAttribute => StringComparer.Ordinal;
     public static StringComparer GridColumn => StringComparer.Ordinal;
+    public static StringComparer OtlpAttribute => StringComparer.Ordinal;
 }
 
 internal static class StringComparisons
@@ -37,6 +38,7 @@ internal static class StringComparisons
     public static StringComparison EnvironmentVariableName => StringComparison.InvariantCultureIgnoreCase;
     public static StringComparison UrlPath => StringComparison.OrdinalIgnoreCase;
     public static StringComparison UrlHost => StringComparison.OrdinalIgnoreCase;
-    public static StringComparison Attribute => StringComparison.Ordinal;
+    public static StringComparison HtmlAttribute => StringComparison.Ordinal;
     public static StringComparison GridColumn => StringComparison.Ordinal;
+    public static StringComparison OtlpAttribute => StringComparison.Ordinal;
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -214,6 +214,6 @@ public sealed class ApplicationsSelectHelpersTests
         };
         var applicationKey = OtlpHelpers.GetApplicationKey(resource);
 
-        return new OtlpApplication(applicationKey.Name, applicationKey.InstanceId!, resource, NullLogger.Instance, new TelemetryLimitOptions());
+        return new OtlpApplication(applicationKey.Name, applicationKey.InstanceId!, NullLogger.Instance, new TelemetryLimitOptions());
     }
 }

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -194,27 +194,27 @@ public class LogTests
 
         var unviewedCounts1 = repository.GetApplicationUnviewedErrorLogsCount();
 
-        Assert.True(unviewedCounts1.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "1"))!, out var unviewedCount1));
+        Assert.True(unviewedCounts1.TryGetValue(new ApplicationKey("TestService", "1"), out var unviewedCount1));
         Assert.Equal(2, unviewedCount1);
 
-        Assert.True(unviewedCounts1.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "2"))!, out var unviewedCount2));
+        Assert.True(unviewedCounts1.TryGetValue(new ApplicationKey("TestService", "2"), out var unviewedCount2));
         Assert.Equal(1, unviewedCount2);
 
         repository.MarkViewedErrorLogs(new ApplicationKey("TestService", "1"));
 
         var unviewedCounts2 = repository.GetApplicationUnviewedErrorLogsCount();
 
-        Assert.False(unviewedCounts2.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "1"))!, out _));
+        Assert.False(unviewedCounts2.TryGetValue(new ApplicationKey("TestService", "1"), out _));
 
-        Assert.True(unviewedCounts2.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "2"))!, out unviewedCount2));
+        Assert.True(unviewedCounts2.TryGetValue(new ApplicationKey("TestService", "2"), out unviewedCount2));
         Assert.Equal(1, unviewedCount2);
 
         repository.MarkViewedErrorLogs(null);
 
         var unviewedCounts3 = repository.GetApplicationUnviewedErrorLogsCount();
 
-        Assert.False(unviewedCounts3.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "1"))!, out _));
-        Assert.False(unviewedCounts3.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "2"))!, out _));
+        Assert.False(unviewedCounts3.TryGetValue(new ApplicationKey("TestService", "1"), out _));
+        Assert.False(unviewedCounts3.TryGetValue(new ApplicationKey("TestService", "2"), out _));
     }
 
     [Fact]
@@ -265,8 +265,8 @@ public class LogTests
 
         var unviewedCounts = repository.GetApplicationUnviewedErrorLogsCount();
 
-        Assert.False(unviewedCounts.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "1"))!, out _));
-        Assert.False(unviewedCounts.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "2"))!, out _));
+        Assert.False(unviewedCounts.TryGetValue(new ApplicationKey("TestService", "1"), out _));
+        Assert.False(unviewedCounts.TryGetValue(new ApplicationKey("TestService", "2"), out _));
     }
 
     [Fact]
@@ -317,8 +317,8 @@ public class LogTests
 
         var unviewedCounts = repository.GetApplicationUnviewedErrorLogsCount();
 
-        Assert.False(unviewedCounts.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "1"))!, out _));
-        Assert.True(unviewedCounts.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "2"))!, out var unviewedCount));
+        Assert.False(unviewedCounts.TryGetValue(new ApplicationKey("TestService", "1"), out _));
+        Assert.True(unviewedCounts.TryGetValue(new ApplicationKey("TestService", "2"), out var unviewedCount));
         Assert.Equal(1, unviewedCount);
     }
 
@@ -355,7 +355,7 @@ public class LogTests
 
         var unviewedCounts = repository.GetApplicationUnviewedErrorLogsCount();
 
-        Assert.True(unviewedCounts.TryGetValue(repository.GetApplication(new ApplicationKey("TestService", "1"))!, out var unviewedCount));
+        Assert.True(unviewedCounts.TryGetValue(new ApplicationKey("TestService", "1"), out var unviewedCount));
         Assert.Equal(1, unviewedCount);
     }
 

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -194,9 +194,9 @@ internal static class TelemetryTestHelpers
         return logRecord;
     }
 
-    public static Resource CreateResource(string? name = null, string? instanceId = null)
+    public static Resource CreateResource(string? name = null, string? instanceId = null, IEnumerable<KeyValuePair<string, string>>? attributes = null)
     {
-        return new Resource()
+        var resource = new Resource()
         {
             Attributes =
             {
@@ -204,6 +204,16 @@ internal static class TelemetryTestHelpers
                 new KeyValue { Key = "service.instance.id", Value = new AnyValue { StringValue = instanceId ?? "TestId" } }
             }
         };
+
+        if (attributes != null)
+        {
+            foreach (var attribute in attributes)
+            {
+                resource.Attributes.Add(new KeyValue { Key = attribute.Key, Value = new AnyValue { StringValue = attribute.Value } });
+            }
+        }
+
+        return resource;
     }
 
     public static TelemetryRepository CreateRepository(


### PR DESCRIPTION
## Description

Telemetry is sent with a resource and a resource has attributes. The first time the dashboard sees a resource it caches it using the name and instance id as the key.

Usually, the attributes on a resource are static. However, it is possible for telemetry to be sent with a resource with the same key but different attributes. When the telemetry is viewed in the UI we want those resource attributes to be displayed, not the initial cached attributes.

This PR:

* Adds OtlpApplicationView. It has a collection of properties
* Caches OtlpApplicationView on OtlpApplication. The key is the properties. This allows views to be shared by telemetry.
* Changes telemetry to refer to the app view instead of app, allowing for the correct properties to be displayed in the UI.
* Tests

Fixes https://github.com/dotnet/aspire/issues/5126

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5526)