### PR TITLE
Fix empty trace name when there is no root span

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -64,6 +64,12 @@ public class OtlpTrace
         if (!added)
         {
             Spans.Insert(0, span);
+
+            // If there isn't a root span then the first span is used as the trace name.
+            if (_rootSpan == null && !string.IsNullOrEmpty(span.ParentSpanId))
+            {
+                FullName = BuildFullName(span);
+            }
         }
 
         if (string.IsNullOrEmpty(span.ParentSpanId))
@@ -75,13 +81,18 @@ public class OtlpTrace
                 if (string.IsNullOrEmpty(existingSpan.ParentSpanId))
                 {
                     _rootSpan = existingSpan;
-                    FullName = $"{existingSpan.Source.ApplicationName}: {existingSpan.Name}";
+                    FullName = BuildFullName(existingSpan);
                     break;
                 }
             }
         }
 
         AssertSpanOrder();
+
+        static string BuildFullName(OtlpSpan existingSpan)
+        {
+            return $"{existingSpan.Source.ApplicationName}: {existingSpan.Name}";
+        }
     }
 
     [Conditional("DEBUG")]

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -944,4 +944,119 @@ public class TraceTests
                 AssertId("2", trace.TraceId);
             });
     }
+
+    [Fact]
+    public void AddTraces_OutOfOrder_FullName()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        var request = new GetTracesRequest
+        {
+            ApplicationKey = new ApplicationKey("TestService", "TestId"),
+            FilterText = string.Empty,
+            StartIndex = 0,
+            Count = 10
+        };
+
+        // Act 1
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-3", startTime: s_testTime.AddMinutes(10), endTime: s_testTime.AddMinutes(10), parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        // Assert 1
+        var trace = Assert.Single(repository.GetTraces(request).PagedResult.Items);
+        Assert.Equal("TestService: Test span. Id: 1-3", trace.FullName);
+
+        // Act 2
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(5), endTime: s_testTime.AddMinutes(10), parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        // Assert 2
+        trace = Assert.Single(repository.GetTraces(request).PagedResult.Items);
+        Assert.Equal("TestService: Test span. Id: 1-2", trace.FullName);
+
+        // Act 3
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(10), endTime: s_testTime.AddMinutes(10))
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        // Assert 3
+        trace = Assert.Single(repository.GetTraces(request).PagedResult.Items);
+        Assert.Equal("TestService: Test span. Id: 1-1", trace.FullName);
+
+        // Act 4
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-4", startTime: s_testTime, endTime: s_testTime.AddMinutes(10), parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+        Assert.Equal(0, addContext.FailureCount);
+
+        // Assert 4
+        trace = Assert.Single(repository.GetTraces(request).PagedResult.Items);
+        Assert.Equal("TestService: Test span. Id: 1-1", trace.FullName);
+    }
 }

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -152,7 +152,7 @@ internal static class TelemetryTestHelpers
             ParentSpanId = parentSpanId is null ? ByteString.Empty : ByteString.CopyFrom(Encoding.UTF8.GetBytes(parentSpanId)),
             StartTimeUnixNano = DateTimeToUnixNanoseconds(startTime),
             EndTimeUnixNano = DateTimeToUnixNanoseconds(endTime),
-            Name = "Test span"
+            Name = $"Test span. Id: {spanId}"
         };
         if (events != null)
         {


### PR DESCRIPTION
## Description

I noticed that a trace has a blank name until its root span is received. Use the first span's name until the root span is received.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5527)