### PR TITLE
Suppress gRPC resource service error in host console

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -56,7 +56,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
     {
         await ExecuteAsync(
             WatchResourcesInternal,
-            context.CancellationToken).ConfigureAwait(false);
+            context).ConfigureAwait(false);
 
         async Task WatchResourcesInternal(CancellationToken cancellationToken)
         {
@@ -107,7 +107,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
     {
         await ExecuteAsync(
             WatchResourceConsoleLogsInternal,
-            context.CancellationToken).ConfigureAwait(false);
+            context).ConfigureAwait(false);
 
         async Task WatchResourceConsoleLogsInternal(CancellationToken cancellationToken)
         {
@@ -132,9 +132,9 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
         }
     }
 
-    private async Task ExecuteAsync(Func<CancellationToken, Task> execute, CancellationToken cancellationToken)
+    private async Task ExecuteAsync(Func<CancellationToken, Task> execute, ServerCallContext serverCallContext)
     {
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(hostApplicationLifetime.ApplicationStopping, cancellationToken);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(hostApplicationLifetime.ApplicationStopping, serverCallContext.CancellationToken);
 
         try
         {
@@ -150,7 +150,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
         }
         catch (Exception ex)
         {
-            logger.LogDebug(ex, "Error executing service method.");
+            logger.LogError(ex, $"Error executing service method '{serverCallContext.Method}'.");
             throw;
         }
     }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -127,6 +127,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
         _innerBuilder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error);
         _innerBuilder.Logging.AddFilter("Aspire.Hosting.Dashboard", LogLevel.Error);
+        _innerBuilder.Logging.AddFilter("Grpc.AspNetCore.Server.ServerCallHandler", LogLevel.Error);
 
         // This is so that we can see certificate errors in the resource server in the console logs.
         // See: https://github.com/dotnet/aspire/issues/2914


### PR DESCRIPTION
## Description

The host could display transient gRPC service errors caused by the dashboard quickly starting and stopping streaming methods.

This PR:

* Increases log level of gRPC server logging to error.
* Adds explicit error logging to the resource service so non-transient errors are always reported.

Fixes https://github.com/dotnet/aspire/issues/4213

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: 
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5534)