### PR TITLE
chore: Bump Testcontainers to version 3.10.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <TestcontainersPackageVersion>3.9.0</TestcontainersPackageVersion>
+    <TestcontainersPackageVersion>3.10.0</TestcontainersPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- AWS SDK for .NET dependencies -->

--- a/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
+++ b/tests/Aspire.Microsoft.Data.SqlClient.Tests/SqlServerContainerFixture.cs
@@ -3,7 +3,6 @@
 
 using Aspire.Components.Common.Tests;
 using Aspire.Hosting;
-using DotNet.Testcontainers.Builders;
 using Testcontainers.MsSql;
 using Xunit;
 
@@ -22,7 +21,6 @@ public sealed class SqlServerContainerFixture : IAsyncLifetime
         {
             Container = new MsSqlBuilder()
                             .WithImage($"{SqlServerContainerImageTags.Registry}/{SqlServerContainerImageTags.Image}:{SqlServerContainerImageTags.Tag}")
-                            .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("/opt/mssql-tools18/bin/sqlcmd", "-C", "-Q", "SELECT 1;")) // https://github.com/dotnet/aspire/issues/5057
                             .Build();
             await Container.StartAsync();
         }


### PR DESCRIPTION
## Description

Hi 👋 the PR updates Testcontainers to the latest version `3.10.0`. This version includes a fix for the regression/changes made in the latest MSSQL Docker image (https://github.com/microsoft/mssql-docker/issues/892). The recently added workaround (#5057, #5058) is no longer necessary.

Fixes #5057

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5539)