### PR TITLE
Allow Dashboard application to roll-forward

### DIFF
--- a/src/Aspire.Dashboard/Aspire.Dashboard.csproj
+++ b/src/Aspire.Dashboard/Aspire.Dashboard.csproj
@@ -11,6 +11,12 @@
       CS8002: Referenced assembly does not have a strong name
     -->
     <NoWarn>$(NoWarn);CS1591;CS8002</NoWarn>
+
+    <!-- This Application is a framework-dependent application that targets .NET 8.0. This means that the
+    application is not able to run if the place where it is deployed does not have the .NET 8.0 runtime installed.
+    Given we want to be able to support people running on environments where they only have the 9.0 SDK/runtime installed,
+    we allow roll-forward to the next major in order to support these customers.-->
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Description

In order to better support customers that only have the 9.0 SDK/Runtime installed, we will allow the Dashboard application to roll-forward to the next major, which would then not require the 8.0 runtime to also be installed in order to run the Aspire Dashboard. I have manually validated that with these changes I am able to run an Aspire application in a machine that only has .NET 9 installed. Automated tests will require having a setup where the 9.0 SDK is used, which will be added by @radical with the planned template work for 9.0. Once that is in place, we can go ahead and add automation for this.

Fixes https://github.com/dotnet/aspire/issues/5445

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No. Tests will come in a subsequent PR once 9.0 tests infra is ready.
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5540)