### PR TITLE
Add new DCP schema

### DIFF
--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -141,6 +141,12 @@ internal sealed class VolumeMount
     // True if the mounted file system is supposed to be read-only
     [JsonPropertyName("readOnly")]
     public bool IsReadOnly { get; set; } = false;
+
+    /// <summary>
+    /// Health probes to be run for the container.
+    /// </summary>
+    [JsonPropertyName("healthProbes")]
+    public List<HealthProbe>? HealthProbes { get; set; }
 }
 
 internal sealed class ContainerNetworkConnection
@@ -286,6 +292,18 @@ internal sealed class ContainerStatus : V1Status
     // Any ContainerNetworks this container is attached to
     [JsonPropertyName("networks")]
     public List<string>? Networks { get; set; }
+
+    /// <summary>
+    /// The health status of the container <see cref="HealthStatus"/> for allowed values.
+    /// </summary>
+    [JsonPropertyName("healthStatus")]
+    public string? HealthStatus { get; set; }
+
+    /// <summary>
+    /// Latest results for health probes configured for the container.
+    /// </summary>
+    [JsonPropertyName("healthProbeResults")]
+    public List<HealthProbeResult>? HealthProbeResults { get; set;}
 
     // Note: the ContainerStatus has "Message" property that represents a human-readable information about Container state.
     // It is provided by V1Status base class.

--- a/src/Aspire.Hosting/Dcp/Model/ContainerExec.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ContainerExec.cs
@@ -122,10 +122,13 @@ internal sealed class ContainerExec : CustomResource<ContainerExecSpec, Containe
     {
         var containerExec = new ContainerExec(new ContainerExecSpec
         {
+            ContainerName = containerName,
             Command = command,
-        });
-        containerExec.Kind = Dcp.ContainerExecKind;
-        containerExec.ApiVersion = Dcp.GroupVersion.ToString();
+        })
+        {
+            Kind = Dcp.ContainerExecKind,
+            ApiVersion = Dcp.GroupVersion.ToString()
+        };
         containerExec.Metadata.Name = name;
         containerExec.Metadata.NamespaceProperty = string.Empty;
 

--- a/src/Aspire.Hosting/Dcp/Model/ContainerExec.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ContainerExec.cs
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+using k8s.Models;
+
+namespace Aspire.Hosting.Dcp.Model;
+
+internal sealed class ContainerExecSpec
+{
+    /// <summary>
+    /// The name of the <see cref="Container"/> resource (DCP model name, not the Docker/Podman name)
+    /// to execute the command in. If no resource exists with the given name, the command will remain in
+    /// a pending state until a resource with the given name is created.
+    /// </summary>
+    [JsonPropertyName("containerName")]
+    public string? ContainerName { get; set; }
+
+    /// <summary>
+    /// Optional working directory for the command (in the container filesystem).
+    /// </summary>
+    [JsonPropertyName("workingDirectory")]
+    public string? WorkingDirectory { get; set; }
+
+    /// <summary>
+    /// Optional environment variables to set for the executing command.
+    /// </summary>
+    [JsonPropertyName("env")]
+    public List<EnvVar>? Env { get; set; }
+
+    /// <summary>
+    /// Optional environment files to use to populate Container environment during startup
+    /// </summary>
+    [JsonPropertyName("envFiles")]
+    public List<string>? EnvFiles { get; set; }
+
+    /// <summary>
+    /// Command to run in the container.
+    /// </summary>
+    [JsonPropertyName("command")]
+    public string? Command { get; set; }
+
+    /// <summary>
+    /// Optional arguments to pass to the command that starts the container.
+    /// </summary>
+    [JsonPropertyName("args")]
+    public List<string>? Args { get; set; }
+}
+
+internal sealed class ContainerExecStatus : V1Status
+{
+    /// <summary>
+    /// The current state of the container execution. See <see cref="ExecutableState"/> for possible values.
+    /// </summary>
+    [JsonPropertyName("state")]
+    public string? State { get; set; } = ExecutableState.Unknown;
+
+    /// <summary>
+    /// Start (attempt) timestamp.
+    /// </summary>
+    [JsonPropertyName("startupTimestamp")]
+    public DateTimeOffset? StartupTimestamp { get; set; }
+
+    /// <summary>
+    /// The time when the command finished execution
+    /// </summary>
+    [JsonPropertyName("finishTimestamp")]
+    public DateTimeOffset? FinishTimestamp { get; set; }
+
+    /// <summary>
+    /// Exit code of the process associated with the ContainerExec.
+    /// The value is equal to UnknownExitCode if the command was not started, is still running, or the exit code is not available.
+    /// </summary>
+    [JsonPropertyName("exitCode")]
+    public int? ExitCode { get; set; }
+
+    /// <summary>
+    /// The path of a temporary file that contains captured standard output data from the ContainerExec command.
+    /// </summary>
+    [JsonPropertyName("stdOutFile")]
+    public string? StdOutFile { get; set; }
+
+    /// <summary>
+    /// The path of a temporary file that contains captured standard error data from the ContainerExec command.
+    /// </summary>
+    [JsonPropertyName("stdErrFile")]
+    public string? StdErrFile { get; set; }
+
+    /// <summary>
+    /// Effective values of environment variables, after all substitutions have been applied
+    /// </summary>
+    [JsonPropertyName("effectiveEnv")]
+    public List<EnvVar>? EffectiveEnv { get; set; }
+
+    /// <summary>
+    /// Effective values of launch arguments to be passed to the ContainerExec, after all substitutions are applied.
+    /// </summary>
+    [JsonPropertyName("effectiveArgs")]
+    public List<string>? EffectiveArgs { get; set; }
+}
+
+/// <summary>
+/// Represents a command to be executed in a given <see cref="Container"/> resource.
+/// </summary>
+internal sealed class ContainerExec : CustomResource<ContainerExecSpec, ContainerExecStatus>
+{
+    /// <summary>
+    /// Create a new <see cref="ContainerExec"/> resource.
+    /// </summary>
+    /// <param name="spec">The <see cref="ContainerExecSpec"/> describing the new resource</param>
+    [JsonConstructor]
+    public ContainerExec(ContainerExecSpec spec) : base(spec) { }
+
+    /// <summary>
+    /// Create a new <see cref="ContainerExec"/> resource.
+    /// </summary>
+    /// <param name="name">Resource name of the ContainerExec instance</param>
+    /// <param name="containerName">Resource name of the Container to run the command in</param>
+    /// <param name="command">The command name to run</param>
+    /// <returns>A new ContainerExec instance</returns>
+    public static ContainerExec Create(string name, string containerName, string command)
+    {
+        var containerExec = new ContainerExec(new ContainerExecSpec
+        {
+            Command = command,
+        });
+        containerExec.Kind = Dcp.ContainerExecKind;
+        containerExec.ApiVersion = Dcp.GroupVersion.ToString();
+        containerExec.Metadata.Name = name;
+        containerExec.Metadata.NamespaceProperty = string.Empty;
+
+        return containerExec;
+    }
+
+    public bool LogsAvailable =>
+        this.Status?.State == ExecutableState.Running
+        || this.Status?.State == ExecutableState.Finished
+        || this.Status?.State == ExecutableState.Terminated;
+}

--- a/src/Aspire.Hosting/Dcp/Model/Executable.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Executable.cs
@@ -9,105 +9,170 @@ using k8s.Models;
 
 internal sealed class ExecutableSpec
 {
-    // Path to Executable binary
+    /// <summary>
+    /// Path to Executable binary
+    /// </summary>
     [JsonPropertyName("executablePath")]
     public string? ExecutablePath { get; set; }
 
-    // The working directory for the Executable
+    /// <summary>
+    /// The working directory for the Executable
+    /// </summary>
     [JsonPropertyName("workingDirectory")]
     public string? WorkingDirectory { get; set; }
 
-    // Launch arguments to be passed to the Executable
+    /// <summary>
+    /// Launch arguments to be passed to the Executable
+    /// </summary>
     [JsonPropertyName("args")]
     public List<string>? Args { get; set; }
 
-    // Environment variables to be set for the Executable
+    /// <summary>
+    /// Environment variables to be set for the Executable
+    /// </summary>
     [JsonPropertyName("env")]
     public List<EnvVar>? Env { get; set; }
 
-    // Environment files to use to populate Executable environment during startup.
+    /// <summary>
+    /// Environment files to use to populate Executable environment during startup.
+    /// </summary>
     [JsonPropertyName("envFiles")]
     public List<string>? EnvFiles { get; set; }
 
-    // The execution type for the Executable
+    /// <summary>
+    /// The execution type for the Executable
+    /// </summary>
     [JsonPropertyName("executionType")]
     public string? ExecutionType { get; set; }
+
+    /// <summary>
+    /// Health probes to be run for the Executable.
+    /// </summary>
+    [JsonPropertyName("healthProbes")]
+    public List<HealthProbe>? HealthProbes { get; set; }
 }
 
 internal static class ExecutionType
 {
-    // Executable will be run directly by the controller, as a child process
+    /// <summary>
+    /// Executable will be run directly by the controller, as a child process
+    /// </summary>
     public const string Process = "Process";
 
-    // Executable will be run via an IDE such as Visual Studio or Visual Studio Code.
+    /// <summary>
+    /// Executable will be run via an IDE such as Visual Studio or Visual Studio Code.
+    /// </summary>
     public const string IDE = "IDE";
 }
 
 internal sealed class ExecutableStatus : V1Status
 {
-    // The execution ID is the identifier for the actual-state counterpart of the Executable.
-    // For ExecutionType == Process it is the process ID. Process IDs will be eventually reused by OS,
-    // but a combination of process ID and startup timestamp is unique for each Executable instance.
-    // For ExecutionType == IDE it is the IDE session ID.
+    /// <summary>
+    /// The execution ID is the identifier for the actual-state counterpart of the Executable.
+    /// For ExecutionType == Process it is the process ID. Process IDs will be eventually reused by OS,
+    /// but a combination of process ID and startup timestamp is unique for each Executable instance.
+    /// For ExecutionType == IDE it is the IDE session ID.
+    /// </summary>
     [JsonPropertyName("executionID")]
     public string? ExecutionID { get; set; }
 
+    /// <summary>
+    /// The process ID of the Executable.
+    /// </summary>
     [JsonPropertyName("pid")]
     public int ProcessId { get; set; }
 
-    // The current state of the process/IDE session started for this executable
+    /// <summary>
+    /// The current state of the process/IDE session started for this executable
+    /// </summary>
     [JsonPropertyName("state")]
     public string? State { get; set; } = ExecutableState.Unknown;
 
-    // Start (attempt) timestamp.
+    /// <summary>
+    /// Start (attempt) timestamp.
+    /// </summary>
     [JsonPropertyName("startupTimestamp")]
     public DateTimeOffset? StartupTimestamp { get; set; }
 
-    // The time when the replica finished execution
+    /// <summary>
+    /// The time when the replica finished execution
+    /// </summary>
     [JsonPropertyName("finishTimestamp")]
     public DateTimeOffset? FinishTimestamp { get; set; }
 
-    // Exit code of the process associated with the Executable.
-    // The value is equal to UnknownExitCode if the Executable was not started, is still running, or the exit code is not available.
+    /// <summary>
+    /// Exit code of the process associated with the Executable.
+    /// The value is equal to UnknownExitCode if the Executable was not started, is still running, or the exit code is not available.
+    /// </summary>
     [JsonPropertyName("exitCode")]
     public int? ExitCode { get; set; }
 
-    // The path of a temporary file that contains captured standard output data from the Executable process.
+    /// <summary>
+    /// The path of a temporary file that contains captured standard output data from the Executable process.
+    /// </summary>
     [JsonPropertyName("stdOutFile")]
     public string? StdOutFile { get; set; }
 
-    // The path of a temporary file that contains captured standard error data from the Executable process.
+    /// <summary>
+    /// The path of a temporary file that contains captured standard error data from the Executable process.
+    /// </summary>
     [JsonPropertyName("stdErrFile")]
     public string? StdErrFile { get; set; }
 
-    // Effective values of environment variables, after all substitutions have been applied
+    /// <summary>
+    /// Effective values of environment variables, after all substitutions have been applied
+    /// </summary>
     [JsonPropertyName("effectiveEnv")]
     public List<EnvVar>? EffectiveEnv { get; set; }
 
-    // Effective values of launch arguments to be passed to the Executable, after all substitutions are applied.
+    /// <summary>
+    /// Effective values of launch arguments to be passed to the Executable, after all substitutions are applied.
+    /// </summary>
     [JsonPropertyName("effectiveArgs")]
     public List<string>? EffectiveArgs { get; set; }
+
+    /// <summary>
+    /// The health status of the Executable <see cref="HealthStatus"/> for allowed values.
+    /// </summary>
+    [JsonPropertyName("healthStatus")]
+    public string? HealthStatus { get; set; }
+
+    /// <summary>
+    /// Latest results for health probes configured for the Executable.
+    /// </summary>
+    [JsonPropertyName("healthProbeResults")]
+    public List<HealthProbeResult>? HealthProbeResults { get; set;}
 }
 
 internal static class ExecutableState
 {
-    // Executable was successfully started and was running last time we checked.
+    /// <summary>
+    /// Executable was successfully started and was running last time we checked.
+    /// </summary>
     public const string Running = "Running";
 
-    // Terminated means the Executable was killed by the controller (e.g. as a result of scale-down, or object deletion).
+    /// <summary>
+    /// Terminated means the Executable was killed by the controller (e.g. as a result of scale-down, or object deletion).
+    /// </summary>
     public const string Terminated = "Terminated";
 
-    // Failed to start means the Executable could not be started (e.g. because of invalid path to program file).
+    /// <summary>
+    /// Failed to start means the Executable could not be started (e.g. because of invalid path to program file).
+    /// </summary>
     public const string FailedToStart = "FailedToStart";
 
-    // Finished means the Executable ran to completion.
+    /// <summary>
+    /// Finished means the Executable ran to completion.
+    /// </summary>
     public const string Finished = "Finished";
 
-    // Unknown means we are not tracking the actual-state counterpart of the Executable (process or IDE run session).
-    // As a result, we do not know whether it already finished, and what is the exit code, if any.
-    // This can happen if a controller launches a process and then terminates.
-    // When a new controller instance comes online, it may see non-zero ExecutionID Status,
-    // but it does not track the corresponding process or IDE session.
+    /// <summary>
+    /// Unknown means we are not tracking the actual-state counterpart of the Executable (process or IDE run session).
+    /// As a result, we do not know whether it already finished, and what is the exit code, if any.
+    /// This can happen if a controller launches a process and then terminates.
+    /// When a new controller instance comes online, it may see non-zero ExecutionID Status,
+    /// but it does not track the corresponding process or IDE session.
+    /// </summary>
     public const string Unknown = "Unknown";
 }
 
@@ -142,7 +207,7 @@ internal sealed class Executable : CustomResource<ExecutableSpec, ExecutableStat
         // In Aspire v1 only one launch configuration, of type "project", is supported.
         // Further, there can be only one instance of project launch configuration per Executable.
 
-        this.Annotate(LaunchConfigurationsAnnotation, string.Empty); // Clear existing annotation, if any. 
+        this.Annotate(LaunchConfigurationsAnnotation, string.Empty); // Clear existing annotation, if any.
         this.AnnotateAsObjectList(LaunchConfigurationsAnnotation, launchConfiguration);
     }
 

--- a/src/Aspire.Hosting/Dcp/Model/ExecutableReplicaSet.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ExecutableReplicaSet.cs
@@ -79,6 +79,14 @@ internal sealed class ExecutableReplicaSetStatus : V1Status
     // Last time the replica set was scaled up or down by the controller
     [JsonPropertyName("lastScaleTime")]
     public DateTimeOffset? LastScaleTime { get; set; }
+
+    /// <summary>
+    /// The health status of the ExecutableReplicaSet <see cref="HealthStatus"/> for allowed values.
+    /// The replica set will be healthy if it has the desired number of healthy replicas, unhealthy if
+    /// it has no healthy replicas, and caution if it has some healthy replicas but not the desired number.
+    /// </summary>
+    [JsonPropertyName("healthStatus")]
+    public string? HealthStatus { get; set; }
 }
 
 internal sealed class ExecutableReplicaSet : CustomResource<ExecutableReplicaSetSpec, ExecutableReplicaSetStatus>

--- a/src/Aspire.Hosting/Dcp/Model/GroupVersion.cs
+++ b/src/Aspire.Hosting/Dcp/Model/GroupVersion.cs
@@ -23,6 +23,7 @@ internal static class Dcp
 
     public static string ExecutableKind { get; } = "Executable";
     public static string ContainerKind { get; } = "Container";
+    public static string ContainerExecKind { get; } = "ContainerExec";
     public static string ContainerNetworkKind { get; } = "ContainerNetwork";
     public static string ServiceKind { get; } = "Service";
     public static string EndpointKind { get; } = "Endpoint";

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -227,6 +227,215 @@ internal static class Rules
     }
 }
 
+internal static class HealthStatus
+{
+    /// <summary>
+    /// DCP considers the resource to be healthy.
+    /// </summary>
+    public const string Healthy = "Healthy";
+
+    /// <summary>
+    /// DCP considers the resource to be unhealthy.
+    /// </summary>
+    public const string Unhealthy = "Unhealthy";
+
+    /// <summary>
+    /// DCP considers the resource to be in a cautionary state (partially healthy or unknown state).
+    /// </summary>
+    public const string Caution = "Caution";
+}
+
+internal sealed class HealthProbe
+{
+    /// <summary>
+    /// Name of the health probe, used to identify the results of a specific probe in the status output
+    /// of the parent resource. Name must be unique for a given parent resource.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name;
+
+    /// <summary>
+    /// The type of health probe. For valid values see <see cref="HealthProbeType"/>.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type;
+
+    /// <summary>
+    /// If <see cref="HealthProbe.Type"> is HTTP, this configures the health probe.
+    /// </summary>
+    [JsonPropertyName("httpProbe")]
+    public HttpHealthProbeConfig? HttpProbe { get; set; }
+
+    /// <summary>
+    /// If <see cref="HealthProbe.Type"> is Executable, this configures the health probe.
+    /// </summary>
+    [JsonPropertyName("executableProbe")]
+    public ExecutableHealthProbeConfig? ExecutableProbe { get; set; }
+
+    /// <summary>
+    /// Determines how often the probe executes.
+    /// </summary>
+    [JsonPropertyName("schedule")]
+    public HealthProbeSchedule? Schedule { get; set; }
+
+    /// <summary>
+    /// Optional annotations (metadata) for the health probe.
+    /// </summary>
+    [JsonPropertyName("annotations")]
+    public IDictionary<string, string>? Annotations { get; set; }
+}
+
+internal static class HealthProbeType
+{
+    /// <summary>
+    /// The health probe makes an HTTP request that expects a success response (i.e. 200).
+    /// </summary>
+    public const string Http = "HTTP";
+
+    /// <summary>
+    /// The health probe runs an executable and expects a successful exit code (0).
+    /// </summary>
+    public const string Executable = "Executable";
+
+    /// <summary>
+    /// The health probe executes a command in a container and expects a successful exit code (0).
+    /// </summary>
+    public const string ContainerExec = "ContainerExec";
+}
+
+internal sealed class HttpHealthProbeConfig
+{
+    /// <summary>
+    /// The URL to probe.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    /// <summary>
+    /// Optional collection of HTTP headers to apply to the health probe request.
+    /// </summary>
+    public List<HttpProbeHeader>? Headers { get; set; }
+}
+
+internal sealed class HttpProbeHeader
+{
+    /// <summary>
+    /// The name of the header.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The (optional) value of the header.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public string? Value { get; set; }
+}
+
+internal sealed class ExecutableHealthProbeConfig
+{
+    // Labels to apply to probe Executable objects
+    [JsonPropertyName("labels")]
+    public IDictionary<string, string>? Labels { get; set; }
+
+    // Annotations to apply to probe Executable objects
+    [JsonPropertyName("annotations")]
+    public IDictionary<string, string>? Annotations { get; set; }
+
+    // Spec for the probe Executable
+    [JsonPropertyName("spec")]
+    public ExecutableSpec Spec { get; set; } = new ExecutableSpec();
+}
+
+internal sealed class HealthProbeSchedule
+{
+    /// <summary>
+    /// The schedule kind for the health probe. For valid values see <see cref="HealthProbeScheduleKind"/>.
+    /// </summary>
+    [JsonPropertyName("kind")]
+    public string? Kind { get; set; };
+
+    /// <summary>
+    /// The interval at which the health probe should be run.
+    /// </summary>
+    [JsonPropertyName("interval")]
+    public TimeSpan? Interval { get; set; }
+
+    /// <summary>
+    /// Optional timeout for the health probe, which will mark the probe as failed if it takes longer than this duration.
+    /// </summary>
+    [JsonPropertyName("timeout")]
+    public TimeSpan? Timeout { get; set; }
+
+    /// <summary>
+    /// Optional initial delay before the health probe starts running.
+    /// </summary>
+    [JsonPropertyName("initialDelay")]
+    public TimeSpan? InitialDelay { get; set; }
+}
+
+internal static class HealthProbeScheduleKind
+{
+    /// <summary>
+    /// The health probe is run continuously (based on the configured schedule).
+    /// </summary>
+    public const string Continuous = "Continuous";
+
+    /// <summary>
+    /// The health probe is run based on the configured schedule until it succeeds once, at
+    /// which point it is considered successful for the remainder of the parent object's lifetime.
+    /// This is useful for expensive startup probes such as checking for a database to be ready to
+    /// accept requests.
+    /// </summary>
+    public const string UntilSuccess = "UntilSuccess";
+}
+
+internal sealed class HealthProbeResult
+{
+    /// <summary>
+    /// The outcome of the health probe (success, failure, etc.)
+    /// </summary>
+    [JsonPropertyName("outcome")]
+    public string? Outcome { get; set;}
+
+    /// <summary>
+    /// The timestamp when the health probe result was determined.
+    /// </summary>
+    [JsonPropertyName("timestamp")]
+    public DateTimeOffset? Timestamp { get; set; }
+
+    /// <summary>
+    /// The name of the probe that generated this result. Corresponds to a specific <see cref="HealthProbe"/>
+    /// configured in the spec of the parent resource.
+    /// </summary>
+    [JsonPropertyName("probeName")]
+    public string? ProbeName { get; set; }
+
+    /// <summary>
+    /// Optional human-readable message describing the probe outcome.
+    /// </summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+}
+
+internal static class HealthProbeOutcome
+{
+    /// <summary>
+    /// The health probe was successful.
+    /// </summary>
+    public const string Success = "Success";
+
+    /// <summary>
+    /// The health probe failed.
+    /// </summary>
+    public const string Failure = "Failure";
+
+    /// <summary>
+    /// The health probe hasn't succeeded or failed yet.
+    /// </summary>
+    public const string Unknown = "Unknown";
+}
+
 internal static class Logs
 {
     public const string StreamTypeStartupStdOut = "startup_stdout";

--- a/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
+++ b/src/Aspire.Hosting/Dcp/Model/ModelCommon.cs
@@ -261,13 +261,13 @@ internal sealed class HealthProbe
     public string? Type;
 
     /// <summary>
-    /// If <see cref="HealthProbe.Type"> is HTTP, this configures the health probe.
+    /// If <see cref="HealthProbe.Type"/> is HTTP, this configures the health probe.
     /// </summary>
     [JsonPropertyName("httpProbe")]
     public HttpHealthProbeConfig? HttpProbe { get; set; }
 
     /// <summary>
-    /// If <see cref="HealthProbe.Type"> is Executable, this configures the health probe.
+    /// If <see cref="HealthProbe.Type"/> is Executable, this configures the health probe.
     /// </summary>
     [JsonPropertyName("executableProbe")]
     public ExecutableHealthProbeConfig? ExecutableProbe { get; set; }
@@ -353,7 +353,7 @@ internal sealed class HealthProbeSchedule
     /// The schedule kind for the health probe. For valid values see <see cref="HealthProbeScheduleKind"/>.
     /// </summary>
     [JsonPropertyName("kind")]
-    public string? Kind { get; set; };
+    public string? Kind { get; set; }
 
     /// <summary>
     /// The interval at which the health probe should be run.


### PR DESCRIPTION
## Description

* Added new ContainerExec types for DCP to allow executing commands in a running container resource
* Added initial HealthProbe/HealthStatus types to Container and Executable schema
  * The HealthProbe types are implemented in DCP, but the probe logic isn't wired up yet

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5547)