### PR TITLE
Allow referencing older version of AppHost package for backward compatibility

### DIFF
--- a/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
+++ b/src/Aspire.Hosting.Sdk/Aspire.Hosting.Sdk.csproj
@@ -15,7 +15,7 @@
     <None Include="..\Aspire.Hosting\build\*.targets" Link="SDK\%(Filename)%(Extension)" Pack="true" PackagePath="Sdk\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Update="SDK\AutoImport.props;SDK\*.targets" Pack="true" PackagePath="Sdk\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
     <None Update="SDK\Sdk.in.props" Pack="true" PerformTextReplacement="True" PackagePath="Sdk\Sdk.props" CopyToOutputDirectory="PreserveNewest" />
-    <None Update="SDK\Sdk.targets" Pack="true" PackagePath="Sdk\Sdk.targets" />
+    <None Update="SDK\Sdk.in.targets" Pack="true" PerformTextReplacement="True" PackagePath="Sdk\Sdk.targets" />
   </ItemGroup>
 
 </Project>

--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets
@@ -71,13 +71,17 @@
       <_AppHostVersion>%(_AppHostPackageReference.Version)</_AppHostVersion>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(_AppHostVersion)' != ''">
-      <__CurrentAppHostVersionMessage> You are using version $(_AppHostVersion).</__CurrentAppHostVersionMessage>
+    <PropertyGroup Condition="'$(_AppHostVersion)' != '' and $([MSBuild]::VersionLessThan('$(_AppHostVersion)', '8.2.0'))">
+      <!-- If we find the version to Aspire.Hosting.AppHost package but it is lower than 8.2.0, then we fall back
+      to use the Dashboard and DCP packages that match the version of the installed workload for backwards compatibility.
+      This results in the same behavior that we had before moving Dashboard and DCP out of the workload, since the version
+      is again just matching to the one the workload has. -->
+      <_AppHostVersion>@VERSION@</_AppHostVersion>
     </PropertyGroup>
 
     <!-- At this point, we should have the version either by CPM or PackageReference, so we fail if not.  -->
-    <Error Condition="'$(_AppHostVersion)' == '' or $([MSBuild]::VersionLessThan('$(_AppHostVersion)', '8.2.0'))" 
-       Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that needs a package reference to Aspire.Hosting.AppHost version 8.2.0 or above to work correctly.$(__CurrentAppHostVersionMessage)" />
+    <Error Condition="'$(_AppHostVersion)' == ''" 
+       Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that needs a package reference to Aspire.Hosting.AppHost version 8.2.0 or above to work correctly." />
 
     <!-- Now that we have the version, we add the package references -->
     <ItemGroup>

--- a/tests/Aspire.Hosting.Testing.Tests/Directory.Build.targets
+++ b/tests/Aspire.Hosting.Testing.Tests/Directory.Build.targets
@@ -4,7 +4,7 @@
 
   <!-- NOTE: These lines are only required because we are using P2P references, not NuGet. They will not exist in real apps. -->
   <Import Project="..\..\src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.targets" />
-  <Import Project="..\..\src\Aspire.Hosting.Sdk\SDK\Sdk.targets" />
+  <Import Project="..\..\src\Aspire.Hosting.Sdk\SDK\Sdk.in.targets" />
 
   <PropertyGroup>
     <!-- This is for in-repo testing and required for Aspire.Hosting.AppHost targets loading correctly. On real projects, this comes from SDK.props in Aspire.Hosting.SDK. -->

--- a/tests/Aspire.Hosting.Tests/MSBuildTests.cs
+++ b/tests/Aspire.Hosting.Tests/MSBuildTests.cs
@@ -87,7 +87,7 @@ builder.Build().Run();
             File.WriteAllText(Path.Combine(appHostDirectory, "Directory.Build.targets"), $"""
 <Project>
   <Import Project="{repoRoot}\src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.targets" />
-  <Import Project="{repoRoot}\src\Aspire.Hosting.Sdk\SDK\Sdk.targets" />
+  <Import Project="{repoRoot}\src\Aspire.Hosting.Sdk\SDK\Sdk.in.targets" />
 </Project>
 """);
 

--- a/tests/Aspire.Workload.Tests/AppHostTemplateTests.cs
+++ b/tests/Aspire.Workload.Tests/AppHostTemplateTests.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using Xunit.Abstractions;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace Aspire.Workload.Tests;
+
+public partial class AppHostTemplateTests : WorkloadTestsBase
+{
+    public AppHostTemplateTests(ITestOutputHelper testOutput)
+        : base(testOutput)
+    {
+    }
+
+    [Fact]
+    public async Task EnsureProjectsReferencing8_1_0WorkloadCanBuild()
+    {
+        string projectId = "aspire-can-reference-8.1.0";
+        await using var project = await AspireProject.CreateNewTemplateProjectAsync(
+            projectId,
+            "aspire-apphost",
+            _testOutput,
+            BuildEnvironment.ForDefaultFramework,
+            string.Empty,
+            false);
+        
+        var projectPath = Path.Combine(project.RootDir, $"{projectId}.csproj");
+
+        // Replace the reference to Aspire.Hosting.AppHost with version 8.1.0
+        var newContents = AppHostPackageReferenceRegex().Replace(File.ReadAllText(projectPath), @"$1""8.1.0""");
+
+        File.WriteAllText(projectPath, newContents);
+
+        // Ensure project builds successfully
+        await project.BuildAsync(workingDirectory: project.RootDir);
+    }
+
+    [GeneratedRegex(@"(PackageReference\s.*""Aspire\.Hosting\.AppHost.*Version=)""[^""]+""")]
+    private static partial Regex AppHostPackageReferenceRegex();
+}

--- a/tests/Aspire.Workload.Tests/AppHostTemplateTests.cs
+++ b/tests/Aspire.Workload.Tests/AppHostTemplateTests.cs
@@ -15,7 +15,7 @@ public partial class AppHostTemplateTests : WorkloadTestsBase
     }
 
     [Fact]
-    public async Task EnsureProjectsReferencing8_1_0WorkloadCanBuild()
+    public async Task EnsureProjectsReferencing8_1_0AppHostWithNewerWorkloadCanBuild()
     {
         string projectId = "aspire-can-reference-8.1.0";
         await using var project = await AspireProject.CreateNewTemplateProjectAsync(

--- a/tests/Aspire.Workload.Tests/AppHostTemplateTests.cs
+++ b/tests/Aspire.Workload.Tests/AppHostTemplateTests.cs
@@ -3,7 +3,6 @@
 
 using Xunit;
 using Xunit.Abstractions;
-using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace Aspire.Workload.Tests;

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -140,7 +140,7 @@
 
   <ImportGroup Condition="'$(RepoRoot)' != 'null' and '$(TestsRunningOutsideOfRepo)' != 'true' and '$(IsAspireHost)' == 'true'">
     <Import Project="$(RepoRoot)src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.targets" Condition="Exists('$(RepoRoot)src\Aspire.Hosting.AppHost\build\Aspire.Hosting.AppHost.targets')" />
-    <Import Project="$(RepoRoot)src\Aspire.Hosting.Sdk\SDK\Sdk.targets" Condition="Exists('$(RepoRoot)src\Aspire.Hosting.Sdk\SDK\Sdk.targets')" />
+    <Import Project="$(RepoRoot)src\Aspire.Hosting.Sdk\SDK\Sdk.in.targets" Condition="Exists('$(RepoRoot)src\Aspire.Hosting.Sdk\SDK\Sdk.in.targets')" />
   </ImportGroup>
 
   <PropertyGroup Condition="'$(RepoRoot)' != 'null' and '$(TestsRunningOutsideOfRepo)' != 'true' and '$(IsAspireHost)' == 'true'">

--- a/tests/Shared/WorkloadTesting/AspireProject.cs
+++ b/tests/Shared/WorkloadTesting/AspireProject.cs
@@ -261,10 +261,12 @@ public class AspireProject : IAsyncDisposable
         _testOutput.WriteLine($"-- Ready to run tests --");
     }
 
-    public async Task BuildAsync(string[]? extraBuildArgs = default, CancellationToken token = default)
+    public async Task BuildAsync(string[]? extraBuildArgs = default, CancellationToken token = default, string? workingDirectory = null)
     {
+        workingDirectory ??= Path.Combine(RootDir, $"{Id}.AppHost");
+
         using var restoreCmd = new DotNetCommand(_testOutput, buildEnv: _buildEnv, label: "restore")
-                                    .WithWorkingDirectory(Path.Combine(RootDir, $"{Id}.AppHost"));
+                                    .WithWorkingDirectory(workingDirectory);
         var res = await restoreCmd.ExecuteAsync($"restore \"-bl:{Path.Combine(LogPath!, $"{Id}-restore.binlog")}\" /p:TreatWarningsAsErrors=true");
         res.EnsureSuccessful();
 
@@ -274,7 +276,7 @@ public class AspireProject : IAsyncDisposable
             buildArgs += " " + string.Join(" ", extraBuildArgs);
         }
         using var buildCmd = new DotNetCommand(_testOutput, buildEnv: _buildEnv, label: "build")
-                                        .WithWorkingDirectory(Path.Combine(RootDir, $"{Id}.AppHost"));
+                                        .WithWorkingDirectory(workingDirectory);
         res = await buildCmd.ExecuteAsync(buildArgs);
         res.EnsureSuccessful();
     }


### PR DESCRIPTION
## Description

This would walk back on a decision we took in 8.2.0 where we forced people to reference the 8.2.0 AppHost package when moving to the new workload, and instead allow for backward compatibility preserving the old behavior where, if that is the case, then the version of dashboard and DCP people would get would match the version of the workload they have installed.

The intention would be to backport this to release/8.2 branch so it can be serviced in 8.2.1

cc: @DamianEdwards @davidfowl @eerhardt @maddymontaquila @radical 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: 
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5556)