### PR TITLE
Apply workaround to unblock Azure Functions integration tests

### DIFF
--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Workaround for buggy project file search in Azure Functions host. See https://github.com/dotnet/aspire/pull/5591 for more info. -->
     <ExtensionsCsProjDirectory Condition="'$(RepoRoot)' == '' or '$(ContinuousIntegrationBuild)' == 'true'">$(MSBuildProjectDirectory)/../WorkerExtensions</ExtensionsCsProjDirectory>
   </PropertyGroup>
   <ItemGroup>

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <ExtensionsCsProjDirectory Condition="'$(RepoRoot)' == '' or '$(ContinuousIntegrationBuild)' == 'true'">$(MSBuildProjectDirectory)/../WorkerExtensions</ExtensionsCsProjDirectory>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -56,7 +56,6 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/5564", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     [RequiresDocker]
     [RequiresTools(["func"])]
     public async Task AzureFunctionsTest()


### PR DESCRIPTION
Our Helix integration tests are currently failing with the following exception:

> Can't determine Project to build. Expected 1 .csproj or .fsproj but found 2

When the `AzureFuntionsTest.Functions` project is referenced in the `Aspire.Playground.Tests` a build runs and the Azure Functions SDK generates a `WorkerExtensions.csproj` to the intermediary output directory. When the inner build facilitated by `func start` runs, Azure Functions host will check if only 1 project file exists in the Functions project. This check if currently recursive so on Helix environments it will find both the `AzureFunctionsTest.Functions.csproj` and the generated `WorkerExtensions.csproj`. To workaround this bug, we use the `ExtensionsCsProjDirectory` property from the Functions SDK to emit the `WorkerExtensions.csproj` to a sibling directory instead of the intermediary output directory.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5591)