### PR TITLE
Support Service Bus resources in Azure Functions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -172,6 +172,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.6.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.5"/>
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.0.0-preview1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/AzureFunctionsEndToEnd.ApiService.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/AzureFunctionsEndToEnd.ApiService.csproj
@@ -14,6 +14,7 @@
     <AspireProjectOrPackageReference Include="Aspire.Azure.Storage.Blobs" />
     <AspireProjectOrPackageReference Include="Aspire.Azure.Storage.Queues" />
     <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.EventHubs" />
+    <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.ServiceBus" />
   </ItemGroup>
 
 </Project>

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
@@ -3,6 +3,7 @@ using System.Text;
 #if !SKIP_EVENTHUBS_EMULATION
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
+using Azure.Messaging.ServiceBus;
 #endif
 using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
@@ -15,6 +16,7 @@ builder.AddAzureQueueClient("queue");
 builder.AddAzureBlobClient("blob");
 #if !SKIP_EVENTHUBS_EMULATION
 builder.AddAzureEventHubProducerClient("eventhubs", static settings => settings.EventHubName = "myhub");
+builder.AddAzureServiceBusClient("messaging");
 #endif
 
 var app = builder.Build();
@@ -53,6 +55,13 @@ app.MapGet("/publish/eventhubs", async (EventHubProducerClient client, Cancellat
     var data = new BinaryData(Encoding.UTF8.GetBytes(RandomString(length)));
     await client.SendAsync([new EventData(data)]);
     return Results.Ok("Message sent to Azure EventHubs.");
+});
+app.MapGet("/publish/asb", async (ServiceBusClient client, CancellationToken cancellationToken, int length = 20) =>
+{
+    var sender = client.CreateSender("myqueue");
+    var message = new ServiceBusMessage(Encoding.UTF8.GetBytes(RandomString(length)));
+    await sender.SendMessageAsync(message, cancellationToken);
+    return Results.Ok("Message sent to Azure Service Bus.");
 });
 #endif
 

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj
@@ -13,6 +13,7 @@
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Functions" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.EventHubs" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Storage" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.ServiceBus" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
   </ItemGroup>
 

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
@@ -8,12 +8,14 @@ var blob = storage.AddBlobs("blob");
 
 #if !SKIP_EVENTHUBS_EMULATION
 var eventHubs = builder.AddAzureEventHubs("eventhubs").RunAsEmulator().AddEventHub("myhub");
+var serviceBus = builder.AddAzureServiceBus("messaging").AddQueue("myqueue");
 #endif
 
 var funcApp = builder.AddAzureFunctionsProject<Projects.AzureFunctionsEndToEnd_Functions>("funcapp")
     .WithExternalHttpEndpoints()
 #if !SKIP_EVENTHUBS_EMULATION
     .WithReference(eventHubs)
+    .WithReference(serviceBus)
 #endif
     .WithReference(blob)
     .WithReference(queue);
@@ -21,6 +23,7 @@ var funcApp = builder.AddAzureFunctionsProject<Projects.AzureFunctionsEndToEnd_F
 builder.AddProject<Projects.AzureFunctionsEndToEnd_ApiService>("apiservice")
 #if !SKIP_EVENTHUBS_EMULATION
     .WithReference(eventHubs)
+    .WithReference(serviceBus)
 #endif
     .WithReference(queue)
     .WithReference(blob)

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" />

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyServiceBusTrigger.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyServiceBusTrigger.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace AzureFunctionsEndToEnd.Functions;
+
+public class MyServiceBusTrigger(ILogger<MyServiceBusTrigger> logger)
+{
+    [Function(nameof(MyServiceBusTrigger))]
+    public void Run([ServiceBusTrigger("myqueue", Connection = "messaging" )] ServiceBusReceivedMessage message)
+    {
+        logger.LogInformation("Message ID: {id}", message.MessageId);
+        logger.LogInformation("Message Body: {body}", message.Body);
+        logger.LogInformation("Message Content-Type: {contentType}", message.ContentType);
+    }
+}

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusResource.cs
@@ -14,7 +14,7 @@ namespace Aspire.Hosting.Azure;
 /// <param name="name">The name of the resource.</param>
 /// <param name="configureConstruct">Callback to configure the Azure Service Bus resource.</param>
 public class AzureServiceBusResource(string name, Action<ResourceModuleConstruct> configureConstruct)
-    : AzureConstructResource(name, configureConstruct), IResourceWithConnectionString
+    : AzureConstructResource(name, configureConstruct), IResourceWithConnectionString, IResourceWithAzureFunctionsConfig
 {
     internal List<(string Name, Action<IResourceBuilder<AzureServiceBusResource>, ResourceModuleConstruct, ServiceBusQueue>? Configure)> Queues { get; } = [];
     internal List<(string Name, Action<IResourceBuilder<AzureServiceBusResource>, ResourceModuleConstruct, ServiceBusTopic>? Configure)> Topics { get; } = [];
@@ -30,4 +30,9 @@ public class AzureServiceBusResource(string name, Action<ResourceModuleConstruct
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         ReferenceExpression.Create($"{ServiceBusEndpoint}");
+
+    void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
+    {
+        target[$"{connectionName}__fullyQualifiedNamespace"] = ServiceBusEndpoint;
+    }
 }

--- a/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
+++ b/tests/Aspire.Playground.Tests/ProjectSpecificTests.cs
@@ -105,12 +105,21 @@ public class ProjectSpecificTests(ITestOutputHelper _testOutput)
             resourceName: "funcapp",
             timeoutSecs: 160);
 
-        // Assert that EventHubs triggers work correctly
 #if !SKIP_EVENTHUBS_EMULATION
+        // Assert that EventHubs triggers work correctly
         await app.CreateHttpClient("apiservice").GetAsync("/publish/eventhubs");
         await WaitForAllTextAsync(app,
             [
                 "Executed 'Functions.MyEventHubTrigger'"
+            ],
+            resourceName: "funcapp",
+            timeoutSecs: 160);
+
+        // Assert that ServiceBus triggers work correctly
+        await app.CreateHttpClient("apiservice").GetAsync("/publish/asb");
+        await WaitForAllTextAsync(app,
+            [
+                "Executed 'Functions.MyServiceBusTrigger'"
             ],
             resourceName: "funcapp",
             timeoutSecs: 160);


### PR DESCRIPTION
## Description

Follow-up to https://github.com/dotnet/aspire/pull/5418.

Add support for ServiceBus references to Azure Functions projects by implementing the `IResourceWithAzureFunctionsConfig` interface on the `AzureServiceBusResource`.

Added tests and validating locally. Tests for this scenario are exempt from CI since Azure Service Bus requires access to provisioning in CI.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [X] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes -- tests only run locally, require Service Bus provisioning
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [X] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5593)