### PR TITLE
Offer an extensibility point to library registering a builder in DI

### DIFF
--- a/src/Components/Aspire.Confluent.Kafka/ConsumerBuilderExtensions.cs
+++ b/src/Components/Aspire.Confluent.Kafka/ConsumerBuilderExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Confluent.Kafka;
+
+namespace Aspire.Confluent.Kafka;
+
+internal static class ConsumerBuilderExtensions
+{
+    public static void OverrideConnectionString<TKey, TValue>(this ConsumerBuilder<TKey, TValue> builder, string connectionString)
+    {
+        var configProperty = builder.GetType()
+            .GetProperty("Config", BindingFlags.NonPublic | BindingFlags.Instance) ?? throw new InvalidOperationException(
+            "The 'Config' property of type 'ConsumerBuilder<TKey, TValue>' is not found");
+
+        // Retrieve the reference to the internal Config property and enumerate it to a temporary collection.
+        var config = configProperty
+            .GetValue(builder) as IEnumerable<KeyValuePair<string, string>> ?? [];
+
+        // Create a new dictionary to hold the updated configuration.
+        var updatedConfig = new Dictionary<string, string>(config)
+        {
+            // Override the connection string.
+            ["bootstrap.servers"] = connectionString
+        };
+
+        // Set the updated configuration back to the builder.
+        configProperty
+            .SetValue(builder, updatedConfig);
+    }
+}

--- a/src/Components/Aspire.Confluent.Kafka/ProducerBuilderExtensions.cs
+++ b/src/Components/Aspire.Confluent.Kafka/ProducerBuilderExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Confluent.Kafka;
+
+namespace Aspire.Confluent.Kafka;
+
+internal static class ProducerBuilderExtensions
+{
+    public static void OverrideConnectionString<TKey, TValue>(this ProducerBuilder<TKey, TValue> builder, string connectionString)
+    {
+        var configProperty = builder.GetType()
+            .GetProperty("Config", BindingFlags.NonPublic | BindingFlags.Instance) ?? throw new InvalidOperationException(
+            "The 'Config' property of type 'ProducerBuilder<TKey, TValue>' is not found");
+
+        // Retrieve the reference to the internal Config property and enumerate it to a temporary collection.
+        var config = configProperty
+            .GetValue(builder) as IEnumerable<KeyValuePair<string, string>> ?? [];
+
+        // Create a new dictionary to hold the updated configuration.
+        var updatedConfig = new Dictionary<string, string>(config)
+        {
+            // Override the connection string.
+            ["bootstrap.servers"] = connectionString
+        };
+
+        // Set the updated configuration back to the builder.
+        configProperty
+            .SetValue(builder, updatedConfig);
+    }
+}


### PR DESCRIPTION
## Description

Offer an extensibility point to users using a library that register a `ConsumerBuilder<TKey, TValue>` or a `ProducerBuilder<TKey, TValue>` in DI by allowing pulling that builder from DI and overriding the BootstrapServers property with Aspire ConnectionString instead of newing one in Aspire.

Fixes # (issue)

No issue created yet but i can create one if needed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5605)