### PR TITLE
Update container lifetime API and add schema for lifecycleKey property

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ContainerLifetimeAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerLifetimeAnnotation.cs
@@ -15,9 +15,23 @@ public enum ContainerLifetime
     /// </summary>
     Default,
     /// <summary>
-    /// The resource is persistent and will not be disposed of when the AppHost shuts down.
+    /// Attempt to re-use a previously created resource (based on the container name) if one exists. Do not destroy the container on AppHost shutdown.
     /// </summary>
-    CreateIfNotExistsPersistOnExit,
+    /// <remarks>
+    /// In the event that a container with the given name does not exist, a new container will always be created based on the
+    /// current <see cref="ContainerResource"/> configuration.
+    /// <para>When an existing container IS found, Aspire MAY re-use it based on the following criteria:</para>
+    /// <list type="bullet">
+    /// <item>If the container WAS NOT originally created by Aspire, the existing container will be re-used.</item>
+    /// <item>If the container WAS originally created by Aspire:
+    /// <list type="bullet">
+    /// <item>And the <see cref="ContainerResource"/> configuration DOES match the existing container, the existing container will be re-used.</item>
+    /// <item>And the <see cref="ContainerResource"/> configuration DOES NOT match the existing container, the existing container will be stopped
+    /// and a new container created in order to apply the updated configuration.</item>
+    /// </list></item>
+    /// </list>
+    /// </remarks>
+    Persistent,
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ContainerLifetimeAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerLifetimeAnnotation.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Lifetime modes for container resources
 /// </summary>
-public enum ContainerLifetimeType
+public enum ContainerLifetime
 {
     /// <summary>
     /// The default lifetime behavior should apply. This will create the resource when the AppHost starts and dispose of it when the AppHost shuts down.
@@ -17,7 +17,7 @@ public enum ContainerLifetimeType
     /// <summary>
     /// The resource is persistent and will not be disposed of when the AppHost shuts down.
     /// </summary>
-    Persistent,
+    CreateIfNotExistsPersistOnExit,
 }
 
 /// <summary>
@@ -29,5 +29,5 @@ public sealed class ContainerLifetimeAnnotation : IResourceAnnotation
     /// <summary>
     /// Gets or sets the lifetime type for the container resource.
     /// </summary>
-    public required ContainerLifetimeType LifetimeType { get; set; }
+    public required ContainerLifetime Lifetime { get; set; }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -235,18 +235,18 @@ public static class ResourceExtensions
     }
 
     /// <summary>
-    /// Gets the lifetime type of the container for the specified resoruce. Defaults to <see cref="ContainerLifetimeType.Default"/> if
+    /// Gets the lifetime type of the container for the specified resoruce. Defaults to <see cref="ContainerLifetime.Default"/> if
     /// no <see cref="ContainerLifetimeAnnotation"/> is found.
     /// </summary>
     /// <param name="resource">The resource to the get the ContainerLifetimeType for.</param>
-    /// <returns>The <see cref="ContainerLifetimeType"/> from the <see cref="ContainerLifetimeAnnotation"/> for the resource (if the annotation exists). Defaults to <see cref="ContainerLifetimeType.Default"/> if the annotation is not set.</returns>
-    internal static ContainerLifetimeType GetContainerLifetimeType(this IResource resource)
+    /// <returns>The <see cref="ContainerLifetime"/> from the <see cref="ContainerLifetimeAnnotation"/> for the resource (if the annotation exists). Defaults to <see cref="ContainerLifetime.Default"/> if the annotation is not set.</returns>
+    internal static ContainerLifetime GetContainerLifetimeType(this IResource resource)
     {
         if (resource.TryGetLastAnnotation<ContainerLifetimeAnnotation>(out var lifetimeAnnotation))
         {
-            return lifetimeAnnotation.LifetimeType;
+            return lifetimeAnnotation.Lifetime;
         }
 
-        return ContainerLifetimeType.Default;
+        return ContainerLifetime.Default;
     }
 }

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -230,7 +230,7 @@ public static class ContainerResourceBuilderExtensions
     /// <param name="lifetime">The lifetime behavior of the container resource (defaults behavior is <see cref="ContainerLifetime.Default"/>)</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <example>
-    /// Marking a container resource to have a <see cref="ContainerLifetime.CreateIfNotExistsPersistOnExit"/> lifetime.
+    /// Marking a container resource to have a <see cref="ContainerLifetime.Persistent"/> lifetime.
     /// <code language="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     /// builder.AddContainer("mycontainer", "myimage")

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -227,10 +227,10 @@ public static class ContainerResourceBuilderExtensions
     /// </summary>
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">Builder for the container resource.</param>
-    /// <param name="lifetimeType">The lifetime behavior of the container resource (defaults behavior is <see cref="ContainerLifetimeType.Default"/>)</param>
+    /// <param name="lifetime">The lifetime behavior of the container resource (defaults behavior is <see cref="ContainerLifetime.Default"/>)</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     /// <example>
-    /// Marking a container resource to have a <see cref="ContainerLifetimeType.Persistent"/> lifetime.
+    /// Marking a container resource to have a <see cref="ContainerLifetime.CreateIfNotExistsPersistOnExit"/> lifetime.
     /// <code language="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     /// builder.AddContainer("mycontainer", "myimage")
@@ -238,9 +238,9 @@ public static class ContainerResourceBuilderExtensions
     /// </code>
     /// </example>
     [Experimental("ASPIRECONTAINERLIFETIME001")]
-    public static IResourceBuilder<T> WithContainerLifetime<T>(this IResourceBuilder<T> builder, ContainerLifetimeType lifetimeType) where T : ContainerResource
+    public static IResourceBuilder<T> WithLifetime<T>(this IResourceBuilder<T> builder, ContainerLifetime lifetime) where T : ContainerResource
     {
-        return builder.WithAnnotation(new ContainerLifetimeAnnotation { LifetimeType = lifetimeType }, ResourceAnnotationMutationBehavior.Replace);
+        return builder.WithAnnotation(new ContainerLifetimeAnnotation { Lifetime = lifetime }, ResourceAnnotationMutationBehavior.Replace);
     }
 
     private static IResourceBuilder<T> ThrowResourceIsNotContainer<T>(IResourceBuilder<T> builder) where T : ContainerResource

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1366,7 +1366,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
             ctr.Spec.ContainerName = containerObjectName; // Use the same name for container orchestrator (Docker, Podman) resource and DCP object name.
 
-            if (container.GetContainerLifetimeType() == ContainerLifetime.CreateIfNotExistsPersistOnExit)
+            if (container.GetContainerLifetimeType() == ContainerLifetime.Persistent)
             {
                 ctr.Spec.Persistent = true;
             }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1356,7 +1356,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
             var nameSuffix = string.Empty;
 
-            if (container.GetContainerLifetimeType() == ContainerLifetimeType.Default)
+            if (container.GetContainerLifetimeType() == ContainerLifetime.Default)
             {
                 nameSuffix = GetRandomNameSuffix();
             }
@@ -1366,7 +1366,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
             ctr.Spec.ContainerName = containerObjectName; // Use the same name for container orchestrator (Docker, Podman) resource and DCP object name.
 
-            if (container.GetContainerLifetimeType() == ContainerLifetimeType.Persistent)
+            if (container.GetContainerLifetimeType() == ContainerLifetime.CreateIfNotExistsPersistOnExit)
             {
                 ctr.Spec.Persistent = true;
             }

--- a/src/Aspire.Hosting/Dcp/Model/Container.cs
+++ b/src/Aspire.Hosting/Dcp/Model/Container.cs
@@ -63,6 +63,13 @@ internal sealed class ContainerSpec
 
     [JsonPropertyName("networks")]
     public List<ContainerNetworkConnection>? Networks { get; set; }
+
+    /// <summary>
+    /// Optional lifecycle key for the resource (used to identify changes to persistent resources requiring a restart).
+    /// If unset, DCP will calculate a default lifecycle key based on a hash of various resource spec properties.
+    /// </summary>
+    [JsonPropertyName("lifecycleKey")]
+    public string? LifecycleKey { get; set; }
 }
 
 internal sealed class BuildContext
@@ -304,6 +311,12 @@ internal sealed class ContainerStatus : V1Status
     /// </summary>
     [JsonPropertyName("healthProbeResults")]
     public List<HealthProbeResult>? HealthProbeResults { get; set;}
+
+    /// <summary>
+    /// The lifecycle key for the resource (used to identify changes to persistent resources requiring a restart).
+    /// </summary>
+    [JsonPropertyName("lifecycleKey")]
+    public string? LifecycleKey { get; set; }
 
     // Note: the ContainerStatus has "Message" property that represents a human-readable information about Container state.
     // It is provided by V1Status base class.

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -25,7 +25,7 @@ Aspire.Hosting.ApplicationModel.ContainerLifetimeAnnotation.Lifetime.get -> Aspi
 Aspire.Hosting.ApplicationModel.ContainerLifetimeAnnotation.Lifetime.set -> void
 Aspire.Hosting.ApplicationModel.ContainerLifetime
 Aspire.Hosting.ApplicationModel.ContainerLifetime.Default = 0 -> Aspire.Hosting.ApplicationModel.ContainerLifetime
-Aspire.Hosting.ApplicationModel.ContainerLifetime.CreateIfNotExistsPersistOnExit = 1 -> Aspire.Hosting.ApplicationModel.ContainerLifetime
+Aspire.Hosting.ApplicationModel.ContainerLifetime.Persistent = 1 -> Aspire.Hosting.ApplicationModel.ContainerLifetime
 Aspire.Hosting.ApplicationModel.ConnectionStringReference.ConnectionName.get -> string?
 Aspire.Hosting.ApplicationModel.ConnectionStringReference.ConnectionName.set -> void
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.HealthStatus.get -> Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -21,11 +21,11 @@ Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent.Resource.get -> A
 Aspire.Hosting.ApplicationModel.ConnectionStringAvailableEvent.Services.get -> System.IServiceProvider!
 Aspire.Hosting.ApplicationModel.ContainerLifetimeAnnotation
 Aspire.Hosting.ApplicationModel.ContainerLifetimeAnnotation.ContainerLifetimeAnnotation() -> void
-Aspire.Hosting.ApplicationModel.ContainerLifetimeAnnotation.LifetimeType.get -> Aspire.Hosting.ApplicationModel.ContainerLifetimeType
-Aspire.Hosting.ApplicationModel.ContainerLifetimeAnnotation.LifetimeType.set -> void
-Aspire.Hosting.ApplicationModel.ContainerLifetimeType
-Aspire.Hosting.ApplicationModel.ContainerLifetimeType.Default = 0 -> Aspire.Hosting.ApplicationModel.ContainerLifetimeType
-Aspire.Hosting.ApplicationModel.ContainerLifetimeType.Persistent = 1 -> Aspire.Hosting.ApplicationModel.ContainerLifetimeType
+Aspire.Hosting.ApplicationModel.ContainerLifetimeAnnotation.Lifetime.get -> Aspire.Hosting.ApplicationModel.ContainerLifetime
+Aspire.Hosting.ApplicationModel.ContainerLifetimeAnnotation.Lifetime.set -> void
+Aspire.Hosting.ApplicationModel.ContainerLifetime
+Aspire.Hosting.ApplicationModel.ContainerLifetime.Default = 0 -> Aspire.Hosting.ApplicationModel.ContainerLifetime
+Aspire.Hosting.ApplicationModel.ContainerLifetime.CreateIfNotExistsPersistOnExit = 1 -> Aspire.Hosting.ApplicationModel.ContainerLifetime
 Aspire.Hosting.ApplicationModel.ConnectionStringReference.ConnectionName.get -> string?
 Aspire.Hosting.ApplicationModel.ConnectionStringReference.ConnectionName.set -> void
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.HealthStatus.get -> Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?
@@ -74,7 +74,7 @@ Aspire.Hosting.IDistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eve
 static Aspire.Hosting.ApplicationModel.ResourceExtensions.GetEnvironmentVariableValuesAsync(this Aspire.Hosting.ApplicationModel.IResourceWithEnvironment! resource, Aspire.Hosting.DistributedApplicationOperation applicationOperation = Aspire.Hosting.DistributedApplicationOperation.Run) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.Dictionary<string!, string!>!>
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, string? targetState = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, System.Collections.Generic.IEnumerable<string!>! targetStates, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
-static Aspire.Hosting.ContainerResourceBuilderExtensions.WithContainerLifetime<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, Aspire.Hosting.ApplicationModel.ContainerLifetimeType lifetimeType) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
+static Aspire.Hosting.ContainerResourceBuilderExtensions.WithLifetime<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, Aspire.Hosting.ApplicationModel.ContainerLifetime lifetime) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
 static Aspire.Hosting.ParameterResourceBuilderExtensions.AddParameter(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, Aspire.Hosting.ApplicationModel.ParameterDefault! value, bool secret = false, bool persist = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource!>!
 static Aspire.Hosting.ParameterResourceBuilderExtensions.AddParameter(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name, string! value, bool secret = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource!>!
 static Aspire.Hosting.ProjectResourceBuilderExtensions.WithEndpointsInEnvironment(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>! builder, System.Func<Aspire.Hosting.ApplicationModel.EndpointAnnotation!, bool>! filter) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ProjectResource!>!


### PR DESCRIPTION
## Description

Renames the `WithContainerLifetime` experimental API to `WithLifetime`, changes the `ContainerLifetimeType` enum to `ContainerLifetime` and renames `ContainerLifetimeType.Persistent` to `ContainerLifetime.CreateIfNotExistsPersistOnExit` as a more explicit description of the lifetime behavior.

Adds DCP schema for `lifecycleKey` which can be used to configure the lifetime of persistent containers (if not set, DCP will calculate a default lifecycle key value). If set, DCP will check existing persistent containers for to see if they have a matching lifecycle key. If not, the container will be destroyed and re-created based on the new AppHost config.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No (modified newly added experimental API)
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: TBD
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5630)