### PR TITLE
[tests] Improve Cosmos EndToEnd test

### DIFF
--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -5,7 +5,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var db = builder.AddAzureCosmosDB("cosmos")
                 .AddDatabase("db")
-                .RunAsEmulator(resource => resource.WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "2"));
+                .RunAsEmulator();
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -5,7 +5,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var db = builder.AddAzureCosmosDB("cosmos")
                 .AddDatabase("db")
-                .RunAsEmulator();
+                .RunAsEmulator(resource => resource.WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "2"));
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
@@ -32,6 +32,7 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
             _integrationServicesFixture.EnsureAppHasResources(resourceName);
             try
             {
+                _testOutput.WriteLine($"**** Sending request for {resourceName}");
                 var response = await _integrationServicesFixture.IntegrationServiceA.HttpGetAsync("http", $"/{resourceName}/verify");
                 var responseContent = await response.Content.ReadAsStringAsync();
 

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -88,7 +88,7 @@ public class TestProgram : IDisposable
             {
                 var cosmos = AppBuilder
                                 .AddAzureCosmosDB("cosmos")
-                                .RunAsEmulator(resource => resource.WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "2"));
+                                .RunAsEmulator();
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(cosmos);
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.eventhubs))

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -8,6 +8,7 @@ using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Testing;
 using Aspire.TestProject;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 public class TestProgram : IDisposable
 {
@@ -94,6 +95,18 @@ public class TestProgram : IDisposable
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(eventHub);
             }
         }
+
+        AppBuilder.Services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.AddSimpleConsole(configure =>
+            {
+                configure.SingleLine = true;
+            });
+            logging.SetMinimumLevel(LogLevel.Debug);
+            logging.AddFilter("Aspire", LogLevel.Debug);
+            logging.AddFilter(builder.Environment.ApplicationName, LogLevel.Debug);
+        });
 
         AppBuilder.Services.AddHostedService<ResourceLoggerForwarderService>();
         AppBuilder.Services.AddLifecycleHook<EndPointWriterHook>();

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -86,7 +86,9 @@ public class TestProgram : IDisposable
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.cosmos) || !resourcesToSkip.HasFlag(TestResourceNames.efcosmos))
             {
-                var cosmos = AppBuilder.AddAzureCosmosDB("cosmos").RunAsEmulator();
+                var cosmos = AppBuilder
+                                .AddAzureCosmosDB("cosmos")
+                                .RunAsEmulator(resource => resource.WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "2"));
                 IntegrationServiceABuilder = IntegrationServiceABuilder.WithReference(cosmos);
             }
             if (!resourcesToSkip.HasFlag(TestResourceNames.eventhubs))

--- a/tests/testproject/TestProject.WorkerA/Worker.cs
+++ b/tests/testproject/TestProject.WorkerA/Worker.cs
@@ -20,7 +20,7 @@ public class Worker : BackgroundService
             {
                 _logger.LogInformation("Worker running at: {Time}", DateTimeOffset.Now);
             }
-            await Task.Delay(1000, stoppingToken);
+            await Task.Delay(30_000, stoppingToken);
         }
     }
 }


### PR DESCRIPTION
Wait for the texts indicating that the db, and service are ready for requests before sending the http request. This helps with unnecessary attempts, and wait times in the retry pipeline.

- **[tests] TestProject.WorkerA - reduce pings logged to every 30s instead of 1s to reduce noise in the logs**
- **[tests] TestProject.AppHost - use single line logging to help with matching log texts in the tests**
- **[tests] EndToEnd tests - add some text to wait for before sending the http request**

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5639)