### PR TITLE
CosmosDB emulator: set default number of partitions to 1

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -100,12 +100,12 @@ public static class AzureCosmosExtensions
                    Tag = "latest"
                });
 
-        if (configureContainer != null)
-        {
-            var surrogate = new AzureCosmosDBEmulatorResource(builder.Resource);
-            var surrogateBuilder = builder.ApplicationBuilder.CreateResourceBuilder(surrogate);
-            configureContainer(surrogateBuilder);
-        }
+        var surrogate = new AzureCosmosDBEmulatorResource(builder.Resource);
+        var surrogateBuilder = builder.ApplicationBuilder.CreateResourceBuilder(surrogate);
+        // Set a low default number of partitions to improve container startup time
+        surrogateBuilder.WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "1");
+
+        configureContainer?.Invoke(surrogateBuilder);
 
         return builder;
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceExtensionsTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Xunit;
 
@@ -172,5 +173,31 @@ public class AzureResourceExtensionsTests
 
         var actualTag = containerImageAnnotation.Tag;
         Assert.Equal(imageTag ?? "latest", actualTag);
+    }
+
+    [Fact]
+    public async Task AddAzureCosmosDBWithEmulatorGetDefaultNumberOfPartitions()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos");
+
+        cosmos.RunAsEmulator();
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("2", config["AZURE_COSMOS_EMULATOR_PARTITION_COUNT"]);
+    }
+
+    [Fact]
+    public async Task AddAzureCosmosDBWithEmulatorCanOverrideNumberOfPartitions()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var cosmos = builder.AddAzureCosmosDB("cosmos");
+
+        cosmos.RunAsEmulator(r => r.WithEnvironment("AZURE_COSMOS_EMULATOR_PARTITION_COUNT", "30"));
+        var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
+
+        Assert.Equal("30", config["AZURE_COSMOS_EMULATOR_PARTITION_COUNT"]);
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceExtensionsTests.cs
@@ -185,7 +185,7 @@ public class AzureResourceExtensionsTests
         cosmos.RunAsEmulator();
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(cosmos.Resource, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
-        Assert.Equal("2", config["AZURE_COSMOS_EMULATOR_PARTITION_COUNT"]);
+        Assert.Equal("1", config["AZURE_COSMOS_EMULATOR_PARTITION_COUNT"]);
     }
 
     [Fact]


### PR DESCRIPTION
This helps improve the container startup time for the emulator.

Note that log shows `n+1` partitions being started. For example with `AZURE_COSMOS_EMULATOR_PARTITION_COUNT=1` the container logs show:

```
Started 1/2 partitions
Started 2/2 partitions
Started
```

Fixes https://github.com/dotnet/aspire/issues/2177 .