### PR TITLE
Add debugger display to HealthCheckAnnotation

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/HealthCheckAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/HealthCheckAnnotation.cs
@@ -1,12 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
 /// An annotation which tracks the name of the health check used to detect to health of a resource.
 /// </summary>
 /// <param name="key">The key for the health check in the app host which associated with this resource.</param>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Key = {Key}")]
 public class HealthCheckAnnotation(string key) : IResourceAnnotation
 {
     /// <summary>


### PR DESCRIPTION
I saw this new annotation was missing debugger display info.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5642)