### PR TITLE
Fix buildArgs for dockerfile.v0 schema tests.

### DIFF
--- a/src/Schema/aspire-8.0.json
+++ b/src/Schema/aspire-8.0.json
@@ -38,6 +38,9 @@
               },
               "bindings": {
                 "$ref": "#/definitions/bindings"
+              },
+              "buildArgs": {
+                "$ref": "#/definitions/buildArgs"
               }
             },
             "additionalProperties": false
@@ -523,6 +526,13 @@
         }
       },
       "additionalProperties": false
+    },
+    "buildArgs": {
+      "type": "object",
+      "description": "A list of build arguments which are used during container build (for dockerfile.v0 resource type).",
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "bindings": {
       "type": "object",

--- a/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
@@ -320,6 +320,50 @@ public class SchemaTests
     }
 
     [Fact]
+    public void ManifestWithDockerfileV0ResourceAndBuildFieldAndArgsIsAccepted()
+    {
+        var manifestText = """
+            {
+              "resources": {
+                "mycontainer": {
+                  "type": "dockerfile.v0",
+                  "context": "relativepath",
+                  "path": "relativepath/Dockerfile",
+                  "buildArgs": {
+                    "ARG1": "an arg"
+                  }
+                }
+              }
+            }
+            """;
+
+        AssertValid(manifestText);
+    }
+
+    [Fact]
+    public void ManifestWithContainerV1ResourceAndBuildFieldAndArgsIsAccepted()
+    {
+        var manifestText = """
+            {
+              "resources": {
+                "mycontainer": {
+                  "type": "container.v1",
+                  "build": {
+                    "context": "relativepath",
+                    "dockerfile": "relativepath/Dockerfile",
+                    "args": {
+                      "ARG1": "an arg"
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        AssertValid(manifestText);
+    }
+
+    [Fact]
     public void ManifestWithContainerV1ResourceAndImageFieldIsAccepted()
     {
         var manifestText = """


### PR DESCRIPTION
## Description

We were missing some schema for `dockerfile.v0` and test cases for build args in both `dockerfile.v0` and `container.v1`. Once this merges in the schema needs to be published to schema store as well.

Fixes #4864 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5643)