### PR TITLE
Make volume icon size consistent with other inline icons

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -142,7 +142,7 @@
                             <div>
                                 @if (context.IsReadOnly)
                                 {
-                                    <FluentIcon Value="@(new Icons.Regular.Size12.LockClosed())" />
+                                    <FluentIcon Value="@(new Icons.Regular.Size16.LockClosed())" Style="vertical-align: text-bottom" />
                                 }
                                 @context.MountType
                             </div>


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/5635

Make this icon the same size as other icons inline with standard text: state icon on resources page and error/warning/exception icons on structured logs page.

Before:
![image](https://github.com/user-attachments/assets/9e04e625-85c3-4de6-9591-3e326283de08)

After:
![image](https://github.com/user-attachments/assets/1f6b6ee8-df96-41d4-8bc5-e85c286b1ccd)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5644)