### PR TITLE
[tests] SlimTestProgramTests: Wait for services to start

### DIFF
--- a/tests/Aspire.Hosting.Tests/SlimTestProgramTests.cs
+++ b/tests/Aspire.Hosting.Tests/SlimTestProgramTests.cs
@@ -17,7 +17,6 @@ public class SlimTestProgramTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/5637", TestPlatforms.Windows)]
     public async Task TestProjectStartsAndStopsCleanly()
     {
         var testProgram = _slimTestProgramFixture.TestProgram;
@@ -42,7 +41,6 @@ public class SlimTestProgramTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/5637", TestPlatforms.Windows)]
     public async Task TestPortOnEndpointAnnotationAndAllocatedEndpointAnnotationMatch()
     {
         var testProgram = _slimTestProgramFixture.TestProgram;
@@ -61,7 +59,6 @@ public class SlimTestProgramTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/aspire/issues/5637", TestPlatforms.Windows)]
     public async Task TestPortOnEndpointAnnotationAndAllocatedEndpointAnnotationMatchForReplicatedServices()
     {
         var testProgram = _slimTestProgramFixture.TestProgram;

--- a/tests/Aspire.Hosting.Tests/TestProgramFixture.cs
+++ b/tests/Aspire.Hosting.Tests/TestProgramFixture.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.Testing;
+using Aspire.Hosting.Tests.Utils;
 using Xunit;
 
 namespace Aspire.Hosting.Tests;
@@ -63,12 +64,15 @@ public class SlimTestProgramFixture : TestProgramFixture
     public override async Task WaitReadyStateAsync(CancellationToken cancellationToken = default)
     {
         // Make sure services A, B and C are running
+        await App.WaitForTextAsync("Application started.", "servicea", cancellationToken);
         using var clientA = App.CreateHttpClient(TestProgram.ServiceABuilder.Resource.Name, "http");
         await clientA.GetStringAsync("/", cancellationToken);
 
+        await App.WaitForTextAsync("Application started.", "serviceb", cancellationToken);
         using var clientB = App.CreateHttpClient(TestProgram.ServiceBBuilder.Resource.Name, "http");
         await clientB.GetStringAsync("/", cancellationToken);
 
+        await App.WaitForTextAsync("Application started.", "servicec", cancellationToken);
         using var clientC = App.CreateHttpClient(TestProgram.ServiceCBuilder.Resource.Name, "http");
         await clientC.GetStringAsync("/", cancellationToken);
     }


### PR DESCRIPTION
The HttpClient used in the tests don't have resilience, so if
`TestProgram` takes longer to startup, then http requests to the
services can fail.

Instead, explicitly wait for `Application started` messages on the
services before sending a request.

Fixes https://github.com/dotnet/aspire/issues/5637

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5668)