### PR TITLE
[tests] Disable '/ef' endpoint for cosmos in Playground tests

### DIFF
--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -191,7 +191,8 @@ public class AppHostTests
                     new ("milvus", "Milvus Proxy successfully initialized and ready to serve"),
                 ]),
             new TestEndpoints("CosmosEndToEnd.AppHost",
-                resourceEndpoints: new() { { "api", ["/alive", "/health", "/", "/ef"] } },
+                resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
+                // "/ef" - disabled due to https://github.com/dotnet/aspire/issues/5415
                 waitForTexts: [
                     new ("cosmos", "Started$"),
                     new ("api", "Application started")


### PR DESCRIPTION
Issue: https://github.com/dotnet/aspire/issues/5415

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5671)