### PR TITLE
Don't throw from hosted services

### DIFF
--- a/src/Aspire.Hosting.Testing/ResourceLoggerForwarderService.cs
+++ b/src/Aspire.Hosting.Testing/ResourceLoggerForwarderService.cs
@@ -52,7 +52,7 @@ internal sealed class ResourceLoggerForwarderService(
 
             await Task.WhenAll(logWatchTasks).ConfigureAwait(false);
         }
-        catch (TaskCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             // this was expected as the token was canceled
         }

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckScheduler.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckScheduler.cs
@@ -33,16 +33,23 @@ internal class ResourceHealthCheckScheduler : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var resourceEvents = _resourceNotificationService.WatchAsync(stoppingToken);
-
-        await foreach (var resourceEvent in resourceEvents.ConfigureAwait(false))
+        try
         {
-            if (resourceEvent.Snapshot.State?.Text == KnownResourceStates.Running)
+            var resourceEvents = _resourceNotificationService.WatchAsync(stoppingToken);
+
+            await foreach (var resourceEvent in resourceEvents.ConfigureAwait(false))
             {
-                // Each time we receive an event that tells us that the resource is
-                // running we need to enable the health check annotation.
-                UpdateCheckEnablement(resourceEvent.Resource, true);
+                if (resourceEvent.Snapshot.State?.Text == KnownResourceStates.Running)
+                {
+                    // Each time we receive an event that tells us that the resource is
+                    // running we need to enable the health check annotation.
+                    UpdateCheckEnablement(resourceEvent.Resource, true);
+                }
             }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // This was expected as the token was canceled
         }
     }
 

--- a/tests/Aspire.Hosting.Testing.Tests/ResourceLoggerForwarderServiceTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/ResourceLoggerForwarderServiceTests.cs
@@ -27,7 +27,7 @@ public class ResourceLoggerForwarderServiceTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task ExecuteThrowsOperationCanceledWhenAppStoppingTokenSignaled()
+    public async Task ExecuteDoesNotThrowOperationCanceledWhenAppStoppingTokenSignaled()
     {
         var hostApplicationLifetime = new TestHostApplicationLifetime();
         var resourceNotificationService = new ResourceNotificationService(NullLogger<ResourceNotificationService>.Instance, hostApplicationLifetime);
@@ -44,10 +44,7 @@ public class ResourceLoggerForwarderServiceTests(ITestOutputHelper output)
         // Signal the stopping token
         hostApplicationLifetime.StopApplication();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-        {
-            await resourceLogForwarder.ExecuteTask;
-        });
+        await resourceLogForwarder.ExecuteTask;
     }
 
     [Fact]


### PR DESCRIPTION
- Shutting down the host cancels the hosted services and they shouldn't throw as a result. This reduces noise in tests as they call stop on the host on failure resulting in more exceptions than necessary

Should clean up errors like these:

```
fail: Microsoft.Extensions.Hosting.Internal.Host[9]
      BackgroundService failed
      System.OperationCanceledException: The operation was canceled.
         at System.Threading.Channels.AsyncOperation`1.GetResult(Int16 token)
         at System.Threading.Channels.ChannelReader`1.ReadAllAsync(CancellationToken cancellationToken)+MoveNext()
         at System.Threading.Channels.ChannelReader`1.ReadAllAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
         at Aspire.Hosting.ApplicationModel.ResourceNotificationService.WatchAsync(CancellationToken cancellationToken)+MoveNext() in /_/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs:line 168
         at Aspire.Hosting.ApplicationModel.ResourceNotificationService.WatchAsync(CancellationToken cancellationToken)+MoveNext() in /_/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs:line 168
         at Aspire.Hosting.ApplicationModel.ResourceNotificationService.WatchAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
         at Aspire.Hosting.Testing.ResourceLoggerForwarderService.WatchNotifications(CancellationToken cancellationToken) in /_/src/Aspire.Hosting.Testing/ResourceLoggerForwarderService.cs:line 42
         at Aspire.Hosting.Testing.ResourceLoggerForwarderService.WatchNotifications(CancellationToken cancellationToken) in /_/src/Aspire.Hosting.Testing/ResourceLoggerForwarderService.cs:line 42
         at Microsoft.Extensions.Hosting.Internal.Host.TryExecuteBackgroundServiceAsync(BackgroundService backgroundService)
```

and these:

```
BackgroundService failed
      System.OperationCanceledException: The operation was canceled.
         at System.Threading.Channels.AsyncOperation`1.GetResult(Int16 token)
         at System.Threading.Channels.ChannelReader`1.ReadAllAsync(CancellationToken cancellationToken)+MoveNext()
         at System.Threading.Channels.ChannelReader`1.ReadAllAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
         at Aspire.Hosting.ApplicationModel.ResourceNotificationService.WatchAsync(CancellationToken cancellationToken)+MoveNext() in /_/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs:line 168
         at Aspire.Hosting.ApplicationModel.ResourceNotificationService.WatchAsync(CancellationToken cancellationToken)+MoveNext() in /_/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs:line 168
         at Aspire.Hosting.ApplicationModel.ResourceNotificationService.WatchAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
         at Aspire.Hosting.Health.ResourceHealthCheckScheduler.ExecuteAsync(CancellationToken stoppingToken) in /_/src/Aspire.Hosting/Health/ResourceHealthCheckScheduler.cs:line 38
         at Aspire.Hosting.Health.ResourceHealthCheckScheduler.ExecuteAsync(CancellationToken stoppingToken) in /_/src/Aspire.Hosting/Health/ResourceHealthCheckScheduler.cs:line 38
         at Microsoft.Extensions.Hosting.Internal.Host.TryExecuteBackgroundServiceAsync(BackgroundService backgroundService)
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5699)