### PR TITLE
Refactor console logs page and friends

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -7,8 +7,7 @@
     ForId="@_selectId"
     Orientation="Orientation.Horizontal" />
 
-<FluentSelect @ref="_resourceSelectComponent"
-              Items="Resources"
+<FluentSelect Items="Resources"
               Id="@_selectId"
               OptionValue="@(c => c!.Name)"
               OptionDisabled="@(c => !CanSelectGrouping && c!.Id?.Type is Otlp.Model.OtlpApplicationType.ResourceGrouping)"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -4,7 +4,6 @@
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Microsoft.AspNetCore.Components;
-using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Controls;
@@ -35,33 +34,9 @@ public partial class ResourceSelect
     [Inject]
     public required IJSRuntime JS { get; init; }
 
-    private FluentSelect<SelectViewModel<ResourceTypeDetails>>? _resourceSelectComponent;
-
     private static void ValuedChanged(string value)
     {
         // Do nothing. Required for bunit change to trigger SelectedOptionChanged.
-    }
-
-    /// <summary>
-    /// Workaround for issue in fluent-select web component where the display value of the
-    /// selected item doesn't update automatically when the item changes.
-    /// </summary>
-    public async ValueTask UpdateDisplayValueAsync()
-    {
-        if (_resourceSelectComponent is null)
-        {
-            return;
-        }
-
-        try
-        {
-            await JS.InvokeVoidAsync("updateFluentSelectDisplayValue", _resourceSelectComponent.Element);
-        }
-        catch (JSDisconnectedException)
-        {
-            // Per https://learn.microsoft.com/aspnet/core/blazor/javascript-interoperability/?view=aspnetcore-7.0#javascript-interop-calls-without-a-circuit
-            // this is one of the calls that will fail if the circuit is disconnected, and we just need to catch the exception so it doesn't pollute the logs
-        }
     }
 
     private string? GetPopupHeight()

--- a/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.cs
@@ -91,7 +91,11 @@ public partial class AspirePageContentLayout : ComponentBase
                 Modal = false,
                 PrimaryAction = null,
                 SecondaryAction = null,
-                OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, InvokeListeners)
+                OnDialogClosing = EventCallback.Factory.Create<DialogInstance>(this, async () =>
+                {
+                    await InvokeListenersAsync();
+                    _toolbarPanel = null;
+                })
             });
     }
 
@@ -101,13 +105,13 @@ public partial class AspirePageContentLayout : ComponentBase
         {
             await _toolbarPanel.CloseAsync();
             // CloseAsync doesn't invoke OnDialogClosing, so we need to call InvokeListeners ourselves
-            await InvokeListeners();
+            await InvokeListenersAsync();
 
             _toolbarPanel = null;
         }
     }
 
-    private async Task InvokeListeners()
+    private async Task InvokeListenersAsync()
     {
         foreach (var dialogCloseListener in DialogCloseListeners.Values)
         {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -3,8 +3,6 @@
 
 @using Aspire.Dashboard.Resources
 @namespace Aspire.Dashboard.Components.Pages
-@inject IStringLocalizer<Dashboard.Resources.ConsoleLogs> Loc
-@inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
 <PageTitle><ApplicationName ResourceName="@nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsPageTitle)" Loc="@Loc" /></PageTitle>
 
@@ -18,8 +16,7 @@
             <h1 class="page-header">@Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsHeader)]</h1>
         </PageTitleSection>
         <ToolbarSection>
-            <ResourceSelect @ref="_resourceSelectComponent"
-                            Resources="_resources"
+            <ResourceSelect Resources="_resources"
                             AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.ResourceLabel)]"
                             @bind-SelectedResource="PageViewModel.SelectedOption"
                             @bind-SelectedResource:after="HandleSelectedOptionChangedAsync" />
@@ -32,7 +29,7 @@
 
         <MobilePageTitleToolbarSection>
             <FluentLabel Typo="Typography.Body" aria-live="polite" aria-label="@Loc[nameof(Dashboard.Resources.ConsoleLogs.LogStatusLabel)]">
-                @if (PageViewModel.SelectedOption.Id is not null)
+                @if (PageViewModel.SelectedOption?.Id is not null)
                 {
                     @($"{PageViewModel.SelectedOption.Name}: {PageViewModel.Status}")
                 }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -4,8 +4,8 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Aspire.Dashboard.Components.Controls;
 using Aspire.Dashboard.Components.Layout;
+using Aspire.Dashboard.ConsoleLogs;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
@@ -13,11 +13,23 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Localization;
 
 namespace Aspire.Dashboard.Components.Pages;
 
 public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPageWithSessionAndUrlState<ConsoleLogs.ConsoleLogsViewModel, ConsoleLogs.ConsoleLogsPageState>
 {
+    private sealed class ConsoleLogsSubscription
+    {
+        private readonly CancellationTokenSource _cts = new();
+
+        public required string Name { get; init; }
+        public Task? SubscriptionTask { get; set; }
+
+        public CancellationToken CancellationToken => _cts.Token;
+        public void Cancel() => _cts.Cancel();
+    }
+
     [Inject]
     public required IDashboardClient DashboardClient { get; init; }
 
@@ -33,21 +45,25 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     [Inject]
     public required DimensionManager DimensionManager { get; init; }
 
+    [Inject]
+    public required IStringLocalizer<Dashboard.Resources.ConsoleLogs> Loc { get; init; }
+
+    [Inject]
+    public required IStringLocalizer<ControlsStrings> ControlsStringsLoc { get; init; }
+
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; init; }
 
     [Parameter]
     public string? ResourceName { get; set; }
 
-    private readonly TaskCompletionSource _whenDomReady = new();
     private readonly CancellationTokenSource _resourceSubscriptionCancellation = new();
-    private readonly CancellationSeries _logSubscriptionCancellationSeries = new();
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private ImmutableList<SelectViewModel<ResourceTypeDetails>>? _resources;
     private Task? _resourceSubscriptionTask;
+    private ConsoleLogsSubscription? _consoleLogsSubscription;
 
     // UI
-    private ResourceSelect? _resourceSelectComponent;
     private SelectViewModel<ResourceTypeDetails> _noSelection = null!;
     private LogViewer _logViewer = null!;
     private AspirePageContentLayout? _contentLayout;
@@ -149,32 +165,38 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     protected override async Task OnParametersSetAsync()
     {
-        if (DimensionManager.IsResizing && PageViewModel.InitialisedSuccessfully is true)
+        Logger.LogDebug("Initializing console logs view model.");
+        if (await this.InitializeViewModelAsync())
         {
             return;
         }
 
-        Logger.LogDebug("Initializing console logs view model.");
-        await this.InitializeViewModelAsync();
-
-        await ClearLogsAsync();
-
-        if (PageViewModel.SelectedResource is not null)
+        if (PageViewModel.SelectedResource?.Name != _consoleLogsSubscription?.Name)
         {
-            await LoadLogsAsync();
-        }
-        else
-        {
-            await StopWatchingLogsAsync();
-        }
-    }
+            ConsoleLogsSubscription? newConsoleLogsSubscription = null;
+            if (PageViewModel.SelectedResource is not null)
+            {
+                newConsoleLogsSubscription = new ConsoleLogsSubscription { Name = PageViewModel.SelectedResource!.Name };
+            }
 
-    protected override void OnAfterRender(bool firstRender)
-    {
-        if (firstRender)
-        {
-            // Let anyone waiting know that the render is complete, so we have access to the underlying log viewer.
-            _whenDomReady.SetResult();
+            if (_consoleLogsSubscription is { } currentSubscription)
+            {
+                currentSubscription.Cancel();
+                _consoleLogsSubscription = newConsoleLogsSubscription;
+
+                await TaskHelpers.WaitIgnoreCancelAsync(currentSubscription.SubscriptionTask);
+            }
+            else
+            {
+                _consoleLogsSubscription = newConsoleLogsSubscription;
+            }
+
+            ClearLogs();
+
+            if (newConsoleLogsSubscription is not null)
+            {
+                LoadLogs(newConsoleLogsSubscription);
+            }
         }
     }
 
@@ -249,61 +271,75 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     private void UpdateResourcesList() => _resources = GetConsoleLogResourceSelectViewModels(_resourceByName, _noSelection, Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsUnknownState)]);
 
-    private Task ClearLogsAsync()
+    private void ClearLogs()
     {
-        return _logViewer is not null ? _logViewer.ClearLogsAsync() : Task.CompletedTask;
+        _logViewer?.ClearLogs();
     }
 
-    private async ValueTask LoadLogsAsync()
+    private void LoadLogs(ConsoleLogsSubscription newConsoleLogsSubscription)
     {
-        // Wait for the first render to complete so that the log viewer is available
-        await _whenDomReady.Task;
-
-        if (PageViewModel.SelectedResource is null)
-        {
-            PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsNoResourceSelected)];
-        }
-        else if (_logViewer is null)
+        if (_logViewer is null)
         {
             PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsInitializingLogViewer)];
         }
         else
         {
-            Logger.LogDebug("Subscribing to console logs for resource {ResourceName}.", PageViewModel.SelectedResource.Name);
-
-            var cancellationToken = await _logSubscriptionCancellationSeries.NextAsync();
-
-            var subscription = DashboardClient.SubscribeConsoleLogs(PageViewModel.SelectedResource.Name, cancellationToken);
-
-            if (subscription is not null)
+            var consoleLogsTask = Task.Run(async () =>
             {
-                var task = _logViewer.SetLogSourceAsync(PageViewModel.SelectedResource.Name, subscription);
+                newConsoleLogsSubscription.CancellationToken.ThrowIfCancellationRequested();
 
-                PageViewModel.InitialisedSuccessfully = true;
+                Logger.LogDebug("Subscribing to console logs for resource {ResourceName}.", newConsoleLogsSubscription.Name);
+
+                var subscription = DashboardClient.SubscribeConsoleLogs(newConsoleLogsSubscription.Name, newConsoleLogsSubscription.CancellationToken);
+
                 PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsWatchingLogs)];
+                await InvokeAsync(StateHasChanged);
 
-                // Indicate when logs finish (other than by cancellation).
-                _ = task.ContinueWith(
-                    _ => PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs)],
-                    CancellationToken.None,
-                    TaskContinuationOptions.NotOnCanceled,
-                    TaskScheduler.Current);
-            }
-            else
-            {
-                PageViewModel.InitialisedSuccessfully = false;
-                PageViewModel.Status = Loc[PageViewModel.SelectedResource.IsContainer()
-                    ? nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsFailedToInitialize)
-                    : nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLogsNotYetAvailable)];
-            }
+                try
+                {
+                    var logParser = new LogParser();
+                    await foreach (var batch in subscription.ConfigureAwait(true))
+                    {
+                        if (batch.Count is 0)
+                        {
+                            continue;
+                        }
+
+                        foreach (var (lineNumber, content, isErrorOutput) in batch)
+                        {
+                            // Set the base line number using the reported line number of the first log line.
+                            if (_logViewer.LogEntries.EntriesCount == 0)
+                            {
+                                _logViewer.LogEntries.BaseLineNumber = lineNumber;
+                            }
+
+                            var logEntry = logParser.CreateLogEntry(content, isErrorOutput);
+                            _logViewer.LogEntries.InsertSorted(logEntry);
+                        }
+
+                        await _logViewer.LogsAddedAsync();
+                    }
+                }
+                finally
+                {
+                    Logger.LogDebug("Finished watching logs for resource {ResourceName}.", newConsoleLogsSubscription.Name);
+
+                    // If the subscription is being canceled then a new one could be starting.
+                    // Don't set the status when finishing because overwrite the status from the new subscription.
+                    if (!newConsoleLogsSubscription.CancellationToken.IsCancellationRequested)
+                    {
+                        PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs)];
+                        await InvokeAsync(StateHasChanged);
+                    }
+                }
+            });
+
+            newConsoleLogsSubscription.SubscriptionTask = consoleLogsTask;
         }
     }
 
     private async Task HandleSelectedOptionChangedAsync()
     {
-        await StopWatchingLogsAsync();
-        await ClearLogsAsync();
-
         PageViewModel.SelectedResource = PageViewModel.SelectedOption?.Id?.InstanceId is null ? null : _resourceByName[PageViewModel.SelectedOption.Id.InstanceId];
         await this.AfterViewModelChangedAsync(_contentLayout, isChangeInToolbar: false);
     }
@@ -336,12 +372,16 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         }
 
         await InvokeAsync(StateHasChanged);
+    }
 
-        // Workaround for issue in fluent-select web component where the display value of the
-        // selected item doesn't update automatically when the item changes
-        if (_resourceSelectComponent is not null)
+    private async Task StopAndClearConsoleLogsSubscriptionAsync()
+    {
+        if (_consoleLogsSubscription is { } consoleLogsSubscription)
         {
-            await _resourceSelectComponent.UpdateDisplayValueAsync();
+            consoleLogsSubscription.Cancel();
+            await TaskHelpers.WaitIgnoreCancelAsync(consoleLogsSubscription.SubscriptionTask);
+
+            _consoleLogsSubscription = null;
         }
     }
 
@@ -349,10 +389,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     {
         await _resourceSubscriptionCancellation.CancelAsync();
         _resourceSubscriptionCancellation.Dispose();
-
-        await StopWatchingLogsAsync();
-
         await TaskHelpers.WaitIgnoreCancelAsync(_resourceSubscriptionTask);
+
+        await StopAndClearConsoleLogsSubscriptionAsync();
 
         if (_logViewer is { } logViewer)
         {
@@ -360,14 +399,11 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         }
     }
 
-    private Task StopWatchingLogsAsync() => _logSubscriptionCancellationSeries.ClearAsync();
-
     public class ConsoleLogsViewModel
     {
         public required string Status { get; set; }
         public required SelectViewModel<ResourceTypeDetails> SelectedOption { get; set; }
         public required ResourceViewModel? SelectedResource { get; set; }
-        public bool? InitialisedSuccessfully { get; set; }
     }
 
     public class ConsoleLogsPageState
@@ -383,7 +419,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
             viewModel.SelectedOption = selectedOption;
             viewModel.SelectedResource = selectedOption.Id?.InstanceId is null ? null : _resourceByName[selectedOption.Id.InstanceId];
-            viewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLogsNotYetAvailable)];
+            viewModel.Status ??= Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLogsNotYetAvailable)];
         }
         else
         {

--- a/src/Aspire.Dashboard/Components/Pages/IPageWithSessionAndUrlState.cs
+++ b/src/Aspire.Dashboard/Components/Pages/IPageWithSessionAndUrlState.cs
@@ -79,7 +79,14 @@ public static class PageExtensions
         }
     }
 
-    public static async Task InitializeViewModelAsync<TViewModel, TSerializableViewModel>(this IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel> page) where TSerializableViewModel : class
+    /// <summary>
+    /// If first visiting the page then initialize page state from storage and redirect using page state.
+    /// </summary>
+    /// <returns>
+    /// A value indicating whether there was a page redirect. Further page initialization should check the return value
+    /// and wait until parameters are updated if there was a page redirect.
+    /// </returns>
+    public static async Task<bool> InitializeViewModelAsync<TViewModel, TSerializableViewModel>(this IPageWithSessionAndUrlState<TViewModel, TSerializableViewModel> page) where TSerializableViewModel : class
     {
         if (string.Equals(page.BasePath, page.NavigationManager.ToBaseRelativePath(page.NavigationManager.Uri)))
         {
@@ -92,12 +99,13 @@ public static class PageExtensions
                 if (newUrl != "/" + page.BasePath)
                 {
                     page.NavigationManager.NavigateTo(newUrl);
-                    return;
+                    return true;
                 }
             }
         }
 
         ArgumentNullException.ThrowIfNull(page.PageViewModel, nameof(page.PageViewModel));
         page.UpdateViewModelFromQuery(page.PageViewModel);
+        return false;
     }
 }

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -101,7 +101,10 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
 
     protected override async Task OnParametersSetAsync()
     {
-        await this.InitializeViewModelAsync();
+        if (await this.InitializeViewModelAsync())
+        {
+            return;
+        }
         UpdateSubscription();
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -191,7 +191,10 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
 
     protected override async Task OnParametersSetAsync()
     {
-        await this.InitializeViewModelAsync();
+        if (await this.InitializeViewModelAsync())
+        {
+            return;
+        }
         UpdateSubscription();
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -158,7 +158,10 @@ public partial class Traces : IPageWithSessionAndUrlState<TracesPageViewModel, T
 
     protected override async Task OnParametersSetAsync()
     {
-        await this.InitializeViewModelAsync();
+        if (await this.InitializeViewModelAsync())
+        {
+            return;
+        }
 
         TracesViewModel.ApplicationKey = PageViewModel.SelectedApplication.Id?.GetApplicationKey();
         UpdateSubscription();

--- a/src/Aspire.Dashboard/Components/Resize/BrowserDimensionWatcher.cs
+++ b/src/Aspire.Dashboard/Components/Resize/BrowserDimensionWatcher.cs
@@ -50,14 +50,12 @@ public class BrowserDimensionWatcher : ComponentBase
             || newViewportInformation.IsUltraLowWidth != ViewportInformation.IsUltraLowWidth)
         {
             ViewportInformation = newViewportInformation;
-            DimensionManager.IsResizing = true;
             // A re-render happens on components after ViewportInformationChanged is invoked
             // we should invoke InvokeOnViewportInformationChanged first so that listeners of it
             // that are outside of the UI tree have the current viewport kind internally when components
             // call them
             DimensionManager.InvokeOnViewportInformationChanged(newViewportInformation);
             await ViewportInformationChanged.InvokeAsync(newViewportInformation);
-            DimensionManager.IsResizing = false;
         }
     }
 }

--- a/src/Aspire.Dashboard/Components/Resize/DimensionManager.cs
+++ b/src/Aspire.Dashboard/Components/Resize/DimensionManager.cs
@@ -11,7 +11,6 @@ public class DimensionManager
     public event ViewportSizeChangedEventHandler? OnViewportSizeChanged;
     public event ViewportInformationChangedEventHandler? OnViewportInformationChanged;
 
-    public bool IsResizing { get; set; }
     public ViewportInformation ViewportInformation => _viewportInformation ?? throw new ArgumentNullException(nameof(_viewportInformation));
     public ViewportSize ViewportSize=> _viewportSize ?? throw new ArgumentNullException(nameof(_viewportSize));
 

--- a/src/Aspire.Dashboard/Model/Otlp/SelectViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SelectViewModel.cs
@@ -6,10 +6,28 @@ using System.Diagnostics;
 namespace Aspire.Dashboard.Model.Otlp;
 
 [DebuggerDisplay(@"Name = {Name}, Id = \{{Id}\}")]
-public class SelectViewModel<T>
+public class SelectViewModel<T> : IEquatable<SelectViewModel<T>>
 {
     public required string Name { get; init; }
     public required T? Id { get; init; }
+
+    public bool Equals(SelectViewModel<T>? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        // Allow the type to implement IEquatable for when comparing SelectViewModel.
+        // Complex types can implement the interface so they can match by more than just reference.
+        // The is important for when lists check the selected item is a value in the items list.
+        // If it isn't then the list clears the selected value.
+        return EqualityComparer<T>.Default.Equals(Id, other.Id);
+    }
 
     public override string ToString()
     {

--- a/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
+++ b/src/Aspire.Dashboard/Model/ResourceTypeDetails.cs
@@ -8,7 +8,7 @@ using Aspire.Dashboard.Otlp.Storage;
 namespace Aspire.Dashboard.Model;
 
 [DebuggerDisplay("Type = {Type}, InstanceId = {InstanceId}, ReplicaSetName = {ReplicaSetName}")]
-public class ResourceTypeDetails
+public class ResourceTypeDetails : IEquatable<ResourceTypeDetails>
 {
     private ResourceTypeDetails(OtlpApplicationType type, string? instanceId, string? replicaSetName)
     {
@@ -49,5 +49,20 @@ public class ResourceTypeDetails
     public override string ToString()
     {
         return $"Type = {Type}, InstanceId = {InstanceId}, ReplicaSetName = {ReplicaSetName}";
+    }
+
+    public bool Equals(ResourceTypeDetails? other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+
+        if (Type != other.Type || InstanceId != other.InstanceId || ReplicaSetName != other.ReplicaSetName)
+        {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
@@ -458,7 +458,7 @@ internal sealed class DashboardClient : IDashboardClient
         }
     }
 
-    async IAsyncEnumerable<IReadOnlyList<ResourceLogLine>>? IDashboardClient.SubscribeConsoleLogs(string resourceName, [EnumeratorCancellation] CancellationToken cancellationToken)
+    async IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> IDashboardClient.SubscribeConsoleLogs(string resourceName, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         EnsureInitialized();
 

--- a/src/Aspire.Dashboard/ResourceService/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/ResourceService/IDashboardClient.cs
@@ -49,7 +49,7 @@ public interface IDashboardClient : IAsyncDisposable
     /// </remarks>
     /// <para>It is important that callers trigger <paramref name="cancellationToken"/>
     /// so that resources owned by the sequence and its consumers can be freed.</para>
-    IAsyncEnumerable<IReadOnlyList<ResourceLogLine>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken);
+    IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken);
 
     Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken);
 }

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -160,12 +160,6 @@ window.copyTextToClipboard = function (id, text, precopy, postcopy) {
    }, 1500);
 };
 
-window.updateFluentSelectDisplayValue = function (fluentSelect) {
-    if (fluentSelect) {
-        fluentSelect.updateDisplayValue();
-    }
-}
-
 function isActiveElementInput() {
     const currentElement = document.activeElement;
     // fluent components may have shadow roots that contain inputs

--- a/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
+++ b/tests/Aspire.Dashboard.Components.Tests/Aspire.Dashboard.Components.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <Compile Include="$(TestsSharedDir)Telemetry\*.cs" LinkBase="shared/Telemetry" />
+    <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
@@ -51,7 +51,7 @@ public class ApplicationNameTests : TestContext
         public string ApplicationName => "<marquee>An HTML title!</marquee>";
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
     }
 }

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -1,0 +1,154 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Frozen;
+using System.Threading.Channels;
+using Aspire.Dashboard.Components.Resize;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.BrowserStorage;
+using Bunit;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.FluentUI.AspNetCore.Components;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Dashboard.Components.Tests.Pages;
+
+[UseCulture("en-US")]
+public partial class ConsoleLogsTests : TestContext
+{
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public ConsoleLogsTests(ITestOutputHelper testOutputHelper)
+    {
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public void ResourceName_MultiRender_SubscribeConsoleLogsOnce()
+    {
+        // Arrange
+        var subscribedResourceNames = new List<string>();
+        var consoleLogsChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceLogLine>>();
+        var resourceChannel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(
+            isEnabled: true,
+            consoleLogsChannelProvider: name =>
+            {
+                subscribedResourceNames.Add(name);
+                return consoleLogsChannel;
+            },
+            resourceChannelProvider: () => resourceChannel);
+
+        SetupConsoleLogsServices(dashboardClient);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
+        // Act
+        var cut = RenderComponent<Components.Pages.ConsoleLogs>(builder =>
+        {
+            builder.Add(p => p.ResourceName, "test-resource");
+            builder.Add(p => p.ViewportInformation, viewport);
+        });
+
+        var instance = cut.Instance;
+        var logger = Services.GetRequiredService<ILogger<ConsoleLogsTests>>();
+        var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
+
+        logger.LogInformation("Console log page is waiting for resource.");
+        cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsLoadingResources)]);
+
+        var testResource = CreateResourceViewModel("test-resource", KnownResourceState.Running);
+        resourceChannel.Writer.TryWrite([
+            new ResourceViewModelChange(ResourceViewModelChangeType.Upsert, testResource)
+        ]);
+
+        // Assert
+        logger.LogInformation("Waiting for selected resource.");
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource == testResource);
+        cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsWatchingLogs)]);
+
+        // Ensure component is rendered again.
+        cut.SetParametersAndRender(builder => { });
+
+        consoleLogsChannel.Writer.TryWrite([new ResourceLogLine(1, "Test content", IsErrorMessage: false)]);
+        consoleLogsChannel.Writer.Complete();
+
+        logger.LogInformation("Waiting for finish message.");
+        cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs)]);
+
+        Assert.Equal("test-resource", Assert.Single(subscribedResourceNames));
+    }
+
+    private void SetupConsoleLogsServices(TestDashboardClient? dashboardClient = null)
+    {
+        var version = typeof(FluentMain).Assembly.GetName().Version!;
+
+        var dividerModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Divider/FluentDivider.razor.js", version));
+        dividerModule.SetupVoid("setDividerAriaOrientation");
+
+        var inputLabelModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Label/FluentInputLabel.razor.js", version));
+        inputLabelModule.SetupVoid("setInputAriaLabel", _ => true);
+
+        var listModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/List/ListComponentBase.razor.js", version));
+
+        var searchModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Search/FluentSearch.razor.js", version));
+        searchModule.SetupVoid("addAriaHidden", _ => true);
+
+        var keycodeModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/KeyCode/FluentKeyCode.razor.js", version));
+        keycodeModule.Setup<string>("RegisterKeyCode", _ => true);
+
+        JSInterop.SetupVoid("initializeContinuousScroll");
+        JSInterop.SetupVoid("resetContinuousScrollPosition");
+
+        var loggerFactory = IntegrationTestHelpers.CreateLoggerFactory(_testOutputHelper);
+
+        Services.AddLocalization();
+        Services.AddSingleton<ILoggerFactory>(loggerFactory);
+        Services.AddSingleton<BrowserTimeProvider, TestTimeProvider>();
+        Services.AddSingleton<IMessageService, MessageService>();
+        Services.AddSingleton<IOptions<DashboardOptions>>(Options.Create(new DashboardOptions()));
+        Services.AddSingleton<DimensionManager>();
+        Services.AddSingleton<IDialogService, DialogService>();
+        Services.AddSingleton<ISessionStorage, TestSessionStorage>();
+        Services.AddSingleton<ILocalStorage, TestLocalStorage>();
+        Services.AddSingleton<ShortcutManager>();
+        Services.AddSingleton<LibraryConfiguration>();
+        Services.AddSingleton<IKeyCodeService, KeyCodeService>();
+        Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient());
+    }
+
+    private static string GetFluentFile(string filePath, Version version)
+    {
+        return $"{filePath}?v={version}";
+    }
+
+    // display name will be replica set when there are multiple resources with the same display name
+    private static ResourceViewModel CreateResourceViewModel(string appName, KnownResourceState? state, string? displayName = null)
+    {
+        return new ResourceViewModel
+        {
+            Name = appName,
+            ResourceType = "CustomResource",
+            DisplayName = displayName ?? appName,
+            Uid = Guid.NewGuid().ToString(),
+            CreationTimeStamp = DateTime.UtcNow,
+            Environment = [],
+            Properties = FrozenDictionary<string, Value>.Empty,
+            Urls = [],
+            Volumes = [],
+            State = state?.ToString(),
+            KnownState = state,
+            StateStyle = null,
+            Commands = []
+        };
+    }
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/IntegrationTestHelpers.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using Xunit.Abstractions;
+
+namespace Aspire.Dashboard.Components.Tests.Shared;
+
+public static class IntegrationTestHelpers
+{
+    public static ILoggerFactory CreateLoggerFactory(ITestOutputHelper testOutputHelper, ITestSink? testSink = null)
+    {
+        return LoggerFactory.Create(builder =>
+        {
+            builder.AddXunit(testOutputHelper, LogLevel.Trace, DateTimeOffset.UtcNow);
+            builder.SetMinimumLevel(LogLevel.Trace);
+            if (testSink != null)
+            {
+                builder.AddProvider(new TestLoggerProvider(testSink));
+            }
+        });
+    }
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/TestDashboardClient.cs
@@ -1,19 +1,34 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Aspire.Dashboard.Model;
 
 namespace Aspire.Dashboard.Components.Tests.Shared;
 
 public class TestDashboardClient : IDashboardClient
 {
+    private readonly Func<string, Channel<IReadOnlyList<ResourceLogLine>>>? _consoleLogsChannelProvider;
+    private readonly Func<Channel<IReadOnlyList<ResourceViewModelChange>>>? _resourceChannelProvider;
+
     public bool IsEnabled { get; }
     public Task WhenConnected { get; } = Task.CompletedTask;
     public string ApplicationName { get; } = "TestApp";
 
+    public TestDashboardClient(
+        bool? isEnabled = false,
+        Func<string, Channel<IReadOnlyList<ResourceLogLine>>>? consoleLogsChannelProvider = null,
+        Func<Channel<IReadOnlyList<ResourceViewModelChange>>>? resourceChannelProvider = null)
+    {
+        IsEnabled = isEnabled ?? false;
+        _consoleLogsChannelProvider = consoleLogsChannelProvider;
+        _resourceChannelProvider = resourceChannelProvider;
+    }
+
     public ValueTask DisposeAsync()
     {
-        throw new NotImplementedException();
+        return default;
     }
 
     public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken)
@@ -21,13 +36,38 @@ public class TestDashboardClient : IDashboardClient
         throw new NotImplementedException();
     }
 
-    public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken)
+    public async IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        if (_consoleLogsChannelProvider == null)
+        {
+            throw new InvalidOperationException("No channel provider set.");
+        }
+
+        var channel = _consoleLogsChannelProvider(resourceName);
+
+        await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken))
+        {
+            yield return item;
+        }
     }
 
     public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken)
     {
-        throw new NotImplementedException();
+        if (_resourceChannelProvider == null)
+        {
+            throw new InvalidOperationException("No channel provider set.");
+        }
+
+        var channel = _resourceChannelProvider();
+
+        return Task.FromResult(new ResourceViewModelSubscription([], BuildSubscription(channel, cancellationToken)));
+
+        async static IAsyncEnumerable<IReadOnlyList<ResourceViewModelChange>> BuildSubscription(Channel<IReadOnlyList<ResourceViewModelChange>> channel, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await foreach (var item in channel.Reader.ReadAllAsync(cancellationToken))
+            {
+                yield return item;
+            }
+        }
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -36,7 +36,7 @@ public sealed class MockDashboardClient : IDashboardClient
     public string ApplicationName => "IntegrationTestApplication";
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken) => throw new NotImplementedException();
-    public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
+    public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
 
     public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken)
     {

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -216,7 +216,7 @@ public class ResourceOutgoingPeerResolverTests
         public string ApplicationName => "ApplicationName";
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
         public Task<ResourceCommandResponseViewModel> ExecuteResourceCommandAsync(string resourceName, string resourceType, CommandViewModel command, CancellationToken cancellationToken) => throw new NotImplementedException();
-        public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>>? SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public IAsyncEnumerable<IReadOnlyList<ResourceLogLine>> SubscribeConsoleLogs(string resourceName, CancellationToken cancellationToken) => throw new NotImplementedException();
         public Task<ResourceViewModelSubscription> SubscribeResourcesAsync(CancellationToken cancellationToken) => subscribeResult;
     }
 }


### PR DESCRIPTION
I really looked into what the console page is doing and why issues keep coming up. Problems I see:

* The page is reinitializing the query on every parameter update. It should only care when the selected resource changes.
* There are multiple cancellation tokens at work (one on page, on in log viewer control).
* The log viewer control seems unnessarily complex. Can be much simpler if the page pushes data into it.
* No way to cancel a resources logs subscription and then wait for it to clean up before starting new subscription. Created race conditions in state

Changes in PR:

* Only update console query if the selected resource changes. Remove hacks to ignore resizing and focus on when the query actually needs to change.
* Fix opening mobile view of the select resource dialog. I ran into this while testing and I think this is an unnoticed regression on main. I don't know when it started. Blazor was removing the selected value because it didn't match the any value in the resource list. The resource subscription event on this page changes the resource list. Improved by adding equality interfaces to bound values.
* Removed the JS display update for the select list. It doesn't appear to me to be needed anymore. I see items updating as resources are started and stop. Maybe the fix above sorted the issue out. @adamint Please double check that all scenarios are still working after it is removed.
* Simplify log viewer to accept logs given to it rather than reading from the source itself.
* Adds ConsoleLogs page test

Fixes https://github.com/dotnet/aspire/issues/5691

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
