### PR TITLE
WaitFor for MySql

### DIFF
--- a/playground/mysql/MySqlDb.AppHost/Program.cs
+++ b/playground/mysql/MySqlDb.AppHost/Program.cs
@@ -12,6 +12,6 @@ var catalogDb = builder.AddMySql("mysql")
 
 builder.AddProject<Projects.MySql_ApiService>("apiservice")
     .WithExternalHttpEndpoints()
-    .WithReference(catalogDb);
+    .WithReference(catalogDb).WaitFor(catalogDb);
 
 builder.Build().Run();

--- a/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
+++ b/src/Aspire.Hosting.MySql/Aspire.Hosting.MySql.csproj
@@ -22,6 +22,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.MySql" />
+  </ItemGroup>
+
+    <ItemGroup>
     <!-- Required for PhpMyAdminConfigWriterHook -->
     <InternalsVisibleTo Include="Aspire.Hosting.MySql.Tests" />
   </ItemGroup>

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using Aspire.Components.Common.Tests;
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.EntityFrameworkCore;
@@ -10,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using MySqlConnector;
 using Polly;
@@ -21,6 +23,101 @@ namespace Aspire.Hosting.MySql.Tests;
 public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
 {
     private static readonly Predicate<string> s_mySqlReadyText = log => log.Contains("ready for connections") && log.Contains("port: 3306");
+
+    [Fact]
+    [RequiresDocker]
+    public async Task VerifyWaitForOnMySqlBlocksDependentResources()
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var healthCheckTcs = new TaskCompletionSource<HealthCheckResult>();
+        builder.Services.AddHealthChecks().AddAsyncCheck("blocking_check", () =>
+        {
+            return healthCheckTcs.Task;
+        });
+
+        var resource = builder.AddMySql("resource")
+                              .WithHealthCheck("blocking_check");
+
+        var dependentResource = builder.AddMySql("dependentresource")
+                                       .WaitFor(resource);
+
+        using var app = builder.Build();
+
+        var pendingStart = app.StartAsync(cts.Token);
+
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
+
+        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+
+        healthCheckTcs.SetResult(HealthCheckResult.Healthy());
+
+        await rns.WaitForResourceAsync(resource.Resource.Name, (re => re.Snapshot.HealthStatus == HealthStatus.Healthy), cts.Token);
+
+        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+
+        await pendingStart;
+
+        await app.StopAsync();
+    }
+
+    [Fact]
+    [RequiresDocker]
+    public async Task VerifyWaitForOnMySqlDatabaseBlocksDependentResources()
+    {
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var healthCheckTcs = new TaskCompletionSource<HealthCheckResult>();
+        builder.Services.AddHealthChecks().AddAsyncCheck("blocking_check", () =>
+        {
+            return healthCheckTcs.Task;
+        });
+
+        var resource = builder.AddMySql("resource")
+                              .WithHealthCheck("blocking_check");
+
+        var db = resource.AddDatabase("db");
+
+        var dependentResource = builder.AddMySql("dependentresource")
+                                       .WaitFor(db);
+
+        using var app = builder.Build();
+
+        var pendingStart = app.StartAsync(cts.Token);
+
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
+
+        await rns.WaitForResourceAsync(db.Resource.Name, KnownResourceStates.Running, cts.Token);
+
+        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+
+        healthCheckTcs.SetResult(HealthCheckResult.Healthy());
+
+        await rns.WaitForResourceAsync(resource.Resource.Name, (re => re.Snapshot.HealthStatus == HealthStatus.Healthy), cts.Token);
+
+        // Create the database.
+        var connectionString = await resource.Resource.ConnectionStringExpression.GetValueAsync(cts.Token);
+        using var connection = new MySqlConnection(connectionString);
+        await connection.OpenAsync(cts.Token);
+
+        var command = connection.CreateCommand();
+        command.CommandText = "CREATE DATABASE db;";
+        await command.ExecuteNonQueryAsync(cts.Token);
+
+        await rns.WaitForResourceAsync(db.Resource.Name, re => re.Snapshot.HealthStatus == HealthStatus.Healthy, cts.Token);
+
+        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+
+        await pendingStart;
+
+        await app.StopAsync();
+    }
 
     [Fact]
     [RequiresDocker]

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -35,7 +35,7 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
         });
 
         var redis = builder.AddRedis("redis")
-                              .WithHealthCheck("blocking_check");
+                           .WithHealthCheck("blocking_check");
 
         var dependentResource = builder.AddRedis("dependentresource")
                                        .WaitFor(redis); // Just using another redis instance as a dependent resource.


### PR DESCRIPTION
## Description

Adds support for WaitFor for MySql resources.

Contributes to #5645 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5705)