### PR TITLE
Support net9+ VMR properties

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <!-- When building from source, we want to use the live repo contents as opposed to cloning the repo. -->
-  <PropertyGroup Condition="'$(ArcadeBuildFromSource)' == 'true'">
+  <PropertyGroup Condition="'$(ArcadeBuildFromSource)' == 'true' or '$(DotNetBuildRepo)' == 'true'">
     <CopySrcInsteadOfClone>true</CopySrcInsteadOfClone>
   </PropertyGroup>
 </Project>

--- a/eng/apicompat/PublicApiAnalyzer.targets
+++ b/eng/apicompat/PublicApiAnalyzer.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition="'$(UsePublicApiAnalyzers)' == 'true' AND '$(DotNetBuildFromSource)' != 'true'">
+  <ItemGroup Condition="'$(UsePublicApiAnalyzers)' == 'true' AND '$(DotNetBuildFromSource)' != 'true' AND '$(DotNetBuildSourceOnly)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" ExcludeAssets="Compile" PrivateAssets="All" />
     <AdditionalFiles Include="$(ProjectDir)PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="$(ProjectDir)PublicAPI.Unshipped.txt" />


### PR DESCRIPTION
We want to remove the old source build properties from VMR builds in net10. This repo is still on net8, which is fine. Adding support for the net9+ properties will enable removal of support for the old properties in .NET 10 Arcade.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5709)