### PR TITLE
Fix mininterval test for real

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
@@ -56,6 +56,7 @@ public sealed class Subscription : IDisposable
                 }
             }
 
+            _lastExecute = DateTime.UtcNow;
             return true;
         }
         finally
@@ -92,7 +93,6 @@ public sealed class Subscription : IDisposable
 
                 Logger.LogTrace("Subscription '{Name}' executing.", Name);
                 await _callback().ConfigureAwait(false);
-                _lastExecute = DateTime.UtcNow;
             }
             catch (Exception ex)
             {

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/LogTests.cs
@@ -669,7 +669,7 @@ public class LogTests
 
         var callCount = 0;
         var resultChannel = Channel.CreateUnbounded<int>();
-        var subscription = repository.OnNewLogs(applicationKey: null, SubscriptionType.Read, () =>
+        var subscription = repository.OnNewLogs(applicationKey: null, SubscriptionType.Read, async () =>
         {
             if (!stopwatch.IsRunning)
             {
@@ -681,7 +681,7 @@ public class LogTests
             }
             ++callCount;
             resultChannel.Writer.TryWrite(callCount);
-            return Task.CompletedTask;
+            await Task.Delay(20);
         });
 
         // Act


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspire/issues/5700

Reproduced locally by adding a delay to the call back. The issue was the execute time was set outside of the lock, and could create a race with new logs coming in before the last execute date was set.

I have no idea why this test suddenly became flaky. The code and the test haven't changed in weeks 🤷 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5728)