### PR TITLE
WaitFor for Cosmos DB

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,6 +70,7 @@
     <PackageVersion Include="AspNetCore.HealthChecks.Azure.Storage.Blobs" Version="8.0.1" />
     <PackageVersion Include="AspNetCore.HealthChecks.Azure.Storage.Queues" Version="8.0.1" />
     <PackageVersion Include="AspNetCore.HealthChecks.AzureServiceBus" Version="8.0.1" />
+    <PackageVersion Include="AspNetCore.HealthChecks.CosmosDb" Version="8.0.1" />
     <PackageVersion Include="AspNetCore.HealthChecks.Kafka" Version="8.0.1" />
     <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.MySql" Version="8.0.1" />

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -9,7 +9,7 @@ var db = builder.AddAzureCosmosDB("cosmos")
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()
-       .WithReference(db);
+       .WithReference(db).WaitFor(db);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -3,9 +3,17 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+#pragma warning disable ASPIRECONTAINERLIFETIME001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 var db = builder.AddAzureCosmosDB("cosmos")
                 .AddDatabase("db")
-                .RunAsEmulator();
+                .RunAsEmulator(c => {
+                    c.WithLifetime(ContainerLifetime.Persistent);
+                    c.WithEndpoint("emulator", (e) =>
+                    {
+                        e.Port = 8889;
+                    });
+                 });
+#pragma warning restore ASPIRECONTAINERLIFETIME001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/Program.cs
@@ -3,17 +3,9 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-#pragma warning disable ASPIRECONTAINERLIFETIME001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 var db = builder.AddAzureCosmosDB("cosmos")
                 .AddDatabase("db")
-                .RunAsEmulator(c => {
-                    c.WithLifetime(ContainerLifetime.Persistent);
-                    c.WithEndpoint("emulator", (e) =>
-                    {
-                        e.Port = 8889;
-                    });
-                 });
-#pragma warning restore ASPIRECONTAINERLIFETIME001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                .RunAsEmulator();
 
 builder.AddProject<Projects.CosmosEndToEnd_ApiService>("api")
        .WithExternalHttpEndpoints()

--- a/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
+++ b/src/Aspire.Hosting.Azure.CosmosDB/Aspire.Hosting.Azure.CosmosDB.csproj
@@ -14,10 +14,13 @@
 
   <ItemGroup>
     <Compile Include="..\Shared\Cosmos\CosmosConstants.cs" Link="Shared\CosmosConstants.cs" />
+    <Compile Include="..\Shared\Cosmos\CosmosUtils.cs" Link="Shared\CosmosUtils.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="AspNetCore.HealthChecks.CosmosDb" />
     <PackageReference Include="Azure.Provisioning" />
     <PackageReference Include="Azure.Provisioning.CosmosDB" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -94,8 +94,7 @@ public static class AzureCosmosExtensions
 
             if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
             {
-                var accountEndpoint = uri.ToString();
-                return new CosmosClient(accountEndpoint, new DefaultAzureCredential(), clientOptions);
+                return new CosmosClient(uri.OriginalString, new DefaultAzureCredential(), clientOptions);
             }
             else
             {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -3,10 +3,14 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
+using Aspire.Hosting.Azure.Cosmos;
+using Azure.Identity;
 using Azure.Provisioning;
 using Azure.Provisioning.CosmosDB;
 using Azure.Provisioning.KeyVaults;
 using Azure.ResourceManager.CosmosDB.Models;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Aspire.Hosting;
@@ -69,9 +73,46 @@ public static class AzureCosmosExtensions
         };
 
         var resource = new AzureCosmosDBResource(name, configureConstruct);
+
+        string? connectionString = null;
+
+        builder.Eventing.Subscribe<ConnectionStringAvailableEvent>(resource, async (@event, ct) =>
+        {
+            connectionString = await resource.ConnectionStringExpression.GetValueAsync(ct).ConfigureAwait(false);
+
+            if (connectionString == null)
+            {
+                throw new DistributedApplicationException($"ConnectionStringAvailableEvent was published for the '{resource.Name}' resource but the connection string was null.");
+            }
+        });
+
+        var healthCheckKey = $"{name}_check";
+        builder.Services.AddHealthChecks().AddAzureCosmosDB(sp =>
+        {
+            var clientOptions = new CosmosClientOptions();
+            clientOptions.CosmosClientTelemetryOptions.DisableDistributedTracing = true;
+
+            if (Uri.TryCreate(connectionString, UriKind.Absolute, out var uri))
+            {
+                var accountEndpoint = uri.ToString();
+                return new CosmosClient(accountEndpoint, new DefaultAzureCredential(), clientOptions);
+            }
+            else
+            {
+                if (CosmosUtils.IsEmulatorConnectionString(connectionString))
+                {
+                    clientOptions.ConnectionMode = ConnectionMode.Gateway;
+                    clientOptions.LimitToEndpoint = true;
+                }
+
+                return new CosmosClient(connectionString, clientOptions);
+            }
+        }, name: healthCheckKey);
+
         return builder.AddResource(resource)
                       .WithParameter(AzureBicepResource.KnownParameters.KeyVaultName)
-                      .WithManifestPublishingCallback(resource.WriteToManifest);
+                      .WithManifestPublishingCallback(resource.WriteToManifest)
+                      .WithHealthCheck(healthCheckKey);
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureCosmosDBEmulatorFunctionalTests.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Components.Common.Tests;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureCosmosDBEmulatorFunctionalTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    [RequiresDocker]
+    public async Task VerifyWaitForOnCosmosDBEmulatorBlocksDependentResources()
+    {
+        // Cosmos can be pretty slow to spin up, lets give it plenty of time.
+        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        var healthCheckTcs = new TaskCompletionSource<HealthCheckResult>();
+        builder.Services.AddHealthChecks().AddAsyncCheck("blocking_check", () =>
+        {
+            return healthCheckTcs.Task;
+        });
+
+        var resource = builder.AddAzureCosmosDB("resource")
+                              .RunAsEmulator()
+                              .WithHealthCheck("blocking_check");
+
+        var dependentResource = builder.AddAzureCosmosDB("dependentresource")
+                                       .RunAsEmulator()
+                                       .WaitFor(resource);
+
+        using var app = builder.Build();
+
+        var pendingStart = app.StartAsync(cts.Token);
+
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
+
+        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
+
+        healthCheckTcs.SetResult(HealthCheckResult.Healthy());
+
+        await rns.WaitForResourceAsync(resource.Resource.Name, (re => re.Snapshot.HealthStatus == HealthStatus.Healthy), cts.Token);
+
+        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
+
+        await pendingStart;
+
+        await app.StopAsync();
+    }
+
+}


### PR DESCRIPTION
## Description

This PR adds `WaitFor` support for Cosmos DB.

Related #5645 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5729)