### PR TITLE
Fix issue with duplicate entry in manifest for AWS CloudFormation reference

### DIFF
--- a/src/Aspire.Hosting.AWS/CloudFormation/CloudFormationExtensions.cs
+++ b/src/Aspire.Hosting.AWS/CloudFormation/CloudFormationExtensions.cs
@@ -92,7 +92,10 @@ public static class CloudFormationExtensions
     public static IResourceBuilder<T> WithEnvironment<T>(this IResourceBuilder<T> builder, string name, StackOutputReference stackOutputReference)
         where T : IResourceWithEnvironment
     {
-        stackOutputReference.Resource.Annotations.Add(new CloudFormationReferenceAnnotation(builder.Resource.Name));
+        if (!stackOutputReference.Resource.Annotations.Any(x => x is CloudFormationReferenceAnnotation cf && string.Equals(cf.TargetResource, builder.Resource.Name, StringComparison.Ordinal)))
+        {
+            stackOutputReference.Resource.Annotations.Add(new CloudFormationReferenceAnnotation(builder.Resource.Name));
+        }
 
         return builder.WithEnvironment(async ctx =>
         {
@@ -149,7 +152,10 @@ public static class CloudFormationExtensions
     public static IResourceBuilder<TDestination> WithReference<TDestination>(this IResourceBuilder<TDestination> builder, IResourceBuilder<ICloudFormationResource> cloudFormationResourceBuilder, string configSection = Constants.DefaultConfigSection)
         where TDestination : IResourceWithEnvironment
     {
-        cloudFormationResourceBuilder.WithAnnotation(new CloudFormationReferenceAnnotation(builder.Resource.Name));
+        if (!cloudFormationResourceBuilder.Resource.Annotations.Any(x => x is CloudFormationReferenceAnnotation cf && string.Equals(cf.TargetResource, builder.Resource.Name, StringComparison.Ordinal)))
+        {
+            cloudFormationResourceBuilder.WithAnnotation(new CloudFormationReferenceAnnotation(builder.Resource.Name));
+        }
 
         builder.WithEnvironment(async ctx =>
         {


### PR DESCRIPTION
## Description

With CloudFormation each `WithReference` or `WithEnvironment` call was adding an annotation to define the reference from the CloudFormation stack to the resource. The annotation should only be added once so that it is only written to the manifest once. This PR adds a guard to only add the annotation if it doesn't exist.

Fixes # (issue)
https://github.com/dotnet/aspire/pull/5744/files#r1762273663

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5748)