### PR TITLE
Orchestrators and Operators

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceAddedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceAddedEvent.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Eventing;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Event that is raised when a resource is has been added to the application model.
+/// </summary>
+/// <param name="resource">The <see cref="IResource"/> being that was added to the model.</param>
+public class ResourceAddedEvent(IResource resource) : IDistributedApplicationEvent
+{
+    /// <summary>
+    /// The <see cref="IResource"/> that was added to the model.
+    /// </summary>
+    public IResource Resource => resource;
+}

--- a/src/Aspire.Hosting/ApplicationModel/ResourceAddingEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceAddingEvent.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Eventing;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Event that is raised when a resource is being added to the application model.
+/// </summary>
+/// <param name="resource">The <see cref="IResource"/> being added to the model.</param>
+public class ResourceAddingEvent(IResource resource) : IDistributedApplicationEvent
+{
+    /// <summary>
+    /// The <see cref="IResource"/> being added to the model.
+    /// </summary>
+    public IResource Resource => resource;
+}

--- a/src/Aspire.Hosting/DistributedApplication.cs
+++ b/src/Aspire.Hosting/DistributedApplication.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
+using Aspire.Hosting.Orchestration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -270,6 +271,9 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// <inheritdoc cref="IHost.StartAsync" />
     public virtual async Task StartAsync(CancellationToken cancellationToken = default)
     {
+        // HACK: Need to figure out the best approach for making sure that the orchestrator
+        //       singleton has always been instansiated before we start firing off events etc.
+        _ = Services.GetRequiredService<DistributedApplicationOrchestrator>();
         await ExecuteBeforeStartHooksAsync(cancellationToken).ConfigureAwait(false);
         await _host.StartAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -307,6 +311,9 @@ public class DistributedApplication : IHost, IAsyncDisposable
     /// </remarks>
     public virtual async Task RunAsync(CancellationToken cancellationToken = default)
     {
+        // HACK: Need to figure out the best approach for making sure that the orchestrator
+        //       singleton has always been instansiated before we start firing off events etc.
+        _ = Services.GetRequiredService<DistributedApplicationOrchestrator>();
         await ExecuteBeforeStartHooksAsync(cancellationToken).ConfigureAwait(false);
         await _host.RunAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/src/Aspire.Hosting/Eventing/IDistributedApplicationEventing.cs
+++ b/src/Aspire.Hosting/Eventing/IDistributedApplicationEventing.cs
@@ -46,4 +46,16 @@ public interface IDistributedApplicationEventing
     /// <returns>A task that can be awaited.</returns>
     [Experimental("ASPIREEVENTING001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     Task PublishAsync<T>(T @event, CancellationToken cancellationToken = default) where T : IDistributedApplicationEvent;
+
+    /// <summary>
+    /// Queues an event for publishing by the eventing system.
+    /// </summary>
+    /// <typeparam name="T">The type of the event</typeparam>
+    /// <param name="event">The event.</param>
+    /// <remarks>
+    /// <para>This is useful for when code wants to queue an event to publish asynchronously and has no
+    /// need to await publishing.</para>
+    /// </remarks>
+    [Experimental("ASPIREEVENTING001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
+    void Queue<T>(T @event) where T : IDistributedApplicationEvent;
 }

--- a/src/Aspire.Hosting/Orchestration/DistributedApplicationHeartbeatEvent.cs
+++ b/src/Aspire.Hosting/Orchestration/DistributedApplicationHeartbeatEvent.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Eventing;
+
+namespace Aspire.Hosting.Orchestration;
+
+internal class DistributedApplicationHeartbeatEvent : IDistributedApplicationEvent
+{
+}

--- a/src/Aspire.Hosting/Orchestration/DistributedApplicationOrchestrator.cs
+++ b/src/Aspire.Hosting/Orchestration/DistributedApplicationOrchestrator.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Eventing;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.Orchestration;
+
+internal class DistributedApplicationOrchestrator : BackgroundService, IHostedLifecycleService
+{
+    private readonly ILogger<DistributedApplicationOrchestrator> _logger;
+    private readonly DistributedApplicationExecutionContext _executionContext;
+    private readonly IDistributedApplicationEventing _eventing;
+
+    public DistributedApplicationOrchestrator(ILogger<DistributedApplicationOrchestrator> logger, DistributedApplicationExecutionContext executionContext, IDistributedApplicationEventing eventing)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _executionContext = executionContext ?? throw new ArgumentNullException(nameof(executionContext));
+        _eventing = eventing ?? throw new ArgumentNullException(nameof(eventing));
+        _eventing.Subscribe<ResourceAddedEvent>(OnResourceAddedAsync);
+    }
+
+    public Task StartedAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Distributed application orchestrator started.");
+        return Task.CompletedTask;
+    }
+
+    public Task StartingAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Distributed application orchestrator starting.");
+        return Task.CompletedTask;
+    }
+
+    public Task StoppedAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Distributed application orchestrator stopped.");
+        return Task.CompletedTask;
+    }
+
+    public Task StoppingAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Distributed application orchestrator stopping.");
+        return Task.CompletedTask;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (_executionContext.IsPublishMode)
+        {
+            return;
+        }
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(1000, stoppingToken).ConfigureAwait(false); // Heartbeat delay.
+            await _eventing.PublishAsync(new DistributedApplicationHeartbeatEvent(), stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    private Task OnResourceAddedAsync(ResourceAddedEvent @event, CancellationToken cancellationToken)
+    {
+        if (_executionContext.IsPublishMode)
+        {
+            return Task.CompletedTask;
+        }
+        // TODO: Add code to resolve the "operator" for this resource and hand it off.
+
+        _logger.LogInformation("Resource added: {Resource} ({ResourceType}).", @event.Resource.Name, @event.Resource.GetType());
+        return Task.CompletedTask;
+    }
+}

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -37,6 +37,12 @@ Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.Volumes.init -> void
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.HealthCheckAnnotation(string! key) -> void
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.Key.get -> string!
+Aspire.Hosting.ApplicationModel.ResourceAddedEvent
+Aspire.Hosting.ApplicationModel.ResourceAddedEvent.Resource.get -> Aspire.Hosting.ApplicationModel.IResource!
+Aspire.Hosting.ApplicationModel.ResourceAddedEvent.ResourceAddedEvent(Aspire.Hosting.ApplicationModel.IResource! resource) -> void
+Aspire.Hosting.ApplicationModel.ResourceAddingEvent
+Aspire.Hosting.ApplicationModel.ResourceAddingEvent.Resource.get -> Aspire.Hosting.ApplicationModel.IResource!
+Aspire.Hosting.ApplicationModel.ResourceAddingEvent.ResourceAddingEvent(Aspire.Hosting.ApplicationModel.IResource! resource) -> void
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.ResourceNotificationService(Microsoft.Extensions.Logging.ILogger<Aspire.Hosting.ApplicationModel.ResourceNotificationService!>! logger, Microsoft.Extensions.Hosting.IHostApplicationLifetime! hostApplicationLifetime) -> void
 Aspire.Hosting.ApplicationModel.ResourceNotificationService.WaitForResourceAsync(string! resourceName, System.Func<Aspire.Hosting.ApplicationModel.ResourceEvent!, bool>! predicate, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ResourceEvent!>!
 Aspire.Hosting.ApplicationModel.VolumeSnapshot
@@ -50,9 +56,12 @@ Aspire.Hosting.ApplicationModel.VolumeSnapshot.Target.get -> string!
 Aspire.Hosting.ApplicationModel.VolumeSnapshot.Target.init -> void
 Aspire.Hosting.ApplicationModel.VolumeSnapshot.VolumeSnapshot(string? Source, string! Target, string! MountType, bool IsReadOnly) -> void
 Aspire.Hosting.DistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eventing.IDistributedApplicationEventing!
+Aspire.Hosting.DistributedApplicationBuilder.Eventing.init -> void
+Aspire.Hosting.DistributedApplicationBuilder.Resources.init -> void
 Aspire.Hosting.Eventing.DistributedApplicationEventing
 Aspire.Hosting.Eventing.DistributedApplicationEventing.DistributedApplicationEventing() -> void
 Aspire.Hosting.Eventing.DistributedApplicationEventing.PublishAsync<T>(T event, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Aspire.Hosting.Eventing.DistributedApplicationEventing.Queue<T>(T event) -> void
 Aspire.Hosting.Eventing.DistributedApplicationEventing.Subscribe<T>(Aspire.Hosting.ApplicationModel.IResource! resource, System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! callback) -> Aspire.Hosting.Eventing.DistributedApplicationEventSubscription!
 Aspire.Hosting.Eventing.DistributedApplicationEventing.Subscribe<T>(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! callback) -> Aspire.Hosting.Eventing.DistributedApplicationEventSubscription!
 Aspire.Hosting.Eventing.DistributedApplicationEventing.Unsubscribe(Aspire.Hosting.Eventing.DistributedApplicationEventSubscription! subscription) -> void
@@ -65,6 +74,7 @@ Aspire.Hosting.Eventing.DistributedApplicationResourceEventSubscription.Resource
 Aspire.Hosting.Eventing.IDistributedApplicationEvent
 Aspire.Hosting.Eventing.IDistributedApplicationEventing
 Aspire.Hosting.Eventing.IDistributedApplicationEventing.PublishAsync<T>(T event, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Aspire.Hosting.Eventing.IDistributedApplicationEventing.Queue<T>(T event) -> void
 Aspire.Hosting.Eventing.IDistributedApplicationEventing.Subscribe<T>(Aspire.Hosting.ApplicationModel.IResource! resource, System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! callback) -> Aspire.Hosting.Eventing.DistributedApplicationEventSubscription!
 Aspire.Hosting.Eventing.IDistributedApplicationEventing.Subscribe<T>(System.Func<T, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! callback) -> Aspire.Hosting.Eventing.DistributedApplicationEventSubscription!
 Aspire.Hosting.Eventing.IDistributedApplicationEventing.Unsubscribe(Aspire.Hosting.Eventing.DistributedApplicationEventSubscription! subscription) -> void

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading.Channels;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Eventing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,7 @@ public class DashboardLifecycleHookTests
 
         var resourceLoggerService = new ResourceLoggerService();
         var resourceNotificationService = new ResourceNotificationService(NullLogger<ResourceNotificationService>.Instance, new TestHostApplicationLifetime());
+        var eventing = new DistributedApplicationEventing();
         var configuration = new ConfigurationBuilder().Build();
         var hook = new DashboardLifecycleHook(
             configuration,
@@ -45,7 +47,7 @@ public class DashboardLifecycleHookTests
             resourceLoggerService,
             factory);
 
-        var model = new DistributedApplicationModel(new ResourceCollection());
+        var model = new DistributedApplicationModel(new ResourceCollection(eventing));
         await hook.BeforeStartAsync(model, CancellationToken.None);
 
         await resourceNotificationService.PublishUpdateAsync(model.Resources.Single(), s => s);


### PR DESCRIPTION
## Description

This PR is experimental and used to facilitate some discussion. At the moment the internal implementation of the app host has a few fundamental issues:

1. Some resources (such as child resources) don't have anything "driving" them. For example there isn't really a centralized place where we manage the state of a child resource - we instead expect the `ApplicationExecutor` and `AzureProvisioner` to just know to make sure that the child resource has the same state as the parent resource.
2. Startup blocks in that we wait for each resource to start before we consider the IHost "started". 

I'd like to see us tackle these two issues. The goal of this PR is to explore this space. This PR will introduce two fundamental concepts:

1. The orchestrator; this is a top level singleton in the app host which is responsible for observing that a resource has been added to the model, and selecting an _operator_.
2. Operators; plugins to the app host which know how to handle resources of a particular type. The goal is to start to make resource start-up more reactive to app model changes and less a sequential thing where we spin up the app executor and provisioner. Instead the orchestrator will look at each resource and advertise to a singleton operator of each type that it is now responsible for a resource. The application executor would evolve into becoming an operator for containers and executables.

What does this do for us? Well it allows us to create a default built-in operator for `IResourceWithParent` resources (generics issue ahead here) - the built-in operator will simply make sure that the status is propagated UNLESS a specific provisioner is defined (probably via an annotation).

So far this PR doesn't have all of this. The first step is to build an orchestrator which is capable of observing that resources are added to the app model. I've done this by giving the resource collection an instance of the eventing singleton. In addition I've added a `Queue` method to queue events. The idea is that in the early stages of application startup we queue events that will then execute at the earliest possible moment in the applications lifecycle.

The handler for this event would resolve the operator for a resource and hand off ownership to that operator.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5749)