### PR TITLE
Rename default network to workaround bug where Docker loses exposed port info

### DIFF
--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -84,6 +84,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
     // The second purpose of the suffix is to play a role of a unique OpenTelemetry service instance ID.
     private const int RandomNameSuffixLength = 8;
 
+    private const string DefaultAspireNetworkName = "default-aspire-network";
+
     private readonly ILogger<ApplicationExecutor> _logger = logger;
     private readonly DistributedApplicationModel _model = model;
     private readonly Dictionary<string, IResource> _applicationModel = model.Resources.ToDictionary(r => r.Name);
@@ -1412,7 +1414,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             {
                 new ContainerNetworkConnection
                 {
-                    Name = "aspire-network",
+                    Name = DefaultAspireNetworkName,
                     Aliases = new List<string> { container.Name },
                 }
             };
@@ -1472,7 +1474,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             if (containerResources.Any())
             {
                 // The network will be created with a unique postfix to avoid conflicts with other Aspire AppHost networks
-                tasks.Add(kubernetesService.CreateAsync(ContainerNetwork.Create("aspire-network"), cancellationToken));
+                tasks.Add(kubernetesService.CreateAsync(ContainerNetwork.Create(DefaultAspireNetworkName), cancellationToken));
             }
 
             foreach (var cr in containerResources)


### PR DESCRIPTION
## Description

When disconnecting from the first connected network in a multi-network container (first network seems to be determined alphabetically), Docker can lose the exposed port info (no longer reported with Docker inspect, despite the original exposed port still being associated with the container). This PR updates the default network name we use to `default-aspire-network` in order to come after the default Docker `bridge` network.

Fixes #5741

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5754)