### PR TITLE
Add autocomplete of values when filtering telemetry

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -11,15 +11,16 @@
 
     <FluentStack Orientation="Orientation.Vertical" VerticalGap="12">
         <div class="filter-input-container">
-            <FluentCombobox TOption="SelectViewModel<string>"
-                            Placeholder="@Loc[nameof(Dialogs.FilterDialogFieldPlaceholder)]"
-                            Label="@Loc[nameof(Dialogs.FilterDialogParameterInputLabel)]"
-                            Items="@_parameters"
-                            @bind-SelectedOption="@_formModel.Parameter"
-                            Width="100%"
-                            Height="500px"
-                            OptionText="@(c => c.Name)"
-                            OptionDisabled="@(c => c.Id is null)" />
+            <FluentSelect TOption="SelectViewModel<string>"
+                          Placeholder="@Loc[nameof(Dialogs.FilterDialogFieldPlaceholder)]"
+                          Label="@Loc[nameof(Dialogs.FilterDialogParameterInputLabel)]"
+                          Items="@_parameters"
+                          @bind-SelectedOption="@_formModel.Parameter"
+                          @bind-SelectedOption:after="ParameterChangedAsync"
+                          Width="100%"
+                          Style="max-height:400px"
+                          OptionText="@(c => c.Name)"
+                          OptionDisabled="@(c => c.Id is null)" />
         </div>
 
         <div class="filter-input-container">
@@ -32,8 +33,15 @@
         </div>
 
         <div class="filter-input-container">
-            <FluentTextField @bind-Value="_formModel.Value"
-                             Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]" Style="width:100%" />
+            <FluentCombobox TOption="SelectViewModel<string>"
+                            @bind-Value="_formModel.Value"
+                            @bind-Value:after="ValueChanged"
+                            Items="@_filteredValues"
+                            Width="100%"
+                            Height="400px"
+                            OptionText="@(c => c.Name)"
+                            Immediate="true"
+                            Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]" />
             <ValidationMessage For="() => _formModel.Value" />
         </div>
 

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -35,6 +35,7 @@
         <div class="filter-input-container">
             <FluentCombobox TOption="SelectViewModel<FieldValue>"
                             @bind-Value="_formModel.Value"
+                            @bind-Value:after="ValueChanged"
                             Items="@_filteredValues"
                             Width="100%"
                             Height="400px"

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -48,7 +48,7 @@
                         @* There is FluentUI bug that causes bad data if there is additional text in an option. *@
                         @* https://github.com/microsoft/fluentui-blazor/issues/2695 *@
                         @* Workaround this issue by inserting extra text using CSS. *@
-                        <span data-filtercount="@optionContext.Id!.Count"></span>                        
+                        <span data-filtercount="@optionContext.Id!.Count"></span>
                     </FluentBadge>
                     @optionContext.Name
                 </OptionTemplate>

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -33,15 +33,22 @@
         </div>
 
         <div class="filter-input-container">
-            <FluentCombobox TOption="SelectViewModel<string>"
+            <FluentCombobox TOption="SelectViewModel<FieldValue>"
                             @bind-Value="_formModel.Value"
-                            @bind-Value:after="ValueChanged"
                             Items="@_filteredValues"
                             Width="100%"
                             Height="400px"
                             OptionText="@(c => c.Name)"
+                            OptionValue="@(c => c.Name)"
                             Immediate="true"
-                            Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]" />
+                            Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]">
+                <OptionTemplate Context="optionContext">
+                    <FluentBadge Circular=true Appearance="Appearance.Neutral" Slot="end">
+                        @optionContext.Id!.Count
+                    </FluentBadge>
+                    @optionContext.Name
+                </OptionTemplate>
+            </FluentCombobox>
             <ValidationMessage For="() => _formModel.Value" />
         </div>
 

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor
@@ -18,7 +18,7 @@
                           @bind-SelectedOption="@_formModel.Parameter"
                           @bind-SelectedOption:after="ParameterChangedAsync"
                           Width="100%"
-                          Style="max-height:400px"
+                          Height="400px"
                           OptionText="@(c => c.Name)"
                           OptionDisabled="@(c => c.Id is null)" />
         </div>
@@ -44,7 +44,10 @@
                             Label="@Loc[nameof(Dialogs.FilterDialogTextValuePlaceholder)]">
                 <OptionTemplate Context="optionContext">
                     <FluentBadge Circular=true Appearance="Appearance.Neutral" Slot="end">
-                        @optionContext.Id!.Count
+                        @* There is FluentUI bug that causes bad data if there is additional text in an option. *@
+                        @* https://github.com/microsoft/fluentui-blazor/issues/2695 *@
+                        @* Workaround this issue by inserting extra text using CSS. *@
+                        <span data-filtercount="@optionContext.Id!.Count"></span>                        
                     </FluentBadge>
                     @optionContext.Name
                 </OptionTemplate>

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -26,8 +26,10 @@ public partial class FilterDialog
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
 
-    private LogDialogFormModel _formModel = default!;
+    private FilterDialogFormModel _formModel = default!;
     private List<SelectViewModel<string>> _parameters = default!;
+    private List<SelectViewModel<string>> _filteredValues = default!;
+    private List<SelectViewModel<string>>? _allValues;
 
     public EditContext EditContext { get; private set; } = default!;
 
@@ -41,8 +43,10 @@ public partial class FilterDialog
             CreateFilterSelectViewModel(FilterCondition.NotContains)
         ];
 
-        _formModel = new LogDialogFormModel();
+        _formModel = new FilterDialogFormModel();
         EditContext = new EditContext(_formModel);
+
+        _filteredValues = [];
     }
 
     protected override void OnParametersSet()
@@ -75,6 +79,60 @@ public partial class FilterDialog
             _formModel.Parameter = _parameters.FirstOrDefault();
             _formModel.Condition = _filterConditions.Single(c => c.Id == FilterCondition.Contains);
             _formModel.Value = "";
+        }
+
+        UpdateParameterFieldValues();
+        ValueChanged();
+    }
+
+    private void UpdateParameterFieldValues()
+    {
+        if (_formModel.Parameter?.Id is { } parameterName)
+        {
+            var fieldValues = Content.GetFieldValues(parameterName);
+            _allValues = fieldValues
+                .OrderByDescending(kvp => kvp.Value)
+                .ThenBy(kvp => kvp.Key, StringComparers.OtlpFieldValue)
+                .Select(kvp => new SelectViewModel<string> { Id = kvp.Key, Name = kvp.Key })
+                .ToList();
+        }
+        else
+        {
+            _allValues = null;
+        }
+    }
+
+    private async Task ParameterChangedAsync()
+    {
+        UpdateParameterFieldValues();
+
+        _formModel.Value = "";
+        StateHasChanged();
+
+        // Clearing the selected value and the combo box items together wasn't correctly clearing the selected value.
+        // This is hacky, but adding a delay between the two operations puts the combo box in the right state.
+        await Task.Delay(100);
+        ValueChanged();
+    }
+
+    // There is a bug in FluentUI that prevents the value changing immediately. Will be fixed in a future FluentUI update.
+    // https://github.com/microsoft/fluentui-blazor/issues/2672
+    private void ValueChanged()
+    {
+        if (_allValues != null)
+        {
+            IEnumerable<SelectViewModel<string>> newValues = _allValues;
+            if (!string.IsNullOrEmpty(_formModel.Value))
+            {
+                newValues = newValues.Where(vm => vm.Name.Contains(_formModel.Value!));
+            }
+
+            // Limit to 1000 items to avoid the combo box have too many items and impacting UI perf.
+            _filteredValues = newValues.Take(1000).ToList();
+        }
+        else
+        {
+            _filteredValues = [];
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -112,6 +112,7 @@ public partial class FilterDialog
 
         // Clearing the selected value and the combo box items together wasn't correctly clearing the selected value.
         // This is hacky, but adding a delay between the two operations puts the combo box in the right state.
+        // Limitation of FluentUI: https://github.com/microsoft/fluentui-blazor/issues/2708
         await Task.Delay(100);
         ValueChanged();
     }
@@ -170,7 +171,7 @@ public partial class FilterDialog
         }
     }
 
-    private class FieldValue
+    private sealed class FieldValue
     {
         public required string Value { get; init; }
         public required int Count { get; init; }

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.cs
@@ -49,7 +49,7 @@ public partial class FilterDialog
         _filteredValues = [];
     }
 
-    protected override async Task OnParametersSetAsync()
+    protected override void OnParametersSet()
     {
         var knownFields = Content.KnownKeys.Select(p => new SelectViewModel<string> { Id = p, Name = TelemetryFilter.ResolveFieldName(p) }).ToList();
         var customFields = Content.PropertyKeys.Select(p => new SelectViewModel<string> { Id = p, Name = TelemetryFilter.ResolveFieldName(p) }).ToList();
@@ -82,7 +82,7 @@ public partial class FilterDialog
         }
 
         UpdateParameterFieldValues();
-        await ValueChanged();
+        ValueChanged();
     }
 
     private void UpdateParameterFieldValues()
@@ -113,14 +113,13 @@ public partial class FilterDialog
         // Clearing the selected value and the combo box items together wasn't correctly clearing the selected value.
         // This is hacky, but adding a delay between the two operations puts the combo box in the right state.
         await Task.Delay(100);
-        await ValueChanged();
+        ValueChanged();
     }
 
     // There is a bug in FluentUI that prevents the value changing immediately. Will be fixed in a future FluentUI update.
     // https://github.com/microsoft/fluentui-blazor/issues/2672
-    private Task ValueChanged()
+    private void ValueChanged()
     {
-
         if (_allValues != null)
         {
             IEnumerable<SelectViewModel<FieldValue>> newValues = _allValues;
@@ -136,8 +135,6 @@ public partial class FilterDialog
         {
             _filteredValues = [];
         }
-
-        return Task.CompletedTask;
     }
 
     private void Cancel()

--- a/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.css
+++ b/src/Aspire.Dashboard/Components/Dialogs/FilterDialog.razor.css
@@ -1,0 +1,3 @@
+::deep [data-filtercount]::before {
+    content: attr(data-filtercount);
+}

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -287,7 +287,8 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         {
             Filter = entry,
             PropertyKeys = TelemetryRepository.GetLogPropertyKeys(PageViewModel.SelectedApplication.Id?.GetApplicationKey()),
-            KnownKeys = KnownStructuredLogFields.AllFields
+            KnownKeys = KnownStructuredLogFields.AllFields,
+            GetFieldValues = TelemetryRepository.GetLogsFieldValues
         };
         await DialogService.ShowPanelAsync<FilterDialog>(data, parameters);
     }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -333,6 +333,7 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
             Filter = entry,
             PropertyKeys = TelemetryRepository.GetTracePropertyKeys(PageViewModel.SelectedApplication.Id?.GetApplicationKey()),
             KnownKeys = KnownTraceFields.AllFields,
+            GetFieldValues = TelemetryRepository.GetTraceFieldValues
         };
         await DialogService.ShowPanelAsync<FilterDialog>(data, parameters);
     }

--- a/src/Aspire.Dashboard/Model/FilterDialogViewModel.cs
+++ b/src/Aspire.Dashboard/Model/FilterDialogViewModel.cs
@@ -10,4 +10,5 @@ public sealed class FilterDialogViewModel
     public required TelemetryFilter? Filter { get; init; }
     public required List<string> KnownKeys { get; init; }
     public required List<string> PropertyKeys { get; init; }
+    public required Func<string, Dictionary<string, int>> GetFieldValues { get; init; }
 }

--- a/src/Aspire.Dashboard/Model/Otlp/FilterDialogFormModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/FilterDialogFormModel.cs
@@ -5,12 +5,17 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Aspire.Dashboard.Model.Otlp;
 
-public class LogDialogFormModel
+public class FilterDialogFormModel
 {
     [Required]
     public SelectViewModel<string>? Parameter { get; set; }
+
     [Required]
     public SelectViewModel<FilterCondition>? Condition { get; set; }
+
+    // Set a max length on value because it will be added to the query string.
+    // Max length is protection against accidently building a query string that exceeds limits because of a very long value.
     [Required]
+    [MaxLength(1024)]
     public string? Value { get; set; }
 }

--- a/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/TelemetryFilter.cs
@@ -58,14 +58,14 @@ public class TelemetryFilter : IEquatable<TelemetryFilter>
     private static Func<string?, string, bool> ConditionToFuncString(FilterCondition c) =>
         c switch
         {
-            FilterCondition.Equals => (a, b) => string.Equals(a, b, StringComparison.OrdinalIgnoreCase),
-            FilterCondition.Contains => (a, b) => a != null && a.Contains(b, StringComparison.OrdinalIgnoreCase),
+            FilterCondition.Equals => (a, b) => string.Equals(a, b, StringComparisons.OtlpFieldValue),
+            FilterCondition.Contains => (a, b) => a != null && a.Contains(b, StringComparisons.OtlpFieldValue),
             // Condition.GreaterThan => (a, b) => a > b,
             // Condition.LessThan => (a, b) => a < b,
             // Condition.GreaterThanOrEqual => (a, b) => a >= b,
             // Condition.LessThanOrEqual => (a, b) => a <= b,
-            FilterCondition.NotEqual => (a, b) => !string.Equals(a, b, StringComparison.OrdinalIgnoreCase),
-            FilterCondition.NotContains => (a, b) => a != null && !a.Contains(b, StringComparison.OrdinalIgnoreCase),
+            FilterCondition.NotEqual => (a, b) => !string.Equals(a, b, StringComparisons.OtlpFieldValue),
+            FilterCondition.NotContains => (a, b) => a != null && !a.Contains(b, StringComparisons.OtlpFieldValue),
             _ => throw new ArgumentOutOfRangeException(nameof(c), c, null)
         };
 
@@ -97,35 +97,6 @@ public class TelemetryFilter : IEquatable<TelemetryFilter>
             _ => throw new ArgumentOutOfRangeException(nameof(c), c, null)
         };
 
-    private string? GetFieldValue(OtlpLogEntry x)
-    {
-        return Field switch
-        {
-            KnownStructuredLogFields.MessageField => x.Message,
-            KnownStructuredLogFields.ApplicationField => x.ApplicationView.Application.ApplicationName,
-            KnownStructuredLogFields.TraceIdField => x.TraceId,
-            KnownStructuredLogFields.SpanIdField => x.SpanId,
-            KnownStructuredLogFields.OriginalFormatField => x.OriginalFormat,
-            KnownStructuredLogFields.CategoryField => x.Scope.ScopeName,
-            _ => x.Attributes.GetValue(Field)
-        };
-    }
-
-    private string? GetFieldValue(OtlpSpan x)
-    {
-        return Field switch
-        {
-            KnownTraceFields.ApplicationField => x.Source.Application.ApplicationName,
-            KnownTraceFields.TraceIdField => x.TraceId,
-            KnownTraceFields.SpanIdField => x.SpanId,
-            KnownTraceFields.KindField => x.Kind.ToString(),
-            KnownTraceFields.StatusField => x.Status.ToString(),
-            KnownTraceFields.SourceField => x.Scope.ScopeName,
-            KnownTraceFields.NameField => x.Name,
-            _ => x.Attributes.GetValue(Field)
-        };
-    }
-
     public IEnumerable<OtlpLogEntry> Apply(IEnumerable<OtlpLogEntry> input)
     {
         switch (Field)
@@ -153,14 +124,14 @@ public class TelemetryFilter : IEquatable<TelemetryFilter>
             default:
                 {
                     var func = ConditionToFuncString(Condition);
-                    return input.Where(x => func(GetFieldValue(x), Value));
+                    return input.Where(x => func(OtlpLogEntry.GetFieldValue(x, Field), Value));
                 }
         }
     }
 
     public bool Apply(OtlpSpan span)
     {
-        var fieldValue = GetFieldValue(span);
+        var fieldValue = OtlpSpan.GetFieldValue(span, Field);
         var func = ConditionToFuncString(Condition);
         return func(fieldValue, Value);
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model.Otlp;
 using OpenTelemetry.Proto.Logs.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
@@ -88,4 +89,18 @@ public class OtlpLogEntry
         SeverityNumber.Fatal4 => LogLevel.Critical,
         _ => LogLevel.None
     };
+
+    public static string? GetFieldValue(OtlpLogEntry log, string field)
+    {
+        return field switch
+        {
+            KnownStructuredLogFields.MessageField => log.Message,
+            KnownStructuredLogFields.ApplicationField => log.ApplicationView.Application.ApplicationName,
+            KnownStructuredLogFields.TraceIdField => log.TraceId,
+            KnownStructuredLogFields.SpanIdField => log.SpanId,
+            KnownStructuredLogFields.OriginalFormatField => log.OriginalFormat,
+            KnownStructuredLogFields.CategoryField => log.Scope.ScopeName,
+            _ => log.Attributes.GetValue(field)
+        };
+    }
 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using Aspire.Dashboard.Model.Otlp;
 
 namespace Aspire.Dashboard.Otlp.Model;
 
@@ -100,5 +101,20 @@ public class OtlpSpan
     private string DebuggerToString()
     {
         return $@"SpanId = {SpanId}, StartTime = {StartTime.ToLocalTime():h:mm:ss.fff tt}, ParentSpanId = {ParentSpanId}, TraceId = {Trace.TraceId}";
+    }
+
+    public static string? GetFieldValue(OtlpSpan span, string field)
+    {
+        return field switch
+        {
+            KnownTraceFields.ApplicationField => span.Source.Application.ApplicationName,
+            KnownTraceFields.TraceIdField => span.TraceId,
+            KnownTraceFields.SpanIdField => span.SpanId,
+            KnownTraceFields.KindField => span.Kind.ToString(),
+            KnownTraceFields.StatusField => span.Status.ToString(),
+            KnownTraceFields.SourceField => span.Scope.ScopeName,
+            KnownTraceFields.NameField => span.Name,
+            _ => span.Attributes.GetValue(field)
+        };
     }
 }

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -623,7 +623,7 @@ fluent-data-grid-cell.no-ellipsis {
 }
 
 .filter-input-container {
-    width: 75%;
+    width: 85%;
 }
 
 .layout fluent-toolbar > .fluent-input-label {

--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -22,6 +22,7 @@ internal static class StringComparers
     public static StringComparer HtmlAttribute => StringComparer.Ordinal;
     public static StringComparer GridColumn => StringComparer.Ordinal;
     public static StringComparer OtlpAttribute => StringComparer.Ordinal;
+    public static StringComparer OtlpFieldValue => StringComparer.OrdinalIgnoreCase;
 }
 
 internal static class StringComparisons
@@ -41,4 +42,5 @@ internal static class StringComparisons
     public static StringComparison HtmlAttribute => StringComparison.Ordinal;
     public static StringComparison GridColumn => StringComparison.Ordinal;
     public static StringComparison OtlpAttribute => StringComparison.Ordinal;
+    public static StringComparison OtlpFieldValue => StringComparison.OrdinalIgnoreCase;
 }


### PR DESCRIPTION
I think this is pretty cool. PR adds:

* Autocomplete of values when filtering telemetry
* Works for structured logs and traces
* Works for adhoc attributes and known fields

Fixes https://github.com/dotnet/aspire/issues/5746

Depends on https://github.com/dotnet/aspire/pull/5751 being merged first.

Demo:

![filters-autocomplete](https://github.com/user-attachments/assets/7fa1b1fb-f6d2-4613-8344-55b8fbaf648e)

Updated demo - the autocomplete now shows a count with how many times a value is used. Makes it more obvious why the values are ordered the way they are (most frequently used first):

![image](https://github.com/user-attachments/assets/6bfb72c1-2d60-4a48-81ae-f9d548b99536)


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5762)