### PR TITLE
Show aggregate health status in the dashboard

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -74,7 +74,8 @@ public partial class ResourceDetails
             new KnownProperty(KnownProperties.Resource.DisplayName, Loc[Resources.Resources.ResourcesDetailsDisplayNameProperty]),
             new KnownProperty(KnownProperties.Resource.State, Loc[Resources.Resources.ResourcesDetailsStateProperty]),
             new KnownProperty(KnownProperties.Resource.CreateTime, Loc[Resources.Resources.ResourcesDetailsStartTimeProperty]),
-            new KnownProperty(KnownProperties.Resource.ExitCode, Loc[Resources.Resources.ResourcesDetailsExitCodeProperty])
+            new KnownProperty(KnownProperties.Resource.ExitCode, Loc[Resources.Resources.ResourcesDetailsExitCodeProperty]),
+            new KnownProperty(KnownProperties.Resource.HealthState, Loc[Resources.Resources.ResourcesDetailsHealthStateProperty])
         ];
         _projectProperties =
         [

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -94,7 +94,7 @@
                                 <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c))">
                                     <ResourceNameDisplay Resource="context" FilterText="@_filter" FormatName="GetResourceName" />
                                 </AspireTemplateColumn>
-                                <AspireTemplateColumn ColumnId="@StateColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort" Tooltip="true" TooltipText="@(c => c.State.Humanize())">
+                                <AspireTemplateColumn ColumnId="@StateColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort" Tooltip="true" TooltipText="@(c => GetResourceStateTooltip(c))">
                                     <StateColumnDisplay Resource="@context" UnviewedErrorCounts="@_applicationUnviewedErrorCounts" />
                                 </AspireTemplateColumn>
                                 <AspireTemplateColumn ColumnId="@StartTimeColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" TooltipText="@(context => context.CreationTimeStamp != null ? FormatHelpers.FormatDateTime(TimeProvider, context.CreationTimeStamp.Value, MillisecondsDisplay.None, CultureInfo.CurrentCulture) : null)" Tooltip="true">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -11,6 +11,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
+using Humanizer;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -330,6 +331,11 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             });
         }
     }
+
+    private static string GetResourceStateTooltip(ResourceViewModel resource) =>
+        resource.ShowReadinessState() ?
+        $"{resource.State.Humanize()} ({resource.ReadinessState.Humanize()})"
+        : resource.State.Humanize();
 
     private static (string Value, string? ContentAfterValue, string ValueToCopy, string Tooltip)? GetSourceColumnValueAndTooltip(ResourceViewModel resource)
     {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor
@@ -3,6 +3,7 @@
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Otlp.Storage
 @using Aspire.Dashboard.Resources
+@using Microsoft.Extensions.Diagnostics.HealthChecks
 @using Humanizer
 
 @inject IStringLocalizer<Columns> Loc
@@ -78,9 +79,20 @@ else if (!string.IsNullOrEmpty(Resource.StateStyle))
 }
 else
 {
-    <FluentIcon Icon="Icons.Filled.Size16.CheckmarkCircle"
-                Color="Color.Success"
-                Class="severity-icon" />
+    switch (Resource.ReadinessState)
+    {
+        // Unknown state is treated as ready state (we don't know if it's ready or not)
+        case ReadinessState.Unknown or ReadinessState.Ready:
+            <FluentIcon Icon="Icons.Filled.Size16.CheckmarkCircle"
+                        Color="Color.Success"
+                        Class="severity-icon" />
+            break;
+        default:
+            <FluentIcon Icon="Icons.Regular.Size16.CheckmarkCircleWarning"
+                        Color="Color.Neutral"
+                        Class="severity-icon" />
+            break;
+    }
 }
 
 @if (Resource.HasNoState())
@@ -89,7 +101,14 @@ else
 }
 else
 {
-    <span>@Resource.State.Humanize()</span>
+    if (Resource.ShowReadinessState())
+    {
+        <span>@Resource.State.Humanize() (@Resource.ReadinessState.Humanize())</span>
+    }
+    else
+    {
+        <span>@Resource.State.Humanize()</span>
+    }
 }
 
 <UnreadLogErrorsBadge UnviewedErrorCounts="UnviewedErrorCounts" Resource="@Resource" />

--- a/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
@@ -33,4 +33,8 @@ internal static class ResourceViewModelExtensions
     }
 
     public static bool HasNoState(this ResourceViewModel resource) => string.IsNullOrEmpty(resource.State);
+
+    // We only care about the readiness state if the resource is running
+    public static bool ShowReadinessState(this ResourceViewModel resource) =>
+        resource.IsRunningState() && resource.ReadinessState is ReadinessState.NotReady;
 }

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -20,6 +20,7 @@ public sealed class ResourceViewModel
     public required string Uid { get; init; }
     public required string? State { get; init; }
     public required string? StateStyle { get; init; }
+    public required ReadinessState ReadinessState { get; init; }
     public required DateTime? CreationTimeStamp { get; init; }
     public required ImmutableArray<EnvironmentVariableViewModel> Environment { get; init; }
     public required ImmutableArray<UrlViewModel> Urls { get; init; }
@@ -58,6 +59,13 @@ public sealed class ResourceViewModel
 
         return resource.DisplayName;
     }
+}
+
+public enum ReadinessState
+{
+    Unknown,
+    NotReady,
+    Ready
 }
 
 [DebuggerDisplay("CommandType = {CommandType}, DisplayName = {DisplayName}")]

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -31,6 +31,11 @@ partial class Resource
                 State = HasState ? State : null,
                 KnownState = HasState ? Enum.TryParse(State, out KnownResourceState knownState) ? knownState : null : null,
                 StateStyle = HasStateStyle ? StateStyle : null,
+                ReadinessState = HasHealthState ? HealthState switch
+                {
+                    HealthStateKind.Healthy => ReadinessState.Ready,
+                    _ => ReadinessState.NotReady,
+                } : ReadinessState.Unknown,
                 Commands = GetCommands()
             };
         }

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -241,6 +241,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Health State.
+        /// </summary>
+        public static string ResourcesDetailsHealthStateProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsHealthStateProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Project path.
         /// </summary>
         public static string ResourcesDetailsProjectPathProperty {

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -232,4 +232,7 @@
   <data name="ResourceDetailsViewConsoleLogs" xml:space="preserve">
     <value>View console logs</value>
   </data>
+  <data name="ResourcesDetailsHealthStateProperty" xml:space="preserve">
+    <value>Health State</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Ukončovací kód</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">Cesta k projektu</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Exitcode</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">Projektpfad</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Código de salida</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">Ruta de acceso del proyecto</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Code de sortie</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">Chemin de projet</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Codice di uscita</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">Percorso del progetto</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -102,6 +102,11 @@
         <target state="translated">終了コード</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">プロジェクト パス</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -102,6 +102,11 @@
         <target state="translated">종료 코드</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">프로젝트 경로</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Kod zakończenia</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">Ścieżka projektu</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Código de saída</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">Caminho do projeto</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Код завершения</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">Путь к проекту</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Çıkış kodu</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">Proje yolu</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -102,6 +102,11 @@
         <target state="translated">退出代码</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">项目路径</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -102,6 +102,11 @@
         <target state="translated">結束代碼</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsHealthStateProperty">
+        <source>Health State</source>
+        <target state="new">Health State</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">
         <source>Project path</source>
         <target state="translated">專案路徑</target>

--- a/src/Aspire.Hosting/ApplicationModel/ReplicaInstancesAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ReplicaInstancesAnnotation.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Keep track of active replicas ids from DCP.
+/// </summary>
+internal class ReplicaInstancesAnnotation : IResourceAnnotation
+{
+    public ConcurrentDictionary<string, string> Instances { get; } = [];
+}

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -3,6 +3,8 @@
 
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.ResourceService.Proto.V1;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Dashboard;
@@ -42,7 +44,14 @@ internal sealed class DashboardServiceData : IAsyncDisposable
                     Environment = snapshot.EnvironmentVariables,
                     ExitCode = snapshot.ExitCode,
                     State = snapshot.State?.Text,
-                    StateStyle = snapshot.State?.Style
+                    StateStyle = snapshot.State?.Style,
+                    HealthState = resource.TryGetLastAnnotation<HealthCheckAnnotation>(out _) ? snapshot.HealthStatus switch
+                    {
+                        HealthStatus.Healthy => HealthStateKind.Healthy,
+                        HealthStatus.Unhealthy => HealthStateKind.Unhealthy,
+                        HealthStatus.Degraded => HealthStateKind.Degraded,
+                        _ => HealthStateKind.Unknown,
+                    } : null
                 };
             }
 

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.ResourceService.Proto.V1;
 using Google.Protobuf.WellKnownTypes;
 
 namespace Aspire.Hosting.Dashboard;
@@ -22,8 +23,8 @@ internal abstract class ResourceSnapshot
     public required DateTime? CreationTimeStamp { get; init; }
     public required ImmutableArray<EnvironmentVariableSnapshot> Environment { get; init; }
     public required ImmutableArray<VolumeSnapshot> Volumes { get; init; }
-
     public required ImmutableArray<UrlSnapshot> Urls { get; init; }
+    public required HealthStateKind? HealthState { get; set; }
 
     protected abstract IEnumerable<(string Key, Value Value)> GetProperties();
 
@@ -38,6 +39,7 @@ internal abstract class ResourceSnapshot
             yield return (KnownProperties.Resource.State, State is null ? Value.ForNull() : Value.ForString(State));
             yield return (KnownProperties.Resource.ExitCode, ExitCode is null ? Value.ForNull() : Value.ForString(ExitCode.Value.ToString("D", CultureInfo.InvariantCulture)));
             yield return (KnownProperties.Resource.CreateTime, CreationTimeStamp is null ? Value.ForNull() : Value.ForString(CreationTimeStamp.Value.ToString("O")));
+            yield return (KnownProperties.Resource.HealthState, HealthState is null ? Value.ForNull() : Value.ForString(HealthState.ToString()));
 
             foreach (var pair in GetProperties())
             {

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -20,6 +20,11 @@ partial class Resource
             StateStyle = snapshot.StateStyle ?? "",
         };
 
+        if (snapshot.HealthState is HealthStateKind healthState)
+        {
+            resource.HealthState = healthState;
+        }
+
         if (snapshot.CreationTimeStamp.HasValue)
         {
             resource.CreatedAt = Timestamp.FromDateTime(snapshot.CreationTimeStamp.Value.ToUniversalTime());

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -170,6 +170,16 @@ message Resource {
 
     // The set of volumes mounted to the resource. Only applies to containers.
     repeated Volume volumes = 15;
+
+    // The aggregate health state of the resource
+    optional HealthStateKind HealthState = 16;
+}
+
+enum HealthStateKind {
+    UNKNOWN = 0;
+    HEALTHY = 1;
+    UNHEALTHY = 2;
+    DEGRADED = 3;
 }
 
 ////////////////////////////////////////////

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -394,6 +394,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                     {
                         _logger.LogTrace("Deleting application model resource {ResourceName} with {ResourceKind} resource {ResourceName}", appModelResource.Name, resourceKind, resource.Metadata.Name);
                     }
+
+                    if (appModelResource.TryGetLastAnnotation<ReplicaInstancesAnnotation>(out var replicaAnnotation))
+                    {
+                        replicaAnnotation.Instances.TryRemove(resource.Metadata.Name, out _);
+                    }
                 }
                 else
                 {
@@ -586,6 +591,15 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
     private CustomResourceSnapshot ToSnapshot(Container container, CustomResourceSnapshot previous)
     {
+        if (container.AppModelResourceName is not null &&
+            _applicationModel.TryGetValue(container.AppModelResourceName, out var appModelResource))
+        {
+            if (appModelResource.TryGetLastAnnotation<ReplicaInstancesAnnotation>(out var replicaAnnotation))
+            {
+                replicaAnnotation.Instances.TryAdd(container.Metadata.Name, container.Metadata.Name);
+            }
+        }
+
         var containerId = container.Status?.ContainerId;
         var urls = GetUrls(container);
         var volumes = GetVolumes(container);
@@ -639,6 +653,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             _applicationModel.TryGetValue(executable.AppModelResourceName, out var appModelResource))
         {
             projectPath = appModelResource is ProjectResource p ? p.GetProjectMetadata().ProjectPath : null;
+
+            if (appModelResource.TryGetLastAnnotation<ReplicaInstancesAnnotation>(out var replicaAnnotation))
+            {
+                replicaAnnotation.Instances.TryAdd(executable.Metadata.Name, executable.Metadata.Name);
+            }
         }
 
         var state = executable.AppModelInitialState is "Hidden" ? "Hidden" : executable.Status?.State;
@@ -1021,6 +1040,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
         foreach (var executable in modelExecutableResources)
         {
+            EnsureReplicaInstancesAnnotation(executable);
+
             var nameSuffix = GetRandomNameSuffix();
             var exeName = GetObjectNameForResource(executable, nameSuffix);
             var exePath = executable.Command;
@@ -1050,6 +1071,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             {
                 throw new InvalidOperationException("A project resource is missing required metadata"); // Should never happen.
             }
+
+            EnsureReplicaInstancesAnnotation(project);
 
             int replicas = project.GetReplicaCount();
 
@@ -1102,7 +1125,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
                 if (!string.IsNullOrEmpty(_distributedApplicationOptions.Configuration))
                 {
-                    exeSpec.Args.AddRange(new [] {"-c", _distributedApplicationOptions.Configuration});
+                    exeSpec.Args.AddRange(new[] { "-c", _distributedApplicationOptions.Configuration });
                 }
 
                 // We pretty much always want to suppress the normal launch profile handling
@@ -1131,6 +1154,16 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             var exeAppResource = new AppResource(project, ers);
             AddServicesProducedInfo(project, annotationHolder, exeAppResource);
             _appResources.Add(exeAppResource);
+        }
+    }
+
+    private static void EnsureReplicaInstancesAnnotation(IResource resource)
+    {
+        // Make sure we have a replica annotation on the resource.
+        // this is so that we can populate the running instance ids
+        if (!resource.TryGetLastAnnotation<ReplicaInstancesAnnotation>(out _))
+        {
+            resource.Annotations.Add(new ReplicaInstancesAnnotation());
         }
     }
 
@@ -1370,7 +1403,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 throw new InvalidOperationException();
             }
 
-            var nameSuffix = container.GetContainerLifetimeType() switch
+            EnsureReplicaInstancesAnnotation(container);
+
+            var nameSuffix = string.Empty;
+
+            if (container.GetContainerLifetimeType() == ContainerLifetime.Default)
             {
                 ContainerLifetime.Default => GetRandomNameSuffix(),
                 // Compute a short hash of the content root path to differentiate between multiple AppHost projects with similar resource names
@@ -1718,9 +1755,9 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 {
                     var dcpBuildSecret = new BuildContextSecret
                     {
-                      Id = buildSecret.Key,
-                      Type = "env",
-                      Value = valueString
+                        Id = buildSecret.Key,
+                        Type = "env",
+                        Value = valueString
                     };
                     dcpBuildSecrets.Add(dcpBuildSecret);
                 }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1405,9 +1405,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
             EnsureReplicaInstancesAnnotation(container);
 
-            var nameSuffix = string.Empty;
-
-            if (container.GetContainerLifetimeType() == ContainerLifetime.Default)
+            var nameSuffix = container.GetContainerLifetimeType() switch
             {
                 ContainerLifetime.Default => GetRandomNameSuffix(),
                 // Compute a short hash of the content root path to differentiate between multiple AppHost projects with similar resource names

--- a/src/Aspire.Hosting/Health/ResourceNotificationHealthCheckPublisher.cs
+++ b/src/Aspire.Hosting/Health/ResourceNotificationHealthCheckPublisher.cs
@@ -21,6 +21,17 @@ internal class ResourceNotificationHealthCheckPublisher(DistributedApplicationMo
                 {
                     HealthStatus = status
                 }).ConfigureAwait(false);
+
+                if (resource.TryGetLastAnnotation<ReplicaInstancesAnnotation>(out var replicaAnnotation))
+                {
+                    foreach (var (id, _) in replicaAnnotation.Instances)
+                    {
+                        await resourceNotificationService.PublishUpdateAsync(resource, id, s => s with
+                        {
+                            HealthStatus = status
+                        }).ConfigureAwait(false);
+                    }
+                }
             }
         }
     }

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -22,6 +22,7 @@ internal static class KnownProperties
         public const string ExitCode = "resource.exitCode";
         public const string CreateTime = "resource.createTime";
         public const string Source = "resource.source";
+        public const string HealthState = "resource.healthState";
         public const string ConnectionString = "resource.connectionString";
     }
 

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -148,6 +148,7 @@ public partial class ConsoleLogsTests : TestContext
             State = state?.ToString(),
             KnownState = state,
             StateStyle = null,
+            ReadinessState = ReadinessState.Ready,
             Commands = []
         };
     }

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/CreateResourceSelectModelsTests.cs
@@ -118,6 +118,7 @@ public class CreateResourceSelectModelsTests
             State = state?.ToString(),
             KnownState = state,
             StateStyle = null,
+            ReadinessState = ReadinessState.Ready,
             Commands = []
         };
     }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -27,6 +27,7 @@ public sealed class MockDashboardClient : IDashboardClient
         State = "Running",
         Uid = Guid.NewGuid().ToString(),
         StateStyle = null,
+        ReadinessState = ReadinessState.Ready,
         Urls = [],
         Volumes = []
     };

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceEndpointHelpersTests.cs
@@ -203,6 +203,7 @@ public sealed class ResourceEndpointHelpersTests
             State = null,
             KnownState = null,
             StateStyle = null,
+            ReadinessState = ReadinessState.Ready,
             Commands = []
         };
     }

--- a/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ResourceOutgoingPeerResolverTests.cs
@@ -26,6 +26,7 @@ public class ResourceOutgoingPeerResolverTests
             Urls = servicePort is null || servicePort is null ? [] : [new UrlViewModel(name, new($"http://{serviceAddress}:{servicePort}"), isInternal: false)],
             Volumes = [],
             State = null,
+            ReadinessState = ReadinessState.Ready,
             KnownState = null,
             StateStyle = null,
             Commands = []

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/PostgresFunctionalTests.cs
@@ -212,6 +212,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
 
     [Fact]
     [RequiresDocker]
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/5785")]
     public async Task VerifyWithPgWeb()
     {
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
@@ -237,6 +238,7 @@ public class PostgresFunctionalTests(ITestOutputHelper testOutputHelper)
         client.DefaultRequestHeaders.Add("x-session-id", Guid.NewGuid().ToString());
 
         var response = await client.PostAsync("/api/connect", httpContent);
+        var d = await response.Content.ReadAsStringAsync();
         response.EnsureSuccessStatusCode();
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -193,7 +193,8 @@ public class ResourcePublisherTests
             DisplayName = "",
             Urls = [],
             Volumes = [],
-            Environment = []
+            Environment = [],
+            HealthState = null
         };
     }
 }


### PR DESCRIPTION
## Description

Added the aggregated health state to the resource server protocol to enable showing it in the dashboard.

Contributes to #5569

https://github.com/user-attachments/assets/40ad1d4b-3d3c-4d7c-a766-8d41af0eca67


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: 
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5770)