### PR TITLE
Fix console logs page when linked from resource

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -41,7 +41,7 @@
         </MobilePageTitleToolbarSection>
 
         <MainSection>
-            <LogViewer @ref="_logViewer"/>
+            <LogViewer @ref="LogViewer"/>
         </MainSection>
     </AspirePageContentLayout>
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -65,8 +65,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     private ConsoleLogsSubscription? _consoleLogsSubscription;
 
     // UI
+    public LogViewer LogViewer = null!;
     private SelectViewModel<ResourceTypeDetails> _noSelection = null!;
-    private LogViewer _logViewer = null!;
     private AspirePageContentLayout? _contentLayout;
 
     // State
@@ -197,7 +197,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             // Wait for the first render to complete so that the log viewer is available.
             await _logViewerReadyTcs.Task;
 
-            _logViewer.ClearLogs();
+            LogViewer.ClearLogs();
 
             if (newConsoleLogsSubscription is not null)
             {
@@ -311,16 +311,16 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                     foreach (var (lineNumber, content, isErrorOutput) in batch)
                     {
                         // Set the base line number using the reported line number of the first log line.
-                        if (_logViewer.LogEntries.EntriesCount == 0)
+                        if (LogViewer.LogEntries.EntriesCount == 0)
                         {
-                            _logViewer.LogEntries.BaseLineNumber = lineNumber;
+                            LogViewer.LogEntries.BaseLineNumber = lineNumber;
                         }
 
                         var logEntry = logParser.CreateLogEntry(content, isErrorOutput);
-                        _logViewer.LogEntries.InsertSorted(logEntry);
+                        LogViewer.LogEntries.InsertSorted(logEntry);
                     }
 
-                    await _logViewer.LogsAddedAsync();
+                    await LogViewer.LogsAddedAsync();
                 }
             }
             finally
@@ -395,7 +395,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
         await StopAndClearConsoleLogsSubscriptionAsync();
 
-        if (_logViewer is { } logViewer)
+        if (LogViewer is { } logViewer)
         {
             await logViewer.DisposeAsync();
         }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -57,6 +57,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     [Parameter]
     public string? ResourceName { get; set; }
 
+    private readonly TaskCompletionSource _logViewerReadyTcs = new();
     private readonly CancellationTokenSource _resourceSubscriptionCancellation = new();
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private ImmutableList<SelectViewModel<ResourceTypeDetails>>? _resources;
@@ -118,7 +119,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             {
                 if (_resourceByName.TryGetValue(ResourceName, out var selectedResource))
                 {
-                    SetSelectedResourceOption(selectedResource);
+                    await SetSelectedResourceOption(selectedResource);
                 }
             }
             else
@@ -144,19 +145,21 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                         // we should mark it as selected
                         if (ResourceName is not null && PageViewModel.SelectedResource is null && changeType == ResourceViewModelChangeType.Upsert && string.Equals(ResourceName, resource.Name))
                         {
-                            SetSelectedResourceOption(resource);
+                            await SetSelectedResourceOption(resource);
                         }
                     }
                 }
             });
         }
 
-        void SetSelectedResourceOption(ResourceViewModel resource)
+        async Task SetSelectedResourceOption(ResourceViewModel resource)
         {
             Debug.Assert(_resources is not null);
 
             PageViewModel.SelectedOption = _resources.Single(option => option.Id?.Type is not OtlpApplicationType.ResourceGrouping && string.Equals(ResourceName, option.Id?.InstanceId, StringComparison.Ordinal));
             PageViewModel.SelectedResource = resource;
+
+            await this.AfterViewModelChangedAsync(_contentLayout, isChangeInToolbar: false);
 
             Logger.LogDebug("Selected console resource from name {ResourceName}.", ResourceName);
             loadingTcs.TrySetResult();
@@ -191,12 +194,23 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                 _consoleLogsSubscription = newConsoleLogsSubscription;
             }
 
-            ClearLogs();
+            // Wait for the first render to complete so that the log viewer is available.
+            await _logViewerReadyTcs.Task;
+
+            _logViewer.ClearLogs();
 
             if (newConsoleLogsSubscription is not null)
             {
                 LoadLogs(newConsoleLogsSubscription);
             }
+        }
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _logViewerReadyTcs.SetResult();
         }
     }
 
@@ -271,71 +285,59 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     private void UpdateResourcesList() => _resources = GetConsoleLogResourceSelectViewModels(_resourceByName, _noSelection, Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsUnknownState)]);
 
-    private void ClearLogs()
-    {
-        _logViewer?.ClearLogs();
-    }
-
     private void LoadLogs(ConsoleLogsSubscription newConsoleLogsSubscription)
     {
-        if (_logViewer is null)
+        var consoleLogsTask = Task.Run(async () =>
         {
-            PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsInitializingLogViewer)];
-        }
-        else
-        {
-            var consoleLogsTask = Task.Run(async () =>
+            newConsoleLogsSubscription.CancellationToken.ThrowIfCancellationRequested();
+
+            Logger.LogDebug("Subscribing to console logs for resource {ResourceName}.", newConsoleLogsSubscription.Name);
+
+            var subscription = DashboardClient.SubscribeConsoleLogs(newConsoleLogsSubscription.Name, newConsoleLogsSubscription.CancellationToken);
+
+            PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsWatchingLogs)];
+            await InvokeAsync(StateHasChanged);
+
+            try
             {
-                newConsoleLogsSubscription.CancellationToken.ThrowIfCancellationRequested();
-
-                Logger.LogDebug("Subscribing to console logs for resource {ResourceName}.", newConsoleLogsSubscription.Name);
-
-                var subscription = DashboardClient.SubscribeConsoleLogs(newConsoleLogsSubscription.Name, newConsoleLogsSubscription.CancellationToken);
-
-                PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsWatchingLogs)];
-                await InvokeAsync(StateHasChanged);
-
-                try
+                var logParser = new LogParser();
+                await foreach (var batch in subscription.ConfigureAwait(true))
                 {
-                    var logParser = new LogParser();
-                    await foreach (var batch in subscription.ConfigureAwait(true))
+                    if (batch.Count is 0)
                     {
-                        if (batch.Count is 0)
+                        continue;
+                    }
+
+                    foreach (var (lineNumber, content, isErrorOutput) in batch)
+                    {
+                        // Set the base line number using the reported line number of the first log line.
+                        if (_logViewer.LogEntries.EntriesCount == 0)
                         {
-                            continue;
+                            _logViewer.LogEntries.BaseLineNumber = lineNumber;
                         }
 
-                        foreach (var (lineNumber, content, isErrorOutput) in batch)
-                        {
-                            // Set the base line number using the reported line number of the first log line.
-                            if (_logViewer.LogEntries.EntriesCount == 0)
-                            {
-                                _logViewer.LogEntries.BaseLineNumber = lineNumber;
-                            }
-
-                            var logEntry = logParser.CreateLogEntry(content, isErrorOutput);
-                            _logViewer.LogEntries.InsertSorted(logEntry);
-                        }
-
-                        await _logViewer.LogsAddedAsync();
+                        var logEntry = logParser.CreateLogEntry(content, isErrorOutput);
+                        _logViewer.LogEntries.InsertSorted(logEntry);
                     }
+
+                    await _logViewer.LogsAddedAsync();
                 }
-                finally
+            }
+            finally
+            {
+                Logger.LogDebug("Finished watching logs for resource {ResourceName}.", newConsoleLogsSubscription.Name);
+
+                // If the subscription is being canceled then a new one could be starting.
+                // Don't set the status when finishing because overwrite the status from the new subscription.
+                if (!newConsoleLogsSubscription.CancellationToken.IsCancellationRequested)
                 {
-                    Logger.LogDebug("Finished watching logs for resource {ResourceName}.", newConsoleLogsSubscription.Name);
-
-                    // If the subscription is being canceled then a new one could be starting.
-                    // Don't set the status when finishing because overwrite the status from the new subscription.
-                    if (!newConsoleLogsSubscription.CancellationToken.IsCancellationRequested)
-                    {
-                        PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs)];
-                        await InvokeAsync(StateHasChanged);
-                    }
+                    PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsFinishedWatchingLogs)];
+                    await InvokeAsync(StateHasChanged);
                 }
-            });
+            }
+        });
 
-            newConsoleLogsSubscription.SubscriptionTask = consoleLogsTask;
-        }
+        newConsoleLogsSubscription.SubscriptionTask = consoleLogsTask;
     }
 
     private async Task HandleSelectedOptionChangedAsync()

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -57,7 +57,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     [Parameter]
     public string? ResourceName { get; set; }
 
-    private readonly TaskCompletionSource _logViewerReadyTcs = new();
+    private readonly TaskCompletionSource _logViewerReadyTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly CancellationTokenSource _resourceSubscriptionCancellation = new();
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private ImmutableList<SelectViewModel<ResourceTypeDetails>>? _resources;

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -89,7 +89,7 @@ public partial class ConsoleLogsTests : TestContext
     }
 
     [Fact]
-    public void ResourceName_ViaUrlAndResourceLoaded_WaitRender()
+    public void ResourceName_ViaUrlAndResourceLoaded_LogViewerUpdated()
     {
         // Arrange
         var testResource = CreateResourceViewModel("test-resource", KnownResourceState.Running);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -125,9 +125,10 @@ public partial class ConsoleLogsTests : TestContext
 
         // Assert
         logger.LogInformation("Resource and subscription should be set immediately on first render.");
-        Assert.Equal(testResource, instance.PageViewModel.SelectedResource);
-        Assert.Equal(loc[nameof(Resources.ConsoleLogs.ConsoleLogsWatchingLogs)], instance.PageViewModel.Status);
-        Assert.Equal("test-resource", Assert.Single(subscribedResourceNames));
+        cut.WaitForState(() => instance.PageViewModel.SelectedResource == testResource);
+        cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsWatchingLogs)]);
+
+        cut.WaitForAssertion(() => Assert.Single(subscribedResourceNames));
 
         logger.LogInformation("Log results are added to log viewer.");
         consoleLogsChannel.Writer.TryWrite([new ResourceLogLine(1, "Hello world", IsErrorMessage: false)]);

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ConsoleLogsTests.cs
@@ -124,14 +124,13 @@ public partial class ConsoleLogsTests : TestContext
         var loc = Services.GetRequiredService<IStringLocalizer<Resources.ConsoleLogs>>();
 
         // Assert
-        logger.LogInformation("Waiting for selected resource.");
-        cut.WaitForState(() => instance.PageViewModel.SelectedResource == testResource);
-        cut.WaitForState(() => instance.PageViewModel.Status == loc[nameof(Resources.ConsoleLogs.ConsoleLogsWatchingLogs)]);
-
+        logger.LogInformation("Resource and subscription should be set immediately on first render.");
+        Assert.Equal(testResource, instance.PageViewModel.SelectedResource);
+        Assert.Equal(loc[nameof(Resources.ConsoleLogs.ConsoleLogsWatchingLogs)], instance.PageViewModel.Status);
         Assert.Equal("test-resource", Assert.Single(subscribedResourceNames));
 
+        logger.LogInformation("Log results are added to log viewer.");
         consoleLogsChannel.Writer.TryWrite([new ResourceLogLine(1, "Hello world", IsErrorMessage: false)]);
-
         cut.WaitForState(() => instance.LogViewer.LogEntries.EntriesCount > 0);
     }
 


### PR DESCRIPTION
I rewrote the console logs page [here](https://github.com/dotnet/aspire/pull/5703) but introduced a regression when loading logs when linked from a resource. Fixed in this PR with included test.

Fixes https://github.com/dotnet/aspire/issues/5764

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5776)