### PR TITLE
[dashpages] Dashpage layout improvements

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/DashpageCharts.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/DashpageCharts.razor
@@ -13,7 +13,7 @@
 <FluentGrid Spacing="3" AdaptiveRendering="true" Justify="JustifyContent.FlexStart" Class="dashpage-chart-grid">
     @foreach (var chart in SelectedDashpage.Charts)
     {
-        if (Instruments.FirstOrDefault(i => i.Name == chart.InstrumentName) is { } instrument)
+        if (Instruments.FirstOrDefault(i => StringComparers.OtlpInstrumentName.Equals(i.Name, chart.InstrumentName)) is { } instrument)
         {
             @if (ViewportInformation.IsDesktop)
             {

--- a/src/Aspire.Dashboard/Components/Controls/Chart/DashpageCharts.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/DashpageCharts.razor
@@ -10,44 +10,27 @@
     <h3 title="@SelectedDashpage.Name">@SelectedDashpage.Name</h3>
 }
 
-<FluentGrid Spacing="3" AdaptiveRendering="true" Justify="JustifyContent.FlexStart" Class="dashpage-chart-grid">
+<section class="dashpage-chart-grid">
     @foreach (var chart in SelectedDashpage.Charts)
     {
         if (Instruments.FirstOrDefault(i => StringComparers.OtlpInstrumentName.Equals(i.Name, chart.InstrumentName)) is { } instrument)
         {
-            @if (ViewportInformation.IsDesktop)
-            {
-                <FluentGridItem sm="12" md="6" lg="4" Class="dashpage-chart-grid-item">
-                    <FluentCard AreaRestricted="false">
-                        <DashpageChartContainer
-                            ApplicationKey="@(SelectedApplication.Id!.GetApplicationKey())"
-                            MeterName="@(instrument.Parent.MeterName)"
-                            InstrumentName="@(instrument.Name)"
-                            Duration="@SelectedDuration.Id"
-                            ActiveView="@(SelectedViewKind ?? Metrics.MetricViewKind.Graph)"
-                            OnViewChangedAsync="@OnViewChangedAsync"
-                            Applications="@Applications" />
-                    </FluentCard>
-                </FluentGridItem>
-            }
-            else
-            {
-                <div class="dashpage-chart-grid-item">
-                    <FluentCard AreaRestricted="true">
-                        <DashpageChartContainer
-                            ApplicationKey="@(SelectedApplication.Id!.GetApplicationKey())"
-                            MeterName="@(instrument.Parent.MeterName)"
-                            InstrumentName="@(instrument.Name)"
-                            Duration="@SelectedDuration.Id"
-                            ActiveView="@(SelectedViewKind ?? Metrics.MetricViewKind.Graph)"
-                            OnViewChangedAsync="@OnViewChangedAsync"
-                            Applications="@Applications" />
-                    </FluentCard>
-                </div>
-            }
+            <article class="dashpage-chart-tile">
+                @*AreaRestricted="false"*@
+                <FluentCard>
+                    <DashpageChartContainer
+                        ApplicationKey="@SelectedApplication.Id!.GetApplicationKey()"
+                        MeterName="@instrument.Parent.MeterName"
+                        InstrumentName="@instrument.Name"
+                        Duration="@SelectedDuration.Id"
+                        ActiveView="@(SelectedViewKind ?? Metrics.MetricViewKind.Graph)"
+                        OnViewChangedAsync="@OnViewChangedAsync"
+                        Applications="@Applications" />
+                </FluentCard>
+            </article>
         }
     }
-</FluentGrid>
+</section>
 
 @code {
     [Parameter, EditorRequired]

--- a/src/Aspire.Dashboard/Components/Controls/Chart/DashpageCharts.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/DashpageCharts.razor.css
@@ -1,0 +1,11 @@
+.dashpage-chart-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.dashpage-chart-grid .dashpage-chart-tile {
+    flex: 1 1 25%;
+    box-sizing: border-box;
+    min-width: 400px;
+}

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.css
@@ -104,46 +104,10 @@
     margin-right: 10px;
 }
 
-@media (min-width: 768px) {
-    ::deep .plotly-chart-container {
-        margin-left: -40px;
-    }
-    ::deep .dashpage-chart-grid {
-        padding: 2px;
-    }
-}
-
-@media (max-width: 768px) {
-    ::deep .plotly-chart-container {
-        margin-left: -20px;
-    }
-
-    ::deep .dashpage-chart-grid {
-        padding: 10px;
-        display: block;
-    }
-
-    ::deep .dashpage-chart-grid-item {
-        width: 100%;
-    }
-}
-
 ::deep .plotly-chart-container {
     width: 100%;
     max-width: 650px;
     aspect-ratio: 13 / 9;
-}
-
-@media (min-width: 768px) {
-    ::deep .plotly-chart-container {
-        margin-left: -40px;
-    }
-}
-
-@media (max-width: 768px) {
-    ::deep .plotly-chart-container {
-        margin-left: -20px;
-    }
 }
 
 ::deep .metric-info-icon {


### PR DESCRIPTION
Make dashpage responsive to container, not viewport

`FluentGrid` uses `@media` queries for breakpoints, which work on the window size (viewport area). However we have a splitter in this UI, and dragging it should cause the dashpage area to relayout as the container size changes.

This change removes `FluentGrid` and instead uses flexbox layout directly.

> [!NOTE]
> This PR is to the `feature/dashpages` branch, not `main`.

## Before

![dashpage-layout-before](https://github.com/user-attachments/assets/17ce31f9-fe52-4106-84e0-99f75042259b)

## After

![dashpage-layout-after](https://github.com/user-attachments/assets/77e405dc-a9ea-4252-891c-50bdc5147782)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5784)