### PR TITLE
Stop "mask" button from jumping on mouse enter

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -24,16 +24,6 @@
             @ContentAfterValue
         </span>
     }
-    @if (EnableMasking)
-    {
-        <div @onclick:stopPropagation="true">
-            <FluentButton Appearance="Appearance.Lightweight"
-                          IconEnd="@(IsMasked ? _unmaskIcon : _maskIcon)"
-                          Title="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])"
-                          OnClick="ToggleMaskStateAsync"
-                          aria-label="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])" />
-        </div>
-    }
 
     @{
         (string, object)[] uncapturedCopyAttributes = [
@@ -75,4 +65,15 @@
             </FluentMenuItem>
         </FluentMenu>
     </div>
+
+    @if (EnableMasking)
+    {
+        <div @onclick:stopPropagation="true">
+            <FluentButton Appearance="Appearance.Lightweight"
+                          IconEnd="@(IsMasked ? _unmaskIcon : _maskIcon)"
+                          Title="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])"
+                          OnClick="ToggleMaskStateAsync"
+                          aria-label="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])" />
+        </div>
+    }
 </div>


### PR DESCRIPTION
## Description

In details views, we show sensitive values as masked by default. The user has to click a button to show them on screen. This prevents accidentally revealing secrets to onlookers.

The mask button is visible for any sensitive value.

There is also a menu button, that opens a popup to allow copying and visualizing the value. This button is only displayed when the mouse hovers over the row in the name/value grid.

Previously, these were (in order):

- Mask button (always visible)
- Menu button (visible on hover)

Because these were right-aligned, the mask button would be pushed left to make space for the menu button on house hover.

To the user who wanted to toggle a row's mask status, the button they want to press would jump to the left just as the mouse got close. This is surprising and a bit annoying.

This change reorders the buttons so that nothing moves on screen when the mouse hovers over the row.

## Before

![hover-before](https://github.com/user-attachments/assets/504ddc1d-2d77-4354-99b0-d930177cf160)

## After

![hover-after](https://github.com/user-attachments/assets/71697ff9-be6a-44f7-8f64-9e4eeef2a538)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5799)