### PR TITLE
Configuration schema generator: fix missing cref inside para tag

### DIFF
--- a/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
+++ b/src/Tools/ConfigurationSchemaGenerator/ConfigSchemaEmitter.cs
@@ -544,7 +544,8 @@ internal sealed partial class ConfigSchemaEmitter(SchemaGenerationSpec spec, Com
     {
         if (element.Name == "para" || element.Name == "p")
         {
-            return $"<br/><br/>{element.Value}<br/><br/>";
+            var innerText = string.Join(string.Empty, element.Nodes().Select(GetNodeText));
+            return $"<br/><br/>{innerText}<br/><br/>";
         }
 
         if (element.Name == "br")

--- a/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
+++ b/tests/ConfigurationSchemaGenerator.Tests/GeneratorTests.cs
@@ -123,6 +123,7 @@ public partial class GeneratorTests
     [InlineData("<see cref=\"M:System.Diagnostics.Debug.Assert(bool)\"/>", "'System.Diagnostics.Debug.Assert(bool)'")]
     [InlineData("<see cref=\"E:System.Windows.Input.ICommand.CanExecuteChanged\"/>", "'System.Windows.Input.ICommand.CanExecuteChanged'")]
     [InlineData("<exception cref=\"T:System.InvalidOperationException\" />", "'System.InvalidOperationException'")]
+    [InlineData("<para><exception cref=\"T:System.InvalidOperationException\" /></para>", "'System.InvalidOperationException'")]
     public void ShouldQuoteCrefAttributes(string input, string expected)
     {
         var summaryElement = ConvertToSummaryElement(input);


### PR DESCRIPTION
## Description

Ported fix from https://github.com/SteeltoeOSS/Steeltoe/pull/1358 back to Aspire.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5800)