### PR TITLE
Inject commands on all DCP based resources

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -12,9 +12,9 @@ internal static class CommandsConfigurationExtensions
     internal const string StopType = "stop";
     internal const string RestartType = "restart";
 
-    internal static IResourceBuilder<T> WithLifeCycleCommands<T>(this IResourceBuilder<T> builder) where T : IResource
+    internal static void AddLifeCycleCommands(this IResource resource)
     {
-        builder.WithCommand(
+        resource.Annotations.Add(new ResourceCommandAnnotation(
             type: StartType,
             displayName: "Start",
             executeCommand: async context =>
@@ -40,9 +40,9 @@ internal static class CommandsConfigurationExtensions
                 }
             },
             iconName: "Play",
-            isHighlighted: true);
+            isHighlighted: true));
 
-        builder.WithCommand(
+        resource.Annotations.Add(new ResourceCommandAnnotation(
             type: StopType,
             displayName: "Stop",
             executeCommand: async context =>
@@ -68,9 +68,9 @@ internal static class CommandsConfigurationExtensions
                 }
             },
             iconName: "Stop",
-            isHighlighted: true);
+            isHighlighted: true));
 
-        builder.WithCommand(
+        resource.Annotations.Add(new ResourceCommandAnnotation(
             type: RestartType,
             displayName: "Restart",
             executeCommand: async context =>
@@ -93,9 +93,7 @@ internal static class CommandsConfigurationExtensions
                 }
             },
             iconName: "ArrowCounterclockwise",
-            isHighlighted: false);
-
-        return builder;
+            isHighlighted: false));
 
         static bool IsStopped(string? state) => state is "Exited" or "Finished" or "FailedToStart";
         static bool IsStopping(string? state) => state is "Stopping";

--- a/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ContainerResourceBuilderExtensions.cs
@@ -150,7 +150,6 @@ public static class ContainerResourceBuilderExtensions
         // if the annotation doesn't exist, create it with the given image and add it to the collection
         var containerImageAnnotation = new ContainerImageAnnotation() { Image = image, Tag = tag };
         builder.Resource.Annotations.Add(containerImageAnnotation);
-        builder.WithLifeCycleCommands();
         return builder;
     }
 

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1044,7 +1044,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
         foreach (var executable in modelExecutableResources)
         {
-            EnsureReplicaInstancesAnnotation(executable);
+            EnsureRequiredAnnotations(executable);
 
             var nameSuffix = GetRandomNameSuffix();
             var exeName = GetObjectNameForResource(executable, nameSuffix);
@@ -1076,7 +1076,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 throw new InvalidOperationException("A project resource is missing required metadata"); // Should never happen.
             }
 
-            EnsureReplicaInstancesAnnotation(project);
+            EnsureRequiredAnnotations(project);
 
             var replicas = project.GetReplicaCount();
 
@@ -1165,8 +1165,11 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         }
     }
 
-    private static void EnsureReplicaInstancesAnnotation(IResource resource)
+    private static void EnsureRequiredAnnotations(IResource resource)
     {
+        // Add the default lifecycle commands (start/stop/restart)
+        resource.AddLifeCycleCommands();
+
         // Make sure we have a replica annotation on the resource.
         // this is so that we can populate the running instance ids
         if (!resource.TryGetLastAnnotation<ReplicaInstancesAnnotation>(out _))
@@ -1411,7 +1414,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 throw new InvalidOperationException();
             }
 
-            EnsureReplicaInstancesAnnotation(container);
+            EnsureRequiredAnnotations(container);
 
             var nameSuffix = container.GetContainerLifetimeType() switch
             {

--- a/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ExecutableResourceBuilderExtensions.cs
@@ -47,8 +47,7 @@ public static class ExecutableResourceBuilderExtensions
                           {
                               context.Args.AddRange(args);
                           }
-                      })
-                      .WithLifeCycleCommands();
+                      });
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs
@@ -282,7 +282,6 @@ public static class ProjectResourceBuilderExtensions
 
         builder.WithOtlpExporter();
         builder.ConfigureConsoleLogs();
-        builder.WithLifeCycleCommands();
 
         var projectResource = builder.Resource;
 

--- a/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
+++ b/tests/Aspire.EndToEnd.Tests/IntegrationServicesTests.cs
@@ -49,6 +49,7 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
     public Task VerifyAzureEventHubsComponentWorks()
         => VerifyComponentWorks(TestResourceNames.eventhubs);
 
+    [ActiveIssue("https://github.com/dotnet/aspire/issues/5820")]
     [ConditionalTheory]
     [Trait("scenario", "cosmos")]
     [InlineData(TestResourceNames.cosmos)]
@@ -65,7 +66,8 @@ public class IntegrationServicesTests : IClassFixture<IntegrationServicesFixture
 
     [Fact]
     // Include all the scenarios here so this test gets run for all of them.
-    [Trait("scenario", "cosmos")]
+    // https://github.com/dotnet/aspire/issues/5820
+    // [Trait("scenario", "cosmos")]
     [Trait("scenario", "basicservices")]
     public Task VerifyHealthyOnIntegrationServiceA()
         => RunTestAsync(async () =>

--- a/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
@@ -8,24 +8,6 @@ namespace Aspire.Hosting.Tests;
 
 public class ResourceCommandAnnotationTests
 {
-    [Fact]
-    public void AddContainer_HasKnownCommandAnnotations()
-    {
-        HasKnownCommandAnnotationsCore(builder => builder.AddContainer("name", "image"));
-    }
-
-    [Fact]
-    public void AddProject_HasKnownCommandAnnotations()
-    {
-        HasKnownCommandAnnotationsCore(builder => builder.AddProject("name", "path", o => o.ExcludeLaunchProfile = true));
-    }
-
-    [Fact]
-    public void AddExecutable_HasKnownCommandAnnotations()
-    {
-        HasKnownCommandAnnotationsCore(builder => builder.AddExecutable("name", "command", "workingDirectory"));
-    }
-
     [Theory]
     [InlineData(CommandsConfigurationExtensions.StartType, "Starting", ResourceCommandState.Disabled)]
     [InlineData(CommandsConfigurationExtensions.StartType, "Stopping", ResourceCommandState.Hidden)]
@@ -53,6 +35,7 @@ public class ResourceCommandAnnotationTests
         // Arrange
         var builder = DistributedApplication.CreateBuilder();
         var resourceBuilder = builder.AddContainer("name", "image");
+        resourceBuilder.Resource.AddLifeCycleCommands();
 
         var startCommand = resourceBuilder.Resource.Annotations.OfType<ResourceCommandAnnotation>().Single(a => a.Type == commandType);
 
@@ -70,21 +53,5 @@ public class ResourceCommandAnnotationTests
 
         // Assert
         Assert.Equal(commandState, state);
-    }
-
-    private static void HasKnownCommandAnnotationsCore<T>(Func<IDistributedApplicationBuilder, IResourceBuilder<T>> createResourceBuilder) where T : IResource
-    {
-        // Arrange
-        var builder = DistributedApplication.CreateBuilder();
-
-        // Act
-        var resourceBuilder = createResourceBuilder(builder);
-
-        // Assert
-        var commandAnnotations = resourceBuilder.Resource.Annotations.OfType<ResourceCommandAnnotation>().ToList();
-        Assert.Collection(commandAnnotations,
-            a => Assert.Equal(CommandsConfigurationExtensions.StartType, a.Type),
-            a => Assert.Equal(CommandsConfigurationExtensions.StopType, a.Type),
-            a => Assert.Equal(CommandsConfigurationExtensions.RestartType, a.Type));
     }
 }

--- a/tests/Aspire.Playground.Tests/AppHostTests.cs
+++ b/tests/Aspire.Playground.Tests/AppHostTests.cs
@@ -164,13 +164,14 @@ public class AppHostTests
                 waitForTexts: [
                     new ("milvus", "Milvus Proxy successfully initialized and ready to serve"),
                 ]),
-            new TestEndpoints("CosmosEndToEnd.AppHost",
-                resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
-                // "/ef" - disabled due to https://github.com/dotnet/aspire/issues/5415
-                waitForTexts: [
-                    new ("cosmos", "Started$"),
-                    new ("api", "Application started")
-                ]),
+            // Cosmos emulator is extremely slow to start up and unreliable in CI
+            //new TestEndpoints("CosmosEndToEnd.AppHost",
+            //    resourceEndpoints: new() { { "api", ["/alive", "/health", "/"] } },
+            //    // "/ef" - disabled due to https://github.com/dotnet/aspire/issues/5415
+            //    waitForTexts: [
+            //        new ("cosmos", "Started$"),
+            //        new ("api", "Application started")
+            //    ]),
             new TestEndpoints("Keycloak.AppHost",
                 resourceEndpoints: new() { { "apiservice", ["/alive", "/health"] } }),
             new TestEndpoints("Mongo.AppHost",

--- a/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
+++ b/tests/Aspire.Playground.Tests/Infrastructure/DistributedApplicationTestFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
@@ -46,9 +46,9 @@ internal static class DistributedApplicationTestFactory
             {
                 logging.AddXunit(testOutput);
             }
-            logging.SetMinimumLevel(LogLevel.Debug);
-            logging.AddFilter("Aspire", LogLevel.Debug);
-            logging.AddFilter(builder.Environment.ApplicationName, LogLevel.Debug);
+            logging.SetMinimumLevel(LogLevel.Trace);
+            logging.AddFilter("Aspire", LogLevel.Trace);
+            logging.AddFilter(builder.Environment.ApplicationName, LogLevel.Trace);
         });
 
         return builder;


### PR DESCRIPTION
## Description

Follow up to https://github.com/dotnet/aspire/pull/5538. Wire up commands later in the cycle so that we get all resources that DCP considers valid (this fixes emulators and other dynamically added resources that don't go through extension methods).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5802)