### PR TITLE
WithPgAdmin - Respect UserName Parameter

### DIFF
--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json;
 using System.Text;
+using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Utils;
@@ -85,7 +85,7 @@ public static class PostgresBuilderExtensions
             //
             //       https://github.com/npgsql/npgsql/blob/c3b31c393de66a4b03fba0d45708d46a2acb06d2/src/Npgsql/NpgsqlConnection.cs#L445
             //
-            connection.ConnectionString = connection.ConnectionString + ";Database=postgres;";
+            connection.ConnectionString += ";Database=postgres;";
         });
 
         return builder.AddResource(postgresServer)
@@ -215,7 +215,7 @@ public static class PostgresBuilderExtensions
                         // This will need to be refactored once updated service discovery APIs are available
                         writer.WriteString("Host", endpoint.Resource.Name);
                         writer.WriteNumber("Port", (int)endpoint.TargetPort!);
-                        writer.WriteString("Username", "postgres");
+                        writer.WriteString("Username", postgresInstance.UserNameParameter?.Value ?? "postgres");
                         writer.WriteString("SSLMode", "prefer");
                         writer.WriteString("MaintenanceDB", "postgres");
                         writer.WriteString("PasswordExecCommand", $"echo '{postgresInstance.PasswordParameter.Value}'"); // HACK: Generating a pass file and playing around with chmod is too painful.

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -452,8 +452,9 @@ public class AddPostgresTests
     public async Task WithPostgresProducesValidServersJsonFile()
     {
         var builder = DistributedApplication.CreateBuilder();
+        var username = builder.AddParameter("pg-user", "myuser");
         var pg1 = builder.AddPostgres("mypostgres1").WithPgAdmin(pga => pga.WithHostPort(8081));
-        var pg2 = builder.AddPostgres("mypostgres2").WithPgAdmin(pga => pga.WithHostPort(8081));
+        var pg2 = builder.AddPostgres("mypostgres2", username).WithPgAdmin(pga => pga.WithHostPort(8081));
 
         // Add fake allocated endpoints.
         pg1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
@@ -486,7 +487,7 @@ public class AddPostgresTests
         Assert.Equal("Servers", servers.GetProperty("2").GetProperty("Group").GetString());
         Assert.Equal("mypostgres2", servers.GetProperty("2").GetProperty("Host").GetString());
         Assert.Equal(5432, servers.GetProperty("2").GetProperty("Port").GetInt32());
-        Assert.Equal("postgres", servers.GetProperty("2").GetProperty("Username").GetString());
+        Assert.Equal("myuser", servers.GetProperty("2").GetProperty("Username").GetString());
         Assert.Equal("prefer", servers.GetProperty("2").GetProperty("SSLMode").GetString());
         Assert.Equal("postgres", servers.GetProperty("2").GetProperty("MaintenanceDB").GetString());
         Assert.Equal($"echo '{pg2.Resource.PasswordParameter.Value}'", servers.GetProperty("2").GetProperty("PasswordExecCommand").GetString());


### PR DESCRIPTION
## Description

This fixes a small bug where the username parameter is not respected when using `WithPgAdmin` - w/o persistent container lifetimes (coming soon I know!) this is very annoying to have to refix on every PgAdmin load.

The approach I took is the exact same as the methodology used in `WithPgWeb`.

Fixes #6236
Fixes https://github.com/dotnet/aspire/issues/4100

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5805)