### PR TITLE
Uses values from constants in documentation

### DIFF
--- a/playground/AspireEventHub/EventHubsConsumer/Consumer.cs
+++ b/playground/AspireEventHub/EventHubsConsumer/Consumer.cs
@@ -11,7 +11,7 @@ namespace EventHubsConsumer;
 ///   production scenario, as it offers a much more robust experience with higher throughput.
 ///
 ///   It is important to note that this method does not guarantee fairness amongst the partitions during iteration; each of the partitions compete to publish
-///   events to be read by the enumerator.  Depending on service communication, there may be a clustering of events per partition and/or there may be a noticeable
+///   events to be read by the enumerator. Depending on service communication, there may be a clustering of events per partition and/or there may be a noticeable
 ///   bias for a given partition or subset of partitions.
 ///
 ///   Each reader of events is presented with an independent iterator; if there are multiple readers, each receive their own copy of an event to

--- a/src/Aspire.Dashboard/Authentication/AspirePolicyEvaluator.cs
+++ b/src/Aspire.Dashboard/Authentication/AspirePolicyEvaluator.cs
@@ -30,11 +30,11 @@ public class AspirePolicyEvaluator : IPolicyEvaluator
 
     /// <summary>
     /// Does authentication for <see cref="AuthorizationPolicy.AuthenticationSchemes"/> and sets the resulting
-    /// <see cref="ClaimsPrincipal"/> to <see cref="HttpContext.User"/>.  If no schemes are set, this is a no-op.
+    /// <see cref="ClaimsPrincipal"/> to <see cref="HttpContext.User"/>. If no schemes are set, this is a no-op.
     /// </summary>
     /// <param name="policy">The <see cref="AuthorizationPolicy"/>.</param>
     /// <param name="context">The <see cref="HttpContext"/>.</param>
-    /// <returns><see cref="AuthenticateResult.Success"/> unless all schemes specified by <see cref="AuthorizationPolicy.AuthenticationSchemes"/> failed to authenticate.  </returns>
+    /// <returns><see cref="AuthenticateResult.Success"/> unless all schemes specified by <see cref="AuthorizationPolicy.AuthenticationSchemes"/> failed to authenticate.</returns>
     public virtual async Task<AuthenticateResult> AuthenticateAsync(AuthorizationPolicy policy, HttpContext context)
     {
         if (policy.AuthenticationSchemes != null && policy.AuthenticationSchemes.Count > 0)

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
+using Aspire.Hosting.Azure.Storage;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning;
 using Azure.Provisioning.Storage;
@@ -16,7 +17,7 @@ namespace Aspire.Hosting;
 public static class AzureStorageExtensions
 {
     /// <summary>
-    /// Adds an Azure Storage resource to the application model.This resource can be used to create Azure blob, table, and queue resources.
+    /// Adds an Azure Storage resource to the application model. This resource can be used to create Azure blob, table, and queue resources.
     /// </summary>
     /// <param name="builder">The builder for the distributed application.</param>
     /// <param name="name">The name of the resource.</param>
@@ -29,7 +30,7 @@ public static class AzureStorageExtensions
     }
 
     /// <summary>
-    /// Adds an Azure Storage resource to the application model.This resource can be used to create Azure blob, table, and queue resources.
+    /// Adds an Azure Storage resource to the application model. This resource can be used to create Azure blob, table, and queue resources.
     /// </summary>
     /// <param name="builder">The builder for the distributed application.</param>
     /// <param name="name">The name of the resource.</param>
@@ -92,7 +93,7 @@ public static class AzureStorageExtensions
     }
 
     /// <summary>
-    /// Configures an Azure Storage resource to be emulated using Azurite. This resource requires an <see cref="AzureStorageResource"/> to be added to the application model. This version the package defaults to version 3.29.0 of the mcr.microsoft.com/azure-storage/azurite container image.
+    /// Configures an Azure Storage resource to be emulated using Azurite. This resource requires an <see cref="AzureStorageResource"/> to be added to the application model. This version of the package defaults to the <inheritdoc cref="StorageEmulatorContainerImageTags.Tag"/> tag of the <inheritdoc cref="StorageEmulatorContainerImageTags.Registry"/>/<inheritdoc cref="StorageEmulatorContainerImageTags.Image"/> container image.
     /// </summary>
     /// <param name="builder">The Azure storage resource builder.</param>
     /// <param name="configureContainer">Callback that exposes underlying container used for emulation to allow for customization.</param>
@@ -109,9 +110,9 @@ public static class AzureStorageExtensions
                .WithEndpoint(name: "table", targetPort: 10002)
                .WithAnnotation(new ContainerImageAnnotation
                {
-                   Registry = "mcr.microsoft.com",
-                   Image = "azure-storage/azurite",
-                   Tag = "3.31.0"
+                   Registry = StorageEmulatorContainerImageTags.Registry,
+                   Image = StorageEmulatorContainerImageTags.Image,
+                   Tag = StorageEmulatorContainerImageTags.Tag
                });
 
         if (configureContainer != null)

--- a/src/Aspire.Hosting.Azure.Storage/StorageEmulatorContainerImageTags.cs
+++ b/src/Aspire.Hosting.Azure.Storage/StorageEmulatorContainerImageTags.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Azure.Storage;
+
+internal static class StorageEmulatorContainerImageTags
+{
+    /// <summary>mcr.microsoft.com</summary>
+    public const string Registry = "mcr.microsoft.com";
+
+    /// <summary>azure-storage/azurite</summary>
+    public const string Image = "azure-storage/azurite";
+
+    /// <summary>3.31.0</summary>
+    public const string Tag = "3.31.0";
+}

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -21,7 +21,7 @@ public static class KafkaBuilderExtensions
     private const string Target = "/var/lib/kafka/data";
 
     /// <summary>
-    /// Adds a Kafka resource to the application. A container is used for local development.  This version the package defaults to the 7.6.1 tag of the confluentinc/confluent-local container image.
+    /// Adds a Kafka resource to the application. A container is used for local development. This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.Tag"/> tag of the <inheritdoc cref="KafkaContainerImageTags.Image"/> container image.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency</param>
@@ -77,7 +77,7 @@ public static class KafkaBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a Kafka UI container to the application. This version of the package defaults to the 0.7.2 tag of the provectuslabs/kafka-ui container image.
+    /// Adds a Kafka UI container to the application. This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.KafkaUiTag"/> tag of the <inheritdoc cref="KafkaContainerImageTags.KafkaUiImage"/> container image.
     /// </summary>
     /// <param name="builder">The Kafka server resource builder.</param>
     /// <param name="configureContainer">Configuration callback for KafkaUI container resource.</param>

--- a/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaContainerImageTags.cs
@@ -5,9 +5,18 @@ namespace Aspire.Hosting;
 
 internal static class KafkaContainerImageTags
 {
+    /// <summary>docker.io</summary>
     public const string Registry = "docker.io";
+
+    /// <summary>confluentinc/confluent-local</summary>
     public const string Image = "confluentinc/confluent-local";
+
+    /// <summary>7.7.0</summary>
     public const string Tag = "7.7.0";
+
+    /// <summary>provectuslabs/kafka-ui</summary>
     public const string KafkaUiImage = "provectuslabs/kafka-ui";
+
+    /// <summary>v0.7.2</summary>
     public const string KafkaUiTag = "v0.7.2";
 }

--- a/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class MilvusBuilderExtensions
     /// </code>
     /// </example>
     /// <remarks>
-    /// This version the package defaults to the 2.3-latest tag of the milvusdb/milvus container image.
+    /// This version of the package defaults to the <inheritdoc cref="MilvusContainerImageTags.Tag"/> tag of the <inheritdoc cref="MilvusContainerImageTags.Image"/> container image.
     /// The .NET client library uses the gRPC port by default to communicate and this resource exposes that endpoint.
     /// A web-based administration tool for Milvus can also be added using <see cref="WithAttu"/>.
     /// </remarks>
@@ -172,7 +172,7 @@ public static class MilvusBuilderExtensions
     }
 
     /// <summary>
-    /// Adds an administration and development platform for Milvus to the application model using Attu. This version the package defaults to the 2.3-latest tag of the attu container image
+    /// Adds an administration and development platform for Milvus to the application model using Attu. This version of the package defaults to the <inheritdoc cref="MilvusContainerImageTags.AttuTag"/> tag of the <inheritdoc cref="MilvusContainerImageTags.AttuImage"/> container image
     /// </summary>
     /// <example>
     /// Use in application host with a Milvus resource

--- a/src/Aspire.Hosting.Milvus/MilvusContainerImageTags.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusContainerImageTags.cs
@@ -5,11 +5,19 @@ namespace Aspire.Hosting.Milvus;
 
 internal static class MilvusContainerImageTags
 {
+    /// <summary>docker.io</summary>
     public const string Registry = "docker.io";
+
+    /// <summary>milvusdb/milvus</summary>
     public const string Image = "milvusdb/milvus";
+
+    /// <summary>v2.4.10</summary>
     public const string Tag = "v2.4.10";
 
+    /// <summary>zilliz/attu</summary>
     public const string AttuImage = "zilliz/attu";
+
+    /// <summary>v2.4</summary>
     public const string AttuTag = "v2.4";
 }
 

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class MongoDBBuilderExtensions
     private const int DefaultContainerPort = 27017;
 
     /// <summary>
-    /// Adds a MongoDB resource to the application model. A container is used for local development. This version the package defaults to the 7.0.8 tag of the mongo container image.
+    /// Adds a MongoDB resource to the application model. A container is used for local development. This version of the package defaults to the <inheritdoc cref="MongoDBContainerImageTags.Tag"/> tag of the <inheritdoc cref="MongoDBContainerImageTags.Image"/> container image.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -76,7 +76,7 @@ public static class MongoDBBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a MongoExpress administration and development platform for MongoDB to the application model. This version the package defaults to the 1.0.2-20 tag of the mongo-express container image
+    /// Adds a MongoExpress administration and development platform for MongoDB to the application model. This version of the package defaults to the <inheritdoc cref="MongoDBContainerImageTags.MongoExpressTag"/> tag of the <inheritdoc cref="MongoDBContainerImageTags.MongoExpressImage"/> container image
     /// </summary>
     /// <param name="builder">The MongoDB server resource builder.</param>
     /// <param name="configureContainer">Configuration callback for Mongo Express container resource.</param>

--- a/src/Aspire.Hosting.MongoDB/MongoDBContainerImageTags.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBContainerImageTags.cs
@@ -5,10 +5,21 @@ namespace Aspire.Hosting.MongoDB;
 
 internal static class MongoDBContainerImageTags
 {
+    /// <summary>docker.io</summary>
     public const string Registry = "docker.io";
+
+    /// <summary>library/mongo</summary>
     public const string Image = "library/mongo";
+
+    /// <summary>7.0</summary>
     public const string Tag = "7.0";
+
+    /// <summary>docker.io</summary>
     public const string MongoExpressRegistry = "docker.io";
+
+    /// <summary>library/mongo-express</summary>
     public const string MongoExpressImage = "library/mongo-express";
+
+    /// <summary>1.0</summary>
     public const string MongoExpressTag = "1.0";
 }

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -16,7 +16,7 @@ public static class MySqlBuilderExtensions
     private const string PasswordEnvVarName = "MYSQL_ROOT_PASSWORD";
 
     /// <summary>
-    /// Adds a MySQL server resource to the application model. For local development a container is used. This version the package defaults to the 8.3.0 tag of the mysql container image
+    /// Adds a MySQL server resource to the application model. For local development a container is used. This version of the package defaults to the <inheritdoc cref="MySqlContainerImageTags.Tag"/> tag of the <inheritdoc cref="MySqlContainerImageTags.Image"/> container image
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -112,7 +112,7 @@ public static class MySqlBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a phpMyAdmin administration and development platform for MySql to the application model. This version the package defaults to the 5.2 tag of the phpmyadmin container image
+    /// Adds a phpMyAdmin administration and development platform for MySql to the application model. This version of the package defaults to the <inheritdoc cref="MySqlContainerImageTags.PhpMyAdminTag"/> tag of the <inheritdoc cref="MySqlContainerImageTags.PhpMyAdminImage"/> container image
     /// </summary>
     /// <param name="builder">The MySql server resource builder.</param>
     /// <param name="configureContainer">Callback to configure PhpMyAdmin container resource.</param>

--- a/src/Aspire.Hosting.MySql/MySqlContainerImageTags.cs
+++ b/src/Aspire.Hosting.MySql/MySqlContainerImageTags.cs
@@ -5,10 +5,18 @@ namespace Aspire.Hosting.MySql;
 
 internal static class MySqlContainerImageTags
 {
+    /// <summary>docker.io</summary>
     public const string Registry = "docker.io";
+
+    /// <summary>library/mysql</summary>
     public const string Image = "library/mysql";
+
+    /// <summary>9.0</summary>
     public const string Tag = "9.0";
 
+    /// <summary>library/phpmyadmin</summary>
     public const string PhpMyAdminImage = "library/phpmyadmin";
+
+    /// <summary>5.2</summary>
     public const string PhpMyAdminTag = "5.2";
 }

--- a/src/Aspire.Hosting.Oracle/OracleContainerImageTags.cs
+++ b/src/Aspire.Hosting.Oracle/OracleContainerImageTags.cs
@@ -5,7 +5,12 @@ namespace Aspire.Hosting;
 
 internal static class OracleContainerImageTags
 {
+    /// <summary>container-registry.oracle.com</summary>
     public const string Registry = "container-registry.oracle.com";
+
+    /// <summary>database/free</summary>
     public const string Image = "database/free";
+
+    /// <summary>23.5.0.0</summary>
     public const string Tag = "23.5.0.0";
 }

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -15,7 +15,7 @@ public static class OracleDatabaseBuilderExtensions
     private const string PasswordEnvVarName = "ORACLE_PWD";
 
     /// <summary>
-    /// Adds a Oracle Server resource to the application model. A container is used for local development. This version the package defaults to the 23.3.0.0 tag of the container-registry.oracle.com/database/free container image
+    /// Adds a Oracle Server resource to the application model. A container is used for local development. This version of the package defaults to the <inheritdoc cref="OracleContainerImageTags.Tag"/> tag of the <inheritdoc cref="OracleContainerImageTags.Registry"/>/<inheritdoc cref="OracleContainerImageTags.Image"/> container image
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class PostgresBuilderExtensions
     private const string PasswordEnvVarName = "POSTGRES_PASSWORD";
 
     /// <summary>
-    /// Adds a PostgreSQL resource to the application model. A container is used for local development. This version the package defaults to the 16.2 tag of the postgres container image
+    /// Adds a PostgreSQL resource to the application model. A container is used for local development. This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.Tag"/> tag of the <inheritdoc cref="PostgresContainerImageTags.Image"/> container image
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -153,7 +153,7 @@ public static class PostgresBuilderExtensions
     }
 
     /// <summary>
-    /// Adds a pgAdmin 4 administration and development platform for PostgreSQL to the application model. This version the package defaults to the 8.8 tag of the dpage/pgadmin4 container image
+    /// Adds a pgAdmin 4 administration and development platform for PostgreSQL to the application model. This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.PgAdminTag"/> tag of the <inheritdoc cref="PostgresContainerImageTags.PgAdminImage"/> container image
     /// </summary>
     /// <param name="builder">The PostgreSQL server resource builder.</param>
     /// <param name="configureContainer">Callback to configure PgAdmin container resource.</param>
@@ -289,7 +289,7 @@ public static class PostgresBuilderExtensions
     /// </code>
     /// </example>
     /// <remarks>
-    /// This version the package defaults to the 0.15.0 tag of the sosedoff/pgweb container image.
+    /// This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.PgWebTag"/> tag of the <inheritdoc cref="PostgresContainerImageTags.PgWebImage"/> container image.
     /// </remarks>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<PostgresServerResource> WithPgWeb(this IResourceBuilder<PostgresServerResource> builder, Action<IResourceBuilder<PgWebContainerResource>>? configureContainer = null, string? containerName = null)

--- a/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresContainerImageTags.cs
@@ -5,13 +5,30 @@ namespace Aspire.Hosting.Postgres;
 
 internal static class PostgresContainerImageTags
 {
+    /// <summary>docker.io</summary>
     public const string Registry = "docker.io";
+
+    /// <summary>library/postgres</summary>
     public const string Image = "library/postgres";
+
+    /// <summary>16.4</summary>
     public const string Tag = "16.4";
+
+    /// <summary>docker.io</summary>
     public const string PgAdminRegistry = "docker.io";
+
+    /// <summary>dpage/pgadmin4</summary>
     public const string PgAdminImage = "dpage/pgadmin4";
+
+    /// <summary>8.11</summary>
     public const string PgAdminTag = "8.11";
+
+    /// <summary>docker.io</summary>
     public const string PgWebRegistry = "docker.io";
+
+    /// <summary>sosedoff/pgweb</summary>
     public const string PgWebImage = "sosedoff/pgweb";
+
+    /// <summary>0.15.0</summary>
     public const string PgWebTag = "0.15.0";
 }

--- a/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
@@ -21,7 +21,7 @@ public static class QdrantBuilderExtensions
     /// Adds a Qdrant resource to the application. A container is used for local development.
     /// </summary>
     /// <remarks>
-    /// This version the package defaults to the v1.8.4 tag of the qdrant/qdrant container image.
+    /// This version of the package defaults to the <inheritdoc cref="QdrantContainerImageTags.Tag"/> tag of the <inheritdoc cref="QdrantContainerImageTags.Image"/> container image.
     /// The .NET client library uses the gRPC port by default to communicate and this resource exposes that endpoint.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>

--- a/src/Aspire.Hosting.Qdrant/QdrantContainerImageTags.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantContainerImageTags.cs
@@ -5,7 +5,12 @@ namespace Aspire.Hosting.Qdrant;
 
 internal static class QdrantContainerImageTags
 {
+    /// <summary>docker.io</summary>
     public const string Registry = "docker.io";
+
+    /// <summary>qdrant/qdrant</summary>
     public const string Image = "qdrant/qdrant";
+
+    /// <summary>v1.11.3</summary>
     public const string Tag = "v1.11.3";
 }

--- a/src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.Hosting.Sdk/SDK/Sdk.in.targets
@@ -79,7 +79,7 @@
       <_AppHostVersion>@VERSION@</_AppHostVersion>
     </PropertyGroup>
 
-    <!-- At this point, we should have the version either by CPM or PackageReference, so we fail if not.  -->
+    <!-- At this point, we should have the version either by CPM or PackageReference, so we fail if not. -->
     <Error Condition="'$(_AppHostVersion)' == ''" 
        Text="$(MSBuildProjectName) is a .NET Aspire AppHost project that needs a package reference to Aspire.Hosting.AppHost version 8.2.0 or above to work correctly." />
 

--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AzureMessagingServiceBusSettings.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AzureMessagingServiceBusSettings.cs
@@ -53,7 +53,7 @@ public sealed class AzureMessagingServiceBusSettings : IConnectionStringSettings
     /// Or by setting "AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE" environment variable to "true".
     /// </remarks>
     /// <value>  
-    /// The default value is <see langword="false"/>.  
+    /// The default value is <see langword="false"/>.
     /// </value>
     public bool DisableTracing
     {

--- a/src/Tools/ConfigurationSchemaGenerator/RuntimeSource/Roslyn/GetBestTypeByMetadataName.cs
+++ b/src/Tools/ConfigurationSchemaGenerator/RuntimeSource/Roslyn/GetBestTypeByMetadataName.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.DotnetRuntime.Extensions
             switch (symbol.Kind)
             {
                 case SymbolKind.Alias:
-                    // Aliases are uber private.  They're only visible in the same file that they
+                    // Aliases are uber private. They're only visible in the same file that they
                     // were declared in.
                     return SymbolVisibility.Private;
 


### PR DESCRIPTION
There were some discrepancies between the code documentation and the actual values. This suggested pattern will prevent that, or at least make it obvious to update or catch in PRs by having the summary close to the actually value.

This is how it looks after:

![image](https://github.com/user-attachments/assets/db8d465f-0651-457e-a4b1-de9ea395d8b9)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5806)