### PR TITLE
Rename the dcp resource on restart

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -21,7 +21,7 @@ internal static class CommandsConfigurationExtensions
             {
                 var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
 
-                await executor.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
+                await executor.StartResourceAsync(resource, context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 return CommandResults.Success();
             },
             updateState: context =>
@@ -49,7 +49,7 @@ internal static class CommandsConfigurationExtensions
             {
                 var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
 
-                await executor.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
+                await executor.StopResourceAsync(resource, context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 return CommandResults.Success();
             },
             updateState: context =>
@@ -77,8 +77,8 @@ internal static class CommandsConfigurationExtensions
             {
                 var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
 
-                await executor.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                await executor.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
+                await executor.StopResourceAsync(resource, context.ResourceName, context.CancellationToken).ConfigureAwait(false);
+                await executor.StartResourceAsync(resource, context.ResourceName, context.CancellationToken).ConfigureAwait(false);
                 return CommandResults.Success();
             },
             updateState: context =>


### PR DESCRIPTION
## Description

This change makes the old dcp resource as hidden and makes a new resource. The UI can be a bit jarring as items are removed and then added.

Fixes #5803

PS: It's unclear if we want this change. I just wanted to understand the behavior and potential fix. Instead DCP could reset the log stream state when a new resource is created.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
