### PR TITLE
Support icon variant on commands, make start and stop icons filled

### DIFF
--- a/playground/seq/Seq.AppHost/Program.cs
+++ b/playground/seq/Seq.AppHost/Program.cs
@@ -16,7 +16,7 @@ builder.AddProject<Projects.Seq_ApiService>("api")
 // dashboard launch experience, Refer to Directory.Build.props for the path to
 // the dashboard binary (defaults to the Aspire.Dashboard bin output in the
 // artifacts dir).
-builder.AddProject<Projects.Aspire_Dashboard>("aspire-dashboard");
+builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
 #endif
 
 builder.Build().Run();

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -5,7 +5,7 @@
 @foreach (var highlightedCommand in Commands.Where(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden))
 {
     <FluentButton Appearance="Appearance.Lightweight" Title="@(highlightedCommand.DisplayDescription ?? highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
-        @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && CommandViewModel.ResolveIconName(highlightedCommand.IconName) is { } icon)
+        @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && CommandViewModel.ResolveIconName(highlightedCommand.IconName, highlightedCommand.IconVariant) is { } icon)
         {
             <FluentIcon Value="@icon" />
         }
@@ -18,6 +18,6 @@
 
 <AspireMenuButton
     ButtonAppearance="Appearance.Lightweight"
-    Icon="@(new Icons.Regular.Size24.MoreHorizontal())"
+    Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
     Items="@_menuItems"
     @ref="_menuButton" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -10,8 +10,8 @@ namespace Aspire.Dashboard.Components;
 
 public partial class ResourceActions : ComponentBase
 {
-    private static readonly Icon s_viewDetailsIcon = new Icons.Regular.Size20.Info();
-    private static readonly Icon s_consoleLogsIcon = new Icons.Regular.Size20.SlideText();
+    private static readonly Icon s_viewDetailsIcon = new Icons.Regular.Size16.Info();
+    private static readonly Icon s_consoleLogsIcon = new Icons.Regular.Size16.SlideText();
 
     private AspireMenuButton? _menuButton;
 
@@ -56,7 +56,7 @@ public partial class ResourceActions : ComponentBase
 
             foreach (var command in menuCommands)
             {
-                var icon = (!string.IsNullOrEmpty(command.IconName) && CommandViewModel.ResolveIconName(command.IconName) is { } i) ? i : null;
+                var icon = (!string.IsNullOrEmpty(command.IconName) && CommandViewModel.ResolveIconName(command.IconName, command.IconVariant) is { } i) ? i : null;
 
                 _menuItems.Add(new MenuButtonItem
                 {

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -71,18 +71,20 @@ public enum ReadinessState
 [DebuggerDisplay("CommandType = {CommandType}, DisplayName = {DisplayName}")]
 public sealed class CommandViewModel
 {
-    private static readonly ConcurrentDictionary<string, CustomIcon?> s_iconCache = new();
+    private sealed record IconKey(string IconName, IconVariant IconVariant);
+    private static readonly ConcurrentDictionary<IconKey, CustomIcon?> s_iconCache = new();
 
     public string CommandType { get; }
     public CommandViewModelState State { get; }
     public string DisplayName { get; }
-    public string? DisplayDescription { get; }
-    public string? ConfirmationMessage { get; }
+    public string DisplayDescription { get; }
+    public string ConfirmationMessage { get; }
     public Value? Parameter { get; }
     public bool IsHighlighted { get; }
-    public string? IconName { get; }
+    public string IconName { get; }
+    public IconVariant IconVariant { get; }
 
-    public CommandViewModel(string commandType, CommandViewModelState state, string displayName, string? displayDescription, string? confirmationMessage, Value? parameter, bool isHighlighted, string? iconName)
+    public CommandViewModel(string commandType, CommandViewModelState state, string displayName, string displayDescription, string confirmationMessage, Value? parameter, bool isHighlighted, string iconName, IconVariant iconVariant)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(commandType);
         ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
@@ -95,20 +97,21 @@ public sealed class CommandViewModel
         Parameter = parameter;
         IsHighlighted = isHighlighted;
         IconName = iconName;
+        IconVariant = iconVariant;
     }
 
-    public static CustomIcon? ResolveIconName(string iconName)
+    public static CustomIcon? ResolveIconName(string iconName, IconVariant? iconVariant)
     {
-        // Icons.GetInstance isn't efficent. Cache icon lookup.
-        return s_iconCache.GetOrAdd(iconName, static name =>
+        // Icons.GetInstance isn't efficient. Cache icon lookup.
+        return s_iconCache.GetOrAdd(new IconKey(iconName, iconVariant ?? IconVariant.Regular), static key =>
         {
             try
             {
                 return Icons.GetInstance(new IconInfo
                 {
-                    Name = name,
-                    Variant = IconVariant.Regular,
-                    Size = IconSize.Size20
+                    Name = key.IconName,
+                    Variant = key.IconVariant,
+                    Size = IconSize.Size16
                 });
             }
             catch

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -5,6 +5,7 @@ using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Aspire.Dashboard.Model;
+using FluentUIIconVariant = Microsoft.FluentUI.AspNetCore.Components.IconVariant;
 
 namespace Aspire.ResourceService.Proto.V1;
 
@@ -71,9 +72,9 @@ partial class Resource
         ImmutableArray<CommandViewModel> GetCommands()
         {
             return Commands
-                .Select(c => new CommandViewModel(c.CommandType, Map(c.State), c.DisplayName, c.HasDisplayDescription ? c.DisplayDescription : null, c.ConfirmationMessage, c.Parameter, c.IsHighlighted, c.HasIconName ? c.IconName : null))
+                .Select(c => new CommandViewModel(c.CommandType, MapState(c.State), c.DisplayName, c.DisplayDescription, c.ConfirmationMessage, c.Parameter, c.IsHighlighted, c.IconName, MapIconVariant(c.IconVariant)))
                 .ToImmutableArray();
-            static CommandViewModelState Map(ResourceCommandState state)
+            static CommandViewModelState MapState(ResourceCommandState state)
             {
                 return state switch
                 {
@@ -81,6 +82,15 @@ partial class Resource
                     ResourceCommandState.Disabled => CommandViewModelState.Disabled,
                     ResourceCommandState.Hidden => CommandViewModelState.Hidden,
                     _ => throw new InvalidOperationException("Unknown state: " + state),
+                };
+            }
+            static FluentUIIconVariant MapIconVariant(IconVariant iconVariant)
+            {
+                return iconVariant switch
+                {
+                    IconVariant.Regular => FluentUIIconVariant.Regular,
+                    IconVariant.Filled => FluentUIIconVariant.Filled,
+                    _ => throw new InvalidOperationException("Unknown icon variant: " + iconVariant),
                 };
             }
         }

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -40,6 +40,7 @@ internal static class CommandsConfigurationExtensions
                 }
             },
             iconName: "Play",
+            iconVariant: IconVariant.Filled,
             isHighlighted: true));
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
@@ -68,6 +69,7 @@ internal static class CommandsConfigurationExtensions
                 }
             },
             iconName: "Stop",
+            iconVariant: IconVariant.Filled,
             isHighlighted: true));
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
@@ -93,6 +95,7 @@ internal static class CommandsConfigurationExtensions
                 }
             },
             iconName: "ArrowCounterclockwise",
+            iconVariant: IconVariant.Regular,
             isHighlighted: false));
 
         static bool IsStopped(string? state) => state is "Exited" or "Finished" or "FailedToStart";

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -117,8 +117,9 @@ public sealed record ResourcePropertySnapshot(string Name, object? Value);
 /// <param name="State">The state of the command.</param>
 /// <param name="DisplayName">The display name visible in UI for the command.</param>
 /// <param name="IconName">The icon name for the command. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons</param>
+/// <param name="IconVariant">The icon variant.</param>
 /// <param name="IsHighlighted">A flag indicating whether the command is highlighted in the UI.</param>
-public sealed record ResourceCommandSnapshot(string Type, ResourceCommandState State, string DisplayName, string? IconName, bool IsHighlighted);
+public sealed record ResourceCommandSnapshot(string Type, ResourceCommandState State, string DisplayName, string? IconName, IconVariant? IconVariant, bool IsHighlighted);
 
 /// <summary>
 /// The state of a resource command.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -20,6 +20,7 @@ public sealed class ResourceCommandAnnotation : IResourceAnnotation
         Func<UpdateCommandStateContext, ResourceCommandState> updateState,
         Func<ExecuteCommandContext, Task<ExecuteCommandResult>> executeCommand,
         string? iconName,
+        IconVariant? iconVariant,
         bool isHighlighted)
     {
         ArgumentNullException.ThrowIfNull(type);
@@ -32,6 +33,7 @@ public sealed class ResourceCommandAnnotation : IResourceAnnotation
         UpdateState = updateState;
         ExecuteCommand = executeCommand;
         IconName = iconName;
+        IconVariant = iconVariant;
         IsHighlighted = isHighlighted;
     }
 
@@ -63,9 +65,29 @@ public sealed class ResourceCommandAnnotation : IResourceAnnotation
     public string? IconName { get; }
 
     /// <summary>
+    /// The icon variant for the command.
+    /// </summary>
+    public IconVariant? IconVariant { get; }
+
+    /// <summary>
     /// A flag indicating whether the command is highlighted in the UI.
     /// </summary>
     public bool IsHighlighted { get; }
+}
+
+/// <summary>
+/// The icon variant.
+/// </summary>
+public enum IconVariant
+{
+    /// <summary>
+    /// Regular variant of icons.
+    /// </summary>
+    Regular,
+    /// <summary>
+    /// Filled variant of icons.
+    /// </summary>
+    Filled
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -317,7 +317,7 @@ public class ResourceNotificationService
         {
             var state = annotation.UpdateState(new UpdateCommandStateContext { ResourceSnapshot = previousState, ServiceProvider = serviceProvider });
 
-            return new ResourceCommandSnapshot(annotation.Type, state, annotation.DisplayName, annotation.IconName, annotation.IsHighlighted);
+            return new ResourceCommandSnapshot(annotation.Type, state, annotation.DisplayName, annotation.IconName, annotation.IconVariant, annotation.IsHighlighted);
         }
     }
 

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -58,10 +58,21 @@ partial class Resource
 
         foreach (var command in snapshot.Commands)
         {
-            resource.Commands.Add(new ResourceCommand { CommandType = command.Type, DisplayName = command.DisplayName, IconName = command.IconName, IsHighlighted = command.IsHighlighted, State = MapCommandState(command.State) });
+            resource.Commands.Add(new ResourceCommand { CommandType = command.Type, DisplayName = command.DisplayName, IconName = command.IconName ?? string.Empty, IconVariant = MapIconVariant(command.IconVariant), IsHighlighted = command.IsHighlighted, State = MapCommandState(command.State) });
         }
 
         return resource;
+    }
+
+    private static IconVariant MapIconVariant(Hosting.ApplicationModel.IconVariant? iconVariant)
+    {
+        return iconVariant switch
+        {
+            Hosting.ApplicationModel.IconVariant.Regular => IconVariant.Regular,
+            Hosting.ApplicationModel.IconVariant.Filled => IconVariant.Filled,
+            null => IconVariant.Regular,
+            _ => throw new InvalidOperationException("Unexpected icon variant: " + iconVariant)
+        };
     }
 
     private static ResourceCommandState MapCommandState(Hosting.ApplicationModel.ResourceCommandState state)

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -43,12 +43,19 @@ message ResourceCommand {
     // Optional icon name. This name should be a valid FluentUI icon name.
     // https://aka.ms/fluentui-system-icons
     optional string icon_name = 6;
+    // Optional icon variant.
+    optional IconVariant icon_variant = 7;
     // Optional description of the command, to be shown in the UI.
     // Could be used as a tooltip. May be localized.
-    optional string display_description = 7;
+    optional string display_description = 8;
     // The state of the command. Controls whether the command is enabled, disabled,
     // or hidden in the UI.
-    ResourceCommandState state = 8;
+    ResourceCommandState state = 9;
+}
+
+enum IconVariant {
+    REGULAR = 0;
+    FILLED = 1;
 }
 
 // Represents a request to execute a command.

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -58,12 +58,16 @@ Aspire.Hosting.ApplicationModel.ExecuteCommandResult.Success.init -> void
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.HealthCheckAnnotation(string! key) -> void
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.Key.get -> string!
+Aspire.Hosting.ApplicationModel.IconVariant
+Aspire.Hosting.ApplicationModel.IconVariant.Filled = 1 -> Aspire.Hosting.ApplicationModel.IconVariant
+Aspire.Hosting.ApplicationModel.IconVariant.Regular = 0 -> Aspire.Hosting.ApplicationModel.IconVariant
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.DisplayName.get -> string!
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ExecuteCommand.get -> System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>!
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.IconName.get -> string?
+Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.IconVariant.get -> Aspire.Hosting.ApplicationModel.IconVariant?
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.IsHighlighted.get -> bool
-Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ResourceCommandAnnotation(string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>! updateState, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, string? iconName, bool isHighlighted) -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ResourceCommandAnnotation(string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>! updateState, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, string? iconName, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant, bool isHighlighted) -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.Type.get -> string!
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.UpdateState.get -> System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>!
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot
@@ -71,9 +75,11 @@ Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.DisplayName.get -> strin
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.DisplayName.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IconName.get -> string?
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IconName.init -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IconVariant.get -> Aspire.Hosting.ApplicationModel.IconVariant?
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IconVariant.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IsHighlighted.get -> bool
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IsHighlighted.init -> void
-Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ResourceCommandSnapshot(string! Type, Aspire.Hosting.ApplicationModel.ResourceCommandState State, string! DisplayName, string? IconName, bool IsHighlighted) -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ResourceCommandSnapshot(string! Type, Aspire.Hosting.ApplicationModel.ResourceCommandState State, string! DisplayName, string? IconName, Aspire.Hosting.ApplicationModel.IconVariant? IconVariant, bool IsHighlighted) -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.State.get -> Aspire.Hosting.ApplicationModel.ResourceCommandState
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.State.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Type.get -> string!
@@ -144,7 +150,7 @@ Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.get
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.set -> void
 static Aspire.Hosting.ResourceBuilderExtensions.WaitFor<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WaitForCompletion<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency, int exitCode = 0) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
-static Aspire.Hosting.ResourceBuilderExtensions.WithCommand<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>? updateState = null, string? iconName = null, bool isHighlighted = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithCommand<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>? updateState = null, string? iconName = null, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant = null, bool isHighlighted = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! key) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.FailedToStart -> string!

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -787,6 +787,7 @@ public static class ResourceBuilderExtensions
     /// <para>If a callback isn't specified, the command is always enabled.</para>
     /// </param>
     /// <param name="iconName">The icon name for the command. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons</param>
+    /// <param name="iconVariant">The icon variant.</param>
     /// <param name="isHighlighted">A flag indicating whether the command is highlighted in the UI.</param>
     /// <returns>The resource builder.</returns>
     /// <remarks>
@@ -801,6 +802,7 @@ public static class ResourceBuilderExtensions
         Func<ExecuteCommandContext, Task<ExecuteCommandResult>> executeCommand,
         Func<UpdateCommandStateContext, ResourceCommandState>? updateState = null,
         string? iconName = null,
+        IconVariant? iconVariant = null,
         bool isHighlighted = false) where T : IResource
     {
         // Replace existing annotation with the same name.
@@ -810,6 +812,6 @@ public static class ResourceBuilderExtensions
             builder.Resource.Annotations.Remove(existingAnnotation);
         }
 
-        return builder.WithAnnotation(new ResourceCommandAnnotation(type, displayName, updateState ?? (c => ResourceCommandState.Enabled), executeCommand, iconName, isHighlighted));
+        return builder.WithAnnotation(new ResourceCommandAnnotation(type, displayName, updateState ?? (c => ResourceCommandState.Enabled), executeCommand, iconName, iconVariant, isHighlighted));
     }
 }


### PR DESCRIPTION
## Description

Consistent feedback on the start/stop/restart icons was the stop icon looked like an empty checkbox. The standard for this kind of UI is to have filled icons. For example, VS debugging start/stop buttons are filled.

This PR:

* Adds icon variant option to commands. Defaults to regular.
* Changes start and stop icons to be filled icons.
* Changes the icon size from 20 to 16. Size 20 filled icons felt too big. Size 16 looks good.
* Fixes error when command doesn't have an icon.

Demo:
![image](https://github.com/user-attachments/assets/f0f05f35-c2b0-4b3d-932b-a7ff19329497)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5839)