### PR TITLE
Remove lifecycle commands from dashboard resource

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -57,8 +57,14 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
     {
         if (appModel.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) is { } dashboardResource)
         {
-            var commands = dashboardResource.Annotations.OfType<ResourceCommandAnnotation>().ToList();
-            foreach (var command in commands)
+            // The dashboard is visible during development. Stopping the dashboard with a command breaks the dashboard.
+            // Remove the lifecycle commands so they're not accidently clicked in during development.
+            var lifecycleCommands = dashboardResource.Annotations
+                .OfType<ResourceCommandAnnotation>()
+                .Where(a => a.Type is CommandsConfigurationExtensions.StartType or CommandsConfigurationExtensions.StopType or CommandsConfigurationExtensions.RestartType)
+                .ToList();
+
+            foreach (var command in lifecycleCommands)
             {
                 dashboardResource.Annotations.Remove(command);
             }

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -58,7 +58,7 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
         if (appModel.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) is { } dashboardResource)
         {
             // The dashboard is visible during development. Stopping the dashboard with a command breaks the dashboard.
-            // Remove the lifecycle commands so they're not accidently clicked in during development.
+            // Remove the lifecycle commands so they're not accidently clicked during development.
             var lifecycleCommands = dashboardResource.Annotations
                 .OfType<ResourceCommandAnnotation>()
                 .Where(a => a.Type is CommandsConfigurationExtensions.StartType or CommandsConfigurationExtensions.StopType or CommandsConfigurationExtensions.RestartType)

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -31,24 +31,38 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
     private readonly CancellationTokenSource _shutdownCts = new();
     private Task? _dashboardLogsTask;
 
-    public Task BeforeStartAsync(DistributedApplicationModel model, CancellationToken cancellationToken)
+    public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
     {
         Debug.Assert(executionContext.IsRunMode, "Dashboard resource should only be added in run mode");
 
-        if (model.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) is { } dashboardResource)
+        if (appModel.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) is { } dashboardResource)
         {
             ConfigureAspireDashboardResource(dashboardResource);
 
             // Make the dashboard first in the list so it starts as fast as possible.
-            model.Resources.Remove(dashboardResource);
-            model.Resources.Insert(0, dashboardResource);
+            appModel.Resources.Remove(dashboardResource);
+            appModel.Resources.Insert(0, dashboardResource);
         }
         else
         {
-            AddDashboardResource(model);
+            AddDashboardResource(appModel);
         }
 
         _dashboardLogsTask = WatchDashboardLogsAsync(_shutdownCts.Token);
+
+        return Task.CompletedTask;
+    }
+
+    public Task AfterResourcesCreatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
+    {
+        if (appModel.Resources.SingleOrDefault(r => StringComparers.ResourceName.Equals(r.Name, KnownResourceNames.AspireDashboard)) is { } dashboardResource)
+        {
+            var commands = dashboardResource.Annotations.OfType<ResourceCommandAnnotation>().ToList();
+            foreach (var command in commands)
+            {
+                dashboardResource.Annotations.Remove(command);
+            }
+        }
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
## Description

Tweak to remove start/stop/restart from dashboard resource in the dashboard. Prevent us from clicking stop on the dashboard and breaking everything.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5840)