### PR TITLE
Fix removing lifecycle commands from dashboard

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -14,6 +14,11 @@ internal static class CommandsConfigurationExtensions
 
     internal static void AddLifeCycleCommands(this IResource resource)
     {
+        if (resource.TryGetLastAnnotation<ExcludeLifecycleCommandsAnnotation>(out _))
+        {
+            return;
+        }
+
         resource.Annotations.Add(new ResourceCommandAnnotation(
             type: StartType,
             displayName: "Start",

--- a/src/Aspire.Hosting/ApplicationModel/ExcludeLifecycleCommandsAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExcludeLifecycleCommandsAnnotation.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+[DebuggerDisplay("Type = {GetType().Name,nq}")]
+internal sealed class ExcludeLifecycleCommandsAnnotation : IResourceAnnotation
+{
+}

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -110,6 +110,8 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
 
     private void ConfigureAspireDashboardResource(IResource dashboardResource)
     {
+        // The dashboard resource can be visible during development. We don't want people to be able to stop the dashboard from inside the dashboard.
+        // Exclude the lifecycle commands from the dashboard resource so they're not accidently clicked during development.
         dashboardResource.Annotations.Add(new ExcludeLifecycleCommandsAnnotation());
 
         // Remove endpoint annotations because we are directly configuring

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -71,7 +71,7 @@ public class DashboardLifecycleHookTests
     }
 
     [Fact]
-    public async Task AfterResourcesCreatedAsync_LifecycleCommands_RemovedFromDashboard()
+    public async Task BeforeStartAsync_ExcludeLifecycleCommands_CommandsNotAddedToDashboard()
     {
         // Arrange
         var resourceLoggerService = new ResourceLoggerService();
@@ -88,14 +88,14 @@ public class DashboardLifecycleHookTests
             NullLoggerFactory.Instance);
 
         var model = new DistributedApplicationModel(new ResourceCollection());
+
+        // Act
         await hook.BeforeStartAsync(model, CancellationToken.None);
         var dashboardResource = model.Resources.Single(r => string.Equals(r.Name, KnownResourceNames.AspireDashboard, StringComparisons.ResourceName));
         dashboardResource.AddLifeCycleCommands();
 
-        // Act
-        await hook.AfterResourcesCreatedAsync(model, CancellationToken.None);
-
         // Assert
+        Assert.Single(dashboardResource.Annotations.OfType<ExcludeLifecycleCommandsAnnotation>());
         Assert.Empty(dashboardResource.Annotations.OfType<ResourceCommandAnnotation>());
     }
 


### PR DESCRIPTION
## Description

Previous fix used `AfterResourcesCreatedAsync` to remove annotations. But there could be a race between a resource update being published and `AfterResourcesCreatedAsync` being called.

This PR changes dashboard to have an annotation to exclude it from getting lifecycle commands added

![image](https://github.com/user-attachments/assets/55dca910-a50b-455e-b994-4b9478bfd3dd)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5843)