### PR TITLE
Collapse resource and trace detail sections when no data

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -53,7 +53,7 @@
                     HighlightText="@_filter"
                     GridTemplateColumns="1fr 1.5fr" />
             </FluentAccordionItem>
-            <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsEndpointsHeader)]" Expanded="true">
+            <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsEndpointsHeader)]" Expanded="@_isEndpointsExpanded">
                 <div slot="end">
                     <FluentBadge Appearance="Appearance.Neutral" Circular="true">
                         @FilteredEndpoints.Count()
@@ -68,7 +68,7 @@
                     HighlightText="@_filter"
                     GridTemplateColumns="1fr 1.5fr" />
             </FluentAccordionItem>
-            <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsEnvironmentVariablesHeader)]" Expanded="true">
+            <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsEnvironmentVariablesHeader)]" Expanded="@_isEnvironmentVariablesExpanded">
                 <div slot="end">
                     <FluentBadge Appearance="Appearance.Neutral" Circular="true">
                         @FilteredEnvironmentVariables.Count()
@@ -83,7 +83,7 @@
             </FluentAccordionItem>
             @if (Resource.IsContainer())
             {
-                <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsVolumesHeader)]" Expanded="true">
+                <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsVolumesHeader)]" Expanded="@_isVolumesExpanded">
                     <div slot="end">
                         <FluentBadge Appearance="Appearance.Neutral" Circular="true">
                             @FilteredVolumes.Count()

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -51,6 +51,10 @@ public partial class ResourceDetails
             .Where(vm => (_showAll || vm.KnownProperty != null) && vm.MatchesFilter(_filter))
             .AsQueryable();
 
+    private bool _isVolumesExpanded;
+    private bool _isEnvironmentVariablesExpanded;
+    private bool _isEndpointsExpanded;
+
     private string _filter = "";
     private bool _isMaskAllChecked = true;
 
@@ -61,6 +65,9 @@ public partial class ResourceDetails
         if (!ReferenceEquals(Resource, _resource))
         {
             _resource = Resource;
+            _isEndpointsExpanded = GetEndpoints().Any();
+            _isEnvironmentVariablesExpanded = _resource.Environment.Any();
+            _isVolumesExpanded = _resource.Volumes.Any();
 
             foreach (var item in SensitiveGridItems)
             {

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -65,6 +65,8 @@ public partial class ResourceDetails
         if (!ReferenceEquals(Resource, _resource))
         {
             _resource = Resource;
+
+            // Collapse details sections when they have no data.
             _isEndpointsExpanded = GetEndpoints().Any();
             _isEnvironmentVariablesExpanded = _resource.Environment.Any();
             _isVolumesExpanded = _resource.Volumes.Any();

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -63,7 +63,7 @@
                               GridTemplateColumns="1fr 2fr"
                               HighlightText="@_filter" />
             </FluentAccordionItem>
-            <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsEventsHeader)]" Expanded="true">
+            <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsEventsHeader)]" Expanded="@_isSpanEventsExpanded">
                 <div slot="end">
                     <FluentBadge Appearance="Appearance.Neutral" Circular="true">
                         @FilteredSpanEvents.Count()
@@ -90,7 +90,7 @@
                     </ExtraValueContent>
                 </PropertyGrid>
             </FluentAccordionItem>
-            <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsLinksHeader)]" Expanded="true">
+            <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsLinksHeader)]" Expanded="@_isSpanLinksExpanded">
                 <div slot="end">
                     <FluentBadge Appearance="Appearance.Neutral" Circular="true">
                         @FilteredSpanLinks.Count()
@@ -112,7 +112,7 @@
                     </AspireTemplateColumn>
                 </FluentDataGrid>
             </FluentAccordionItem>
-            <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsBacklinksHeader)]" Expanded="true">
+            <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsBacklinksHeader)]" Expanded="@_isSpanBacklinksExpanded">
                 <div slot="end">
                     <FluentBadge Appearance="Appearance.Neutral" Circular="true">
                         @FilteredSpanBacklinks.Count()

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -78,6 +78,7 @@ public partial class SpanDetails : IDisposable
             _contextAttributes.Add(new KeyValuePair<string, string>("TraceId", ViewModel.Span.TraceId));
         }
 
+        // Collapse details sections when they have no data.
         _isSpanEventsExpanded = ViewModel.Span.Events.Any();
         _isSpanLinksExpanded = ViewModel.Span.Links.Any();
         _isSpanBacklinksExpanded = ViewModel.Span.BackLinks.Any();

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -44,6 +44,10 @@ public partial class SpanDetails : IDisposable
     private IQueryable<SpanLinkViewModel> FilteredSpanBacklinks =>
         ViewModel.Backlinks.Where(e => e.SpanId.Contains(_filter, StringComparison.CurrentCultureIgnoreCase)).AsQueryable();
 
+    private bool _isSpanEventsExpanded;
+    private bool _isSpanLinksExpanded;
+    private bool _isSpanBacklinksExpanded;
+
     private string _filter = "";
     private List<KeyValuePair<string, string>> _contextAttributes = null!;
 
@@ -73,6 +77,10 @@ public partial class SpanDetails : IDisposable
         {
             _contextAttributes.Add(new KeyValuePair<string, string>("TraceId", ViewModel.Span.TraceId));
         }
+
+        _isSpanEventsExpanded = ViewModel.Span.Events.Any();
+        _isSpanLinksExpanded = ViewModel.Span.Links.Any();
+        _isSpanBacklinksExpanded = ViewModel.Span.BackLinks.Any();
     }
 
     public async Task OnViewDetailsAsync(SpanLinkViewModel linkVM)


### PR DESCRIPTION
## Description

Details views have sections of data. These sections are usually shown even when there is no data in them. I think doing this is generally good because it's clearer that there is no data by showing a section with zero rather than completing hiding it, e.g. showing a `Span links = 0` section compared to hiding it altogether. If we hide the sections altogether then people might not think span links are supported at all.

The problem with always showing details sections is they're large when expanded. This PR changes empty sections to be collapsed by default if there is no data.

Note that there is a difference between no data available at all (collapse) vs there is data but it is filtered out (not collapsed).

Before:
![image](https://github.com/user-attachments/assets/83bf36aa-00cb-43d7-9454-cba5f9c0d72c)

After:
![image](https://github.com/user-attachments/assets/3231b528-0a1e-4f1c-b33b-abe2e9145963)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
