### PR TITLE
Build resource logging into Aspire.Hosting

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -155,6 +155,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         hostBuilderOptions.ApplicationName = _entryPoint.Assembly.GetName().Name ?? string.Empty;
         applicationOptions.AssemblyName = _entryPoint.Assembly.GetName().Name ?? string.Empty;
         applicationOptions.DisableDashboard = true;
+        applicationOptions.EnableResourceLogging = true;
         var cfg = hostBuilderOptions.Configuration ??= new();
         var additionalConfig = new Dictionary<string, string?>
         {
@@ -232,7 +233,6 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
     private void OnBuildingCore(DistributedApplicationBuilder applicationBuilder)
     {
         var services = applicationBuilder.Services;
-        services.AddHostedService<ResourceLoggerForwarderService>();
         services.AddHttpClient();
 
         InterceptHostCreation(applicationBuilder);

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -278,6 +278,12 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                 _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<DashboardOptions>, ValidateDashboardOptions>());
             }
 
+            if (options.EnableResourceLogging)
+            {
+                // This must be added before DcpHostService to ensure that it can subscribe to the ResourceNotificationService and ResourceLoggerService
+                _innerBuilder.Services.AddHostedService<ResourceLoggerForwarderService>();
+            }
+
             // Orchestrator
             _innerBuilder.Services.AddSingleton<ApplicationOrchestrator>();
             _innerBuilder.Services.AddHostedService<OrchestratorHostService>();

--- a/src/Aspire.Hosting/DistributedApplicationOptions.cs
+++ b/src/Aspire.Hosting/DistributedApplicationOptions.cs
@@ -36,6 +36,11 @@ public sealed class DistributedApplicationOptions
     public string? ContainerRegistryOverride { get; set; }
 
     /// <summary>
+    /// Enables resource logging. Logs will be written to the logger category (ApplicationName.Resources.{resourceName}).
+    /// </summary>
+    public bool EnableResourceLogging { get; set; }
+
+    /// <summary>
     /// The command line arguments.
     /// </summary>
     public string[]? Args { get; set; }

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -183,6 +183,8 @@ Aspire.Hosting.ApplicationModel.WaitType.WaitForCompletion = 1 -> Aspire.Hosting
 Aspire.Hosting.ApplicationModel.WaitType.WaitUntilHealthy = 0 -> Aspire.Hosting.ApplicationModel.WaitType
 Aspire.Hosting.DistributedApplicationBuilder.AppHostPath.get -> string!
 Aspire.Hosting.DistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eventing.IDistributedApplicationEventing!
+Aspire.Hosting.DistributedApplicationOptions.EnableResourceLogging.get -> bool
+Aspire.Hosting.DistributedApplicationOptions.EnableResourceLogging.set -> void
 Aspire.Hosting.Eventing.DistributedApplicationEventing
 Aspire.Hosting.Eventing.DistributedApplicationEventing.DistributedApplicationEventing() -> void
 Aspire.Hosting.Eventing.DistributedApplicationEventing.PublishAsync<T>(T event, Aspire.Hosting.Eventing.EventDispatchBehavior dispatchBehavior, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Aspire.Hosting/ResourceLoggerForwarderService.cs
+++ b/src/Aspire.Hosting/ResourceLoggerForwarderService.cs
@@ -7,7 +7,7 @@ using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace Aspire.Hosting.Testing;
+namespace Aspire.Hosting;
 
 /// <summary>
 /// A background service that watches resource logs and forwards them to the host's <see cref="ILogger"/> infrastructure.

--- a/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
+++ b/tests/Aspire.EndToEnd.Tests/Aspire.EndToEnd.Tests.csproj
@@ -33,8 +33,6 @@
 
   <ItemGroup Condition="'$(_BuildForTestsRunningOutsideOfRepo)' == 'true'">
     <None Include="..\testproject\**\*" Link="$(DeployOutsideOfRepoSupportFilesDir)%(RecursiveDir)%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
-    <!-- Needed by TestProject.AppHost -->
-    <None Include="$(RepoRoot)src\Aspire.Hosting.Testing\ResourceLoggerForwarderService.cs" Link="$(DeployOutsideOfRepoSupportFilesDir)TestProject.AppHost\ResourceLoggerForwarderService.cs" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\.editorconfig" Link="$(DeployOutsideOfRepoSupportFilesDir)..\%(FileName)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/tests/Aspire.Hosting.Containers.Tests/Aspire.Hosting.Containers.Tests.csproj
+++ b/tests/Aspire.Hosting.Containers.Tests/Aspire.Hosting.Containers.Tests.csproj
@@ -13,8 +13,4 @@
   <ItemGroup>
     <PackageReference Include="Polly.Core" />
   </ItemGroup>
-
-    <ItemGroup>
-    <Compile Include="$(RepoRoot)src\Aspire.Hosting.Testing\ResourceLoggerForwarderService.cs" Link="Utils\ResourceLoggerForwarderService.cs" />
-  </ItemGroup>
 </Project>

--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -51,7 +51,6 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
     public async Task ContainerBuildLogsAreStreamedToAppHost()
     {
         using var builder = TestDistributedApplicationBuilder.Create();
-        builder.Services.AddHostedService<ResourceLoggerForwarderService>();
         builder.Services.AddLogging(logging =>
         {
             logging.AddFakeLogging();

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -26,7 +26,6 @@
     <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.PostgreSQL\PostgresContainerImageTags.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.Redis\RedisContainerImageTags.cs" />
-    <Compile Include="$(RepoRoot)src\Aspire.Hosting.Testing\ResourceLoggerForwarderService.cs" Link="Utils\ResourceLoggerForwarderService.cs" />
 
     <Compile Include="$(RepoRoot)tests\Aspire.Hosting.Testing.Tests\DistributedApplicationHttpClientExtensionsForTests.cs" />
 

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -93,6 +93,7 @@ public sealed class TestDistributedApplicationBuilder : IDistributedApplicationB
             hostBuilderOptions.ApplicationName = appAssembly.GetName().Name;
             applicationOptions.AssemblyName = assemblyName;
             applicationOptions.DisableDashboard = true;
+            applicationOptions.EnableResourceLogging = true;
             var cfg = hostBuilderOptions.Configuration ??= new();
             cfg.AddInMemoryCollection(new Dictionary<string, string?>
             {
@@ -108,12 +109,7 @@ public sealed class TestDistributedApplicationBuilder : IDistributedApplicationB
     public TestDistributedApplicationBuilder WithTestAndResourceLogging(ITestOutputHelper testOutputHelper)
     {
         Services.AddXunitLogging(testOutputHelper);
-        Services.Insert(0, ServiceDescriptor.Singleton<IHostedService, ResourceLoggerForwarderService>());
-        Services.AddLogging(builder =>
-        {
-            builder.AddFilter("Aspire.Hosting", LogLevel.Trace);
-            builder.SetMinimumLevel(LogLevel.Trace);
-        });
+        Services.AddLogging(builder => builder.AddFilter("Aspire.Hosting", LogLevel.Trace));
         return this;
     }
 

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -8,7 +8,6 @@ using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Orchestrator;
-using Aspire.Hosting.Testing;
 using Aspire.Hosting.Tests.Dcp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/testproject/TestProject.AppHost/TestProgram.cs
+++ b/tests/testproject/TestProject.AppHost/TestProgram.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.Lifecycle;
-using Aspire.Hosting.Testing;
 using Aspire.TestProject;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -48,6 +47,7 @@ public class TestProgram : IDisposable
             DisableDashboard = disableDashboard,
             AssemblyName = assemblyName,
             AllowUnsecuredTransport = allowUnsecuredTransport,
+            EnableResourceLogging = true
         });
 
         builder.Configuration["DcpPublisher:DeleteResourcesOnShutdown"] = "true";
@@ -85,7 +85,6 @@ public class TestProgram : IDisposable
             }
         }
 
-        AppBuilder.Services.AddHostedService<ResourceLoggerForwarderService>();
         AppBuilder.Services.AddLifecycleHook<EndPointWriterHook>();
         AppBuilder.Services.AddHttpClient();
     }

--- a/tests/testproject/TestProject.AppHost/TestProject.AppHost.csproj
+++ b/tests/testproject/TestProject.AppHost/TestProject.AppHost.csproj
@@ -16,11 +16,6 @@
 
   <ItemGroup>
     <Compile Include="..\Common\TestResourceNames.cs" />
-
-    <!-- on helix, the file will be in the source directory, so it will get
-      picked up by msbuild by default -->
-    <Compile Condition="'$(RepoRoot)' != ''" Include="$(RepoRoot)src\Aspire.Hosting.Testing\ResourceLoggerForwarderService.cs" Link="Utils\ResourceLoggerForwarderService.cs" />
-
     <ProjectReference Include="..\TestProject.IntegrationServiceA\TestProject.IntegrationServiceA.csproj" AspireProjectMetadataTypeName="IntegrationServiceA" />
     <ProjectReference Include="..\TestProject.ServiceA\TestProject.ServiceA.csproj" AspireProjectMetadataTypeName="ServiceA" />
     <ProjectReference Include="..\TestProject.ServiceB\TestProject.ServiceB.csproj" AspireProjectMetadataTypeName="ServiceB" />


### PR DESCRIPTION
## Description

- ResourceLoggerForwarderService needs to be added before the DcpHostedService is added so that it can subscribe to the resource notification service and capture logs for all resources (before waiting for services to complete).
- Added EnableResourceLogging to DistributedApplicationOptions
- Removed all of the code duplication and instead set the flag in places where it was being used.

Fixes https://github.com/dotnet/aspire/issues/6791

PS: I found this while debugging https://github.com/dotnet/aspire/issues/5821

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
