### PR TITLE
Fix ClientOptions configuration binding for Event Hubs clients

### DIFF
--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubProducerClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubProducerClientComponent.cs
@@ -30,7 +30,7 @@ internal sealed class EventHubProducerClientComponent : EventHubsComponent<Azure
     {
         return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<EventHubProducerClient, EventHubProducerClientOptions>((options, cred) =>
         {
-            // ensure that the connection string or namespace+eventhubname is provided 
+            // ensure that the connection string or namespace+eventhubname is provided
             EnsureConnectionStringOrNamespaceProvided(settings, connectionName, configurationSectionName);
 
             // If no connection is provided use TokenCredential

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubProducerClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/EventHubProducerClientComponent.cs
@@ -30,6 +30,7 @@ internal sealed class EventHubProducerClientComponent : EventHubsComponent<Azure
     {
         return ((IAzureClientFactoryBuilderWithCredential)azureFactoryBuilder).RegisterClientFactory<EventHubProducerClient, EventHubProducerClientOptions>((options, cred) =>
         {
+            // ensure that the connection string or namespace+eventhubname is provided 
             EnsureConnectionStringOrNamespaceProvided(settings, connectionName, configurationSectionName);
 
             // If no connection is provided use TokenCredential
@@ -37,18 +38,15 @@ internal sealed class EventHubProducerClientComponent : EventHubsComponent<Azure
             {
                 return new EventHubProducerClient(settings.FullyQualifiedNamespace, settings.EventHubName, cred, options);
             }
-            else
+
+            // If no specific EventHubName is provided, it has to be in the connection string
+            if (string.IsNullOrEmpty(settings.EventHubName))
             {
-                // If no specific EventHubName is provided, it has to be in the connection string
-                if (string.IsNullOrEmpty(settings.EventHubName))
-                {
-                    return new EventHubProducerClient(settings.ConnectionString, options);
-                }
-                else
-                {
-                    return new EventHubProducerClient(settings.ConnectionString, settings.EventHubName, options);
-                }
+                return new EventHubProducerClient(settings.ConnectionString, options);
             }
+
+            return new EventHubProducerClient(settings.ConnectionString, settings.EventHubName, options);
+
         }, requiresCredential: false);
     }
 }

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
@@ -11,11 +11,12 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Aspire.Azure.Messaging.EventHubs.Tests;
 
-public class AspireEventHubsExtensionsTests
-{
+public class AspireEventHubsExtensionsTests(ITestOutputHelper output)
+{    
     private const string AspireEventHubsSection = "Aspire:Azure:Messaging:EventHubs:";
     private const string EhConnectionString = "Endpoint=sb://aspireeventhubstests.servicebus.windows.net/;" +
                                               "SharedAccessKeyName=fake;SharedAccessKey=fake;EntityPath=MyHub";
@@ -108,9 +109,17 @@ public class AspireEventHubsExtensionsTests
     }
 
     [Theory]
+    [InlineData(false, EventHubProducerClientIndex)]
+    [InlineData(true, EventHubProducerClientIndex)]
+    [InlineData(false, EventHubConsumerClientIndex)]
+    [InlineData(true, EventHubConsumerClientIndex)]
     [InlineData(false, EventProcessorClientIndex)]
     [InlineData(true, EventProcessorClientIndex)]
-    public void BindsEventProcessorClientOptionsIdentifier(bool useKeyed, int clientIndex)
+    [InlineData(false, PartitionReceiverIndex)]
+    [InlineData(true, PartitionReceiverIndex)]
+    [InlineData(false, EventBufferedProducerClientIndex)]
+    [InlineData(true, EventBufferedProducerClientIndex)]
+    public void BindsClientOptionsFromConfigurationWithNamespace(bool useKeyed, int clientIndex)
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
 
@@ -126,8 +135,24 @@ public class AspireEventHubsExtensionsTests
                 CreateConfigKey(
                     $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
                     key, "BlobContainerName"), "checkpoints"),
-            new KeyValuePair<string, string?>("ConnectionStrings:eh", EhConnectionString),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "BlobClientServiceKey"), useKeyed ? "blobs" : null),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    AspireEventHubsSection + s_clientTypes[clientIndex].Name, key, "PartitionId"), "foo"),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "FullyQualifiedNamespace"), FullyQualifiedNamespace),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "EventHubName"), "MyHub"),
         ]);
+
+        output.WriteLine(builder.Configuration.GetDebugView());
 
         if (useKeyed)
         {
@@ -138,12 +163,152 @@ public class AspireEventHubsExtensionsTests
             s_clientAdders[clientIndex](builder, "eh", null);
         }
 
-        using var host = builder.Build();        
+        using var host = builder.Build();
 
-        var client = RetrieveClient(key, clientIndex, host) as EventProcessorClient;
+        var assignedIdentifier = RetrieveClient(key, clientIndex, host) switch
+        {
+            EventProcessorClient processor => processor.Identifier,
+            EventHubConsumerClient consumer => consumer.Identifier,
+            EventHubProducerClient producer => producer.Identifier,
+            PartitionReceiver receiver => receiver.Identifier,
+            EventHubBufferedProducerClient producer => producer.Identifier,
+            _ => null
+        };
 
-        Assert.NotNull(client);
-        Assert.Equal("customidentifier", client.Identifier);
+        Assert.NotNull(assignedIdentifier);
+        Assert.Equal("customidentifier", assignedIdentifier);
+    }
+
+    [Theory]
+    [InlineData(false, EventHubProducerClientIndex)]
+    [InlineData(true, EventHubProducerClientIndex)]
+    [InlineData(false, EventHubConsumerClientIndex)]
+    [InlineData(true, EventHubConsumerClientIndex)]
+    [InlineData(false, EventProcessorClientIndex)]
+    [InlineData(true, EventProcessorClientIndex)]
+    [InlineData(false, PartitionReceiverIndex)]
+    [InlineData(true, PartitionReceiverIndex)]
+    [InlineData(false, EventBufferedProducerClientIndex)]
+    [InlineData(true, EventBufferedProducerClientIndex)]
+    public void BindsClientOptionsFromConfigurationWithConnectionString(bool useKeyed, int clientIndex)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        ConfigureBlobServiceClient(useKeyed, builder.Services);
+
+        var key = useKeyed ? "eh" : null;
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "ClientOptions:Identifier"), "customidentifier"),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "BlobContainerName"), "checkpoints"),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "BlobClientServiceKey"), useKeyed ? "blobs" : null),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    AspireEventHubsSection + s_clientTypes[clientIndex].Name, key, "PartitionId"), "foo"),
+            new KeyValuePair<string, string?>("ConnectionStrings:eh", EhConnectionString)
+        ]);
+
+        output.WriteLine(builder.Configuration.GetDebugView());
+
+        if (useKeyed)
+        {
+            s_keyedClientAdders[clientIndex](builder, "eh", null);
+        }
+        else
+        {
+            s_clientAdders[clientIndex](builder, "eh", null);
+        }
+
+        using var host = builder.Build();
+
+        var assignedIdentifier = RetrieveClient(key, clientIndex, host) switch
+        {
+            EventProcessorClient processor => processor.Identifier,
+            EventHubConsumerClient consumer => consumer.Identifier,
+            EventHubProducerClient producer => producer.Identifier,
+            PartitionReceiver receiver => receiver.Identifier,
+            EventHubBufferedProducerClient producer => producer.Identifier,
+            _ => null
+        };
+
+        Assert.NotNull(assignedIdentifier);
+        Assert.Equal("customidentifier", assignedIdentifier);
+    }
+
+    [Theory]
+    [InlineData(false, EventHubProducerClientIndex)]
+    [InlineData(true, EventHubProducerClientIndex)]
+    [InlineData(false, EventHubConsumerClientIndex)]
+    [InlineData(true, EventHubConsumerClientIndex)]
+    [InlineData(false, EventProcessorClientIndex)]
+    [InlineData(true, EventProcessorClientIndex)]
+    [InlineData(false, PartitionReceiverIndex)]
+    [InlineData(true, PartitionReceiverIndex)]
+    [InlineData(false, EventBufferedProducerClientIndex)]
+    [InlineData(true, EventBufferedProducerClientIndex)]
+    public void BindsClientOptionsFromConfigurationWithConnectionStringAndEventHubName(bool useKeyed, int clientIndex)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+
+        ConfigureBlobServiceClient(useKeyed, builder.Services);
+
+        var key = useKeyed ? "eh" : null;
+        builder.Configuration.AddInMemoryCollection([
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "ClientOptions:Identifier"), "customidentifier"),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "BlobContainerName"), "checkpoints"),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "BlobClientServiceKey"), useKeyed ? "blobs" : null),
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    AspireEventHubsSection + s_clientTypes[clientIndex].Name, key, "PartitionId"), "foo"),            
+            new KeyValuePair<string, string?>(
+                CreateConfigKey(
+                    $"Aspire:Azure:Messaging:EventHubs:{s_clientTypes[clientIndex].Name}",
+                    key, "EventHubName"), "MyHub"),
+            new KeyValuePair<string, string?>("ConnectionStrings:eh", EhConnectionString),
+        ]);
+
+        output.WriteLine(builder.Configuration.GetDebugView());
+
+        if (useKeyed)
+        {
+            s_keyedClientAdders[clientIndex](builder, "eh", null);
+        }
+        else
+        {
+            s_clientAdders[clientIndex](builder, "eh", null);
+        }
+
+        using var host = builder.Build();
+
+        var assignedIdentifier = RetrieveClient(key, clientIndex, host) switch
+        {
+            EventProcessorClient processor => processor.Identifier,
+            EventHubConsumerClient consumer => consumer.Identifier,
+            EventHubProducerClient producer => producer.Identifier,
+            PartitionReceiver receiver => receiver.Identifier,
+            EventHubBufferedProducerClient producer => producer.Identifier,
+            _ => null
+        };
+
+        Assert.NotNull(assignedIdentifier);
+        Assert.Equal("customidentifier", assignedIdentifier);
     }
 
     [Theory]

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
@@ -11,11 +11,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Aspire.Azure.Messaging.EventHubs.Tests;
 
-public class AspireEventHubsExtensionsTests(ITestOutputHelper output)
+public class AspireEventHubsExtensionsTests
 {    
     private const string AspireEventHubsSection = "Aspire:Azure:Messaging:EventHubs:";
     private const string EhConnectionString = "Endpoint=sb://aspireeventhubstests.servicebus.windows.net/;" +
@@ -152,8 +151,6 @@ public class AspireEventHubsExtensionsTests(ITestOutputHelper output)
                     key, "EventHubName"), "MyHub"),
         ]);
 
-        output.WriteLine(builder.Configuration.GetDebugView());
-
         if (useKeyed)
         {
             s_keyedClientAdders[clientIndex](builder, "eh", null);
@@ -215,8 +212,6 @@ public class AspireEventHubsExtensionsTests(ITestOutputHelper output)
                     AspireEventHubsSection + s_clientTypes[clientIndex].Name, key, "PartitionId"), "foo"),
             new KeyValuePair<string, string?>("ConnectionStrings:eh", EhConnectionString)
         ]);
-
-        output.WriteLine(builder.Configuration.GetDebugView());
 
         if (useKeyed)
         {
@@ -283,8 +278,6 @@ public class AspireEventHubsExtensionsTests(ITestOutputHelper output)
                     key, "EventHubName"), "MyHub"),
             new KeyValuePair<string, string?>("ConnectionStrings:eh", EhConnectionString),
         ]);
-
-        output.WriteLine(builder.Configuration.GetDebugView());
 
         if (useKeyed)
         {

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
@@ -110,7 +110,7 @@ public class AspireEventHubsExtensionsTests
     [Theory]
     [InlineData(false, EventProcessorClientIndex)]
     [InlineData(true, EventProcessorClientIndex)]
-    public async Task BindsEventProcessorClientOptionsIdentifier(bool useKeyed, int clientIndex)
+    public void BindsEventProcessorClientOptionsIdentifier(bool useKeyed, int clientIndex)
     {
         var builder = Host.CreateEmptyApplicationBuilder(null);
 

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/AspireEventHubsExtensionsTests.cs
@@ -138,9 +138,7 @@ public class AspireEventHubsExtensionsTests
             s_clientAdders[clientIndex](builder, "eh", null);
         }
 
-        using var host = builder.Build();
-
-        await Task.Delay(500);
+        using var host = builder.Build();        
 
         var client = RetrieveClient(key, clientIndex, host) as EventProcessorClient;
 


### PR DESCRIPTION
Fixes #5903 

### Changes

- All components had slightly different patterns for constructing clients according to configuration, although the logic was identical for all. I have normalized the construction logic for all components to encompass the pattern of one of the following:
  - connectionstring (includes EntityPath)
  - connectingstring & settings.EventHubName (overrides or provides EntityPath)
  - fullyqualifiednamespace & settings.EventHubName (provides EntityPath)
  - partitionreceiver ctor did not follow the same logic as the other clients. Now it does.

- Tests added for all branches of the above logic

- All constructors now provide the correct ClientOptions in the ctor, so bound config is correctly provided for all branches of client construction

### Problem(s)

When binding an Aspire component (in this case EventProcessorClient) to configuration like this:

```json
"Aspire": {
  "Azure": {
    "Messaging": {
      "EventHubs": {
        "EventProcessorClient": {
          "EventHubName": "hub1",
          "BlobContainerName": "checkpoints",            
          "ClientOptions": {
            "Identifier": "Processor1"
          }
        },
```

... EventHubs:* binds, and will correctly set `EventHubName` and `BlobContainerName` but `Identifier` is **not** assigned, and instead a random UUID is returned.

The problem is that the logic that constructs clients does not pass the ClientOptions instance in all branches :/

e.g.

```csharp
                if (!string.IsNullOrEmpty(settings.ConnectionString))
                {
                    if (!string.IsNullOrEmpty(settings.EventHubName))
                    {
                        return new EventProcessorClient(containerClient,
                                                consumerGroup,
                                                settings.ConnectionString,
                                                settings.EventHubName); // << missing options
                    }
                    else
                    {
                        return new EventProcessorClient(containerClient,
                                                consumerGroup,
                                                settings.ConnectionString); // << missing options
                    }
                }
                else
                {
                    return new EventProcessorClient(containerClient,
                        consumerGroup,
                        settings.FullyQualifiedNamespace,
                        settings.EventHubName, cred, options); // includes options
                }
```


/cc @sebastienros 


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5899)