### PR TITLE
Fix console logs after restart

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using Aspire.Dashboard.Configuration;
-using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Metrics.V1;
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -266,9 +266,7 @@ public class ResourceLoggerService
                     }
                 }
 
-                // Get backlog
                 backlogSnapshot = GetBacklogSnapshot();
-
                 OnNewLog += Log;
             }
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceLoggerService.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
-using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Hosting.ConsoleLogs;
 using Microsoft.Extensions.Logging;
 

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -12,6 +12,7 @@ using System.Threading.Channels;
 using Aspire.Dashboard.ConsoleLogs;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.ConsoleLogs;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Eventing;
@@ -392,9 +393,6 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                         logStream.Cancellation.Cancel();
                     }
 
-                    // Complete the log stream
-                    loggerService.Complete(resource.Metadata.Name);
-
                     // TODO: Handle resource deletion
                     if (_logger.IsEnabled(LogLevel.Trace))
                     {
@@ -515,7 +513,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                                 timestamp = result.Value.Timestamp.UtcDateTime;
                             }
 
-                            logger(timestamp, resolvedContent, isError);
+                            logger(LogEntry.Create(timestamp, resolvedContent, isError));
                         }
                     }
                 }

--- a/src/Shared/ChannelExtensions.cs
+++ b/src/Shared/ChannelExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
-using Aspire.Dashboard.Otlp.Storage;
 
 namespace Aspire;
 

--- a/src/Shared/CircularBuffer.cs
+++ b/src/Shared/CircularBuffer.cs
@@ -5,7 +5,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
-namespace Aspire.Dashboard.Otlp.Storage;
+namespace Aspire;
 
 /// <summary>
 /// The circular buffer starts with an empty list and grows to a maximum size.

--- a/src/Shared/ConsoleLogs/LogEntries.cs
+++ b/src/Shared/ConsoleLogs/LogEntries.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Aspire.Dashboard.Otlp.Storage;
 
 namespace Aspire.Hosting.ConsoleLogs;
 

--- a/src/Shared/ConsoleLogs/LogEntry.cs
+++ b/src/Shared/ConsoleLogs/LogEntry.cs
@@ -12,6 +12,16 @@ internal sealed class LogEntry
     public DateTime? Timestamp { get; set; }
     public LogEntryType Type { get; init; } = LogEntryType.Default;
     public int LineNumber { get; set; }
+
+    public static LogEntry Create(DateTime? timestamp, string logMessage, bool isErrorMessage)
+    {
+        return new LogEntry
+        {
+            Timestamp = timestamp,
+            Content = logMessage,
+            Type = isErrorMessage ? LogEntryType.Error : LogEntryType.Default
+        };
+    }
 }
 
 internal enum LogEntryType

--- a/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
+++ b/tests/Aspire.Dashboard.Tests/CircularBufferTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Otlp.Storage;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests;

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text.Json;
 using System.Threading.Channels;
+using Aspire.Hosting.ConsoleLogs;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Tests.Utils;
@@ -61,7 +62,7 @@ public class DashboardLifecycleHookTests
 
         // Act
         var dashboardLoggerState = resourceLoggerService.GetResourceLoggerState(KnownResourceNames.AspireDashboard);
-        dashboardLoggerState.AddLog(timestamp, logMessage, isErrorMessage: false);
+        dashboardLoggerState.AddLog(LogEntry.Create(timestamp, logMessage, isErrorMessage: false), inMemorySource: true);
 
         // Assert
         var logContext = await logChannel.Reader.ReadAsync();

--- a/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
@@ -461,7 +461,7 @@ public class ApplicationExecutorTests
         // State is clear when no longer watching.
         await AsyncTestHelpers.AssertIsTrueRetryAsync(
             () => loggerState.GetBacklogSnapshot().Length == 0,
-            "Backlog is asyncronously cleared after watch ends.");
+            "Backlog is asynchronously cleared after watch ends.");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ResourceLoggerServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceLoggerServiceTests.cs
@@ -79,11 +79,16 @@ public class ResourceLoggerServiceTests
             l => Assert.Equal("2000-12-29T20:59:59.0000000Z Hello, world!", l.Content),
             l => Assert.Equal("2000-12-29T20:59:59.0000000Z Hello, error!", l.Content));
 
-        // New sub should not get new logs as the stream is completed
+        // The backlog should be cleared once there are no subscribers.
+        Assert.Empty(service.GetResourceLoggerState(testResource.Name).GetBacklogSnapshot());
+
+        // New sub should replay logs again.
         logsLoop = ConsoleLoggingTestHelpers.WatchForLogsAsync(service, 100, testResource);
         allLogs = await logsLoop.WaitAsync(TimeSpan.FromSeconds(15));
 
-        Assert.Empty(allLogs);
+        Assert.Collection(allLogs,
+            l => Assert.Equal("2000-12-29T20:59:59.0000000Z Hello, world!", l.Content),
+            l => Assert.Equal("2000-12-29T20:59:59.0000000Z Hello, error!", l.Content));
     }
 
     [Fact]
@@ -137,6 +142,71 @@ public class ResourceLoggerServiceTests
         // The backlog should be cleared so only new logs are received
         Assert.Single(allLogs);
         Assert.Equal("2000-12-29T20:59:59.0000000Z The third log", allLogs[0].Content);
+    }
+
+    [Fact]
+    public async Task InMemoryLogsPreservedBetweenWatches()
+    {
+        var testResource = new TestResource("myResource");
+        var service = ConsoleLoggingTestHelpers.GetResourceLoggerService();
+        var logger = service.GetLogger(testResource);
+
+        // Log before watching
+        logger.LogInformation("Before watching!");
+
+        var subsLoop = WatchForSubscribers(service);
+        var logsEnumerator1 = service.WatchAsync(testResource).GetAsyncEnumerator();
+        var logsLoop = ConsoleLoggingTestHelpers.WatchForLogsAsync(logsEnumerator1, 1);
+
+        // Wait for subscriber to be added
+        await subsLoop.WaitAsync(TimeSpan.FromSeconds(15));
+
+        // Read before watching log
+        var allLogs = await logsLoop.WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.Equal("2000-12-29T20:59:59.0000000Z Before watching!", allLogs[0].Content);
+        Assert.False(allLogs[0].IsErrorMessage);
+
+        // Log while watching
+        logger.LogInformation("While watching!");
+
+        logsLoop = ConsoleLoggingTestHelpers.WatchForLogsAsync(logsEnumerator1, 1);
+        allLogs = await logsLoop.WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.Equal("2000-12-29T20:59:59.0000000Z While watching!", allLogs[0].Content);
+        Assert.False(allLogs[0].IsErrorMessage);
+
+        // New sub should get the previous logs (backlog)
+        subsLoop = WatchForSubscribers(service);
+        var logsEnumerator2 = service.WatchAsync(testResource).GetAsyncEnumerator();
+        logsLoop = ConsoleLoggingTestHelpers.WatchForLogsAsync(logsEnumerator2, 2);
+        await subsLoop.WaitAsync(TimeSpan.FromSeconds(15));
+        allLogs = await logsLoop.WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.Equal(2, allLogs.Count);
+        Assert.Equal("2000-12-29T20:59:59.0000000Z Before watching!", allLogs[0].Content);
+        Assert.Equal("2000-12-29T20:59:59.0000000Z While watching!", allLogs[1].Content);
+
+        await logsEnumerator1.DisposeAsync();
+        await logsEnumerator2.DisposeAsync();
+
+        logger.LogInformation("After watching!");
+
+        // The backlog should be cleared once there are no subscribers.
+        Assert.Empty(service.GetResourceLoggerState(testResource.Name).GetBacklogSnapshot());
+
+        subsLoop = WatchForSubscribers(service);
+        var logsEnumerator3 = service.WatchAsync(testResource).GetAsyncEnumerator();
+        logsLoop = ConsoleLoggingTestHelpers.WatchForLogsAsync(logsEnumerator3, 4);
+        await subsLoop.WaitAsync(TimeSpan.FromSeconds(15));
+        logger.LogInformation("While watching again!");
+        allLogs = await logsLoop.WaitAsync(TimeSpan.FromSeconds(15));
+
+        Assert.Equal(4, allLogs.Count);
+        Assert.Equal("2000-12-29T20:59:59.0000000Z Before watching!", allLogs[0].Content);
+        Assert.Equal("2000-12-29T20:59:59.0000000Z While watching!", allLogs[1].Content);
+        Assert.Equal("2000-12-29T20:59:59.0000000Z After watching!", allLogs[2].Content);
+        Assert.Equal("2000-12-29T20:59:59.0000000Z While watching again!", allLogs[3].Content);
     }
 
     private sealed class TestResource(string name) : Resource(name)


### PR DESCRIPTION
PR changes:

* Don't complete a resource logger when a resource is deleted. The only scenario where resources are deleted right now is restart, and we still want logs to be available after a restart.
* Correctly display in-memory logs, i.e. logs written by resource logger service, when viewing the console logs page. They're no longer cleared away when console logs watch stops.

Fixes https://github.com/dotnet/aspire/issues/5803

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5909)