### PR TITLE
Fix metrics grouping empty attributes and unset attributes dimensions together

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -47,6 +47,8 @@ app.MapGet("/write-console", () =>
 app.MapGet("/increment-counter", (TestMetrics metrics) =>
 {
     metrics.IncrementCounter(1, new TagList([new KeyValuePair<string, object?>("add-tag", "1")]));
+    metrics.IncrementCounter(2, new TagList([new KeyValuePair<string, object?>("add-tag", "")]));
+    metrics.IncrementCounter(3, default);
 
     return "Counter incremented";
 });

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -208,8 +208,8 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
                 {
                     var text = v switch
                     {
-                        null => Loc[ControlsStrings.Unset],
-                        { Length: 0 } => Loc[ControlsStrings.Empty],
+                        null => Loc[ControlsStrings.LabelUnset],
+                        { Length: 0 } => Loc[ControlsStrings.LabelEmpty],
                         _ => v
                     };
                     return new DimensionValueViewModel

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -134,11 +134,7 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
         var value = OtlpHelpers.GetValue(attributes, filter.Name);
         foreach (var item in filter.SelectedValues)
         {
-            if (item.Empty && string.IsNullOrEmpty(value))
-            {
-                return true;
-            }
-            if (item.Name == value)
+            if (item.Value == value)
             {
                 return true;
             }
@@ -210,11 +206,16 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
 
                 dimensionModel.Values.AddRange(item.Value.OrderBy(v => v).Select(v =>
                 {
-                    var empty = string.IsNullOrEmpty(v);
+                    var text = v switch
+                    {
+                        null => "(Unset)",
+                        { Length: 0 } => "(Empty)",
+                        _ => v
+                    };
                     return new DimensionValueViewModel
                     {
-                        Name = empty ? "(Empty)" : v,
-                        Empty = empty
+                        Text = text,
+                        Value = v
                     };
                 }));
 
@@ -242,7 +243,7 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
                         // Automatically select new incoming values if existing values are all selected.
                         var newSelectedValues = (existing.AreAllValuesSelected ?? false)
                             ? item.Values
-                            : item.Values.Where(newValue => existing.SelectedValues.Any(existingValue => existingValue.Name == newValue.Name));
+                            : item.Values.Where(newValue => existing.SelectedValues.Any(existingValue => existingValue.Value == newValue.Value));
 
                         foreach (var v in newSelectedValues)
                         {

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -1,11 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Components.Pages;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Aspire.Dashboard.Otlp.Storage;
+using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
 
@@ -204,12 +204,12 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
                     Name = item.Key
                 };
 
-                dimensionModel.Values.AddRange(item.Value.OrderBy(v => v).Select(v =>
+                dimensionModel.Values.AddRange(item.Value.Select(v =>
                 {
                     var text = v switch
                     {
-                        null => "(Unset)",
-                        { Length: 0 } => "(Empty)",
+                        null => Loc[ControlsStrings.Unset],
+                        { Length: 0 } => Loc[ControlsStrings.Empty],
                         _ => v
                     };
                     return new DimensionValueViewModel
@@ -217,7 +217,7 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
                         Text = text,
                         Value = v
                     };
-                }));
+                }).OrderBy(v => v.Text));
 
                 filters.Add(dimensionModel);
             }
@@ -270,8 +270,8 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
         var id = newTab.Id?.Substring("tab-".Length);
 
         if (id is null
-            || !Enum.TryParse(typeof(Metrics.MetricViewKind), id, out var o)
-            || o is not Metrics.MetricViewKind viewKind)
+            || !Enum.TryParse(typeof(Pages.Metrics.MetricViewKind), id, out var o)
+            || o is not Pages.Metrics.MetricViewKind viewKind)
         {
             return Task.CompletedTask;
         }

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -18,7 +18,7 @@
                             GenerateHeader="GenerateHeaderOption.None">
                 <ChildContent>
                     <AspirePropertyColumn Tooltip="true" TooltipText="@(c => c.Name)" Property="@(c => c.Name)"/>
-                    <AspireTemplateColumn Tooltip="true" TooltipText="@(c => c.SelectedValues.Count == 0 ? Loc[nameof(ControlsStrings.None)] : string.Join(", ", c.SelectedValues.Select(v => v.Name)))">
+                    <AspireTemplateColumn Tooltip="true" TooltipText="@(c => c.SelectedValues.Count == 0 ? Loc[nameof(ControlsStrings.None)] : string.Join(", ", c.SelectedValues.OrderBy(v => v.Text).Select(v => v.Text)))">
                         <FluentOverflow Class="dimension-overflow">
                             <ChildContent>
                                 @if (context.SelectedValues.Count == 0)
@@ -28,11 +28,11 @@
                                 else
                                 {
                                     var i = 0;
-                                    foreach (var item in context.SelectedValues.OrderBy(g => g.Name))
+                                    foreach (var item in context.SelectedValues.OrderBy(v => v.Text))
                                     {
                                         // Always display the first item by setting a fixed value.
                                         <FluentOverflowItem Fixed="@((i == 0) ? OverflowItemFixed.Ellipsis : OverflowItemFixed.None)">
-                                            <span class="dimension-tag">@item.Name</span>
+                                            <span class="dimension-tag">@item.Text</span>
                                         </FluentOverflowItem>
                                         i++;
                                     }
@@ -67,11 +67,11 @@
                                                 ShowIndeterminate="false"
                                                 ThreeStateOrderUncheckToIntermediate="true"
                                                 @bind-CheckState="context.AreAllValuesSelected"/>
-                                @foreach (var tag in context.Values)
+                                @foreach (var tag in context.Values.OrderBy(v => v.Text))
                                 {
                                     var isChecked = context.SelectedValues.Contains(tag);
-                                    <FluentCheckbox Label="@tag.Name"
-                                                    title="@tag.Name"
+                                    <FluentCheckbox Label="@tag.Text"
+                                                    title="@tag.Text"
                                                     @key=tag
                                                     @bind-Value:get="isChecked"
                                                     @bind-Value:set="c => context.OnTagSelectionChanged(tag, c)"/>

--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartFilters.razor
@@ -18,12 +18,12 @@
                             GenerateHeader="GenerateHeaderOption.None">
                 <ChildContent>
                     <AspirePropertyColumn Tooltip="true" TooltipText="@(c => c.Name)" Property="@(c => c.Name)"/>
-                    <AspireTemplateColumn Tooltip="true" TooltipText="@(c => c.SelectedValues.Count == 0 ? Loc[nameof(ControlsStrings.None)] : string.Join(", ", c.SelectedValues.OrderBy(v => v.Text).Select(v => v.Text)))">
+                    <AspireTemplateColumn Tooltip="true" TooltipText="@(c => c.SelectedValues.Count == 0 ? Loc[nameof(ControlsStrings.LabelNone)] : string.Join(", ", c.SelectedValues.OrderBy(v => v.Text).Select(v => v.Text)))">
                         <FluentOverflow Class="dimension-overflow">
                             <ChildContent>
                                 @if (context.SelectedValues.Count == 0)
                                 {
-                                    <FluentBadge>@Loc[nameof(ControlsStrings.None)]</FluentBadge>
+                                    <FluentBadge>@Loc[nameof(ControlsStrings.LabelNone)]</FluentBadge>
                                 }
                                 else
                                 {
@@ -62,7 +62,7 @@
                             <Header>@context.Name</Header>
                             <Body>
                             <FluentStack Orientation="Orientation.Vertical" Class="dimension-popup">
-                                <FluentCheckbox Label="@Loc[nameof(ControlsStrings.All)]"
+                                <FluentCheckbox Label="@Loc[nameof(ControlsStrings.LabelAll)]"
                                                 ThreeState="true"
                                                 ShowIndeterminate="false"
                                                 ThreeStateOrderUncheckToIntermediate="true"

--- a/src/Aspire.Dashboard/Components/Controls/SelectResourceTypes.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SelectResourceTypes.razor
@@ -6,7 +6,7 @@
 @inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
 <FluentStack Orientation="Orientation.Vertical">
-    <FluentCheckbox Label="@ControlsStringsLoc[nameof(ControlsStrings.All)]"
+    <FluentCheckbox Label="@ControlsStringsLoc[nameof(ControlsStrings.LabelAll)]"
                     ThreeState="true"
                     ShowIndeterminate="false"
                     onkeydown="e => console.log(e)"

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -83,7 +83,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     protected override async Task OnInitializedAsync()
     {
         _logEntries = new(Options.Value.Frontend.MaxConsoleLogCount);
-        _noSelection = new() { Id = null, Name = ControlsStringsLoc[nameof(ControlsStrings.None)] };
+        _noSelection = new() { Id = null, Name = ControlsStringsLoc[nameof(ControlsStrings.LabelNone)] };
         PageViewModel = new ConsoleLogsViewModel { SelectedOption = _noSelection, SelectedResource = null, Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLoadingResources)] };
 
         var loadingTcs = new TaskCompletionSource();

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -80,7 +80,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
         _selectApplication = new SelectViewModel<ResourceTypeDetails>
         {
             Id = null,
-            Name = ControlsStringsLoc[ControlsStrings.None]
+            Name = ControlsStringsLoc[ControlsStrings.LabelNone]
         };
 
         PageViewModel = new MetricsViewModel

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -161,12 +161,12 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
         _allApplication = new()
         {
             Id = null,
-            Name = ControlsStringsLoc[nameof(Dashboard.Resources.ControlsStrings.All)]
+            Name = ControlsStringsLoc[nameof(Dashboard.Resources.ControlsStrings.LabelAll)]
         };
 
         _logLevels = new List<SelectViewModel<LogLevel?>>
         {
-            new SelectViewModel<LogLevel?> { Id = null, Name = ControlsStringsLoc[nameof(Dashboard.Resources.ControlsStrings.All)] },
+            new SelectViewModel<LogLevel?> { Id = null, Name = ControlsStringsLoc[nameof(Dashboard.Resources.ControlsStrings.LabelAll)] },
             new SelectViewModel<LogLevel?> { Id = LogLevel.Trace, Name = "Trace" },
             new SelectViewModel<LogLevel?> { Id = LogLevel.Debug, Name = "Debug" },
             new SelectViewModel<LogLevel?> { Id = LogLevel.Information, Name = "Information" },

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -144,7 +144,7 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
             new GridColumn(Name: DetailsColumn, DesktopWidth: "0.5fr", MobileWidth: "1fr")
         ];
 
-        _allApplication = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = ControlsStringsLoc[name: nameof(ControlsStrings.All)] };
+        _allApplication = new SelectViewModel<ResourceTypeDetails> { Id = null, Name = ControlsStringsLoc[name: nameof(ControlsStrings.LabelAll)] };
         PageViewModel = new TracesPageViewModel { SelectedApplication = _allApplication };
 
         UpdateApplications();

--- a/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
+++ b/src/Aspire.Dashboard/Model/DimensionFilterViewModel.cs
@@ -56,10 +56,10 @@ public class DimensionFilterViewModel
     private string DebuggerToString() => $"Name = {Name}, SelectedValues = {SelectedValues.Count}";
 }
 
-[DebuggerDisplay("Name = {Name}, Empty = {Empty}")]
+[DebuggerDisplay("Text = {Text}, Value = {Value}")]
 public class DimensionValueViewModel
 {
-    public required string Name { get; init; }
-    public bool Empty { get; init; }
+    public required string Text { get; init; }
+    public required string? Value { get; init; }
 }
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -27,7 +27,7 @@ public class OtlpInstrumentData
 {
     public required OtlpInstrumentSummary Summary { get; init; }
     public required List<DimensionScope> Dimensions { get; init; }
-    public required Dictionary<string, List<string>> KnownAttributeValues { get; init; }
+    public required Dictionary<string, List<string?>> KnownAttributeValues { get; init; }
 }
 
 [DebuggerDisplay("Name = {Summary.Name}, Unit = {Summary.Unit}, Type = {Summary.Type}")]
@@ -37,7 +37,7 @@ public class OtlpInstrument
     public required TelemetryLimitOptions Options { get; init; }
 
     public Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> Dimensions { get; } = new(ScopeAttributesComparer.Instance);
-    public Dictionary<string, List<string>> KnownAttributeValues { get; } = new();
+    public Dictionary<string, List<string?>> KnownAttributeValues { get; } = new();
 
     public void AddMetrics(Metric metric, ref KeyValuePair<string, string>[]? tempAttributes)
     {
@@ -94,22 +94,22 @@ public class OtlpInstrument
         {
             if (!KnownAttributeValues.TryGetValue(key, out var values))
             {
-                KnownAttributeValues.Add(key, values = new List<string>());
+                KnownAttributeValues.Add(key, values = new List<string?>());
 
                 // If the key is new and there are already dimensions, add an empty value because there are dimensions without this key.
                 if (!isFirst)
                 {
-                    TryAddValue(values, string.Empty);
+                    TryAddValue(values, null);
                 }
             }
 
             var currentDimensionValue = OtlpHelpers.GetValue(durableAttributes, key);
-            TryAddValue(values, currentDimensionValue ?? string.Empty);
+            TryAddValue(values, currentDimensionValue);
         }
 
         return dimension;
 
-        static void TryAddValue(List<string> values, string value)
+        static void TryAddValue(List<string?> values, string? value)
         {
             if (!values.Contains(value))
             {

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1083,7 +1083,7 @@ public sealed class TelemetryRepository
         else
         {
             var allDimensions = new List<DimensionScope>();
-            var allKnownAttributes = new Dictionary<string, List<string>>();
+            var allKnownAttributes = new Dictionary<string, List<string?>>();
 
             foreach (var instrument in instruments)
             {

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -61,15 +61,6 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (All).
-        /// </summary>
-        public static string All {
-            get {
-                return ResourceManager.GetString("All", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to application.
         /// </summary>
         public static string ApplicationLower {
@@ -183,15 +174,6 @@ namespace Aspire.Dashboard.Resources {
         public static string DurationColumnHeader {
             get {
                 return ResourceManager.GetString("DurationColumnHeader", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to (Empty).
-        /// </summary>
-        public static string Empty {
-            get {
-                return ResourceManager.GetString("Empty", resourceCulture);
             }
         }
         
@@ -331,6 +313,42 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (All).
+        /// </summary>
+        public static string LabelAll {
+            get {
+                return ResourceManager.GetString("LabelAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (Empty).
+        /// </summary>
+        public static string LabelEmpty {
+            get {
+                return ResourceManager.GetString("LabelEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (None).
+        /// </summary>
+        public static string LabelNone {
+            get {
+                return ResourceManager.GetString("LabelNone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (Unset).
+        /// </summary>
+        public static string LabelUnset {
+            get {
+                return ResourceManager.GetString("LabelUnset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading....
         /// </summary>
         public static string Loading {
@@ -426,15 +444,6 @@ namespace Aspire.Dashboard.Resources {
         public static string NameColumnHeader {
             get {
                 return ResourceManager.GetString("NameColumnHeader", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to (None).
-        /// </summary>
-        public static string None {
-            get {
-                return ResourceManager.GetString("None", resourceCulture);
             }
         }
         
@@ -822,15 +831,6 @@ namespace Aspire.Dashboard.Resources {
         public static string TraceDetailAttributesHeader {
             get {
                 return ResourceManager.GetString("TraceDetailAttributesHeader", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to (Unset).
-        /// </summary>
-        public static string Unset {
-            get {
-                return ResourceManager.GetString("Unset", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.Designer.cs
@@ -187,6 +187,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (Empty).
+        /// </summary>
+        public static string Empty {
+            get {
+                return ResourceManager.GetString("Empty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Show all.
         /// </summary>
         public static string EnvironmentVariablesFilterToggleShowAll {
@@ -673,6 +682,33 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add filter.
+        /// </summary>
+        public static string StructuredFilteringAddFilter {
+            get {
+                return ResourceManager.GetString("StructuredFilteringAddFilter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filters.
+        /// </summary>
+        public static string StructuredFilteringFilters {
+            get {
+                return ResourceManager.GetString("StructuredFilteringFilters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No filters.
+        /// </summary>
+        public static string StructuredFilteringNoFilters {
+            get {
+                return ResourceManager.GetString("StructuredFilteringNoFilters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Context.
         /// </summary>
         public static string StructuredLogsDetailsContextHeader {
@@ -786,6 +822,15 @@ namespace Aspire.Dashboard.Resources {
         public static string TraceDetailAttributesHeader {
             get {
                 return ResourceManager.GetString("TraceDetailAttributesHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (Unset).
+        /// </summary>
+        public static string Unset {
+            get {
+                return ResourceManager.GetString("Unset", resourceCulture);
             }
         }
         

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -215,7 +215,7 @@
   <data name="ViewAction" xml:space="preserve">
     <value>View</value>
   </data>
-  <data name="All" xml:space="preserve">
+  <data name="LabelAll" xml:space="preserve">
     <value>(All)</value>
   </data>
   <data name="ChartContainerAllTags" xml:space="preserve">
@@ -230,7 +230,7 @@
   <data name="ChartContainerShowCountLabel" xml:space="preserve">
     <value>Show count</value>
   </data>
-  <data name="None" xml:space="preserve">
+  <data name="LabelNone" xml:space="preserve">
     <value>(None)</value>
   </data>
   <data name="MetricTableStartColumnHeader" xml:space="preserve">
@@ -386,10 +386,10 @@
   <data name="StructuredFilteringAddFilter" xml:space="preserve">
     <value>Add filter</value>
   </data>
-  <data name="Empty" xml:space="preserve">
+  <data name="LabelEmpty" xml:space="preserve">
     <value>(Empty)</value>
   </data>
-  <data name="Unset" xml:space="preserve">
+  <data name="LabelUnset" xml:space="preserve">
     <value>(Unset)</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/ControlsStrings.resx
+++ b/src/Aspire.Dashboard/Resources/ControlsStrings.resx
@@ -386,4 +386,10 @@
   <data name="StructuredFilteringAddFilter" xml:space="preserve">
     <value>Add filter</value>
   </data>
+  <data name="Empty" xml:space="preserve">
+    <value>(Empty)</value>
+  </data>
+  <data name="Unset" xml:space="preserve">
+    <value>(Unset)</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(Vše)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">aplikace</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">Doba trvání</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">Zobrazit hodnotu</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Načítání…</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">Název</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(Žádný)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Atributy</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.cs.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Doba trvání</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">Událost</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Atributy</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(Alle)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">Anwendung</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">Dauer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">Wert anzeigen</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Wird geladen...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">Name</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(Keine)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Attribute</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.de.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Dauer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">Ereignis</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Attribute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(Todas)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">aplicación</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">Duración</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">Mostrar valor</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Cargando...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">Nombre</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(Ninguno)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Atributos</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.es.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Duración</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">Evento</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Atributos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Durée</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">Événement</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Attributs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.fr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(Tout)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">application</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">Durée</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">Afficher une valeur</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Chargement...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">Nom</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(Aucun)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Attributs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Durata</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">Evento</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Attributi</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.it.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(Tutti)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">applicazione</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">Durata</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">Mostra valore</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Caricamento in corso...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">Nome</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(Nessuno)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Attributi</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(すべて)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">アプリケーション</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">継続時間</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">値の表示</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">読み込み中...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">名前</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(なし)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">属性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ja.xlf
@@ -72,6 +72,11 @@
         <target state="translated">継続時間</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">イベント</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">属性</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(모두)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">애플리케이션</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">기간</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">값 표시</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">로드 중...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">이름</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(없음)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">특성</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ko.xlf
@@ -72,6 +72,11 @@
         <target state="translated">기간</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">이벤트</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">특성</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(Wszystko)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">aplikacja</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">Czas trwania</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">Pokaż wartość</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Trwa ładowanie...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">Nazwa</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(Brak)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Atrybuty</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pl.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Czas trwania</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">Zdarzenie</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Atrybuty</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Duração</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">Evento</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Atributos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.pt-BR.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(Tudo)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">aplicativo</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">Duração</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">Exibir valor</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Carregando...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">Nome</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(Nenhum)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Atributos</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(Все)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">приложение</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">Длительность</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">Показать значение</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Идет загрузка...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">Имя</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(Нет)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Атрибуты</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.ru.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Длительность</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">Событие</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Атрибуты</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(Tümü)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">uygulama</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">Süre</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">Değeri göster</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">Yükleniyor...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">Ad</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(Yok)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Öznitelikler</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.tr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Süre</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">Olay</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">Öznitelikler</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(全部)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">应用程序</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">持续时间</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">显示值</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">正在加载...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">名称</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(无)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">属性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hans.xlf
@@ -72,6 +72,11 @@
         <target state="translated">持续时间</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">事件</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">属性</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ControlsStrings.resx">
     <body>
-      <trans-unit id="All">
-        <source>(All)</source>
-        <target state="translated">(全部)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ApplicationLower">
         <source>application</source>
         <target state="translated">應用程式</target>
@@ -70,11 +65,6 @@
       <trans-unit id="DurationColumnHeader">
         <source>Duration</source>
         <target state="translated">持續時間</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Empty">
-        <source>(Empty)</source>
-        <target state="new">(Empty)</target>
         <note />
       </trans-unit>
       <trans-unit id="EventColumnHeader">
@@ -152,6 +142,26 @@
         <target state="translated">顯示值</target>
         <note />
       </trans-unit>
+      <trans-unit id="LabelAll">
+        <source>(All)</source>
+        <target state="new">(All)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelEmpty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelNone">
+        <source>(None)</source>
+        <target state="new">(None)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LabelUnset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading">
         <source>Loading...</source>
         <target state="translated">正在載入...</target>
@@ -205,11 +215,6 @@
       <trans-unit id="NameColumnHeader">
         <source>Name</source>
         <target state="translated">名稱</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="None">
-        <source>(None)</source>
-        <target state="translated">(無)</target>
         <note />
       </trans-unit>
       <trans-unit id="PageToolbarLandmark">
@@ -405,11 +410,6 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">屬性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Unset">
-        <source>(Unset)</source>
-        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/ControlsStrings.zh-Hant.xlf
@@ -72,6 +72,11 @@
         <target state="translated">持續時間</target>
         <note />
       </trans-unit>
+      <trans-unit id="Empty">
+        <source>(Empty)</source>
+        <target state="new">(Empty)</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EventColumnHeader">
         <source>Event</source>
         <target state="translated">事件</target>
@@ -400,6 +405,11 @@
       <trans-unit id="TraceDetailAttributesHeader">
         <source>Attributes</source>
         <target state="translated">屬性</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Unset">
+        <source>(Unset)</source>
+        <target state="new">(Unset)</target>
         <note />
       </trans-unit>
       <trans-unit id="ViewAction">

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/MetricsTests.cs
@@ -335,7 +335,8 @@ public class MetricsTests
                             CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(2)),
                             CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key1", "value1")]),
                             CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key1", "value2")]),
-                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key1", "value1"), KeyValuePair.Create("key2", "value1")])
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key1", "value1"), KeyValuePair.Create("key2", "value1")]),
+                            CreateSumMetric(metricName: "test", startTime: s_testTime.AddMinutes(1), attributes: [KeyValuePair.Create("key1", "value1"), KeyValuePair.Create("key2", "")])
                         }
                     }
                 }
@@ -372,15 +373,15 @@ public class MetricsTests
             e =>
             {
                 Assert.Equal("key1", e.Key);
-                Assert.Equal(new[] { "", "value1", "value2" }, e.Value);
+                Assert.Equal(new[] { null, "value1", "value2" }, e.Value);
             },
             e =>
             {
                 Assert.Equal("key2", e.Key);
-                Assert.Equal(new[] { "", "value1" }, e.Value);
+                Assert.Equal(new[] { null, "value1", "" }, e.Value);
             });
 
-        Assert.Equal(4, instrumentData.Dimensions.Count);
+        Assert.Equal(5, instrumentData.Dimensions.Count);
 
         var dimension = instrumentData.Dimensions.Single(d => d.Attributes.Length == 0);
         var exemplar = Assert.Single(dimension.Values[0].Exemplars);


### PR DESCRIPTION
## Description

I had an offline discussion with IDE folks who were adding UI for viewing metrics. A topic came up about the difference between an empty value vs an unset value. It occured to me that the metrics page doesn't distinguish between the two.

This PR:
* Gives different filter options: `(Empty)` to match dimensions with an empty string value. `(Unset)` to match dimensions with no value set.
* Fixes some minor ordering issues I noticed while in this area.
* Uses localization for special attribute values.

Fixes https://github.com/dotnet/aspire/issues/5913

![metrics-unset-empty](https://github.com/user-attachments/assets/0ddbe181-6070-4a23-88ee-6448480982e9)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
