### PR TITLE
Fix KubernetesHasResourceNameForContainersAndExes

### DIFF
--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -638,11 +638,8 @@ public class DistributedApplicationTests
         {
             "redis",
             "postgres",
-            "mongodb",
             "cosmos",
-            "mysql",
-            "rabbitmq",
-            "kafka"
+            "eventhubns"
         };
 
         await foreach (var resource in s.WatchAsync<Container>(cancellationToken: token))


### PR DESCRIPTION
## Description

Adjust container list expectations to fix KubernetesHasResourceNameForContainersAndExes.
Fixes #5920

Change only in test code.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5921)