### PR TITLE
Disable flaky Workload tests on Windows

### DIFF
--- a/tests/Aspire.Workload.Tests/Aspire.Workload.Tests.csproj
+++ b/tests/Aspire.Workload.Tests/Aspire.Workload.Tests.csproj
@@ -6,6 +6,11 @@
     <TestUsingWorkloads>true</TestUsingWorkloads>
     <InstallWorkloadForTesting>true</InstallWorkloadForTesting>
 
+    <!-- https://github.com/dotnet/aspire/issues/5926
+     The template tests are unreliable ever since we merged the workload removal PR.
+     Temporarily skipping them while we work on making them reliable -->
+    <SkipTests Condition="'$(OS)' == 'Windows_NT'">true</SkipTests>
+
     <XunitRunnerJson>xunit.runner.json</XunitRunnerJson>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory).runsettings</RunSettingsFilePath>
     <TestArchiveTestsDir>$(TestArchiveTestsDirForWorkloadTests)</TestArchiveTestsDir>

--- a/tests/Aspire.Workload.Tests/Aspire.Workload.Tests.csproj
+++ b/tests/Aspire.Workload.Tests/Aspire.Workload.Tests.csproj
@@ -6,11 +6,6 @@
     <TestUsingWorkloads>true</TestUsingWorkloads>
     <InstallWorkloadForTesting>true</InstallWorkloadForTesting>
 
-    <!-- https://github.com/dotnet/aspire/issues/5926
-     The template tests are unreliable ever since we merged the workload removal PR.
-     Temporarily skipping them while we work on making them reliable -->
-    <SkipTests Condition="'$(OS)' == 'Windows_NT'">true</SkipTests>
-
     <XunitRunnerJson>xunit.runner.json</XunitRunnerJson>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory).runsettings</RunSettingsFilePath>
     <TestArchiveTestsDir>$(TestArchiveTestsDirForWorkloadTests)</TestArchiveTestsDir>

--- a/tests/helix/send-to-helix-ci.proj
+++ b/tests/helix/send-to-helix-ci.proj
@@ -4,7 +4,10 @@
       <TestCategory Include="basictests" />
       <!-- no docker on windows -->
       <TestCategory Condition="'$(OS)' != 'Windows_NT'" Include="endtoendtests" />
-      <TestCategory Include="workloadtests" />
+      <!-- https://github.com/dotnet/aspire/issues/5926
+     The template tests are unreliable ever since we merged the workload removal PR.
+     Temporarily skipping them while we work on making them reliable -->
+      <TestCategory Condition="'$(OS)' != 'Windows_NT'" Include="workloadtests" />
       <!-- no docker on windows -->
       <TestCategory Condition="'$(OS)' != 'Windows_NT'" Include="buildonhelixtests" />
 


### PR DESCRIPTION
## Description

Temporarily disable the workload tests in Windows as they have been very unreliable since merging the workload removal PR. @radical is already working on re-structuring these tests, so as part of that change they will be re-enabled promptly. Tests will continue to run on Linux as they seem to be reliable there.

Related https://github.com/dotnet/aspire/issues/5926

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5927)