### PR TITLE
Fix mobile->desktop detail panel size staying full screen

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -26,8 +26,8 @@
     {
         <FluentSplitter Orientation="@Orientation" Collapsed="@(!_internalShowDetails)"
                         OnResized="HandleSplitterResize"
-                        Panel1Size="@_panel1Size" Panel2Size="@_panel2Size"
-                        Panel1MinSize="150px" Panel2MinSize="150px"
+                        Panel1Size="@EffectivePanel1Size" Panel2Size="@EffectivePanel2Size"
+                        Panel1MinSize="@PanelMinimumSize" Panel2MinSize="@PanelMinimumSize"
                         BarSize="5"
                         @ref="_splitterRef">
             <Panel1>

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor.cs
@@ -77,6 +77,11 @@ public partial class SummaryDetailsView<T> : IGlobalKeydownListener, IDisposable
     private bool _internalShowDetails;
     private FluentSplitter? _splitterRef;
 
+    public string EffectivePanel1Size => ViewportInformation.IsDesktop ? _panel1Size : "0fr";
+    public string EffectivePanel2Size => ViewportInformation.IsDesktop ? _panel2Size : "1fr";
+
+    public string PanelMinimumSize => ViewportInformation.IsDesktop ? "150px" : "0";
+
     protected override void OnInitialized()
     {
         ResetPanelSizes();
@@ -125,7 +130,6 @@ public partial class SummaryDetailsView<T> : IGlobalKeydownListener, IDisposable
         // This is required because we only want to show details after resolving size and orientation
         // to avoid a flash of content in the wrong location.
         _internalShowDetails = ShowDetails;
-        SetPanelToFullScreenOnMobile();
     }
 
     private async Task RaiseOnResizeAsync()
@@ -214,15 +218,6 @@ public partial class SummaryDetailsView<T> : IGlobalKeydownListener, IDisposable
         // These need to not use culture-specific formatting because it needs to be a valid CSS value
         _panel1Size = string.Create(CultureInfo.InvariantCulture, $"{panel1Fraction:F3}fr");
         _panel2Size = string.Create(CultureInfo.InvariantCulture, $"{(1 - panel1Fraction):F3}fr");
-    }
-
-    private void SetPanelToFullScreenOnMobile()
-    {
-        if (!ViewportInformation.IsDesktop)
-        {
-            // panel 1 will have a height of 0, so its fraction of 1 is also 0
-            SetPanelSizes(panel1Fraction: 0);
-        }
     }
 
     public IReadOnlySet<AspireKeyboardShortcut> SubscribedShortcuts { get; } = new HashSet<AspireKeyboardShortcut>


### PR DESCRIPTION
## Description

Fixes #5197. I had incorrectly saved the updated panel sizes when switching to mobile view - instead, effective panel size should be computed as a property.

demo:

https://github.com/user-attachments/assets/40704ef6-5878-42a1-acd3-476395b2da80

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5928)