### PR TITLE
Make file log change test less flaky and remove post configure from dashboard web app

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -79,11 +79,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     /// Create a new instance of the <see cref="DashboardWebApplication"/> class.
     /// </summary>
     /// <param name="preConfigureBuilder">Configuration for the internal app builder *before* normal dashboard configuration is done. This is for unit testing.</param>
-    /// <param name="postConfigureBuilder">Configuration for the internal app builder *after* normal dashboard configuration is done. This is for unit testing.</param>
     /// <param name="options">Environment configuration for the internal app builder. This is for unit testing</param>
     public DashboardWebApplication(
         Action<WebApplicationBuilder>? preConfigureBuilder = null,
-        Action<WebApplicationBuilder>? postConfigureBuilder = null,
         WebApplicationOptions? options = null)
     {
         var builder = options is not null ? WebApplication.CreateBuilder(options) : WebApplication.CreateBuilder();
@@ -199,7 +197,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
 
         // Data from the server.
-        builder.Services.AddScoped<IDashboardClient, DashboardClient>();
+        builder.Services.TryAddScoped<IDashboardClient, DashboardClient>();
 
         // OTLP services.
         builder.Services.AddGrpc();
@@ -237,8 +235,6 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         {
             options.Cookie.Name = DashboardAntiForgeryCookieName;
         });
-
-        postConfigureBuilder?.Invoke(builder);
 
         _app = builder.Build();
 

--- a/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
+++ b/tests/Aspire.Dashboard.Tests/Aspire.Dashboard.Tests.csproj
@@ -21,6 +21,7 @@
 
     <ProjectReference Include="..\..\src\Aspire.Dashboard\Aspire.Dashboard.csproj" />
 
+    <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(TestsSharedDir)TestCertificateLoader.cs" Link="shared/TestCertificateLoader.cs" />
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
     <Compile Include="$(TestsSharedDir)Telemetry\*.cs" LinkBase="shared/Telemetry" />

--- a/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/IntegrationTestHelpers.cs
@@ -7,6 +7,7 @@ using Aspire.Hosting;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Grpc.Net.Client.Configuration;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
@@ -38,16 +39,18 @@ public static class IntegrationTestHelpers
     public static DashboardWebApplication CreateDashboardWebApplication(
         ITestOutputHelper testOutputHelper,
         Action<Dictionary<string, string?>>? additionalConfiguration = null,
+        Action<WebApplicationBuilder>? preConfigureBuilder = null,
         ITestSink? testSink = null)
     {
         var loggerFactory = CreateLoggerFactory(testOutputHelper, testSink);
 
-        return CreateDashboardWebApplication(loggerFactory, additionalConfiguration);
+        return CreateDashboardWebApplication(loggerFactory, additionalConfiguration, preConfigureBuilder);
     }
 
     public static DashboardWebApplication CreateDashboardWebApplication(
         ILoggerFactory loggerFactory,
-        Action<Dictionary<string, string?>>? additionalConfiguration = null)
+        Action<Dictionary<string, string?>>? additionalConfiguration = null,
+        Action<WebApplicationBuilder>? preConfigureBuilder = null)
     {
         var initialData = new Dictionary<string, string?>
         {
@@ -67,6 +70,8 @@ public static class IntegrationTestHelpers
 
         var dashboardWebApplication = new DashboardWebApplication(builder =>
         {
+            preConfigureBuilder?.Invoke(builder);
+
             builder.Services.PostConfigure<LoggerFilterOptions>(o =>
             {
                 o.Rules.Clear();

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
@@ -8,7 +8,6 @@ using Aspire.Hosting;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Xunit;
 
 namespace Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
@@ -58,11 +57,7 @@ public class DashboardServerFixture : IAsyncLifetime
             preConfigureBuilder: builder =>
             {
                 builder.Configuration.AddConfiguration(config);
-            },
-            postConfigureBuilder: builder =>
-            {
-                builder.Services.RemoveAll<IDashboardClient>();
-                builder.Services.AddSingleton<IDashboardClient, MockDashboardClient>();
+                builder.Services.AddScoped<IDashboardClient, MockDashboardClient>();
             });
 
         await DashboardApp.StartAsync();

--- a/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
+++ b/tests/Aspire.Hosting.Tests/Aspire.Hosting.Tests.csproj
@@ -21,6 +21,7 @@
 
     <Compile Include="$(TestsSharedDir)Logging\*.cs" LinkBase="shared/Logging" />
     <Compile Include="$(TestsSharedDir)ConsoleLogging\*.cs" LinkBase="shared" />
+    <Compile Include="$(TestsSharedDir)AsyncTestHelpers.cs" Link="shared/AsyncTestHelpers.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.PostgreSQL\PostgresContainerImageTags.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.Redis\RedisContainerImageTags.cs" />
     <Compile Include="$(RepoRoot)src\Aspire.Hosting.Testing\ResourceLoggerForwarderService.cs" Link="Utils\ResourceLoggerForwarderService.cs" />

--- a/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
@@ -11,6 +11,7 @@ using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Tests.Utils;
 using k8s.Models;
+using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Shared/AsyncTestHelpers.cs
+++ b/tests/Shared/AsyncTestHelpers.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace Aspire.Hosting.Tests.Utils;
+namespace Microsoft.AspNetCore.InternalTesting;
 
 internal static class AsyncTestHelpers
 {


### PR DESCRIPTION
## Description

Saw a test failure in `Configuration_FileConfigDirectoryReloadsChanges_Success` in a PR: https://dev.azure.com/dnceng-public/public/_build/results?buildId=818111&view=ms.vss-test-web.build-test-results-tab&runId=21226062&resultId=100416&paneView=debug

PR improves the delay and enabled logging. Also simplified some web app configuration.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5933)