### PR TITLE
Fail to start when health check registration is missing for resource.

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -278,6 +278,35 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
     private void ConfigureHealthChecks()
     {
+        _innerBuilder.Services.AddSingleton<IValidateOptions<HealthCheckServiceOptions>>(sp =>
+        {
+            var appModel = sp.GetRequiredService<DistributedApplicationModel>();
+            var logger = sp.GetRequiredService<ILogger<DistributedApplicationBuilder>>();
+
+            // Generic message (we update it in the callback to make it more specific).
+            var failureMessage = "A health check registration is missing. Check logs for more details.";
+
+            return new ValidateOptions<HealthCheckServiceOptions>(null, (options) =>
+            {
+                var resourceHealthChecks = appModel.Resources.SelectMany(
+                    r => r.Annotations.OfType<HealthCheckAnnotation>().Select(hca => new { Resource = r, Annotation = hca })
+                    );
+
+                var healthCheckRegistrationKeys = options.Registrations.Select(hcr => hcr.Name).ToHashSet();
+                var missingResourceHealthChecks = resourceHealthChecks.Where(rhc => !healthCheckRegistrationKeys.Contains(rhc.Annotation.Key));
+
+                foreach (var missingResourceHealthCheck in missingResourceHealthChecks)
+                {
+                    sp.GetRequiredService<ILogger<DistributedApplicationBuilder>>().LogCritical(
+                        "The health check '{Key}' is not registered and is required for resource '{ResourceName}'.",
+                        missingResourceHealthCheck.Annotation.Key,
+                        missingResourceHealthCheck.Resource.Name);
+                }
+
+                return !missingResourceHealthChecks.Any();
+            }, failureMessage);
+        });
+
         _innerBuilder.Services.AddSingleton<IConfigureOptions<HealthCheckPublisherOptions>>(sp =>
         {
             return new ConfigureOptions<HealthCheckPublisherOptions>(options =>

--- a/tests/Aspire.Hosting.Tests/HealthCheckTests.cs
+++ b/tests/Aspire.Hosting.Tests/HealthCheckTests.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Hosting.Tests;
+
+public class HealthCheckTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task BuildThrowsOnMissingHealthCheckRegistration()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        builder.Services.AddLogging(b => {
+            b.AddXunit(testOutputHelper);
+            b.AddFakeLogging();
+        });
+
+        builder.AddResource(new CustomResource("test"))
+               .WithHealthCheck("test_check");
+        var app = builder.Build();
+
+        var ex = await Assert.ThrowsAsync<OptionsValidationException>(async () =>
+        {
+            await app.StartAsync();
+        });
+
+        Assert.Equal("A health check registration is missing. Check logs for more details.", ex.Message);
+
+        var collector = app.Services.GetFakeLogCollector();
+        var logs = collector.GetSnapshot();
+
+        Assert.Contains(
+            logs,
+            l => l.Message == "The health check 'test_check' is not registered and is required for resource 'test'."
+            );
+    }
+
+    public class CustomResource(string name) : Resource(name)
+    {
+
+    }
+}


### PR DESCRIPTION
## Description

This PR adds an options validator which checks to ensure that all health checks registrations referenced by resources in `HealthCheckAnnotation` instances are present. If they are not then we log a critical warning and throw blocking startup.

Fixes #5910 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5938)