### PR TITLE
Add support for dashboard listening on any IP

### DIFF
--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -141,6 +141,9 @@ public sealed class OtlpCors
 {
     public string? AllowedOrigins { get; set; }
     public string? AllowedHeaders { get; set; }
+
+    [MemberNotNullWhen(true, nameof(AllowedOrigins))]
+    public bool IsCorsEnabled => !string.IsNullOrEmpty(AllowedOrigins);
 }
 
 // Don't set values after validating/parsing options.

--- a/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Aspire.Dashboard/Configuration/DashboardOptions.cs
@@ -69,8 +69,8 @@ public sealed class AllowedCertificateRule
 // Don't set values after validating/parsing options.
 public sealed class OtlpOptions
 {
-    private BindingAddress? _parsedGrpcEndpointUrl;
-    private BindingAddress? _parsedHttpEndpointUrl;
+    private BindingAddress? _parsedGrpcEndpointAddress;
+    private BindingAddress? _parsedHttpEndpointAddress;
     private byte[]? _primaryApiKeyBytes;
     private byte[]? _secondaryApiKeyBytes;
 
@@ -83,14 +83,14 @@ public sealed class OtlpOptions
 
     public List<AllowedCertificateRule> AllowedCertificates { get; set; } = new();
 
-    public BindingAddress? GetGrpcEndpointUri()
+    public BindingAddress? GetGrpcEndpointAddress()
     {
-        return _parsedGrpcEndpointUrl;
+        return _parsedGrpcEndpointAddress;
     }
 
-    public BindingAddress? GetHttpEndpointUri()
+    public BindingAddress? GetHttpEndpointAddress()
     {
-        return _parsedHttpEndpointUrl;
+        return _parsedHttpEndpointAddress;
     }
 
     public byte[] GetPrimaryApiKeyBytes()
@@ -111,13 +111,13 @@ public sealed class OtlpOptions
             return false;
         }
 
-        if (!string.IsNullOrEmpty(GrpcEndpointUrl) && !OptionsHelpers.TryParseBindingAddress(GrpcEndpointUrl, out _parsedGrpcEndpointUrl))
+        if (!string.IsNullOrEmpty(GrpcEndpointUrl) && !OptionsHelpers.TryParseBindingAddress(GrpcEndpointUrl, out _parsedGrpcEndpointAddress))
         {
             errorMessage = $"Failed to parse OTLP gRPC endpoint URL '{GrpcEndpointUrl}'.";
             return false;
         }
 
-        if (!string.IsNullOrEmpty(HttpEndpointUrl) && !OptionsHelpers.TryParseBindingAddress(HttpEndpointUrl, out _parsedHttpEndpointUrl))
+        if (!string.IsNullOrEmpty(HttpEndpointUrl) && !OptionsHelpers.TryParseBindingAddress(HttpEndpointUrl, out _parsedHttpEndpointAddress))
         {
             errorMessage = $"Failed to parse OTLP HTTP endpoint URL '{HttpEndpointUrl}'.";
             return false;
@@ -146,7 +146,7 @@ public sealed class OtlpCors
 // Don't set values after validating/parsing options.
 public sealed class FrontendOptions
 {
-    private List<BindingAddress>? _parsedEndpointUrls;
+    private List<BindingAddress>? _parsedEndpointAddresses;
     private byte[]? _browserTokenBytes;
 
     public string? EndpointUrls { get; set; }
@@ -166,10 +166,10 @@ public sealed class FrontendOptions
 
     public byte[]? GetBrowserTokenBytes() => _browserTokenBytes;
 
-    public IReadOnlyList<BindingAddress> GetEndpointUris()
+    public IReadOnlyList<BindingAddress> GetEndpointAddresses()
     {
-        Debug.Assert(_parsedEndpointUrls is not null, "Should have been parsed during validation.");
-        return _parsedEndpointUrls;
+        Debug.Assert(_parsedEndpointAddresses is not null, "Should have been parsed during validation.");
+        return _parsedEndpointAddresses;
     }
 
     internal bool TryParseOptions([NotNullWhen(false)] out string? errorMessage)
@@ -182,12 +182,12 @@ public sealed class FrontendOptions
         else
         {
             var parts = EndpointUrls.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var uris = new List<BindingAddress>(parts.Length);
+            var addresses = new List<BindingAddress>(parts.Length);
             foreach (var part in parts)
             {
                 if (OptionsHelpers.TryParseBindingAddress(part, out var bindingAddress))
                 {
-                    uris.Add(bindingAddress);
+                    addresses.Add(bindingAddress);
                 }
                 else
                 {
@@ -195,7 +195,7 @@ public sealed class FrontendOptions
                     return false;
                 }
             }
-            _parsedEndpointUrls = uris;
+            _parsedEndpointAddresses = addresses;
         }
 
         _browserTokenBytes = BrowserToken != null ? Encoding.UTF8.GetBytes(BrowserToken) : null;

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -447,46 +447,46 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     private void ConfigureKestrelEndpoints(WebApplicationBuilder builder, DashboardOptions dashboardOptions)
     {
         // A single endpoint is configured if URLs are the same and the port isn't dynamic.
-        var frontendUris = dashboardOptions.Frontend.GetEndpointAddresses();
-        var otlpGrpcUri = dashboardOptions.Otlp.GetGrpcEndpointAddress();
-        var otlpHttpUri = dashboardOptions.Otlp.GetHttpEndpointAddress();
-        var hasSingleEndpoint = frontendUris.Count == 1 && IsSameOrNull(frontendUris[0], otlpGrpcUri) && IsSameOrNull(frontendUris[0], otlpHttpUri);
+        var frontendAddresses = dashboardOptions.Frontend.GetEndpointAddresses();
+        var otlpGrpcAddress = dashboardOptions.Otlp.GetGrpcEndpointAddress();
+        var otlpHttpAddress = dashboardOptions.Otlp.GetHttpEndpointAddress();
+        var hasSingleEndpoint = frontendAddresses.Count == 1 && IsSameOrNull(frontendAddresses[0], otlpGrpcAddress) && IsSameOrNull(frontendAddresses[0], otlpHttpAddress);
 
         var initialValues = new Dictionary<string, string?>();
-        var browserEndpointNames = new List<string>(capacity: frontendUris.Count);
+        var browserEndpointNames = new List<string>(capacity: frontendAddresses.Count);
 
         if (!hasSingleEndpoint)
         {
             // Translate high-level config settings such as DOTNET_DASHBOARD_OTLP_ENDPOINT_URL and ASPNETCORE_URLS
             // to Kestrel's schema for loading endpoints from configuration.
-            if (otlpGrpcUri != null)
+            if (otlpGrpcAddress != null)
             {
-                AddEndpointConfiguration(initialValues, "OtlpGrpc", otlpGrpcUri.ToString(), HttpProtocols.Http2, requiredClientCertificate: dashboardOptions.Otlp.AuthMode == OtlpAuthMode.ClientCertificate);
+                AddEndpointConfiguration(initialValues, "OtlpGrpc", otlpGrpcAddress.ToString(), HttpProtocols.Http2, requiredClientCertificate: dashboardOptions.Otlp.AuthMode == OtlpAuthMode.ClientCertificate);
             }
-            if (otlpHttpUri != null)
+            if (otlpHttpAddress != null)
             {
-                AddEndpointConfiguration(initialValues, "OtlpHttp", otlpHttpUri.ToString(), HttpProtocols.Http1AndHttp2, requiredClientCertificate: dashboardOptions.Otlp.AuthMode == OtlpAuthMode.ClientCertificate);
+                AddEndpointConfiguration(initialValues, "OtlpHttp", otlpHttpAddress.ToString(), HttpProtocols.Http1AndHttp2, requiredClientCertificate: dashboardOptions.Otlp.AuthMode == OtlpAuthMode.ClientCertificate);
             }
 
-            if (frontendUris.Count == 1)
+            if (frontendAddresses.Count == 1)
             {
                 browserEndpointNames.Add("Browser");
-                AddEndpointConfiguration(initialValues, "Browser", frontendUris[0].ToString());
+                AddEndpointConfiguration(initialValues, "Browser", frontendAddresses[0].ToString());
             }
             else
             {
-                for (var i = 0; i < frontendUris.Count; i++)
+                for (var i = 0; i < frontendAddresses.Count; i++)
                 {
                     var name = $"Browser{i}";
                     browserEndpointNames.Add(name);
-                    AddEndpointConfiguration(initialValues, name, frontendUris[i].ToString());
+                    AddEndpointConfiguration(initialValues, name, frontendAddresses[i].ToString());
                 }
             }
         }
         else
         {
             // At least one gRPC endpoint must be present.
-            var url = otlpGrpcUri?.ToString() ?? otlpHttpUri?.ToString();
+            var url = otlpGrpcAddress?.ToString() ?? otlpHttpAddress?.ToString();
             AddEndpointConfiguration(initialValues, "OtlpGrpc", url!, HttpProtocols.Http1AndHttp2, requiredClientCertificate: dashboardOptions.Otlp.AuthMode == OtlpAuthMode.ClientCertificate);
         }
 

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -141,8 +141,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
         ConfigureKestrelEndpoints(builder, dashboardOptions);
 
-        var browserHttpsPort = dashboardOptions.Frontend.GetEndpointUris().FirstOrDefault(IsHttpsOrNull)?.Port;
-        var isAllHttps = browserHttpsPort is not null && IsHttpsOrNull(dashboardOptions.Otlp.GetGrpcEndpointUri()) && IsHttpsOrNull(dashboardOptions.Otlp.GetHttpEndpointUri());
+        var browserHttpsPort = dashboardOptions.Frontend.GetEndpointAddresses().FirstOrDefault(IsHttpsOrNull)?.Port;
+        var isAllHttps = browserHttpsPort is not null && IsHttpsOrNull(dashboardOptions.Otlp.GetGrpcEndpointAddress()) && IsHttpsOrNull(dashboardOptions.Otlp.GetHttpEndpointAddress());
         if (isAllHttps)
         {
             // Explicitly configure the HTTPS redirect port as we're possibly listening on multiple HTTPS addresses
@@ -447,9 +447,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
     private void ConfigureKestrelEndpoints(WebApplicationBuilder builder, DashboardOptions dashboardOptions)
     {
         // A single endpoint is configured if URLs are the same and the port isn't dynamic.
-        var frontendUris = dashboardOptions.Frontend.GetEndpointUris();
-        var otlpGrpcUri = dashboardOptions.Otlp.GetGrpcEndpointUri();
-        var otlpHttpUri = dashboardOptions.Otlp.GetHttpEndpointUri();
+        var frontendUris = dashboardOptions.Frontend.GetEndpointAddresses();
+        var otlpGrpcUri = dashboardOptions.Otlp.GetGrpcEndpointAddress();
+        var otlpHttpUri = dashboardOptions.Otlp.GetHttpEndpointAddress();
         var hasSingleEndpoint = frontendUris.Count == 1 && IsSameOrNull(frontendUris[0], otlpGrpcUri) && IsSameOrNull(frontendUris[0], otlpHttpUri);
 
         var initialValues = new Dictionary<string, string?>();
@@ -612,9 +612,9 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         }
     }
 
-    private static bool IsSameOrNull(BindingAddress frontendUri, BindingAddress? otlpUrl)
+    private static bool IsSameOrNull(BindingAddress frontendAddress, BindingAddress? otlpAddress)
     {
-        return otlpUrl == null || (frontendUri.Equals(otlpUrl) && otlpUrl.Port != 0);
+        return otlpAddress == null || (frontendAddress.Equals(otlpAddress) && otlpAddress.Port != 0);
     }
 
     private static void ConfigureAuthentication(WebApplicationBuilder builder, DashboardOptions dashboardOptions)
@@ -822,7 +822,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         return _app.DisposeAsync();
     }
 
-    private static bool IsHttpsOrNull(BindingAddress? uri) => uri == null || string.Equals(uri.Scheme, "https", StringComparison.Ordinal);
+    private static bool IsHttpsOrNull(BindingAddress? address) => address == null || string.Equals(address.Scheme, "https", StringComparison.Ordinal);
 }
 
 public record EndpointInfo(string Address, IPEndPoint EndPoint, bool isHttps);

--- a/src/Aspire.Dashboard/Otlp/Http/OtlpHttpEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/Otlp/Http/OtlpHttpEndpointsBuilder.cs
@@ -24,7 +24,7 @@ public static class OtlpHttpEndpointsBuilder
 
     public static void MapHttpOtlpApi(this IEndpointRouteBuilder endpoints, OtlpOptions options)
     {
-        var httpEndpoint = options.GetHttpEndpointUri();
+        var httpEndpoint = options.GetHttpEndpointAddress();
         if (httpEndpoint == null)
         {
             // Don't map OTLP HTTP route endpoints if there isn't a Kestrel endpoint to access them with.

--- a/tests/Aspire.Dashboard.Tests/CustomAssert.cs
+++ b/tests/Aspire.Dashboard.Tests/CustomAssert.cs
@@ -10,6 +10,6 @@ public static class CustomAssert
     public static void AssertExceedsMinInterval(TimeSpan duration, TimeSpan minInterval)
     {
         // Timers are not precise, so we allow for a small margin of error.
-        Assert.True(duration >= minInterval.Subtract(TimeSpan.FromMilliseconds(30)), $"Elapsed time {duration} should be greater than min interval {minInterval}.");
+        Assert.True(duration >= minInterval.Subtract(TimeSpan.FromMilliseconds(50)), $"Elapsed time {duration} should be greater than min interval {minInterval}.");
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -36,7 +36,7 @@ public class FrontendBrowserTokenAuthTests
         });
         await app.StartAsync();
 
-        using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendEndPointAccessor().EndPoint}") };
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
         var response = await client.GetAsync("/");
@@ -58,7 +58,7 @@ public class FrontendBrowserTokenAuthTests
         });
         await app.StartAsync();
 
-        using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendEndPointAccessor().EndPoint}") };
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act 1
         var response1 = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: apiKey));
@@ -113,7 +113,7 @@ public class FrontendBrowserTokenAuthTests
         });
         await app.StartAsync();
 
-        using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendEndPointAccessor().EndPoint}") };
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
         var response = await client.GetAsync(DashboardUrls.LoginUrl(returnUrl: DashboardUrls.TracesUrl(), token: "Wrong!"));
@@ -138,7 +138,7 @@ public class FrontendBrowserTokenAuthTests
         });
         await app.StartAsync();
 
-        using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendEndPointAccessor().EndPoint}") };
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
         var response = await client.PostAsync("/api/validatetoken?token=" + requestToken, content: null);

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendOpenIdConnectAuthTests.cs
@@ -33,7 +33,7 @@ public class FrontendOpenIdConnectAuthTests(ITestOutputHelper testOutputHelper)
             AllowAutoRedirect = false
         };
 
-        using var client = new HttpClient(handler) { BaseAddress = new Uri($"http://{app.FrontendEndPointAccessor().EndPoint}") };
+        using var client = new HttpClient(handler) { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act
         var response = await client.GetAsync("/");

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpGrpcServiceTests.cs
@@ -245,7 +245,7 @@ public class OtlpGrpcServiceTests
         await app.StartAsync();
 
         using var channel = IntegrationTestHelpers.CreateGrpcChannel(
-            $"https://{app.FrontendEndPointAccessor().EndPoint}",
+            $"https://{app.FrontendSingleEndPointAccessor().EndPoint}",
             _testOutputHelper,
             validationCallback: cert =>
             {

--- a/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/OtlpHttpServiceTests.cs
@@ -194,7 +194,7 @@ public class OtlpHttpServiceTests
         });
         await app.StartAsync();
 
-        using var httpClient = IntegrationTestHelpers.CreateHttpClient($"https://{app.FrontendEndPointAccessor().EndPoint}",
+        using var httpClient = IntegrationTestHelpers.CreateHttpClient($"https://{app.FrontendSingleEndPointAccessor().EndPoint}",
             validationCallback: cert =>
             {
                 clientCallbackCert = cert;

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/PlaywrightTestsBase.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/PlaywrightTestsBase.cs
@@ -38,7 +38,7 @@ public class PlaywrightTestsBase<TDashboardServerFixture> : IClassFixture<TDashb
         _context ??= await PlaywrightFixture.Browser.NewContextAsync(new BrowserNewContextOptions
         {
             IgnoreHTTPSErrors = true,
-            BaseURL = DashboardServerFixture.DashboardApp.FrontendEndPointAccessor().Address
+            BaseURL = DashboardServerFixture.DashboardApp.FrontendSingleEndPointAccessor().Address
         });
 
         return await _context.NewPageAsync();

--- a/tests/Aspire.Dashboard.Tests/Integration/ResponseCompressionTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/ResponseCompressionTests.cs
@@ -19,7 +19,7 @@ public class ResponseCompressionTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         using var httpClientHandler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.None };
-        using var client = new HttpClient(httpClientHandler) { BaseAddress = new Uri($"http://{app.FrontendEndPointAccessor().EndPoint}") };
+        using var client = new HttpClient(httpClientHandler) { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act 1
         var request = new HttpRequestMessage(HttpMethod.Get, DashboardUrls.StructuredLogsBasePath);
@@ -41,7 +41,7 @@ public class ResponseCompressionTests(ITestOutputHelper testOutputHelper)
         await app.StartAsync();
 
         using var httpClientHandler = new HttpClientHandler { AutomaticDecompression = DecompressionMethods.None };
-        using var client = new HttpClient(httpClientHandler) { BaseAddress = new Uri($"http://{app.FrontendEndPointAccessor().EndPoint}") };
+        using var client = new HttpClient(httpClientHandler) { BaseAddress = new Uri($"http://{app.FrontendSingleEndPointAccessor().EndPoint}") };
 
         // Act 1
         var request = new HttpRequestMessage(HttpMethod.Get, path);

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Http;
 using Aspire.Hosting;
@@ -44,7 +45,6 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
                 data[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "http://+:0";
                 data[DashboardConfigNames.DashboardOtlpGrpcUrlName.ConfigKey] = "http://+:0";
                 data[DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://+:0";
-
             });
 
         // Act
@@ -52,8 +52,13 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
 
         // Assert
         AssertDynamicIPEndpoint(app.FrontendEndPointAccessor);
+        AssertIPv4OrIPv6Endpoint(app.FrontendEndPointAccessor);
+
         AssertDynamicIPEndpoint(app.OtlpServiceGrpcEndPointAccessor);
+        AssertIPv4OrIPv6Endpoint(app.OtlpServiceGrpcEndPointAccessor);
+
         AssertDynamicIPEndpoint(app.OtlpServiceHttpEndPointAccessor);
+        AssertIPv4OrIPv6Endpoint(app.OtlpServiceGrpcEndPointAccessor);
     }
 
     [Fact]
@@ -600,6 +605,13 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         // Assert
         Assert.Collection(app.ValidationFailures,
             s => Assert.Contains(DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey, s));
+    }
+
+    private static void AssertIPv4OrIPv6Endpoint(Func<EndpointInfo> endPointAccessor)
+    {
+        // Check that the specified dynamic port of 0 is overridden with the actual port number.
+        var ipEndPoint = endPointAccessor().EndPoint;
+        Assert.True(ipEndPoint.Address.Equals(IPAddress.Any) || ipEndPoint.Address.Equals(IPAddress.IPv6Any), "Endpoint address should be IPv4 or IPv6.");
     }
 
     private static void AssertDynamicIPEndpoint(Func<EndpointInfo> endPointAccessor)

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -637,7 +637,7 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
 
     private static void AssertIPv4OrIPv6Endpoint(Func<EndpointInfo> endPointAccessor)
     {
-        // Check that the specified dynamic port of 0 is overridden with the actual port number.
+        // Check that the address is IPv4 or IPv6 any.
         var ipEndPoint = endPointAccessor().EndPoint;
         Assert.True(ipEndPoint.Address.Equals(IPAddress.Any) || ipEndPoint.Address.Equals(IPAddress.IPv6Any), "Endpoint address should be IPv4 or IPv6.");
     }

--- a/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/StartupTests.cs
@@ -31,6 +31,29 @@ public class StartupTests(ITestOutputHelper testOutputHelper)
         // Assert
         AssertDynamicIPEndpoint(app.FrontendEndPointAccessor);
         AssertDynamicIPEndpoint(app.OtlpServiceGrpcEndPointAccessor);
+        AssertDynamicIPEndpoint(app.OtlpServiceHttpEndPointAccessor);
+    }
+
+    [Fact]
+    public async Task EndPointAccessors_AppStarted_IPv4OrIPv6()
+    {
+        // Arrange
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(testOutputHelper,
+            additionalConfiguration: data =>
+            {
+                data[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = "http://+:0";
+                data[DashboardConfigNames.DashboardOtlpGrpcUrlName.ConfigKey] = "http://+:0";
+                data[DashboardConfigNames.DashboardOtlpHttpUrlName.ConfigKey] = "http://+:0";
+
+            });
+
+        // Act
+        await app.StartAsync();
+
+        // Assert
+        AssertDynamicIPEndpoint(app.FrontendEndPointAccessor);
+        AssertDynamicIPEndpoint(app.OtlpServiceGrpcEndPointAccessor);
+        AssertDynamicIPEndpoint(app.OtlpServiceHttpEndPointAccessor);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

While looking at https://github.com/dotnet/aspire/issues/5940, I noticed that Aspire dashboard docker container used `http://0:0:0:0:8080` at its binding in the dockerfile instead of `http://+:8080` like all other containers are configured.

The reason is the dashboard doesn't support ASP.NET Core's "any IP" syntax. Fixed in this PR.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5941)