### PR TITLE
Copy parent health checks into child to drive sync status.

### DIFF
--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -612,9 +612,19 @@ public static class ResourceBuilderExtensions
             // the child resource itself does not have any health checks setup.
             var parentBuilder = builder.ApplicationBuilder.CreateResourceBuilder(dependencyResourceWithParent.Parent);
             builder.WaitFor(parentBuilder);
+
+            var parentHealthCheckAnnotations = parentBuilder.Resource.Annotations.OfType<HealthCheckAnnotation>().Select(hca => hca.Key);
+            var resourceHealthCheckAnnotations = builder.Resource.Annotations.OfType<HealthCheckAnnotation>().Select(hca => hca.Key);
+            var missingHealthChecks = parentHealthCheckAnnotations.Except(resourceHealthCheckAnnotations);
+
+            foreach (var missingHealthCheck in missingHealthChecks)
+            {
+                dependency.WithHealthCheck(missingHealthCheck);
+            }
         }
 
-        return builder.WithAnnotation(new WaitAnnotation(dependency.Resource, WaitType.WaitUntilHealthy));
+        builder.WithAnnotation(new WaitAnnotation(dependency.Resource, WaitType.WaitUntilHealthy));
+        return builder;
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

This is one possible solution for #5943. When using `WaitFor` on a resource that has a parent we'll automatically copy the health check annotations from the parent into the child. It works well because the same loop that sets the health status on the parent, sets it on the child. The copy occurs just before the app host starts so we can pick up any health checks that may have been manually added after the `WaitFor` is invoked.

Fixes #5943

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5944)