### PR TITLE
Span details fixes

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor
@@ -71,6 +71,7 @@
                 </div>
                 <PropertyGrid TItem="OtlpSpanEvent"
                               Items="@FilteredSpanEvents"
+                              ItemKey="@((r) => r.InternalId)"
                               GridTemplateColumns="1fr 2fr"
                               NameColumnTitle="@(Loc[nameof(ControlsStrings.TimeOffsetColumnHeader)])"
                               ValueColumnTitle="@(Loc[nameof(ControlsStrings.EventColumnHeader)])"
@@ -96,20 +97,18 @@
                         @FilteredSpanLinks.Count()
                     </FluentBadge>
                 </div>
-                <FluentDataGrid ResizeLabel="@AspireFluentDataGridHeaderCell.GetResizeLabel(Loc)"
-                                ResizeType="DataGridResizeType.Discrete"
-                                TGridItem="SpanLinkViewModel"
+                <FluentDataGrid TGridItem="SpanLinkViewModel"
                                 Items="@FilteredSpanLinks"
                                 Style="width:100%"
                                 GenerateHeader="GenerateHeaderOption.Sticky"
                                 GridTemplateColumns="4fr 1fr"
                                 ShowHover="true">
-                    <AspireTemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsSpanColumnHeader)]">
+                    <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsSpanColumnHeader)]">
                         @WriteSpanLink(context)
-                    </AspireTemplateColumn>
-                    <AspireTemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsDetailsColumnHeader)]">
+                    </TemplateColumn>
+                    <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsDetailsColumnHeader)]">
                         <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => OnViewDetailsAsync(context))">@Loc[nameof(ControlsStrings.ViewAction)]</FluentButton>
-                    </AspireTemplateColumn>
+                    </TemplateColumn>
                 </FluentDataGrid>
             </FluentAccordionItem>
             <FluentAccordionItem Heading="@Loc[nameof(ControlsStrings.SpanDetailsBacklinksHeader)]" Expanded="@_isSpanBacklinksExpanded">
@@ -118,20 +117,18 @@
                         @FilteredSpanBacklinks.Count()
                     </FluentBadge>
                 </div>
-                <FluentDataGrid ResizeLabel="@AspireFluentDataGridHeaderCell.GetResizeLabel(Loc)"
-                                ResizeType="DataGridResizeType.Discrete"
-                                TGridItem="SpanLinkViewModel"
+                <FluentDataGrid TGridItem="SpanLinkViewModel"
                                 Items="@FilteredSpanBacklinks"
                                 Style="width:100%"
                                 GenerateHeader="GenerateHeaderOption.Sticky"
                                 GridTemplateColumns="4fr 1fr"
                                 ShowHover="true">
-                    <AspireTemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsSpanColumnHeader)]">
+                    <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsSpanColumnHeader)]">
                         @WriteSpanLink(context)
-                    </AspireTemplateColumn>
-                    <AspireTemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsDetailsColumnHeader)]">
+                    </TemplateColumn>
+                    <TemplateColumn Title="@Loc[nameof(ControlsStrings.SpanDetailsDetailsColumnHeader)]">
                         <FluentButton Appearance="Appearance.Lightweight" OnClick="@(() => OnViewDetailsAsync(context))">@Loc[nameof(ControlsStrings.ViewAction)]</FluentButton>
-                    </AspireTemplateColumn>
+                    </TemplateColumn>
                 </FluentDataGrid>
             </FluentAccordionItem>
         </FluentAccordion>

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpanEvent.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpanEvent.cs
@@ -13,6 +13,7 @@ public class OtlpSpanAttributeItem(string name, string value) : IPropertyGridIte
 
 public class OtlpSpanEvent(OtlpSpan span) : IPropertyGridItem
 {
+    public required Guid InternalId { get; init; }
     public required string Name { get; init; }
     public required DateTime Time { get; init; }
     public required KeyValuePair<string, string>[] Attributes { get; init; }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -1022,6 +1022,7 @@ public sealed class TelemetryRepository
         {
             events.Add(new OtlpSpanEvent(newSpan)
             {
+                InternalId = Guid.NewGuid(),
                 Name = e.Name,
                 Time = OtlpHelpers.UnixNanoSecondsToDateTime(e.TimeUnixNano),
                 Attributes = e.Attributes.ToKeyValuePairs(options)


### PR DESCRIPTION
## Description

I got an error when visiting span details when a span has multiple events at the same time. Also, the span and details headers on links and backlinks sections were disabled.

This PR:

* Adds internal id to span events and uses it as the item key in the UI
* Uses normal headers for span and details headers

After:
![image](https://github.com/user-attachments/assets/c73092d1-f475-418a-b2ec-9a63f5cd9b5f)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5946)