### PR TITLE
Use bicep friendly name for default Azure Functions storage resource

### DIFF
--- a/src/Aspire.Hosting.Azure.Functions/Aspire.Hosting.Azure.Functions.csproj
+++ b/src/Aspire.Hosting.Azure.Functions/Aspire.Hosting.Azure.Functions.csproj
@@ -38,4 +38,8 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Aspire.Hosting.Azure.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -12,6 +12,8 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 public static class AzureFunctionsProjectResourceExtensions
 {
+    internal const string DefaultAzureFunctionsHostStorageName = "azFuncHostStorage";
+
     /// <summary>
     /// Adds an Azure Functions project to the distributed application.
     /// </summary>
@@ -24,11 +26,11 @@ public static class AzureFunctionsProjectResourceExtensions
         var resource = new AzureFunctionsProjectResource(name);
 
         // Add the default storage resource if it doesn't already exist.
-        var storage = builder.Resources.OfType<AzureStorageResource>().FirstOrDefault(r => r.Name == "azure-functions-default-storage");
+        var storage = builder.Resources.OfType<AzureStorageResource>().FirstOrDefault(r => r.Name == DefaultAzureFunctionsHostStorageName);
 
         if (storage is null)
         {
-            storage = builder.AddAzureStorage("azure-functions-default-storage").RunAsEmulator().Resource;
+            storage = builder.AddAzureStorage("azFuncHostStorage").RunAsEmulator().Resource;
 
             builder.Eventing.Subscribe<BeforeStartEvent>((data, token) =>
             {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -17,7 +17,7 @@ public class AzureFunctionsTests
 
         // Assert that default storage resource is configured
         Assert.Contains(builder.Resources, resource =>
-            resource is AzureStorageResource && resource.Name == "azure-functions-default-storage");
+            resource is AzureStorageResource && resource.Name == AzureFunctionsProjectResourceExtensions.DefaultAzureFunctionsHostStorageName);
         // Assert that custom project resource type is configured
         Assert.Contains(builder.Resources, resource =>
             resource is AzureFunctionsProjectResource && resource.Name == "funcapp");


### PR DESCRIPTION
The name we currently use for the default Azure Functions host storage resource doesn't play nice with bicep since it contains hyphen which are used as identifiers in the bicep grammar. It's also lengthy so it ends up getting truncated (azureFunctionsDefaultSt). Fixing this by removing the hyphens and shortening the default name.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5963)