### PR TITLE
Improve browser token login link when running in a container

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -250,7 +250,7 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
 
             if (!string.IsNullOrEmpty(browserToken))
             {
-                LoggingHelpers.WriteDashboardUrl(distributedApplicationLogger, dashboardUrls, browserToken);
+                LoggingHelpers.WriteDashboardUrl(distributedApplicationLogger, dashboardUrls, browserToken, isContainer: false);
             }
         }));
     }

--- a/src/Shared/LoggingHelpers.cs
+++ b/src/Shared/LoggingHelpers.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting;
 
 internal static class LoggingHelpers
 {
-    public static void WriteDashboardUrl(ILogger logger, string? dashboardUrls, string? token)
+    public static void WriteDashboardUrl(ILogger logger, string? dashboardUrls, string? token, bool isContainer)
     {
         if (string.IsNullOrEmpty(token))
         {
@@ -17,7 +17,10 @@ internal static class LoggingHelpers
 
         if (StringUtils.TryGetUriFromDelimitedString(dashboardUrls, ";", out var firstDashboardUrl))
         {
-            logger.LogInformation("Login to the dashboard at {DashboardLoginUrl}", $"{firstDashboardUrl.GetLeftPart(UriPartial.Authority)}/login?t={token}");
+            var message = !isContainer
+                ? "Login to the dashboard at {DashboardLoginUrl}"
+                : "Login to the dashboard at {DashboardLoginUrl}. The URL may need changes depending on how network access to the container is configured.";
+            logger.LogInformation(message, $"{firstDashboardUrl.GetLeftPart(UriPartial.Authority)}/login?t={token}");
         }
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -207,11 +207,63 @@ public class FrontendBrowserTokenAuthTests
                 Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
             });
+    }
 
-        object? GetValue(object? values, string key)
+    [Theory]
+    [InlineData("http://+:0", "localhost")]
+    [InlineData("http://0.0.0.0:0", "localhost")]
+    [InlineData("http://127.0.0.1:0", "127.0.0.1")]
+    [InlineData("http://aspire-test-hostname:0", "aspire-test-hostname")]
+    public async Task LogOutput_AnyIP_LoginLinkLocalhost(string frontendUrl, string linkHost)
+    {
+        // Arrange
+        var testSink = new TestSink();
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
         {
-            var list = values as IReadOnlyList<KeyValuePair<string, object>>;
-            return list?.SingleOrDefault(kvp => kvp.Key == key).Value;
-        }
+            config[DashboardConfigNames.DashboardFrontendUrlName.ConfigKey] = frontendUrl;
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+        }, testSink: testSink);
+
+        // Act
+        await app.StartAsync();
+
+        // Assert
+        var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
+
+        // Testing via the log template is kind of hacky. If this becomes a problem then consider adding proper log definitions and match via ID.
+        var loginLinkLog = l.Single(w => "Login to the dashboard at {DashboardLoginUrl}" == (string?)GetValue(w.State, "{OriginalFormat}"));
+
+        var uri = new Uri((string)GetValue(loginLinkLog.State, "DashboardLoginUrl")!, UriKind.Absolute);
+        var queryString = HttpUtility.ParseQueryString(uri.Query);
+        Assert.NotNull(queryString["t"]);
+
+        Assert.Equal(linkHost, uri.Host);
+    }
+
+    [Fact]
+    public async Task LogOutput_InContainer_LoginLinkContainerMessage()
+    {
+        // Arrange
+        var testSink = new TestSink();
+        await using var app = IntegrationTestHelpers.CreateDashboardWebApplication(_testOutputHelper, config =>
+        {
+            config["DOTNET_RUNNING_IN_CONTAINER"] = "true";
+            config[DashboardConfigNames.DashboardFrontendAuthModeName.ConfigKey] = FrontendAuthMode.BrowserToken.ToString();
+        }, testSink: testSink);
+
+        // Act
+        await app.StartAsync();
+
+        // Assert
+        var l = testSink.Writes.Where(w => w.LoggerName == typeof(DashboardWebApplication).FullName).ToList();
+
+        // Testing via the log template is kind of hacky. If this becomes a problem then consider adding proper log definitions and match via ID.
+        Assert.Single(l.Where(w => "Login to the dashboard at {DashboardLoginUrl}. The URL may need changes depending on how network access to the container is configured." == (string?)GetValue(w.State, "{OriginalFormat}")));
+    }
+
+    private static object? GetValue(object? values, string key)
+    {
+        var list = values as IReadOnlyList<KeyValuePair<string, object>>;
+        return list?.SingleOrDefault(kvp => kvp.Key == key).Value;
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/PlaywrightTestsBase.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/PlaywrightTestsBase.cs
@@ -38,7 +38,7 @@ public class PlaywrightTestsBase<TDashboardServerFixture> : IClassFixture<TDashb
         _context ??= await PlaywrightFixture.Browser.NewContextAsync(new BrowserNewContextOptions
         {
             IgnoreHTTPSErrors = true,
-            BaseURL = DashboardServerFixture.DashboardApp.FrontendSingleEndPointAccessor().Address
+            BaseURL = DashboardServerFixture.DashboardApp.FrontendSingleEndPointAccessor().GetResolvedAddress()
         });
 
         return await _context.NewPageAsync();


### PR DESCRIPTION
## Description

PR changes:

Builds on top of https://github.com/dotnet/aspire/pull/5941. Should be merged after that PR.

* Replace any IP host with localhost in browser token login link that is written to logs.
* Detect when the dashboard is running in a container and mention that the URL might need to be changed depending on container network configuration.

Fixes https://github.com/dotnet/aspire/issues/5940

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5968)