### PR TITLE
Fix start/stop/restart command tooltips

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -4,7 +4,7 @@
 
 @foreach (var highlightedCommand in Commands.Where(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden))
 {
-    <FluentButton Appearance="Appearance.Lightweight" Title="@(highlightedCommand.DisplayDescription ?? highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
+    <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
         @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && CommandViewModel.ResolveIconName(highlightedCommand.IconName, highlightedCommand.IconVariant) is { } icon)
         {
             <FluentIcon Value="@icon" />

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
 using Aspire.Hosting.Dcp;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,9 +9,9 @@ namespace Aspire.Hosting.ApplicationModel;
 
 internal static class CommandsConfigurationExtensions
 {
-    internal const string StartType = "start";
-    internal const string StopType = "stop";
-    internal const string RestartType = "restart";
+    internal const string StartType = "resource-start";
+    internal const string StopType = "resource-stop";
+    internal const string RestartType = "resource-restart";
 
     internal static void AddLifeCycleCommands(this IResource resource)
     {
@@ -21,7 +22,7 @@ internal static class CommandsConfigurationExtensions
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
             type: StartType,
-            displayName: "Start",
+            displayName: GetDisplayName("Start {0}", resource),
             executeCommand: async context =>
             {
                 var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
@@ -50,7 +51,7 @@ internal static class CommandsConfigurationExtensions
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
             type: StopType,
-            displayName: "Stop",
+            displayName: GetDisplayName("Stop {0}", resource),
             executeCommand: async context =>
             {
                 var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
@@ -79,7 +80,7 @@ internal static class CommandsConfigurationExtensions
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
             type: RestartType,
-            displayName: "Restart",
+            displayName: GetDisplayName("Restart {0}", resource),
             executeCommand: async context =>
             {
                 var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
@@ -107,5 +108,26 @@ internal static class CommandsConfigurationExtensions
         static bool IsStopping(string? state) => state is "Stopping";
         static bool IsStarting(string? state) => state is "Starting";
         static bool IsWaiting(string? state) => state is "Waiting";
+        static string GetDisplayName(string template, IResource resource)
+        {
+            string resourceType;
+            if (resource.IsContainer())
+            {
+                resourceType = "container";
+            }
+            else if (resource is ProjectResource)
+            {
+                resourceType = "project";
+            }
+            else if (resource is ExecutableResource)
+            {
+                resourceType = "executable";
+            }
+            else
+            {
+                resourceType = "resource";
+            }
+            return string.Format(CultureInfo.InvariantCulture, template, resourceType);
+        }
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using Aspire.Hosting.Dcp;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -22,7 +21,7 @@ internal static class CommandsConfigurationExtensions
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
             type: StartType,
-            displayName: GetDisplayName("Start {0}", resource),
+            displayName: "Start",
             executeCommand: async context =>
             {
                 var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
@@ -51,7 +50,7 @@ internal static class CommandsConfigurationExtensions
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
             type: StopType,
-            displayName: GetDisplayName("Stop {0}", resource),
+            displayName: "Stop",
             executeCommand: async context =>
             {
                 var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
@@ -80,7 +79,7 @@ internal static class CommandsConfigurationExtensions
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
             type: RestartType,
-            displayName: GetDisplayName("Restart {0}", resource),
+            displayName: "Restart",
             executeCommand: async context =>
             {
                 var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
@@ -108,26 +107,5 @@ internal static class CommandsConfigurationExtensions
         static bool IsStopping(string? state) => state is "Stopping";
         static bool IsStarting(string? state) => state is "Starting";
         static bool IsWaiting(string? state) => state is "Waiting";
-        static string GetDisplayName(string template, IResource resource)
-        {
-            string resourceType;
-            if (resource.IsContainer())
-            {
-                resourceType = "container";
-            }
-            else if (resource is ProjectResource)
-            {
-                resourceType = "project";
-            }
-            else if (resource is ExecutableResource)
-            {
-                resourceType = "executable";
-            }
-            else
-            {
-                resourceType = "resource";
-            }
-            return string.Format(CultureInfo.InvariantCulture, template, resourceType);
-        }
     }
 }


### PR DESCRIPTION
## Description

Tooltips had stopped working on start/stop/restart buttons. This PR fixes and improves them:

* Fix falling back from description to name if description is an empty string.
* ~Add the resource type to display name. Tooltip (or name in action menu) displays "Start container", "Stop container", etc.~

Do people like showing the resource type? Is "Restart container" better than "Restart"?

![image](https://github.com/user-attachments/assets/d0716adb-d488-4f5d-8266-65d2efc9785b)

![image](https://github.com/user-attachments/assets/2dbfe0a9-2506-43e4-b052-d80f1253ff07)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5969)