### PR TITLE
Clean up how we write parameters to the manifest

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
@@ -37,8 +37,8 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
         }
         {
           name: 'connectionstrings--account'
-          value: account_secretoutputs_connectionstring
           identity: outputs_azure_container_registry_managed_identity_id
+          keyVaultUrl: account_secretoutputs_connectionstring
         }
         {
           name: 'value'

--- a/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
@@ -2,6 +2,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -130,6 +131,9 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
 
             public void WriteToManifest(ManifestPublishingContext context, AzureConstructResource construct)
             {
+                // Assert that the construct has no parameters
+                Debug.Assert(construct.Parameters.Count == 0);
+
                 construct.WriteToManifest(context);
 
                 // We're handling custom resource writing here instead of in the AzureConstructResource

--- a/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Lifecycle;
+using Aspire.Hosting.Publishing;
 using Azure.Provisioning;
 using Azure.Provisioning.AppContainers;
 using Azure.Provisioning.Expressions;
@@ -81,7 +82,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
 
             var construct = new AzureConstructResource(resource.Name, context.BuildContainerApp);
 
-            construct.Annotations.Add(new ManifestPublishingCallbackAnnotation(construct.WriteToManifest));
+            construct.Annotations.Add(new ManifestPublishingCallbackAnnotation(c => context.WriteToManifest(c, construct)));
 
             return construct;
         }
@@ -127,6 +128,26 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
 
             public List<(ContainerAppVolume, ContainerAppVolumeMount)> Volumes { get; } = [];
 
+            public void WriteToManifest(ManifestPublishingContext context, AzureConstructResource construct)
+            {
+                construct.WriteToManifest(context);
+
+                // We're handling custom resource writing here instead of in the AzureConstructResource
+                // this is because we're tracking the BicepParameter instances as we process the resource
+                if (Parameters.Count > 0)
+                {
+                    context.Writer.WriteStartObject("params");
+                    foreach (var (key, value) in Parameters)
+                    {
+                        context.Writer.WriteString(key, value.ValueExpression);
+
+                        context.TryAddDependentResources(value);
+                    }
+
+                    context.Writer.WriteEndObject();
+                }
+            }
+
             public void BuildContainerApp(ResourceModuleConstruct c)
             {
                 var containerAppIdParam = AllocateParameter(_containerAppEnviromentContext.ContainerAppEnvironmentId);
@@ -144,8 +165,6 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                 {
                     Name = resource.Name.ToLowerInvariant()
                 };
-
-                c.Add(containerAppResource);
 
                 // TODO: Add managed identities only when required
                 AddManagedIdentites(containerAppResource);
@@ -189,10 +208,13 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                     containerAppContainer.VolumeMounts.Add(mountedVolume);
                 }
 
-                foreach (var (key, value) in Parameters)
+                // Add parameters to the construct
+                foreach (var (_, parameter) in _bicepParameters)
                 {
-                    c.Resource.Parameters[key] = value;
+                    c.Add(parameter);
                 }
+
+                c.Add(containerAppResource);
 
                 if (resource.TryGetAnnotationsOfType<ContainerAppCustomizationAnnotation>(out var annotations))
                 {
@@ -569,7 +591,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                     EndpointProperty.Url => GetHostValue($"{scheme}://", suffix: isHttpIngress ? null : $":{port}"),
                     EndpointProperty.Host or EndpointProperty.IPV4Host => GetHostValue(),
                     EndpointProperty.Port => port.ToString(CultureInfo.InvariantCulture),
-                    EndpointProperty.TargetPort => targetPort is null ? AllocateTargetPortParameter() : targetPort,
+                    EndpointProperty.TargetPort => targetPort is null ? AllocateContainerPortParameter() : targetPort,
                     EndpointProperty.Scheme => scheme,
                     _ => throw new NotSupportedException(),
                 };
@@ -680,7 +702,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
             private BicepParameter AllocateContainerImageParameter()
                 => AllocateParameter(ProjectResourceExpression.GetContainerImageExpression((ProjectResource)resource));
 
-            private BicepValue<int> AllocateTargetPortParameter()
+            private BicepValue<int> AllocateContainerPortParameter()
                 => AllocateParameter(ProjectResourceExpression.GetContainerPortExpression((ProjectResource)resource));
 
             private BicepParameter AllocateManagedIdentityIdParameter()
@@ -732,7 +754,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                 if (_httpIngress is { } ingress)
                 {
                     caIngress.External = ingress.External;
-                    caIngress.TargetPort = ingress.Port ?? AllocateTargetPortParameter();
+                    caIngress.TargetPort = ingress.Port ?? AllocateContainerPortParameter();
                     caIngress.Transport = ingress.Http2 ? ContainerAppIngressTransportMethod.Http2 : ContainerAppIngressTransportMethod.Http;
                 }
                 else if (_additionalPorts.Count > 0)

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -520,6 +520,8 @@ public class AzureContainerAppsTests
         builder.AddContainer("api", "myimage")
             .PublishAsAzureContainerApp((module, c) =>
             {
+                Assert.Contains(c, module.GetResources());
+
                 c.Template.Value!.Scale.Value!.MinReplicas = 0;
             });
 


### PR DESCRIPTION
- Don't use the parameters on the resource, instead write them directly to the construct. Since we're generating them and referencing them directly.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5986)