### PR TITLE
Fix roles on default Storage resource  and endpoint mappings for Functions

### DIFF
--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -35,12 +35,15 @@ public static class AzureFunctionsProjectResourceExtensions
             // account when deployed. We assign this role to the host storage resource when running in publish mode.
             if (builder.ExecutionContext.IsPublishMode)
             {
-#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-                storage = builder.AddAzureStorage(DefaultAzureFunctionsHostStorageName, (builder, construct, storageAccount) =>
+                var configureConstruct = (ResourceModuleConstruct construct) =>
                 {
+#pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                    var storageAccount = construct.GetResources().OfType<StorageAccount>().FirstOrDefault(r => r.ResourceName == DefaultAzureFunctionsHostStorageName)
+                        ?? throw new InvalidOperationException($"Could not find storage account with '{DefaultAzureFunctionsHostStorageName}' name.");
                     construct.Add(storageAccount.AssignRole(StorageBuiltInRole.StorageAccountContributor, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
-                }).RunAsEmulator().Resource;
 #pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                };
+                storage = builder.AddAzureStorage(DefaultAzureFunctionsHostStorageName).ConfigureConstruct(configureConstruct).RunAsEmulator().Resource;
             }
             else
             {

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -84,7 +84,7 @@ public static class AzureFunctionsProjectResourceExtensions
                 // Functions host is still initialized using the classic WebHostBuilder.
                 if (context.ExecutionContext.IsPublishMode)
                 {
-                   var endpoint = resource.GetEndpoint("http");
+                    var endpoint = resource.GetEndpoint("http");
                     context.EnvironmentVariables["ASPNETCORE_URLS"] = ReferenceExpression.Create($"http://+:{endpoint.Property(EndpointProperty.TargetPort)}");
                 }
 

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -84,7 +84,8 @@ public static class AzureFunctionsProjectResourceExtensions
                 // Functions host is still initialized using the classic WebHostBuilder.
                 if (context.ExecutionContext.IsPublishMode)
                 {
-                    context.EnvironmentVariables["ASPNETCORE_URLS"] = "http://+:8080";
+                   var endpoint = resource.GetEndpoint("http");
+                    context.EnvironmentVariables["ASPNETCORE_URLS"] = ReferenceExpression.Create($"http://+:{endpoint.Property(EndpointProperty.TargetPort)}");
                 }
 
                 // Set the storage connection string.


### PR DESCRIPTION
This pull request resolves two issues with Functions apps on Aspire to ACA.

The. first commit is because blob triggers require `StorageAccountContributor` access on the host storage account at startup in order to properly initialize the blob trigger listener. This role assignment isn't configured by default on the Azure Storage resource so we add it to the default resource when under publish mode.

If users are configuring their own host storage, they'll need to configure the role assignments themselves in the construction callback.

We could be more conservative here and only apply this logic if we detect a blob resource is configured in the environment, but applying this behavior by default in all cases seems the least likely to cause spookiness.

The second commit configures the container image used by Azure Functions to listen on and expose the non-priviliged port :8080 by default to avoid permissions issues when initializing the Azure Functions host. The [Functions image used](https://github.com/Azure/azure-functions-docker/blob/dev/host/4/bookworm/dotnet-isolated/dotnet8-isolated/dotnet8-isolated.Dockerfile#L26-L29) extends the default .NET images but overrides the port used for back-compat reasons. 


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6000)