### PR TITLE
Added default labels to issue feature & bug templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -1,5 +1,6 @@
 name: 🐞 Bug Report
 description: Create a report about something that is not working
+labels: [ 'bug' ]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/20_feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/20_feature-request.yml
@@ -1,5 +1,6 @@
 name: 💡 Feature request
 description: Suggest an idea for this project
+labels: [ 'enhancement' ]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Description

I've seen @davidfowl adding `bug` and `enhancement` labels manually to a lot of issues, these could however be set automatically by the issue template.