### PR TITLE
Add console logs button to main grid

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -3,7 +3,7 @@
 @using Microsoft.FluentUI.AspNetCore.Components.DesignTokens
 @inherits FluentComponentBase
 
-<FluentButton Id="@MenuButtonId" Appearance="@ButtonAppearance" aria-haspopup="true" aria-expanded="@_visible" @onclick="ToggleMenu" @onkeydown="OnKeyDown" Disabled="@(!Items.Where(i => !i.IsDivider).Any())">
+<FluentButton Id="@MenuButtonId" Title="@Title" Appearance="@ButtonAppearance" aria-haspopup="true" aria-expanded="@_visible" @onclick="ToggleMenu" @onkeydown="OnKeyDown" Disabled="@(!Items.Where(i => !i.IsDivider).Any())">
     @if (string.IsNullOrWhiteSpace(Text))
     {
         <FluentIcon Value="@_icon" />

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor.cs
@@ -27,6 +27,9 @@ public partial class AspireMenuButton : FluentComponentBase
     [Parameter]
     public Appearance? ButtonAppearance { get; set; }
 
+    [Parameter]
+    public string? Title { get; set; }
+
     public string MenuButtonId { get; } = Identifier.NewId();
 
     protected override void OnParametersSet()

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -2,7 +2,7 @@
 @using Aspire.Dashboard.Model
 @using Microsoft.FluentUI.AspNetCore.Components
 
-@foreach (var highlightedCommand in Commands.Where(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden))
+@if (_highlightedCommand is { } highlightedCommand)
 {
     <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
         @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && CommandViewModel.ResolveIconName(highlightedCommand.IconName, highlightedCommand.IconVariant) is { } icon)
@@ -15,14 +15,23 @@
         }
     </FluentButton>
 }
+else
+{
+    @* Spacer to keep consistent placing of following buttons if there is no highlighted command *@
+    <div style="display:inline-block; width:32px;"></div>
+}
 
 <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
                   Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
                   Items="@_menuItems"
-                  @ref="_menuButton" />
+                  @ref="_menuButton"
+                  Title="@Loc[nameof(Resources.Resources.ResourceResourceActions)]" />
 
-<FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+@if (ViewportInformation.IsDesktop)
+{
+    <FluentDivider Class="action-divider" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
 
-<FluentButton Appearance="Appearance.Lightweight" Title="@Loc[nameof(Resources.Resources.ResourceActionConsoleLogsText)]" OnClick="@(() => OnConsoleLogs.InvokeAsync())">
-    <FluentIcon Value="@s_consoleLogsIcon" />
-</FluentButton>
+    <FluentButton Appearance="Appearance.Lightweight" Title="@Loc[nameof(Resources.Resources.ResourceActionConsoleLogsText)]" OnClick="@(() => OnConsoleLogs.InvokeAsync())">
+        <FluentIcon Value="@s_consoleLogsIcon" />
+    </FluentButton>
+}

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -16,12 +16,13 @@
     </FluentButton>
 }
 
+<AspireMenuButton ButtonAppearance="Appearance.Lightweight"
+                  Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
+                  Items="@_menuItems"
+                  @ref="_menuButton" />
+
+<FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
+
 <FluentButton Appearance="Appearance.Lightweight" Title="@Loc[nameof(Resources.Resources.ResourceActionConsoleLogsText)]" OnClick="@(() => OnConsoleLogs.InvokeAsync())">
     <FluentIcon Value="@s_consoleLogsIcon" />
 </FluentButton>
-
-<AspireMenuButton
-    ButtonAppearance="Appearance.Lightweight"
-    Icon="@(new Icons.Regular.Size20.MoreHorizontal())"
-    Items="@_menuItems"
-    @ref="_menuButton" />

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -16,6 +16,10 @@
     </FluentButton>
 }
 
+<FluentButton Appearance="Appearance.Lightweight" Title="@Loc[nameof(Resources.Resources.ResourceActionConsoleLogsText)]" OnClick="@(() => OnConsoleLogs.InvokeAsync())">
+    <FluentIcon Value="@s_consoleLogsIcon" />
+</FluentButton>
+
 <AspireMenuButton
     ButtonAppearance="Appearance.Lightweight"
     Icon="@(new Icons.Regular.Size20.MoreHorizontal())"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -4,24 +4,36 @@
 
 @if (ViewportInformation.IsDesktop)
 {
-    @if (_highlightedCommand is { } highlightedCommand)
+    // Either display commands or a spacer.
+    // Spacer keeps a consistent placing of following buttons if there are less highlighted commands for this resource.
+    @for (var i = 0; i < MaxHighlightedCount; i++)
     {
-        <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
-            @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && CommandViewModel.ResolveIconName(highlightedCommand.IconName, highlightedCommand.IconVariant) is { } icon)
-            {
-                <FluentIcon Value="@icon" />
-            }
-            else
-            {
-                @highlightedCommand.DisplayName
-            }
-        </FluentButton>
+        if (i < _highlightedCommands.Count)
+        {
+            var highlightedCommand = _highlightedCommands[i];
+
+            <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
+                @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && CommandViewModel.ResolveIconName(highlightedCommand.IconName, highlightedCommand.IconVariant) is { } icon)
+                {
+                    <FluentIcon Value="@icon" />
+                }
+                else
+                {
+                    @highlightedCommand.DisplayName
+                }
+            </FluentButton>
+        }
+        else
+        {
+            <div style="display:inline-block; width:32px;"></div>
+        }
     }
-    else
-    {
-        @* Spacer to keep consistent placing of following buttons if there is no highlighted command *@
-        <div style="display:inline-block; width:32px;"></div>
-    }
+
+    <FluentButton Appearance="Appearance.Lightweight" Title="@Loc[nameof(Resources.Resources.ResourceActionConsoleLogsText)]" OnClick="@(() => OnConsoleLogs.InvokeAsync())">
+        <FluentIcon Value="@s_consoleLogsIcon" />
+    </FluentButton>
+
+    <FluentDivider Class="action-divider" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
 }
 
 <AspireMenuButton ButtonAppearance="Appearance.Lightweight"
@@ -29,12 +41,3 @@
                   Items="@_menuItems"
                   @ref="_menuButton"
                   Title="@Loc[nameof(Resources.Resources.ResourceResourceActions)]" />
-
-@if (ViewportInformation.IsDesktop)
-{
-    <FluentDivider Class="action-divider" Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />
-
-    <FluentButton Appearance="Appearance.Lightweight" Title="@Loc[nameof(Resources.Resources.ResourceActionConsoleLogsText)]" OnClick="@(() => OnConsoleLogs.InvokeAsync())">
-        <FluentIcon Value="@s_consoleLogsIcon" />
-    </FluentButton>
-}

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -2,23 +2,26 @@
 @using Aspire.Dashboard.Model
 @using Microsoft.FluentUI.AspNetCore.Components
 
-@if (_highlightedCommand is { } highlightedCommand)
+@if (ViewportInformation.IsDesktop)
 {
-    <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
-        @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && CommandViewModel.ResolveIconName(highlightedCommand.IconName, highlightedCommand.IconVariant) is { } icon)
-        {
-            <FluentIcon Value="@icon" />
-        }
-        else
-        {
-            @highlightedCommand.DisplayName
-        }
-    </FluentButton>
-}
-else
-{
-    @* Spacer to keep consistent placing of following buttons if there is no highlighted command *@
-    <div style="display:inline-block; width:32px;"></div>
+    @if (_highlightedCommand is { } highlightedCommand)
+    {
+        <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
+            @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && CommandViewModel.ResolveIconName(highlightedCommand.IconName, highlightedCommand.IconVariant) is { } icon)
+            {
+                <FluentIcon Value="@icon" />
+            }
+            else
+            {
+                @highlightedCommand.DisplayName
+            }
+        </FluentButton>
+    }
+    else
+    {
+        @* Spacer to keep consistent placing of following buttons if there is no highlighted command *@
+        <div style="display:inline-block; width:32px;"></div>
+    }
 }
 
 <AspireMenuButton ButtonAppearance="Appearance.Lightweight"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -53,7 +53,14 @@ public partial class ResourceActions : ComponentBase
             OnClick = OnConsoleLogs.InvokeAsync
         });
 
-        _highlightedCommand = Commands.FirstOrDefault(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden);
+        if (ViewportInformation.IsDesktop)
+        {
+            _highlightedCommand = Commands.FirstOrDefault(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden);
+        }
+        else
+        {
+            _highlightedCommand = null;
+        }
 
         var menuCommands = Commands.Where(c => c != _highlightedCommand && c.State != CommandViewModelState.Hidden).ToList();
         if (menuCommands.Count > 0)

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -42,6 +42,7 @@ public partial class ResourceActions : ComponentBase
     protected override void OnParametersSet()
     {
         _menuItems.Clear();
+        _highlightedCommands.Clear();
 
         _menuItems.Add(new MenuButtonItem
         {
@@ -59,10 +60,6 @@ public partial class ResourceActions : ComponentBase
         if (ViewportInformation.IsDesktop)
         {
             _highlightedCommands.AddRange(Commands.Where(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden).Take(MaxHighlightedCount));
-        }
-        else
-        {
-            _highlightedCommands.Clear();
         }
 
         var menuCommands = Commands.Where(c => !_highlightedCommands.Contains(c) && c.State != CommandViewModelState.Hidden).ToList();

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -30,10 +30,13 @@ public partial class ResourceActions : ComponentBase
     [Parameter]
     public required EventCallback OnConsoleLogs { get; set; }
 
+    [Parameter]
+    public required int MaxHighlightedCount { get; set; }
+
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; set; }
 
-    private CommandViewModel? _highlightedCommand;
+    private readonly List<CommandViewModel> _highlightedCommands = new();
     private readonly List<MenuButtonItem> _menuItems = new();
 
     protected override void OnParametersSet()
@@ -55,14 +58,14 @@ public partial class ResourceActions : ComponentBase
 
         if (ViewportInformation.IsDesktop)
         {
-            _highlightedCommand = Commands.FirstOrDefault(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden);
+            _highlightedCommands.AddRange(Commands.Where(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden).Take(MaxHighlightedCount));
         }
         else
         {
-            _highlightedCommand = null;
+            _highlightedCommands.Clear();
         }
 
-        var menuCommands = Commands.Where(c => c != _highlightedCommand && c.State != CommandViewModelState.Hidden).ToList();
+        var menuCommands = Commands.Where(c => !_highlightedCommands.Contains(c) && c.State != CommandViewModelState.Hidden).ToList();
         if (menuCommands.Count > 0)
         {
             _menuItems.Add(new MenuButtonItem { IsDivider = true });

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -30,6 +30,10 @@ public partial class ResourceActions : ComponentBase
     [Parameter]
     public required EventCallback OnConsoleLogs { get; set; }
 
+    [CascadingParameter]
+    public required ViewportInformation ViewportInformation { get; set; }
+
+    private CommandViewModel? _highlightedCommand;
     private readonly List<MenuButtonItem> _menuItems = new();
 
     protected override void OnParametersSet()
@@ -49,7 +53,9 @@ public partial class ResourceActions : ComponentBase
             OnClick = OnConsoleLogs.InvokeAsync
         });
 
-        var menuCommands = Commands.Where(c => !c.IsHighlighted && c.State != CommandViewModelState.Hidden).ToList();
+        _highlightedCommand = Commands.FirstOrDefault(c => c.IsHighlighted && c.State != CommandViewModelState.Hidden);
+
+        var menuCommands = Commands.Where(c => c != _highlightedCommand && c.State != CommandViewModelState.Hidden).ToList();
         if (menuCommands.Count > 0)
         {
             _menuItems.Add(new MenuButtonItem { IsDivider = true });

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -114,7 +114,7 @@
                                                             AdditionalMessage="@additionalMessage" />
                                 </AspireTemplateColumn>
                                 <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesActionsColumnHeader)]">
-                                    <div style="display: inline-block;" @onclick:stopPropagation="true">
+                                    <div style="resource-action-container" @onclick:stopPropagation="true">
                                         <ResourceActions Commands="@context.Commands"
                                                          CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)"
                                                          OnViewDetails="@((buttonId) => ShowResourceDetailsAsync(context, buttonId))"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -114,11 +114,12 @@
                                                             AdditionalMessage="@additionalMessage" />
                                 </AspireTemplateColumn>
                                 <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesActionsColumnHeader)]">
-                                    <div style="resource-action-container" @onclick:stopPropagation="true">
+                                    <div class="resource-action-container" @onclick:stopPropagation="true">
                                         <ResourceActions Commands="@context.Commands"
                                                          CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)"
                                                          OnViewDetails="@((buttonId) => ShowResourceDetailsAsync(context, buttonId))"
-                                                         OnConsoleLogs="@(() => NavigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: context.Name)))" />
+                                                         OnConsoleLogs="@(() => NavigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: context.Name)))"
+                                                         MaxHighlightedCount="_maxHighlightedCount" />
                                     </div>
                                 </AspireTemplateColumn>
                             </ChildContent>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -32,3 +32,7 @@
 ::deep fluent-data-grid {
     overflow-x: clip;
 }
+
+::deep resource-action-container {
+    display: inline-block;
+}

--- a/src/Aspire.Dashboard/Components/Resize/GridColumnManager.razor
+++ b/src/Aspire.Dashboard/Components/Resize/GridColumnManager.razor
@@ -1,0 +1,3 @@
+﻿<CascadingValue Value="@ViewportInformation">
+    @ChildContent
+</CascadingValue>

--- a/src/Aspire.Dashboard/Components/Resize/GridColumnManager.razor.cs
+++ b/src/Aspire.Dashboard/Components/Resize/GridColumnManager.razor.cs
@@ -4,11 +4,10 @@
 using System.Text;
 using Aspire.Dashboard.Model;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Rendering;
 
 namespace Aspire.Dashboard.Components.Resize;
 
-public class GridColumnManager : ComponentBase, IDisposable
+public partial class GridColumnManager : ComponentBase, IDisposable
 {
     private Dictionary<string, GridColumn> _columnById = null!;
     private float _availableFraction = 1;
@@ -29,14 +28,6 @@ public class GridColumnManager : ComponentBase, IDisposable
     {
         DimensionManager.OnViewportSizeChanged += OnViewportSizeChanged;
         _columnById = Columns.ToDictionary(c => c.Name, StringComparers.GridColumn);
-    }
-
-    protected override void BuildRenderTree(RenderTreeBuilder builder)
-    {
-        if (ChildContent is { } c)
-        {
-            c(builder);
-        }
     }
 
     private void OnViewportSizeChanged(object sender, ViewportSizeChangedEventArgs e)
@@ -121,3 +112,4 @@ public class GridColumnManager : ComponentBase, IDisposable
         DimensionManager.OnViewportSizeChanged -= OnViewportSizeChanged;
     }
 }
+

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -142,6 +142,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Resource actions.
+        /// </summary>
+        public static string ResourceResourceActions {
+            get {
+                return ResourceManager.GetString("ResourceResourceActions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Actions.
         /// </summary>
         public static string ResourcesActionsColumnHeader {

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -242,4 +242,7 @@
     <value>{0} "{1}" starting</value>
     <comment>{0} is the resource. {1} is the display name of the command.</comment>
   </data>
+  <data name="ResourceResourceActions" xml:space="preserve">
+    <value>Resource actions</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Zobrazit protokoly konzoly</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="translated">Akce</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Konsolenprotokolle anzeigen</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="translated">Aktionen</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -47,6 +47,11 @@
         <target state="new">View console logs</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="new">Actions</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Afficher les journaux de console</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="translated">Actions</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -47,6 +47,11 @@
         <target state="new">View console logs</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="new">Actions</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">コンソール ログの表示</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="translated">アクション</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -47,6 +47,11 @@
         <target state="new">View console logs</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="new">Actions</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Wyświetl dzienniki konsoli</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="translated">Akcje</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="new">View console logs</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="new">Actions</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Просмотр журналов консоли</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="translated">Действия</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -47,6 +47,11 @@
         <target state="new">View console logs</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="new">Actions</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="new">View console logs</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="new">Actions</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="new">View console logs</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceResourceActions">
+        <source>Resource actions</source>
+        <target state="new">Resource actions</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesActionsColumnHeader">
         <source>Actions</source>
         <target state="new">Actions</target>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -629,3 +629,8 @@ fluent-data-grid-cell.no-ellipsis {
 .layout fluent-toolbar > .fluent-input-label {
     margin-bottom: 0;
 }
+
+.action-divider {
+    display: unset;
+    vertical-align: sub;
+}

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -631,6 +631,6 @@ fluent-data-grid-cell.no-ellipsis {
 }
 
 .action-divider {
-    display: unset;
+    display: inline;
     vertical-align: sub;
 }


### PR DESCRIPTION
## Description

I made a bunch of changes to make this look good:

* Add console logs action button to main grid
* Now up to one command can be highlighted (first in order). If there is no highlighted command then a spacer is added for consistent width
* Add tooltip to actions button
* Top-level actions are all hidden in mobile view. Just actions menu button is visible

Fixes https://github.com/dotnet/aspire/issues/5975

![image](https://github.com/user-attachments/assets/ebc59835-3b27-4739-85fc-883f96395d73)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6011)