### PR TITLE
Guarantee default Functions host storage has unique name

### DIFF
--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -27,7 +27,7 @@ public static class AzureFunctionsProjectResourceExtensions
         var resource = new AzureFunctionsProjectResource(name);
 
         // Add the default storage resource if it doesn't already exist.
-        var storageResourceName = builder.CreateStorageName();
+        var storageResourceName = builder.CreateDefaultStorageName();
         AzureStorageResource storage;
 
         // Azure Functions blob triggers require StorageAccountContributor access to the host storage
@@ -93,7 +93,7 @@ public static class AzureFunctionsProjectResourceExtensions
                 }
 
                 // Set the storage connection string.
-                ((IResourceWithAzureFunctionsConfig)resource.HostStorage).ApplyAzureFunctionsConfiguration(context.EnvironmentVariables, "Storage");
+                ((IResourceWithAzureFunctionsConfig)resource.HostStorage).ApplyAzureFunctionsConfiguration(context.EnvironmentVariables, "AzureWebJobsStorage");
             })
             .WithArgs(context =>
             {
@@ -192,7 +192,7 @@ public static class AzureFunctionsProjectResourceExtensions
         });
     }
 
-    private static string CreateStorageName(this IDistributedApplicationBuilder builder)
+    private static string CreateDefaultStorageName(this IDistributedApplicationBuilder builder)
     {
         var applicationHash = builder.Configuration["AppHost:Sha256"]![..5].ToLowerInvariant();
         return $"{DefaultAzureFunctionsHostStorageName}{applicationHash}";

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
-using Microsoft.Extensions.DependencyInjection;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Azure.Provisioning.Storage;
-using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Azure;
 
@@ -15,8 +13,7 @@ namespace Aspire.Hosting.Azure;
 /// </summary>
 public static class AzureFunctionsProjectResourceExtensions
 {
-    internal const string DefaultAzureFunctionsHostStorageName = "azFuncHostStorage";
-    internal const string LogCategoryName = "Aspire.Hosting.Azure.AzureFunctionsProjectResource";
+    internal const string DefaultAzureFunctionsHostStorageName = "defaultazfuncstorage";
 
     /// <summary>
     /// Adds an Azure Functions project to the distributed application.
@@ -30,65 +27,52 @@ public static class AzureFunctionsProjectResourceExtensions
         var resource = new AzureFunctionsProjectResource(name);
 
         // Add the default storage resource if it doesn't already exist.
-        var storage = builder.Resources.OfType<AzureStorageResource>().FirstOrDefault(r => r.Name == DefaultAzureFunctionsHostStorageName);
+        var storageResourceName = builder.CreateStorageName();
+        AzureStorageResource storage;
 
-        if (storage is null)
+        // Azure Functions blob triggers require StorageAccountContributor access to the host storage
+        // account when deployed. We assign this role to the host storage resource when running in publish mode.
+        if (builder.ExecutionContext.IsPublishMode)
         {
-            // Azure Functions blob triggers require StorageAccountContributor access to the host storage
-            // account when deployed. We assign this role to the host storage resource when running in publish mode.
-            if (builder.ExecutionContext.IsPublishMode)
+            var configureConstruct = (ResourceModuleConstruct construct) =>
             {
-                var configureConstruct = (ResourceModuleConstruct construct) =>
-                {
 #pragma warning disable AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-                    var storageAccount = construct.GetResources().OfType<StorageAccount>().FirstOrDefault(r => r.ResourceName == DefaultAzureFunctionsHostStorageName)
-                        ?? throw new InvalidOperationException($"Could not find storage account with '{DefaultAzureFunctionsHostStorageName}' name.");
-                    construct.Add(storageAccount.AssignRole(StorageBuiltInRole.StorageAccountContributor, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
+                var storageAccount = construct.GetResources().OfType<StorageAccount>().FirstOrDefault(r => r.ResourceName == storageResourceName)
+                    ?? throw new InvalidOperationException($"Could not find storage account with '{storageResourceName}' name.");
+                construct.Add(storageAccount.AssignRole(StorageBuiltInRole.StorageAccountContributor, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
 #pragma warning restore AZPROVISION001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-                };
-                storage = builder.AddAzureStorage(DefaultAzureFunctionsHostStorageName).ConfigureConstruct(configureConstruct).RunAsEmulator().Resource;
-            }
-            else
-            {
-                storage = builder.AddAzureStorage(DefaultAzureFunctionsHostStorageName).RunAsEmulator().Resource;
-            }
-            storage.Annotations.Add(new DefaultAzureFunctionsHostStorageAnnotation());
-            builder.Eventing.Subscribe<BeforeStartEvent>((data, token) =>
-            {
-                var removeStorage = true;
-                // Look at all of the resources and if none of them use the default storage, then we can remove it.
-                // This is because we're unable to cleanly add a resource to the builder from within a callback.
-                foreach (var item in data.Model.Resources.OfType<AzureFunctionsProjectResource>())
-                {
-                    if (item.HostStorage == storage)
-                    {
-                        removeStorage = false;
-                    }
-                }
-
-                if (removeStorage)
-                {
-                    data.Model.Resources.Remove(storage);
-                }
-
-                return Task.CompletedTask;
-            });
+            };
+            storage = builder.AddAzureStorage(storageResourceName)
+                .ConfigureConstruct(configureConstruct)
+                .RunAsEmulator().Resource;
         }
+        else
+        {
+            storage = builder.AddAzureStorage(storageResourceName).RunAsEmulator().Resource;
+        }
+
+        builder.Eventing.Subscribe<BeforeStartEvent>((data, token) =>
+        {
+            var removeStorage = true;
+            // Look at all of the resources and if none of them use the default storage, then we can remove it.
+            // This is because we're unable to cleanly add a resource to the builder from within a callback.
+            foreach (var item in data.Model.Resources.OfType<AzureFunctionsProjectResource>())
+            {
+                if (item.HostStorage == storage)
+                {
+                    removeStorage = false;
+                }
+            }
+
+            if (removeStorage)
+            {
+                data.Model.Resources.Remove(storage);
+            }
+
+            return Task.CompletedTask;
+        });
 
         resource.HostStorage = storage;
-
-        if (!resource.HostStorage.Annotations.OfType<DefaultAzureFunctionsHostStorageAnnotation>().Any())
-        {
-            builder.Eventing.Subscribe<BeforeStartEvent>((data, token) =>
-            {
-
-                var logger = data.Services.GetRequiredService<ILoggerFactory>().CreateLogger(LogCategoryName);
-                logger.LogWarning(
-                "Found existing default Storage resource '{StorageName}' for Azure Functions project '{ResourceName}'. ", storage.Name, resource.Name);
-
-                return Task.CompletedTask;
-            });
-        }
 
         return builder.AddResource(resource)
             .WithAnnotation(new TProject())
@@ -206,5 +190,11 @@ public static class AzureFunctionsProjectResourceExtensions
             connectionName ??= source.Resource.Name;
             source.Resource.ApplyAzureFunctionsConfiguration(context.EnvironmentVariables, connectionName);
         });
+    }
+
+    private static string CreateStorageName(this IDistributedApplicationBuilder builder)
+    {
+        var applicationHash = builder.Configuration["AppHost:Sha256"]![..5].ToLowerInvariant();
+        return $"{DefaultAzureFunctionsHostStorageName}{applicationHash}";
     }
 }

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -40,7 +40,6 @@ public static class AzureFunctionsProjectResourceExtensions
 
         if (storage is null)
         {
-            s_isFirstInvocation = false;
             // Azure Functions blob triggers require StorageAccountContributor access to the host storage
             // account when deployed. We assign this role to the host storage resource when running in publish mode.
             if (builder.ExecutionContext.IsPublishMode)
@@ -84,7 +83,6 @@ public static class AzureFunctionsProjectResourceExtensions
         {
             if (s_isFirstInvocation)
             {
-                s_isFirstInvocation = false;
                 builder.Eventing.Subscribe<BeforeStartEvent>((data, token) =>
                 {
                     var logger = data.Services.GetRequiredService<ILoggerFactory>().CreateLogger(LogCategoryName);
@@ -96,6 +94,7 @@ public static class AzureFunctionsProjectResourceExtensions
             }
         }
 
+        s_isFirstInvocation = false;
         resource.HostStorage = storage;
 
         return builder.AddResource(resource)

--- a/src/Aspire.Hosting.Azure.Functions/DefaultAzureFunctionsHostStorageAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DefaultAzureFunctionsHostStorageAnnotation.cs
@@ -1,6 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-using Aspire.Hosting.ApplicationModel;
-
-internal class DefaultAzureFunctionsHostStorageAnnotation : IResourceAnnotation { }

--- a/src/Aspire.Hosting.Azure.Functions/DefaultAzureFunctionsHostStorageAnnotation.cs
+++ b/src/Aspire.Hosting.Azure.Functions/DefaultAzureFunctionsHostStorageAnnotation.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+internal class DefaultAzureFunctionsHostStorageAnnotation : IResourceAnnotation { }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -105,7 +105,6 @@ public class AzureFunctionsTests(ITestOutputHelper testOutputHelper)
     [InlineData(false)]
     public async Task AddAzureFunctionsProject_LogsWhenUsingPreExistingDefaultStorage(bool defaultHostStorageAlreadyExists)
     {
-        AzureFunctionsProjectResourceExtensions.s_isFirstInvocation = true;
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
         var testSink = new TestSink();
         var loggerFactory = CreateLoggerFactory(testOutputHelper, testSink);
@@ -133,7 +132,6 @@ public class AzureFunctionsTests(ITestOutputHelper testOutputHelper)
     [RequiresDocker]
     public async Task AddAzureFunctionsProject_DoesNotLogWhenMultipleProjectsRegistered()
     {
-        AzureFunctionsProjectResourceExtensions.s_isFirstInvocation = true;
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
         var testSink = new TestSink();
         var loggerFactory = CreateLoggerFactory(testOutputHelper, testSink);
@@ -159,7 +157,6 @@ public class AzureFunctionsTests(ITestOutputHelper testOutputHelper)
     [RequiresDocker]
     public async Task AddAzureFunctionsProject_LogsWhenHostStorageConfiguredWithMultipleProjects()
     {
-        AzureFunctionsProjectResourceExtensions.s_isFirstInvocation = true;
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
         var testSink = new TestSink();
         var loggerFactory = CreateLoggerFactory(testOutputHelper, testSink);
@@ -173,11 +170,23 @@ public class AzureFunctionsTests(ITestOutputHelper testOutputHelper)
         var host = builder.Build();
         await host.StartAsync();
 
-        Assert.Single(testSink.Writes, write =>
+        Assert.Contains(testSink.Writes, write =>
             write.LogLevel == LogLevel.Warning &&
             write.LoggerName == AzureFunctionsProjectResourceExtensions.LogCategoryName &&
             write.Message is { } message &&
-            message.Contains("Found existing default Storage resource 'azFuncHostStorage' for Azure Functions projects"));
+            message.Contains("Found existing default Storage resource 'azFuncHostStorage' for Azure Functions project 'funcapp'."));
+
+        Assert.Contains(testSink.Writes, write =>
+            write.LogLevel == LogLevel.Warning &&
+            write.LoggerName == AzureFunctionsProjectResourceExtensions.LogCategoryName &&
+            write.Message is { } message &&
+            message.Contains("Found existing default Storage resource 'azFuncHostStorage' for Azure Functions project 'funcapp2'."));
+
+        Assert.Contains(testSink.Writes, write =>
+            write.LogLevel == LogLevel.Warning &&
+            write.LoggerName == AzureFunctionsProjectResourceExtensions.LogCategoryName &&
+            write.Message is { } message &&
+            message.Contains("Found existing default Storage resource 'azFuncHostStorage' for Azure Functions project 'funcapp3'."));
 
         await host.StopAsync();
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -124,7 +124,8 @@ public class AzureFunctionsTests
         var model = host.Services.GetRequiredService<DistributedApplicationModel>();
         Assert.DoesNotContain(model.Resources.OfType<AzureStorageResource>(),
             r => r.Name.StartsWith(AzureFunctionsProjectResourceExtensions.DefaultAzureFunctionsHostStorageName));
-        Assert.Contains(model.Resources.OfType<AzureStorageResource>(), r => r.Name == "my-own-storage");
+        var storageResource = Assert.Single(model.Resources.OfType<AzureStorageResource>());
+        Assert.Equal("my-own-storage", storageResource.Name);
 
         await host.StopAsync();
     }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureFunctionsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Components.Common.Tests;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
@@ -99,6 +100,7 @@ public class AzureFunctionsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Theory]
+    [RequiresDocker]
     [InlineData(true)]
     [InlineData(false)]
     public async Task AddAzureFunctionsProject_LogsWhenUsingPreExistingDefaultStorage(bool defaultHostStorageAlreadyExists)
@@ -123,9 +125,12 @@ public class AzureFunctionsTests(ITestOutputHelper testOutputHelper)
             write.LoggerName == AzureFunctionsProjectResourceExtensions.LogCategoryName &&
             write.Message is { } message &&
             message.Contains("Found existing default Storage resource 'azFuncHostStorage' for Azure Functions project")) != null);
+
+        await host.StopAsync();
     }
 
     [Fact]
+    [RequiresDocker]
     public async Task AddAzureFunctionsProject_DoesNotLogWhenMultipleProjectsRegistered()
     {
         AzureFunctionsProjectResourceExtensions.s_isFirstInvocation = true;
@@ -146,9 +151,12 @@ public class AzureFunctionsTests(ITestOutputHelper testOutputHelper)
             write.LoggerName == AzureFunctionsProjectResourceExtensions.LogCategoryName &&
             write.Message is { } message &&
             message.Contains("Found existing default Storage resource 'azFuncHostStorage' for Azure Functions projects"));
+
+        await host.StopAsync();
     }
 
     [Fact]
+    [RequiresDocker]
     public async Task AddAzureFunctionsProject_LogsWhenHostStorageConfiguredWithMultipleProjects()
     {
         AzureFunctionsProjectResourceExtensions.s_isFirstInvocation = true;
@@ -170,6 +178,8 @@ public class AzureFunctionsTests(ITestOutputHelper testOutputHelper)
             write.LoggerName == AzureFunctionsProjectResourceExtensions.LogCategoryName &&
             write.Message is { } message &&
             message.Contains("Found existing default Storage resource 'azFuncHostStorage' for Azure Functions projects"));
+
+        await host.StopAsync();
     }
 
     public static ILoggerFactory CreateLoggerFactory(ITestOutputHelper testOutputHelper, ITestSink? testSink = null)


### PR DESCRIPTION
Log a warning when an Azure Storage resource with the default name (`azFuncHostStorage`) is already configured as a resource then it will be used as the default host storage.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6012)