### PR TITLE
Add a maximum log batch size to avoid exceeding max message size limit

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -122,6 +122,13 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 #else
         // Don't log routine dashboard HTTP request info or static file access
         // These logs generate a lot of noise when locally debugging.
+        builder.Logging.SetMinimumLevel(LogLevel.Debug);
+        builder.Logging.AddFilter("Aspire.Dashboard", LogLevel.Debug);
+        builder.Logging.AddFilter("Aspire.Dashboard.Authentication", LogLevel.Information);
+        builder.Logging.AddFilter("Aspire.Dashboard.Otlp", LogLevel.Information);
+        builder.Logging.AddFilter("Microsoft", LogLevel.Information);
+        builder.Logging.AddFilter("Grpc", LogLevel.Information);
+        builder.Logging.AddFilter("Microsoft.AspNetCore.Cors", LogLevel.Warning);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Routing.EndpointMiddleware", LogLevel.Warning);
         builder.Logging.AddFilter("Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware", LogLevel.Warning);

--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -120,14 +120,16 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         builder.Logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.None);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Server.Kestrel", LogLevel.Error);
 #else
-        // Don't log routine dashboard HTTP request info or static file access
-        // These logs generate a lot of noise when locally debugging.
+        // Log more when running the dashboard as debug.
         builder.Logging.SetMinimumLevel(LogLevel.Debug);
         builder.Logging.AddFilter("Aspire.Dashboard", LogLevel.Debug);
+
+        // Don't log routine dashboard HTTP request info or static file access
+        // These logs generate a lot of noise when locally debugging.
+        builder.Logging.AddFilter("Grpc", LogLevel.Information);
         builder.Logging.AddFilter("Aspire.Dashboard.Authentication", LogLevel.Information);
         builder.Logging.AddFilter("Aspire.Dashboard.Otlp", LogLevel.Information);
         builder.Logging.AddFilter("Microsoft", LogLevel.Information);
-        builder.Logging.AddFilter("Grpc", LogLevel.Information);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Cors", LogLevel.Warning);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
         builder.Logging.AddFilter("Microsoft.AspNetCore.Routing.EndpointMiddleware", LogLevel.Warning);

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -21,6 +21,9 @@ namespace Aspire.Hosting.Dashboard;
 internal sealed partial class DashboardService(DashboardServiceData serviceData, IHostEnvironment hostEnvironment, IHostApplicationLifetime hostApplicationLifetime, ILogger<DashboardService> logger)
     : Aspire.ResourceService.Proto.V1.DashboardService.DashboardServiceBase
 {
+    // gRPC has a maximum receive size. Force logs into batches to avoid exceeding receive size.
+    public const int LogMaxBatchSize = 200;
+
     // Calls that consume or produce streams must create a linked cancellation token
     // with IHostApplicationLifetime.ApplicationStopping to ensure eager cancellation
     // of pending connections during shutdown.
@@ -71,7 +74,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
 
             await foreach (var batch in updates.WithCancellation(cancellationToken).ConfigureAwait(false))
             {
-                WatchResourcesChanges changes = new();
+                var changes = new WatchResourcesChanges();
 
                 foreach (var update in batch)
                 {
@@ -118,14 +121,20 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
 
             await foreach (var group in subscription.WithCancellation(cancellationToken).ConfigureAwait(false))
             {
-                var update = new WatchResourceConsoleLogsUpdate();
+                var sent = 0;
 
-                foreach (var (lineNumber, content, isErrorMessage) in group)
+                while (sent < group.Count)
                 {
-                    update.LogLines.Add(new ConsoleLogLine() { LineNumber = lineNumber, Text = content, IsStdErr = isErrorMessage });
-                }
+                    var update = new WatchResourceConsoleLogsUpdate();
 
-                await responseStream.WriteAsync(update, cancellationToken).ConfigureAwait(false);
+                    foreach (var (lineNumber, content, isErrorMessage) in group.Skip(sent).Take(LogMaxBatchSize))
+                    {
+                        update.LogLines.Add(new ConsoleLogLine() { LineNumber = lineNumber, Text = content, IsStdErr = isErrorMessage });
+                        sent++;
+                    }
+
+                    await responseStream.WriteAsync(update, cancellationToken).ConfigureAwait(false);
+                }
             }
         }
     }

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -22,7 +22,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
     : Aspire.ResourceService.Proto.V1.DashboardService.DashboardServiceBase
 {
     // gRPC has a maximum receive size. Force logs into batches to avoid exceeding receive size.
-    public const int LogMaxBatchSize = 200;
+    public const int LogMaxBatchSize = 500;
 
     // Calls that consume or produce streams must create a linked cancellation token
     // with IHostApplicationLifetime.ApplicationStopping to ensure eager cancellation

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -20,6 +20,7 @@ public class DashboardServiceTests
     [Fact]
     public async Task WatchResourceConsoleLogs_LargePendingData_BatchResults()
     {
+        // Arrange
         var resourceLoggerService = new ResourceLoggerService();
         var resourceNotificationService = new ResourceNotificationService(NullLogger<ResourceNotificationService>.Instance, new TestHostApplicationLifetime(), new ServiceCollection().BuildServiceProvider(), resourceLoggerService);
         var dashboardServiceData = new DashboardServiceData(resourceNotificationService, resourceLoggerService, NullLogger<DashboardServiceData>.Instance, new DashboardCommandExecutor(new ServiceCollection().BuildServiceProvider()));
@@ -35,11 +36,13 @@ public class DashboardServiceTests
         var context = TestServerCallContext.Create();
         var writer = new TestServerStreamWriter<WatchResourceConsoleLogsUpdate>(context);
 
+        // Act
         var task = dashboardService.WatchResourceConsoleLogs(
             new WatchResourceConsoleLogsRequest { ResourceName = "test-resource" },
             writer,
             context);
 
+        // Assert
         var logsCollection = new List<WatchResourceConsoleLogsUpdate>();
         for (var i = 0; i < 5; i++)
         {
@@ -48,7 +51,6 @@ public class DashboardServiceTests
         }
 
         resourceLoggerService.Complete("test-resource");
-
         await task;
     }
 

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dashboard;
+using Aspire.Hosting.Tests.Utils;
+using Aspire.Hosting.Tests.Utils.Grpc;
+using Aspire.ResourceService.Proto.V1;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using DashboardService = Aspire.Hosting.Dashboard.DashboardService;
+
+namespace Aspire.Hosting.Tests.Dashboard;
+
+public class DashboardServiceTests
+{
+    [Fact]
+    public async Task WatchResourceConsoleLogs_LargePendingData_BatchResults()
+    {
+        var resourceLoggerService = new ResourceLoggerService();
+        var resourceNotificationService = new ResourceNotificationService(NullLogger<ResourceNotificationService>.Instance, new TestHostApplicationLifetime(), new ServiceCollection().BuildServiceProvider(), resourceLoggerService);
+        var dashboardServiceData = new DashboardServiceData(resourceNotificationService, resourceLoggerService, NullLogger<DashboardServiceData>.Instance, new DashboardCommandExecutor(new ServiceCollection().BuildServiceProvider()));
+        var dashboardService = new DashboardService(dashboardServiceData, new TestHostEnvironment(), new TestHostApplicationLifetime(), NullLogger<DashboardService>.Instance);
+
+        var logger = resourceLoggerService.GetLogger("test-resource");
+        var totalLogs = DashboardService.LogMaxBatchSize * 5;
+        for (var i = 0; i < totalLogs; i++)
+        {
+            logger.LogInformation("Log message {Count}", i + 1);
+        }
+
+        var context = TestServerCallContext.Create();
+        var writer = new TestServerStreamWriter<WatchResourceConsoleLogsUpdate>(context);
+
+        var task = dashboardService.WatchResourceConsoleLogs(
+            new WatchResourceConsoleLogsRequest { ResourceName = "test-resource" },
+            writer,
+            context);
+
+        var logsCollection = new List<WatchResourceConsoleLogsUpdate>();
+        for (var i = 0; i < 5; i++)
+        {
+            logsCollection.Add(await writer.ReadNextAsync());
+            Assert.Equal(DashboardService.LogMaxBatchSize, logsCollection[i].LogLines.Count);
+        }
+
+        resourceLoggerService.Complete("test-resource");
+
+        await task;
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string ApplicationName { get; set; } = default!;
+        public IFileProvider ContentRootFileProvider { get; set; } = default!;
+        public string ContentRootPath { get; set; } = default!;
+        public string EnvironmentName { get; set; } = default!;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Utils/Grpc/TestAsyncStreamReader.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/Grpc/TestAsyncStreamReader.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Grpc.Core;
+
+namespace Aspire.Hosting.Tests.Utils.Grpc;
+
+public class TestAsyncStreamReader<T> : IAsyncStreamReader<T> where T : class
+{
+    private readonly Channel<T> _channel;
+    private readonly ServerCallContext _serverCallContext;
+
+    public T Current { get; private set; } = null!;
+
+    public TestAsyncStreamReader(ServerCallContext serverCallContext)
+    {
+        _channel = Channel.CreateUnbounded<T>();
+        _serverCallContext = serverCallContext;
+    }
+
+    public void AddMessage(T message)
+    {
+        if (!_channel.Writer.TryWrite(message))
+        {
+            throw new InvalidOperationException("Unable to write message.");
+        }
+    }
+
+    public void Complete()
+    {
+        _channel.Writer.Complete();
+    }
+
+    public async Task<bool> MoveNext(CancellationToken cancellationToken)
+    {
+        _serverCallContext.CancellationToken.ThrowIfCancellationRequested();
+
+        if (await _channel.Reader.WaitToReadAsync(cancellationToken) &&
+            _channel.Reader.TryRead(out var message))
+        {
+            Current = message;
+            return true;
+        }
+        else
+        {
+            Current = null!;
+            return false;
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Utils/Grpc/TestServerCallContext.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/Grpc/TestServerCallContext.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Grpc.Core;
+
+namespace Aspire.Hosting.Tests.Utils.Grpc;
+
+public class TestServerCallContext : ServerCallContext
+{
+    private readonly Metadata _requestHeaders;
+    private readonly CancellationToken _cancellationToken;
+    private readonly Metadata _responseTrailers;
+    private readonly AuthContext _authContext;
+    private readonly Dictionary<object, object> _userState;
+    private WriteOptions? _writeOptions;
+
+    public Metadata? ResponseHeaders { get; private set; }
+
+    private TestServerCallContext(Metadata requestHeaders, CancellationToken cancellationToken)
+    {
+        _requestHeaders = requestHeaders;
+        _cancellationToken = cancellationToken;
+        _responseTrailers = new Metadata();
+        _authContext = new AuthContext(string.Empty, new Dictionary<string, List<AuthProperty>>());
+        _userState = new Dictionary<object, object>();
+    }
+
+    protected override string MethodCore => "MethodName";
+    protected override string HostCore => "HostName";
+    protected override string PeerCore => "PeerName";
+    protected override DateTime DeadlineCore { get; }
+    protected override Metadata RequestHeadersCore => _requestHeaders;
+    protected override CancellationToken CancellationTokenCore => _cancellationToken;
+    protected override Metadata ResponseTrailersCore => _responseTrailers;
+    protected override Status StatusCore { get; set; }
+    protected override WriteOptions? WriteOptionsCore { get => _writeOptions; set { _writeOptions = value; } }
+    protected override AuthContext AuthContextCore => _authContext;
+
+    protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions? options)
+    {
+        throw new NotImplementedException();
+    }
+
+    protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders)
+    {
+        if (ResponseHeaders != null)
+        {
+            throw new InvalidOperationException("Response headers have already been written.");
+        }
+
+        ResponseHeaders = responseHeaders;
+        return Task.CompletedTask;
+    }
+
+    protected override IDictionary<object, object> UserStateCore => _userState;
+
+    public static TestServerCallContext Create(Metadata? requestHeaders = null, CancellationToken cancellationToken = default)
+    {
+        return new TestServerCallContext(requestHeaders ?? new Metadata(), cancellationToken);
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Utils/Grpc/TestServerStreamWriter.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/Grpc/TestServerStreamWriter.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Channels;
+using Grpc.Core;
+
+namespace Aspire.Hosting.Tests.Utils.Grpc;
+
+public class TestServerStreamWriter<T> : IServerStreamWriter<T> where T : class
+{
+    private readonly ServerCallContext _serverCallContext;
+    private readonly Channel<T> _channel;
+
+    public WriteOptions? WriteOptions { get; set; }
+
+    public TestServerStreamWriter(ServerCallContext serverCallContext)
+    {
+        _channel = Channel.CreateUnbounded<T>();
+
+        _serverCallContext = serverCallContext;
+    }
+
+    public void Complete()
+    {
+        _channel.Writer.Complete();
+    }
+
+    public IAsyncEnumerable<T> ReadAllAsync()
+    {
+        return _channel.Reader.ReadAllAsync();
+    }
+
+    public async Task<T> ReadNextAsync()
+    {
+        if (await _channel.Reader.WaitToReadAsync())
+        {
+            _channel.Reader.TryRead(out var message);
+            return message!;
+        }
+
+        throw new InvalidOperationException("Unable to read message.");
+    }
+
+    public Task WriteAsync(T message, CancellationToken cancellationToken)
+    {
+        if (_serverCallContext.CancellationToken.IsCancellationRequested ||
+            _serverCallContext.CancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(_serverCallContext.CancellationToken);
+        }
+
+        if (!_channel.Writer.TryWrite(message))
+        {
+            throw new InvalidOperationException("Unable to write message.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task WriteAsync(T message)
+    {
+        return WriteAsync(message, CancellationToken.None);
+    }
+}


### PR DESCRIPTION
## Description

While trying to repo https://github.com/dotnet/aspire/issues/6007 I managed to generate enough logs to exceed the max receive size limit (4MB). I've had a feeling we'd see this one day with initial snapshots of existing data, but this is the first time I've seen it.

This PR forces console logs into batches with a max size of 500. It doesn't guarentee we don't exceed the size because we don't limit log line size, but it should prevent most cases of big data.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6018)