### PR TITLE
Remove bad link to Microsoft.FluentUI.AspNetCore.Components CSS

### DIFF
--- a/src/Aspire.Dashboard/Components/App.razor
+++ b/src/Aspire.Dashboard/Components/App.razor
@@ -7,7 +7,6 @@
     <base href="/" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="stylesheet" href="_content/Microsoft.FluentUI.AspNetCore.Components/css/reboot.css" />
-    <link rel="stylesheet" href="_content/Microsoft.FluentUI.AspNetCore.Components/Microsoft.FluentUI.AspNetCore.Components.bundle.scp.css" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="stylesheet" href="css/highlight.css" />
     <link rel="stylesheet" href="Aspire.Dashboard.styles.css" />


### PR DESCRIPTION
## Description

While trying to repo https://github.com/dotnet/aspire/issues/6007 I noticed a CSS link was returning a 404. The file in the fluent UI package now has some random text added to it, preumebly to avoid caching issues.

It looks like FluentUI adds this reference automatically anyway, so it isn't needed anymore.

![image](https://github.com/user-attachments/assets/491a4ef0-3a7f-408c-bb39-4d25e0f77620)

@vnbaaij I see you last changed this line of code. Do you know why it might have been present? Is there any disadvantage to having fluent UI automatically get this CSS file? (maybe it is downloaded more quickly by explicitly being in the header?)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
