### PR TITLE
Cancel console logs load await when unloaded

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -149,8 +149,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             {
                 await foreach (var changes in subscription.WithCancellation(_resourceSubscriptionToken).ConfigureAwait(false))
                 {
-                    // TODO: This could be updated to be more efficient.
-                    // It should apply on the resource changes in a batch and then update the UI.
                     foreach (var (changeType, resource) in changes)
                     {
                         await OnResourceChanged(changeType, resource);

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -24,12 +24,16 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 {
     private sealed class ConsoleLogsSubscription
     {
+        private static int s_subscriptionId;
+
         private readonly CancellationTokenSource _cts = new();
+        private readonly int _subscriptionId = Interlocked.Increment(ref s_subscriptionId);
 
         public required string Name { get; init; }
         public Task? SubscriptionTask { get; set; }
 
         public CancellationToken CancellationToken => _cts.Token;
+        public int SubscriptionId => _subscriptionId;
         public void Cancel() => _cts.Cancel();
     }
 
@@ -63,9 +67,10 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     [Parameter]
     public string? ResourceName { get; set; }
 
-    private readonly CancellationTokenSource _resourceSubscriptionCancellation = new();
+    private readonly CancellationTokenSource _resourceSubscriptionCts = new();
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private ImmutableList<SelectViewModel<ResourceTypeDetails>>? _resources;
+    private CancellationToken _resourceSubscriptionToken;
     private Task? _resourceSubscriptionTask;
     private ConsoleLogsSubscription? _consoleLogsSubscription;
     internal LogEntries _logEntries = null!;
@@ -82,6 +87,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     protected override async Task OnInitializedAsync()
     {
+        _resourceSubscriptionToken = _resourceSubscriptionCts.Token;
         _logEntries = new(Options.Value.Frontend.MaxConsoleLogCount);
         _noSelection = new() { Id = null, Name = ControlsStringsLoc[nameof(ControlsStrings.LabelNone)] };
         PageViewModel = new ConsoleLogsViewModel { SelectedOption = _noSelection, SelectedResource = null, Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLoadingResources)] };
@@ -93,12 +99,17 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         // Wait for resource to be selected. If selected resource isn't available after a few seconds then stop waiting.
         try
         {
-            await loadingTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await loadingTcs.Task.WaitAsync(TimeSpan.FromSeconds(5), _resourceSubscriptionToken);
             Logger.LogDebug("Loading task completed.");
+        }
+        catch (OperationCanceledException)
+        {
+            Logger.LogDebug("Load task canceled.");
         }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Load timeout while waiting for resource {ResourceName}.", ResourceName);
+            PageViewModel.Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLogsNotYetAvailable)];
         }
 
         async Task TrackResourceSnapshotsAsync()
@@ -108,7 +119,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                 return;
             }
 
-            var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_resourceSubscriptionCancellation.Token);
+            var (snapshot, subscription) = await DashboardClient.SubscribeResourcesAsync(_resourceSubscriptionToken);
 
             Logger.LogDebug("Received initial resource snapshot with {ResourceCount} resources.", snapshot.Length);
 
@@ -125,7 +136,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             {
                 if (_resourceByName.TryGetValue(ResourceName, out var selectedResource))
                 {
-                    await SetSelectedResourceOption(selectedResource);
+                    SetSelectedResourceOption(selectedResource);
                 }
             }
             else
@@ -136,7 +147,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
             _resourceSubscriptionTask = Task.Run(async () =>
             {
-                await foreach (var changes in subscription.WithCancellation(_resourceSubscriptionCancellation.Token).ConfigureAwait(false))
+                await foreach (var changes in subscription.WithCancellation(_resourceSubscriptionToken).ConfigureAwait(false))
                 {
                     // TODO: This could be updated to be more efficient.
                     // It should apply on the resource changes in a batch and then update the UI.
@@ -151,21 +162,21 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                         // we should mark it as selected
                         if (ResourceName is not null && PageViewModel.SelectedResource is null && changeType == ResourceViewModelChangeType.Upsert && string.Equals(ResourceName, resource.Name))
                         {
-                            await SetSelectedResourceOption(resource);
+                            SetSelectedResourceOption(resource);
                         }
                     }
+
+                    await InvokeAsync(StateHasChanged);
                 }
             });
         }
 
-        async Task SetSelectedResourceOption(ResourceViewModel resource)
+        void SetSelectedResourceOption(ResourceViewModel resource)
         {
             Debug.Assert(_resources is not null);
 
             PageViewModel.SelectedOption = _resources.Single(option => option.Id?.Type is not OtlpApplicationType.ResourceGrouping && string.Equals(ResourceName, option.Id?.InstanceId, StringComparison.Ordinal));
             PageViewModel.SelectedResource = resource;
-
-            await this.AfterViewModelChangedAsync(_contentLayout, isChangeInToolbar: false);
 
             Logger.LogDebug("Selected console resource from name {ResourceName}.", ResourceName);
             loadingTcs.TrySetResult();
@@ -189,13 +200,14 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             if (selectedResourceName is not null)
             {
                 newConsoleLogsSubscription = new ConsoleLogsSubscription { Name = selectedResourceName };
+                Logger.LogDebug("Creating new subscription {SubscriptionId}.", newConsoleLogsSubscription.SubscriptionId);
 
                 if (Logger.IsEnabled(LogLevel.Debug))
                 {
                     newConsoleLogsSubscription.CancellationToken.Register(state =>
                     {
                         var s = (ConsoleLogsSubscription)state!;
-                        Logger.LogDebug("Canceling current subscription to {ResourceName}.", s.Name);
+                        Logger.LogDebug("Canceling subscription {SubscriptionId} to {ResourceName}.", s.SubscriptionId, s.Name);
                     }, newConsoleLogsSubscription);
                 }
             }
@@ -295,12 +307,12 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     private void LoadLogs(ConsoleLogsSubscription newConsoleLogsSubscription)
     {
-        Logger.LogDebug("Starting log subscription.");
+        Logger.LogDebug("Starting log subscription {SubscriptionId}.", newConsoleLogsSubscription.SubscriptionId);
         var consoleLogsTask = Task.Run(async () =>
         {
             newConsoleLogsSubscription.CancellationToken.ThrowIfCancellationRequested();
 
-            Logger.LogDebug("Subscribing to console logs for resource {ResourceName}.", newConsoleLogsSubscription.Name);
+            Logger.LogDebug("Subscribing to console logs with subscription {SubscriptionId} to resource {ResourceName}.", newConsoleLogsSubscription.SubscriptionId, newConsoleLogsSubscription.Name);
 
             var subscription = DashboardClient.SubscribeConsoleLogs(newConsoleLogsSubscription.Name, newConsoleLogsSubscription.CancellationToken);
 
@@ -334,7 +346,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             }
             finally
             {
-                Logger.LogDebug("Finished watching logs for resource {ResourceName}.", newConsoleLogsSubscription.Name);
+                Logger.LogDebug("Subscription {SubscriptionId} finished watching logs for resource {ResourceName}.", newConsoleLogsSubscription.SubscriptionId, newConsoleLogsSubscription.Name);
 
                 // If the subscription is being canceled then a new one could be starting.
                 // Don't set the status when finishing because overwrite the status from the new subscription.
@@ -381,8 +393,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
             UpdateResourcesList();
         }
-
-        await InvokeAsync(StateHasChanged);
     }
 
     private async Task StopAndClearConsoleLogsSubscriptionAsync()
@@ -398,8 +408,8 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     public async ValueTask DisposeAsync()
     {
-        await _resourceSubscriptionCancellation.CancelAsync();
-        _resourceSubscriptionCancellation.Dispose();
+        _resourceSubscriptionCts.Cancel();
+        _resourceSubscriptionCts.Dispose();
         await TaskHelpers.WaitIgnoreCancelAsync(_resourceSubscriptionTask);
 
         await StopAndClearConsoleLogsSubscriptionAsync();


### PR DESCRIPTION
## Description

I think this fixes the console logs page breaking when quickly refreshed multiple times. My theory is that reloading the page rapidly could cause a race between initializes, and an old render to overwrite the new and resulting in a blank screen.

There are some other improvements I've made to the page that I've left in the PR.

* Use cancellation token with loadingTcs delay (I think this is the real fix)
* Correctly display a message if a resource is not available
* Invoke state change after processing a batch of resources, rather than per-resource
* Remove unnecessary `AfterViewModelChangedAsync` call on page load. No need to set state because at this point we're loading from state
* Improve logging throughout console logs

Fixes https://github.com/dotnet/aspire/issues/6007

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6023)