### PR TITLE
Fix scrollbars added when opening menus

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -72,7 +72,10 @@
 
     <FluentDialogProvider/>
     <FluentTooltipProvider />
-    <FluentMenuProvider />
+    @* Temporary work around for https://github.com/microsoft/fluentui-blazor/issues/2736 *@
+    <div style="position: fixed; bottom: 0;">
+        <FluentMenuProvider />
+    </div>
     <div id="blazor-error-ui">
         @Loc[nameof(Layout.MainLayoutUnhandledErrorMessage)]
         <a href="" class="reload">@Loc[nameof(Layout.MainLayoutUnhandledErrorReload)]</a>


### PR DESCRIPTION
## Description

There is a bug in FluentUI that causes scrollbars to appear when the menu is opened near the edge of the page: https://github.com/microsoft/fluentui-blazor/issues/2736

~Temporarily disable using menu service until it is fixed. This could cause menus to appear beneath a splitter section (the menu service was introduced to fix this problem). However, menus appearing beneath a splitter section is a sometimes problem, compared to bad scrollbars which is an always problem.~

Update: FluentUI folks recommended a better fix. Minor temporary change that we can revert in the future when FluentUI package is updated.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6039)