### PR TITLE
Show toast immediately when a command is started

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -66,7 +66,7 @@
         <FluentMessageBarProvider Section="@MessageBarSection" Class="top-messagebar"/>
     </div>
     <FluentBodyContent Class="custom-body-content body-content">
-        <FluentToastProvider/>
+        <FluentToastProvider MaxToastCount="3" Timeout="5000" />
         @Body
     </FluentBodyContent>
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -314,30 +314,58 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             }
         }
 
-        var response = await DashboardClient.ExecuteResourceCommandAsync(resource.Name, resource.ResourceType, command, CancellationToken.None);
-
         var messageResourceName = GetResourceName(resource);
 
+        var toastParameters = new ToastParameters<CommunicationToastContent>()
+        {
+            Id = Guid.NewGuid().ToString(),
+            Intent = ToastIntent.Progress,
+            Title = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Resources.ResourceCommandStarting)], messageResourceName, command.DisplayName),
+            Content = new CommunicationToastContent()
+        };
+
+        // Show a toast immediately to indicate the command is starting.
+        ToastService.ShowCommunicationToast(toastParameters);
+
+        var response = await DashboardClient.ExecuteResourceCommandAsync(resource.Name, resource.ResourceType, command, CancellationToken.None);
+
+        // Update toast with the result;
         if (response.Kind == ResourceCommandResponseKind.Succeeded)
         {
-            ToastService.ShowSuccess(string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Resources.ResourceCommandSuccess)], command.DisplayName + " " + messageResourceName));
+            toastParameters.Title = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Resources.ResourceCommandSuccess)], messageResourceName, command.DisplayName);
+            toastParameters.Intent = ToastIntent.Success;
+            toastParameters.Icon = GetIntentIcon(ToastIntent.Success);
         }
         else
         {
-            ToastService.ShowCommunicationToast(new ToastParameters<CommunicationToastContent>()
-            {
-                Intent = ToastIntent.Error,
-                Title = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Resources.ResourceCommandFailed)], command.DisplayName + " " + messageResourceName),
-                PrimaryAction = Loc[nameof(Dashboard.Resources.Resources.ResourceCommandToastViewLogs)],
-                OnPrimaryAction = EventCallback.Factory.Create<ToastResult>(this, () => NavigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: resource.Name))),
-                Content = new CommunicationToastContent()
-                {
-                    Details = response.ErrorMessage
-                }
-            });
+            toastParameters.Title = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Resources.ResourceCommandFailed)], messageResourceName, command.DisplayName);
+            toastParameters.Intent = ToastIntent.Error;
+            toastParameters.Icon = GetIntentIcon(ToastIntent.Error);
+            toastParameters.Content.Details = response.ErrorMessage;
+            toastParameters.PrimaryAction = Loc[nameof(Dashboard.Resources.Resources.ResourceCommandToastViewLogs)];
+            toastParameters.OnPrimaryAction = EventCallback.Factory.Create<ToastResult>(this, () => NavigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: resource.Name)));
         }
+
+        ToastService.UpdateToast(toastParameters.Id, toastParameters);
     }
 
+    private static (Icon Icon, Color Color)? GetIntentIcon(ToastIntent intent)
+    {
+        return intent switch
+        {
+            ToastIntent.Success => (new Icons.Filled.Size24.CheckmarkCircle(), Color.Success),
+            ToastIntent.Warning => (new Icons.Filled.Size24.Warning(), Color.Warning),
+            ToastIntent.Error => (new Icons.Filled.Size24.DismissCircle(), Color.Error),
+            ToastIntent.Info => (new Icons.Filled.Size24.Info(), Color.Info),
+            ToastIntent.Progress => (new Icons.Regular.Size24.Flash(), Color.Neutral),
+            ToastIntent.Upload => (new Icons.Regular.Size24.ArrowUpload(), Color.Neutral),
+            ToastIntent.Download => (new Icons.Regular.Size24.ArrowDownload(), Color.Neutral),
+            ToastIntent.Event => (new Icons.Regular.Size24.CalendarLtr(), Color.Neutral),
+            ToastIntent.Mention => (new Icons.Regular.Size24.Person(), Color.Neutral),
+            ToastIntent.Custom => null,
+            _ => throw new InvalidOperationException()
+        };
+    }
     private static string GetResourceStateTooltip(ResourceViewModel resource) =>
         resource.ShowReadinessState() ?
         $"{resource.State.Humanize()} ({resource.ReadinessState.Humanize()})"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -349,6 +349,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         ToastService.UpdateToast(toastParameters.Id, toastParameters);
     }
 
+    // Copied from FluentUI.
     private static (Icon Icon, Color Color)? GetIntentIcon(ToastIntent intent)
     {
         return intent switch
@@ -366,6 +367,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             _ => throw new InvalidOperationException()
         };
     }
+
     private static string GetResourceStateTooltip(ResourceViewModel resource) =>
         resource.ShowReadinessState() ?
         $"{resource.State.Humanize()} ({resource.ReadinessState.Humanize()})"

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &quot;{0}&quot; command failed.
+        ///   Looks up a localized string similar to {0} &quot;{1}&quot; failed.
         /// </summary>
         public static string ResourceCommandFailed {
             get {
@@ -88,7 +88,16 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &quot;{0}&quot; command succeeded.
+        ///   Looks up a localized string similar to {0} &quot;{1}&quot; starting.
+        /// </summary>
+        public static string ResourceCommandStarting {
+            get {
+                return ResourceManager.GetString("ResourceCommandStarting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} &quot;{1}&quot; succeeded.
         /// </summary>
         public static string ResourceCommandSuccess {
             get {
@@ -97,7 +106,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to View Logs.
+        ///   Looks up a localized string similar to View console logs.
         /// </summary>
         public static string ResourceCommandToastViewLogs {
             get {

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -210,15 +210,15 @@
     <value>State</value>
   </data>
   <data name="ResourceCommandFailed" xml:space="preserve">
-    <value>"{0}" command failed</value>
-    <comment>{0} is the display name of the command that failed</comment>
+    <value>{0} "{1}" failed</value>
+    <comment>{0} is the resource. {1} is the display name of the command.</comment>
   </data>
   <data name="ResourceCommandSuccess" xml:space="preserve">
-    <value>"{0}" command succeeded</value>
-    <comment>{0} is the display name of the command that succeeded</comment>
+    <value>{0} "{1}" succeeded</value>
+    <comment>{0} is the resource. {1} is the display name of the command.</comment>
   </data>
   <data name="ResourceCommandToastViewLogs" xml:space="preserve">
-    <value>View Logs</value>
+    <value>View console logs</value>
   </data>
   <data name="ResourcesActionsColumnHeader" xml:space="preserve">
     <value>Actions</value>
@@ -237,5 +237,9 @@
   </data>
   <data name="ResourcesDetailsStopTimeProperty" xml:space="preserve">
     <value>Stop time</value>
+  </data>
+  <data name="ResourceCommandStarting" xml:space="preserve">
+    <value>{0} "{1}" starting</value>
+    <comment>{0} is the resource. {1} is the display name of the command.</comment>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">Provedení příkazu "{0}" se nezdařilo</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">Příkaz "{0}" proběhl úspěšně.</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">Zobrazit protokoly</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">Zobrazit protokoly</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">Befehl "{0}" fehlgeschlagen</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">Ausführen des Befehls "{0}" erfolgreich</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">Protokolle anzeigen</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">Protokolle anzeigen</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">Error del comando "{0}"</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">El comando "{0}" se ejecutó correctamente</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">Ver registros</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">Ver registros</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">Échec de la commande « {0} »</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">Commande « {0} » réussie</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">Afficher les journaux</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">Afficher les journaux</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">Comando "{0}" non riuscito</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">Comando "{0}" riuscito</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">Visualizzare i log</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">Visualizzare i log</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">"{0}" コマンドが失敗しました</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">"{0}" コマンドが成功しました</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">ログの表示</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">ログの表示</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">"{0}" 명령이 실패했습니다.</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">"{0}" 명령이 성공했습니다.</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">로그 보기</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">로그 보기</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">Niepowodzenie polecenia „{0}”</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">Polecenie „{0}” zostało pomyślnie wykonane</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">Wyświetl dzienniki</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">Wyświetl dzienniki</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">O comando “{0}” falhou</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">O comando “{0}” foi bem-sucedido</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">Exibir os Logs</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">Exibir os Logs</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">Сбой команды "{0}"</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">Команда "{0}" успешно выполнена</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">Просмотреть журналы</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">Просмотреть журналы</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">"{0}" komutu başarısız oldu</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">"{0}" komutu başarılı oldu</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">Günlükleri Görüntüle</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">Günlükleri Görüntüle</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">“{0}”命令失败</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">“{0}”命令已成功</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">查看日志</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">查看日志</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -13,18 +13,23 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourceCommandFailed">
-        <source>"{0}" command failed</source>
-        <target state="translated">"{0}" 命令失敗</target>
-        <note>{0} is the display name of the command that failed</note>
+        <source>{0} "{1}" failed</source>
+        <target state="new">{0} "{1}" failed</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
+      </trans-unit>
+      <trans-unit id="ResourceCommandStarting">
+        <source>{0} "{1}" starting</source>
+        <target state="new">{0} "{1}" starting</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandSuccess">
-        <source>"{0}" command succeeded</source>
-        <target state="translated">"{0}" 命令成功</target>
-        <note>{0} is the display name of the command that succeeded</note>
+        <source>{0} "{1}" succeeded</source>
+        <target state="new">{0} "{1}" succeeded</target>
+        <note>{0} is the resource. {1} is the display name of the command.</note>
       </trans-unit>
       <trans-unit id="ResourceCommandToastViewLogs">
-        <source>View Logs</source>
-        <target state="translated">檢視記錄</target>
+        <source>View console logs</source>
+        <target state="needs-review-translation">檢視記錄</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceDetailsEndpointUrl">

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -120,7 +120,7 @@ internal sealed class DashboardServiceData : IAsyncDisposable
                 catch (Exception ex)
                 {
                     logger.LogError(ex, "Error executing command '{Type}'.", type);
-                    return (ExecuteCommandResult.Failure, "Command threw an unhandled exception.");
+                    return (ExecuteCommandResult.Failure, "Unhandled exception thrown.");
                 }
             }
         }

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -120,7 +120,7 @@ internal sealed class DashboardServiceData : IAsyncDisposable
                 catch (Exception ex)
                 {
                     logger.LogError(ex, "Error executing command '{Type}'.", type);
-                    return (ExecuteCommandResult.Failure, "Command throw an unhandled exception.");
+                    return (ExecuteCommandResult.Failure, "Command threw an unhandled exception.");
                 }
             }
         }


### PR DESCRIPTION
## Description

Commands show a toast to indicate success/failure. However, the toast is shown at the end of the command. There is no indication that a command is starting. Starting and stopping resource commands are fast (approx 1 sec) but commands could run for much longer. It would be a bad experience not to have any visual indication that the button was successfully clicked.

I looked into the FluentUI toast API and it supports updating a toast after it is opened. We can use that to provide feedback on the command from start to end.

PR updates commands to show a toast when command starts and then update it based on the result. Also, small tweaks to display fewer toasts, and slightly shorter time.

![toast-starting](https://github.com/user-attachments/assets/3cccb90a-0830-4bd4-9ce8-319afa6b4630)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
