### PR TITLE
Add all resource command options to annotation and extension method

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -44,6 +44,9 @@ internal static class CommandsConfigurationExtensions
                     return ResourceCommandState.Hidden;
                 }
             },
+            displayDescription: null,
+            parameter: null,
+            confirmationMessage: null,
             iconName: "Play",
             iconVariant: IconVariant.Filled,
             isHighlighted: true));
@@ -73,6 +76,9 @@ internal static class CommandsConfigurationExtensions
                     return ResourceCommandState.Hidden;
                 }
             },
+            displayDescription: null,
+            parameter: null,
+            confirmationMessage: null,
             iconName: "Stop",
             iconVariant: IconVariant.Filled,
             isHighlighted: true));
@@ -99,6 +105,9 @@ internal static class CommandsConfigurationExtensions
                     return ResourceCommandState.Enabled;
                 }
             },
+            displayDescription: null,
+            parameter: null,
+            confirmationMessage: null,
             iconName: "ArrowCounterclockwise",
             iconVariant: IconVariant.Regular,
             isHighlighted: false));

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -142,10 +142,22 @@ public sealed record ResourcePropertySnapshot(string Name, object? Value)
 /// <param name="Type">The type of command. The type uniquely identifies the command.</param>
 /// <param name="State">The state of the command.</param>
 /// <param name="DisplayName">The display name visible in UI for the command.</param>
+/// <param name="DisplayDescription">
+/// Optional description of the command, to be shown in the UI.
+/// Could be used as a tooltip. May be localized.
+/// </param>
+/// <param name="Parameter">
+/// Optional parameter that configures the command in some way.
+/// Clients must return any value provided by the server when invoking the command.
+/// </param>
+/// <param name="ConfirmationMessage">
+/// When a confirmation message is specified, the UI will prompt with an OK/Cancel dialog
+/// and the confirmation message before starting the command.
+/// </param>
 /// <param name="IconName">The icon name for the command. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons</param>
 /// <param name="IconVariant">The icon variant.</param>
 /// <param name="IsHighlighted">A flag indicating whether the command is highlighted in the UI.</param>
-public sealed record ResourceCommandSnapshot(string Type, ResourceCommandState State, string DisplayName, string? IconName, IconVariant? IconVariant, bool IsHighlighted);
+public sealed record ResourceCommandSnapshot(string Type, ResourceCommandState State, string DisplayName, string? DisplayDescription, object? Parameter, string? ConfirmationMessage, string? IconName, IconVariant? IconVariant, bool IsHighlighted);
 
 /// <summary>
 /// The state of a resource command.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -19,6 +19,9 @@ public sealed class ResourceCommandAnnotation : IResourceAnnotation
         string displayName,
         Func<UpdateCommandStateContext, ResourceCommandState> updateState,
         Func<ExecuteCommandContext, Task<ExecuteCommandResult>> executeCommand,
+        string? displayDescription,
+        object? parameter,
+        string? confirmationMessage,
         string? iconName,
         IconVariant? iconVariant,
         bool isHighlighted)
@@ -32,6 +35,9 @@ public sealed class ResourceCommandAnnotation : IResourceAnnotation
         DisplayName = displayName;
         UpdateState = updateState;
         ExecuteCommand = executeCommand;
+        DisplayDescription = displayDescription;
+        Parameter = parameter;
+        ConfirmationMessage = confirmationMessage;
         IconName = iconName;
         IconVariant = iconVariant;
         IsHighlighted = isHighlighted;
@@ -58,6 +64,24 @@ public sealed class ResourceCommandAnnotation : IResourceAnnotation
     /// The result is used to indicate success or failure in the UI.
     /// </summary>
     public Func<ExecuteCommandContext, Task<ExecuteCommandResult>> ExecuteCommand { get; }
+
+    /// <summary>
+    /// Optional description of the command, to be shown in the UI.
+    /// Could be used as a tooltip. May be localized.
+    /// </summary>
+    public string? DisplayDescription { get; }
+
+    /// <summary>
+    /// Optional parameter that configures the command in some way.
+    /// Clients must return any value provided by the server when invoking the command.
+    /// </summary>
+    public object? Parameter { get; }
+
+    /// <summary>
+    /// When a confirmation message is specified, the UI will prompt with an OK/Cancel dialog
+    /// and the confirmation message before starting the command.
+    /// </summary>
+    public string? ConfirmationMessage { get; }
 
     /// <summary>
     /// The icon name for the command. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -459,7 +459,7 @@ public class ResourceNotificationService
         {
             var state = annotation.UpdateState(new UpdateCommandStateContext { ResourceSnapshot = previousState, ServiceProvider = serviceProvider });
 
-            return new ResourceCommandSnapshot(annotation.Type, state, annotation.DisplayName, annotation.IconName, annotation.IconVariant, annotation.IsHighlighted);
+            return new ResourceCommandSnapshot(annotation.Type, state, annotation.DisplayName, annotation.DisplayDescription, annotation.Parameter, annotation.ConfirmationMessage, annotation.IconName, annotation.IconVariant, annotation.IsHighlighted);
         }
     }
 

--- a/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/GenericResourceSnapshot.cs
@@ -14,15 +14,7 @@ internal sealed class GenericResourceSnapshot(CustomResourceSnapshot state) : Re
     {
         foreach (var (key, value, isSensitive) in state.Properties)
         {
-            var result = value switch
-            {
-                string s => Value.ForString(s),
-                int i => Value.ForNumber(i),
-                IEnumerable<string> list => Value.ForList(list.Select(Value.ForString).ToArray()),
-                IEnumerable<int> list => Value.ForList(list.Select(i => Value.ForNumber(i)).ToArray()),
-                null => Value.ForNull(),
-                _ => Value.ForString(value.ToString())
-            };
+            var result = ConvertToValue(value);
 
             yield return (key, result, isSensitive);
         }

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -52,4 +52,17 @@ internal abstract class ResourceSnapshot
             }
         }
     }
+
+    public static Value ConvertToValue(object? value)
+    {
+        return value switch
+        {
+            string s => Value.ForString(s),
+            int i => Value.ForNumber(i),
+            IEnumerable<string> list => Value.ForList(list.Select(Value.ForString).ToArray()),
+            IEnumerable<int> list => Value.ForList(list.Select(i => Value.ForNumber(i)).ToArray()),
+            null => Value.ForNull(),
+            _ => Value.ForString(value.ToString())
+        };
+    }
 }

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -68,7 +68,7 @@ partial class Resource
 
         foreach (var command in snapshot.Commands)
         {
-            resource.Commands.Add(new ResourceCommand { CommandType = command.Type, DisplayName = command.DisplayName, IconName = command.IconName ?? string.Empty, IconVariant = MapIconVariant(command.IconVariant), IsHighlighted = command.IsHighlighted, State = MapCommandState(command.State) });
+            resource.Commands.Add(new ResourceCommand { CommandType = command.Type, DisplayName = command.DisplayName, DisplayDescription = command.DisplayDescription ?? string.Empty, Parameter = ResourceSnapshot.ConvertToValue(command.Parameter), ConfirmationMessage = command.ConfirmationMessage ?? string.Empty, IconName = command.IconName ?? string.Empty, IconVariant = MapIconVariant(command.IconVariant), IsHighlighted = command.IsHighlighted, State = MapCommandState(command.State) });
         }
 
         return resource;

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -68,6 +68,17 @@ Aspire.Hosting.ApplicationModel.ExecuteCommandResult.Success.init -> void
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.HealthCheckAnnotation(string! key) -> void
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.Key.get -> string!
+Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ConfirmationMessage.get -> string?
+Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.DisplayDescription.get -> string?
+Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.Parameter.get -> object?
+Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ResourceCommandAnnotation(string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>! updateState, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, string? displayDescription, object? parameter, string? confirmationMessage, string? iconName, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant, bool isHighlighted) -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ConfirmationMessage.get -> string?
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ConfirmationMessage.init -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.DisplayDescription.get -> string?
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.DisplayDescription.init -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Parameter.get -> object?
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Parameter.init -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ResourceCommandSnapshot(string! Type, Aspire.Hosting.ApplicationModel.ResourceCommandState State, string! DisplayName, string? DisplayDescription, object? Parameter, string? ConfirmationMessage, string? IconName, Aspire.Hosting.ApplicationModel.IconVariant? IconVariant, bool IsHighlighted) -> void
 Aspire.Hosting.ApplicationModel.ResourceNameAttribute
 Aspire.Hosting.ApplicationModel.ResourceNameAttribute.ResourceNameAttribute() -> void
 Aspire.Hosting.ApplicationModel.IconVariant
@@ -79,7 +90,6 @@ Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ExecuteCommand.get -> 
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.IconName.get -> string?
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.IconVariant.get -> Aspire.Hosting.ApplicationModel.IconVariant?
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.IsHighlighted.get -> bool
-Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ResourceCommandAnnotation(string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>! updateState, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, string? iconName, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant, bool isHighlighted) -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.Type.get -> string!
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.UpdateState.get -> System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>!
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot
@@ -91,7 +101,6 @@ Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IconVariant.get -> Aspir
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IconVariant.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IsHighlighted.get -> bool
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IsHighlighted.init -> void
-Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ResourceCommandSnapshot(string! Type, Aspire.Hosting.ApplicationModel.ResourceCommandState State, string! DisplayName, string? IconName, Aspire.Hosting.ApplicationModel.IconVariant? IconVariant, bool IsHighlighted) -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.State.get -> Aspire.Hosting.ApplicationModel.ResourceCommandState
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.State.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Type.get -> string!
@@ -207,7 +216,7 @@ Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.get
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.set -> void
 static Aspire.Hosting.ResourceBuilderExtensions.WaitFor<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WaitForCompletion<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency, int exitCode = 0) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
-static Aspire.Hosting.ResourceBuilderExtensions.WithCommand<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>? updateState = null, string? iconName = null, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant = null, bool isHighlighted = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithCommand<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>? updateState = null, string? displayDescription = null, object? parameter = null, string? confirmationMessage = null, string? iconName = null, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant = null, bool isHighlighted = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! key) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.FailedToStart -> string!

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -721,6 +721,18 @@ public static class ResourceBuilderExtensions
     /// <para>A callback that is used to update the command state. The callback is executed when the command's resource snapshot is updated.</para>
     /// <para>If a callback isn't specified, the command is always enabled.</para>
     /// </param>
+    /// <param name="displayDescription">
+    /// Optional description of the command, to be shown in the UI.
+    /// Could be used as a tooltip. May be localized.
+    /// </param>
+    /// <param name="parameter">
+    /// Optional parameter that configures the command in some way.
+    /// Clients must return any value provided by the server when invoking the command.
+    /// </param>
+    /// <param name="confirmationMessage">
+    /// When a confirmation message is specified, the UI will prompt with an OK/Cancel dialog
+    /// and the confirmation message before starting the command.
+    /// </param>
     /// <param name="iconName">The icon name for the command. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons</param>
     /// <param name="iconVariant">The icon variant.</param>
     /// <param name="isHighlighted">A flag indicating whether the command is highlighted in the UI.</param>
@@ -736,6 +748,9 @@ public static class ResourceBuilderExtensions
         string displayName,
         Func<ExecuteCommandContext, Task<ExecuteCommandResult>> executeCommand,
         Func<UpdateCommandStateContext, ResourceCommandState>? updateState = null,
+        string? displayDescription = null,
+        object? parameter = null,
+        string? confirmationMessage = null,
         string? iconName = null,
         IconVariant? iconVariant = null,
         bool isHighlighted = false) where T : IResource
@@ -747,6 +762,6 @@ public static class ResourceBuilderExtensions
             builder.Resource.Annotations.Remove(existingAnnotation);
         }
 
-        return builder.WithAnnotation(new ResourceCommandAnnotation(type, displayName, updateState ?? (c => ResourceCommandState.Enabled), executeCommand, iconName, iconVariant, isHighlighted));
+        return builder.WithAnnotation(new ResourceCommandAnnotation(type, displayName, updateState ?? (c => ResourceCommandState.Enabled), executeCommand, displayDescription, parameter, confirmationMessage, iconName, iconVariant, isHighlighted));
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -4,7 +4,9 @@
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Tests.Utils.Grpc;
+using Aspire.Hosting.Utils;
 using Aspire.ResourceService.Proto.V1;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -12,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using DashboardService = Aspire.Hosting.Dashboard.DashboardService;
+using Resource = Aspire.Hosting.ApplicationModel.Resource;
 
 namespace Aspire.Hosting.Tests.Dashboard;
 
@@ -23,7 +26,7 @@ public class DashboardServiceTests
         // Arrange
         var resourceLoggerService = new ResourceLoggerService();
         var resourceNotificationService = new ResourceNotificationService(NullLogger<ResourceNotificationService>.Instance, new TestHostApplicationLifetime(), new ServiceCollection().BuildServiceProvider(), resourceLoggerService);
-        var dashboardServiceData = new DashboardServiceData(resourceNotificationService, resourceLoggerService, NullLogger<DashboardServiceData>.Instance, new DashboardCommandExecutor(new ServiceCollection().BuildServiceProvider()));
+        await using var dashboardServiceData = new DashboardServiceData(resourceNotificationService, resourceLoggerService, NullLogger<DashboardServiceData>.Instance, new DashboardCommandExecutor(new ServiceCollection().BuildServiceProvider()));
         var dashboardService = new DashboardService(dashboardServiceData, new TestHostEnvironment(), new TestHostApplicationLifetime(), NullLogger<DashboardService>.Instance);
 
         var logger = resourceLoggerService.GetLogger("test-resource");
@@ -54,11 +57,78 @@ public class DashboardServiceTests
         await task;
     }
 
+    [Fact]
+    public async Task WatchResources_ResourceHasCommands_CommandsSentWithResponse()
+    {
+        // Arrange
+        var resourceLoggerService = new ResourceLoggerService();
+        var resourceNotificationService = new ResourceNotificationService(NullLogger<ResourceNotificationService>.Instance, new TestHostApplicationLifetime(), new ServiceCollection().BuildServiceProvider(), resourceLoggerService);
+        await using var dashboardServiceData = new DashboardServiceData(resourceNotificationService, resourceLoggerService, NullLogger<DashboardServiceData>.Instance, new DashboardCommandExecutor(new ServiceCollection().BuildServiceProvider()));
+        var dashboardService = new DashboardService(dashboardServiceData, new TestHostEnvironment(), new TestHostApplicationLifetime(), NullLogger<DashboardService>.Instance);
+
+        var testResource = new TestResource("test-resource");
+        using var applicationBuilder = TestDistributedApplicationBuilder.Create();
+        var builder = applicationBuilder.AddResource(testResource);
+        builder.WithCommand(
+            type: "TestType",
+            displayName: "Display name!",
+            executeCommand: c => Task.FromResult(CommandResults.Success()),
+            updateState: c => ApplicationModel.ResourceCommandState.Enabled,
+            displayDescription: "Display description!",
+            parameter: new [] {"One", "Two"},
+            confirmationMessage: "Confirmation message!",
+            iconName: "Icon name!",
+            iconVariant: ApplicationModel.IconVariant.Filled,
+            isHighlighted: true);
+
+        await resourceNotificationService.PublishUpdateAsync(testResource, s => s);
+
+        var cts = new CancellationTokenSource();
+        var context = TestServerCallContext.Create(cancellationToken: cts.Token);
+        var writer = new TestServerStreamWriter<WatchResourcesUpdate>(context);
+
+        // Act
+        var task = dashboardService.WatchResources(
+            new WatchResourcesRequest(),
+            writer,
+            context);
+
+        // Assert
+        var update = await writer.ReadNextAsync();
+
+        var resourceData = Assert.Single(update.InitialData.Resources);
+        var commandData = Assert.Single(resourceData.Commands);
+
+        Assert.Equal("TestType", commandData.CommandType);
+        Assert.Equal("Display name!", commandData.DisplayName);
+        Assert.Equal("Display description!", commandData.DisplayDescription);
+        Assert.Equal(Value.ForList(Value.ForString("One"), Value.ForString("Two")), commandData.Parameter);
+        Assert.Equal("Confirmation message!", commandData.ConfirmationMessage);
+        Assert.Equal("Icon name!", commandData.IconName);
+        Assert.Equal(ResourceService.Proto.V1.IconVariant.Filled, commandData.IconVariant);
+        Assert.True(commandData.IsHighlighted);
+
+        cts.Cancel();
+
+        try
+        {
+            await task;
+        }
+        catch (OperationCanceledException)
+        {
+            // Ok if this error is thrown.
+        }
+    }
+
     private sealed class TestHostEnvironment : IHostEnvironment
     {
         public string ApplicationName { get; set; } = default!;
         public IFileProvider ContentRootFileProvider { get; set; } = default!;
         public string ContentRootPath { get; set; } = default!;
         public string EnvironmentName { get; set; } = default!;
+    }
+
+    private sealed class TestResource(string name) : Resource(name)
+    {
     }
 }


### PR DESCRIPTION
## Description

Some command fields weren't exposed on command annotation and extension method. Added in this PR.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6047)