### PR TITLE
Improve the handling of Container to Container references

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBEmulatorConnectionString.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBEmulatorConnectionString.cs
@@ -1,11 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Cosmos;
 
 namespace Aspire.Hosting.Azure;
 
 internal static class AzureCosmosDBEmulatorConnectionString
 {
-    public static string Create(int port) => $"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint=https://127.0.0.1:{port};DisableServerCertificateValidation=True;";
+    public static ReferenceExpression Create(EndpointReference endpoint) => ReferenceExpression.Create($"AccountKey={CosmosConstants.EmulatorAccountKey};AccountEndpoint=https://{endpoint.Property(EndpointProperty.IPV4Host)}:{endpoint.Property(EndpointProperty.Port)};DisableServerCertificateValidation=True;");
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -33,7 +33,7 @@ public class AzureCosmosDBResource(string name, Action<ResourceModuleConstruct> 
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         IsEmulator
-        ? ReferenceExpression.Create($"{AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint.Port)}")
+        ? AzureCosmosDBEmulatorConnectionString.Create(EmulatorEndpoint)
         : ReferenceExpression.Create($"{ConnectionString}");
 }
 

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageEmulatorConnectionString.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageEmulatorConnectionString.cs
@@ -1,8 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-using System.Text;
+using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Azure;
 
@@ -10,27 +9,30 @@ internal static class AzureStorageEmulatorConnectionString
 {
     // Use defaults from https://learn.microsoft.com/azure/storage/common/storage-configure-connection-string#connect-to-the-emulator-account-using-the-shortcut
     private const string ConnectionStringHeader = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;";
-    private const string BlobEndpointTemplate = "BlobEndpoint=http://127.0.0.1:{0}/devstoreaccount1;";
-    private const string QueueEndpointTemplate = "QueueEndpoint=http://127.0.0.1:{0}/devstoreaccount1;";
-    private const string TableEndpointTemplate = "TableEndpoint=http://127.0.0.1:{0}/devstoreaccount1;";
 
-    public static string Create(int? blobPort = null, int? queuePort = null, int? tablePort = null)
+    static void AppendEndpointExpression(ReferenceExpressionBuilder builder, string key, EndpointReference endpoint)
     {
-        var builder = new StringBuilder(ConnectionStringHeader);
+        builder.Append($"{key}=http://{endpoint.Property(EndpointProperty.IPV4Host)}:{endpoint.Property(EndpointProperty.Port)}/devstoreaccount1;");
+    }
 
-        if (blobPort is not null)
+    public static ReferenceExpression Create(EndpointReference? blobEndpoint = null, EndpointReference? queueEndpoint = null, EndpointReference? tableEndpoint = null)
+    {
+        var builder = new ReferenceExpressionBuilder();
+        builder.AppendLiteral(ConnectionStringHeader);
+
+        if (blobEndpoint is not null)
         {
-            builder.AppendFormat(CultureInfo.InvariantCulture, BlobEndpointTemplate, blobPort);
+            AppendEndpointExpression(builder, "BlobEndpoint", blobEndpoint);
         }
-        if (queuePort is not null)
+        if (queueEndpoint is not null)
         {
-            builder.AppendFormat(CultureInfo.InvariantCulture, QueueEndpointTemplate, queuePort);
+            AppendEndpointExpression(builder, "QueueEndpoint", queueEndpoint);
         }
-        if (tablePort is not null)
+        if (tableEndpoint is not null)
         {
-            builder.AppendFormat(CultureInfo.InvariantCulture, TableEndpointTemplate, tablePort);
+            AppendEndpointExpression(builder, "TableEndpoint", tableEndpoint);
         }
 
-        return builder.ToString();
+        return builder.Build();
     }
 }

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageEmulatorConnectionString.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageEmulatorConnectionString.cs
@@ -10,7 +10,7 @@ internal static class AzureStorageEmulatorConnectionString
     // Use defaults from https://learn.microsoft.com/azure/storage/common/storage-configure-connection-string#connect-to-the-emulator-account-using-the-shortcut
     private const string ConnectionStringHeader = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;";
 
-    static void AppendEndpointExpression(ReferenceExpressionBuilder builder, string key, EndpointReference endpoint)
+    private static void AppendEndpointExpression(ReferenceExpressionBuilder builder, string key, EndpointReference endpoint)
     {
         builder.Append($"{key}=http://{endpoint.Property(EndpointProperty.IPV4Host)}:{endpoint.Property(EndpointProperty.Port)}/devstoreaccount1;");
     }

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageResource.cs
@@ -47,19 +47,19 @@ public class AzureStorageResource(string name, Action<ResourceModuleConstruct> c
     /// </summary>
     /// <returns></returns>
     internal ReferenceExpression GetEmulatorConnectionString() => IsEmulator
-       ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(blobPort: EmulatorBlobEndpoint.Port, queuePort: EmulatorQueueEndpoint.Port, tablePort: EmulatorTableEndpoint.Port)}")
+       ? AzureStorageEmulatorConnectionString.Create(blobEndpoint: EmulatorBlobEndpoint, queueEndpoint: EmulatorQueueEndpoint, tableEndpoint: EmulatorTableEndpoint)
        : throw new InvalidOperationException("The Azure Storage resource is not running in the local emulator.");
 
     internal ReferenceExpression GetTableConnectionString() => IsEmulator
-        ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(tablePort: EmulatorTableEndpoint.Port)}")
+        ? AzureStorageEmulatorConnectionString.Create(tableEndpoint: EmulatorTableEndpoint)
         : ReferenceExpression.Create($"{TableEndpoint}");
 
     internal ReferenceExpression GetQueueConnectionString() => IsEmulator
-        ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(queuePort: EmulatorQueueEndpoint.Port)}")
+        ? AzureStorageEmulatorConnectionString.Create(queueEndpoint: EmulatorQueueEndpoint)
         : ReferenceExpression.Create($"{QueueEndpoint}");
 
     internal ReferenceExpression GetBlobConnectionString() => IsEmulator
-        ? ReferenceExpression.Create($"{AzureStorageEmulatorConnectionString.Create(blobPort: EmulatorBlobEndpoint.Port)}")
+        ? AzureStorageEmulatorConnectionString.Create(blobEndpoint: EmulatorBlobEndpoint)
         : ReferenceExpression.Create($"{BlobEndpoint}");
 
     void IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -9,7 +9,7 @@ internal class ExpressionResolver
 {
     // Resolve an expression when it is being used from inside a container
     // This means that if the target is also a container, we're dealing with container-to-container communication
-    static async ValueTask<string?> ResolveWithContainerSource(object? value, CancellationToken cancellationToken)
+    static async ValueTask<string?> ResolveWithContainerSource(object? value, HashSet<EndpointReference> processedEndpoints, CancellationToken cancellationToken)
     {
         async Task<string?> EvalEndpoint(EndpointReference endpointReference, EndpointProperty property)
         {
@@ -17,14 +17,23 @@ internal class ExpressionResolver
             // Otherwise, we get the wrong values for IsContainer and Name
             var target = endpointReference.Resource.GetRootResource();
 
+            string UseContainerNameAsHostName()
+            {
+                // Keep track of the fact that we've processed the host property for this endpoint
+                processedEndpoints.Add(endpointReference);
+                return target.Name;
+            }
+
             return (property, target.IsContainer()) switch
             {
                 // If Container -> Container, we go directly to the container name, bypassing the host
-                (EndpointProperty.Host or EndpointProperty.IPV4Host, true) => target.Name,
+                (EndpointProperty.Host or EndpointProperty.IPV4Host, true) => UseContainerNameAsHostName(),
+                // If Container -> Container, we use the target port, since we're not going through the host.
+                // But only do this if we have also processed the host property for that same endpoint.
+                // This allows the host and port to be handled in a unified way.
+                (EndpointProperty.Port, true) when processedEndpoints.Contains(endpointReference) => await endpointReference.Property(EndpointProperty.TargetPort).GetValueAsync(cancellationToken).ConfigureAwait(false),
                 // If Container -> Exe, we need to go through the container host
                 (EndpointProperty.Host or EndpointProperty.IPV4Host, false) => endpointReference.ContainerHost,
-                // If Container -> Container, we use the target port, since we're not going through the host
-                (EndpointProperty.Port, true) => await endpointReference.Property(EndpointProperty.TargetPort).GetValueAsync(cancellationToken).ConfigureAwait(false),
                 (EndpointProperty.Url, _) => string.Format(CultureInfo.InvariantCulture, "{0}://{1}:{2}",
                                                 endpointReference.Scheme,
                                                 await EvalEndpoint(endpointReference, EndpointProperty.Host).ConfigureAwait(false),
@@ -41,7 +50,7 @@ internal class ExpressionResolver
 
             for (var i = 0; i < expr.ValueProviders.Count; i++)
             {
-                args[i] = await ResolveWithContainerSource(expr.ValueProviders[i], cancellationToken).ConfigureAwait(false);
+                args[i] = await ResolveWithContainerSource(expr.ValueProviders[i], processedEndpoints, cancellationToken).ConfigureAwait(false);
             }
 
             return string.Format(CultureInfo.InvariantCulture, expr.Format, args);
@@ -49,8 +58,8 @@ internal class ExpressionResolver
 
         return value switch
         {
-            ConnectionStringReference cs => await ResolveWithContainerSource(cs.Resource.ConnectionStringExpression, cancellationToken).ConfigureAwait(false),
-            IResourceWithConnectionString cs => await ResolveWithContainerSource(cs.ConnectionStringExpression, cancellationToken).ConfigureAwait(false),
+            ConnectionStringReference cs => await ResolveWithContainerSource(cs.Resource.ConnectionStringExpression, processedEndpoints, cancellationToken).ConfigureAwait(false),
+            IResourceWithConnectionString cs => await ResolveWithContainerSource(cs.ConnectionStringExpression, processedEndpoints, cancellationToken).ConfigureAwait(false),
             ReferenceExpression ex => await EvalExpression(ex).ConfigureAwait(false),
             EndpointReference endpointReference => await EvalEndpoint(endpointReference, EndpointProperty.Url).ConfigureAwait(false),
             EndpointReferenceExpression ep => await EvalEndpoint(ep.Endpoint, ep.Property).ConfigureAwait(false),
@@ -65,6 +74,6 @@ internal class ExpressionResolver
             // Exe -> Exe and Exe -> Container cases
             false => await valueProvider.GetValueAsync(cancellationToken).ConfigureAwait(false),
             // Container -> Exe and Container -> Container cases
-            true => await ResolveWithContainerSource(valueProvider, cancellationToken).ConfigureAwait(false)
+            true => await ResolveWithContainerSource(valueProvider, [], cancellationToken).ConfigureAwait(false)
         };
 }

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -15,7 +15,7 @@ internal class ExpressionResolver
         {
             // We need to use the top resource, e.g. AzureStorageResource instead of AzureBlobResource
             // Otherwise, we get the wrong values for IsContainer and Name
-            var target = endpointReference.Resource.GetTopResource();
+            var target = endpointReference.Resource.GetRootResource();
 
             return (property, target.IsContainer()) switch
             {
@@ -28,6 +28,8 @@ internal class ExpressionResolver
 
         async Task<string?> EvalExpression(ReferenceExpression expr)
         {
+            // This logic is similar to ReferenceExpression.GetValueAsync, except that we recurse on
+            // our own resolver method
             var args = new object?[expr.ValueProviders.Count];
 
             for (var i = 0; i < expr.ValueProviders.Count; i++)

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -9,7 +9,7 @@ internal class ExpressionResolver
 {
     // Resolve an expression when it is being used from inside a container
     // This means that if the target is also a container, we're dealing with container-to-container communication
-    static async ValueTask<string?> ResolveWithContainerSource(object? value, CancellationToken cancellationToken)
+    static async ValueTask<string?> ResolveWithContainerSource(object? value, string defaultContainerHostName, CancellationToken cancellationToken)
     {
         async Task<string?> EvalEndpoint(EndpointReference endpointReference, EndpointProperty property)
         {
@@ -20,6 +20,7 @@ internal class ExpressionResolver
             return (property, target.IsContainer()) switch
             {
                 (EndpointProperty.Host or EndpointProperty.IPV4Host, true) => target.Name,
+                (EndpointProperty.Host or EndpointProperty.IPV4Host, false) => defaultContainerHostName,
                 (EndpointProperty.Port, true) => await endpointReference.Property(EndpointProperty.TargetPort).GetValueAsync(cancellationToken).ConfigureAwait(false),
                 (EndpointProperty.Url, true) => $"{endpointReference.Scheme}://{target.Name}:{endpointReference.TargetPort}",
                 _ => await endpointReference.Property(property).GetValueAsync(cancellationToken).ConfigureAwait(false)
@@ -34,7 +35,7 @@ internal class ExpressionResolver
 
             for (var i = 0; i < expr.ValueProviders.Count; i++)
             {
-                args[i] = await ResolveWithContainerSource(expr.ValueProviders[i], cancellationToken).ConfigureAwait(false);
+                args[i] = await ResolveWithContainerSource(expr.ValueProviders[i], defaultContainerHostName, cancellationToken).ConfigureAwait(false);
             }
 
             return string.Format(CultureInfo.InvariantCulture, expr.Format, args);
@@ -42,8 +43,8 @@ internal class ExpressionResolver
 
         return value switch
         {
-            ConnectionStringReference cs => await ResolveWithContainerSource(cs.Resource.ConnectionStringExpression, cancellationToken).ConfigureAwait(false),
-            IResourceWithConnectionString cs => await ResolveWithContainerSource(cs.ConnectionStringExpression, cancellationToken).ConfigureAwait(false),
+            ConnectionStringReference cs => await ResolveWithContainerSource(cs.Resource.ConnectionStringExpression, defaultContainerHostName, cancellationToken).ConfigureAwait(false),
+            IResourceWithConnectionString cs => await ResolveWithContainerSource(cs.ConnectionStringExpression, defaultContainerHostName, cancellationToken).ConfigureAwait(false),
             ReferenceExpression ex => await EvalExpression(ex).ConfigureAwait(false),
             EndpointReference endpointReference => await EvalEndpoint(endpointReference, EndpointProperty.Url).ConfigureAwait(false),
             EndpointReferenceExpression ep => await EvalEndpoint(ep.Endpoint, ep.Property).ConfigureAwait(false),
@@ -52,11 +53,11 @@ internal class ExpressionResolver
         };
     }
 
-    internal static async ValueTask<string?> Resolve(bool sourceIsContainer, IValueProvider valueProvider, CancellationToken cancellationToken)
+    internal static async ValueTask<string?> Resolve(bool sourceIsContainer, IValueProvider valueProvider, string defaultContainerHostName, CancellationToken cancellationToken)
     {
         return sourceIsContainer switch
         {
-            true => await ResolveWithContainerSource(valueProvider, cancellationToken).ConfigureAwait(false),
+            true => await ResolveWithContainerSource(valueProvider, defaultContainerHostName, cancellationToken).ConfigureAwait(false),
             false => await valueProvider.GetValueAsync(cancellationToken).ConfigureAwait(false)
         };
     }

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -7,42 +7,63 @@ namespace Aspire.Hosting.ApplicationModel;
 
 internal class ExpressionResolver
 {
-    // Resolve an expression when it is being used from inside a container
-    // This means that if the target is also a container, we're dealing with container-to-container communication
-    static async ValueTask<string?> ResolveWithContainerSource(object? value, HashSet<EndpointReference> processedEndpoints, CancellationToken cancellationToken)
+    /// <summary>
+    /// Resolve an expression when it is being used from inside a container.
+    /// So it's either a container-to-container or container-to-exe communication.
+    /// </summary>
+    static async ValueTask<string?> ResolveWithContainerSourceAsync(object? value, Dictionary<EndpointReference, bool[]> processedEndpoints, bool preprocessMode, CancellationToken cancellationToken)
     {
-        async Task<string?> EvalEndpoint(EndpointReference endpointReference, EndpointProperty property)
+        async Task<string?> EvalEndpointAsync(EndpointReference endpointReference, EndpointProperty property)
         {
+            if (preprocessMode)
+            {
+                if (!processedEndpoints.TryGetValue(endpointReference, out var hostAndPortFound))
+                {
+                    hostAndPortFound = new bool[2];
+                    processedEndpoints[endpointReference] = hostAndPortFound;
+                }
+
+                if (property is EndpointProperty.Host or EndpointProperty.IPV4Host)
+                {
+                    hostAndPortFound[0] = true;
+                }
+                else if (property == EndpointProperty.Port)
+                {
+                    hostAndPortFound[1] = true;
+                }
+                else if (property == EndpointProperty.Url)
+                {
+                    hostAndPortFound[0] = hostAndPortFound[1] = true;
+                }
+
+                return string.Empty;
+            }
+
             // We need to use the root resource, e.g. AzureStorageResource instead of AzureBlobResource
             // Otherwise, we get the wrong values for IsContainer and Name
             var target = endpointReference.Resource.GetRootResource();
 
-            string UseContainerNameAsHostName()
-            {
-                // Keep track of the fact that we've processed the host property for this endpoint
-                processedEndpoints.Add(endpointReference);
-                return target.Name;
-            }
+            bool HasBothHostAndPort() => processedEndpoints[endpointReference][0] && processedEndpoints[endpointReference][1];
 
             return (property, target.IsContainer()) switch
             {
                 // If Container -> Container, we go directly to the container name, bypassing the host
-                (EndpointProperty.Host or EndpointProperty.IPV4Host, true) => UseContainerNameAsHostName(),
+                (EndpointProperty.Host or EndpointProperty.IPV4Host, true) when HasBothHostAndPort() => target.Name,
                 // If Container -> Container, we use the target port, since we're not going through the host.
                 // But only do this if we have also processed the host property for that same endpoint.
                 // This allows the host and port to be handled in a unified way.
-                (EndpointProperty.Port, true) when processedEndpoints.Contains(endpointReference) => await endpointReference.Property(EndpointProperty.TargetPort).GetValueAsync(cancellationToken).ConfigureAwait(false),
+                (EndpointProperty.Port, true) when HasBothHostAndPort() => await endpointReference.Property(EndpointProperty.TargetPort).GetValueAsync(cancellationToken).ConfigureAwait(false),
                 // If Container -> Exe, we need to go through the container host
                 (EndpointProperty.Host or EndpointProperty.IPV4Host, false) => endpointReference.ContainerHost,
                 (EndpointProperty.Url, _) => string.Format(CultureInfo.InvariantCulture, "{0}://{1}:{2}",
                                                 endpointReference.Scheme,
-                                                await EvalEndpoint(endpointReference, EndpointProperty.Host).ConfigureAwait(false),
-                                                await EvalEndpoint(endpointReference, EndpointProperty.Port).ConfigureAwait(false)),
+                                                await EvalEndpointAsync(endpointReference, EndpointProperty.Host).ConfigureAwait(false),
+                                                await EvalEndpointAsync(endpointReference, EndpointProperty.Port).ConfigureAwait(false)),
                 _ => await endpointReference.Property(property).GetValueAsync(cancellationToken).ConfigureAwait(false)
             };
         }
 
-        async Task<string?> EvalExpression(ReferenceExpression expr)
+        async Task<string?> EvalExpressionAsync(ReferenceExpression expr)
         {
             // This logic is similar to ReferenceExpression.GetValueAsync, except that we recurse on
             // our own resolver method
@@ -50,7 +71,7 @@ internal class ExpressionResolver
 
             for (var i = 0; i < expr.ValueProviders.Count; i++)
             {
-                args[i] = await ResolveWithContainerSource(expr.ValueProviders[i], processedEndpoints, cancellationToken).ConfigureAwait(false);
+                args[i] = await ResolveWithContainerSourceAsync(expr.ValueProviders[i], processedEndpoints, preprocessMode, cancellationToken).ConfigureAwait(false);
             }
 
             return string.Format(CultureInfo.InvariantCulture, expr.Format, args);
@@ -58,22 +79,28 @@ internal class ExpressionResolver
 
         return value switch
         {
-            ConnectionStringReference cs => await ResolveWithContainerSource(cs.Resource.ConnectionStringExpression, processedEndpoints, cancellationToken).ConfigureAwait(false),
-            IResourceWithConnectionString cs => await ResolveWithContainerSource(cs.ConnectionStringExpression, processedEndpoints, cancellationToken).ConfigureAwait(false),
-            ReferenceExpression ex => await EvalExpression(ex).ConfigureAwait(false),
-            EndpointReference endpointReference => await EvalEndpoint(endpointReference, EndpointProperty.Url).ConfigureAwait(false),
-            EndpointReferenceExpression ep => await EvalEndpoint(ep.Endpoint, ep.Property).ConfigureAwait(false),
+            ConnectionStringReference cs => await ResolveWithContainerSourceAsync(cs.Resource.ConnectionStringExpression, processedEndpoints, preprocessMode, cancellationToken).ConfigureAwait(false),
+            IResourceWithConnectionString cs => await ResolveWithContainerSourceAsync(cs.ConnectionStringExpression, processedEndpoints, preprocessMode, cancellationToken).ConfigureAwait(false),
+            ReferenceExpression ex => await EvalExpressionAsync(ex).ConfigureAwait(false),
+            EndpointReference endpointReference => await EvalEndpointAsync(endpointReference, EndpointProperty.Url).ConfigureAwait(false),
+            EndpointReferenceExpression ep => await EvalEndpointAsync(ep.Endpoint, ep.Property).ConfigureAwait(false),
             IValueProvider vp => await vp.GetValueAsync(cancellationToken).ConfigureAwait(false),
             _ => throw new NotImplementedException()
         };
     }
 
-    internal static async ValueTask<string?> Resolve(bool sourceIsContainer, IValueProvider valueProvider, CancellationToken cancellationToken) =>
-        sourceIsContainer switch
+    internal static async ValueTask<string?> ResolveAsync(bool sourceIsContainer, IValueProvider valueProvider, CancellationToken cancellationToken)
+    {
+        var processedEndpoints = new Dictionary<EndpointReference, bool[]>();
+
+        await ResolveWithContainerSourceAsync(valueProvider, processedEndpoints, preprocessMode: true, cancellationToken).ConfigureAwait(false);
+
+        return sourceIsContainer switch
         {
             // Exe -> Exe and Exe -> Container cases
             false => await valueProvider.GetValueAsync(cancellationToken).ConfigureAwait(false),
             // Container -> Exe and Container -> Container cases
-            true => await ResolveWithContainerSource(valueProvider, [], cancellationToken).ConfigureAwait(false)
+            true => await ResolveWithContainerSourceAsync(valueProvider, processedEndpoints, preprocessMode: false, cancellationToken).ConfigureAwait(false)
         };
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExpressionResolver.cs
@@ -53,12 +53,10 @@ internal class ExpressionResolver
         };
     }
 
-    internal static async ValueTask<string?> Resolve(bool sourceIsContainer, IValueProvider valueProvider, CancellationToken cancellationToken)
-    {
-        return sourceIsContainer switch
+    internal static async ValueTask<string?> Resolve(bool sourceIsContainer, IValueProvider valueProvider, CancellationToken cancellationToken) =>
+        sourceIsContainer switch
         {
             true => await ResolveWithContainerSource(valueProvider, cancellationToken).ConfigureAwait(false),
             false => await valueProvider.GetValueAsync(cancellationToken).ConfigureAwait(false)
         };
-    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -249,4 +249,17 @@ public static class ResourceExtensions
 
         return ContainerLifetime.Default;
     }
+
+    /// <summary>
+    /// Get the top resource in the resource hierarchy.
+    /// e.g. for a AzureBlobStorageResource, the top resource is the AzureStorageResource.
+    /// </summary>
+    internal static IResource GetTopResource(this IResource resource)
+    {
+        return resource switch
+        {
+            IResourceWithParent resWithParent => resWithParent.Parent.GetTopResource(),
+            _ => resource
+        };
+    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -254,12 +254,10 @@ public static class ResourceExtensions
     /// Get the top resource in the resource hierarchy.
     /// e.g. for a AzureBlobStorageResource, the top resource is the AzureStorageResource.
     /// </summary>
-    internal static IResource GetRootResource(this IResource resource)
-    {
-        return resource switch
+    internal static IResource GetRootResource(this IResource resource) =>
+        resource switch
         {
             IResourceWithParent resWithParent => resWithParent.Parent.GetRootResource(),
             _ => resource
         };
-    }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceExtensions.cs
@@ -254,11 +254,11 @@ public static class ResourceExtensions
     /// Get the top resource in the resource hierarchy.
     /// e.g. for a AzureBlobStorageResource, the top resource is the AzureStorageResource.
     /// </summary>
-    internal static IResource GetTopResource(this IResource resource)
+    internal static IResource GetRootResource(this IResource resource)
     {
         return resource switch
         {
-            IResourceWithParent resWithParent => resWithParent.Parent.GetTopResource(),
+            IResourceWithParent resWithParent => resWithParent.Parent.GetRootResource(),
             _ => resource
         };
     }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1367,9 +1367,9 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         await createResource().ConfigureAwait(false);
     }
 
-    private static async Task<string?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, bool isContainer, CancellationToken cancellationToken)
+    private async Task<string?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, bool isContainer, CancellationToken cancellationToken)
     {
-        var task = ExpressionResolver.Resolve(isContainer, valueProvider, cancellationToken);
+        var task = ExpressionResolver.Resolve(isContainer, valueProvider, DefaultContainerHostName, cancellationToken);
 
         if (!task.IsCompleted)
         {

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1367,50 +1367,9 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         await createResource().ConfigureAwait(false);
     }
 
-    static async ValueTask<string?> Resolve(bool sourceIsContainer, object? value, CancellationToken cancellationToken)
-    {
-        async Task<string?> EvalEndpoint(EndpointReference endpointReference, EndpointProperty property)
-        {
-            // We need to use the top resource, e.g. AzureStorageResource instead of AzureBlobResource
-            // Otherwise, we get the wrong values for IsContainer and Name
-            IResource target = endpointReference.Resource.GetTopResource();
-
-            return (property, sourceIsContainer && target.IsContainer()) switch
-            {
-                (EndpointProperty.Host or EndpointProperty.IPV4Host, true) => target.Name,
-                (EndpointProperty.Port, true) => await endpointReference.Property(EndpointProperty.TargetPort).GetValueAsync(cancellationToken).ConfigureAwait(false),
-                (EndpointProperty.Url, true) => $"{endpointReference.Scheme}://{target.Name}:{endpointReference.TargetPort}",
-                _ => await endpointReference.Property(property).GetValueAsync(cancellationToken).ConfigureAwait(false)
-            };
-        }
-
-        async Task<string?> EvalExpression(ReferenceExpression expr)
-        {
-            var args = new object?[expr.ValueProviders.Count];
-
-            for (var i = 0; i < expr.ValueProviders.Count; i++)
-            {
-                args[i] = await Resolve(sourceIsContainer, expr.ValueProviders[i], cancellationToken).ConfigureAwait(false);
-            }
-
-            return string.Format(CultureInfo.InvariantCulture, expr.Format, args);
-        }
-
-        return value switch
-        {
-            ConnectionStringReference cs => await Resolve(sourceIsContainer, cs.Resource.ConnectionStringExpression, cancellationToken).ConfigureAwait(false),
-            IResourceWithConnectionString cs => await Resolve(sourceIsContainer, cs.ConnectionStringExpression, cancellationToken).ConfigureAwait(false),
-            ReferenceExpression ex => await EvalExpression(ex).ConfigureAwait(false),
-            EndpointReference endpointReference => await EvalEndpoint(endpointReference, EndpointProperty.Url).ConfigureAwait(false),
-            EndpointReferenceExpression ep => await EvalEndpoint(ep.Endpoint, ep.Property).ConfigureAwait(false),
-            IValueProvider vp => await vp.GetValueAsync(cancellationToken).ConfigureAwait(false),
-            _ => throw new NotImplementedException()
-        };
-    }
-
     private static async Task<string?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, bool isContainer, CancellationToken cancellationToken)
     {
-        var task = Resolve(isContainer, valueProvider, cancellationToken);
+        var task = ExpressionResolver.Resolve(isContainer, valueProvider, cancellationToken);
 
         if (!task.IsCompleted)
         {

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1367,9 +1367,9 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
         await createResource().ConfigureAwait(false);
     }
 
-    private async Task<string?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, bool isContainer, CancellationToken cancellationToken)
+    private static async Task<string?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, bool isContainer, CancellationToken cancellationToken)
     {
-        var task = ExpressionResolver.Resolve(isContainer, valueProvider, DefaultContainerHostName, cancellationToken);
+        var task = ExpressionResolver.Resolve(isContainer, valueProvider, cancellationToken);
 
         if (!task.IsCompleted)
         {

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1369,7 +1369,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
     private static async Task<string?> GetValue(string? key, IValueProvider valueProvider, ILogger logger, bool isContainer, CancellationToken cancellationToken)
     {
-        var task = ExpressionResolver.Resolve(isContainer, valueProvider, cancellationToken);
+        var task = ExpressionResolver.ResolveAsync(isContainer, valueProvider, cancellationToken);
 
         if (!task.IsCompleted)
         {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -19,6 +19,7 @@ using Azure.Provisioning.Expressions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
+using System.Net.Sockets;
 
 namespace Aspire.Hosting.Azure.Tests;
 
@@ -1827,17 +1828,24 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var queue = storage.AddQueues("queue");
         var table = storage.AddTables("table");
 
-        var blobqs = AzureStorageEmulatorConnectionString.Create(blobPort: 10000);
-        var queueqs = AzureStorageEmulatorConnectionString.Create(queuePort: 10001);
-        var tableqs = AzureStorageEmulatorConnectionString.Create(tablePort: 10002);
+        EndpointReference GetEndpointReference(string name, int port)
+            => new(storage.Resource, new EndpointAnnotation(ProtocolType.Tcp, name: name, targetPort: port));
+
+        var blobqs = AzureStorageEmulatorConnectionString.Create(blobEndpoint: GetEndpointReference("blob", 10000)).ValueExpression;
+        var queueqs = AzureStorageEmulatorConnectionString.Create(queueEndpoint: GetEndpointReference("queue", 10001)).ValueExpression;
+        var tableqs = AzureStorageEmulatorConnectionString.Create(tableEndpoint: GetEndpointReference("table", 10002)).ValueExpression;
 
         Assert.Equal(blobqs, blob.Resource.ConnectionStringExpression.ValueExpression);
         Assert.Equal(queueqs, queue.Resource.ConnectionStringExpression.ValueExpression);
         Assert.Equal(tableqs, table.Resource.ConnectionStringExpression.ValueExpression);
 
-        Assert.Equal(blobqs, await ((IResourceWithConnectionString)blob.Resource).GetConnectionStringAsync());
-        Assert.Equal(queueqs, await ((IResourceWithConnectionString)queue.Resource).GetConnectionStringAsync());
-        Assert.Equal(tableqs, await ((IResourceWithConnectionString)table.Resource).GetConnectionStringAsync());
+        string Resolve(string? qs, string name, int port) =>
+            qs!.Replace("{storage.bindings." + name + ".host}", "127.0.0.1")
+               .Replace("{storage.bindings." + name + ".port}", port.ToString());
+
+        Assert.Equal(Resolve(blobqs, "blob", 10000), await((IResourceWithConnectionString)blob.Resource).GetConnectionStringAsync());
+        Assert.Equal(Resolve(queueqs, "queue", 10001), await ((IResourceWithConnectionString)queue.Resource).GetConnectionStringAsync());
+        Assert.Equal(Resolve(tableqs, "table", 10002), await ((IResourceWithConnectionString)table.Resource).GetConnectionStringAsync());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -207,7 +207,13 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
         Assert.True(cosmos.Resource.IsContainer());
 
-        Assert.Equal(await cosmos.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None), await ((IResourceWithConnectionString)cosmos.Resource).GetConnectionStringAsync());
+        var csExpr = cosmos.Resource.ConnectionStringExpression;
+        var cs = await csExpr.GetValueAsync(CancellationToken.None);
+
+        var prefix = "AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;AccountEndpoint=";
+        Assert.Equal(prefix + "https://{cosmos.bindings.emulator.host}:{cosmos.bindings.emulator.port};DisableServerCertificateValidation=True;", csExpr.ValueExpression);
+        Assert.Equal(prefix + "https://127.0.0.1:10001;DisableServerCertificateValidation=True;", cs);
+        Assert.Equal(cs, await ((IResourceWithConnectionString)cosmos.Resource).GetConnectionStringAsync());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -207,10 +207,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
         Assert.True(cosmos.Resource.IsContainer());
 
-        var cs = AzureCosmosDBEmulatorConnectionString.Create(10001);
-
-        Assert.Equal(cs, cosmos.Resource.ConnectionStringExpression.ValueExpression);
-        Assert.Equal(cs, await ((IResourceWithConnectionString)cosmos.Resource).GetConnectionStringAsync());
+        Assert.Equal(await cosmos.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None), await ((IResourceWithConnectionString)cosmos.Resource).GetConnectionStringAsync());
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -28,7 +28,8 @@ public class ExpressionResolverTests
         }
 
         var csRef = new ConnectionStringReference(test.Resource, false);
-        Assert.Equal(expectedConnectionString, await ExpressionResolver.Resolve(sourceIsContainer, csRef, CancellationToken.None));
+        var connectionString = await ExpressionResolver.Resolve(sourceIsContainer, csRef, CancellationToken.None);
+        Assert.Equal(expectedConnectionString, connectionString);
     }
 
     [Theory]
@@ -58,14 +59,24 @@ public class ExpressionResolverTests
     }
 }
 
-sealed class TestContainerResource(string name) : ContainerResource(name), IResourceWithConnectionString, IResourceWithEndpoints
+sealed class TestContainerResource : ContainerResource, IResourceWithConnectionString, IResourceWithEndpoints
 {
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"TestEndpoint=http://{MyEndpoint.Property(EndpointProperty.IPV4Host)}:{MyEndpoint.Property(EndpointProperty.Port)}/stuff;");
-    public EndpointReference MyEndpoint => new(this, "endpoint");
+    private readonly EndpointReference _myEndpoint;
+    public TestContainerResource(string name) : base(name)
+    {
+        _myEndpoint = new(this, "endpoint");
+    }
+
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"TestEndpoint=http://{_myEndpoint.Property(EndpointProperty.IPV4Host)}:{_myEndpoint.Property(EndpointProperty.Port)}/stuff;");
 }
 
-sealed class TestContainerResourceWithUrlExpression(string name) : ContainerResource(name), IResourceWithConnectionString, IResourceWithEndpoints
+sealed class TestContainerResourceWithUrlExpression : ContainerResource, IResourceWithConnectionString, IResourceWithEndpoints
 {
-    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"Url={MyEndpoint.Property(EndpointProperty.Url)};");
-    public EndpointReference MyEndpoint => new(this, "endpoint");
+    private readonly EndpointReference _myEndpoint;
+    public TestContainerResourceWithUrlExpression(string name) : base(name)
+    {
+        _myEndpoint = new(this, "endpoint");
+    }
+
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"Url={_myEndpoint.Property(EndpointProperty.Url)};");
 }

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Aspire.Hosting.Tests;
+public class ExpressionResolverTests
+{
+    [Theory]
+    [InlineData(false, false, "TestEndpoint=http://127.0.0.1:12345/stuff;")]
+    [InlineData(false, true, "TestEndpoint=http://127.0.0.1:12345/stuff;")]
+    [InlineData(true, false, "TestEndpoint=http://ContainerHostName:12345/stuff;")]
+    [InlineData(true, true, "TestEndpoint=http://mytest:1000/stuff;")]
+    public async Task ExpressionResolverWorksWithAllCombinationsOfExesAndContainers(bool sourceIsContainer, bool targetIsContainer, string expectedConnectionString)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var test = builder.AddResource(new TestContainerResource("mytest"))
+            .WithEndpoint("endpoint", e =>
+            {
+                e.UriScheme = "http";
+                e.AllocatedEndpoint = new(e, "localhost", 12345, containerHostAddress: "ContainerHostName", targetPortExpression: "1000");
+            });
+
+        if (targetIsContainer)
+        {
+            test = test.WithImage("someimage");
+        }
+
+        var connRef = new ConnectionStringReference(test.Resource, false);
+        var task = ExpressionResolver.Resolve(sourceIsContainer, connRef, CancellationToken.None);
+
+        Assert.Equal(expectedConnectionString, await task);
+    }
+}
+
+sealed class TestContainerResource(string name) : ContainerResource(name), IResourceWithConnectionString, IResourceWithEndpoints
+{
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"TestEndpoint=http://{MyEndpoint.Property(EndpointProperty.IPV4Host)}:{MyEndpoint.Property(EndpointProperty.Port)}/stuff;");
+    public EndpointReference MyEndpoint => new(this, "endpoint");
+}

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -26,10 +26,8 @@ public class ExpressionResolverTests
             test = test.WithImage("someimage");
         }
 
-        var connRef = new ConnectionStringReference(test.Resource, false);
-        var task = ExpressionResolver.Resolve(sourceIsContainer, connRef, CancellationToken.None);
-
-        Assert.Equal(expectedConnectionString, await task);
+        var csRef = new ConnectionStringReference(test.Resource, false);
+        Assert.Equal(expectedConnectionString, await ExpressionResolver.Resolve(sourceIsContainer, csRef, CancellationToken.None));
     }
 }
 

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -10,7 +10,7 @@ public class ExpressionResolverTests
     [InlineData(false, false, "TestEndpoint=http://127.0.0.1:12345/stuff;")]
     [InlineData(false, true, "TestEndpoint=http://127.0.0.1:12345/stuff;")]
     [InlineData(true, false, "TestEndpoint=http://ContainerHostName:12345/stuff;")]
-    [InlineData(true, true, "TestEndpoint=http://mytest:1000/stuff;")]
+    [InlineData(true, true, "TestEndpoint=http://mytest:10000/stuff;")]
     public async Task ExpressionResolverWorksWithAllCombinationsOfExesAndContainers(bool sourceIsContainer, bool targetIsContainer, string expectedConnectionString)
     {
         var builder = DistributedApplication.CreateBuilder();
@@ -18,7 +18,8 @@ public class ExpressionResolverTests
         var test = builder.AddResource(new TestContainerResource("mytest"))
             .WithEndpoint("endpoint", e =>
             {
-                e.AllocatedEndpoint = new(e, "localhost", 12345, containerHostAddress: "ContainerHostName", targetPortExpression: "1000");
+                e.UriScheme = "http";
+                e.AllocatedEndpoint = new(e, "localhost", 12345, containerHostAddress: "ContainerHostName", targetPortExpression: "10000");
             });
 
         if (targetIsContainer)
@@ -29,10 +30,42 @@ public class ExpressionResolverTests
         var csRef = new ConnectionStringReference(test.Resource, false);
         Assert.Equal(expectedConnectionString, await ExpressionResolver.Resolve(sourceIsContainer, csRef, CancellationToken.None));
     }
+
+    [Theory]
+    [InlineData(false, false, "Url=http://localhost:12345;")]
+    [InlineData(false, true, "Url=http://localhost:12345;")]
+    [InlineData(true, false, "Url=http://ContainerHostName:12345;")]
+    [InlineData(true, true, "Url=http://mytest:10000;")]
+    public async Task ExpressionResolverWorksWithAllCombinationsOfExesAndContainersUrlProp(bool sourceIsContainer, bool targetIsContainer, string expectedConnectionString)
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var test = builder.AddResource(new TestContainerResourceWithUrlExpression("mytest"))
+            .WithEndpoint("endpoint", e =>
+            {
+                e.UriScheme = "http";
+                e.AllocatedEndpoint = new(e, "localhost", 12345, containerHostAddress: "ContainerHostName", targetPortExpression: "10000");
+            });
+
+        if (targetIsContainer)
+        {
+            test = test.WithImage("someimage");
+        }
+
+        var csRef = new ConnectionStringReference(test.Resource, false);
+        var connectionString = await ExpressionResolver.Resolve(sourceIsContainer, csRef, CancellationToken.None);
+        Assert.Equal(expectedConnectionString, connectionString);
+    }
 }
 
 sealed class TestContainerResource(string name) : ContainerResource(name), IResourceWithConnectionString, IResourceWithEndpoints
 {
     public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"TestEndpoint=http://{MyEndpoint.Property(EndpointProperty.IPV4Host)}:{MyEndpoint.Property(EndpointProperty.Port)}/stuff;");
+    public EndpointReference MyEndpoint => new(this, "endpoint");
+}
+
+sealed class TestContainerResourceWithUrlExpression(string name) : ContainerResource(name), IResourceWithConnectionString, IResourceWithEndpoints
+{
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"Url={MyEndpoint.Property(EndpointProperty.Url)};");
     public EndpointReference MyEndpoint => new(this, "endpoint");
 }

--- a/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
+++ b/tests/Aspire.Hosting.Tests/ExpressionResolverTests.cs
@@ -18,7 +18,6 @@ public class ExpressionResolverTests
         var test = builder.AddResource(new TestContainerResource("mytest"))
             .WithEndpoint("endpoint", e =>
             {
-                e.UriScheme = "http";
                 e.AllocatedEndpoint = new(e, "localhost", 12345, containerHostAddress: "ContainerHostName", targetPortExpression: "1000");
             });
 


### PR DESCRIPTION
## Description

Replace the `ReplaceLocalhostWithContainerHost` hack with proper expression handling that covers all cases of (Exe, Host) x (Exe, Host) referencing.

Fixes #3735

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6049)