### PR TITLE
Resolve KafkaHealthCheck from container (#6035)

### DIFF
--- a/src/Components/Aspire.Confluent.Kafka/AspireKafkaConsumerExtensions.cs
+++ b/src/Components/Aspire.Confluent.Kafka/AspireKafkaConsumerExtensions.cs
@@ -137,8 +137,8 @@ public static class AspireKafkaConsumerExtensions
                 ? ConfluentKafkaCommon.ConsumerHealthCheckName
                 : string.Concat(ConfluentKafkaCommon.KeyedConsumerHealthCheckName, connectionName);
 
-            builder.TryAddHealthCheck(new HealthCheckRegistration(healthCheckName,
-                sp =>
+            builder.Services.TryAddKeyedSingleton<KafkaHealthCheck>(healthCheckName,
+                (sp, _) =>
                 {
                     var connectionFactory = serviceKey is null
                         ? sp.GetRequiredService<ConsumerConnectionFactory<TKey, TValue>>()
@@ -150,7 +150,10 @@ public static class AspireKafkaConsumerExtensions
                     options.Configuration.MessageTimeoutMs = 1000;
                     options.Configuration.StatisticsIntervalMs = 0;
                     return new KafkaHealthCheck(options);
-                },
+                });
+
+            builder.TryAddHealthCheck(new HealthCheckRegistration(healthCheckName,
+                sp => sp.GetRequiredKeyedService<KafkaHealthCheck>(healthCheckName),
                 failureStatus: default,
                 tags: default));
         }

--- a/src/Components/Aspire.Confluent.Kafka/AspireKafkaProducerExtensions.cs
+++ b/src/Components/Aspire.Confluent.Kafka/AspireKafkaProducerExtensions.cs
@@ -137,8 +137,8 @@ public static class AspireKafkaProducerExtensions
                 ? ConfluentKafkaCommon.ProducerHealthCheckName
                 : string.Concat(ConfluentKafkaCommon.KeyedProducerHealthCheckName, connectionName);
 
-            builder.TryAddHealthCheck(new HealthCheckRegistration(healthCheckName,
-                sp =>
+            builder.Services.TryAddKeyedSingleton<KafkaHealthCheck>(healthCheckName,
+                (sp, _) =>
                 {
                     var connectionFactory = serviceKey is null
                         ? sp.GetRequiredService<ProducerConnectionFactory<TKey, TValue>>()
@@ -150,7 +150,10 @@ public static class AspireKafkaProducerExtensions
                     options.Configuration.MessageTimeoutMs = 1000;
                     options.Configuration.StatisticsIntervalMs = 0;
                     return new KafkaHealthCheck(options);
-                },
+                });
+
+            builder.TryAddHealthCheck(new HealthCheckRegistration(healthCheckName,
+                sp => sp.GetRequiredKeyedService<KafkaHealthCheck>(healthCheckName),
                 failureStatus: default,
                 tags: default));
         }


### PR DESCRIPTION
## Description

This PR addresses a memory leak in the `Aspire.Confluent.Kafka` component caused by the creation of a new KafkaHealthCheck instance on each health check execution and the lack of proper disposal. The fix ensures that KafkaHealthCheck is registered as a singleton in the `ServiceCollection`, allowing reuse of the same instance for health checks. This change prevents unnecessary object creation and ensures proper resource management by allowing disposal of the KafkaHealthCheck instance when needed.

Fixes #6035 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6051)