### PR TITLE
Update to the latest Azure.Provisioning version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <TestcontainersPackageVersion>3.10.0</TestcontainersPackageVersion>
-    <AzureProvisiongVersion>1.0.0-alpha.20240918.3</AzureProvisiongVersion>
+    <AzureProvisiongVersion>1.0.0-alpha.20240930.1</AzureProvisiongVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- AWS SDK for .NET dependencies -->
@@ -40,13 +40,13 @@
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.Provisioning" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20240918.1" />
+    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20240927.4" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20240927.4" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20240912.5" />
     <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.EventHubs" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.KeyVault" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20240918.1" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20240927.4" />
     <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Redis" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Search" Version="$(AzureProvisiongVersion)" />
@@ -57,6 +57,7 @@
     <PackageVersion Include="Azure.Provisioning.WebPubSub" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.3" />
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.3.0" />
+    <PackageVersion Include="Azure.ResourceManager.Resources" Version="1.9.0" />
     <!-- ASP.NET Core dependencies -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Certificate" Version="$(MicrosoftAspNetCoreAuthenticationCertificatePackageVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion)" />

--- a/playground/AspireEventHub/EventHubs.AppHost/ehstorage.module.bicep
+++ b/playground/AspireEventHub/EventHubs.AppHost/ehstorage.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource ehstorage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource ehstorage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: take('ehstorage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -25,7 +25,7 @@ resource ehstorage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
   name: 'default'
   parent: ehstorage
 }

--- a/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
+++ b/playground/AspireEventHub/EventHubs.AppHost/eventhubns.module.bicep
@@ -7,7 +7,7 @@ param principalId string
 
 param principalType string
 
-resource eventhubns 'Microsoft.EventHub/namespaces@2017-04-01' = {
+resource eventhubns 'Microsoft.EventHub/namespaces@2024-01-01' = {
   name: take('eventhubns-${uniqueString(resourceGroup().id)}', 256)
   location: location
   sku: {

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/account.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/account.module.bicep
@@ -3,11 +3,11 @@ param location string = resourceGroup().location
 
 param keyVaultName string
 
-resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-resource account 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
+resource account 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
   name: take('account-${uniqueString(resourceGroup().id)}', 44)
   location: location
   properties: {
@@ -28,7 +28,7 @@ resource account 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
   }
 }
 
-resource db 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15-preview' = {
+resource db 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
   name: 'db'
   location: location
   properties: {
@@ -39,7 +39,7 @@ resource db 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15-previ
   parent: account
 }
 
-resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'connectionString'
   properties: {
     value: 'AccountEndpoint=${account.properties.documentEndpoint};AccountKey=${account.listKeys().primaryMasterKey}'

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/api.module.bicep
@@ -20,11 +20,11 @@ param outputs_azure_container_registry_endpoint string
 
 param api_containerimage string
 
-resource account_secretoutputs_kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+resource account_secretoutputs_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: account_secretoutputs
 }
 
-resource account_secretoutputs_kv_connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' existing = {
+resource account_secretoutputs_kv_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
   name: 'connectionString'
   parent: account_secretoutputs_kv
 }

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/storage.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/storage.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -25,7 +25,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
   name: 'default'
   parent: storage
 }

--- a/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/storage.module.bicep
+++ b/playground/AzureStorageEndToEnd/AzureStorageEndToEnd.AppHost/storage.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -25,7 +25,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
   name: 'default'
   parent: storage
 }

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
@@ -3,11 +3,11 @@ param location string = resourceGroup().location
 
 param keyVaultName string
 
-resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
+resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
   name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
   location: location
   properties: {
@@ -28,7 +28,7 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
   }
 }
 
-resource db 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15-preview' = {
+resource db 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
   name: 'db'
   location: location
   properties: {
@@ -39,7 +39,7 @@ resource db 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15-previ
   parent: cosmos
 }
 
-resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'connectionString'
   properties: {
     value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'

--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource openai 'Microsoft.CognitiveServices/accounts@2022-12-01' = {
+resource openai 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
   name: take('openai-${uniqueString(resourceGroup().id)}', 64)
   location: location
   kind: 'OpenAI'
@@ -32,7 +32,7 @@ resource openai_CognitiveServicesOpenAIContributor 'Microsoft.Authorization/role
   scope: openai
 }
 
-resource gpt-4o 'Microsoft.CognitiveServices/accounts/deployments@2022-12-01' = {
+resource gpt-4o 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
   name: 'gpt-4o'
   properties: {
     model: {

--- a/playground/bicep/BicepSample.AppHost/appConfig.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/appConfig.module.bicep
@@ -7,7 +7,7 @@ param principalType string
 
 param sku string
 
-resource appConfig 'Microsoft.AppConfiguration/configurationStores@2019-10-01' = {
+resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' = {
   name: take('appConfig-${uniqueString(resourceGroup().id)}', 50)
   location: location
   properties: {

--- a/playground/bicep/BicepSample.AppHost/cosmos.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/cosmos.module.bicep
@@ -3,11 +3,11 @@ param location string = resourceGroup().location
 
 param keyVaultName string
 
-resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
+resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
   name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
   location: location
   properties: {
@@ -28,7 +28,7 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
   }
 }
 
-resource db3 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15-preview' = {
+resource db3 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
   name: 'db3'
   location: location
   properties: {
@@ -39,7 +39,7 @@ resource db3 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15-prev
   parent: cosmos
 }
 
-resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'connectionString'
   properties: {
     value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'

--- a/playground/bicep/BicepSample.AppHost/kv3.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/kv3.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource kv3 'Microsoft.KeyVault/vaults@2019-09-01' = {
+resource kv3 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: take('kv3-${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {

--- a/playground/bicep/BicepSample.AppHost/lawkspc.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/lawkspc.module.bicep
@@ -1,7 +1,7 @@
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource lawkspc 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource lawkspc 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: take('lawkspc-${uniqueString(resourceGroup().id)}', 63)
   location: location
   properties: {

--- a/playground/bicep/BicepSample.AppHost/postgres2.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/postgres2.module.bicep
@@ -8,7 +8,7 @@ param administratorLoginPassword string
 
 param keyVaultName string
 
-resource postgres2 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+resource postgres2 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('postgres${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -40,7 +40,7 @@ resource postgres2 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
   }
 }
 
-resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
   name: 'AllowAllAzureIps'
   properties: {
     endIpAddress: '0.0.0.0'
@@ -49,16 +49,16 @@ resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flex
   parent: postgres2
 }
 
-resource db2 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2022-12-01' = {
+resource db2 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
   name: 'db2'
   parent: postgres2
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'connectionString'
   properties: {
     value: 'Host=${postgres2.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'

--- a/playground/bicep/BicepSample.AppHost/sb.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/sb.module.bicep
@@ -7,7 +7,7 @@ param principalId string
 
 param principalType string
 
-resource sb 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
+resource sb 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
   name: take('sb-${uniqueString(resourceGroup().id)}', 50)
   location: location
   properties: {

--- a/playground/bicep/BicepSample.AppHost/signalr.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/signalr.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource signalr 'Microsoft.SignalRService/signalR@2022-02-01' = {
+resource signalr 'Microsoft.SignalRService/signalR@2024-03-01' = {
   name: take('signalr-${uniqueString(resourceGroup().id)}', 63)
   location: location
   properties: {

--- a/playground/bicep/BicepSample.AppHost/storage.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/storage.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -25,7 +25,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
   name: 'default'
   parent: storage
 }

--- a/playground/bicep/BicepSample.AppHost/wps.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/wps.module.bicep
@@ -9,7 +9,7 @@ param principalId string
 
 param principalType string
 
-resource wps 'Microsoft.SignalRService/webPubSub@2021-10-01' = {
+resource wps 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps-${uniqueString(resourceGroup().id)}', 63)
   location: location
   sku: {

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -17,8 +17,8 @@ var sku = builder.AddParameter("storagesku");
 var locationOverride = builder.AddParameter("locationOverride");
 var storage = builder.AddAzureStorage("storage", (_, construct, account) =>
 {
-    account.Sku = new StorageSku() { Name = sku.AsBicepParameter(construct) };
-    account.Location = locationOverride.AsBicepParameter(construct);
+    account.Sku = new StorageSku() { Name = sku.AsProvisioningParameter(construct) };
+    account.Location = locationOverride.AsProvisioningParameter(construct);
 });
 
 var blobs = storage.AddBlobs("blobs");
@@ -32,7 +32,7 @@ var keyvault = builder.AddAzureKeyVault("mykv", (_, construct, keyVault) =>
     {
         Parent = keyVault,
         Name = "mysecret",
-        Properties = new SecretProperties { Value = signaturesecret.AsBicepParameter(construct) }
+        Properties = new SecretProperties { Value = signaturesecret.AsProvisioningParameter(construct) }
     };
     construct.Add(secret);
 });

--- a/playground/cdk/CdkSample.AppHost/appConfig.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/appConfig.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource appConfig 'Microsoft.AppConfiguration/configurationStores@2019-10-01' = {
+resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' = {
   name: take('appConfig-${uniqueString(resourceGroup().id)}', 50)
   location: location
   properties: {

--- a/playground/cdk/CdkSample.AppHost/cosmos.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/cosmos.module.bicep
@@ -3,11 +3,11 @@ param location string = resourceGroup().location
 
 param keyVaultName string
 
-resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
+resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
   name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
   location: location
   properties: {
@@ -28,7 +28,7 @@ resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
   }
 }
 
-resource cosmosdb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15-preview' = {
+resource cosmosdb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
   name: 'cosmosdb'
   location: location
   properties: {
@@ -39,7 +39,7 @@ resource cosmosdb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15
   parent: cosmos
 }
 
-resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'connectionString'
   properties: {
     value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'

--- a/playground/cdk/CdkSample.AppHost/logAnalyticsWorkspace.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/logAnalyticsWorkspace.module.bicep
@@ -1,7 +1,7 @@
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: take('logAnalyticsWorkspace-${uniqueString(resourceGroup().id)}', 63)
   location: location
   properties: {

--- a/playground/cdk/CdkSample.AppHost/mykv.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/mykv.module.bicep
@@ -8,7 +8,7 @@ param principalId string
 
 param principalType string
 
-resource mykv 'Microsoft.KeyVault/vaults@2019-09-01' = {
+resource mykv 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: take('mykv-${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -34,7 +34,7 @@ resource mykv_KeyVaultAdministrator 'Microsoft.Authorization/roleAssignments@202
   scope: mykv
 }
 
-resource mysecret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource mysecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'mysecret'
   properties: {
     value: signaturesecret

--- a/playground/cdk/CdkSample.AppHost/pgsql.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/pgsql.module.bicep
@@ -8,7 +8,7 @@ param administratorLoginPassword string
 
 param keyVaultName string
 
-resource pgsql 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+resource pgsql 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('pgsql${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -40,7 +40,7 @@ resource pgsql 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
   }
 }
 
-resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
   name: 'AllowAllAzureIps'
   properties: {
     endIpAddress: '0.0.0.0'
@@ -49,16 +49,16 @@ resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flex
   parent: pgsql
 }
 
-resource pgsqldb 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2022-12-01' = {
+resource pgsqldb 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
   name: 'pgsqldb'
   parent: pgsql
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'connectionString'
   properties: {
     value: 'Host=${pgsql.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'

--- a/playground/cdk/CdkSample.AppHost/pgsql2.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/pgsql2.module.bicep
@@ -7,7 +7,7 @@ param principalType string
 
 param principalName string
 
-resource pgsql2 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+resource pgsql2 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('pgsql${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -37,7 +37,7 @@ resource pgsql2 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
   }
 }
 
-resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
   name: 'AllowAllAzureIps'
   properties: {
     endIpAddress: '0.0.0.0'
@@ -46,7 +46,7 @@ resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flex
   parent: pgsql2
 }
 
-resource pgsql2_admin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2022-12-01' = {
+resource pgsql2_admin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2024-08-01' = {
   name: principalId
   properties: {
     principalName: principalName

--- a/playground/cdk/CdkSample.AppHost/servicebus.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/servicebus.module.bicep
@@ -7,7 +7,7 @@ param principalId string
 
 param principalType string
 
-resource servicebus 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
+resource servicebus 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
   name: take('servicebus-${uniqueString(resourceGroup().id)}', 50)
   location: location
   properties: {

--- a/playground/cdk/CdkSample.AppHost/signalr.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/signalr.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource signalr 'Microsoft.SignalRService/signalR@2022-02-01' = {
+resource signalr 'Microsoft.SignalRService/signalR@2024-03-01' = {
   name: take('signalr-${uniqueString(resourceGroup().id)}', 63)
   location: location
   properties: {

--- a/playground/cdk/CdkSample.AppHost/storage.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/storage.module.bicep
@@ -9,7 +9,7 @@ param principalId string
 
 param principalType string
 
-resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: locationOverride
@@ -29,7 +29,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
   name: 'default'
   parent: storage
 }

--- a/playground/orleans/Orleans.AppHost/storage.module.bicep
+++ b/playground/orleans/Orleans.AppHost/storage.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
   name: take('storage${uniqueString(resourceGroup().id)}', 24)
   kind: 'StorageV2'
   location: location
@@ -25,7 +25,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
 }
 
-resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
   name: 'default'
   parent: storage
 }

--- a/playground/signalr/SignalR.AppHost/signalr1.module.bicep
+++ b/playground/signalr/SignalR.AppHost/signalr1.module.bicep
@@ -5,7 +5,7 @@ param principalId string
 
 param principalType string
 
-resource signalr1 'Microsoft.SignalRService/signalR@2022-02-01' = {
+resource signalr1 'Microsoft.SignalRService/signalR@2024-03-01' = {
   name: take('signalr1-${uniqueString(resourceGroup().id)}', 63)
   location: location
   properties: {

--- a/playground/waitfor/WaitForSandbox.AppHost/pg.module.bicep
+++ b/playground/waitfor/WaitForSandbox.AppHost/pg.module.bicep
@@ -8,7 +8,7 @@ param administratorLoginPassword string
 
 param keyVaultName string
 
-resource pg 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+resource pg 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: take('pg${uniqueString(resourceGroup().id)}', 24)
   location: location
   properties: {
@@ -40,7 +40,7 @@ resource pg 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
   }
 }
 
-resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
   name: 'AllowAllAzureIps'
   properties: {
     endIpAddress: '0.0.0.0'
@@ -49,16 +49,16 @@ resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flex
   parent: pg
 }
 
-resource db 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2022-12-01' = {
+resource db 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
   name: 'db'
   parent: pg
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'connectionString'
   properties: {
     value: 'Host=${pg.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'

--- a/playground/webpubsub/WebPubSub.AppHost/wps1.module.bicep
+++ b/playground/webpubsub/WebPubSub.AppHost/wps1.module.bicep
@@ -9,7 +9,7 @@ param principalId string
 
 param principalType string
 
-resource wps1 'Microsoft.SignalRService/webPubSub@2021-10-01' = {
+resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
   name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
   location: location
   sku: {

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -49,7 +49,7 @@ public static class AzureAppConfigurationExtensions
             };
             construct.Add(store);
 
-            construct.Add(new BicepOutput("appConfigEndpoint", typeof(string)) { Value = store.Endpoint });
+            construct.Add(new ProvisioningOutput("appConfigEndpoint", typeof(string)) { Value = store.Endpoint });
 
             construct.Add(store.AssignRole(AppConfigurationBuiltInRole.AppConfigurationDataOwner, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
 

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -71,13 +71,13 @@ public static class AzureApplicationInsightsExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var appTypeParameter = new BicepParameter("applicationType", typeof(string))
+            var appTypeParameter = new ProvisioningParameter("applicationType", typeof(string))
             {
                 Value = new StringLiteral("web")
             };
             construct.Add(appTypeParameter);
 
-            var kindParameter = new BicepParameter("kind", typeof(string))
+            var kindParameter = new ProvisioningParameter("kind", typeof(string))
             {
                 Value = new StringLiteral("web")
             };
@@ -94,7 +94,7 @@ public static class AzureApplicationInsightsExtensions
             if (logAnalyticsWorkspace != null)
             {
                 // If someone provides a workspace via the extension method we should use it.
-                appInsights.WorkspaceResourceId = logAnalyticsWorkspace.Resource.WorkspaceId.AsBicepParameter(construct, AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId);
+                appInsights.WorkspaceResourceId = logAnalyticsWorkspace.Resource.WorkspaceId.AsProvisioningParameter(construct, AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId);
             }
             else if (builder.ExecutionContext.IsRunMode)
             {
@@ -119,7 +119,7 @@ public static class AzureApplicationInsightsExtensions
                 // If the user does not supply a log analytics workspace of their own, and we are in publish mode
                 // then we want AZD to provide one to us.
                 construct.Resource.Parameters.TryAdd(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, null);
-                var logAnalyticsWorkspaceParameter = new BicepParameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, typeof(string))
+                var logAnalyticsWorkspaceParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, typeof(string))
                 {
                     Value = new StringLiteral("web")
                 };
@@ -127,7 +127,7 @@ public static class AzureApplicationInsightsExtensions
                 appInsights.WorkspaceResourceId = logAnalyticsWorkspaceParameter;
             }
 
-            construct.Add(new BicepOutput("appInsightsConnectionString", typeof(string)) { Value = appInsights.ConnectionString });
+            construct.Add(new ProvisioningOutput("appInsightsConnectionString", typeof(string)) { Value = appInsights.ConnectionString });
 
             if (configureResource != null)
             {

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -61,7 +61,7 @@ public static class AzureOpenAIExtensions
             };
             construct.Add(cogServicesAccount);
 
-            construct.Add(new BicepOutput("connectionString", typeof(string))
+            construct.Add(new ProvisioningOutput("connectionString", typeof(string))
             {
                 Value = new InterpolatedString(
                         "Endpoint={0}",
@@ -85,9 +85,9 @@ public static class AzureOpenAIExtensions
             var cdkDeployments = new List<CognitiveServicesAccountDeployment>();
             foreach (var deployment in resource.Deployments)
             {
-                var cdkDeployment = new CognitiveServicesAccountDeployment(deployment.Name, cogServicesAccount.ResourceVersion)
+                var cdkDeployment = new CognitiveServicesAccountDeployment(deployment.Name)
                 {
-                    Name = deployment.Name,     
+                    Name = deployment.Name,
                     Parent = cogServicesAccount,
                     Properties = new CognitiveServicesAccountDeploymentProperties()
                     {

--- a/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
@@ -141,7 +141,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                 construct.WriteToManifest(context);
 
                 // We're handling custom resource writing here instead of in the AzureConstructResource
-                // this is because we're tracking the provisioningParameter instances as we process the resource
+                // this is because we're tracking the ProvisioningParameter instances as we process the resource
                 if (Parameters.Count > 0)
                 {
                     context.Writer.WriteStartObject("params");

--- a/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
@@ -141,7 +141,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                 construct.WriteToManifest(context);
 
                 // We're handling custom resource writing here instead of in the AzureConstructResource
-                // this is because we're tracking the ProvisioningParameter instances as we process the resource
+                // this is because we're tracking the provisioningParameter instances as we process the resource
                 if (Parameters.Count > 0)
                 {
                     context.Writer.WriteStartObject("params");
@@ -773,13 +773,13 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                     _allocatedParameters[parameter] = parameterName;
                 }
 
-                if (!_provisioningParameters.TryGetValue(parameterName, out var ProvisioningParameter))
+                if (!_provisioningParameters.TryGetValue(parameterName, out var provisioningParameter))
                 {
-                    _provisioningParameters[parameterName] = ProvisioningParameter = new ProvisioningParameter(parameterName, type ?? typeof(string)) { IsSecure = secretType != SecretType.None };
+                    _provisioningParameters[parameterName] = provisioningParameter = new ProvisioningParameter(parameterName, type ?? typeof(string)) { IsSecure = secretType != SecretType.None };
                 }
 
                 Parameters[parameterName] = parameter;
-                return ProvisioningParameter;
+                return provisioningParameter;
             }
 
             private void AddIngress(ContainerAppConfiguration config)
@@ -935,9 +935,9 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                     {
                         arguments.Add(s);
                     }
-                    else if (argument is ProvisioningParameter ProvisioningParameter)
+                    else if (argument is ProvisioningParameter provisioningParameter)
                     {
-                        arguments.Add(ProvisioningParameter);
+                        arguments.Add(provisioningParameter);
                     }
                     else
                     {

--- a/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.ContainerApps/AzureContanierAppsInfrastructure.cs
@@ -103,7 +103,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
         private sealed class ContainerAppContext(IResource resource, ContainerAppEnviromentContext containerAppEnviromentContext)
         {
             private readonly Dictionary<object, string> _allocatedParameters = [];
-            private readonly Dictionary<string, BicepParameter> _bicepParameters = [];
+            private readonly Dictionary<string, ProvisioningParameter> _provisioningParameters = [];
             private readonly ContainerAppEnviromentContext _containerAppEnviromentContext = containerAppEnviromentContext;
 
             record struct EndpointMapping(string Scheme, string Host, int Port, int? TargetPort, bool IsHttpIngress, bool External);
@@ -113,9 +113,9 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
             private (int? Port, bool Http2, bool External)? _httpIngress;
             private readonly List<int> _additionalPorts = [];
 
-            private BicepParameter? _managedIdentityIdParameter;
-            private BicepParameter? _containerRegistryUrlParameter;
-            private BicepParameter? _containerRegistryManagedIdentityIdParameter;
+            private ProvisioningParameter? _managedIdentityIdParameter;
+            private ProvisioningParameter? _containerRegistryUrlParameter;
+            private ProvisioningParameter? _containerRegistryManagedIdentityIdParameter;
 
             public IResource Resource => resource;
 
@@ -141,7 +141,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                 construct.WriteToManifest(context);
 
                 // We're handling custom resource writing here instead of in the AzureConstructResource
-                // this is because we're tracking the BicepParameter instances as we process the resource
+                // this is because we're tracking the ProvisioningParameter instances as we process the resource
                 if (Parameters.Count > 0)
                 {
                     context.Writer.WriteStartObject("params");
@@ -160,7 +160,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
             {
                 var containerAppIdParam = AllocateParameter(_containerAppEnviromentContext.ContainerAppEnvironmentId);
 
-                BicepParameter? containerImageParam = null;
+                ProvisioningParameter? containerImageParam = null;
 
                 if (!resource.TryGetContainerImageName(out var containerImageName))
                 {
@@ -217,7 +217,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                 }
 
                 // Add parameters to the construct
-                foreach (var (_, parameter) in _bicepParameters)
+                foreach (var (_, parameter) in _provisioningParameters)
                 {
                     c.Add(parameter);
                 }
@@ -539,7 +539,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                     BicepValue<string> s => s,
                     string s => s,
                     BicepValueFormattableString fs => Interpolate(fs),
-                    BicepParameter p => p,
+                    ProvisioningParameter p => p,
                     _ => throw new NotSupportedException("Unsupported value type " + val.GetType())
                 };
             }
@@ -712,7 +712,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                 throw new NotSupportedException("Unsupported value type " + value.GetType());
             }
 
-            private BicepParameter AllocateVolumeStorageAccount(ContainerMountType type, string volumeIndex) =>
+            private ProvisioningParameter AllocateVolumeStorageAccount(ContainerMountType type, string volumeIndex) =>
                 AllocateParameter(VolumeStorageExpression.GetVolumeStorage(resource, type, volumeIndex));
 
             private BicepValue<string> AllocateKeyVaultSecretUriReference(BicepSecretOutputReference secretOutputReference)
@@ -744,13 +744,13 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                             "secretUri");
             }
 
-            private BicepParameter AllocateContainerImageParameter()
+            private ProvisioningParameter AllocateContainerImageParameter()
                 => AllocateParameter(ProjectResourceExpression.GetContainerImageExpression((ProjectResource)resource));
 
             private BicepValue<int> AllocateContainerPortParameter()
                 => AllocateParameter(ProjectResourceExpression.GetContainerPortExpression((ProjectResource)resource));
 
-            private BicepParameter AllocateManagedIdentityIdParameter()
+            private ProvisioningParameter AllocateManagedIdentityIdParameter()
                 => _managedIdentityIdParameter ??= AllocateParameter(_containerAppEnviromentContext.ManagedIdentityId);
 
             private void AllocateContainerRegistryParameters()
@@ -759,7 +759,7 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                 _containerRegistryManagedIdentityIdParameter ??= AllocateParameter(_containerAppEnviromentContext.ContainerRegistryManagedIdentityId);
             }
 
-            private BicepParameter AllocateParameter(IManifestExpressionProvider parameter, Type? type = null, SecretType secretType = SecretType.None)
+            private ProvisioningParameter AllocateParameter(IManifestExpressionProvider parameter, Type? type = null, SecretType secretType = SecretType.None)
             {
                 if (!_allocatedParameters.TryGetValue(parameter, out var parameterName))
                 {
@@ -773,13 +773,13 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                     _allocatedParameters[parameter] = parameterName;
                 }
 
-                if (!_bicepParameters.TryGetValue(parameterName, out var bicepParameter))
+                if (!_provisioningParameters.TryGetValue(parameterName, out var ProvisioningParameter))
                 {
-                    _bicepParameters[parameterName] = bicepParameter = new BicepParameter(parameterName, type ?? typeof(string)) { IsSecure = secretType != SecretType.None };
+                    _provisioningParameters[parameterName] = ProvisioningParameter = new ProvisioningParameter(parameterName, type ?? typeof(string)) { IsSecure = secretType != SecretType.None };
                 }
 
                 Parameters[parameterName] = parameter;
-                return bicepParameter;
+                return ProvisioningParameter;
             }
 
             private void AddIngress(ContainerAppConfiguration config)
@@ -935,9 +935,9 @@ internal sealed class AzureContainerAppsInfastructure(ILogger<AzureContainerApps
                     {
                         arguments.Add(s);
                     }
-                    else if (argument is BicepParameter bicepParameter)
+                    else if (argument is ProvisioningParameter ProvisioningParameter)
                     {
-                        arguments.Add(bicepParameter);
+                        arguments.Add(ProvisioningParameter);
                     }
                     else
                     {

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -48,7 +48,7 @@ public static class AzureCosmosExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var kvNameParam = new BicepParameter("keyVaultName", typeof(string));
+            var kvNameParam = new ProvisioningParameter("keyVaultName", typeof(string));
             construct.Add(kvNameParam);
 
             var keyVault = KeyVaultService.FromExisting("keyVault");
@@ -80,7 +80,7 @@ public static class AzureCosmosExtensions
             List<CosmosDBSqlDatabase> cosmosSqlDatabases = new List<CosmosDBSqlDatabase>();
             foreach (var databaseName in azureResource.Databases)
             {
-                var cosmosSqlDatabase = new CosmosDBSqlDatabase(databaseName, cosmosAccount.ResourceVersion)
+                var cosmosSqlDatabase = new CosmosDBSqlDatabase(databaseName)
                 {
                     Parent = cosmosAccount,
                     Name = databaseName,

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -47,7 +47,7 @@ public static class AzureEventHubsExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var skuParameter = new BicepParameter("sku", typeof(string))
+            var skuParameter = new ProvisioningParameter("sku", typeof(string))
             {
                 Value = new StringLiteral("Standard")
             };
@@ -65,7 +65,7 @@ public static class AzureEventHubsExtensions
 
             construct.Add(eventHubsNamespace.AssignRole(EventHubsBuiltInRole.AzureEventHubsDataOwner, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
 
-            construct.Add(new BicepOutput("eventHubsEndpoint", typeof(string)) { Value = eventHubsNamespace.ServiceBusEndpoint });
+            construct.Add(new ProvisioningOutput("eventHubsEndpoint", typeof(string)) { Value = eventHubsNamespace.ServiceBusEndpoint });
 
             var azureResource = (AzureEventHubsResource)construct.Resource;
             var azureResourceBuilder = builder.CreateResourceBuilder(azureResource);

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -57,7 +57,7 @@ public static class AzureKeyVaultResourceExtensions
             };
             construct.Add(keyVault);
 
-            construct.Add(new BicepOutput("vaultUri", typeof(string))
+            construct.Add(new ProvisioningOutput("vaultUri", typeof(string))
             {
                 Value =
                     new MemberExpression(

--- a/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
@@ -51,7 +51,7 @@ public static class AzureLogAnalyticsWorkspaceExtensions
             };
             construct.Add(workspace);
 
-            construct.Add(new BicepOutput("logAnalyticsWorkspaceId", typeof(string))
+            construct.Add(new ProvisioningOutput("logAnalyticsWorkspaceId", typeof(string))
             {
                 Value = workspace.Id
             });

--- a/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceResource.cs
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceResource.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Hosting.Azure;

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -41,13 +41,13 @@ public static class AzurePostgresExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var administratorLogin = new BicepParameter("administratorLogin", typeof(string));
+            var administratorLogin = new ProvisioningParameter("administratorLogin", typeof(string));
             construct.Add(administratorLogin);
 
-            var administratorLoginPassword = new BicepParameter("administratorLoginPassword", typeof(string)) { IsSecure = true };
+            var administratorLoginPassword = new ProvisioningParameter("administratorLoginPassword", typeof(string)) { IsSecure = true };
             construct.Add(administratorLoginPassword);
 
-            var kvNameParam = new BicepParameter("keyVaultName", typeof(string));
+            var kvNameParam = new ProvisioningParameter("keyVaultName", typeof(string));
             construct.Add(kvNameParam);
 
             var keyVault = KeyVaultService.FromExisting("keyVault");
@@ -195,7 +195,7 @@ public static class AzurePostgresExtensions
                 PasswordAuth = PostgreSqlFlexibleServerPasswordAuthEnum.Disabled
             };
 
-            var admin = new PostgreSqlFlexibleServerActiveDirectoryAdministrator($"{azureResource.Name}_admin", postgres.ResourceVersion)
+            var admin = new PostgreSqlFlexibleServerActiveDirectoryAdministrator($"{azureResource.Name}_admin")
             {
                 Parent = postgres,
                 Name = construct.PrincipalIdParameter,
@@ -211,7 +211,7 @@ public static class AzurePostgresExtensions
             }
             construct.Add(admin);
 
-            construct.Add(new BicepOutput("connectionString", typeof(string))
+            construct.Add(new ProvisioningOutput("connectionString", typeof(string))
             {
                 Value = BicepFunction.Interpolate($"Host={postgres.FullyQualifiedDomainName};Username={construct.PrincipalNameParameter}")
             });
@@ -386,13 +386,13 @@ public static class AzurePostgresExtensions
                 var postgres = construct.GetResources().OfType<PostgreSqlFlexibleServer>().FirstOrDefault(r => r.ResourceName == builder.Resource.Name)
                     ?? throw new InvalidOperationException($"Could not find a PostgreSqlFlexibleServer with name {builder.Resource.Name}.");
 
-                var administratorLogin = new BicepParameter("administratorLogin", typeof(string));
+                var administratorLogin = new ProvisioningParameter("administratorLogin", typeof(string));
                 construct.Add(administratorLogin);
 
-                var administratorLoginPassword = new BicepParameter("administratorLoginPassword", typeof(string)) { IsSecure = true };
+                var administratorLoginPassword = new ProvisioningParameter("administratorLoginPassword", typeof(string)) { IsSecure = true };
                 construct.Add(administratorLoginPassword);
 
-                var kvNameParam = new BicepParameter("keyVaultName", typeof(string));
+                var kvNameParam = new ProvisioningParameter("keyVaultName", typeof(string));
                 construct.Add(kvNameParam);
 
                 var keyVault = KeyVaultService.FromExisting("keyVault");
@@ -447,7 +447,7 @@ public static class AzurePostgresExtensions
         construct.Add(postgres);
 
         // Opens access to all Azure services.
-        construct.Add(new PostgreSqlFlexibleServerFirewallRule("postgreSqlFirewallRule_AllowAllAzureIps", postgres.ResourceVersion)
+        construct.Add(new PostgreSqlFlexibleServerFirewallRule("postgreSqlFirewallRule_AllowAllAzureIps")
         {
             Parent = postgres,
             Name = "AllowAllAzureIps",
@@ -458,7 +458,7 @@ public static class AzurePostgresExtensions
         if (distributedApplicationBuilder.ExecutionContext.IsRunMode)
         {
             // Opens access to the Internet.
-            construct.Add(new PostgreSqlFlexibleServerFirewallRule("postgreSqlFirewallRule_AllowAllIps", postgres.ResourceVersion)
+            construct.Add(new PostgreSqlFlexibleServerFirewallRule("postgreSqlFirewallRule_AllowAllIps")
             {
                 Parent = postgres,
                 Name = "AllowAllIps",
@@ -471,7 +471,7 @@ public static class AzurePostgresExtensions
         {
             var resourceName = databaseNames.Key;
             var databaseName = databaseNames.Value;
-            var pgsqlDatabase = new PostgreSqlFlexibleServerDatabase(resourceName, postgres.ResourceVersion)
+            var pgsqlDatabase = new PostgreSqlFlexibleServerDatabase(resourceName)
             {
                 Parent = postgres,
                 Name = databaseName
@@ -500,7 +500,7 @@ public static class AzurePostgresExtensions
             {
                 resourcesToRemove.Add(resource);
             }
-            else if (resource is BicepOutput output && output.ResourceName == "connectionString")
+            else if (resource is ProvisioningOutput output && output.ResourceName == "connectionString")
             {
                 resourcesToRemove.Add(resource);
             }

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -52,7 +52,7 @@ public static class AzureRedisExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var kvNameParam = new BicepParameter("keyVaultName", typeof(string));
+            var kvNameParam = new ProvisioningParameter("keyVaultName", typeof(string));
             construct.Add(kvNameParam);
 
             var keyVault = KeyVaultService.FromExisting("keyVault");
@@ -167,7 +167,7 @@ public static class AzureRedisExtensions
             var disableAccessKeys = BicepValue<string>.DefineProperty(redis, "DisableAccessKeyAuthentication", ["properties", "disableAccessKeyAuthentication"], isOutput: false, isRequired: false);
             disableAccessKeys.Assign("true");
 
-            construct.Add(new RedisCacheAccessPolicyAssignment($"{redis.ResourceName}_contributor", redis.ResourceVersion)
+            construct.Add(new RedisCacheAccessPolicyAssignment($"{redis.ResourceName}_contributor")
             {
                 Parent = redis,
                 AccessPolicyName = "Data Contributor",
@@ -175,7 +175,7 @@ public static class AzureRedisExtensions
                 ObjectIdAlias = construct.PrincipalNameParameter
             });
 
-            construct.Add(new BicepOutput("connectionString", typeof(string))
+            construct.Add(new ProvisioningOutput("connectionString", typeof(string))
             {
                 Value = BicepFunction.Interpolate($"{redis.HostName},ssl=true")
             });
@@ -267,7 +267,7 @@ public static class AzureRedisExtensions
                var redis = construct.GetResources().OfType<CdkRedisResource>().FirstOrDefault(r => r.ResourceName == builder.Resource.Name)
                    ?? throw new InvalidOperationException($"Could not find a RedisResource with name {builder.Resource.Name}.");
 
-               var kvNameParam = new BicepParameter("keyVaultName", typeof(string));
+               var kvNameParam = new ProvisioningParameter("keyVaultName", typeof(string));
                construct.Add(kvNameParam);
 
                var keyVault = KeyVaultService.FromExisting("keyVault");
@@ -295,7 +295,7 @@ public static class AzureRedisExtensions
 
     private static CdkRedisResource CreateRedisResource(ResourceModuleConstruct construct)
     {
-        var redisCache = new CdkRedisResource(construct.Resource.Name, "2024-03-01") // TODO: resource version should come from CDK
+        var redisCache = new CdkRedisResource(construct.Resource.Name)
         {
             Sku = new RedisSku()
             {
@@ -330,7 +330,7 @@ public static class AzureRedisExtensions
             {
                 resourcesToRemove.Add(resource);
             }
-            else if (resource is BicepOutput output && output.ResourceName == "connectionString")
+            else if (resource is ProvisioningOutput output && output.ResourceName == "connectionString")
             {
                 resourcesToRemove.Add(resource);
             }

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -67,7 +67,7 @@ public static class AzureSearchExtensions
             // TODO: The endpoint format should move into the CDK so we can maintain this
             // logic in a single location and have a better chance at supporting more than
             // just public Azure in the future.  https://github.com/Azure/azure-sdk-for-net/issues/42640
-            construct.Add(new BicepOutput("connectionString", typeof(string))
+            construct.Add(new ProvisioningOutput("connectionString", typeof(string))
             {
                 Value = BicepFunction.Interpolate($"Endpoint=https://{search.Name}.search.windows.net")
             });

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -42,7 +42,7 @@ public static class AzureServiceBusExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var skuParameter = new BicepParameter("sku", typeof(string))
+            var skuParameter = new ProvisioningParameter("sku", typeof(string))
             {
                 Value = new StringLiteral("Standard")
             };
@@ -61,7 +61,7 @@ public static class AzureServiceBusExtensions
 
             construct.Add(serviceBusNamespace.AssignRole(ServiceBusBuiltInRole.AzureServiceBusDataOwner, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
 
-            construct.Add(new BicepOutput("serviceBusEndpoint", typeof(string)) { Value = serviceBusNamespace.ServiceBusEndpoint });
+            construct.Add(new ProvisioningOutput("serviceBusEndpoint", typeof(string)) { Value = serviceBusNamespace.ServiceBusEndpoint });
 
             var azureResource = (AzureServiceBusResource)construct.Resource;
             var azureResourceBuilder = builder.CreateResourceBuilder(azureResource);

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -41,7 +41,7 @@ public static class AzureSignalRExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var service = new SignalRService(name, "2022-02-01") // TODO: resource version should come from CDK
+            var service = new SignalRService(name)
             {
                 Kind = SignalRServiceKind.SignalR,
                 Sku = new SignalRResourceSku()
@@ -62,7 +62,7 @@ public static class AzureSignalRExtensions
             };
             construct.Add(service);
 
-            construct.Add(new BicepOutput("hostName", typeof(string)) { Value = service.HostName });
+            construct.Add(new ProvisioningOutput("hostName", typeof(string)) { Value = service.HostName });
 
             construct.Add(service.AssignRole(SignalRBuiltInRole.SignalRAppServer, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
 

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -40,7 +40,7 @@ public static class AzureSqlExtensions
             };
             construct.Add(sqlServer);
 
-            construct.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllAzureIps", sqlServer.ResourceVersion)
+            construct.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllAzureIps")
             {
                 Parent = sqlServer,
                 Name = "AllowAllAzureIps",
@@ -54,7 +54,7 @@ public static class AzureSqlExtensions
                 // the principalType.
                 sqlServer.Administrators.Value!.PrincipalType = construct.PrincipalTypeParameter;
 
-                construct.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllIps", sqlServer.ResourceVersion)
+                construct.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllIps")
                 {
                     Parent = sqlServer,
                     Name = "AllowAllIps",
@@ -68,7 +68,7 @@ public static class AzureSqlExtensions
             {
                 var resourceName = databaseNames.Key;
                 var databaseName = databaseNames.Value;
-                var sqlDatabase = new SqlDatabase(resourceName, sqlServer.ResourceVersion)
+                var sqlDatabase = new SqlDatabase(resourceName)
                 {
                     Parent = sqlServer,
                     Name = databaseName
@@ -77,7 +77,7 @@ public static class AzureSqlExtensions
                 sqlDatabases.Add(sqlDatabase);
             }
 
-            construct.Add(new BicepOutput("sqlServerFqdn", typeof(string)) { Value = sqlServer.FullyQualifiedDomainName });
+            construct.Add(new ProvisioningOutput("sqlServerFqdn", typeof(string)) { Value = sqlServer.FullyQualifiedDomainName });
 
             var resource = (AzureSqlServerResource)construct.Resource;
             var resourceBuilder = builder.ApplicationBuilder.CreateResourceBuilder(resource);

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -75,9 +75,9 @@ public static class AzureStorageExtensions
             construct.Add(storageAccount.AssignRole(StorageBuiltInRole.StorageTableDataContributor, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
             construct.Add(storageAccount.AssignRole(StorageBuiltInRole.StorageQueueDataContributor, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
 
-            construct.Add(new BicepOutput("blobEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.Value!.BlobUri });
-            construct.Add(new BicepOutput("queueEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.Value!.QueueUri });
-            construct.Add(new BicepOutput("tableEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.Value!.TableUri });
+            construct.Add(new ProvisioningOutput("blobEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.Value!.BlobUri });
+            construct.Add(new ProvisioningOutput("queueEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.Value!.QueueUri });
+            construct.Add(new ProvisioningOutput("tableEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.Value!.TableUri });
 
             var resource = (AzureStorageResource)construct.Resource;
             var resourceBuilder = builder.CreateResourceBuilder(resource);

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -43,20 +43,20 @@ public static class AzureWebPubSubExtensions
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             // Supported values are Free_F1 Standard_S1 Premium_P1
-            var skuParameter = new BicepParameter("sku", typeof(string))
+            var skuParameter = new ProvisioningParameter("sku", typeof(string))
             {
                 Value = new StringLiteral("Free_F1")
             };
             construct.Add(skuParameter);
 
             // Supported values are 1 2 5 10 20 50 100
-            var capacityParameter = new BicepParameter("capacity", typeof(int))
+            var capacityParameter = new ProvisioningParameter("capacity", typeof(int))
             {
                 Value = new BicepValue<int>(1)
             };
             construct.Add(capacityParameter);
 
-            var service = new WebPubSubService(name, "2021-10-01") // TODO: resource version should come from CDK
+            var service = new WebPubSubService(name)
             {
                 Sku = new BillingInfoSku()
                 {
@@ -67,7 +67,7 @@ public static class AzureWebPubSubExtensions
             };
             construct.Add(service);
 
-            construct.Add(new BicepOutput("endpoint", typeof(string)) { Value = BicepFunction.Interpolate($"https://{service.HostName}") });
+            construct.Add(new ProvisioningOutput("endpoint", typeof(string)) { Value = BicepFunction.Interpolate($"https://{service.HostName}") });
 
             construct.Add(service.AssignRole(WebPubSubBuiltInRole.WebPubSubServiceOwner, construct.PrincipalTypeParameter, construct.PrincipalIdParameter));
 

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Azure.Provisioning.KeyVault" />
     <PackageReference Include="Azure.ResourceManager.Authorization" />
     <PackageReference Include="Azure.ResourceManager.KeyVault" />
+    <PackageReference Include="Azure.ResourceManager.Resources" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" />
   </ItemGroup>

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -54,7 +54,7 @@ public class AzureConstructResource(string name, Action<ResourceModuleConstruct>
             }
 
             var isSecure = aspireParameter.Value is ParameterResource { Secret: true } || aspireParameter.Value is BicepSecretOutputReference;
-            var constructParameter = new BicepParameter(aspireParameter.Key, typeof(string)) { IsSecure = isSecure };
+            var constructParameter = new ProvisioningParameter(aspireParameter.Key, typeof(string)) { IsSecure = isSecure };
             resourceModuleConstruct.Add(constructParameter);
         }
 
@@ -127,24 +127,24 @@ public static class AzureConstructResourceExtensions
     }
 
     /// <summary>
-    /// Creates a new <see cref="BicepParameter"/> in <paramref name="construct"/>, or reuses an existing bicep parameter if one with
+    /// Creates a new <see cref="ProvisioningParameter"/> in <paramref name="construct"/>, or reuses an existing bicep parameter if one with
     /// the same name already exists, that corresponds to <paramref name="parameterResourceBuilder"/>.
     /// </summary>
     /// <param name="parameterResourceBuilder">
     /// The <see cref="IResourceBuilder{ParameterResource}"/> that represents a parameter in the <see cref="Aspire.Hosting.ApplicationModel" />
-    /// to get or create a corresponding <see cref="BicepParameter"/>.
+    /// to get or create a corresponding <see cref="ProvisioningParameter"/>.
     /// </param>
-    /// <param name="construct">The <see cref="ResourceModuleConstruct"/> that contains the <see cref="BicepParameter"/>.</param>
+    /// <param name="construct">The <see cref="ResourceModuleConstruct"/> that contains the <see cref="ProvisioningParameter"/>.</param>
     /// <param name="parameterName">The name of the parameter to be assigned.</param>
     /// <returns>
-    /// The corresponding <see cref="BicepParameter"/> that was found or newly created.
+    /// The corresponding <see cref="ProvisioningParameter"/> that was found or newly created.
     /// </returns>
     /// <remarks>
     /// This is useful when assigning a <see cref="BicepValue"/> to the value of an Aspire <see cref="ParameterResource"/>.
     /// </remarks>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters",
         Justification = "The 'this' arguments are mutually exclusive")]
-    public static BicepParameter AsBicepParameter(this IResourceBuilder<ParameterResource> parameterResourceBuilder, ResourceModuleConstruct construct, string? parameterName = null)
+    public static ProvisioningParameter AsProvisioningParameter(this IResourceBuilder<ParameterResource> parameterResourceBuilder, ResourceModuleConstruct construct, string? parameterName = null)
     {
         ArgumentNullException.ThrowIfNull(parameterResourceBuilder);
         ArgumentNullException.ThrowIfNull(construct);
@@ -156,7 +156,7 @@ public static class AzureConstructResourceExtensions
         var parameter = construct.GetParameters().FirstOrDefault(p => p.ResourceName == parameterName);
         if (parameter is null)
         {
-            parameter = new BicepParameter(parameterName, typeof(string))
+            parameter = new ProvisioningParameter(parameterName, typeof(string))
             {
                 IsSecure = parameterResourceBuilder.Resource.Secret
             };
@@ -167,23 +167,23 @@ public static class AzureConstructResourceExtensions
     }
 
     /// <summary>
-    /// Creates a new <see cref="BicepParameter"/> in <paramref name="construct"/>, or reuses an existing bicep parameter if one with
+    /// Creates a new <see cref="ProvisioningParameter"/> in <paramref name="construct"/>, or reuses an existing bicep parameter if one with
     /// the same name already exists, that corresponds to <paramref name="outputReference"/>.
     /// </summary>
     /// <param name="outputReference">
-    /// The <see cref="BicepOutputReference"/> that contains the value to use for the <see cref="BicepParameter"/>.
+    /// The <see cref="BicepOutputReference"/> that contains the value to use for the <see cref="ProvisioningParameter"/>.
     /// </param>
-    /// <param name="construct">The <see cref="ResourceModuleConstruct"/> that contains the <see cref="BicepParameter"/>.</param>
+    /// <param name="construct">The <see cref="ResourceModuleConstruct"/> that contains the <see cref="ProvisioningParameter"/>.</param>
     /// <param name="parameterName">The name of the parameter to be assigned.</param>
     /// <returns>
-    /// The corresponding <see cref="BicepParameter"/> that was found or newly created.
+    /// The corresponding <see cref="ProvisioningParameter"/> that was found or newly created.
     /// </returns>
     /// <remarks>
     /// This is useful when assigning a <see cref="BicepValue"/> to the value of an Aspire <see cref="BicepOutputReference"/>.
     /// </remarks>
     [SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters",
         Justification = "The 'this' arguments are mutually exclusive")]
-    public static BicepParameter AsBicepParameter(this BicepOutputReference outputReference, ResourceModuleConstruct construct, string? parameterName = null)
+    public static ProvisioningParameter AsProvisioningParameter(this BicepOutputReference outputReference, ResourceModuleConstruct construct, string? parameterName = null)
     {
         ArgumentNullException.ThrowIfNull(outputReference);
         ArgumentNullException.ThrowIfNull(construct);
@@ -195,7 +195,7 @@ public static class AzureConstructResourceExtensions
         var parameter = construct.GetParameters().FirstOrDefault(p => p.ResourceName == parameterName);
         if (parameter is null)
         {
-            parameter = new BicepParameter(parameterName, typeof(string));
+            parameter = new ProvisioningParameter(parameterName, typeof(string));
             construct.Add(parameter);
         }
 
@@ -215,7 +215,7 @@ public class ResourceModuleConstruct : Infrastructure
         // Always add a default location parameter.
         // azd assumes there will be a location parameter for every module.
         // The Infrastructure location resolver will resolve unset Location properties to this parameter.
-        Add(new BicepParameter("location", typeof(string))
+        Add(new ProvisioningParameter("location", typeof(string))
         {
             Description = "The location for the resource(s) to be deployed.",
             Value = BicepFunction.GetResourceGroup().Location
@@ -230,17 +230,17 @@ public class ResourceModuleConstruct : Infrastructure
     /// <summary>
     /// The common principalId parameter injected into most Aspire-based Bicep files.
     /// </summary>
-    public BicepParameter PrincipalIdParameter => new BicepParameter("principalId", typeof(string));
+    public ProvisioningParameter PrincipalIdParameter => new ProvisioningParameter("principalId", typeof(string));
 
     /// <summary>
     /// The common principalType parameter injected into most Aspire-based Bicep files.
     /// </summary>
-    public BicepParameter PrincipalTypeParameter => new BicepParameter("principalType", typeof(string));
+    public ProvisioningParameter PrincipalTypeParameter => new ProvisioningParameter("principalType", typeof(string));
 
     /// <summary>
     /// The common principalName parameter injected into some Aspire-based Bicep files.
     /// </summary>
-    public BicepParameter PrincipalNameParameter => new BicepParameter("principalName", typeof(string));
+    public ProvisioningParameter PrincipalNameParameter => new ProvisioningParameter("principalName", typeof(string));
 
-    internal IEnumerable<BicepParameter> GetParameters() => GetResources().OfType<BicepParameter>();
+    internal IEnumerable<ProvisioningParameter> GetParameters() => GetResources().OfType<ProvisioningParameter>();
 }

--- a/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
@@ -6,16 +6,16 @@ Aspire.Hosting.Azure.AzureResourceOptions.AzureResourceOptions() -> void
 Aspire.Hosting.Azure.AzureResourceOptions.ProvisioningContext.get -> Azure.Provisioning.ProvisioningContext!
 Aspire.Hosting.AzureConstructResource.ProvisioningContext.get -> Azure.Provisioning.ProvisioningContext?
 Aspire.Hosting.AzureConstructResource.ProvisioningContext.set -> void
-Aspire.Hosting.ResourceModuleConstruct.PrincipalIdParameter.get -> Azure.Provisioning.BicepParameter!
-Aspire.Hosting.ResourceModuleConstruct.PrincipalNameParameter.get -> Azure.Provisioning.BicepParameter!
-Aspire.Hosting.ResourceModuleConstruct.PrincipalTypeParameter.get -> Azure.Provisioning.BicepParameter!
+Aspire.Hosting.ResourceModuleConstruct.PrincipalIdParameter.get -> Azure.Provisioning.ProvisioningParameter!
+Aspire.Hosting.ResourceModuleConstruct.PrincipalNameParameter.get -> Azure.Provisioning.ProvisioningParameter!
+Aspire.Hosting.ResourceModuleConstruct.PrincipalTypeParameter.get -> Azure.Provisioning.ProvisioningParameter!
 override Aspire.Hosting.Azure.AspireV8ResourceNamePropertyResolver.ResolveName(Azure.Provisioning.ProvisioningContext! context, Azure.Provisioning.Primitives.Resource! resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements) -> Azure.Provisioning.BicepValue<string!>?
 static Aspire.Hosting.AzureBicepResourceExtensions.WithParameter<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, string! name, Aspire.Hosting.ApplicationModel.EndpointReference! value) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
 static Aspire.Hosting.AzureBicepResourceExtensions.WithParameter<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, string! name, Aspire.Hosting.ApplicationModel.ReferenceExpression! value) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
 Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig
 Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(System.Collections.Generic.IDictionary<string!, object!>! target, string! connectionName) -> void
-static Aspire.Hosting.AzureConstructResourceExtensions.AsBicepParameter(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource!>! parameterResourceBuilder, Aspire.Hosting.ResourceModuleConstruct! construct, string? parameterName = null) -> Azure.Provisioning.BicepParameter!
-static Aspire.Hosting.AzureConstructResourceExtensions.AsBicepParameter(this Aspire.Hosting.Azure.BicepOutputReference! outputReference, Aspire.Hosting.ResourceModuleConstruct! construct, string? parameterName = null) -> Azure.Provisioning.BicepParameter!
+static Aspire.Hosting.AzureConstructResourceExtensions.AsProvisioningParameter(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource!>! parameterResourceBuilder, Aspire.Hosting.ResourceModuleConstruct! construct, string? parameterName = null) -> Azure.Provisioning.ProvisioningParameter!
+static Aspire.Hosting.AzureConstructResourceExtensions.AsProvisioningParameter(this Aspire.Hosting.Azure.BicepOutputReference! outputReference, Aspire.Hosting.ResourceModuleConstruct! construct, string? parameterName = null) -> Azure.Provisioning.ProvisioningParameter!
 static Aspire.Hosting.AzureConstructResourceExtensions.ConfigureConstruct<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, System.Action<Aspire.Hosting.ResourceModuleConstruct!>! configure) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!
 *REMOVED*Aspire.Hosting.ResourceModuleConstruct.PrincipalIdParameter.get -> Azure.Provisioning.Parameter
 *REMOVED*Aspire.Hosting.ResourceModuleConstruct.PrincipalNameParameter.get -> Azure.Provisioning.Parameter

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -47,7 +47,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             {
                 var id = new UserAssignedIdentity("id");
                 construct.Add(id);
-                construct.Add(new BicepOutput("cid", typeof(string)) { Value = id.ClientId });
+                construct.Add(new ProvisioningOutput("cid", typeof(string)) { Value = id.ClientId });
             }
 
             return new()
@@ -247,11 +247,11 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param keyVaultName string
 
-            resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
 
-            resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
+            resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
               name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
               location: location
               properties: {
@@ -272,7 +272,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource mydatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15-preview' = {
+            resource mydatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
               name: 'mydatabase'
               location: location
               properties: {
@@ -283,7 +283,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: cosmos
             }
 
-            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {
                 value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'
@@ -340,11 +340,11 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param keyVaultName string
 
-            resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
 
-            resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15-preview' = {
+            resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
               name: take('cosmos-${uniqueString(resourceGroup().id)}', 44)
               location: location
               properties: {
@@ -365,7 +365,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource mydatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15-preview' = {
+            resource mydatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
               name: 'mydatabase'
               location: location
               properties: {
@@ -376,7 +376,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: cosmos
             }
 
-            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {
                 value: 'AccountEndpoint=${cosmos.properties.documentEndpoint};AccountKey=${cosmos.listKeys().primaryMasterKey}'
@@ -435,7 +435,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource appConfig 'Microsoft.AppConfiguration/configurationStores@2019-10-01' = {
+            resource appConfig 'Microsoft.AppConfiguration/configurationStores@2024-05-01' = {
               name: take('appConfig-${uniqueString(resourceGroup().id)}', 50)
               location: location
               properties: {
@@ -568,7 +568,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource law-appInsights 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+            resource law-appInsights 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
               name: take('law-appInsights-${uniqueString(resourceGroup().id)}', 63)
               location: location
               properties: {
@@ -668,7 +668,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
-            resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+            resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
               name: take('logAnalyticsWorkspace-${uniqueString(resourceGroup().id)}', 63)
               location: location
               properties: {
@@ -717,7 +717,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 Sku = new StorageSku() { Name = StorageSkuName.StandardLrs }
             };
             construct.Add(storage);
-            construct.Add(new BicepOutput("storageAccountName", typeof(string)) { Value = storage.Name });
+            construct.Add(new ProvisioningOutput("storageAccountName", typeof(string)) { Value = storage.Name });
         });
 
         var manifest = await ManifestUtils.GetManifest(construct1.Resource);
@@ -739,7 +739,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             var storage = new StorageAccount("storage")
             {
                 Kind = StorageKind.StorageV2,
-                Sku = new StorageSku() { Name = skuName.AsBicepParameter(construct) }
+                Sku = new StorageSku() { Name = skuName.AsProvisioningParameter(construct) }
             };
             construct.Add(storage);
             moduleConstruct = construct;
@@ -778,7 +778,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             var storage = new StorageAccount("storage")
             {
                 Kind = StorageKind.StorageV2,
-                Sku = new StorageSku() { Name = skuName.AsBicepParameter(construct, parameterName: "sku") }
+                Sku = new StorageSku() { Name = skuName.AsProvisioningParameter(construct, parameterName: "sku") }
             };
             construct.Add(storage);
             moduleConstruct = construct;
@@ -838,7 +838,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param keyVaultName string
 
-            resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
 
@@ -859,7 +859,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {
                 value: '${cache.properties.hostName},ssl=true,password=${cache.listKeys().primaryKey}'
@@ -901,7 +901,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource mykv 'Microsoft.KeyVault/vaults@2019-09-01' = {
+            resource mykv 'Microsoft.KeyVault/vaults@2023-07-01' = {
               name: take('mykv-${uniqueString(resourceGroup().id)}', 24)
               location: location
               properties: {
@@ -963,7 +963,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource mykv 'Microsoft.KeyVault/vaults@2019-09-01' = {
+            resource mykv 'Microsoft.KeyVault/vaults@2023-07-01' = {
               name: take('mykv-${uniqueString(resourceGroup().id)}', 24)
               location: location
               properties: {
@@ -1025,7 +1025,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource signalr 'Microsoft.SignalRService/signalR@2022-02-01' = {
+            resource signalr 'Microsoft.SignalRService/signalR@2024-03-01' = {
               name: take('signalr-${uniqueString(resourceGroup().id)}', 63)
               location: location
               properties: {
@@ -1303,11 +1303,11 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param keyVaultName string
 
-            resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
 
-            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
               name: take('postgres${uniqueString(resourceGroup().id)}', 24)
               location: location
               properties: {
@@ -1335,7 +1335,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+            resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
               name: 'AllowAllAzureIps'
               properties: {
                 endIpAddress: '0.0.0.0'
@@ -1344,7 +1344,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: postgres
             }
 
-            resource postgreSqlFirewallRule_AllowAllIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+            resource postgreSqlFirewallRule_AllowAllIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
               name: 'AllowAllIps'
               properties: {
                 endIpAddress: '255.255.255.255'
@@ -1353,12 +1353,12 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: postgres
             }
 
-            resource db 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2022-12-01' = {
+            resource db 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
               name: 'dbName'
               parent: postgres
             }
 
-            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {
                 value: 'Host=${postgres.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'
@@ -1423,11 +1423,11 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param keyVaultName string
 
-            resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
 
-            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
               name: take('postgres${uniqueString(resourceGroup().id)}', 24)
               location: location
               properties: {
@@ -1455,7 +1455,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+            resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
               name: 'AllowAllAzureIps'
               properties: {
                 endIpAddress: '0.0.0.0'
@@ -1464,12 +1464,12 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: postgres
             }
 
-            resource db 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2022-12-01' = {
+            resource db 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
               name: 'dbName'
               parent: postgres
             }
 
-            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {
                 value: 'Host=${postgres.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'
@@ -1629,7 +1629,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource sb 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
+            resource sb 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
               name: take('sb-${uniqueString(resourceGroup().id)}', 50)
               location: location
               properties: {
@@ -1724,7 +1724,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource wps1 'Microsoft.SignalRService/webPubSub@2021-10-01' = {
+            resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
               name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
               location: location
               sku: {
@@ -1791,7 +1791,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource wps1 'Microsoft.SignalRService/webPubSub@2021-10-01' = {
+            resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
               name: take('wps1-${uniqueString(resourceGroup().id)}', 63)
               location: location
               sku: {
@@ -1859,7 +1859,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         {
             sa.Sku = new StorageSku()
             {
-                Name = storagesku.AsBicepParameter(construct)
+                Name = storagesku.AsProvisioningParameter(construct)
             };
         });
 
@@ -1895,7 +1895,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+            resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
               name: take('storage${uniqueString(resourceGroup().id)}', 24)
               kind: 'StorageV2'
               location: location
@@ -1915,7 +1915,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
               name: 'default'
               parent: storage
             }
@@ -2015,7 +2015,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         {
             sa.Sku = new StorageSku()
             {
-                Name = storagesku.AsBicepParameter(construct)
+                Name = storagesku.AsProvisioningParameter(construct)
             };
             sa.AllowSharedKeyAccess = true;
         });
@@ -2052,7 +2052,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+            resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
               name: take('storage${uniqueString(resourceGroup().id)}', 24)
               kind: 'StorageV2'
               location: location
@@ -2072,7 +2072,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
               name: 'default'
               parent: storage
             }
@@ -2172,7 +2172,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         {
             sa.Sku = new StorageSku()
             {
-                Name = storagesku.AsBicepParameter(construct)
+                Name = storagesku.AsProvisioningParameter(construct)
             };
         });
 
@@ -2208,7 +2208,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+            resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
               name: take('storage${uniqueString(resourceGroup().id)}', 24)
               kind: 'StorageV2'
               location: location
@@ -2228,7 +2228,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
               name: 'default'
               parent: storage
             }
@@ -2328,7 +2328,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         {
             sa.Sku = new StorageSku()
             {
-                Name = storagesku.AsBicepParameter(construct)
+                Name = storagesku.AsProvisioningParameter(construct)
             };
             sa.AllowSharedKeyAccess = true;
         });
@@ -2365,7 +2365,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+            resource storage 'Microsoft.Storage/storageAccounts@2024-01-01' = {
               name: take('storage${uniqueString(resourceGroup().id)}', 24)
               kind: 'StorageV2'
               location: location
@@ -2385,7 +2385,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+            resource blobs 'Microsoft.Storage/storageAccounts/blobServices@2024-01-01' = {
               name: 'default'
               parent: storage
             }
@@ -2483,7 +2483,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         // Add search and parameterize the SKU
         var sku = builder.AddParameter("searchSku");
         var search = builder.AddAzureSearch("search", (_, construct, search) =>
-            search.SearchSkuName = sku.AsBicepParameter(construct));
+            search.SearchSkuName = sku.AsProvisioningParameter(construct));
 
         // Pretend we deployed it
         const string fakeConnectionString = "mysearchconnectionstring";
@@ -2641,7 +2641,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource openai 'Microsoft.CognitiveServices/accounts@2022-12-01' = {
+            resource openai 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
               name: take('openai-${uniqueString(resourceGroup().id)}', 64)
               location: location
               kind: 'OpenAI'
@@ -2668,7 +2668,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               scope: openai
             }
 
-            resource mymodel 'Microsoft.CognitiveServices/accounts/deployments@2022-12-01' = {
+            resource mymodel 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
               name: 'mymodel'
               properties: {
                 model: {
@@ -2684,7 +2684,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: openai
             }
 
-            resource embedding-model 'Microsoft.CognitiveServices/accounts/deployments@2022-12-01' = {
+            resource embedding-model 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
               name: 'embedding-model'
               properties: {
                 model: {
@@ -2749,7 +2749,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             var vault = r.GetResources().OfType<KeyVaultService>().Single();
             Assert.NotNull(vault);
 
-            r.Add(new BicepOutput("vaultUri", typeof(string))
+            r.Add(new ProvisioningOutput("vaultUri", typeof(string))
             {
                 Value =
                     new MemberExpression(
@@ -2787,7 +2787,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
             @description('The location for the resource(s) to be deployed.')
             param location string = resourceGroup().location
 
-            resource kv 'Microsoft.KeyVault/vaults@2019-09-01' = {
+            resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
               name: take('kv-${uniqueString(resourceGroup().id)}', 24)
               location: location
               properties: {
@@ -2800,7 +2800,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               }
             }
 
-            resource secret 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+            resource secret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'kvs'
               properties: {
                 value: '00000000-0000-0000-0000-000000000000'

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -356,11 +356,11 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
 
         param api_containerimage string
 
-        resource mydb_secretoutputs_kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+        resource mydb_secretoutputs_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
           name: mydb_secretoutputs
         }
 
-        resource mydb_secretoutputs_kv_connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' existing = {
+        resource mydb_secretoutputs_kv_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
           name: 'connectionString'
           parent: mydb_secretoutputs_kv
         }
@@ -832,11 +832,11 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
 
         param outputs_azure_container_apps_environment_id string
 
-        resource mydb_secretoutputs_kv 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+        resource mydb_secretoutputs_kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
           name: mydb_secretoutputs
         }
 
-        resource mydb_secretoutputs_kv_connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' existing = {
+        resource mydb_secretoutputs_kv_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' existing = {
           name: 'connectionString'
           parent: mydb_secretoutputs_kv
         }

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
@@ -41,7 +41,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
         {
             allowAllIpsFirewall = """
 
-                resource postgreSqlFirewallRule_AllowAllIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+                resource postgreSqlFirewallRule_AllowAllIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
                   name: 'AllowAllIps'
                   properties: {
                     endIpAddress: '255.255.255.255'
@@ -68,7 +68,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
 
             param principalName string
 
-            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
               name: take('postgres${uniqueString(resourceGroup().id)}', 24)
               location: location
               properties: {
@@ -98,7 +98,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
               }
             }
 
-            resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+            resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
               name: 'AllowAllAzureIps'
               properties: {
                 endIpAddress: '0.0.0.0'
@@ -107,7 +107,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
               parent: postgres
             }
             {{allowAllIpsFirewall}}
-            resource postgres_admin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2022-12-01' = {
+            resource postgres_admin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2024-08-01' = {
               name: principalId
               properties: {
                 principalName: principalName
@@ -168,7 +168,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
 
             param keyVaultName string
 
-            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2022-12-01' = {
+            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
               name: take('postgres${uniqueString(resourceGroup().id)}', 24)
               location: location
               properties: {
@@ -200,7 +200,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
               }
             }
 
-            resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+            resource postgreSqlFirewallRule_AllowAllAzureIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
               name: 'AllowAllAzureIps'
               properties: {
                 endIpAddress: '0.0.0.0'
@@ -209,7 +209,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
               parent: postgres
             }
 
-            resource postgreSqlFirewallRule_AllowAllIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2022-12-01' = {
+            resource postgreSqlFirewallRule_AllowAllIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
               name: 'AllowAllIps'
               properties: {
                 endIpAddress: '255.255.255.255'
@@ -218,11 +218,11 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
               parent: postgres
             }
 
-            resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
 
-            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {
                 value: 'Host=${postgres.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -123,11 +123,11 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
               }
             }
 
-            resource keyVault 'Microsoft.KeyVault/vaults@2019-09-01' existing = {
+            resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
               name: keyVaultName
             }
             
-            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+            resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {
                 value: '${cache.properties.hostName},ssl=true,password=${cache.listKeys().primaryKey}'

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
@@ -47,7 +47,7 @@ public class AzureResourceOptionsTests(ITestOutputHelper output)
 
                 param principalType string
 
-                resource sb 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
+                resource sb 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
                   name: toLower(take('sb${uniqueString(resourceGroup().id)}', 24))
                   location: location
                   properties: {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -29,7 +29,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
 
             param principalType string
 
-            resource sb 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
+            resource sb 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
               name: take('sb-${uniqueString(resourceGroup().id)}', 50)
               location: location
               properties: {


### PR DESCRIPTION
## Description

This has changes for:

* The default resource versions are now up to date
* Bicep Parameter|Output are renamed to Provisioning Parameter|Output

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected. We need stable versions of these packages
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: https://github.com/dotnet/docs-aspire/issues/1652

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6061)