### PR TITLE
Improve console log batching by counting characters

### DIFF
--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -136,6 +136,9 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                             ? content[..LogMaxBatchCharacters]
                             : content;
 
+                        // Count number of characters to figure out if batch exceeds the limit.
+                        // We could calculate byte size here with UTF8 encoding, but that would add overhead.
+                        // Character count plus a conservative limit should be fine.
                         currentChars += resolvedContent.Length;
 
                         if (currentChars <= LogMaxBatchCharacters)

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -137,8 +137,8 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
                             : content;
 
                         // Count number of characters to figure out if batch exceeds the limit.
-                        // We could calculate byte size here with UTF8 encoding, but that would add overhead.
-                        // Character count plus a conservative limit should be fine.
+                        // We could calculate byte size here with UTF8 encoding, but getting the exact size of the text and message
+                        // would be a bit more complicated. Character count plus a conservative limit should be fine.
                         currentChars += resolvedContent.Length;
 
                         if (currentChars <= LogMaxBatchCharacters)

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -21,8 +21,9 @@ namespace Aspire.Hosting.Dashboard;
 internal sealed partial class DashboardService(DashboardServiceData serviceData, IHostEnvironment hostEnvironment, IHostApplicationLifetime hostApplicationLifetime, ILogger<DashboardService> logger)
     : Aspire.ResourceService.Proto.V1.DashboardService.DashboardServiceBase
 {
-    // gRPC has a maximum receive size. Force logs into batches to avoid exceeding receive size.
-    public const int LogMaxBatchSize = 500;
+    // gRPC has a maximum receive size of 4MB. Force logs into batches to avoid exceeding receive size.
+    // Protobuf sends strings as UTF8. Be conservative and assume the average character byte size is 2.
+    public const int LogMaxBatchCharacters = 1024 * 1024 * 2;
 
     // Calls that consume or produce streams must create a linked cancellation token
     // with IHostApplicationLifetime.ApplicationStopping to ensure eager cancellation
@@ -121,16 +122,31 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
 
             await foreach (var group in subscription.WithCancellation(cancellationToken).ConfigureAwait(false))
             {
-                var sent = 0;
+                var sentLines = 0;
 
-                while (sent < group.Count)
+                while (sentLines < group.Count)
                 {
                     var update = new WatchResourceConsoleLogsUpdate();
+                    var currentChars = 0;
 
-                    foreach (var (lineNumber, content, isErrorMessage) in group.Skip(sent).Take(LogMaxBatchSize))
+                    foreach (var (lineNumber, content, isErrorMessage) in group.Skip(sentLines))
                     {
-                        update.LogLines.Add(new ConsoleLogLine() { LineNumber = lineNumber, Text = content, IsStdErr = isErrorMessage });
-                        sent++;
+                        // Truncate excessively long lines.
+                        var resolvedContent = content.Length > LogMaxBatchCharacters
+                            ? content[..LogMaxBatchCharacters]
+                            : content;
+
+                        currentChars += resolvedContent.Length;
+
+                        if (currentChars <= LogMaxBatchCharacters)
+                        {
+                            update.LogLines.Add(new ConsoleLogLine() { LineNumber = lineNumber, Text = resolvedContent, IsStdErr = isErrorMessage });
+                            sentLines++;
+                        }
+                        else
+                        {
+                            break;
+                        }
                     }
 
                     await responseStream.WriteAsync(update, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Description

I noticed that log batching made console logs slow when loading a lot of data (i.e. 10,000 lines). This PR changes batching to be based on characters rather than lines. It should be less likely to error and allow more lines in typical usage.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6065)