### PR TITLE
Filter containers out of Azure Provisioner.

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -52,12 +52,16 @@ internal sealed class AzureProvisioner(
         var azureResources = new List<(IResource, IAzureResource)>();
         foreach (var resource in appModel.Resources)
         {
-            if (resource is IAzureResource azureResource)
+            if (resource.IsContainer())
+            {
+                continue;
+            }
+            else if (resource is IAzureResource azureResource)
             {
                 // If we are dealing with an Azure resource then we just return it.
                 azureResources.Add((resource, azureResource));
             }
-            if (resource.Annotations.OfType<AzureBicepResourceAnnotation>().SingleOrDefault() is { } annotation)
+            else if (resource.Annotations.OfType<AzureBicepResourceAnnotation>().SingleOrDefault() is { } annotation)
             {
                 // If we aren't an Azure resource and there is no surrogate, return null for
                 // the Azure resource in the tuple (we'll filter it out later.


### PR DESCRIPTION
## Description

Fixes a bug where we were processing azure resources that were running in emulator mode inside the provisioner. We should not process Azure resources that are running in emulator mode.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6066)