### PR TITLE
Highlight search matches in resource details

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -16,6 +16,7 @@
         <GridValue
             ValueDescription="@(NameColumnTitle ?? Loc[nameof(ControlsStrings.NameColumnHeader)])"
             Value="@context.Name"
+            EnableHighlighting="@(!string.IsNullOrEmpty(HighlightText))"
             HighlightText="@HighlightText" />
     </AspireTemplateColumn>
     <AspireTemplateColumn Title="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])" Class="valueColumn" SortBy="@ValueSort" Sortable="@IsValueSortable">
@@ -23,6 +24,7 @@
             ValueDescription="@(ValueColumnTitle ?? Loc[nameof(ControlsStrings.PropertyGridValueColumnHeader)])"
             Value="@context.Value"
             ContentAfterValue="@ContentAfterValue(context)"
+            EnableHighlighting="@(!string.IsNullOrEmpty(HighlightText))"
             HighlightText="@HighlightText"
             EnableMasking="@context.IsValueSensitive"
             IsMasked="@context.IsValueMasked"

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.cs
@@ -61,11 +61,13 @@ public interface IPropertyGridItem
     /// Gets whether this item matches a filter string.
     /// </summary>
     /// <remarks>
-    /// Default implementation returns <see langword="false"/>.
+    /// Default implementation checks against <see cref="Name"/> and <see cref="Value"/>.
     /// </remarks>
     /// <param name="filter">The search text to match against.</param>
     /// <returns><see langword="true"/> if this item matches the filter, otherwise <see langword="false"/>.</returns>
-    public bool MatchesFilter(string filter) => false;
+    public bool MatchesFilter(string filter)
+        => Name?.Contains(filter, StringComparison.CurrentCultureIgnoreCase) == true ||
+           Value?.Contains(filter, StringComparison.CurrentCultureIgnoreCase) == true;
 }
 
 public partial class PropertyGrid<TItem> where TItem : IPropertyGridItem

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -32,7 +32,7 @@ public partial class ResourceDetails
 
     private IQueryable<EnvironmentVariableViewModel> FilteredEnvironmentVariables =>
         Resource.Environment
-            .Where(vm => (_showAll || vm.FromSpec) && vm.MatchesFilter(_filter))
+            .Where(vm => (_showAll || vm.FromSpec) && ((IPropertyGridItem)vm).MatchesFilter(_filter))
             .AsQueryable();
 
     private IQueryable<DisplayedEndpoint> FilteredEndpoints =>
@@ -41,10 +41,9 @@ public partial class ResourceDetails
             .AsQueryable();
 
     private IQueryable<VolumeViewModel> FilteredVolumes =>
-        Resource.Volumes.Where(vm =>
-            vm.Source?.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true ||
-            vm.Target?.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true
-        ).AsQueryable();
+        Resource.Volumes
+            .Where(vm => vm.MatchesFilter(_filter))
+            .AsQueryable();
 
     private IQueryable<ResourcePropertyViewModel> FilteredResourceProperties =>
         GetResourceProperties(ordered: true)

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -146,10 +146,6 @@ public sealed class EnvironmentVariableViewModel : IPropertyGridItem
 
     public bool IsValueSensitive => true;
 
-    public bool MatchesFilter(string filter)
-        => Name.Contains(filter, StringComparison.CurrentCultureIgnoreCase) ||
-           Value?.Contains(filter, StringComparison.CurrentCultureIgnoreCase) == true;
-
     public EnvironmentVariableViewModel(string name, string? value, bool fromSpec)
     {
         // Name should always have a value, but somehow an empty/whitespace name can reach this point.
@@ -251,4 +247,8 @@ public sealed record class VolumeViewModel(string? Source, string Target, string
     string? IPropertyGridItem.Name => Source;
 
     string? IPropertyGridItem.Value => Target;
+
+    public bool MatchesFilter(string filter) =>
+        Source?.Contains(filter, StringComparison.CurrentCultureIgnoreCase) == true ||
+        Target?.Contains(filter, StringComparison.CurrentCultureIgnoreCase) == true;
 }


### PR DESCRIPTION
## Description

This enables highlighting of matching substrings in items shown in the resource details view.

It also creates a default search via the interface so that all property grids participate in search.

## Before

![image](https://github.com/user-attachments/assets/9fc1362e-5f37-46c5-89d1-b0db85d63007)

## After

![image](https://github.com/user-attachments/assets/856ce1c7-2726-4aa4-afb3-090ce9fd7190)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6071)