### PR TITLE
Enable dotnet watch Hot Reload

### DIFF
--- a/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.props
+++ b/src/Aspire.Hosting.AppHost/build/Aspire.Hosting.AppHost.props
@@ -11,10 +11,4 @@
     <Using Include="Aspire.Hosting.ApplicationModel" />
   </ItemGroup>
 
-  <ItemDefinitionGroup>
-    <ProjectReference>
-      <Watch>false</Watch>
-    </ProjectReference>
-  </ItemDefinitionGroup>
-
 </Project>


### PR DESCRIPTION
## Description

Allows `dotnet-watch` to enable Hot Reload for the projects.

Follow up on https://github.com/dotnet/sdk/pull/43884

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [ ] No
