### PR TITLE
Rename components to integrations in templates

### DIFF
--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
@@ -10,7 +10,7 @@ using Azure.Storage.Queues;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire components.
+// Add service defaults & Aspire integrations.
 builder.AddServiceDefaults();
 builder.AddAzureQueueClient("queue");
 builder.AddAzureBlobClient("blob");

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
@@ -10,7 +10,7 @@ using Azure.Storage.Queues;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire integrations.
+// Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 builder.AddAzureQueueClient("queue");
 builder.AddAzureBlobClient("blob");

--- a/playground/Qdrant/Qdrant.ApiService/Program.cs
+++ b/playground/Qdrant/Qdrant.ApiService/Program.cs
@@ -3,7 +3,7 @@ using Qdrant.Client.Grpc;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire components.
+// Add service defaults & Aspire integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/playground/Qdrant/Qdrant.ApiService/Program.cs
+++ b/playground/Qdrant/Qdrant.ApiService/Program.cs
@@ -3,7 +3,7 @@ using Qdrant.Client.Grpc;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire integrations.
+// Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/playground/keycloak/Keycloak.ApiService/Program.cs
+++ b/playground/keycloak/Keycloak.ApiService/Program.cs
@@ -1,6 +1,6 @@
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire components.
+// Add service defaults & Aspire integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/playground/keycloak/Keycloak.ApiService/Program.cs
+++ b/playground/keycloak/Keycloak.ApiService/Program.cs
@@ -1,6 +1,6 @@
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire integrations.
+// Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/playground/keycloak/Keycloak.Web/Program.cs
+++ b/playground/keycloak/Keycloak.Web/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire components.
+// Add service defaults & Aspire integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/playground/keycloak/Keycloak.Web/Program.cs
+++ b/playground/keycloak/Keycloak.Web/Program.cs
@@ -7,7 +7,7 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire integrations.
+// Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/playground/milvus/MilvusPlayground.ApiService/Program.cs
+++ b/playground/milvus/MilvusPlayground.ApiService/Program.cs
@@ -2,7 +2,7 @@ using Milvus.Client;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire components.
+// Add service defaults & Aspire integrations.
 builder.AddServiceDefaults();
 
 builder.AddMilvusClient("milvus");

--- a/playground/milvus/MilvusPlayground.ApiService/Program.cs
+++ b/playground/milvus/MilvusPlayground.ApiService/Program.cs
@@ -2,7 +2,7 @@ using Milvus.Client;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire integrations.
+// Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 
 builder.AddMilvusClient("milvus");

--- a/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Program.cs
@@ -1,6 +1,6 @@
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire components.
+// Add service defaults & Aspire integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Program.cs
@@ -1,6 +1,6 @@
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire integrations.
+// Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.Web/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.Web/Program.cs
@@ -3,7 +3,7 @@ using Aspire_StarterApplication._1.Web.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire components.
+// Add service defaults & Aspire integrations.
 builder.AddServiceDefaults();
 #if (UseRedisCache)
 builder.AddRedisOutputCache("cache");

--- a/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.Web/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.Web/Program.cs
@@ -3,7 +3,7 @@ using Aspire_StarterApplication._1.Web.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire integrations.
+// Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 #if (UseRedisCache)
 builder.AddRedisOutputCache("cache");

--- a/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Program.cs
@@ -1,6 +1,6 @@
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire components.
+// Add service defaults & Aspire integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.ApiService/Program.cs
@@ -1,6 +1,6 @@
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire integrations.
+// Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 
 // Add services to the container.

--- a/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.Web/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.Web/Program.cs
@@ -3,7 +3,7 @@ using Aspire_StarterApplication._1.Web.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire components.
+// Add service defaults & Aspire integrations.
 builder.AddServiceDefaults();
 #if (UseRedisCache)
 builder.AddRedisOutputCache("cache");

--- a/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.Web/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.Web/Program.cs
@@ -3,7 +3,7 @@ using Aspire_StarterApplication._1.Web.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add service defaults & Aspire integrations.
+// Add service defaults & Aspire client integrations.
 builder.AddServiceDefaults();
 #if (UseRedisCache)
 builder.AddRedisOutputCache("cache");


### PR DESCRIPTION
Just a small thing I noticed when creating a project with the templates. We're still using the old "components" verbiage in the code comment.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6091)