### PR TITLE
Add fallback to 20px icon in commands

### DIFF
--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -9,6 +9,23 @@ for (var i = 0; i < 10; i++)
 }
 
 var serviceBuilder = builder.AddProject<Projects.Stress_ApiService>("stress-apiservice", launchProfileName: null);
+serviceBuilder.WithCommand(
+    type: "icon-test",
+    displayName: "Icon test",
+    executeCommand: (c) =>
+    {
+        return Task.FromResult(CommandResults.Success());
+    },
+    iconName: "CloudDatabase");
+serviceBuilder.WithCommand(
+    type: "icon-test-highlighted",
+    displayName: "Icon test highlighted",
+    executeCommand: (c) =>
+    {
+        return Task.FromResult(CommandResults.Success());
+    },
+    iconName: "CloudDatabase",
+    isHighlighted: true);
 
 for (var i = 0; i < 30; i++)
 {

--- a/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
+++ b/src/Aspire.Dashboard/Components/Controls/AspireMenuButton.razor
@@ -29,7 +29,7 @@
                 @if (item.Icon != null)
                 {
                     <span slot="start">
-                        <FluentIcon Value="@item.Icon" Style="vertical-align: middle;" />
+                        <FluentIcon Value="@item.Icon" Style="vertical-align: middle;" Width="16px" />
                     </span>
                 }
             </FluentMenuItem>

--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor
@@ -15,7 +15,7 @@
             <FluentButton Appearance="Appearance.Lightweight" Title="@(!string.IsNullOrEmpty(highlightedCommand.DisplayDescription) ? highlightedCommand.DisplayDescription : highlightedCommand.DisplayName)" OnClick="@(() => CommandSelected.InvokeAsync(highlightedCommand))" Disabled="@(highlightedCommand.State == CommandViewModelState.Disabled)">
                 @if (!string.IsNullOrEmpty(highlightedCommand.IconName) && CommandViewModel.ResolveIconName(highlightedCommand.IconName, highlightedCommand.IconVariant) is { } icon)
                 {
-                    <FluentIcon Value="@icon" />
+                    <FluentIcon Value="@icon" Width="16px" />
                 }
                 else
                 {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -154,7 +154,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             new GridColumn(Name: StartTimeColumn, DesktopWidth: "1.5fr"),
             new GridColumn(Name: SourceColumn, DesktopWidth: "2.5fr"),
             new GridColumn(Name: EndpointsColumn, DesktopWidth: "2.5fr", MobileWidth: "2fr"),
-            new GridColumn(Name: ActionsColumn, DesktopWidth: "minmax(125px, 1.5fr)", MobileWidth: "1fr")
+            new GridColumn(Name: ActionsColumn, DesktopWidth: "minmax(150px, 1.5fr)", MobileWidth: "1fr")
         ];
         _applicationUnviewedErrorCounts = TelemetryRepository.GetApplicationUnviewedErrorLogsCount();
 

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -639,9 +639,11 @@ fluent-data-grid-cell.no-ellipsis {
 
 .action-divider {
     display: inline;
-    vertical-align: sub;
+    height: 20px;
 }
 
 .grid-action-container {
-    display: inline-block;
+    display: inline-flex;
+    column-gap: 4px;
+    align-items: center;
 }


### PR DESCRIPTION
## Description

We display 16px icons in the UI. Some icons aren't available in this size so fallback to 20px and then resize in browser. 20px is the most popular icon size so should be fine for all usage.

Database + cloud icon which is only available in 20px or greater:

![image](https://github.com/user-attachments/assets/80523135-a0fb-42f9-a7e1-217868bc68a0)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6093)