### PR TITLE
Update Azure Sql to use new API pattern

### DIFF
--- a/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/Program.cs
+++ b/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/Program.cs
@@ -3,8 +3,8 @@
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-var sql1 = builder.AddSqlServer("sql1")
-                  .PublishAsAzureSqlDatabase();
+var sql1 = builder.AddAzureSqlServer("sql1")
+                  .RunAsContainer();
 
 var db1 = sql1.AddDatabase("db1");
 

--- a/playground/bicep/BicepSample.AppHost/Program.cs
+++ b/playground/bicep/BicepSample.AppHost/Program.cs
@@ -33,7 +33,7 @@ var blobs = storage.AddBlobs("blob");
 var tables = storage.AddTables("table");
 var queues = storage.AddQueues("queue");
 
-var sqlServer = builder.AddSqlServer("sql").AsAzureSqlDatabase().AddDatabase("db");
+var sqlServer = builder.AddAzureSqlServer("sql").AddDatabase("db");
 
 var administratorLogin = builder.AddParameter("administratorLogin");
 var administratorLoginPassword = builder.AddParameter("administratorLoginPassword", secret: true);

--- a/playground/bicep/BicepSample.AppHost/postgres2.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/postgres2.module.bicep
@@ -66,7 +66,7 @@ resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   parent: keyVault
 }
 
-resource db2_connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource db2_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'db2-connectionString'
   properties: {
     value: 'Host=${postgres2.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=db2'

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -23,7 +23,7 @@ var storage = builder.AddAzureStorage("storage", (_, construct, account) =>
 
 var blobs = storage.AddBlobs("blobs");
 
-var sqldb = builder.AddSqlServer("sql").AsAzureSqlDatabase().AddDatabase("sqldb");
+var sqldb = builder.AddAzureSqlServer("sql").AddDatabase("sqldb");
 
 var signaturesecret = builder.AddParameter("signaturesecret", secret: true);
 var keyvault = builder.AddAzureKeyVault("mykv", (_, construct, keyVault) =>

--- a/playground/cdk/CdkSample.AppHost/pgsql.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/pgsql.module.bicep
@@ -66,7 +66,7 @@ resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   parent: keyVault
 }
 
-resource pgsqldb_connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource pgsqldb_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'pgsqldb-connectionString'
   properties: {
     value: 'Host=${pgsql.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=pgsqldb'

--- a/playground/waitfor/WaitForSandbox.AppHost/aspire-manifest.json
+++ b/playground/waitfor/WaitForSandbox.AppHost/aspire-manifest.json
@@ -65,6 +65,31 @@
         }
       }
     },
+    "frontend": {
+      "type": "project.v0",
+      "path": "../WaitFor.Frontend/WaitFor.Frontend.csproj",
+      "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory",
+        "ASPNETCORE_FORWARDEDHEADERS_ENABLED": "true",
+        "HTTP_PORTS": "{frontend.bindings.http.targetPort}",
+        "services__api__http__0": "{api.bindings.http.url}",
+        "services__api__https__0": "{api.bindings.https.url}"
+      },
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http"
+        },
+        "https": {
+          "scheme": "https",
+          "protocol": "tcp",
+          "transport": "http"
+        }
+      }
+    },
     "pg-username": {
       "type": "parameter.v0",
       "value": "{pg-username.inputs.value}",

--- a/playground/waitfor/WaitForSandbox.AppHost/pg.module.bicep
+++ b/playground/waitfor/WaitForSandbox.AppHost/pg.module.bicep
@@ -66,7 +66,7 @@ resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   parent: keyVault
 }
 
-resource db_connectionString 'Microsoft.KeyVault/vaults/secrets@2019-09-01' = {
+resource db_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
   name: 'db-connectionString'
   properties: {
     value: 'Host=${pg.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=db'

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -226,9 +226,9 @@ public static class AzurePostgresExtensions
     }
 
     /// <summary>
-    /// Adds an Azure PostgreSQLQL database to the application model.
+    /// Adds an Azure PostgreSQL database to the application model.
     /// </summary>
-    /// <param name="builder">The Azure PostgreSQLQL server resource builder.</param>
+    /// <param name="builder">The Azure PostgreSQL server resource builder.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="databaseName">The name of the database. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
@@ -263,11 +263,11 @@ public static class AzurePostgresExtensions
     /// <summary>
     /// Configures an Azure PostgreSQL Flexible Server resource to run locally in a container.
     /// </summary>
-    /// <param name="builder">The Azure PostgreSQLQL server resource builder.</param>
+    /// <param name="builder">The Azure PostgreSQL server resource builder.</param>
     /// <param name="configureContainer">Callback that exposes underlying container to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{AzurePostgresFlexibleServerResource}"/> builder.</returns>
     /// <example>
-    /// The following example creates an Azure PostgreSQL Flexible Server resource that runs locally is a
+    /// The following example creates an Azure PostgreSQL Flexible Server resource that runs locally in a
     /// PostgreSQL container and referencing that resource in a .NET project.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
@@ -331,7 +331,7 @@ public static class AzurePostgresExtensions
     /// <summary>
     /// Configures the resource to use password authentication for Azure PostgreSQL Flexible Server.
     /// </summary>
-    /// <param name="builder">The Azure PostgreSQLQL server resource builder.</param>
+    /// <param name="builder">The Azure PostgreSQL server resource builder.</param>
     /// <param name="userName">The parameter used to provide the user name for the PostgreSQL resource. If <see langword="null"/> a default value will be used.</param>
     /// <param name="password">The parameter used to provide the administrator password for the PostgreSQL resource. If <see langword="null"/> a random password will be generated.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{AzurePostgresFlexibleServerResource}"/> builder.</returns>

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerDatabaseResource.cs
@@ -8,7 +8,7 @@ using Aspire.Hosting.ApplicationModel;
 namespace Aspire.Hosting.Azure;
 
 /// <summary>
-/// A resource that represents a PostgreSQL database. This is a child resource of a <see cref="AzurePostgresFlexibleServerResource"/>.
+/// A resource that represents an Azure PostgreSQL database. This is a child resource of an <see cref="AzurePostgresFlexibleServerResource"/>.
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -195,7 +195,7 @@ public static class AzureRedisExtensions
     /// <param name="configureContainer">Callback that exposes underlying container to allow for customization.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{AzureRedisCacheResource}"/> builder.</returns>
     /// <example>
-    /// The following example creates an Azure Cache for Redis resource that runs locally is a
+    /// The following example creates an Azure Cache for Redis resource that runs locally in a
     /// Redis container and referencing that resource in a .NET project.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);

--- a/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
+++ b/src/Aspire.Hosting.Azure.Sql/Aspire.Hosting.Azure.Sql.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.SqlServer\Aspire.Hosting.SqlServer.csproj" />
     <PackageReference Include="Azure.Provisioning" />

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Azure;
+
+/// <summary>
+/// A resource that represents an Azure SQL database. This is a child resource of an <see cref="AzureSqlServerResource"/>.
+/// </summary>
+/// <param name="name">The name of the resource.</param>
+/// <param name="databaseName">The database name.</param>
+/// <param name="parent">The Azure SQL Database (server) parent resource associated with this database.</param>
+public class AzureSqlDatabaseResource(string name, string databaseName, AzureSqlServerResource parent)
+    : Resource(ThrowIfNull(name)), IResourceWithParent<AzureSqlServerResource>, IResourceWithConnectionString
+{
+    /// <summary>
+    /// Gets the parent Azure SQL Database (server) resource.
+    /// </summary>
+    public AzureSqlServerResource Parent { get; } = ThrowIfNull(parent);
+
+    /// <summary>
+    /// Gets the connection string expression for the Azure SQL database.
+    /// </summary>
+    public ReferenceExpression ConnectionStringExpression =>
+        ReferenceExpression.Create($"{Parent};Database={DatabaseName}");
+
+    /// <summary>
+    /// Gets the database name.
+    /// </summary>
+    public string DatabaseName { get; } = ThrowIfNull(databaseName);
+
+    private static T ThrowIfNull<T>([NotNull] T? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        => argument ?? throw new ArgumentNullException(paramName);
+}

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -17,67 +17,14 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class AzureSqlExtensions
 {
-    internal static IResourceBuilder<SqlServerServerResource> PublishAsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder, Action<IResourceBuilder<AzureSqlServerResource>, ResourceModuleConstruct, SqlServer, IEnumerable<SqlDatabase>>? configureResource, bool useProvisioner = false)
+    [Obsolete]
+    private static IResourceBuilder<SqlServerServerResource> PublishAsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder, Action<IResourceBuilder<AzureSqlServerResource>, ResourceModuleConstruct, SqlServer, IEnumerable<SqlDatabase>>? configureResource, bool useProvisioner = false)
     {
         builder.ApplicationBuilder.AddAzureProvisioning();
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var sqlServer = new SqlServer(builder.Resource.Name)
-            {
-                Administrators = new ServerExternalAdministrator()
-                {
-                    AdministratorType = SqlAdministratorType.ActiveDirectory,
-                    IsAzureADOnlyAuthenticationEnabled = true,
-                    Sid = construct.PrincipalIdParameter,
-                    Login = construct.PrincipalNameParameter,
-                    TenantId = BicepFunction.GetSubscription().TenantId
-                },
-                Version = "12.0",
-                PublicNetworkAccess = ServerNetworkAccessFlag.Enabled,
-                MinTlsVersion = SqlMinimalTlsVersion.Tls1_2,
-                Tags = { { "aspire-resource-name", construct.Resource.Name } }
-            };
-            construct.Add(sqlServer);
-
-            construct.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllAzureIps")
-            {
-                Parent = sqlServer,
-                Name = "AllowAllAzureIps",
-                StartIPAddress = "0.0.0.0",
-                EndIPAddress = "0.0.0.0"
-            });
-
-            if (builder.ApplicationBuilder.ExecutionContext.IsRunMode)
-            {
-                // When in run mode we inject the users identity and we need to specify
-                // the principalType.
-                sqlServer.Administrators.Value!.PrincipalType = construct.PrincipalTypeParameter;
-
-                construct.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllIps")
-                {
-                    Parent = sqlServer,
-                    Name = "AllowAllIps",
-                    StartIPAddress = "0.0.0.0",
-                    EndIPAddress = "255.255.255.255"
-                });
-            }
-
-            List<SqlDatabase> sqlDatabases = new List<SqlDatabase>();
-            foreach (var databaseNames in builder.Resource.Databases)
-            {
-                var resourceName = databaseNames.Key;
-                var databaseName = databaseNames.Value;
-                var sqlDatabase = new SqlDatabase(resourceName)
-                {
-                    Parent = sqlServer,
-                    Name = databaseName
-                };
-                construct.Add(sqlDatabase);
-                sqlDatabases.Add(sqlDatabase);
-            }
-
-            construct.Add(new ProvisioningOutput("sqlServerFqdn", typeof(string)) { Value = sqlServer.FullyQualifiedDomainName });
+            var (sqlServer, sqlDatabases) = CreateSqlServer(construct, builder.ApplicationBuilder, builder.Resource.Databases);
 
             var resource = (AzureSqlServerResource)construct.Resource;
             var resourceBuilder = builder.ApplicationBuilder.CreateResourceBuilder(resource);
@@ -116,6 +63,7 @@ public static class AzureSqlExtensions
     /// </summary>
     /// <param name="builder">The builder for the SQL Server resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(AddAzureSqlServer)} instead to add an Azure SQL server resource.")]
     public static IResourceBuilder<SqlServerServerResource> PublishAsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder)
     {
         return builder.PublishAsAzureSqlDatabase(null);
@@ -127,6 +75,7 @@ public static class AzureSqlExtensions
     /// <param name="builder">The builder for the SQL Server resource.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.Sql.SqlServer"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(AddAzureSqlServer)} instead to add an Azure SQL server resource.")]
     [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<SqlServerServerResource> PublishAsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder, Action<IResourceBuilder<AzureSqlServerResource>, ResourceModuleConstruct, SqlServer, IEnumerable<SqlDatabase>>? configureResource)
     {
@@ -138,6 +87,7 @@ public static class AzureSqlExtensions
     /// </summary>
     /// <param name="builder">The builder for the SQL Server resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(AddAzureSqlServer)} instead to add an Azure SQL server resource.")]
     public static IResourceBuilder<SqlServerServerResource> AsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder)
     {
         return builder.AsAzureSqlDatabase(null);
@@ -149,9 +99,199 @@ public static class AzureSqlExtensions
     /// <param name="builder">The builder for the SQL Server resource.</param>
     /// <param name="configureResource">Callback to configure the underlying <see cref="global::Azure.Provisioning.Sql.SqlServer"/> resource.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(AddAzureSqlServer)} instead to add an Azure SQL server resource.")]
     [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<SqlServerServerResource> AsAzureSqlDatabase(this IResourceBuilder<SqlServerServerResource> builder, Action<IResourceBuilder<AzureSqlServerResource>, ResourceModuleConstruct, SqlServer, IEnumerable<SqlDatabase>>? configureResource)
     {
         return builder.PublishAsAzureSqlDatabase(configureResource, useProvisioner: true);
+    }
+
+    /// <summary>
+    /// Adds an Azure SQL Database (server) resource to the application model.
+    /// </summary>
+    /// <param name="builder">The builder for the distributed application.</param>
+    /// <param name="name">The name of the resource.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{AzureSqlServerResource}"/> builder.</returns>
+    public static IResourceBuilder<AzureSqlServerResource> AddAzureSqlServer(this IDistributedApplicationBuilder builder, string name)
+    {
+        builder.AddAzureProvisioning();
+
+        var configureConstruct = (ResourceModuleConstruct construct) =>
+        {
+            var azureResource = (AzureSqlServerResource)construct.Resource;
+            CreateSqlServer(construct, builder, azureResource.Databases);
+        };
+
+        var resource = new AzureSqlServerResource(name, configureConstruct);
+        var azureSqlServer = builder.AddResource(resource)
+            .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)
+            .WithParameter(AzureBicepResource.KnownParameters.PrincipalName)
+            .WithManifestPublishingCallback(resource.WriteToManifest);
+
+        if (builder.ExecutionContext.IsRunMode)
+        {
+            // When in run mode we inject the users identity and we need to specify
+            // the principalType.
+            azureSqlServer.WithParameter(AzureBicepResource.KnownParameters.PrincipalType);
+        }
+
+        return azureSqlServer;
+    }
+
+    /// <summary>
+    /// Adds an Azure SQL Database to the application model.
+    /// </summary>
+    /// <param name="builder">The builder for the Azure SQL resource.</param>
+    /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
+    /// <param name="databaseName">The name of the database. If not provided, this defaults to the same value as <paramref name="name"/>.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
+    public static IResourceBuilder<AzureSqlDatabaseResource> AddDatabase(this IResourceBuilder<AzureSqlServerResource> builder, string name, string? databaseName = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(name);
+
+        // Use the resource name as the database name if it's not provided
+        databaseName ??= name;
+
+        var azureResource = builder.Resource;
+        var azureSqlDatabase = new AzureSqlDatabaseResource(name, databaseName, azureResource);
+
+        builder.Resource.AddDatabase(name, databaseName);
+
+        if (azureResource.InnerResource is null)
+        {
+            return builder.ApplicationBuilder.AddResource(azureSqlDatabase);
+        }
+        else
+        {
+            // need to add the database to the InnerResource
+            var innerBuilder = builder.ApplicationBuilder.CreateResourceBuilder(azureResource.InnerResource);
+            innerBuilder.AddDatabase(name, databaseName);
+
+            // create a builder, but don't add the Azure database to the model because the InnerResource already has it
+            return builder.ApplicationBuilder.CreateResourceBuilder(azureSqlDatabase);
+        }
+    }
+
+    /// <summary>
+    /// Configures an Azure SQL Database (server) resource to run locally in a container.
+    /// </summary>
+    /// <param name="builder">The builder for the Azure SQL resource.</param>
+    /// <param name="configureContainer">Callback that exposes underlying container to allow for customization.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{AzureSqlServerResource}"/> builder.</returns>
+    /// <example>
+    /// The following example creates an Azure SQL Database (server) resource that runs locally in a
+    /// SQL Server container and referencing that resource in a .NET project.
+    /// <code lang="csharp">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    ///
+    /// var data = builder.AddAzureSqlServer("data")
+    ///     .RunAsContainer();
+    ///
+    /// builder.AddProject&lt;Projects.ProductService&gt;()
+    ///     .WithReference(data);
+    ///
+    /// builder.Build().Run();
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<AzureSqlServerResource> RunAsContainer(this IResourceBuilder<AzureSqlServerResource> builder, Action<IResourceBuilder<SqlServerServerResource>>? configureContainer = null)
+    {
+        if (builder.ApplicationBuilder.ExecutionContext.IsPublishMode)
+        {
+            return builder;
+        }
+
+        var azureResource = builder.Resource;
+        RemoveAzureResources(builder.ApplicationBuilder, azureResource);
+
+        var sqlContainer = builder.ApplicationBuilder.AddSqlServer(azureResource.Name);
+
+        azureResource.InnerResource = sqlContainer.Resource;
+
+        foreach (var database in azureResource.Databases)
+        {
+            sqlContainer.AddDatabase(database.Key, database.Value);
+        }
+
+        configureContainer?.Invoke(sqlContainer);
+
+        return builder;
+    }
+
+    private static void RemoveAzureResources(IDistributedApplicationBuilder appBuilder, AzureSqlServerResource azureResource)
+    {
+        List<IResource> resourcesToRemove = [azureResource];
+        resourcesToRemove.AddRange(
+            appBuilder.Resources.OfType<AzureSqlDatabaseResource>()
+                .Where(db => db.Parent == azureResource));
+
+        foreach (var resource in resourcesToRemove)
+        {
+            appBuilder.Resources.Remove(resource);
+        }
+    }
+
+    private static (SqlServer Server, List<SqlDatabase> Databases) CreateSqlServer(
+        ResourceModuleConstruct construct,
+        IDistributedApplicationBuilder distributedApplicationBuilder,
+        IReadOnlyDictionary<string, string> databases)
+    {
+        var sqlServer = new SqlServer(construct.Resource.Name)
+        {
+            Administrators = new ServerExternalAdministrator()
+            {
+                AdministratorType = SqlAdministratorType.ActiveDirectory,
+                IsAzureADOnlyAuthenticationEnabled = true,
+                Sid = construct.PrincipalIdParameter,
+                Login = construct.PrincipalNameParameter,
+                TenantId = BicepFunction.GetSubscription().TenantId
+            },
+            Version = "12.0",
+            PublicNetworkAccess = ServerNetworkAccessFlag.Enabled,
+            MinTlsVersion = SqlMinimalTlsVersion.Tls1_2,
+            Tags = { { "aspire-resource-name", construct.Resource.Name } }
+        };
+        construct.Add(sqlServer);
+
+        construct.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllAzureIps")
+        {
+            Parent = sqlServer,
+            Name = "AllowAllAzureIps",
+            StartIPAddress = "0.0.0.0",
+            EndIPAddress = "0.0.0.0"
+        });
+
+        if (distributedApplicationBuilder.ExecutionContext.IsRunMode)
+        {
+            // When in run mode we inject the users identity and we need to specify
+            // the principalType.
+            sqlServer.Administrators.Value!.PrincipalType = construct.PrincipalTypeParameter;
+
+            construct.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllIps")
+            {
+                Parent = sqlServer,
+                Name = "AllowAllIps",
+                StartIPAddress = "0.0.0.0",
+                EndIPAddress = "255.255.255.255"
+            });
+        }
+
+        var sqlDatabases = new List<SqlDatabase>();
+        foreach (var databaseNames in databases)
+        {
+            var resourceName = databaseNames.Key;
+            var databaseName = databaseNames.Value;
+            var sqlDatabase = new SqlDatabase(resourceName)
+            {
+                Parent = sqlServer,
+                Name = databaseName
+            };
+            construct.Add(sqlDatabase);
+            sqlDatabases.Add(sqlDatabase);
+        }
+
+        construct.Add(new ProvisioningOutput("sqlServerFqdn", typeof(string)) { Value = sqlServer.FullyQualifiedDomainName });
+
+        return (sqlServer, sqlDatabases);
     }
 }

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlServerResource.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlServerResource.cs
@@ -8,10 +8,32 @@ namespace Aspire.Hosting.Azure;
 /// <summary>
 /// Represents an Azure Sql Server resource.
 /// </summary>
-/// <param name="innerResource">The <see cref="SqlServerServerResource"/> that this resource wraps.</param>
-/// <param name="configureConstruct">Callback to populate the construct with Azure resources.</param>
-public class AzureSqlServerResource(SqlServerServerResource innerResource, Action<ResourceModuleConstruct> configureConstruct) : AzureConstructResource(innerResource.Name, configureConstruct), IResourceWithConnectionString
+public class AzureSqlServerResource : AzureConstructResource, IResourceWithConnectionString
 {
+    private readonly Dictionary<string, string> _databases = new Dictionary<string, string>(StringComparers.ResourceName);
+    private readonly bool _useInnerResourceAnnotations;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureSqlServerResource"/> class.
+    /// </summary>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="configureConstruct">Callback to populate the construct with Azure resources.</param>
+    public AzureSqlServerResource(string name, Action<ResourceModuleConstruct> configureConstruct)
+        : base(name, configureConstruct) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureSqlServerResource"/> class.
+    /// </summary>
+    /// <param name="innerResource">The <see cref="SqlServerServerResource"/> that this resource wraps.</param>
+    /// <param name="configureConstruct">Callback to populate the construct with Azure resources.</param>
+    [Obsolete($"This method is obsolete and will be removed in a future version. Use {nameof(AzureSqlExtensions.AddAzureSqlServer)} instead to add an Azure SQL server resource.")]
+    public AzureSqlServerResource(SqlServerServerResource innerResource, Action<ResourceModuleConstruct> configureConstruct)
+        : base(innerResource.Name, configureConstruct)
+    {
+        InnerResource = innerResource;
+        _useInnerResourceAnnotations = true;
+    }
+
     /// <summary>
     /// Gets the fully qualified domain name (FQDN) output reference from the bicep template for the Azure SQL Server resource.
     /// </summary>
@@ -21,12 +43,22 @@ public class AzureSqlServerResource(SqlServerServerResource innerResource, Actio
     /// Gets the connection template for the manifest for the Azure SQL Server resource.
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create(
-            $"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
-
-    /// <inheritdoc/>
-    public override string Name => innerResource.Name;
+        InnerResource?.ConnectionStringExpression ??
+            ReferenceExpression.Create(
+                $"Server=tcp:{FullyQualifiedDomainName},1433;Encrypt=True;Authentication=\"Active Directory Default\"");
 
     /// <inheritdoc />
-    public override ResourceAnnotationCollection Annotations => innerResource.Annotations;
+    public override ResourceAnnotationCollection Annotations => _useInnerResourceAnnotations ? InnerResource!.Annotations : base.Annotations;
+
+    /// <summary>
+    /// A dictionary where the key is the resource name and the value is the database name.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Databases => _databases;
+
+    internal void AddDatabase(string name, string databaseName)
+    {
+        _databases.TryAdd(name, databaseName);
+    }
+
+    internal SqlServerServerResource? InnerResource { get; set; }
 }

--- a/src/Aspire.Hosting.Azure.Sql/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure.Sql/PublicAPI.Unshipped.txt
@@ -1,2 +1,12 @@
 #nullable enable
-
+Aspire.Hosting.Azure.AzureSqlDatabaseResource
+Aspire.Hosting.Azure.AzureSqlDatabaseResource.AzureSqlDatabaseResource(string! name, string! databaseName, Aspire.Hosting.Azure.AzureSqlServerResource! parent) -> void
+Aspire.Hosting.Azure.AzureSqlDatabaseResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
+Aspire.Hosting.Azure.AzureSqlDatabaseResource.DatabaseName.get -> string!
+Aspire.Hosting.Azure.AzureSqlDatabaseResource.Parent.get -> Aspire.Hosting.Azure.AzureSqlServerResource!
+Aspire.Hosting.Azure.AzureSqlServerResource.AzureSqlServerResource(string! name, System.Action<Aspire.Hosting.ResourceModuleConstruct!>! configureConstruct) -> void
+Aspire.Hosting.Azure.AzureSqlServerResource.Databases.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+*REMOVED*override Aspire.Hosting.Azure.AzureSqlServerResource.Name.get -> string!
+static Aspire.Hosting.AzureSqlExtensions.AddAzureSqlServer(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureSqlServerResource!>!
+static Aspire.Hosting.AzureSqlExtensions.AddDatabase(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureSqlServerResource!>! builder, string! name, string? databaseName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureSqlDatabaseResource!>!
+static Aspire.Hosting.AzureSqlExtensions.RunAsContainer(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureSqlServerResource!>! builder, System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SqlServerServerResource!>!>? configureContainer = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureSqlServerResource!>!

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -65,13 +65,14 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 #pragma warning disable CS0618 // Type or member is obsolete
                 { builder => builder.AddPostgres("x").AsAzurePostgresFlexibleServer() },
                 { builder => builder.AddRedis("x").AsAzureRedis() },
+                { builder => builder.AddSqlServer("x").AsAzureSqlDatabase() },
 #pragma warning restore CS0618 // Type or member is obsolete
                 { builder => builder.AddAzurePostgresFlexibleServer("x") },
                 { builder => builder.AddAzureRedis("x") },
                 { builder => builder.AddAzureSearch("x") },
                 { builder => builder.AddAzureServiceBus("x") },
                 { builder => builder.AddAzureSignalR("x") },
-                { builder => builder.AddSqlServer("x").AsAzureSqlDatabase() },
+                { builder => builder.AddAzureSqlServer("x") },
                 { builder => builder.AddAzureStorage("x") },
             };
         }
@@ -1074,6 +1075,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var sql = builder.AddSqlServer("sql").AsAzureSqlDatabase((azureSqlBuilder, _, sql, _) =>
         {
             azureSqlBuilder.Resource.Outputs["sqlServerFqdn"] = "myserver";
@@ -1083,6 +1085,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 sql.MinTlsVersion = SqlMinimalTlsVersion.Tls1_3;
             }
         });
+#pragma warning restore CS0618 // Type or member is obsolete
         sql.AddDatabase("db", "dbName");
 
         var manifest = await ManifestUtils.GetManifestWithBicep(sql.Resource);
@@ -1172,6 +1175,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
     {
         using var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
 
+#pragma warning disable CS0618 // Type or member is obsolete
         var sql = builder.AddSqlServer("sql").AsAzureSqlDatabase((azureSqlBuilder, _, sql, _) =>
         {
             azureSqlBuilder.Resource.Outputs["sqlServerFqdn"] = "myserver";
@@ -1181,6 +1185,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 sql.MinTlsVersion = SqlMinimalTlsVersion.Tls1_3;
             }
         });
+#pragma warning restore CS0618 // Type or member is obsolete
         sql.AddDatabase("db", "dbName");
 
         var manifest = await ManifestUtils.GetManifestWithBicep(sql.Resource);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
@@ -1,0 +1,174 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Hosting.Azure.Tests;
+
+public class AzureSqlExtensionsTests(ITestOutputHelper output)
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AddAzureSqlServer(bool publishMode)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(publishMode ? DistributedApplicationOperation.Publish : DistributedApplicationOperation.Run);
+
+        var sql = builder.AddAzureSqlServer("sql");
+
+        sql.AddDatabase("db1");
+        sql.AddDatabase("db2", "db2Name");
+
+        var manifest = await ManifestUtils.GetManifestWithBicep(sql.Resource);
+
+        var principalTypeParam = "";
+        if (!publishMode)
+        {
+            principalTypeParam = """
+                ,
+                    "principalType": ""
+                """;
+        }
+        var expectedManifest = $$"""
+            {
+              "type": "azure.bicep.v0",
+              "connectionString": "Server=tcp:{sql.outputs.sqlServerFqdn},1433;Encrypt=True;Authentication=\u0022Active Directory Default\u0022",
+              "path": "sql.module.bicep",
+              "params": {
+                "principalId": "",
+                "principalName": ""{{principalTypeParam}}
+              }
+            }
+            """;
+        Assert.Equal(expectedManifest, manifest.ManifestNode.ToString());
+
+        var allowAllIpsFirewall = "";
+        var bicepPrincipalTypeParam = "";
+        var bicepPrincipalTypeSetter = "";
+        if (!publishMode)
+        {
+            allowAllIpsFirewall = """
+
+                resource sqlFirewallRule_AllowAllIps 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {
+                  name: 'AllowAllIps'
+                  properties: {
+                    endIpAddress: '255.255.255.255'
+                    startIpAddress: '0.0.0.0'
+                  }
+                  parent: sql
+                }
+                
+                """;
+
+            bicepPrincipalTypeParam = """
+                
+                param principalType string
+                
+                """;
+
+            bicepPrincipalTypeSetter = """
+
+                      principalType: principalType
+                """;
+        }
+
+        var expectedBicep = $$"""
+            @description('The location for the resource(s) to be deployed.')
+            param location string = resourceGroup().location
+
+            param principalId string
+
+            param principalName string
+            {{bicepPrincipalTypeParam}}
+            resource sql 'Microsoft.Sql/servers@2021-11-01' = {
+              name: take('sql-${uniqueString(resourceGroup().id)}', 63)
+              location: location
+              properties: {
+                administrators: {
+                  administratorType: 'ActiveDirectory'{{bicepPrincipalTypeSetter}}
+                  login: principalName
+                  sid: principalId
+                  tenantId: subscription().tenantId
+                  azureADOnlyAuthentication: true
+                }
+                minimalTlsVersion: '1.2'
+                publicNetworkAccess: 'Enabled'
+                version: '12.0'
+              }
+              tags: {
+                'aspire-resource-name': 'sql'
+              }
+            }
+
+            resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {
+              name: 'AllowAllAzureIps'
+              properties: {
+                endIpAddress: '0.0.0.0'
+                startIpAddress: '0.0.0.0'
+              }
+              parent: sql
+            }
+            {{allowAllIpsFirewall}}
+            resource db1 'Microsoft.Sql/servers/databases@2021-11-01' = {
+              name: 'db1'
+              location: location
+              parent: sql
+            }
+
+            resource db2 'Microsoft.Sql/servers/databases@2021-11-01' = {
+              name: 'db2Name'
+              location: location
+              parent: sql
+            }
+
+            output sqlServerFqdn string = sql.properties.fullyQualifiedDomainName
+            """;
+        output.WriteLine(manifest.BicepText);
+        Assert.Equal(expectedBicep, manifest.BicepText);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AddAzureSqlServerRunAsContainerProducesCorrectConnectionString(bool addDbBeforeRunAsContainer)
+    {
+        using var builder = TestDistributedApplicationBuilder.Create();
+
+        var sql = builder.AddAzureSqlServer("sql");
+
+        IResourceBuilder<AzureSqlDatabaseResource> db1 = null!;
+        IResourceBuilder<AzureSqlDatabaseResource> db2 = null!;
+        if (addDbBeforeRunAsContainer)
+        {
+            db1 = sql.AddDatabase("db1");
+            db2 = sql.AddDatabase("db2", "db2Name");
+
+        }
+        sql.RunAsContainer(c =>
+        {
+            c.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 12455));
+        });
+
+        if (!addDbBeforeRunAsContainer)
+        {
+            db1 = sql.AddDatabase("db1");
+            db2 = sql.AddDatabase("db2", "db2Name");
+        }
+
+        Assert.False(sql.Resource.IsContainer(), "The resource should still be the Azure Resource.");
+        var serverConnectionString = await sql.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
+        Assert.StartsWith("Server=127.0.0.1,12455;User ID=sa;Password=", serverConnectionString);
+        Assert.EndsWith(";TrustServerCertificate=true", serverConnectionString);
+
+        var db1ConnectionString = await db1.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
+        Assert.StartsWith("Server=127.0.0.1,12455;User ID=sa;Password=", db1ConnectionString);
+        Assert.EndsWith(";TrustServerCertificate=true;Database=db1", db1ConnectionString);
+
+        var db2ConnectionString = await db2.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
+        Assert.StartsWith("Server=127.0.0.1,12455;User ID=sa;Password=", db2ConnectionString);
+        Assert.EndsWith(";TrustServerCertificate=true;Database=db2Name", db2ConnectionString);
+    }
+}


### PR DESCRIPTION
## Description

We are moving to a new API pattern for Azure resources that can also be used locally as a container.Update Azure Sql Server to follow the same pattern.

* The existing [Publish]AsAzureSqlDatabase methods are marked Obsolete
* New AddAzureSqlServer method is introduced for when you want an Azure resource.
* To use a non-Azure container locally, a new RunAsContainer method is added.

Fix #5998

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: https://github.com/dotnet/docs-aspire/issues/1704

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6094)