### PR TITLE
Show persistent containers in the dashboard

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -3,17 +3,37 @@
 @using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
+
 @inject IStringLocalizer<Columns> Loc
+
+@if (Resource.Properties.TryGetValue(KnownProperties.Container.Lifetime, out var value) &&
+    value.Value.HasStringValue &&
+    StringComparer.Ordinal.Equals(value.Value.StringValue, KnownContainerLifetimes.Persistent))
+{
+    <FluentIcon
+        Icon="Icons.Regular.Size16.Shield"
+        Title="@Loc[nameof(Columns.PersistentContainerIconTooltip)]"
+        Color="Color.Neutral"
+        Class="severity-icon" />
+}
 
 <span title="@FormatName(Resource)"><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)"/></span>
 
 @code {
     [Parameter, EditorRequired]
-    public required ResourceViewModel Resource { get; set; }
+    public required ResourceViewModel Resource { get; init; }
 
     [Parameter, EditorRequired]
-    public required Func<ResourceViewModel, string> FormatName { get; set; }
+    public required Func<ResourceViewModel, string> FormatName { get; init; }
 
     [Parameter, EditorRequired]
-    public required string FilterText { get; set; }
+    public required string FilterText { get; init; }
+
+    private static class KnownContainerLifetimes
+    {
+        // Matches members from Aspire.Hosting.ApplicationModel.ContainerLifetime
+
+        public const string Default = nameof(Default);
+        public const string Persistent = nameof(Persistent);
+    }
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -6,28 +6,28 @@
 
 @inject IStringLocalizer<Columns> Loc
 
+<span title="@FormatName(Resource)"><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)" /></span>
+
 @if (Resource.Properties.TryGetValue(KnownProperties.Container.Lifetime, out var value) &&
     value.Value.HasStringValue &&
     StringComparer.Ordinal.Equals(value.Value.StringValue, KnownContainerLifetimes.Persistent))
 {
     <FluentIcon
-        Icon="Icons.Regular.Size16.Shield"
+        Icon="Icons.Regular.Size16.Pin"
         Title="@Loc[nameof(Columns.PersistentContainerIconTooltip)]"
         Color="Color.Neutral"
-        Class="severity-icon" />
+        Class="persistent-container-icon" />
 }
-
-<span title="@FormatName(Resource)"><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)"/></span>
 
 @code {
     [Parameter, EditorRequired]
-    public required ResourceViewModel Resource { get; init; }
+    public required ResourceViewModel Resource { get; set; }
 
     [Parameter, EditorRequired]
-    public required Func<ResourceViewModel, string> FormatName { get; init; }
+    public required Func<ResourceViewModel, string> FormatName { get; set; }
 
     [Parameter, EditorRequired]
-    public required string FilterText { get; init; }
+    public required string FilterText { get; set; }
 
     private static class KnownContainerLifetimes
     {

--- a/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
+++ b/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
@@ -54,6 +54,7 @@ public sealed class KnownPropertyLookup : IKnownPropertyLookup
             new(KnownProperties.Container.Command, loc[ResourcesDetailsContainerCommandProperty]),
             new(KnownProperties.Container.Args, loc[ResourcesDetailsContainerArgumentsProperty]),
             new(KnownProperties.Container.Ports, loc[ResourcesDetailsContainerPortsProperty]),
+            new(KnownProperties.Container.Lifetime, loc[ResourcesDetailsContainerLifetimeProperty]),
         ];
     }
 

--- a/src/Aspire.Dashboard/Resources/Columns.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Columns.Designer.cs
@@ -97,7 +97,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This resource is persistent and won&apos;t be stopped when the app host is shutdown..
+        ///   Looks up a localized string similar to This container is persistent and won&apos;t be stopped when the app host is shut down..
         /// </summary>
         public static string PersistentContainerIconTooltip {
             get {

--- a/src/Aspire.Dashboard/Resources/Columns.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Columns.Designer.cs
@@ -97,6 +97,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This resource is persistent and won&apos;t be stopped when the app host is shutdown..
+        /// </summary>
+        public static string PersistentContainerIconTooltip {
+            get {
+                return ResourceManager.GetString("PersistentContainerIconTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Container ID: {0}.
         /// </summary>
         public static string ResourceNameDisplayContainerIdText {

--- a/src/Aspire.Dashboard/Resources/Columns.resx
+++ b/src/Aspire.Dashboard/Resources/Columns.resx
@@ -189,4 +189,7 @@
   <data name="EndpointsColumnDisplayOverflowTitle" xml:space="preserve">
     <value>Endpoints</value>
   </data>
+  <data name="PersistentContainerIconTooltip" xml:space="preserve">
+    <value>This resource is persistent and won't be stopped when the app host is shutdown.</value>
+  </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Columns.resx
+++ b/src/Aspire.Dashboard/Resources/Columns.resx
@@ -190,6 +190,6 @@
     <value>Endpoints</value>
   </data>
   <data name="PersistentContainerIconTooltip" xml:space="preserve">
-    <value>This resource is persistent and won't be stopped when the app host is shutdown.</value>
+    <value>This container is persistent and won't be stopped when the app host is shut down.</value>
   </data>
 </root>

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -205,6 +205,15 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Lifetime.
+        /// </summary>
+        public static string ResourcesDetailsContainerLifetimeProperty {
+            get {
+                return ResourceManager.GetString("ResourcesDetailsContainerLifetimeProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Container ports.
         /// </summary>
         public static string ResourcesDetailsContainerPortsProperty {

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -185,6 +185,9 @@
   <data name="ResourcesDetailsContainerPortsProperty" xml:space="preserve">
     <value>Container ports</value>
   </data>
+  <data name="ResourcesDetailsContainerLifetimeProperty" xml:space="preserve">
+    <value>Lifetime</value>
+  </data>
   <data name="ResourcesDetailsDisplayNameProperty" xml:space="preserve">
     <value>Display name</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Podrobnosti o výjimce</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">ID kontejneru: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Ausnahmedetails</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">Container-ID: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Detalles de la excepción</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">Id. de contenedor: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Détails de l’exception</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">ID de conteneur : {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Dettagli eccezione</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">ID contenitore: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">例外の詳細</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">コンテナー ID: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">예외 세부 정보</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">컨테이너 ID: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Szczegóły wyjątku</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">Identyfikator kontenera: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Detalhes da exceção</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">ID do Contêiner: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Подробности исключения</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">ИД контейнера: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Özel durum ayrıntıları</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">Kapsayıcı Kimliği: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">异常详细信息</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">容器 ID: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">例外狀況詳細資料</target>
         <note />
       </trans-unit>
+      <trans-unit id="PersistentContainerIconTooltip">
+        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
+        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">
         <source>Container ID: {0}</source>
         <target state="translated">容器識別碼: {0}</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="PersistentContainerIconTooltip">
-        <source>This resource is persistent and won't be stopped when the app host is shutdown.</source>
-        <target state="new">This resource is persistent and won't be stopped when the app host is shutdown.</target>
+        <source>This container is persistent and won't be stopped when the app host is shut down.</source>
+        <target state="new">This container is persistent and won't be stopped when the app host is shut down.</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourceNameDisplayContainerIdText">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Image kontejneru</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">Porty kontejneru</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Containerimage</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">Containerports</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Imagen de contenedor</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">Puertos de contenedor</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Image conteneur</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">Ports de conteneur</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Immagine contenitore</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">Porte contenitore</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">コンテナー イメージ</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">コンテナー ポート</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">컨테이너 이미지</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">컨테이너 포트</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Obraz kontenera</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">Porty kontenerów</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Imagem de contêiner</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">Portas de contêiner</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Образ контейнера</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">Порты контейнера</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Kapsayıcı görüntüsü</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">Kapsayıcı bağlantı noktaları</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">容器映像</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">容器端口</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">容器映像</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourcesDetailsContainerLifetimeProperty">
+        <source>Lifetime</source>
+        <target state="new">Lifetime</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ResourcesDetailsContainerPortsProperty">
         <source>Container ports</source>
         <target state="translated">容器連接埠</target>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -345,11 +345,16 @@ fluent-data-grid-cell .long-inner-content {
     margin-right: 3px;
 }
 
+.persistent-container-icon {
+    vertical-align: text-bottom;
+    margin-left: 3px;
+}
+
 .align-text-bottom {
     vertical-align: text-bottom;
 }
 
- .visually-hidden {
+.visually-hidden {
      top: 0;
      left: -2px;
      width: 1px;

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -607,6 +607,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 new(KnownProperties.Container.Command, container.Spec.Command),
                 new(KnownProperties.Container.Args, container.Status?.EffectiveArgs ?? []) { IsSensitive = true },
                 new(KnownProperties.Container.Ports, GetPorts()),
+                new(KnownProperties.Container.Lifetime, GetContainerLifetime()),
             ],
             EnvironmentVariables = environment,
             CreationTimeStamp = container.Metadata.CreationTimestamp?.ToUniversalTime(),
@@ -632,6 +633,18 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 }
             }
             return ports.ToImmutable();
+        }
+
+        ContainerLifetime GetContainerLifetime()
+        {
+            if (container.AppModelResourceName is string resourceName &&
+                _applicationModel.TryGetValue(resourceName, out var appModelResource) &&
+                appModelResource.TryGetLastAnnotation<ContainerLifetimeAnnotation>(out var lifetimeAnnotation))
+            {
+                return lifetimeAnnotation.Lifetime;
+            }
+
+            return ContainerLifetime.Default;
         }
     }
 

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -35,6 +35,7 @@ internal static class KnownProperties
         public const string Ports = "container.ports";
         public const string Command = "container.command";
         public const string Args = "container.args";
+        public const string Lifetime = "container.lifetime";
     }
 
     public static class Executable


### PR DESCRIPTION
## Description

Fixes #5947

Adds a property to container resources that models their lifetime.

Shows this value in the resource details view.

<img width="500" src="https://github.com/user-attachments/assets/e9162856-a8c1-4257-966e-f67f87a8a5d0" />

Adds an icon to the container name column for persistent containers, with a tooltip.

![image](https://github.com/user-attachments/assets/cd5cecac-0b5f-4009-80d3-fbce811223b0)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6095)