### PR TITLE
Fix bad ordering of resources by name in some situations

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -158,7 +158,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                         // so if there is no selected resource when we
                         // receive an added resource, and that added resource name == ResourceName,
                         // we should mark it as selected
-                        if (ResourceName is not null && PageViewModel.SelectedResource is null && changeType == ResourceViewModelChangeType.Upsert && string.Equals(ResourceName, resource.Name))
+                        if (ResourceName is not null && PageViewModel.SelectedResource is null && changeType == ResourceViewModelChangeType.Upsert && string.Equals(ResourceName, resource.Name, StringComparisons.ResourceName))
                         {
                             SetSelectedResourceOption(resource);
                         }
@@ -241,7 +241,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
         foreach (var grouping in resourcesByName
             .Where(r => !r.Value.IsHiddenState())
-            .OrderBy(c => c.Value.Name, StringComparers.ResourceName)
+            .OrderBy(c => c.Value, ResourceViewModelNameComparer.Instance)
             .GroupBy(r => r.Value.DisplayName, StringComparers.ResourceName))
         {
             string applicationName;
@@ -261,7 +261,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
                 applicationName = grouping.First().Value.DisplayName;
             }
 
-            foreach (var resource in grouping.Select(g => g.Value).OrderBy(r => r.Name, StringComparers.ResourceName))
+            foreach (var resource in grouping.Select(g => g.Value).OrderBy(r => r, ResourceViewModelNameComparer.Instance))
             {
                 builder.Add(ToOption(resource, grouping.Count() > 1, applicationName));
             }
@@ -372,7 +372,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             _resourceByName[resource.Name] = resource;
             UpdateResourcesList();
 
-            if (string.Equals(PageViewModel.SelectedResource?.Name, resource.Name, StringComparison.Ordinal))
+            if (string.Equals(PageViewModel.SelectedResource?.Name, resource.Name, StringComparisons.ResourceName))
             {
                 PageViewModel.SelectedResource = resource;
             }
@@ -382,7 +382,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             var removed = _resourceByName.TryRemove(resource.Name, out _);
             Debug.Assert(removed, "Cannot remove unknown resource.");
 
-            if (string.Equals(PageViewModel.SelectedResource?.Name, resource.Name, StringComparison.Ordinal))
+            if (string.Equals(PageViewModel.SelectedResource?.Name, resource.Name, StringComparisons.ResourceName))
             {
                 // The selected resource was deleted
                 PageViewModel.SelectedOption = _noSelection;

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -310,7 +310,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
                 continue;
             }
 
-            if (item.DisplayName == resource.DisplayName)
+            if (string.Equals(item.DisplayName, resource.DisplayName, StringComparisons.ResourceName))
             {
                 count++;
                 if (count >= 2)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -141,7 +141,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
 
     private IQueryable<ResourceViewModel>? FilteredResources => _resourceByName.Values.Where(Filter).OrderBy(e => e.ResourceType).ThenBy(e => e, ResourceViewModelNameComparer.Instance).AsQueryable();
 
-    private readonly GridSort<ResourceViewModel> _nameSort = GridSort<ResourceViewModel>.ByAscending(p => p.Name);
+    private readonly GridSort<ResourceViewModel> _nameSort = GridSort<ResourceViewModel>.ByAscending(p => p, ResourceViewModelNameComparer.Instance);
     private readonly GridSort<ResourceViewModel> _stateSort = GridSort<ResourceViewModel>.ByAscending(p => p.State);
     private readonly GridSort<ResourceViewModel> _startTimeSort = GridSort<ResourceViewModel>.ByDescending(p => p.CreationTimeStamp);
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -139,7 +139,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         }
     }
 
-    private IQueryable<ResourceViewModel>? FilteredResources => _resourceByName.Values.Where(Filter).OrderBy(e => e.ResourceType).ThenBy(e => e.Name).AsQueryable();
+    private IQueryable<ResourceViewModel>? FilteredResources => _resourceByName.Values.Where(Filter).OrderBy(e => e.ResourceType).ThenBy(e => e, ResourceViewModelNameComparer.Instance).AsQueryable();
 
     private readonly GridSort<ResourceViewModel> _nameSort = GridSort<ResourceViewModel>.ByAscending(p => p.Name);
     private readonly GridSort<ResourceViewModel> _stateSort = GridSort<ResourceViewModel>.ByAscending(p => p.State);

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -74,6 +74,29 @@ public enum ReadinessState
     Ready
 }
 
+public sealed class ResourceViewModelNameComparer : IComparer<ResourceViewModel>
+{
+    public static readonly ResourceViewModelNameComparer Instance = new();
+
+    public int Compare(ResourceViewModel? x, ResourceViewModel? y)
+    {
+        Debug.Assert(x != null);
+        Debug.Assert(y != null);
+
+        // Use display name by itself first.
+        // This is to avoid the problem of using the full name where one resource is called "database" and another is called "database-admin".
+        // The full names could end up "database-xyz" and "database-admin-xyz", which would put resources out of order.
+        var displayNameResult = StringComparers.ResourceName.Compare(x.DisplayName, y.DisplayName);
+        if (displayNameResult != 0)
+        {
+            return displayNameResult;
+        }
+
+        // Display names are the same so compare with full names.
+        return StringComparers.ResourceName.Compare(x.Name, y.Name);
+    }
+}
+
 [DebuggerDisplay("CommandType = {CommandType}, DisplayName = {DisplayName}")]
 public sealed class CommandViewModel
 {

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -51,7 +51,7 @@ public sealed class ResourceViewModel
                 continue;
             }
 
-            if (item.DisplayName == resource.DisplayName)
+            if (string.Equals(item.DisplayName, resource.DisplayName, StringComparisons.ResourceName))
             {
                 count++;
                 if (count >= 2)

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelNameComparerTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelNameComparerTests.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Tests.Shared.DashboardModel;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class ResourceViewModelNameComparerTests
+{
+    [Fact]
+    public void Compare()
+    {
+        // Arrange
+        var resources = new[]
+        {
+            ModelTestHelpers.CreateResource(appName: "database-dashboard-abc", displayName: "database-dashboard"),
+            ModelTestHelpers.CreateResource(appName: "database-dashboard-xyz", displayName: "database-dashboard"),
+            ModelTestHelpers.CreateResource(appName: "database-xyz", displayName: "database"),
+            ModelTestHelpers.CreateResource(appName: "database-abc", displayName: "database"),
+        };
+
+        // Act
+        var result = resources.OrderBy(v => v, ResourceViewModelNameComparer.Instance);
+
+        // Assert
+        Assert.Collection(result,
+            vm => Assert.Equal("database-abc", vm.Name),
+            vm => Assert.Equal("database-xyz", vm.Name),
+            vm => Assert.Equal("database-dashboard-abc", vm.Name),
+            vm => Assert.Equal("database-dashboard-xyz", vm.Name));
+    }
+}


### PR DESCRIPTION
## Description

There is a problem with ordering resource by "Name" in the UI.

Imagine resources called "database" and another is called "database-admin". The full names could end up:
* "database-xyz" and "database-dashboard-xyz", or
* "database-abc" and "database-dashboard-abc"

The order can change depending on what the randomly generated full name is.

One run of dashboard:
![image](https://github.com/user-attachments/assets/072c0b7f-b781-4c57-b871-d34756216f08)

Another:
![image](https://github.com/user-attachments/assets/46ce6e68-925a-4c0f-8966-b08dac9dbcbc)

PR adds a comparer that orders by display name first, then uses the full name if there are multiple instances with the same display name (replicas)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
