### PR TITLE
Fix apphost crashing when dependencies fail.

### DIFF
--- a/playground/Redis/Redis.AppHost/Program.cs
+++ b/playground/Redis/Redis.AppHost/Program.cs
@@ -6,7 +6,8 @@ var redis = builder.AddRedis("redis")
     .WithRedisInsight(c => c.WithAcceptEula());
 
 var garnet = builder.AddGarnet("garnet")
-    .WithDataVolume();
+    .WithDataVolume()
+    .WithEnvironment(ctx => throw new InvalidOperationException("foo"));
 
 var valkey = builder.AddValkey("valkey")
     .WithDataVolume("valkey-data");

--- a/playground/Redis/Redis.AppHost/Program.cs
+++ b/playground/Redis/Redis.AppHost/Program.cs
@@ -6,8 +6,7 @@ var redis = builder.AddRedis("redis")
     .WithRedisInsight(c => c.WithAcceptEula());
 
 var garnet = builder.AddGarnet("garnet")
-    .WithDataVolume()
-    .WithEnvironment(ctx => throw new InvalidOperationException("foo"));
+    .WithDataVolume();
 
 var valkey = builder.AddValkey("valkey")
     .WithDataVolume("valkey-data");

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -12,6 +12,7 @@ namespace Aspire.Hosting.Tests;
 public class WaitForTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
+    [RequiresDocker]
     public async Task ResourceThatFailsToStartDueToExceptionDoesNotCauseStartAsyncToThrow()
     {
         using var builder = TestDistributedApplicationBuilder.Create().WithTestAndResourceLogging(testOutputHelper);


### PR DESCRIPTION
## Description

Recent change to ensure that the `BeforeResourceStartEvent` is only fired once resulted in the publishing call being moved out of a try catch block. The impact was that if a dependency failed to start and resulted in an exception the exception would bubble out of the DCP resource creation flow inside app executing resulting in the entire app host being brought down.

This PR fixes that issue by catching exceptions in resource startup and routing errors to the appropriate resource logger. This was only an issue for executable resources since they are the only ones (currently) that support replicas.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6101)