### PR TITLE
Fix typo in manifest spec

### DIFF
--- a/docs/specs/manifest-spec.md
+++ b/docs/specs/manifest-spec.md
@@ -37,9 +37,9 @@ builder.Build().Run();
 
 When ```dotnet publish``` is called on the AppHost project containing the code above the application model and dependency projects will be built and the AppHost will be executed in a model which emits an ```aspire-manifest.json``` file in the build artifacts for the AppHost project. The manifest file for the above project would look like the following:
 
-```json
+```jsonc
 {
-    "$schema": "<url ot stable schema version",
+    "$schema": "<url to stable schema version>",
     "components": {
         "postgres": {
             "type": "postgres.v1"


### PR DESCRIPTION
## Description

- Fix typo.
- Use `jsonc` to improve rendering of Markdown in GitHub.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6102)