### PR TITLE
Make popup menu icons consistent

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -40,7 +40,7 @@
                       Class="defaultHidden"
                       Style="float: right; flex-shrink: 0"
                       OnClick="@ToggleMenuOpen">
-            <FluentIcon Style="display:inline;" Icon="Icons.Regular.Size16.MoreVertical" />
+            <FluentIcon Style="display:inline;" Icon="Icons.Regular.Size16.MoreHorizontal" />
         </FluentButton>
 
         <FluentMenu Anchor="@_menuAnchorId" @bind-Open="_isMenuOpen" VerticalThreshold="170" HorizontalPosition="HorizontalPosition.End">


### PR DESCRIPTION
## Description

We use horizontal dots to signify a popup menu throughout the app, except for in `GridValue` where we used vertical dots.

This changes that control to make things consistent.

## Before

<img width="745" alt="image" src="https://github.com/user-attachments/assets/1be35d6d-78b7-4964-94ad-94f70ec4aaa0">

## After

<img width="737" alt="image" src="https://github.com/user-attachments/assets/b1b62edb-66b1-41cb-b405-97d9ce4bb676">

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6107)