### PR TITLE
Update starter template to use WaitFor & add application tracing source

### DIFF
--- a/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-servicedefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-servicedefaults/Extensions.cs
@@ -58,7 +58,8 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
-                tracing.AddAspNetCoreInstrumentation()
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation()
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
                     .AddHttpClientInstrumentation();

--- a/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.AppHost/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.AppHost/Program.cs
@@ -10,7 +10,9 @@ builder.AddProject<Projects.GeneratedClassNamePrefix_Web>("webfrontend")
     .WithExternalHttpEndpoints()
 #if UseRedisCache
     .WithReference(cache)
+    .WaitFor(cache)
 #endif
-    .WithReference(apiService);
+    .WithReference(apiService)
+    .WaitFor(apiService);
 
 builder.Build().Run();

--- a/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net8/templates/aspire-starter/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
@@ -58,7 +58,8 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
-                tracing.AddAspNetCoreInstrumentation()
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation()
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
                     .AddHttpClientInstrumentation();

--- a/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-servicedefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-servicedefaults/Extensions.cs
@@ -58,7 +58,8 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
-                tracing.AddAspNetCoreInstrumentation()
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation()
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
                     .AddHttpClientInstrumentation();

--- a/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.AppHost/Program.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.AppHost/Program.cs
@@ -10,7 +10,9 @@ builder.AddProject<Projects.GeneratedClassNamePrefix_Web>("webfrontend")
     .WithExternalHttpEndpoints()
 #if UseRedisCache
     .WithReference(cache)
+    .WaitFor(cache)
 #endif
-    .WithReference(apiService);
+    .WithReference(apiService)
+    .WaitFor(apiService);
 
 builder.Build().Run();

--- a/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates.9.0.net9/templates/aspire-starter/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
@@ -58,7 +58,8 @@ public static class Extensions
             })
             .WithTracing(tracing =>
             {
-                tracing.AddAspNetCoreInstrumentation()
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation()
                     // Uncomment the following line to enable gRPC instrumentation (requires the OpenTelemetry.Instrumentation.GrpcNetClient package)
                     //.AddGrpcClientInstrumentation()
                     .AddHttpClientInstrumentation();


### PR DESCRIPTION
This updates the starter template to use the new `WaitFor` feature and register tracing for a source named for the application.

Contributes to #6076

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6115)