### PR TITLE
Sanitize bicep indentifiers

### DIFF
--- a/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
+++ b/playground/OpenAIEndToEnd/OpenAIEndToEnd.AppHost/openai.module.bicep
@@ -32,7 +32,7 @@ resource openai_CognitiveServicesOpenAIContributor 'Microsoft.Authorization/role
   scope: openai
 }
 
-resource gpt-4o 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+resource gpt_4o 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
   name: 'gpt-4o'
   properties: {
     model: {

--- a/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationExtensions.cs
@@ -41,7 +41,7 @@ public static class AzureAppConfigurationExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var store = new AppConfigurationStore(name)
+            var store = new AppConfigurationStore(construct.Resource.GetBicepIdentifier())
             {
                 SkuName = "standard",
                 DisableLocalAuth = true,

--- a/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
+++ b/src/Aspire.Hosting.Azure.AppContainers/Aspire.Hosting.Azure.AppContainers.csproj
@@ -17,8 +17,4 @@
     <ProjectReference Include="..\Aspire.Hosting.Azure\Aspire.Hosting.Azure.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\Aspire.Hosting.Azure\Utils\BicepIdentifierHelpers.cs" />
-  </ItemGroup>
-
 </Project>

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -7,7 +7,6 @@ using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Azure.Utils;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Publishing;
 using Azure.Provisioning;
@@ -170,7 +169,7 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                     containerImageParam = AllocateContainerImageParameter();
                 }
 
-                var containerAppResource = new ContainerApp(resource.Name)
+                var containerAppResource = new ContainerApp(AzureResourceExtensions.NormalizeBicepIdentifier(resource.Name))
                 {
                     Name = resource.Name.ToLowerInvariant()
                 };
@@ -731,7 +730,7 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                 if (!KeyVaultSecretRefs.TryGetValue(secretOutputReference.ValueExpression, out var secret))
                 {
                     // Now we resolve the secret
-                    var secretIdentifierName = BicepIdentifierHelpers.Normalize($"{kv.ResourceName}_{secretOutputReference.Name}");
+                    var secretIdentifierName = AzureResourceExtensions.NormalizeBicepIdentifier($"{kv.ResourceName}_{secretOutputReference.Name}");
                     secret = KeyVaultSecret.FromExisting(secretIdentifierName);
                     secret.Name = secretOutputReference.Name;
                     secret.Parent = kv;

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -83,7 +83,7 @@ public static class AzureApplicationInsightsExtensions
             };
             construct.Add(kindParameter);
 
-            var appInsights = new ApplicationInsightsComponent(name)
+            var appInsights = new ApplicationInsightsComponent(construct.Resource.GetBicepIdentifier())
             {
                 ApplicationType = appTypeParameter,
                 Kind = kindParameter,
@@ -99,7 +99,7 @@ public static class AzureApplicationInsightsExtensions
             else if (builder.ExecutionContext.IsRunMode)
             {
                 // ... otherwise if we are in run mode, the provisioner expects us to create one ourselves.
-                var autoInjectedLogAnalyticsWorkspaceName = $"law-{construct.Resource.Name}";
+                var autoInjectedLogAnalyticsWorkspaceName = $"law_{appInsights.ResourceName}";
                 var autoInjectedLogAnalyticsWorkspace = new OperationalInsightsWorkspace(autoInjectedLogAnalyticsWorkspaceName)
                 {
                     Sku = new OperationalInsightsWorkspaceSku()

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -43,7 +43,7 @@ public static class AzureOpenAIExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var cogServicesAccount = new CognitiveServicesAccount(name)
+            var cogServicesAccount = new CognitiveServicesAccount(construct.Resource.GetBicepIdentifier())
             {
                 Kind = "OpenAI",
                 Sku = new CognitiveServicesSku()
@@ -52,7 +52,7 @@ public static class AzureOpenAIExtensions
                 },
                 Properties = new CognitiveServicesAccountProperties()
                 {
-                    CustomSubDomainName = ToLower(Take(Concat(name, GetUniqueString(GetResourceGroup().Id)), 24)),
+                    CustomSubDomainName = ToLower(Take(Concat(construct.Resource.Name, GetUniqueString(GetResourceGroup().Id)), 24)),
                     PublicNetworkAccess = ServiceAccountPublicNetworkAccess.Enabled,
                     // Disable local auth for AOAI since managed identity is used
                     DisableLocalAuth = true
@@ -85,7 +85,7 @@ public static class AzureOpenAIExtensions
             var cdkDeployments = new List<CognitiveServicesAccountDeployment>();
             foreach (var deployment in resource.Deployments)
             {
-                var cdkDeployment = new CognitiveServicesAccountDeployment(deployment.Name)
+                var cdkDeployment = new CognitiveServicesAccountDeployment(AzureResourceExtensions.NormalizeBicepIdentifier(deployment.Name))
                 {
                     Name = deployment.Name,
                     Parent = cogServicesAccount,

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -55,7 +55,7 @@ public static class AzureCosmosExtensions
             keyVault.Name = kvNameParam;
             construct.Add(keyVault);
 
-            var cosmosAccount = new CosmosDBAccount(name)
+            var cosmosAccount = new CosmosDBAccount(construct.Resource.GetBicepIdentifier())
             {
                 Kind = CosmosDBAccountKind.GlobalDocumentDB,
                 ConsistencyPolicy = new ConsistencyPolicy()
@@ -80,7 +80,7 @@ public static class AzureCosmosExtensions
             List<CosmosDBSqlDatabase> cosmosSqlDatabases = new List<CosmosDBSqlDatabase>();
             foreach (var databaseName in azureResource.Databases)
             {
-                var cosmosSqlDatabase = new CosmosDBSqlDatabase(databaseName)
+                var cosmosSqlDatabase = new CosmosDBSqlDatabase(AzureResourceExtensions.NormalizeBicepIdentifier(databaseName))
                 {
                     Parent = cosmosAccount,
                     Name = databaseName,

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -55,7 +55,7 @@ public static class AzureEventHubsExtensions
             };
             construct.Add(skuParameter);
 
-            var eventHubsNamespace = new EventHubsNamespace(name)
+            var eventHubsNamespace = new EventHubsNamespace(construct.Resource.GetBicepIdentifier())
             {
                 Sku = new EventHubsSku()
                 {
@@ -75,7 +75,7 @@ public static class AzureEventHubsExtensions
 
             foreach (var hub in azureResource.Hubs)
             {
-                var hubResource = new EventHub(hub.Name)
+                var hubResource = new EventHub(AzureResourceExtensions.NormalizeBicepIdentifier(hub.Name))
                 {
                     Parent = eventHubsNamespace,
                     Name = hub.Name
@@ -84,8 +84,8 @@ public static class AzureEventHubsExtensions
                 hub.Configure?.Invoke(azureResourceBuilder, construct, hubResource);
             }
         };
-        var resource = new AzureEventHubsResource(name, configureConstruct);
 
+        var resource = new AzureEventHubsResource(name, configureConstruct);
         return builder.AddResource(resource)
                       // These ambient parameters are only available in development time.
                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -42,7 +42,7 @@ public static class AzureKeyVaultResourceExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var keyVault = new KeyVaultService(construct.Resource.Name)
+            var keyVault = new KeyVaultService(construct.Resource.GetBicepIdentifier())
             {
                 Properties = new KeyVaultProperties()
                 {

--- a/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.OperationalInsights/AzureLogAnalyticsWorkspaceExtensions.cs
@@ -41,7 +41,7 @@ public static class AzureLogAnalyticsWorkspaceExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var workspace = new OperationalInsightsWorkspace(name)
+            var workspace = new OperationalInsightsWorkspace(construct.Resource.GetBicepIdentifier())
             {
                 Sku = new OperationalInsightsWorkspaceSku()
                 {

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -195,7 +195,7 @@ public static class AzurePostgresExtensions
                 PasswordAuth = PostgreSqlFlexibleServerPasswordAuthEnum.Disabled
             };
 
-            var admin = new PostgreSqlFlexibleServerActiveDirectoryAdministrator($"{azureResource.Name}_admin")
+            var admin = new PostgreSqlFlexibleServerActiveDirectoryAdministrator($"{postgres.ResourceName}_admin")
             {
                 Parent = postgres,
                 Name = construct.PrincipalIdParameter,

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -421,7 +421,7 @@ public static class AzurePostgresExtensions
 
                 foreach (var database in azureResource.Databases)
                 {
-                    var dbSecret = new KeyVaultSecret(database.Key + "_connectionString")
+                    var dbSecret = new KeyVaultSecret(AzureResourceExtensions.NormalizeBicepIdentifier(database.Key + "_connectionString"))
                     {
                         Parent = keyVault,
                         Name = AzurePostgresFlexibleServerResource.GetDatabaseKeyVaultSecretName(database.Key),
@@ -437,7 +437,7 @@ public static class AzurePostgresExtensions
 
     private static PostgreSqlFlexibleServer CreatePostgreSqlFlexibleServer(ResourceModuleConstruct construct, IDistributedApplicationBuilder distributedApplicationBuilder, IReadOnlyDictionary<string, string> databases)
     {
-        var postgres = new PostgreSqlFlexibleServer(construct.Resource.Name)
+        var postgres = new PostgreSqlFlexibleServer(construct.Resource.GetBicepIdentifier())
         {
             StorageSizeInGB = 32,
             Sku = new PostgreSqlFlexibleServerSku()
@@ -483,9 +483,9 @@ public static class AzurePostgresExtensions
 
         foreach (var databaseNames in databases)
         {
-            var resourceName = databaseNames.Key;
+            var identifierName = AzureResourceExtensions.NormalizeBicepIdentifier(databaseNames.Key);
             var databaseName = databaseNames.Value;
-            var pgsqlDatabase = new PostgreSqlFlexibleServerDatabase(resourceName)
+            var pgsqlDatabase = new PostgreSqlFlexibleServerDatabase(identifierName)
             {
                 Parent = postgres,
                 Name = databaseName

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -383,7 +383,7 @@ public static class AzurePostgresExtensions
             {
                 RemoveActiveDirectoryAuthResources(construct);
 
-                var postgres = construct.GetResources().OfType<PostgreSqlFlexibleServer>().FirstOrDefault(r => r.ResourceName == azureResource.Name)
+                var postgres = construct.GetResources().OfType<PostgreSqlFlexibleServer>().FirstOrDefault(r => r.ResourceName == azureResource.GetBicepIdentifier())
                     ?? throw new InvalidOperationException($"Could not find a PostgreSqlFlexibleServer with name {azureResource.Name}.");
 
                 var administratorLogin = new ProvisioningParameter("administratorLogin", typeof(string));

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -264,7 +264,7 @@ public static class AzureRedisExtensions
            {
                RemoveActiveDirectoryAuthResources(construct);
 
-               var redis = construct.GetResources().OfType<CdkRedisResource>().FirstOrDefault(r => r.ResourceName == builder.Resource.Name)
+               var redis = construct.GetResources().OfType<CdkRedisResource>().FirstOrDefault(r => r.ResourceName == builder.Resource.GetBicepIdentifier())
                    ?? throw new InvalidOperationException($"Could not find a RedisResource with name {builder.Resource.Name}.");
 
                var kvNameParam = new ProvisioningParameter("keyVaultName", typeof(string));
@@ -326,7 +326,7 @@ public static class AzureRedisExtensions
         foreach (var resource in construct.GetResources())
         {
             if (resource is RedisCacheAccessPolicyAssignment accessPolicy &&
-                accessPolicy.ResourceName == $"{construct.Resource.Name}_contributor")
+                accessPolicy.ResourceName == $"{construct.Resource.GetBicepIdentifier()}_contributor")
             {
                 resourcesToRemove.Add(resource);
             }

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -295,7 +295,7 @@ public static class AzureRedisExtensions
 
     private static CdkRedisResource CreateRedisResource(ResourceModuleConstruct construct)
     {
-        var redisCache = new CdkRedisResource(construct.Resource.Name)
+        var redisCache = new CdkRedisResource(construct.Resource.GetBicepIdentifier())
         {
             Sku = new RedisSku()
             {

--- a/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Search/AzureSearchExtensions.cs
@@ -50,7 +50,7 @@ public static class AzureSearchExtensions
 
         void ConfigureSearch(ResourceModuleConstruct construct)
         {
-            var search = new SearchService(name)
+            var search = new SearchService(construct.Resource.GetBicepIdentifier())
             {
                 SearchSkuName = SearchServiceSkuName.Basic,
                 ReplicaCount = 1,

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -48,7 +48,7 @@ public static class AzureServiceBusExtensions
             };
             construct.Add(skuParameter);
 
-            var serviceBusNamespace = new ServiceBusNamespace(name)
+            var serviceBusNamespace = new ServiceBusNamespace(construct.Resource.GetBicepIdentifier())
             {
                 Sku = new ServiceBusSku()
                 {
@@ -69,7 +69,7 @@ public static class AzureServiceBusExtensions
 
             foreach (var queue in azureResource.Queues)
             {
-                var queueResource = new ServiceBusQueue(queue.Name)
+                var queueResource = new ServiceBusQueue(AzureResourceExtensions.NormalizeBicepIdentifier(queue.Name))
                 {
                     Parent = serviceBusNamespace,
                     Name = queue.Name
@@ -80,7 +80,7 @@ public static class AzureServiceBusExtensions
             var topicDictionary = new Dictionary<string, ServiceBusTopic>();
             foreach (var topic in azureResource.Topics)
             {
-                var topicResource = new ServiceBusTopic(topic.Name)
+                var topicResource = new ServiceBusTopic(AzureResourceExtensions.NormalizeBicepIdentifier(topic.Name))
                 {
                     Parent = serviceBusNamespace,
                     Name = topic.Name
@@ -92,7 +92,7 @@ public static class AzureServiceBusExtensions
             foreach (var subscription in azureResource.Subscriptions)
             {
                 var topic = topicDictionary[subscription.TopicName];
-                var subscriptionResource = new ServiceBusSubscription(subscription.Name)
+                var subscriptionResource = new ServiceBusSubscription(AzureResourceExtensions.NormalizeBicepIdentifier(subscription.Name))
                 {
                     Parent = topic,
                     Name = subscription.Name
@@ -101,8 +101,8 @@ public static class AzureServiceBusExtensions
                 subscription.Configure?.Invoke(azureResourceBuilder, construct, subscriptionResource);
             }
         };
-        var resource = new AzureServiceBusResource(name, configureConstruct);
 
+        var resource = new AzureServiceBusResource(name, configureConstruct);
         return builder.AddResource(resource)
                       // These ambient parameters are only available in development time.
                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)

--- a/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
+++ b/src/Aspire.Hosting.Azure.SignalR/AzureSignalRExtensions.cs
@@ -41,7 +41,7 @@ public static class AzureSignalRExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var service = new SignalRService(name)
+            var service = new SignalRService(construct.Resource.GetBicepIdentifier())
             {
                 Kind = SignalRServiceKind.SignalR,
                 Sku = new SignalRResourceSku()

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -236,7 +236,7 @@ public static class AzureSqlExtensions
         IDistributedApplicationBuilder distributedApplicationBuilder,
         IReadOnlyDictionary<string, string> databases)
     {
-        var sqlServer = new SqlServer(construct.Resource.Name)
+        var sqlServer = new SqlServer(construct.Resource.GetBicepIdentifier())
         {
             Administrators = new ServerExternalAdministrator()
             {
@@ -279,9 +279,9 @@ public static class AzureSqlExtensions
         var sqlDatabases = new List<SqlDatabase>();
         foreach (var databaseNames in databases)
         {
-            var resourceName = databaseNames.Key;
+            var identifierName = AzureResourceExtensions.NormalizeBicepIdentifier(databaseNames.Key);
             var databaseName = databaseNames.Value;
-            var sqlDatabase = new SqlDatabase(resourceName)
+            var sqlDatabase = new SqlDatabase(identifierName)
             {
                 Parent = sqlServer,
                 Name = databaseName

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -46,7 +46,7 @@ public static class AzureStorageExtensions
 
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
-            var storageAccount = new StorageAccount(name)
+            var storageAccount = new StorageAccount(construct.Resource.GetBicepIdentifier())
             {
                 Kind = StorageKind.StorageV2,
                 AccessTier = StorageAccountAccessTier.Hot,
@@ -86,8 +86,8 @@ public static class AzureStorageExtensions
             var resourceBuilder = builder.CreateResourceBuilder(resource);
             configureResource?.Invoke(resourceBuilder, construct, storageAccount);
         };
-        var resource = new AzureStorageResource(name, configureConstruct);
 
+        var resource = new AzureStorageResource(name, configureConstruct);
         return builder.AddResource(resource)
                       // These ambient parameters are only available in development time.
                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -56,7 +56,7 @@ public static class AzureWebPubSubExtensions
             };
             construct.Add(capacityParameter);
 
-            var service = new WebPubSubService(name)
+            var service = new WebPubSubService(construct.Resource.GetBicepIdentifier())
             {
                 Sku = new BillingInfoSku()
                 {

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -40,6 +40,8 @@ public static class AzureWebPubSubExtensions
     [Experimental("AZPROVISION001", UrlFormat = "https://aka.ms/dotnet/aspire/diagnostics#{0}")]
     public static IResourceBuilder<AzureWebPubSubResource> AddAzureWebPubSub(this IDistributedApplicationBuilder builder, [ResourceName] string name, Action<IResourceBuilder<AzureWebPubSubResource>, ResourceModuleConstruct, WebPubSubService>? configureResource)
     {
+        builder.AddAzureProvisioning();
+
         var configureConstruct = (ResourceModuleConstruct construct) =>
         {
             // Supported values are Free_F1 Standard_S1 Premium_P1
@@ -77,7 +79,6 @@ public static class AzureWebPubSubExtensions
         };
 
         var resource = new AzureWebPubSubResource(name, configureConstruct);
-
         return builder.AddResource(resource)
                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)
                       .WithParameter(AzureBicepResource.KnownParameters.PrincipalType)

--- a/src/Aspire.Hosting.Azure/AzureBicepResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureBicepResource.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.Utils;
 using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting.Azure;
@@ -300,7 +301,7 @@ public class BicepOutputReference(string name, AzureBicepResource resource) : IM
     /// <summary>
     /// Name of the output.
     /// </summary>
-    public string Name { get; } = name;
+    public string Name { get; } = BicepIdentifierHelpers.ThrowIfInvalid(name);
 
     /// <summary>
     /// The instance of the bicep resource.

--- a/src/Aspire.Hosting.Azure/AzureConstructResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureConstructResource.cs
@@ -149,7 +149,7 @@ public static class AzureConstructResourceExtensions
         ArgumentNullException.ThrowIfNull(parameterResourceBuilder);
         ArgumentNullException.ThrowIfNull(construct);
 
-        parameterName ??= parameterResourceBuilder.Resource.Name;
+        parameterName ??= AzureResourceExtensions.NormalizeBicepIdentifier(parameterResourceBuilder.Resource.Name);
 
         construct.Resource.Parameters[parameterName] = parameterResourceBuilder.Resource;
 

--- a/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Azure.Utils;
 
 namespace Aspire.Hosting;
 
@@ -22,4 +23,21 @@ public static class AzureResourceExtensions
         ParameterResourceBuilderExtensions.ConfigureConnectionStringManifestPublisher((IResourceBuilder<IResourceWithConnectionString>)builder);
         return builder;
     }
+
+    /// <summary>
+    /// Gets the Bicep identifier for the Azure resource.
+    /// </summary>
+    /// <param name="resource">The Azure resource.</param>
+    /// <returns>A valid Bicep identifier.</returns>
+    public static string GetBicepIdentifier(this IAzureResource resource) =>
+        NormalizeBicepIdentifier(resource.Name);
+
+    /// <summary>
+    /// Normalizes the given identifier name to make it a valid Bicep identifier name.
+    /// </summary>
+    /// <param name="identifierName">The identifier name to normalize.</param>
+    /// <returns>A valid Bicep identifier.</returns>
+    // TODO: This API should be deleted when we get the API from Azure.Provisioning
+    public static string NormalizeBicepIdentifier(string identifierName) =>
+        BicepIdentifierHelpers.Normalize(identifierName);
 }

--- a/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
@@ -22,3 +22,5 @@ static Aspire.Hosting.AzureConstructResourceExtensions.ConfigureConstruct<T>(thi
 *REMOVED*Aspire.Hosting.ResourceModuleConstruct.PrincipalTypeParameter.get -> Azure.Provisioning.Parameter
 *REMOVED*static Aspire.Hosting.AzureConstructResourceExtensions.AssignProperty<T>(this Azure.Provisioning.Resource<T>! resource, System.Linq.Expressions.Expression<System.Func<T, object?>!>! propertySelector, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource!>! parameterResourceBuilder, string? parameterName = null) -> void
 *REMOVED*static Aspire.Hosting.AzureConstructResourceExtensions.AssignProperty<T>(this Azure.Provisioning.Resource<T>! resource, System.Linq.Expressions.Expression<System.Func<T, object?>!>! propertySelector, Aspire.Hosting.Azure.BicepOutputReference! outputReference, string? parameterName = null) -> void
+static Aspire.Hosting.AzureResourceExtensions.GetBicepIdentifier(this Aspire.Hosting.ApplicationModel.IAzureResource! resource) -> string!
+static Aspire.Hosting.AzureResourceExtensions.NormalizeBicepIdentifier(string! identifierName) -> string!

--- a/src/Aspire.Hosting.Azure/Utils/BicepIdentifierHelpers.cs
+++ b/src/Aspire.Hosting.Azure/Utils/BicepIdentifierHelpers.cs
@@ -14,7 +14,7 @@ internal static partial class BicepIdentifierHelpers
     [GeneratedRegex("^[A-Za-z_][A-Za-z0-9_]*$")]
     private static partial Regex GetBicepIdentifierExpression();
 
-    internal static void ThrowIfInvalid(string name, [CallerArgumentExpression(nameof(name))] string? paramName = null)
+    internal static string ThrowIfInvalid(string name, [CallerArgumentExpression(nameof(name))] string? paramName = null)
     {
         var regex = GetBicepIdentifierExpression();
 
@@ -24,6 +24,8 @@ internal static partial class BicepIdentifierHelpers
                 "Bicep identifiers must only contain alpha, numeric, and _ characters and must start with an alpha or _ character.",
                 paramName);
         }
+
+        return name;
     }
 
     /// <summary>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -566,15 +566,15 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               location: location
               properties: {
                 Application_Type: applicationType
-                WorkspaceResourceId: law-appInsights.id
+                WorkspaceResourceId: law_appInsights.id
               }
               tags: {
                 'aspire-resource-name': 'appInsights'
               }
             }
 
-            resource law-appInsights 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
-              name: take('law-appInsights-${uniqueString(resourceGroup().id)}', 63)
+            resource law_appInsights 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+              name: take('lawappInsights-${uniqueString(resourceGroup().id)}', 63)
               location: location
               properties: {
                 sku: {
@@ -582,7 +582,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 }
               }
               tags: {
-                'aspire-resource-name': 'law-appInsights'
+                'aspire-resource-name': 'law_appInsights'
               }
             }
 
@@ -2700,7 +2700,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: openai
             }
 
-            resource embedding-model 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
+            resource embedding_model 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
               name: 'embedding-model'
               properties: {
                 model: {

--- a/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzurePostgresExtensionsTests.cs
@@ -17,15 +17,15 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
     {
         using var builder = TestDistributedApplicationBuilder.Create(publishMode ? DistributedApplicationOperation.Publish : DistributedApplicationOperation.Run);
 
-        var postgres = builder.AddAzurePostgresFlexibleServer("postgres");
+        var postgres = builder.AddAzurePostgresFlexibleServer("postgres-data");
 
         var manifest = await ManifestUtils.GetManifestWithBicep(postgres.Resource);
 
         var expectedManifest = """
             {
               "type": "azure.bicep.v0",
-              "connectionString": "{postgres.outputs.connectionString}",
-              "path": "postgres.module.bicep",
+              "connectionString": "{postgres-data.outputs.connectionString}",
+              "path": "postgres-data.module.bicep",
               "params": {
                 "principalId": "",
                 "principalType": "",
@@ -47,7 +47,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
                     endIpAddress: '255.255.255.255'
                     startIpAddress: '0.0.0.0'
                   }
-                  parent: postgres
+                  parent: postgres_data
                 }
             
                 """;
@@ -68,8 +68,8 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
 
             param principalName string
 
-            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
-              name: take('postgres-${uniqueString(resourceGroup().id)}', 63)
+            resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
+              name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
               location: location
               properties: {
                 authConfig: {
@@ -94,7 +94,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
                 tier: 'Burstable'
               }
               tags: {
-                'aspire-resource-name': 'postgres'
+                'aspire-resource-name': 'postgres-data'
               }
             }
 
@@ -104,23 +104,23 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
                 endIpAddress: '0.0.0.0'
                 startIpAddress: '0.0.0.0'
               }
-              parent: postgres
+              parent: postgres_data
             }
             {{allowAllIpsFirewall}}
-            resource postgres_admin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2024-08-01' = {
+            resource postgres_data_admin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2024-08-01' = {
               name: principalId
               properties: {
                 principalName: principalName
                 principalType: principalType
               }
-              parent: postgres
+              parent: postgres_data
               dependsOn: [
-                postgres
+                postgres_data
                 postgreSqlFirewallRule_AllowAllAzureIps{{allowAllIpsDependsOn}}
               ]
             }
 
-            output connectionString string = 'Host=${postgres.properties.fullyQualifiedDomainName};Username=${principalName}'
+            output connectionString string = 'Host=${postgres_data.properties.fullyQualifiedDomainName};Username=${principalName}'
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);
@@ -138,7 +138,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
         var userName = specifyUserName ? builder.AddParameter("user") : null;
         var password = specifyPassword ? builder.AddParameter("password") : null;
 
-        var postgres = builder.AddAzurePostgresFlexibleServer("postgres")
+        var postgres = builder.AddAzurePostgresFlexibleServer("postgres-data")
             .WithPasswordAuthentication(userName, password);
 
         postgres.AddDatabase("db1", "db1Name");
@@ -148,12 +148,12 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
         var expectedManifest = $$"""
             {
               "type": "azure.bicep.v0",
-              "connectionString": "{postgres.secretOutputs.connectionString}",
-              "path": "postgres.module.bicep",
+              "connectionString": "{postgres-data.secretOutputs.connectionString}",
+              "path": "postgres-data.module.bicep",
               "params": {
                 "keyVaultName": "",
-                "administratorLogin": "{{{userName?.Resource.Name ?? "postgres-username"}}.value}",
-                "administratorLoginPassword": "{{{password?.Resource.Name ?? "postgres-password"}}.value}"
+                "administratorLogin": "{{{userName?.Resource.Name ?? "postgres-data-username"}}.value}",
+                "administratorLoginPassword": "{{{password?.Resource.Name ?? "postgres-data-password"}}.value}"
               }
             }
             """;
@@ -170,8 +170,8 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
 
             param keyVaultName string
 
-            resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
-              name: take('postgres-${uniqueString(resourceGroup().id)}', 63)
+            resource postgres_data 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
+              name: take('postgresdata-${uniqueString(resourceGroup().id)}', 63)
               location: location
               properties: {
                 administratorLogin: administratorLogin
@@ -198,7 +198,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
                 tier: 'Burstable'
               }
               tags: {
-                'aspire-resource-name': 'postgres'
+                'aspire-resource-name': 'postgres-data'
               }
             }
 
@@ -208,7 +208,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
                 endIpAddress: '0.0.0.0'
                 startIpAddress: '0.0.0.0'
               }
-              parent: postgres
+              parent: postgres_data
             }
 
             resource postgreSqlFirewallRule_AllowAllIps 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
@@ -217,12 +217,12 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
                 endIpAddress: '255.255.255.255'
                 startIpAddress: '0.0.0.0'
               }
-              parent: postgres
+              parent: postgres_data
             }
 
             resource db1 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
               name: 'db1Name'
-              parent: postgres
+              parent: postgres_data
             }
 
             resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
@@ -232,7 +232,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {
-                value: 'Host=${postgres.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'
+                value: 'Host=${postgres_data.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword}'
               }
               parent: keyVault
             }
@@ -240,7 +240,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
             resource db1_connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'db1-connectionString'
               properties: {
-                value: 'Host=${postgres.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=db1Name'
+                value: 'Host=${postgres_data.properties.fullyQualifiedDomainName};Username=${administratorLogin};Password=${administratorLoginPassword};Database=db1Name'
               }
               parent: keyVault
             }
@@ -256,7 +256,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var postgres = builder.AddAzurePostgresFlexibleServer("postgres");
+        var postgres = builder.AddAzurePostgresFlexibleServer("postgres-data");
 
         IResourceBuilder<AzurePostgresFlexibleServerDatabaseResource> db1 = null!;
         IResourceBuilder<AzurePostgresFlexibleServerDatabaseResource> db2 = null!;
@@ -299,7 +299,7 @@ public class AzurePostgresExtensionsTests(ITestOutputHelper output)
         var usr = builder.AddParameter("usr", "user");
         var pwd = builder.AddParameter("pwd", "p@ssw0rd1", secret: true);
 
-        var postgres = builder.AddAzurePostgresFlexibleServer("postgres");
+        var postgres = builder.AddAzurePostgresFlexibleServer("postgres-data");
 
         if (before)
         {

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -15,15 +15,15 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var redis = builder.AddAzureRedis("cache");
+        var redis = builder.AddAzureRedis("redis-cache");
 
         var manifest = await ManifestUtils.GetManifestWithBicep(redis.Resource);
 
         var expectedManifest = """
             {
               "type": "azure.bicep.v0",
-              "connectionString": "{cache.outputs.connectionString}",
-              "path": "cache.module.bicep",
+              "connectionString": "{redis-cache.outputs.connectionString}",
+              "path": "redis-cache.module.bicep",
               "params": {
                 "principalId": "",
                 "principalName": ""
@@ -40,8 +40,8 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
 
             param principalName string
 
-            resource cache 'Microsoft.Cache/redis@2024-03-01' = {
-              name: take('cache-${uniqueString(resourceGroup().id)}', 63)
+            resource redis_cache 'Microsoft.Cache/redis@2024-03-01' = {
+              name: take('rediscache-${uniqueString(resourceGroup().id)}', 63)
               location: location
               properties: {
                 sku: {
@@ -57,21 +57,21 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
                 disableAccessKeyAuthentication: 'true'
               }
               tags: {
-                'aspire-resource-name': 'cache'
+                'aspire-resource-name': 'redis-cache'
               }
             }
 
-            resource cache_contributor 'Microsoft.Cache/redis/accessPolicyAssignments@2024-03-01' = {
-              name: take('cachecontributor${uniqueString(resourceGroup().id)}', 24)
+            resource redis_cache_contributor 'Microsoft.Cache/redis/accessPolicyAssignments@2024-03-01' = {
+              name: take('rediscachecontributor${uniqueString(resourceGroup().id)}', 24)
               properties: {
                 accessPolicyName: 'Data Contributor'
                 objectId: principalId
                 objectIdAlias: principalName
               }
-              parent: cache
+              parent: redis_cache
             }
 
-            output connectionString string = '${cache.properties.hostName},ssl=true'
+            output connectionString string = '${redis_cache.properties.hostName},ssl=true'
             """;
         output.WriteLine(manifest.BicepText);
         Assert.Equal(expectedBicep, manifest.BicepText);
@@ -82,7 +82,7 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var redis = builder.AddAzureRedis("cache")
+        var redis = builder.AddAzureRedis("redis-cache")
             .WithAccessKeyAuthentication();
 
         var manifest = await ManifestUtils.GetManifestWithBicep(redis.Resource);
@@ -90,8 +90,8 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
         var expectedManifest = """
             {
               "type": "azure.bicep.v0",
-              "connectionString": "{cache.secretOutputs.connectionString}",
-              "path": "cache.module.bicep",
+              "connectionString": "{redis-cache.secretOutputs.connectionString}",
+              "path": "redis-cache.module.bicep",
               "params": {
                 "keyVaultName": ""
               }
@@ -105,8 +105,8 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
 
             param keyVaultName string
 
-            resource cache 'Microsoft.Cache/redis@2024-03-01' = {
-              name: take('cache-${uniqueString(resourceGroup().id)}', 63)
+            resource redis_cache 'Microsoft.Cache/redis@2024-03-01' = {
+              name: take('rediscache-${uniqueString(resourceGroup().id)}', 63)
               location: location
               properties: {
                 sku: {
@@ -119,7 +119,7 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
                 redisConfiguration: { }
               }
               tags: {
-                'aspire-resource-name': 'cache'
+                'aspire-resource-name': 'redis-cache'
               }
             }
 
@@ -130,7 +130,7 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
             resource connectionString 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
               name: 'connectionString'
               properties: {
-                value: '${cache.properties.hostName},ssl=true,password=${cache.listKeys().primaryKey}'
+                value: '${redis_cache.properties.hostName},ssl=true,password=${redis_cache.listKeys().primaryKey}'
               }
               parent: keyVault
             }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureServiceBusExtensionsTests.cs
@@ -53,7 +53,7 @@ public class AzureServiceBusExtensionsTests(ITestOutputHelper output)
               scope: sb
             }
 
-            resource device-connection-state-events1234567890-even-longer 'Microsoft.ServiceBus/namespaces/topics@2024-01-01' = {
+            resource device_connection_state_events1234567890_even_longer 'Microsoft.ServiceBus/namespaces/topics@2024-01-01' = {
               name: 'device-connection-state-events1234567890-even-longer'
               parent: sb
             }


### PR DESCRIPTION
## Description

When we create resources in bicep, we need to ensure the identifier name we use is valid. One common complication is that Aspire resources only allow letters, numbers and a hyphen. But bicep doesn't allow hyphen, but instead an underscore.

Add a new convenience API to get a bicep identifier from an IAzureResource.

Fix https://github.com/dotnet/aspire/issues/6074

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6116)