### PR TITLE
Fix menu displaying under header issue

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -73,7 +73,7 @@
     <FluentDialogProvider/>
     <FluentTooltipProvider />
     @* Temporary work around for https://github.com/microsoft/fluentui-blazor/issues/2736 *@
-    <div style="position: fixed; bottom: 0;">
+    <div style="position: fixed; bottom: 0; z-index: 9900;">
         <FluentMenuProvider />
     </div>
     <div id="blazor-error-ui">


### PR DESCRIPTION
## Description

A workaround was added to stop displaying menu bars. It regressed the menu popup to display under the header. This is a workaround to the workaround to the bug fix 😄 

After fix:
![image](https://github.com/user-attachments/assets/93d70937-33ca-402b-8c3e-78ffce7de3a2)

Fixes https://github.com/dotnet/aspire/issues/6109

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6126)