### PR TITLE
[tests] Fix generation of random ids for projects

### DIFF
--- a/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
@@ -250,7 +250,7 @@ public partial class WorkloadTestsBase
 
     // Don't fixup the prefix so it can have characters meant for testing, like spaces
     public static string GetNewProjectId(string? prefix = null)
-        => (prefix is null ? "" : $"{prefix}_") + Path.GetRandomFileName();
+        => (prefix is null ? "" : $"{prefix}_") + FixupSymbolName(Path.GetRandomFileName());
 
     public static IEnumerable<string> GetProjectNamesForTest()
     {
@@ -367,5 +367,35 @@ public partial class WorkloadTestsBase
             { templateName, TestSdk.CurrentSdkAndPreviousRuntime, TestTargetFramework.Current, TestTemplatesInstall.Net9, null },
             { templateName, TestSdk.CurrentSdkAndPreviousRuntime, TestTargetFramework.Current, TestTemplatesInstall.Net9AndNet8, null },
         };
+
+    // Taken from dotnet/runtime src/tasks/Common/Utils.cs
+    private static readonly char[] s_charsToReplace = new[] { '.', '-', '+', '<', '>' };
+    public static string FixupSymbolName(string name)
+    {
+        UTF8Encoding utf8 = new();
+        byte[] bytes = utf8.GetBytes(name);
+        StringBuilder sb = new();
+
+        foreach (byte b in bytes)
+        {
+            if ((b >= (byte)'0' && b <= (byte)'9') ||
+                (b >= (byte)'a' && b <= (byte)'z') ||
+                (b >= (byte)'A' && b <= (byte)'Z') ||
+                (b == (byte)'_'))
+            {
+                sb.Append((char)b);
+            }
+            else if (s_charsToReplace.Contains((char)b))
+            {
+                sb.Append('_');
+            }
+            else
+            {
+                sb.Append($"_{b:X}_");
+            }
+        }
+
+        return sb.ToString();
+    }
 
 }


### PR DESCRIPTION
In `Aspire.Workload.Tests`, `Path.GetRandomFile()` is used to generate part of the project id, like
`jdzjmany.try`, and that is used to generate the namespace names like
`starter_test.Debug-nunit_jdzjmany.try.Web`. But this generated
namespace name invalid because of the `.try`.

The fix is to sanitize the string returned from `Path.GetRandomFile()`
for use as an identifier.

The failures shows up as a build error:

```
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\Program.cs(1,41): error CS1001: Identifier expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\Program.cs(1,41): error CS1002: ; expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\Program.cs(1,44): error CS1514: { expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\Program.cs(1,44): error CS1513: } expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\Program.cs(2,41): error CS1001: Identifier expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\Program.cs(2,41): error CS1002: ; expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\Program.cs(2,44): error CS1514: { expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\Program.cs(2,44): error CS1513: } expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\Program.cs(43,11): error CS1513: } expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\WeatherApiClient.cs(1,45): error CS1001: Identifier expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\WeatherApiClient.cs(1,49): error CS0116: A namespace cannot directly contain members such as fields, methods or statements
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\WeatherApiClient.cs(1,45): error CS1514: { expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\WeatherApiClient.cs(1,48): error CS1022: Type or namespace definition, or end-of-file expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\WeatherApiClient.cs(1,52): error CS1022: Type or namespace definition, or end-of-file expected
C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.Web\WeatherApiClient.cs(29,2): error CS1513: } expected
  starter test.Debug-nunit_jdzjmany.try.ApiService -> C:\h\w\ABEA0983\t\testroot\starter test.Debug-nunit_jdzjmany.try\starter test.Debug-nunit_jdzjmany.try.ApiService\bin\Debug\net9.0\starter test.Debug-nunit_jdzjmany.try.ApiService.dll
```

Similar issue was seen in `dotnet/runtime` - https://github.com/dotnet/runtime/commit/26990158d9725aa55d0af81f050a7a8e90c35f58