### PR TITLE
Fix not being able to copy endpoints in resource details

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
@@ -60,6 +60,9 @@ public sealed class DisplayedEndpoint : IPropertyGridItem
     /// </summary>
     string? IPropertyGridItem.Value => null;
 
+    public string? ValueToCopy => Url ?? Text;
+    public string? ValueToVisualize => Url ?? Text;
+
     public bool MatchesFilter(string filter)
         => Name.Contains(filter, StringComparison.CurrentCultureIgnoreCase) ||
            Text.Contains(filter, StringComparison.CurrentCultureIgnoreCase);


### PR DESCRIPTION
## Description

Regression caused endpoints not to be copiable in UI:

![image](https://github.com/user-attachments/assets/fae01a79-079c-4235-80ea-dd9122a655d5)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6129)