### PR TITLE
Improve the experience when docker isn't running

### DIFF
--- a/playground/Redis/Redis.AppHost/Program.cs
+++ b/playground/Redis/Redis.AppHost/Program.cs
@@ -16,4 +16,14 @@ builder.AddProject<Projects.Redis_ApiService>("apiservice")
     .WithReference(garnet).WaitFor(garnet)
     .WithReference(valkey).WaitFor(valkey);
 
+#if !SKIP_DASHBOARD_REFERENCE
+// This project is only added in playground projects to support development/debugging
+// of the dashboard. It is not required in end developer code. Comment out this code
+// or build with `/p:SkipDashboardReference=true`, to test end developer
+// dashboard launch experience, Refer to Directory.Build.props for the path to
+// the dashboard binary (defaults to the Aspire.Dashboard bin output in the
+// artifacts dir).
+builder.AddProject<Projects.Aspire_Dashboard>(KnownResourceNames.AspireDashboard);
+#endif
+
 builder.Build().Run();

--- a/playground/Redis/Redis.AppHost/Redis.AppHost.csproj
+++ b/playground/Redis/Redis.AppHost/Redis.AppHost.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Redis" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Garnet" />

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -67,7 +67,7 @@ internal static class CommandsConfigurationExtensions
                 {
                     return ResourceCommandState.Disabled;
                 }
-                else if (!IsStopped(context.ResourceSnapshot.State?.Text) && !IsStarting(context.ResourceSnapshot.State?.Text) && !IsWaiting(context.ResourceSnapshot.State?.Text))
+                else if (!IsStopped(context.ResourceSnapshot.State?.Text) && !IsStarting(context.ResourceSnapshot.State?.Text) && !IsWaiting(context.ResourceSnapshot.State?.Text) && context.ResourceSnapshot.State is not null)
                 {
                     return ResourceCommandState.Enabled;
                 }
@@ -96,7 +96,7 @@ internal static class CommandsConfigurationExtensions
             },
             updateState: context =>
             {
-                if (IsWaiting(context.ResourceSnapshot.State?.Text) || IsStarting(context.ResourceSnapshot.State?.Text) || IsStopping(context.ResourceSnapshot.State?.Text) || IsStopped(context.ResourceSnapshot.State?.Text))
+                if (IsWaiting(context.ResourceSnapshot.State?.Text) || IsStarting(context.ResourceSnapshot.State?.Text) || IsStopping(context.ResourceSnapshot.State?.Text) || IsStopped(context.ResourceSnapshot.State?.Text) || context.ResourceSnapshot.State is null)
                 {
                     return ResourceCommandState.Disabled;
                 }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1724,19 +1724,9 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             throw new FailedToApplyEnvironmentException();
         }
 
-        var installed = _dcpInfo?.Containers?.Installed ?? false;
-        var running = _dcpInfo?.Containers?.Running ?? false;
-        var error = _dcpInfo?.Containers?.Error;
-
-        if (!installed)
+        if (_dcpInfo is not null)
         {
-            resourceLogger.LogError("Container runtime could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.");
-            resourceLogger.LogError("The error from the container runtime check was: {error}", error);
-        }
-        else if (!running)
-        {
-            resourceLogger.LogError("Container runtime was found but appears to be unhealthy.");
-            resourceLogger.LogError("The error from the container runtime check was: {error}", error);
+            DcpDependencyCheck.CheckDcpInfoAndLogErrors(resourceLogger, _options.Value, _dcpInfo);
         }
 
         await kubernetesService.CreateAsync(dcpContainerResource, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -1724,6 +1724,21 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             throw new FailedToApplyEnvironmentException();
         }
 
+        var installed = _dcpInfo?.Containers?.Installed ?? false;
+        var running = _dcpInfo?.Containers?.Running ?? false;
+        var error = _dcpInfo?.Containers?.Error;
+
+        if (!installed)
+        {
+            resourceLogger.LogError("Container runtime could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.");
+            resourceLogger.LogError("The error from the container runtime check was: {error}", error);
+        }
+        else if (!running)
+        {
+            resourceLogger.LogError("Container runtime was found but appears to be unhealthy.");
+            resourceLogger.LogError("The error from the container runtime check was: {error}", error);
+        }
+
         await kubernetesService.CreateAsync(dcpContainerResource, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -93,28 +93,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
 
         try
         {
-            var containerRuntime = _dcpOptions.ContainerRuntime;
-            if (string.IsNullOrEmpty(containerRuntime))
-            {
-                // Default runtime is Docker
-                containerRuntime = "docker";
-            }
-            var installed = dcpInfo.Containers?.Installed ?? false;
-            var running = dcpInfo.Containers?.Running ?? false;
-            var error = dcpInfo.Containers?.Error;
-
-            if (!installed)
-            {
-                _logger.LogCritical("Container runtime '{runtime}' could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.", containerRuntime);
-
-                _logger.LogDebug("The error from the container runtime check was: {error}", error);
-            }
-            else if (!running)
-            {
-                _logger.LogCritical("Container runtime '{runtime}' was found but appears to be unhealthy.", containerRuntime);
-
-                _logger.LogDebug("The error from the container runtime check was: {error}", error);
-            }
+            DcpDependencyCheck.CheckDcpInfoAndLogErrors(_logger, _dcpOptions, dcpInfo);
         }
         finally
         {

--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -7,6 +7,7 @@ using System.IO.Pipelines;
 using System.Net.Sockets;
 using System.Text;
 using Aspire.Dashboard.Utils;
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Dcp.Process;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -18,6 +19,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
 {
     private const int LoggingSocketConnectionBacklog = 3;
     private readonly ApplicationExecutor _appExecutor;
+    private readonly DistributedApplicationModel _applicationModel;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
     private readonly DcpOptions _dcpOptions;
@@ -43,7 +45,8 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         DistributedApplicationExecutionContext executionContext,
         ApplicationExecutor appExecutor,
         IDcpDependencyCheckService dependencyCheckService,
-        Locations locations)
+        Locations locations,
+        DistributedApplicationModel applicationModel)
     {
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<DcpHostService>();
@@ -52,6 +55,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         _appExecutor = appExecutor;
         _dependencyCheckService = dependencyCheckService;
         _locations = locations;
+        _applicationModel = applicationModel;
     }
 
     private bool IsSupported => !_executionContext.IsPublishMode;
@@ -64,10 +68,58 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
         }
 
         // Ensure DCP is installed and has all required dependencies
-        _ = await _dependencyCheckService.GetDcpInfoAsync(cancellationToken).ConfigureAwait(false);
+        var dcpInfo = await _dependencyCheckService.GetDcpInfoAsync(cancellationToken).ConfigureAwait(false);
 
+        EnsureDcpContainerRuntime(dcpInfo);
         EnsureDcpHostRunning();
         await _appExecutor.RunApplicationAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private void EnsureDcpContainerRuntime(DcpInfo? dcpInfo)
+    {
+        if (dcpInfo is null)
+        {
+            return;
+        }
+
+        // If we don't have any resources that need a container then we
+        // don't need to check for a healthy container runtime.
+        if (!_applicationModel.Resources.Any(c => c.IsContainer()))
+        {
+            return;
+        }
+
+        AspireEventSource.Instance.ContainerRuntimeHealthCheckStart();
+
+        try
+        {
+            var containerRuntime = _dcpOptions.ContainerRuntime;
+            if (string.IsNullOrEmpty(containerRuntime))
+            {
+                // Default runtime is Docker
+                containerRuntime = "docker";
+            }
+            var installed = dcpInfo.Containers?.Installed ?? false;
+            var running = dcpInfo.Containers?.Running ?? false;
+            var error = dcpInfo.Containers?.Error;
+
+            if (!installed)
+            {
+                _logger.LogCritical("Container runtime '{runtime}' could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.", containerRuntime);
+
+                _logger.LogDebug("The error from the container runtime check was: {error}", error);
+            }
+            else if (!running)
+            {
+                _logger.LogCritical("Container runtime '{runtime}' was found but appears to be unhealthy.", containerRuntime);
+
+                _logger.LogDebug("The error from the container runtime check was: {error}", error);
+            }
+        }
+        finally
+        {
+            AspireEventSource.Instance?.ContainerRuntimeHealthCheckStop();
+        }
     }
 
     public async Task StopAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Description

- When the container runtime isn't running, log a critical error but continue running and sending requests to dcp. DCP will wait for the container runtime to be healthy (started) and will run the containers.

Fixes https://github.com/dotnet/aspire/issues/5533

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6135)