### PR TITLE
Use `ResourceReadyEvent` in redis-insight for non blocking startup

### DIFF
--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -153,7 +153,7 @@ public static class RedisBuilderExtensions
                                       .WithHttpEndpoint(targetPort: 5540, name: "http")
                                       .ExcludeFromManifest();
 
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterResourcesCreatedEvent>(async (e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<ResourceReadyEvent>(resource, async (e, ct) =>
             {
                 var redisInstances = builder.ApplicationBuilder.Resources.OfType<RedisResource>();
 


### PR DESCRIPTION
## Description
This pull request includes a change to the `src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs` file to improve the event subscription mechanism for Redis resources.

Event subscription improvement:

* [`src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs`](diffhunk://#diff-a5074219d9ede6622333dbc0f6da94c74c45ea8c68faa1c2829b57cd3a614659L156-R156): Changed the event subscription from `AfterResourcesCreatedEvent` to `ResourceReadyEvent` to ensure that the subscription occurs when the resource is ready. (`[src/Aspire.Hosting.Redis/RedisBuilderExtensions.csL156-R156](diffhunk://#diff-a5074219d9ede6622333dbc0f6da94c74c45ea8c68faa1c2829b57cd3a614659L156-R156)`)

Fixes #6136
Fixes #6099 
## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6141)