### PR TITLE
Fix typo in `AfterResourceCreatedEvent description"

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/AfterResourcesCreatedEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/AfterResourcesCreatedEvent.cs
@@ -6,7 +6,7 @@ using Aspire.Hosting.Eventing;
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// This experimental event is published after all resuorces have been created.
+/// This experimental event is published after all resources have been created.
 /// </summary>
 /// <param name="services">The <see cref="IServiceProvider"/> instance.</param>
 /// <param name="model">The <see cref="DistributedApplicationModel"/> instance.</param>


### PR DESCRIPTION
## Description

Fix typo of `resource` in AfterResourceCreatedEvent xml documentation.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6147)