### PR TITLE
Add Microsoft.CodeAnalysis.CSharp to ignored dependabot versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
       - dependency-name: "Microsoft.DotNet.Helix.Sdk"
       - dependency-name: "Microsoft.DotNet.SharedFramework.Sdk"
       - dependency-name: "Microsoft.Build.NoTargets"
+      # Pinned versions that should not be updated
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp"
     groups:
       Azure:
         patterns:


### PR DESCRIPTION
This dependency must stay pinned to an older Roslyn version, so it works with all VS versions we support.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6152)