### PR TITLE
[tests] Fix internal pipeline build

### DIFF
--- a/tests/Shared/WorkloadTesting/TemplateCustomHive.cs
+++ b/tests/Shared/WorkloadTesting/TemplateCustomHive.cs
@@ -90,7 +90,7 @@ public class TemplatesCustomHive
 
     public static string GetPackagePath(string builtNuGetsPath, string templatePackageId)
     {
-        var packageNameRegex = new Regex($@"{templatePackageId}\.\d+\.\d+\.\d+(-[A-z]*\.*\d*)?\.nupkg");
+        var packageNameRegex = new Regex($@"{templatePackageId}\.\d+\.\d+\.\d+(-[A-z\.\d]*\.*\d*)?\.nupkg");
         var packages = Directory.EnumerateFiles(builtNuGetsPath, $"{templatePackageId}*.nupkg")
                         .Where(p => packageNameRegex.IsMatch(Path.GetFileName(p)));
 


### PR DESCRIPTION
Internal builds failed with:
```
Cannot find Aspire.ProjectTemplates*.nupkg in C:\h\w\B25B09EA\p\built-nugets. Packages found in C:\h\w\B25B09EA\p\built-nugets: Aspire.AppHost.Sdk.9.0.0-preview.4.24507.3.nupkg,...

Stack Trace:
  /_/tests/Shared/WorkloadTesting/BuildEnvironment.cs(51,0): at Aspire.Workload.Tests.BuildEnvironment.get_ForDefaultFramework()
  /_/tests/Aspire.Workload.Tests/AppHostTemplateTests.cs(21,0): at Aspire.Workload.Tests.AppHostTemplateTests.EnsureProjectsReferencing8_1_0AppHostWithNewerWorkloadCanBuild()
  --- End of stack trace from previous location ---
  ----- Inner Stack Trace -----
     at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
     at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
     at System.Threading.Tasks.Task.Wait()
  /_/tests/Shared/WorkloadTesting/BuildEnvironment.cs(244,0): at Aspire.Workload.Tests.BuildEnvironment..ctor(Boolean useSystemDotNet, TemplatesCustomHive templatesCustomHive, String sdkDirName)
  /_/tests/Shared/WorkloadTesting/BuildEnvironment.cs(43,0): at Aspire.Workload.Tests.BuildEnvironment.<>c.<.cctor>b__62_2()
     at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
     at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
     at System.Lazy`1.CreateValue()
  /_/tests/Shared/WorkloadTesting/BuildEnvironment.cs(49,0): at Aspire.Workload.Tests.BuildEnvironment.get_ForCurrentSdkAndPreviousRuntime()
  /_/tests/Shared/WorkloadTesting/BuildEnvironment.cs(57,0): at Aspire.Workload.Tests.BuildEnvironment..cctor()
  ----- Inner Stack Trace -----
  /_/tests/Shared/WorkloadTesting/TemplateCustomHive.cs(99,0): at Aspire.Workload.Tests.TemplatesCustomHive.GetPackagePath(String builtNuGetsPath, String templatePackageId)
  /_/tests/Shared/WorkloadTesting/TemplateCustomHive.cs(55,0): at Aspire.Workload.Tests.TemplatesCustomHive.<>c__DisplayClass18_0.<EnsureInstalledAsync>b__0(String id)
     at System.Linq.Enumerable.SelectArrayIterator`2.MoveNext()
     at System.Linq.Enumerable.ZipIterator[TFirst,TSecond,TResult](IEnumerable`1 first, IEnumerable`1 second, Func`3 resultSelector)+MoveNext()
  /_/tests/Shared/WorkloadTesting/TemplateCustomHive.cs(80,0): at Aspire.Workload.Tests.TemplatesCustomHive.EnsureInstalledAsync(BuildEnvironment buildEnvironment)
```

This failed because the regex in the workload tests fails to match the preview version in the package filename.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6167)