### PR TITLE
Ensure unique attributes on telemetry

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/MetricValues/DimensionScope.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Aspire.Dashboard.Configuration;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Metrics.V1;
 
@@ -30,7 +29,7 @@ public class DimensionScope
         _values = new(capacity);
     }
 
-    public void AddPointValue(NumberDataPoint d, TelemetryLimitOptions options, ILogger logger)
+    public void AddPointValue(NumberDataPoint d, OtlpContext context)
     {
         var start = OtlpHelpers.UnixNanoSecondsToDateTime(d.StartTimeUnixNano);
         var end = OtlpHelpers.UnixNanoSecondsToDateTime(d.TimeUnixNano);
@@ -42,7 +41,7 @@ public class DimensionScope
             if (lastLongValue is not null && lastLongValue.Value == value)
             {
                 lastLongValue.End = end;
-                AddExemplars(lastLongValue, d.Exemplars, options, logger);
+                AddExemplars(lastLongValue, d.Exemplars, context);
                 Interlocked.Increment(ref lastLongValue.Count);
             }
             else
@@ -52,7 +51,7 @@ public class DimensionScope
                     start = lastLongValue.End;
                 }
                 _lastValue = new MetricValue<long>(d.AsInt, start, end);
-                AddExemplars(_lastValue, d.Exemplars, options, logger);
+                AddExemplars(_lastValue, d.Exemplars, context);
                 _values.Add(_lastValue);
             }
         }
@@ -62,7 +61,7 @@ public class DimensionScope
             if (lastDoubleValue is not null && lastDoubleValue.Value == d.AsDouble)
             {
                 lastDoubleValue.End = end;
-                AddExemplars(lastDoubleValue, d.Exemplars, options, logger);
+                AddExemplars(lastDoubleValue, d.Exemplars, context);
                 Interlocked.Increment(ref lastDoubleValue.Count);
             }
             else
@@ -72,13 +71,13 @@ public class DimensionScope
                     start = lastDoubleValue.End;
                 }
                 _lastValue = new MetricValue<double>(d.AsDouble, start, end);
-                AddExemplars(_lastValue, d.Exemplars, options, logger);
+                AddExemplars(_lastValue, d.Exemplars, context);
                 _values.Add(_lastValue);
             }
         }
     }
 
-    public void AddHistogramValue(HistogramDataPoint h, TelemetryLimitOptions options, ILogger logger)
+    public void AddHistogramValue(HistogramDataPoint h, OtlpContext context)
     {
         var start = OtlpHelpers.UnixNanoSecondsToDateTime(h.StartTimeUnixNano);
         var end = OtlpHelpers.UnixNanoSecondsToDateTime(h.TimeUnixNano);
@@ -87,7 +86,7 @@ public class DimensionScope
         if (lastHistogramValue is not null && lastHistogramValue.Count == h.Count)
         {
             lastHistogramValue.End = end;
-            AddExemplars(lastHistogramValue, h.Exemplars, options, logger);
+            AddExemplars(lastHistogramValue, h.Exemplars, context);
         }
         else
         {
@@ -105,12 +104,12 @@ public class DimensionScope
                 explicitBounds = h.ExplicitBounds.ToArray();
             }
             _lastValue = new HistogramValue(h.BucketCounts.ToArray(), h.Sum, h.Count, start, end, explicitBounds);
-            AddExemplars(_lastValue, h.Exemplars, options, logger);
+            AddExemplars(_lastValue, h.Exemplars, context);
             _values.Add(_lastValue);
         }
     }
 
-    private static void AddExemplars(MetricValueBase value, RepeatedField<Exemplar> exemplars, TelemetryLimitOptions options, ILogger logger)
+    private static void AddExemplars(MetricValueBase value, RepeatedField<Exemplar> exemplars, OtlpContext context)
     {
         if (exemplars.Count > 0)
         {
@@ -143,7 +142,7 @@ public class DimensionScope
                 {
                     Start = start,
                     Value = exemplarValue,
-                    Attributes = exemplar.FilteredAttributes.ToKeyValuePairs(options, logger),
+                    Attributes = exemplar.FilteredAttributes.ToKeyValuePairs(context),
                     SpanId = exemplar.SpanId.ToHexString(),
                     TraceId = exemplar.TraceId.ToHexString()
                 });

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Storage;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
@@ -29,16 +28,14 @@ public class OtlpApplication
     private readonly Dictionary<OtlpInstrumentKey, OtlpInstrument> _instruments = new();
     private readonly ConcurrentDictionary<KeyValuePair<string, string>[], OtlpApplicationView> _applicationViews = new(ApplicationViewKeyComparer.Instance);
 
-    private readonly ILogger _logger;
-    private readonly TelemetryLimitOptions _options;
+    private readonly OtlpContext _context;
 
-    public OtlpApplication(string name, string instanceId, ILogger logger, TelemetryLimitOptions options)
+    public OtlpApplication(string name, string instanceId, OtlpContext context)
     {
         ApplicationName = name;
         InstanceId = instanceId;
 
-        _logger = logger;
-        _options = options;
+        _context = context;
     }
 
     public void AddMetrics(AddContext context, RepeatedField<ScopeMetrics> scopeMetrics)
@@ -69,8 +66,7 @@ public class OtlpApplication
                                     Type = MapMetricType(metric.DataCase),
                                     Parent = GetMeter(sm.Scope)
                                 },
-                                Options = _options,
-                                Logger = _logger
+                                Context = _context
                             });
                         }
 
@@ -79,7 +75,7 @@ public class OtlpApplication
                     catch (Exception ex)
                     {
                         context.FailureCount++;
-                        _logger.LogInformation(ex, "Error adding metric.");
+                        _context.Logger.LogInformation(ex, "Error adding metric.");
                     }
                 }
             }
@@ -105,7 +101,7 @@ public class OtlpApplication
     {
         if (!_meters.TryGetValue(scope.Name, out var meter))
         {
-            _meters.Add(scope.Name, meter = new OtlpMeter(scope, _options, _logger));
+            _meters.Add(scope.Name, meter = new OtlpMeter(scope, _context));
         }
         return meter;
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpApplication.cs
@@ -69,7 +69,8 @@ public class OtlpApplication
                                     Type = MapMetricType(metric.DataCase),
                                     Parent = GetMeter(sm.Scope)
                                 },
-                                Options = _options
+                                Options = _options,
+                                Logger = _logger
                             });
                         }
 
@@ -104,7 +105,7 @@ public class OtlpApplication
     {
         if (!_meters.TryGetValue(scope.Name, out var meter))
         {
-            _meters.Add(scope.Name, meter = new OtlpMeter(scope, _options));
+            _meters.Add(scope.Name, meter = new OtlpMeter(scope, _options, _logger));
         }
         return meter;
     }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpContext.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+
+namespace Aspire.Dashboard.Otlp.Model;
+
+public sealed class OtlpContext
+{
+    public required ILogger Logger { get; init; }
+    public required TelemetryLimitOptions Options { get; init; }
+}

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
@@ -34,8 +33,7 @@ public class OtlpInstrumentData
 public class OtlpInstrument
 {
     public required OtlpInstrumentSummary Summary { get; init; }
-    public required TelemetryLimitOptions Options { get; init; }
-    public required ILogger Logger { get; init; }
+    public required OtlpContext Context { get; init; }
 
     public Dictionary<ReadOnlyMemory<KeyValuePair<string, string>>, DimensionScope> Dimensions { get; } = new(ScopeAttributesComparer.Instance);
     public Dictionary<string, List<string?>> KnownAttributeValues { get; } = new();
@@ -47,19 +45,19 @@ public class OtlpInstrument
             case Metric.DataOneofCase.Gauge:
                 foreach (var d in metric.Gauge.DataPoints)
                 {
-                    FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Options, Logger);
+                    FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Context);
                 }
                 break;
             case Metric.DataOneofCase.Sum:
                 foreach (var d in metric.Sum.DataPoints)
                 {
-                    FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Options, Logger);
+                    FindScope(d.Attributes, ref tempAttributes).AddPointValue(d, Context);
                 }
                 break;
             case Metric.DataOneofCase.Histogram:
                 foreach (var d in metric.Histogram.DataPoints)
                 {
-                    FindScope(d.Attributes, ref tempAttributes).AddHistogramValue(d, Options, Logger);
+                    FindScope(d.Attributes, ref tempAttributes).AddHistogramValue(d, Context);
                 }
                 break;
         }
@@ -71,7 +69,7 @@ public class OtlpInstrument
         // Copy values to a temporary reusable array.
         //
         // A meter can have attributes. Merge these with the data point attributes when creating a dimension.
-        OtlpHelpers.CopyKeyValuePairs(attributes, Summary.Parent.Attributes, Options, Logger, out var copyCount, ref tempAttributes);
+        OtlpHelpers.CopyKeyValuePairs(attributes, Summary.Parent.Attributes, Context, out var copyCount, ref tempAttributes);
         Array.Sort(tempAttributes, 0, copyCount, KeyValuePairComparer.Instance);
 
         var comparableAttributes = tempAttributes.AsMemory(0, copyCount);
@@ -87,7 +85,7 @@ public class OtlpInstrument
     {
         var isFirst = Dimensions.Count == 0;
         var durableAttributes = comparableAttributes.ToArray();
-        var dimension = new DimensionScope(Options.MaxMetricsCount, durableAttributes);
+        var dimension = new DimensionScope(Context.Options.MaxMetricsCount, durableAttributes);
         Dimensions.Add(durableAttributes, dimension);
 
         var keys = KnownAttributeValues.Keys.Union(durableAttributes.Select(a => a.Key)).Distinct();
@@ -124,8 +122,7 @@ public class OtlpInstrument
         var newInstrument = new OtlpInstrument
         {
             Summary = instrument.Summary,
-            Options = instrument.Options,
-            Logger = instrument.Logger
+            Context = instrument.Context
         };
 
         if (cloneData)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -24,11 +24,14 @@ public class OtlpLogEntry
     public OtlpScope Scope { get; }
     public Guid InternalId { get; }
 
-    public OtlpLogEntry(LogRecord record, OtlpApplicationView logApp, OtlpScope scope, TelemetryLimitOptions options)
+    public OtlpLogEntry(LogRecord record, OtlpApplicationView logApp, OtlpScope scope, TelemetryLimitOptions options, ILogger logger)
     {
+        InternalId = Guid.NewGuid();
+        TimeStamp = OtlpHelpers.UnixNanoSecondsToDateTime(record.TimeUnixNano);
+
         string? originalFormat = null;
         string? parentId = null;
-        Attributes = record.Attributes.ToKeyValuePairs(options, filter: attribute =>
+        Attributes = record.Attributes.ToKeyValuePairs(options, logger, filter: attribute =>
         {
             switch (attribute.Key)
             {
@@ -47,7 +50,6 @@ public class OtlpLogEntry
             }
         });
 
-        TimeStamp = OtlpHelpers.UnixNanoSecondsToDateTime(record.TimeUnixNano);
         Flags = record.Flags;
         Severity = MapSeverity(record.SeverityNumber);
 
@@ -58,7 +60,6 @@ public class OtlpLogEntry
         ParentId = parentId ?? string.Empty;
         ApplicationView = logApp;
         Scope = scope;
-        InternalId = Guid.NewGuid();
     }
 
     private static LogLevel MapSeverity(SeverityNumber severityNumber) => severityNumber switch

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpLogEntry.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model.Otlp;
 using OpenTelemetry.Proto.Logs.V1;
 
@@ -24,14 +23,14 @@ public class OtlpLogEntry
     public OtlpScope Scope { get; }
     public Guid InternalId { get; }
 
-    public OtlpLogEntry(LogRecord record, OtlpApplicationView logApp, OtlpScope scope, TelemetryLimitOptions options, ILogger logger)
+    public OtlpLogEntry(LogRecord record, OtlpApplicationView logApp, OtlpScope scope, OtlpContext context)
     {
         InternalId = Guid.NewGuid();
         TimeStamp = OtlpHelpers.UnixNanoSecondsToDateTime(record.TimeUnixNano);
 
         string? originalFormat = null;
         string? parentId = null;
-        Attributes = record.Attributes.ToKeyValuePairs(options, logger, filter: attribute =>
+        Attributes = record.Attributes.ToKeyValuePairs(context, filter: attribute =>
         {
             switch (attribute.Key)
             {
@@ -53,7 +52,7 @@ public class OtlpLogEntry
         Flags = record.Flags;
         Severity = MapSeverity(record.SeverityNumber);
 
-        Message = OtlpHelpers.TruncateString(record.Body.GetString(), options.MaxAttributeLength);
+        Message = OtlpHelpers.TruncateString(record.Body.GetString(), context.Options.MaxAttributeLength);
         OriginalFormat = originalFormat;
         SpanId = record.SpanId.ToHexString();
         TraceId = record.TraceId.ToHexString();

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Aspire.Dashboard.Configuration;
 using OpenTelemetry.Proto.Common.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
@@ -15,10 +14,10 @@ public class OtlpMeter
 
     public KeyValuePair<string, string>[] Attributes { get; }
 
-    public OtlpMeter(InstrumentationScope scope, TelemetryLimitOptions options, ILogger logger)
+    public OtlpMeter(InstrumentationScope scope, OtlpContext context)
     {
         MeterName = scope.Name;
         Version = scope.Version;
-        Attributes = scope.Attributes.ToKeyValuePairs(options, logger);
+        Attributes = scope.Attributes.ToKeyValuePairs(context);
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpMeter.cs
@@ -15,10 +15,10 @@ public class OtlpMeter
 
     public KeyValuePair<string, string>[] Attributes { get; }
 
-    public OtlpMeter(InstrumentationScope scope, TelemetryLimitOptions options)
+    public OtlpMeter(InstrumentationScope scope, TelemetryLimitOptions options, ILogger logger)
     {
         MeterName = scope.Name;
         Version = scope.Version;
-        Attributes = scope.Attributes.ToKeyValuePairs(options);
+        Attributes = scope.Attributes.ToKeyValuePairs(options, logger);
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
@@ -25,11 +25,11 @@ public class OtlpScope
         Version = string.Empty;
     }
 
-    public OtlpScope(InstrumentationScope scope, TelemetryLimitOptions options)
+    public OtlpScope(InstrumentationScope scope, TelemetryLimitOptions options, ILogger logger)
     {
         ScopeName = scope.Name;
 
-        Attributes = scope.Attributes.ToKeyValuePairs(options);
+        Attributes = scope.Attributes.ToKeyValuePairs(options, logger);
         Version = scope.Version;
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpScope.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Configuration;
 using OpenTelemetry.Proto.Common.V1;
 
 namespace Aspire.Dashboard.Otlp.Model;
@@ -25,11 +24,11 @@ public class OtlpScope
         Version = string.Empty;
     }
 
-    public OtlpScope(InstrumentationScope scope, TelemetryLimitOptions options, ILogger logger)
+    public OtlpScope(InstrumentationScope scope, OtlpContext context)
     {
         ScopeName = scope.Name;
 
-        Attributes = scope.Attributes.ToKeyValuePairs(options, logger);
+        Attributes = scope.Attributes.ToKeyValuePairs(context);
         Version = scope.Version;
     }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
@@ -12,7 +12,7 @@ public sealed class Subscription : IDisposable
     private readonly CancellationToken _cancellationToken;
     private readonly Action _unsubscribe;
     private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
-    private ILogger Logger => _telemetryRepository._logger;
+    private ILogger Logger => _telemetryRepository._otlpContext.Logger;
 
     private DateTime? _lastExecute;
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -54,6 +54,7 @@ public class PlotlyChartTests : TestContext
 
         var options = new TelemetryLimitOptions();
         var logger = NullLogger.Instance;
+        var context = new OtlpContext { Options = options, Logger = logger };
         var instrument = new OtlpInstrument
         {
             Summary = new OtlpInstrumentSummary
@@ -64,11 +65,10 @@ public class PlotlyChartTests : TestContext
                 Parent = new OtlpMeter(new InstrumentationScope
                 {
                     Name = "Parent-Name-<b>Bold</b>"
-                }, options, logger),
+                }, context),
                 Type = OtlpInstrumentType.Sum
             },
-            Options = options,
-            Logger = logger,
+            Context = context
         };
 
         var model = new InstrumentViewModel();
@@ -78,7 +78,7 @@ public class PlotlyChartTests : TestContext
             AsInt = 1,
             StartTimeUnixNano = 0,
             TimeUnixNano = long.MaxValue
-        }, options, logger);
+        }, context);
 
         await model.UpdateDataAsync(instrument.Summary, [dimension]);
 

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/PlotlyChartTests.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Bunit;
+using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using Xunit;
@@ -52,6 +53,7 @@ public class PlotlyChartTests : TestContext
         MetricsSetupHelpers.SetupPlotlyChart(this);
 
         var options = new TelemetryLimitOptions();
+        var logger = NullLogger.Instance;
         var instrument = new OtlpInstrument
         {
             Summary = new OtlpInstrumentSummary
@@ -62,10 +64,11 @@ public class PlotlyChartTests : TestContext
                 Parent = new OtlpMeter(new InstrumentationScope
                 {
                     Name = "Parent-Name-<b>Bold</b>"
-                }, options),
+                }, options, logger),
                 Type = OtlpInstrumentType.Sum
             },
             Options = options,
+            Logger = logger,
         };
 
         var model = new InstrumentViewModel();
@@ -75,7 +78,7 @@ public class PlotlyChartTests : TestContext
             AsInt = 1,
             StartTimeUnixNano = 0,
             TimeUnixNano = long.MaxValue
-        }, options);
+        }, options, logger);
 
         await model.UpdateDataAsync(instrument.Summary, [dimension]);
 

--- a/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ApplicationsSelectHelpersTests.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Tests.Shared.Telemetry;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
@@ -214,6 +214,6 @@ public sealed class ApplicationsSelectHelpersTests
         };
         var applicationKey = OtlpHelpers.GetApplicationKey(resource);
 
-        return new OtlpApplication(applicationKey.Name, applicationKey.InstanceId!, NullLogger.Instance, new TelemetryLimitOptions());
+        return new OtlpApplication(applicationKey.Name, applicationKey.InstanceId!, TelemetryTestHelpers.CreateContext());
     }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
@@ -6,6 +6,7 @@ using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Resources;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Common.V1;
 using Xunit;
 
@@ -30,7 +31,7 @@ public sealed class DefaultInstrumentUnitResolverTests
         {
             Description = "Description!",
             Name = name,
-            Parent = new OtlpMeter(new InstrumentationScope { Name = "meter_name" }, new TelemetryLimitOptions()),
+            Parent = new OtlpMeter(new InstrumentationScope { Name = "meter_name" }, new TelemetryLimitOptions(), NullLogger.Instance),
             Type = OtlpInstrumentType.Gauge,
             Unit = unit
         };

--- a/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DefaultInstrumentUnitResolverTests.cs
@@ -1,12 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Resources;
+using Aspire.Tests.Shared.Telemetry;
 using Microsoft.Extensions.Localization;
-using Microsoft.Extensions.Logging.Abstractions;
 using OpenTelemetry.Proto.Common.V1;
 using Xunit;
 
@@ -31,7 +30,7 @@ public sealed class DefaultInstrumentUnitResolverTests
         {
             Description = "Description!",
             Name = name,
-            Parent = new OtlpMeter(new InstrumentationScope { Name = "meter_name" }, new TelemetryLimitOptions(), NullLogger.Instance),
+            Parent = new OtlpMeter(new InstrumentationScope { Name = "meter_name" }, TelemetryTestHelpers.CreateContext()),
             Type = OtlpInstrumentType.Gauge,
             Unit = unit
         };

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpHelpersTests.cs
@@ -3,10 +3,10 @@
 
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Model;
+using Aspire.Tests.Shared.Telemetry;
 using Google.Protobuf;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using OpenTelemetry.Proto.Common.V1;
 using Xunit;
@@ -156,8 +156,7 @@ public class OtlpHelpersTests
                 new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } }
             },
             [],
-            new TelemetryLimitOptions { MaxAttributeCount = 3 },
-            NullLogger.Instance,
+            TelemetryTestHelpers.CreateContext(options: new TelemetryLimitOptions { MaxAttributeCount = 3 }),
             out var copyCount,
             ref copiedAttributes);
 
@@ -187,8 +186,7 @@ public class OtlpHelpersTests
                 new KeyValue { Key = "key4", Value = new AnyValue { StringValue = "value4" } }
             },
             [],
-            new TelemetryLimitOptions { MaxAttributeCount = 3 },
-            NullLogger.Instance,
+            TelemetryTestHelpers.CreateContext(options: new TelemetryLimitOptions { MaxAttributeCount = 3 }),
             out var copyCount,
             ref copiedAttributes);
 
@@ -232,8 +230,7 @@ public class OtlpHelpersTests
                 new KeyValue { Key = "key4", Value = new AnyValue { StringValue = "value4-2" } }
             },
             [],
-            new TelemetryLimitOptions { MaxAttributeCount = 3 },
-            NullLogger.Instance,
+            TelemetryTestHelpers.CreateContext(options: new TelemetryLimitOptions { MaxAttributeCount = 3 }),
             out var copyCount,
             ref copiedAttributes);
 
@@ -272,8 +269,7 @@ public class OtlpHelpersTests
             [
                 new KeyValuePair<string, string>("parentkey1", "parentvalue1")
             ],
-            new TelemetryLimitOptions { MaxAttributeCount = 3 },
-            NullLogger.Instance,
+            TelemetryTestHelpers.CreateContext(options: new TelemetryLimitOptions { MaxAttributeCount = 3 }),
             out var copyCount,
             ref copiedAttributes);
 
@@ -309,8 +305,7 @@ public class OtlpHelpersTests
             [
                 new KeyValuePair<string, string>("parentkey1", "parentvalue1")
             ],
-            new TelemetryLimitOptions { MaxAttributeCount = 3 },
-            NullLogger.Instance,
+            TelemetryTestHelpers.CreateContext(options: new TelemetryLimitOptions { MaxAttributeCount = 3 }),
             out var copyCount,
             ref copiedAttributes);
 
@@ -353,8 +348,7 @@ public class OtlpHelpersTests
                 new KeyValuePair<string, string>("parentkey2", "parentvalue2"),
                 new KeyValuePair<string, string>("parentkey3", "parentvalue3")
             ],
-            new TelemetryLimitOptions { MaxAttributeCount = 3 },
-            NullLogger.Instance,
+            TelemetryTestHelpers.CreateContext(options: new TelemetryLimitOptions { MaxAttributeCount = 3 }),
             out var copyCount,
             ref copiedAttributes);
 
@@ -390,7 +384,7 @@ public class OtlpHelpersTests
             };
 
         // Act
-        var results = attributes.ToKeyValuePairs(new TelemetryLimitOptions { MaxAttributeCount = 2 }, NullLogger.Instance);
+        var results = attributes.ToKeyValuePairs(TelemetryTestHelpers.CreateContext(options: new TelemetryLimitOptions { MaxAttributeCount = 2 }));
 
         // Act
         Assert.Collection(results,
@@ -425,7 +419,8 @@ public class OtlpHelpersTests
         });
 
         // Act
-        var results = attributes.ToKeyValuePairs(new TelemetryLimitOptions { MaxAttributeCount = 2 }, factory.CreateLogger<OtlpHelpersTests>());
+        var context = TelemetryTestHelpers.CreateContext(options: new TelemetryLimitOptions { MaxAttributeCount = 2 }, logger: factory.CreateLogger<OtlpHelpersTests>());
+        var results = attributes.ToKeyValuePairs(context);
 
         // Assert
         Assert.Collection(results,
@@ -469,7 +464,8 @@ public class OtlpHelpersTests
         });
 
         // Act
-        var results = attributes.ToKeyValuePairs(new TelemetryLimitOptions { MaxAttributeCount = 3 }, factory.CreateLogger<OtlpHelpersTests>(), kv =>
+        var context = TelemetryTestHelpers.CreateContext(options: new TelemetryLimitOptions { MaxAttributeCount = 3 }, logger: factory.CreateLogger<OtlpHelpersTests>());
+        var results = attributes.ToKeyValuePairs(context, kv =>
         {
             return !kv.Key.Contains('-');
         });

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpHelpersTests.cs
@@ -1,8 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Otlp.Model;
 using Google.Protobuf;
+using Google.Protobuf.Collections;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using OpenTelemetry.Proto.Common.V1;
 using Xunit;
 
@@ -136,5 +141,358 @@ public class OtlpHelpersTests
 
         // Assert
         Assert.Equal(@"{""prop1"":[""string!"",1.1,1],""prop2"":""48656c6c6f20776f726c64"",""prop3"":{""nestedProp1"":""nested!""}}", s);
+    }
+
+    [Fact]
+    public void CopyKeyValuePairs_UnderLimit_AllCopied()
+    {
+        // Arrange
+        KeyValuePair<string, string>[]? copiedAttributes = null;
+
+        // Act
+        OtlpHelpers.CopyKeyValuePairs(
+            new RepeatedField<KeyValue>
+            {
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } }
+            },
+            [],
+            new TelemetryLimitOptions { MaxAttributeCount = 3 },
+            NullLogger.Instance,
+            out var copyCount,
+            ref copiedAttributes);
+
+        // Assert
+        Assert.Equal(1, copyCount);
+        Assert.Collection(copiedAttributes,
+            a =>
+            {
+                Assert.Equal("key1", a.Key);
+                Assert.Equal("value1", a.Value);
+            });
+    }
+
+    [Fact]
+    public void CopyKeyValuePairs_OverLimit_LimitCopied()
+    {
+        // Arrange
+        KeyValuePair<string, string>[]? copiedAttributes = null;
+
+        // Act
+        OtlpHelpers.CopyKeyValuePairs(
+            new RepeatedField<KeyValue>
+            {
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } },
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "value2" } },
+                new KeyValue { Key = "key3", Value = new AnyValue { StringValue = "value3" } },
+                new KeyValue { Key = "key4", Value = new AnyValue { StringValue = "value4" } }
+            },
+            [],
+            new TelemetryLimitOptions { MaxAttributeCount = 3 },
+            NullLogger.Instance,
+            out var copyCount,
+            ref copiedAttributes);
+
+        // Assert
+        Assert.Equal(3, copyCount);
+        Assert.Collection(copiedAttributes,
+            a =>
+            {
+                Assert.Equal("key1", a.Key);
+                Assert.Equal("value1", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key2", a.Key);
+                Assert.Equal("value2", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key3", a.Key);
+                Assert.Equal("value3", a.Value);
+            });
+    }
+
+    [Fact]
+    public void CopyKeyValuePairs_OverLimitWithDuplicates_LimitCopied()
+    {
+        // Arrange
+        KeyValuePair<string, string>[]? copiedAttributes = null;
+
+        // Act
+        OtlpHelpers.CopyKeyValuePairs(
+            new RepeatedField<KeyValue>
+            {
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } },
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1-2" } },
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "value2" } },
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "value2-2" } },
+                new KeyValue { Key = "key3", Value = new AnyValue { StringValue = "value3" } },
+                new KeyValue { Key = "key3", Value = new AnyValue { StringValue = "value3-2" } },
+                new KeyValue { Key = "key4", Value = new AnyValue { StringValue = "value4" } },
+                new KeyValue { Key = "key4", Value = new AnyValue { StringValue = "value4-2" } }
+            },
+            [],
+            new TelemetryLimitOptions { MaxAttributeCount = 3 },
+            NullLogger.Instance,
+            out var copyCount,
+            ref copiedAttributes);
+
+        // Assert
+        Assert.Equal(3, copyCount);
+        Assert.Collection(copiedAttributes,
+            a =>
+            {
+                Assert.Equal("key1", a.Key);
+                Assert.Equal("value1-2", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key2", a.Key);
+                Assert.Equal("value2-2", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key3", a.Key);
+                Assert.Equal("value3-2", a.Value);
+            });
+    }
+
+    [Fact]
+    public void CopyKeyValuePairs_HasParent_UnderLimit_LimitCopied()
+    {
+        // Arrange
+        KeyValuePair<string, string>[]? copiedAttributes = null;
+
+        // Act
+        OtlpHelpers.CopyKeyValuePairs(
+            new RepeatedField<KeyValue>
+            {
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } }
+            },
+            [
+                new KeyValuePair<string, string>("parentkey1", "parentvalue1")
+            ],
+            new TelemetryLimitOptions { MaxAttributeCount = 3 },
+            NullLogger.Instance,
+            out var copyCount,
+            ref copiedAttributes);
+
+        // Assert
+        Assert.Equal(2, copyCount);
+        Assert.Collection(copiedAttributes,
+            a =>
+            {
+                Assert.Equal("parentkey1", a.Key);
+                Assert.Equal("parentvalue1", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key1", a.Key);
+                Assert.Equal("value1", a.Value);
+            });
+    }
+
+    [Fact]
+    public void CopyKeyValuePairs_HasParent_OverLimit_LimitCopied()
+    {
+        // Arrange
+        KeyValuePair<string, string>[]? copiedAttributes = null;
+
+        // Act
+        OtlpHelpers.CopyKeyValuePairs(
+            new RepeatedField<KeyValue>
+            {
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } },
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "value2" } },
+                new KeyValue { Key = "key3", Value = new AnyValue { StringValue = "value3" } }
+            },
+            [
+                new KeyValuePair<string, string>("parentkey1", "parentvalue1")
+            ],
+            new TelemetryLimitOptions { MaxAttributeCount = 3 },
+            NullLogger.Instance,
+            out var copyCount,
+            ref copiedAttributes);
+
+        // Assert
+        Assert.Equal(3, copyCount);
+        Assert.Collection(copiedAttributes,
+            a =>
+            {
+                Assert.Equal("parentkey1", a.Key);
+                Assert.Equal("parentvalue1", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key1", a.Key);
+                Assert.Equal("value1", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key2", a.Key);
+                Assert.Equal("value2", a.Value);
+            });
+    }
+
+    [Fact]
+    public void CopyKeyValuePairs_HasParent_ParentLimit_ParentValues()
+    {
+        // Arrange
+        KeyValuePair<string, string>[]? copiedAttributes = null;
+
+        // Act
+        OtlpHelpers.CopyKeyValuePairs(
+            new RepeatedField<KeyValue>
+            {
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } },
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "value2" } },
+                new KeyValue { Key = "key3", Value = new AnyValue { StringValue = "value3" } }
+            },
+            [
+                new KeyValuePair<string, string>("parentkey1", "parentvalue1"),
+                new KeyValuePair<string, string>("parentkey2", "parentvalue2"),
+                new KeyValuePair<string, string>("parentkey3", "parentvalue3")
+            ],
+            new TelemetryLimitOptions { MaxAttributeCount = 3 },
+            NullLogger.Instance,
+            out var copyCount,
+            ref copiedAttributes);
+
+        // Assert
+        Assert.Equal(3, copyCount);
+        Assert.Collection(copiedAttributes,
+            a =>
+            {
+                Assert.Equal("parentkey1", a.Key);
+                Assert.Equal("parentvalue1", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("parentkey2", a.Key);
+                Assert.Equal("parentvalue2", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("parentkey3", a.Key);
+                Assert.Equal("parentvalue3", a.Value);
+            });
+    }
+
+    [Fact]
+    public void ToKeyValuePairs_OverLimit_LimitReturned()
+    {
+        // Arrange
+        var attributes = new RepeatedField<KeyValue>
+            {
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } },
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "value2" } },
+                new KeyValue { Key = "key3", Value = new AnyValue { StringValue = "value3" } }
+            };
+
+        // Act
+        var results = attributes.ToKeyValuePairs(new TelemetryLimitOptions { MaxAttributeCount = 2 }, NullLogger.Instance);
+
+        // Act
+        Assert.Collection(results,
+            a =>
+            {
+                Assert.Equal("key1", a.Key);
+                Assert.Equal("value1", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key2", a.Key);
+                Assert.Equal("value2", a.Value);
+            });
+    }
+
+    [Fact]
+    public void ToKeyValuePairs_OverLimitWithDuplicates_LimitReturned()
+    {
+        // Arrange
+        var attributes = new RepeatedField<KeyValue>
+            {
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } },
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1-2" } },
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "value2" } }
+            };
+
+        var testSink = new TestSink();
+        var factory = LoggerFactory.Create(b =>
+        {
+            b.SetMinimumLevel(LogLevel.Debug);
+            b.AddProvider(new TestLoggerProvider(testSink));
+        });
+
+        // Act
+        var results = attributes.ToKeyValuePairs(new TelemetryLimitOptions { MaxAttributeCount = 2 }, factory.CreateLogger<OtlpHelpersTests>());
+
+        // Assert
+        Assert.Collection(results,
+            a =>
+            {
+                Assert.Equal("key1", a.Key);
+                Assert.Equal("value1-2", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key2", a.Key);
+                Assert.Equal("value2", a.Value);
+            });
+
+        var w = Assert.Single(testSink.Writes);
+        Assert.Equal("Duplicate attribute key1 with different value. Last value wins.", w.Message);
+    }
+
+    [Fact]
+    public void ToKeyValuePairs_OverLimitWithDuplicates_Filter_LimitReturned()
+    {
+        // Arrange
+        var attributes = new RepeatedField<KeyValue>
+            {
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1" } },
+                new KeyValue { Key = "key1", Value = new AnyValue { StringValue = "value1-2" } },
+                new KeyValue { Key = "key1-2", Value = new AnyValue { StringValue = "value1-2" } },
+                new KeyValue { Key = "key1-3", Value = new AnyValue { StringValue = "value1-3" } },
+                new KeyValue { Key = "key1-4", Value = new AnyValue { StringValue = "value1-4" } },
+                new KeyValue { Key = "key1-5", Value = new AnyValue { StringValue = "value1-5" } },
+                new KeyValue { Key = "key2", Value = new AnyValue { StringValue = "value2" } },
+                new KeyValue { Key = "key3", Value = new AnyValue { StringValue = "value3" } },
+                new KeyValue { Key = "key4", Value = new AnyValue { StringValue = "value4" } }
+            };
+
+        var testSink = new TestSink();
+        var factory = LoggerFactory.Create(b =>
+        {
+            b.SetMinimumLevel(LogLevel.Debug);
+            b.AddProvider(new TestLoggerProvider(testSink));
+        });
+
+        // Act
+        var results = attributes.ToKeyValuePairs(new TelemetryLimitOptions { MaxAttributeCount = 3 }, factory.CreateLogger<OtlpHelpersTests>(), kv =>
+        {
+            return !kv.Key.Contains('-');
+        });
+
+        // Assert
+        Assert.Collection(results,
+            a =>
+            {
+                Assert.Equal("key1", a.Key);
+                Assert.Equal("value1-2", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key2", a.Key);
+                Assert.Equal("value2", a.Value);
+            },
+            a =>
+            {
+                Assert.Equal("key3", a.Key);
+                Assert.Equal("value3", a.Value);
+            });
+
+        var w = Assert.Single(testSink.Writes);
+        Assert.Equal("Duplicate attribute key1 with different value. Last value wins.", w.Message);
     }
 }

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -276,4 +276,13 @@ internal static class TelemetryTestHelpers
 
         return value.ToString();
     }
+
+    public static OtlpContext CreateContext(TelemetryLimitOptions? options = null, ILogger? logger = null)
+    {
+        return new OtlpContext
+        {
+            Options = options ?? new TelemetryLimitOptions(),
+            Logger = logger ?? NullLogger.Instance
+        };
+    }
 }


### PR DESCRIPTION
## Description

We added row keys to grids in the dashboard. For properties, the name is the default key. It must be unique or `FluentDataGrid` will error. When testing I found some log entries that errored because they had duplicate attributes. e.g. two `HttpMethod` attributes.

![image](https://github.com/user-attachments/assets/fdd4df0c-8659-4a0d-a857-0431d1b8e79d)

The duplicate attributes are coming are coming from OTLP (i.e. they're external data). We shouldn't be sent duplicate data, but it's not something we can control.

To fix this problem the OTLP collector services only store unique attributes. This matches behavior in [the spec around attribute collections](https://opentelemetry.io/docs/specs/otel/common/#attribute-collections). Last value wins. To help identify if this is a problem, debug logs are written if there are duplicate keys with different values.

Fixes https://github.com/dotnet/aspire/issues/6178

Should be backported to RC1 if possible.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
