### PR TITLE
Retry tests if msbuild crashes

### DIFF
--- a/eng/test-configuration.json
+++ b/eng/test-configuration.json
@@ -4,6 +4,7 @@
   "localRerunCount": 1,
   "retryOnRules": [
     { "testName": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Tests.ConformanceTests.HealthCheckReportsExpectedStatus" } },
-    { "testAssembly": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Tests" }, "failureMessage": { "contains": "RemoteExecutionException : Half-way through waiting for remote process." } }
+    { "testAssembly": { "contains": "Aspire.Elastic.Clients.Elasticsearch.Tests" }, "failureMessage": { "contains": "RemoteExecutionException : Half-way through waiting for remote process." } },
+    { "failureMessage" : { "contains" : "MSBUILD : error MSB4166: Child node" } }
   ]
 }

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -141,6 +141,7 @@
     <!-- Disable playwright tests on helix/linux. Issue: https://github.com/dotnet/aspire/issues/4623 -->
     <HelixPreCommand Condition="'$(DisablePlaywrightTests)' == 'true'" Include="$(_EnvVarSetKeyword) DISABLE_PLAYWRIGHT_TESTS=true" />
 
+    <!-- Issue: https://github.com/dotnet/aspire/pull/6181 -->
     <HelixPreCommand Include="$(_EnvVarSetKeyword) MSBUILDDEBUGPATH=$(_HelixCorrelationPayloadEnvVar)/msbuild-debug" />
 
     <HelixPreCommand Condition="'$(OS)' == 'Windows_NT'" Include="dotnet dev-certs https --trust" />

--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -141,6 +141,8 @@
     <!-- Disable playwright tests on helix/linux. Issue: https://github.com/dotnet/aspire/issues/4623 -->
     <HelixPreCommand Condition="'$(DisablePlaywrightTests)' == 'true'" Include="$(_EnvVarSetKeyword) DISABLE_PLAYWRIGHT_TESTS=true" />
 
+    <HelixPreCommand Include="$(_EnvVarSetKeyword) MSBUILDDEBUGPATH=$(_HelixCorrelationPayloadEnvVar)/msbuild-debug" />
+
     <HelixPreCommand Condition="'$(OS)' == 'Windows_NT'" Include="dotnet dev-certs https --trust" />
 
     <HelixPostCommand Include="$(_CleanupProcessesCommand)" />


### PR DESCRIPTION
And get the msbuild debug files from crashes to aid debugging.

Issue: https://github.com/dotnet/aspire/issues/6163

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6181)