### PR TITLE
Fix opening the settings dialog resetting the theme

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -3,7 +3,11 @@
 @inject IStringLocalizer<Dialogs> Loc
 
 <FluentStack Orientation="Orientation.Vertical" Style="display: contents">
-    <FluentRadioGroup TValue="string" Label="@Loc[nameof(Dialogs.SettingsDialogTheme)]" Value="@_currentSetting" ValueChanged="SettingChangedAsync" Orientation="Orientation.Vertical">
+    <FluentRadioGroup TValue="string"
+                      Label="@Loc[nameof(Dialogs.SettingsDialogTheme)]"
+                      @bind-Value="@_currentSetting"
+                      @bind-Value:after="SettingChangedAsync"
+                      Orientation="Orientation.Vertical">
         <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingSystem">@Loc[nameof(Dialogs.SettingsDialogSystemTheme)]</FluentRadio>
         <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingLight">@Loc[nameof(Dialogs.SettingsDialogLightTheme)]</FluentRadio>
         <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingDark">@Loc[nameof(Dialogs.SettingsDialogDarkTheme)]</FluentRadio>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -7,7 +7,7 @@ using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace Aspire.Dashboard.Components.Dialogs;
 
-public partial class SettingsDialog : IDialogContentComponent, IAsyncDisposable
+public partial class SettingsDialog : IDialogContentComponent, IDisposable
 {
     private string? _currentSetting;
 
@@ -44,9 +44,8 @@ public partial class SettingsDialog : IDialogContentComponent, IAsyncDisposable
         }
     }
 
-    public ValueTask DisposeAsync()
+    public void Dispose()
     {
         _themeChangedSubscription?.Dispose();
-        return ValueTask.CompletedTask;
     }
 }

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -34,6 +34,8 @@ public partial class SettingsDialog : IDialogContentComponent, IAsyncDisposable
 
     private async Task SettingChangedAsync()
     {
+        // The field is being transiently set to null when the value changes. Maybe a bug in FluentUI?
+        // This should never be set to null by the dashboard so we can ignore null values.
         if (_currentSetting != null)
         {
             // The theme isn't changed here. Instead, the MainLayout subscribes to the change event

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -192,7 +192,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
     public async Task LaunchSettingsAsync()
     {
-        DialogParameters parameters = new()
+        var parameters = new DialogParameters
         {
             Title = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogTitle)],
             PrimaryAction = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)],
@@ -216,6 +216,9 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
             await _openPageDialog.CloseAsync();
         }
+
+        // Ensure the currently set theme is immediately available to display in settings dialog.
+        await ThemeManager.EnsureEffectiveThemeAsync();
 
         _openPageDialog = await DialogService.ShowPanelAsync<SettingsDialog>(parameters).ConfigureAwait(true);
     }


### PR DESCRIPTION
## Description

This area hasn't change in a while. I think the regression was caused by FluentUI update at some point that made `FluentRadioGroup` misbehave.

Fixes https://github.com/dotnet/aspire/issues/6020

9.0 bug fix.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
