### PR TITLE
Initial integration of codespace URL rewriting logic into hosting.

### DIFF
--- a/playground/waitfor/WaitForSandbox.AppHost/Properties/launchSettings.json
+++ b/playground/waitfor/WaitForSandbox.AppHost/Properties/launchSettings.json
@@ -11,7 +11,10 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "CODESPACES": "true",
+        "GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN": "app.github.local",
+        "CODESPACE_NAME": "bob"
       }
     },
     "http": {

--- a/playground/waitfor/WaitForSandbox.AppHost/Properties/launchSettings.json
+++ b/playground/waitfor/WaitForSandbox.AppHost/Properties/launchSettings.json
@@ -11,10 +11,7 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:16175",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
-        "CODESPACES": "true",
-        "GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN": "app.github.local",
-        "CODESPACE_NAME": "bob"
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
       }
     },
     "http": {

--- a/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
@@ -36,10 +36,7 @@ internal class CodespacesUrlRewriter(ILogger<CodespacesUrlRewriter> logger, ICon
 
                     if (!originalUrlSnapshot.IsInternal && (uri.Scheme == "http" || uri.Scheme == "https") && uri.Host == "localhost")
                     {
-                        if (remappedUrls is null)
-                        {
-                            remappedUrls = new();
-                        }
+                        remappedUrls ??= new();
 
                         var newUrlSnapshot = originalUrlSnapshot with
                         {

--- a/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Aspire.Hosting.Codespaces;
+
+internal class CodespacesUrlRewriter(IConfiguration configuration, ResourceNotificationService resourceNotificationService) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var gitHubCodespacesPortForwardingDomain = configuration.GetValue<string>("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN") ?? throw new DistributedApplicationException("Codespaces was detected but GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN environment missing.");
+        var codespaceName = configuration.GetValue<string>("CODESPACE_NAME") ?? throw new DistributedApplicationException("Codespaces was detected but CODESPACE_NAME environment missing.");
+
+        do
+        {
+            var resourceEvents = resourceNotificationService.WatchAsync(stoppingToken);
+
+            await foreach (var resourceEvent in resourceEvents.ConfigureAwait(false))
+            {
+                Dictionary<UrlSnapshot, UrlSnapshot>? remappedUrls = null;
+
+                foreach (var originalUrlSnapshot in resourceEvent.Snapshot.Urls)
+                {
+                    var uri = new Uri(originalUrlSnapshot.Url);
+
+                    if (!originalUrlSnapshot.IsInternal && (uri.Scheme == "http" || uri.Scheme == "https") && uri.Host == "localhost")
+                    {
+                        if (remappedUrls is null)
+                        {
+                            remappedUrls = new();
+                        }
+
+                        var newUrlSnapshot = originalUrlSnapshot with
+                        {
+                            Url = $"{uri.Scheme}://{codespaceName}-{uri.Port}.{gitHubCodespacesPortForwardingDomain}{uri.AbsolutePath}"
+                        };
+
+                        remappedUrls.Add(originalUrlSnapshot, newUrlSnapshot);
+                    }
+                }
+
+                if (remappedUrls is not null)
+                {
+                    var transformedUrls = from originalUrl in resourceEvent.Snapshot.Urls
+                                          select remappedUrls.TryGetValue(originalUrl, out var remappedUrl) ? remappedUrl : originalUrl;
+
+                    await resourceNotificationService.PublishUpdateAsync(resourceEvent.Resource, resourceEvent.ResourceId, s => s with
+                    {
+                        Urls = transformedUrls.ToImmutableArray()
+                    }).ConfigureAwait(false);
+                }
+            }
+
+            // Short delay if we crash just to avoid spinning CPU.
+            await Task.Delay(5000, stoppingToken).ConfigureAwait(false);
+        } while (!stoppingToken.IsCancellationRequested);
+    }
+}

--- a/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Codespaces;
 
-internal class CodespacesUrlRewriter(ILogger<CodespacesUrlRewriter> logger, IConfiguration configuration, ResourceNotificationService resourceNotificationService) : BackgroundService
+internal sealed class CodespacesUrlRewriter(ILogger<CodespacesUrlRewriter> logger, IConfiguration configuration, ResourceNotificationService resourceNotificationService) : BackgroundService
 {
     private const string CodespacesEnvironmentVariable = "CODESPACES";
     private const string CodespaceNameEnvironmentVariable = "CODESPACE_NAME";

--- a/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
@@ -5,13 +5,20 @@ using System.Collections.Immutable;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.Codespaces;
 
-internal class CodespacesUrlRewriter(IConfiguration configuration, ResourceNotificationService resourceNotificationService) : BackgroundService
+internal class CodespacesUrlRewriter(ILogger<CodespacesUrlRewriter> logger, IConfiguration configuration, ResourceNotificationService resourceNotificationService) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        if (!configuration.GetValue<bool>("CODESPACES", false))
+        {
+            logger.LogTrace("Not running in Codespaces, skipping URL rewriting.");
+            return;
+        }
+
         var gitHubCodespacesPortForwardingDomain = configuration.GetValue<string>("GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN") ?? throw new DistributedApplicationException("Codespaces was detected but GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN environment missing.");
         var codespaceName = configuration.GetValue<string>("CODESPACE_NAME") ?? throw new DistributedApplicationException("Codespaces was detected but CODESPACE_NAME environment missing.");
 

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -190,7 +190,6 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddSingleton<IDistributedApplicationEventing>(Eventing);
         _innerBuilder.Services.AddHealthChecks();
 
-        ConfigureCodespacesUrlRewriter();
         ConfigureHealthChecks();
 
         if (ExecutionContext.IsRunMode)
@@ -262,6 +261,9 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             _innerBuilder.Services.AddSingleton(new Locations());
             _innerBuilder.Services.AddSingleton<IKubernetesService, KubernetesService>();
 
+            // Codespaces
+            _innerBuilder.Services.AddHostedService<CodespacesUrlRewriter>();
+
             Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.InitializeDcpAnnotations);
         }
 
@@ -279,17 +281,6 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         _innerBuilder.Services.AddSingleton(ExecutionContext);
         LogBuilderConstructed(this);
-    }
-
-    private void ConfigureCodespacesUrlRewriter()
-    {
-        var isRunningInCodepaces = _innerBuilder.Configuration.GetBool("CODESPACES", false);
-        if (!ExecutionContext.IsRunMode || !isRunningInCodepaces)
-        {
-            return;
-        }
-
-        _innerBuilder.Services.AddHostedService<CodespacesUrlRewriter>();
     }
 
     private void ConfigureHealthChecks()

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Codespaces;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Eventing;
@@ -189,6 +190,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         _innerBuilder.Services.AddSingleton<IDistributedApplicationEventing>(Eventing);
         _innerBuilder.Services.AddHealthChecks();
 
+        ConfigureCodespacesUrlRewriter();
         ConfigureHealthChecks();
 
         if (ExecutionContext.IsRunMode)
@@ -277,6 +279,17 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
         _innerBuilder.Services.AddSingleton(ExecutionContext);
         LogBuilderConstructed(this);
+    }
+
+    private void ConfigureCodespacesUrlRewriter()
+    {
+        var isRunningInCodepaces = _innerBuilder.Configuration.GetBool("CODESPACES", false);
+        if (!ExecutionContext.IsRunMode || !isRunningInCodepaces)
+        {
+            return;
+        }
+
+        _innerBuilder.Services.AddHostedService<CodespacesUrlRewriter>();
     }
 
     private void ConfigureHealthChecks()

--- a/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Aspire.Hosting.Tests.Codespaces;
+
+public class CodespacesUrlRewriterTests(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task VerifyUrlsRewriterStopsWhenNotInCodespaces()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+        builder.Services.AddLogging(logging =>
+        {
+            logging.AddFakeLogging();
+            logging.AddXunit(testOutputHelper);
+        });
+
+        var resource = builder.AddResource(new CustomResource("resource"));
+
+        var abortToken = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        using var app = builder.Build();
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        await app.StartAsync(abortToken.Token);
+
+        var collector = app.Services.GetFakeLogCollector();
+
+        var urlRewriterStopped = false;
+
+        while (!abortToken.Token.IsCancellationRequested)
+        {
+            var logs = collector.GetSnapshot();
+            urlRewriterStopped = logs.Any(l => l.Message.Contains("Not running in Codespaces, skipping URL rewriting."));
+            if (urlRewriterStopped)
+            {
+                break;
+            }
+        }
+
+        Assert.True(urlRewriterStopped);
+
+        await app.StopAsync(abortToken.Token);
+    }
+
+    [Fact]
+    public async Task VerifyUrlsRewrittenWhenInCodespaces()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        builder.Configuration["CODESPACES"] = "true";
+        builder.Configuration["GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN"] = "app.github.dev";
+        builder.Configuration["CODESPACE_NAME"] = "test-codespace";
+
+        var resource = builder.AddResource(new CustomResource("resource"));
+
+        var abortToken = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+
+        using var app = builder.Build();
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        await app.StartAsync(abortToken.Token);
+
+        // Push the URL to the resource state.
+        var localhostUrlSnapshot = new UrlSnapshot("Test", "http://localhost:1234", false);
+        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        {
+            State = KnownResourceStates.Running,
+            Urls = [localhostUrlSnapshot]
+        });
+
+        // Wait until
+        var resourceEvent = await rns.WaitForResourceAsync(
+            resource.Resource.Name,
+            (re) => {
+                var match = re.Snapshot.Urls.Length > 0 && re.Snapshot.Urls[0].Url.Contains("app.github.dev");
+                return match;
+            },
+            abortToken.Token);
+
+        Assert.Collection(
+            resourceEvent.Snapshot.Urls,
+            u =>
+            {
+                Assert.Equal("Test", u.Name);
+                Assert.Equal("http://test-codespace-1234.app.github.dev/", u.Url);
+                Assert.False(u.IsInternal);
+            }
+            );
+
+        await app.StopAsync(abortToken.Token);
+    }
+
+    private sealed class CustomResource(string name) : Resource(name)
+    {
+    }
+}


### PR DESCRIPTION
## Description

Adds support for GitHub Codespaces by automatically rewriting the URLs in the dashboard to point to the GitHub Codespaces proxied events.

Fixes #1178 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6183)