### PR TITLE
Show settings as a dialog, not popout, on mobile

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -8,6 +8,6 @@
         <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingLight">@Loc[nameof(Dialogs.SettingsDialogLightTheme)]</FluentRadio>
         <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingDark">@Loc[nameof(Dialogs.SettingsDialogDarkTheme)]</FluentRadio>
     </FluentRadioGroup>
-    <div style="height: 100%;"></div>
+    <div class="settings-dialog-spacer"></div>
     <div class="version">@string.Format(Loc[nameof(Dialogs.SettingsDialogVersion)], VersionHelpers.DashboardDisplayVersion)</div>
 </FluentStack>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -1,13 +1,17 @@
-﻿@using Aspire.Dashboard.Resources
+﻿@using Aspire.Dashboard.Model
+@using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils
 @inject IStringLocalizer<Dialogs> Loc
 
-<FluentStack Orientation="Orientation.Vertical" Style="display: contents">
-    <FluentRadioGroup TValue="string" Label="@Loc[nameof(Dialogs.SettingsDialogTheme)]" Value="@_currentSetting" ValueChanged="SettingChangedAsync" Orientation="Orientation.Vertical">
-        <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingSystem">@Loc[nameof(Dialogs.SettingsDialogSystemTheme)]</FluentRadio>
-        <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingLight">@Loc[nameof(Dialogs.SettingsDialogLightTheme)]</FluentRadio>
-        <FluentRadio Value="@Aspire.Dashboard.Model.ThemeManager.ThemeSettingDark">@Loc[nameof(Dialogs.SettingsDialogDarkTheme)]</FluentRadio>
-    </FluentRadioGroup>
-    <div class="settings-dialog-spacer"></div>
-    <div class="version">@string.Format(Loc[nameof(Dialogs.SettingsDialogVersion)], VersionHelpers.DashboardDisplayVersion)</div>
-</FluentStack>
+<FluentDialogBody>
+    <FluentStack Orientation="Orientation.Vertical" Style="display: flex; height: 100%" VerticalGap="0">
+        <FluentRadioGroup Label="@Loc[nameof(Dialogs.SettingsDialogTheme)]" TValue="string" Value="@_currentSetting" ValueChanged="SettingChangedAsync" Orientation="Orientation.Vertical">
+            <FluentRadio Value="@ThemeManager.ThemeSettingSystem">@Loc[nameof(Dialogs.SettingsDialogSystemTheme)]</FluentRadio>
+            <FluentRadio Value="@ThemeManager.ThemeSettingLight">@Loc[nameof(Dialogs.SettingsDialogLightTheme)]</FluentRadio>
+            <FluentRadio Value="@ThemeManager.ThemeSettingDark">@Loc[nameof(Dialogs.SettingsDialogDarkTheme)]</FluentRadio>
+        </FluentRadioGroup>
+
+        <div class="version">@string.Format(Loc[nameof(Dialogs.SettingsDialogVersion)], VersionHelpers.DashboardDisplayVersion)</div>
+    </FluentStack>
+
+</FluentDialogBody>

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor
@@ -7,7 +7,6 @@
     <FluentStack Orientation="Orientation.Vertical" Style="display: flex; height: 100%" VerticalGap="0">
         <FluentRadioGroup TValue="string"
                           Label="@Loc[nameof(Dialogs.SettingsDialogTheme)]"
-                          Value="@_currentSetting"
                           @bind-Value="@_currentSetting"
                           @bind-Value:after="SettingChangedAsync"
                           Orientation="Orientation.Vertical">

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -195,8 +195,7 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         DialogParameters parameters = new()
         {
             Title = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogTitle)],
-            PrimaryAction = ViewportInformation.IsDesktop ? Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)].Value : null,
-            PrimaryActionEnabled = ViewportInformation.IsDesktop,
+            PrimaryAction =  Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)].Value ,
             SecondaryAction = null,
             TrapFocus = true,
             Modal = true,

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -195,8 +195,8 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         DialogParameters parameters = new()
         {
             Title = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogTitle)],
-            PrimaryAction = Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)],
-            PrimaryActionEnabled = true,
+            PrimaryAction = ViewportInformation.IsDesktop ? Loc[nameof(Resources.Layout.MainLayoutSettingsDialogClose)].Value : null,
+            PrimaryActionEnabled = ViewportInformation.IsDesktop,
             SecondaryAction = null,
             TrapFocus = true,
             Modal = true,

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -217,7 +217,14 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             await _openPageDialog.CloseAsync();
         }
 
-        _openPageDialog = await DialogService.ShowPanelAsync<SettingsDialog>(parameters).ConfigureAwait(true);
+        if (ViewportInformation.IsDesktop)
+        {
+            _openPageDialog = await DialogService.ShowPanelAsync<SettingsDialog>(parameters).ConfigureAwait(true);
+        }
+        else
+        {
+            _openPageDialog = await DialogService.ShowDialogAsync<SettingsDialog>(parameters).ConfigureAwait(true);
+        }
     }
 
     public IReadOnlySet<AspireKeyboardShortcut> SubscribedShortcuts { get; } = new HashSet<AspireKeyboardShortcut>

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -200,10 +200,6 @@ h1 {
      .page-header {
          padding: calc(var(--design-unit) * 1.5px) calc(var(--design-unit) * 2.5px);
      }
-
-     .settings-dialog-spacer {
-         height: 100%;
-     }
  }
 
 .datagrid-overflow-area,
@@ -303,6 +299,13 @@ fluent-data-grid-cell .long-inner-content {
 .version {
     text-align: end;
     font-size: small;
+    width: 100%;
+    flex-grow: 1;
+
+    /* right/bottom align the inner version text */
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: flex-end;
 }
 
 .anchor-no-padding::part(control) {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -200,6 +200,10 @@ h1 {
      .page-header {
          padding: calc(var(--design-unit) * 1.5px) calc(var(--design-unit) * 2.5px);
      }
+
+     .settings-dialog-spacer {
+         height: 100%;
+     }
  }
 
 .datagrid-overflow-area,


### PR DESCRIPTION
## Description

Turns the settings popout into a dialog on mobile

<img src="https://github.com/user-attachments/assets/7439b4a4-4e7d-46d5-b616-bf70ba4c0e52" width="600" />
<img src="https://github.com/user-attachments/assets/5fcb60bc-4e18-4718-ae79-50313a1edf4d" width="400" />

Fixes #5313

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6191)