### PR TITLE
fix mobile horizontal scroll bars when header takes up >100vw

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.css
@@ -18,6 +18,7 @@
     */
     grid-area: page-header;
     white-space: nowrap;
+    overflow: hidden;
 }
 
 ::deep .title-toolbar-inline {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -183,6 +183,11 @@ h1 {
     /* we want less padding on mobile screens to preserve screen height for other elements */
     .page-header {
         padding: calc(var(--design-unit) * 1.5px) calc(var(--design-unit) * 0.5px) 0;
+        width: 100vw;
+    }
+
+    .page-header > h1 {
+        white-space: normal;
     }
 
     .hidden-on-mobile {


### PR DESCRIPTION
## Description

A horizontal scroll bar can appear when the page header is >100vw. This is what is reported in #5355. This PR sets the header to overflow onto the next lines so that the header is visible in its entirety, also removing the scrollbar.

![image](https://github.com/user-attachments/assets/576cce23-92df-4483-abbb-2173d91fcecb)

Fixes #5355 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6192)