### PR TITLE
Prevent preview packages to ship as RC

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,8 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <PreReleaseVersionLabel>rc.1</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel Condition="'$(SuppressFinalPackageVersion)' != 'true'">rc.1</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel Condition="'$(PreReleaseVersionLabel)' == ''">preview.4</PreReleaseVersionLabel>
     <!--
       When running package validation as part of the build, we want to ensure we didn't break the API against the previous
       version of each package. The following property points to the package version that should be used as baseline.

--- a/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
+++ b/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
@@ -6,8 +6,6 @@
     <PackageTags>aspire integration hosting azure webpubsub pubsub websocket</PackageTags>
     <Description>Azure WebPubSub resource types for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)AzureWebPubSub_256x.png</PackageIconFullPath>
-    <!-- This library can't ship stable until Azure.Provisioning.WebPubSub ships stable. -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Azure.WebPubSub/Directory.Build.props
+++ b/src/Aspire.Hosting.Azure.WebPubSub/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <!-- This needs to be set to true before importing parent Directory.Build.props -->
+     <!-- This library can't ship stable until Azure.Provisioning.WebPubSub ships stable. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
+++ b/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PackageTags>aspire integration hosting elasticsearch</PackageTags>
     <Description>Elasticsearch support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Elastic_logo.png</PackageIconFullPath>

--- a/src/Aspire.Hosting.Elasticsearch/Directory.Build.props
+++ b/src/Aspire.Hosting.Elasticsearch/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <PropertyGroup>
+      <!-- This needs to be set to true before importing parent Directory.Build.props -->
+      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    </PropertyGroup>
+  
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  </Project>

--- a/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
+++ b/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PackageTags>aspire integration hosting keycloak</PackageTags>
     <Description>Keycloak support for .NET Aspire.</Description>
   </PropertyGroup>

--- a/src/Aspire.Hosting.Keycloak/Directory.Build.props
+++ b/src/Aspire.Hosting.Keycloak/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <PropertyGroup>
+      <!-- This needs to be set to true before importing parent Directory.Build.props -->
+      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    </PropertyGroup>
+  
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  </Project>

--- a/src/Components/Aspire.Azure.AI.OpenAI/Aspire.Azure.AI.OpenAI.csproj
+++ b/src/Components/Aspire.Azure.AI.OpenAI/Aspire.Azure.AI.OpenAI.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <!-- This library can't ship stable until Azure.AI.OpenAI ships stable. -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PackageTags>$(ComponentAzurePackageTags) ai openai</PackageTags>
     <Description>A client for Azure OpenAI that integrates with Aspire, including logging and telemetry.</Description>
     <PackageIconFullPath>$(SharedDir)AzureOpenAI_256x.png</PackageIconFullPath>

--- a/src/Components/Aspire.Azure.AI.OpenAI/Directory.Build.props
+++ b/src/Components/Aspire.Azure.AI.OpenAI/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
       <!-- This needs to be set to true before importing parent Directory.Build.props -->
-       <!-- This library can't ship stable until Azure.AI.OpenAI ships stable. -->
+      <!-- This library can't ship stable until Azure.AI.OpenAI ships stable. -->
       <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     </PropertyGroup>
   

--- a/src/Components/Aspire.Azure.AI.OpenAI/Directory.Build.props
+++ b/src/Components/Aspire.Azure.AI.OpenAI/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+    <PropertyGroup>
+      <!-- This needs to be set to true before importing parent Directory.Build.props -->
+       <!-- This library can't ship stable until Azure.AI.OpenAI ships stable. -->
+      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    </PropertyGroup>
+  
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  </Project>

--- a/src/Components/Aspire.Elastic.Clients.Elasticsearch/Aspire.Elastic.Clients.Elasticsearch.csproj
+++ b/src/Components/Aspire.Elastic.Clients.Elasticsearch/Aspire.Elastic.Clients.Elasticsearch.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PackageTags>$(ComponentCommonPackageTags) Elasticsearch</PackageTags>
     <Description>A Elasticsearch client that integrates with Aspire, including health checks, logging, and telemetry.</Description>
     <PackageIconFullPath>$(SharedDir)Elastic_logo.png</PackageIconFullPath>

--- a/src/Components/Aspire.Elastic.Clients.Elasticsearch/Directory.Build.props
+++ b/src/Components/Aspire.Elastic.Clients.Elasticsearch/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <PropertyGroup>
+      <!-- This needs to be set to true before importing parent Directory.Build.props -->
+      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    </PropertyGroup>
+  
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  </Project>

--- a/src/Components/Aspire.Keycloak.Authentication/Aspire.Keycloak.Authentication.csproj
+++ b/src/Components/Aspire.Keycloak.Authentication/Aspire.Keycloak.Authentication.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PackageTags>$(ComponentCommonPackageTags) Keycloak</PackageTags>
     <Description>Configures Keycloak as the authentication provider for ASP.NET Core applications.</Description>
     <!-- Disable package validation as this package hasn't shipped yet. -->

--- a/src/Components/Aspire.Keycloak.Authentication/Directory.Build.props
+++ b/src/Components/Aspire.Keycloak.Authentication/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <PropertyGroup>
+      <!-- This needs to be set to true before importing parent Directory.Build.props -->
+      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    </PropertyGroup>
+  
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  </Project>

--- a/src/Components/Aspire.Milvus.Client/Aspire.Milvus.Client.csproj
+++ b/src/Components/Aspire.Milvus.Client/Aspire.Milvus.Client.csproj
@@ -6,7 +6,6 @@
     <PackageTags>$(ComponentCommonPackageTags) milvus database vector search</PackageTags>
     <Description>A Milvus client that integrates with Aspire, including logging.</Description>
     <PackageIconFullPath>$(SharedDir)Milvus_256x.png</PackageIconFullPath>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <NoWarn>$(NoWarn);CS8002</NoWarn> <!-- Milvus.Client packages are not signed -->
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>

--- a/src/Components/Aspire.Milvus.Client/Directory.Build.props
+++ b/src/Components/Aspire.Milvus.Client/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+    <PropertyGroup>
+      <!-- This needs to be set to true before importing parent Directory.Build.props -->
+      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    </PropertyGroup>
+  
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  </Project>

--- a/src/Components/Aspire.OpenAI/Aspire.OpenAI.csproj
+++ b/src/Components/Aspire.OpenAI/Aspire.OpenAI.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <IsPackable>true</IsPackable>
-    <!-- This library can't ship stable until OpenAI ships stable. -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     <PackageTags>$(ComponentCommonPackageTags) ai openai</PackageTags>
     <Description>A client for OpenAI that integrates with Aspire, including metrics and telemetry.</Description>
     <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>

--- a/src/Components/Aspire.OpenAI/Directory.Build.props
+++ b/src/Components/Aspire.OpenAI/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
       <!-- This needs to be set to true before importing parent Directory.Build.props -->
-       <!-- This library can't ship stable until OpenAI ships stable. -->
+      <!-- This library can't ship stable until OpenAI ships stable. -->
       <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
     </PropertyGroup>
   

--- a/src/Components/Aspire.OpenAI/Directory.Build.props
+++ b/src/Components/Aspire.OpenAI/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+    <PropertyGroup>
+      <!-- This needs to be set to true before importing parent Directory.Build.props -->
+       <!-- This library can't ship stable until OpenAI ships stable. -->
+      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    </PropertyGroup>
+  
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  </Project>

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -27,6 +27,12 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="ValidatePreReleaseLabelIsCorrectForPreviewPackages"
+          AfterTargets="Pack"
+          Condition="'$(OfficialBuildId)' != '' and '$(SuppressFinalPackageVersion)' == 'true' and !$(PreReleaseVersionLabel.StartsWith('preview'))">
+    <Error Text="The PreReleaseLabel for package '$(MSBuildProjectName)' must start with 'preview' as it has the SuppressFinalPackageVersion flag set. Current label is '$(PreReleaseVersionLabel)'" />
+  </Target>
+
   <!--
   Logic for generating and comparing the ConfigurationSchema.json file
   -->


### PR DESCRIPTION
## Description

@DamianEdwards @eerhardt, as discussed offline, these changes will make it so that packages that are going to stay in preview once 9.0 ships, won't go to get an RC.1 label, and instead continue shipping as preview.4.

Making this change directly on the rc1 branch and will backport to main.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6195)