### PR TITLE
Don't block on application executor.

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpHostService.cs
+++ b/src/Aspire.Hosting/Dcp/DcpHostService.cs
@@ -72,7 +72,7 @@ internal sealed class DcpHostService : IHostedLifecycleService, IAsyncDisposable
 
         EnsureDcpContainerRuntime(dcpInfo);
         EnsureDcpHostRunning();
-        await _appExecutor.RunApplicationAsync(cancellationToken).ConfigureAwait(false);
+        _ = Task.Run(() => _appExecutor.RunApplicationAsync(cancellationToken).ConfigureAwait(false), cancellationToken);
     }
 
     private void EnsureDcpContainerRuntime(DcpInfo? dcpInfo)


### PR DESCRIPTION
## Description

This is an onion peeling PR to see what happens if we simply no longer block on `ApplicationExecutor` when we start up. I'm expecting lots of things to break in unit tests but have verified that test shop works. This is an exploration based on #6038 but is something we are going to need to tackle as part of #6040.

Fixes #6038 

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6201)