### PR TITLE
Improve back button behavior when restoring state

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/IPageWithSessionAndUrlState.cs
+++ b/src/Aspire.Dashboard/Components/Pages/IPageWithSessionAndUrlState.cs
@@ -98,7 +98,10 @@ public static class PageExtensions
                 // Don't navigate if the URL redirects to itself.
                 if (newUrl != "/" + page.BasePath)
                 {
-                    page.NavigationManager.NavigateTo(newUrl);
+                    // Replace the initial address with this navigation.
+                    // We do this because the visit to "/{BasePath}" then redirect to the final address is automatic from the user perspective.
+                    // Replacing the visit to "/{BasePath}" is good because we want to take the user back to where they started, not an intermediary address.
+                    page.NavigationManager.NavigateTo(newUrl, new NavigationOptions { ReplaceHistoryEntry = true });
                     return true;
                 }
             }


### PR DESCRIPTION
## Description

I noticed that the back button was flaky when navigating around the dashboard. The problem is we add an automatic redirect if there is page state to restore.

e.g.
1. User navigates to `/consolelogs`
2. Page state remembers that user was viewing `myfrontend`
3. Automatic redirect to `/consolelogs/resource/myfrontend` **<- problem**

Fix is to make the automatic redirect replace the temporary intermediary back button history entry. In other words, `/consolelogs` is replaced by `/consolelogs/resource/myfrontend` in back button history.

For 9.0.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6204)