### PR TITLE
Remove unused DI dependencies and cascading parameters

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/MetricTable.razor
@@ -6,7 +6,6 @@
 @using Aspire.Dashboard.Components.Controls.Grid
 
 @inherits Aspire.Dashboard.Components.Controls.Chart.ChartBase
-@inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
 @{
     // these colors line up with P50/P90/P99 colors for the plotly graph

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
@@ -4,7 +4,6 @@
 using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
-using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -78,15 +77,6 @@ public partial class GridValue
 
     [Parameter]
     public string PostCopyToolTip { get; set; } = null!;
-
-    [Inject]
-    public required IDialogService DialogService { get; init; }
-
-    [Inject]
-    public required IJSRuntime JS { get; init; }
-
-    [CascadingParameter]
-    public required ViewportInformation ViewportInformation { get; set; }
 
     private readonly Icon _maskIcon = new Icons.Regular.Size16.EyeOff();
     private readonly Icon _unmaskIcon = new Icons.Regular.Size16.Eye();

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -16,12 +16,6 @@ public partial class ResourceDetails
     [Parameter]
     public bool ShowSpecOnlyToggle { get; set; }
 
-    [Inject]
-    public required ILogger<ResourceDetails> Logger { get; init; }
-
-    [Inject]
-    public required BrowserTimeProvider TimeProvider { get; init; }
-
     private bool IsSpecOnlyToggleDisabled => !Resource.Environment.All(i => !i.FromSpec) && !GetResourceProperties(ordered: false).Any(static vm => vm.KnownProperty is null);
 
     // NOTE Excludes endpoints as they don't expose sensitive items (and enumerating endpoints is non-trivial)

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -4,7 +4,6 @@
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Microsoft.AspNetCore.Components;
-using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -30,9 +29,6 @@ public partial class ResourceSelect
 
     [Parameter]
     public bool CanSelectGrouping { get; set; }
-
-    [Inject]
-    public required IJSRuntime JS { get; init; }
 
     private static void ValuedChanged(string value)
     {

--- a/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanActions.razor.cs
@@ -18,9 +18,6 @@ public partial class SpanActions : ComponentBase
     private AspireMenuButton? _menuButton;
 
     [Inject]
-    public required IStringLocalizer<Resources.TraceDetail> Loc { get; set; }
-
-    [Inject]
     public required IStringLocalizer<Resources.ControlsStrings> ControlsLoc { get; set; }
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SummaryDetailsView.razor
@@ -1,5 +1,4 @@
 ﻿@using Aspire.Dashboard.Resources
-@inject IStringLocalizer<ControlsStrings> Loc
 @typeparam T
 
 <div class="summary-details-container">

--- a/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/TraceActions.razor.cs
@@ -18,9 +18,6 @@ public partial class TraceActions : ComponentBase
     private AspireMenuButton? _menuButton;
 
     [Inject]
-    public required IStringLocalizer<Resources.StructuredLogs> Loc { get; set; }
-
-    [Inject]
     public required IStringLocalizer<Resources.ControlsStrings> ControlsLoc { get; set; }
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor
+++ b/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor
@@ -11,7 +11,6 @@
 @implements IDialogContentComponent<ExemplarsDialogViewModel>
 
 @inject IStringLocalizer<Dialogs> Loc
-@inject IStringLocalizer<ControlsStrings> ControlsStringsLoc
 
 <div style="max-height: 44vh; overflow-y: auto;">
     <FluentDataGrid Items="@MetricView"

--- a/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/ExemplarsDialog.razor.cs
@@ -15,9 +15,6 @@ namespace Aspire.Dashboard.Components.Dialogs;
 
 public partial class ExemplarsDialog : IDisposable
 {
-    [CascadingParameter]
-    public FluentDialog Dialog { get; set; } = default!;
-
     [Parameter]
     public ExemplarsDialogViewModel Content { get; set; } = default!;
 

--- a/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.cs
@@ -48,9 +48,6 @@ public partial class AspirePageContentLayout : ComponentBase
     [Inject]
     public required IDialogService DialogService { get; init; }
 
-    [Inject]
-    public required NavigationManager NavigationManager { get; init; }
-
     private IDialogReference? _toolbarPanel;
 
     public bool IsToolbarPanelOpen => _toolbarPanel is not null;

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -53,9 +53,6 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     public required ILogger<ConsoleLogs> Logger { get; init; }
 
     [Inject]
-    public required DimensionManager DimensionManager { get; init; }
-
-    [Inject]
     public required IStringLocalizer<Dashboard.Resources.ConsoleLogs> Loc { get; init; }
 
     [Inject]

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -12,7 +12,6 @@ using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.JSInterop;
 
@@ -46,10 +45,6 @@ public partial class Resources : ComponentBase, IAsyncDisposable
     public required BrowserTimeProvider TimeProvider { get; init; }
     [Inject]
     public required IJSRuntime JS { get; init; }
-    [Inject]
-    public required ProtectedSessionStorage SessionStorage { get; init; }
-    [Inject]
-    public required DimensionManager DimensionManager { get; init; }
 
     [CascadingParameter]
     public required ViewportInformation ViewportInformation { get; set; }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -54,12 +54,6 @@ public partial class TraceDetail : ComponentBase
     [Inject]
     public required NavigationManager NavigationManager { get; init; }
 
-    [Inject]
-    public required DimensionManager DimensionManager { get; init; }
-
-    [CascadingParameter]
-    public required ViewportInformation ViewportInformation { get; set; }
-
     protected override void OnInitialized()
     {
         _gridColumns = [

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor.cs
@@ -23,9 +23,6 @@ public partial class EndpointsColumnDisplay
     public string? AdditionalMessage { get; set; }
 
     [Inject]
-    public required ILogger<EndpointsColumnDisplay> Logger { get; init; }
-
-    [Inject]
     public required IStringLocalizer<Columns> Loc { get; init; }
 
     private bool _popoverVisible;

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/UnreadLogErrorsBadge.razor.cs
@@ -20,8 +20,6 @@ public partial class UnreadLogErrorsBadge
 
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
-    [Inject]
-    public required NavigationManager NavigationManager { get; init; }
 
     protected override void OnParametersSet()
     {


### PR DESCRIPTION
## Description

Removes DI imports and cascading parameters that were presumably used at one point in time but are no longer used.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6218)