### PR TITLE
Fix headers regression breaking resource dropdown

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor.css
@@ -12,13 +12,8 @@
 }
 
 ::deep.content-header {
-    /*
-        Long titles inside a header don't add an ellipsis when trimmed.
-        Improve here could be to add that feature
-    */
     grid-area: page-header;
-    white-space: nowrap;
-    overflow: hidden;
+    word-break: break-all;
 }
 
 ::deep .title-toolbar-inline {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -23,8 +23,10 @@
                     var headerSpan = trace.RootSpan ?? trace.FirstSpan;
                 }
                 <div class="page-header">
-                    <h1 style="display:inline-block">@GetResourceName(headerSpan.Source): @headerSpan.Name</h1>
-                    <span class="trace-id">@OtlpHelpers.ToShortenedId(trace.TraceId)</span>
+                    <h1>
+                        <span>@GetResourceName(headerSpan.Source): @headerSpan.Name</span>
+                        <span class="trace-id">@OtlpHelpers.ToShortenedId(trace.TraceId)</span>
+                    </h1>                    
                 </div>
             </PageTitleSection>
             <ToolbarSection>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -11,6 +11,7 @@
     color: var(--foreground-subtext-rest);
     padding-left: 0.5rem;
     font-size: 12px;
+    font-weight: normal;
 }
 
 ::deep .trace-view-grid {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.css
@@ -2,6 +2,7 @@
     color: var(--foreground-subtext-rest);
     padding-left: 0.5rem;
     font-size: 12px;
+    font-weight: normal;
 }
 
 .trace-tag {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -183,7 +183,7 @@ h1 {
     /* we want less padding on mobile screens to preserve screen height for other elements */
     .page-header {
         padding: calc(var(--design-unit) * 1.5px) calc(var(--design-unit) * 0.5px) 0;
-        width: 100vw;
+        width: fit-content;
     }
 
     .page-header > h1 {


### PR DESCRIPTION
## Description

There was a regression in https://github.com/dotnet/aspire/pull/6192 that broke selecting resources in dialogs. I took a look and made some improvements:

* `width: 100vw` isn't good on the page header because the page header is nested inside other content with margins and padding. That forces horizontal scroll bar, which forced the need for `overflow: hidden`, which created the bug: resource dropdown is now hidden when expanded.
* Wrap on any character instead of by word. No choice is better all the time, but this stops bad behavior when there is a very long word.
* The trace id wasn't visible. Fixed by putting it inside the `h1`.

**Before:**

![image](https://github.com/user-attachments/assets/1c1259f2-b39e-4e27-ab36-756ec59c3578)

![image](https://github.com/user-attachments/assets/02e7d241-b4d3-4537-97ae-af94b6f2b09e)

**After:**

![image](https://github.com/user-attachments/assets/147f2632-3eef-48ee-a0f1-a984e380d6b7)

(note the trace id is now visible when there is wrapping)

![image](https://github.com/user-attachments/assets/2d4140c8-ff40-42f7-b054-97b834fdc67d)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6219)