### PR TITLE
Fix tick appearing over span bar

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -88,6 +88,7 @@
     grid-row: 1;
     height: 100%;
     display: grid;
+    /* z-index is required so the span is displayed above ticks */
     z-index: 1;
     align-items: center;
 }

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -88,6 +88,7 @@
     grid-row: 1;
     height: 100%;
     display: grid;
+    z-index: 1;
     align-items: center;
 }
 


### PR DESCRIPTION
## Description

The tick is above the span bar. This was broken when adding action popup to this page. Action popup had a bug that made it appear below elements with a z-index. That's fixed, so the z-index can be re-added.

**Before:**

![image](https://github.com/user-attachments/assets/e053a10d-4b06-47d1-8e78-0f1699030a83)

**After:**

![image](https://github.com/user-attachments/assets/3ae33417-5639-49e0-a98e-25f3329388eb)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6220)