### PR TITLE
Standardise presentation of empty cells in grids

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -105,7 +105,7 @@
                                 <AspireTemplateColumn ColumnId="@SourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetSourceColumnValueAndTooltip(ctx)?.Tooltip)">
                                     @if (GetSourceColumnValueAndTooltip(context) is { } columnDisplay)
                                     {
-                                        <SourceColumnDisplay Resource="context" FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip" />
+                                        <SourceColumnDisplay FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip" />
                                     }
                                     else
                                     {

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -107,6 +107,10 @@
                                     {
                                         <SourceColumnDisplay Resource="context" FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip" />
                                     }
+                                    else
+                                    {
+                                        <span>&ndash;</span>
+                                    }
                                 </AspireTemplateColumn>
                                 <AspireTemplateColumn ColumnId="@EndpointsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEndpointsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetEndpointsTooltip(ctx))">
                                     <EndpointsColumnDisplay Resource="context"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -111,8 +111,7 @@
                                 <AspireTemplateColumn ColumnId="@EndpointsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEndpointsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetEndpointsTooltip(ctx))">
                                     <EndpointsColumnDisplay Resource="context"
                                                             HasMultipleReplicas="HasMultipleReplicas(context)"
-                                                            DisplayedEndpoints="@GetDisplayedEndpoints(context, out var additionalMessage)"
-                                                            AdditionalMessage="@additionalMessage" />
+                                                            DisplayedEndpoints="GetDisplayedEndpoints(context)" />
                                 </AspireTemplateColumn>
                                 <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesActionsColumnHeader)]" Class="no-ellipsis">
                                     <div class="grid-action-container" @onclick:stopPropagation="true">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -9,7 +9,6 @@ using Aspire.Dashboard.Extensions;
 
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Storage;
-using Aspire.Dashboard.Resources;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
@@ -416,18 +415,18 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         return null;
     }
 
-    private string GetEndpointsTooltip(ResourceViewModel resource)
+    private static string GetEndpointsTooltip(ResourceViewModel resource)
     {
-        var displayedEndpoints = GetDisplayedEndpoints(resource, out var additionalMessage);
+        var displayedEndpoints = GetDisplayedEndpoints(resource);
 
-        if (additionalMessage is not null)
+        if (displayedEndpoints.Count == 0)
         {
-            return additionalMessage;
+            return "";
         }
 
         if (displayedEndpoints.Count == 1)
         {
-            return displayedEndpoints.First().Text;
+            return displayedEndpoints[0].Text;
         }
 
         var maxShownEndpoints = 3;
@@ -441,17 +440,8 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         return tooltipBuilder.ToString();
     }
 
-    private List<DisplayedEndpoint> GetDisplayedEndpoints(ResourceViewModel resource, out string? additionalMessage)
+    private static List<DisplayedEndpoint> GetDisplayedEndpoints(ResourceViewModel resource)
     {
-        if (resource.Urls.Length == 0)
-        {
-            // If we have no endpoints, and the app isn't running anymore or we're not expecting any, then just say None
-            additionalMessage = ColumnsLoc[nameof(Columns.EndpointsColumnDisplayNone)];
-            return [];
-        }
-
-        additionalMessage = null;
-
         return ResourceEndpointHelpers.GetEndpoints(resource, includeInternalUrls: false);
     }
 

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -421,7 +421,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
 
         if (displayedEndpoints.Count == 0)
         {
-            return "";
+            return "&ndash;";
         }
 
         if (displayedEndpoints.Count == 1)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -147,6 +147,10 @@
                                                     @OtlpHelpers.ToShortenedId(context.TraceId)
                                                 </a>
                                             }
+                                            else
+                                            {
+                                                <span>&ndash;</span>
+                                            }
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.ActionsColumnHeader)]" Class="no-ellipsis">
                                             @{

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -1,7 +1,11 @@
 ﻿@using Aspire.Dashboard.Model
 @namespace Aspire.Dashboard.Components
 
-@if (DisplayedEndpoints.Count == 1)
+@if (DisplayedEndpoints.Count == 0)
+{
+    <span>&ndash;</span>
+}
+else if (DisplayedEndpoints.Count == 1)
 {
     @WriteEndpoint(DisplayedEndpoints[0])
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -31,9 +31,6 @@ else
 
 @code {
     [Parameter, EditorRequired]
-    public required ResourceViewModel Resource { get; set; }
-
-    [Parameter, EditorRequired]
     public required string FilterText { get; set; }
 
     [Parameter, EditorRequired]

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -4,30 +4,20 @@
 @inject IStringLocalizer<Columns> Loc
 @inject IStringLocalizer<Resources> ResourcesLoc
 
-@if (ContentAfterValue is not null)
-{
-    <GridValue Value="@Value"
-               ValueToCopy="@ValueToCopy"
-               ValueDescription="@ResourcesLoc[nameof(Resources.ResourcesSourceColumnHeader)]"
-               EnableHighlighting="true"
-               HighlightText="@FilterText"
-               PreCopyToolTip="@Loc[nameof(Columns.SourceColumnDisplayCopyCommandToClipboard)]"
-               ToolTip="@Tooltip">
-        <ContentAfterValue>
+<GridValue Value="@Value"
+            ValueToCopy="@ValueToCopy"
+            ValueDescription="@ResourcesLoc[nameof(Resources.ResourcesSourceColumnHeader)]"
+            EnableHighlighting="true"
+            HighlightText="@FilterText"
+            PreCopyToolTip="@Loc[nameof(Columns.SourceColumnDisplayCopyCommandToClipboard)]"
+            ToolTip="@Tooltip">
+    <ContentAfterValue>
+        @if (ContentAfterValue is not null)
+        {
             <span class="subtext">@ContentAfterValue</span>
-        </ContentAfterValue>
-    </GridValue>
-}
-else
-{
-    <GridValue Value="@Value"
-               ValueToCopy="@ValueToCopy"
-               ValueDescription="@ResourcesLoc[nameof(Resources.ResourcesSourceColumnHeader)]"
-               EnableHighlighting="true"
-               HighlightText="@FilterText"
-               PreCopyToolTip="@Loc[nameof(Columns.SourceColumnSourceCopyFullPathToClipboard)]"
-               ToolTip="@Tooltip" />
-}
+        }
+    </ContentAfterValue>
+</GridValue>
 
 @code {
     [Parameter, EditorRequired]
@@ -44,5 +34,4 @@ else
 
     [Parameter, EditorRequired]
     public required string Tooltip { get; set; }
-
 }

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
@@ -8,6 +8,10 @@
     // Don't include milliseconds as resource server returned time stamp is second precision.
     @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, timeStamp)
 }
+else
+{
+    <span>&ndash;</span>
+}
 
 @code {
     [Inject]

--- a/src/Aspire.Dashboard/Resources/Columns.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Columns.Designer.cs
@@ -61,15 +61,6 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to None.
-        /// </summary>
-        public static string EndpointsColumnDisplayNone {
-            get {
-                return ResourceManager.GetString("EndpointsColumnDisplayNone", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Endpoints.
         /// </summary>
         public static string EndpointsColumnDisplayOverflowTitle {

--- a/src/Aspire.Dashboard/Resources/Columns.resx
+++ b/src/Aspire.Dashboard/Resources/Columns.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="EndpointsColumnDisplayNone" xml:space="preserve">
-    <value>None</value>
-  </data>
   <data name="EndpointsColumnDisplayPlaceholder" xml:space="preserve">
     <value>Starting...</value>
   </data>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.cs.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">Žádné</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">Koncové body</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.de.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">Keine</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">Endpunkte</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.es.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">Ninguno</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">Puntos de conexión</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.fr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">Aucune</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">Points de terminaison</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.it.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">Nessuno</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">Endpoint</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ja.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">なし</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">エンドポイント</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ko.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">없음</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">엔드포인트</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pl.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">Brak</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">Punkty końcowe</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.pt-BR.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">Nenhum</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">Pontos de extremidade</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.ru.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">Нет</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">Конечные точки</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.tr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">Yok</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">Uç noktalar</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hans.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">无</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">终结点</target>

--- a/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Columns.zh-Hant.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Columns.resx">
     <body>
-      <trans-unit id="EndpointsColumnDisplayNone">
-        <source>None</source>
-        <target state="translated">無</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EndpointsColumnDisplayOverflowTitle">
         <source>Endpoints</source>
         <target state="translated">端點</target>


### PR DESCRIPTION
## Description

Previously, when a cell is empty, we would be inconsistent in our presentation. Sometimes it would appear empty, other times we showed "None".

This change introduces a [en dash](https://en.wikipedia.org/wiki/Dash#En_dash) for empty cells.

---

Here's TestShop when it's starting up:

![image](https://github.com/user-attachments/assets/e2780b3e-52a7-4773-b6fd-f7474507a2de)

Extended this treatment to the "Trace" column in structured logs:

![image](https://github.com/user-attachments/assets/ddaee2b4-e33e-42e2-affa-763a513db7dc)
## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6222)