### PR TITLE
Show exception details in text visualizer dialog

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ExceptionDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ExceptionDetails.razor
@@ -1,52 +1,35 @@
 ﻿@namespace Aspire.Dashboard.Components
 
 @using Aspire.Dashboard.Extensions
+@using Aspire.Dashboard.Components.Dialogs
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
 
 @inject IStringLocalizer<ControlsStrings> Loc
 
-@{
-    var iconId = Guid.NewGuid().ToString();
-    @*
-     * We don't want a browser tooltip to display when hovering over the error icon.
-     * Use alt instead of title for screen readers. Also, the column has a title set
-     * so add a whitespace title to prevent a browser tooltip from displaying.
-     *@
-    var title = " ";
-}
-
 @if (!string.IsNullOrWhiteSpace(ExceptionText))
 {
-    <FluentIcon alt="@Loc[nameof(ControlsStrings.ExceptionDetailsTitle)]"
-                title="@title"
-                Style="flex-shrink: 0"
-                Id="@iconId"
-                Icon="Icons.Filled.Size16.DocumentError"
-                Color="Color.Accent"
-                Class="severity-icon" />
-
-    <FluentTooltip Anchor="@iconId" MaxWidth="650px">
-        <div style="padding: 10px">
-            <h4>@Loc[nameof(ControlsStrings.ExceptionDetailsTitle)]</h4>
-
-            <pre style="white-space: pre-wrap; overflow-wrap: break-word; max-height: 300px; overflow: auto;">@ExceptionText</pre>
-
-            <div style="float: right; margin-bottom: 10px;">
-                <FluentButton Id="@Guid.NewGuid().ToString()"
-                              Appearance="Appearance.Lightweight"
-                              AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(ExceptionText, Loc[nameof(ControlsStrings.GridValueCopyToClipboard)].ToString(), Loc[nameof(ControlsStrings.GridValueCopied)].ToString())">
-                    @Loc[nameof(ControlsStrings.GridValueCopyToClipboard)]
-
-                    <FluentIcon Class="copy-icon align-text-bottom" Style="display:inline;" Icon="Icons.Regular.Size16.Copy" />
-                    <FluentIcon Class="checkmark-icon align-text-bottom" Style="display:none;" Icon="Icons.Regular.Size16.Checkmark" />
-                </FluentButton>
-            </div>
-        </div>
-    </FluentTooltip>
+    <FluentButton Appearance="Appearance.Lightweight"
+                  OnClick="OnExceptionDetailsClicked"
+                  Title="@Loc[nameof(ControlsStrings.ExceptionDetailsTitle)]"
+                  Class="exception-details-button">
+        <FluentIcon Icon="Icons.Filled.Size16.DocumentError"
+                    Color="Color.Accent" />
+    </FluentButton>
 }
 
 @code {
     [Parameter, EditorRequired]
     public required string ExceptionText { get; set; }
+
+    [CascadingParameter]
+    public required ViewportInformation ViewportInformation { get; init; }
+
+    [Inject]
+    public required IDialogService DialogService { get; init; }
+
+    private void OnExceptionDetailsClicked(MouseEventArgs e)
+    {
+        _ = TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, Loc[nameof(ControlsStrings.ExceptionDetailsTitle)], ExceptionText);
+    }
 }

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -3,25 +3,27 @@
 @inject IStringLocalizer<Dialogs> DialogsLoc
 
 <div class="@GetContainerClass()" style="width: inherit;">
+
+    @* Value area *@
+
     @if (EnableMasking && IsMasked)
     {
-        <span class="cellText">
+        <span class="grid-value masked">
             &#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;&#x25cf;
-        </span>
-    }
-    else if (EnableHighlighting)
-    {
-        <span class="cellText" title="@(ToolTip ?? Value)">
-            @ContentBeforeValue
-            <FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />
-            @ContentAfterValue
         </span>
     }
     else
     {
-        <span class="cellText" title="@(ToolTip ?? Value)">
+        <span class="grid-value" title="@(ToolTip ?? Value)">
             @ContentBeforeValue
-            @(MaxDisplayLength.HasValue ? TrimLength(Value) : Value)
+            @if (EnableHighlighting && !string.IsNullOrEmpty(HighlightText))
+            {
+                <FluentHighlighter HighlightedText="@HighlightText" Text="@Value" />
+            }
+            else
+            {
+                @Value
+            }
             @ContentAfterValue
         </span>
     }
@@ -35,46 +37,52 @@
         ];
     }
 
-    <div @onclick:stopPropagation="true" class="defaultHidden">
-        <FluentButton Appearance="Appearance.Lightweight"
-                      Id="@_menuAnchorId"
-                      Class="defaultHidden"
-                      Style="float: right; flex-shrink: 0"
-                      OnClick="@ToggleMenuOpen">
-            <FluentIcon Style="display:inline;" Icon="Icons.Regular.Size16.MoreHorizontal" />
-        </FluentButton>
+    @* Button area *@
 
-        <FluentMenu Anchor="@_menuAnchorId" @bind-Open="_isMenuOpen" VerticalThreshold="170" HorizontalPosition="HorizontalPosition.End">
-            <FluentMenuItem
-                Id="@_copyId"
-                AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(ValueToCopy ?? Value, PreCopyToolTip, PostCopyToolTip, uncapturedCopyAttributes)">
-                <span slot="start">
-                    <FluentIcon Class="copy-icon" Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" Slot="start" />
-                    <FluentIcon Class="checkmark-icon" Style="display:none; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Checkmark" Slot="start" />
-                </span>
-                @PreCopyToolTip
-            </FluentMenuItem>
+    <div @onclick:stopPropagation="true">
 
-            <FluentMenuItem
-                Disabled="@(ValueToVisualize is null && Value is null)"
-                AdditionalAttributes="@FluentUIExtensions.GetOpenTextVisualizerAdditionalAttributes(ValueToVisualize ?? Value!, !string.IsNullOrEmpty(TextVisualizerTitle) ? TextVisualizerTitle : ValueDescription)">
-                <span slot="start">
-                    <FluentIcon Style="display:inline; vertical-align: text-bottom" Icon="Icons.Regular.Size16.Open" Slot="start"/>
-                </span>
+        <span class="defaultHidden">
+            <FluentButton Appearance="Appearance.Lightweight"
+                          Id="@_menuAnchorId"
+                          OnClick="@ToggleMenuOpen">
+                <FluentIcon Icon="Icons.Regular.Size16.MoreHorizontal" />
+            </FluentButton>
 
-                @DialogsLoc[nameof(Dialogs.OpenInTextVisualizer)]
-            </FluentMenuItem>
-        </FluentMenu>
-    </div>
+            <FluentMenu Anchor="@_menuAnchorId" @bind-Open="_isMenuOpen" VerticalThreshold="170" HorizontalPosition="HorizontalPosition.End">
+                <FluentMenuItem
+                    Id="@_copyId"
+                    AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(ValueToCopy ?? Value, PreCopyToolTip, PostCopyToolTip, uncapturedCopyAttributes)">
+                    <span slot="start">
+                        <FluentIcon Style="vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" />
+                    </span>
+                    @PreCopyToolTip
+                </FluentMenuItem>
 
-    @if (EnableMasking)
-    {
-        <div @onclick:stopPropagation="true">
+                <FluentMenuItem
+                    Disabled="@(ValueToVisualize is null && Value is null)"
+                    AdditionalAttributes="@FluentUIExtensions.GetOpenTextVisualizerAdditionalAttributes(ValueToVisualize ?? Value!, !string.IsNullOrEmpty(TextVisualizerTitle) ? TextVisualizerTitle : ValueDescription)">
+                    <span slot="start">
+                        <FluentIcon Style="vertical-align: text-bottom" Icon="Icons.Regular.Size16.Open" />
+                    </span>
+
+                    @DialogsLoc[nameof(Dialogs.OpenInTextVisualizer)]
+                </FluentMenuItem>
+            </FluentMenu>
+        </span>
+
+        @if (ContentInButtonArea is not null)
+        {
+            @ContentInButtonArea
+        }
+
+        @if (EnableMasking)
+        {
             <FluentButton Appearance="Appearance.Lightweight"
                           IconEnd="@(IsMasked ? _unmaskIcon : _maskIcon)"
                           Title="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])"
                           OnClick="ToggleMaskStateAsync"
                           aria-label="@(IsMasked ? Loc[nameof(ControlsStrings.GridValueMaskShowValue)] : Loc[nameof(ControlsStrings.GridValueMaskHideValue)])" />
-        </div>
-    }
+        }
+
+    </div>
 </div>

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
@@ -31,6 +31,12 @@ public partial class GridValue
     public RenderFragment? ContentAfterValue { get; set; }
 
     /// <summary>
+    /// Content to include, if any, in button area to right. Intended for adding extra buttons.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ContentInButtonArea { get; set; }
+
+    /// <summary>
     /// If set, copies this value instead of <see cref="Value"/>.
     /// </summary>
     [Parameter]
@@ -67,9 +73,6 @@ public partial class GridValue
     public EventCallback<bool> IsMaskedChanged { get; set; }
 
     [Parameter]
-    public int? MaxDisplayLength { get; set; }
-
-    [Parameter]
     public string? ToolTip { get; set; }
 
     [Parameter]
@@ -97,16 +100,6 @@ public partial class GridValue
         IsMasked = !IsMasked;
 
         await IsMaskedChanged.InvokeAsync(IsMasked);
-    }
-
-    private string TrimLength(string? text)
-    {
-        if (text is not null && MaxDisplayLength is int maxLength && text.Length > maxLength)
-        {
-            return text[..maxLength];
-        }
-
-        return text ?? "";
     }
 
     private void ToggleMenuOpen()

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -9,7 +9,7 @@
     grid-template-columns: 1fr auto auto;
 }
 
-::deep .cellText {
+::deep .grid-value {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
@@ -19,9 +19,10 @@
     opacity: 0;
     cursor: pointer;
     width: 0;
+    display: inline-block;
 }
 
-::deep:hover .defaultHidden, ::deep:focus-within .defaultHidden  {
+::deep:hover .defaultHidden, ::deep:focus-within .defaultHidden {
     opacity: 1;  /* safari has a bug where hover is not always called on an invisible element, so we use opacity instead */
     width: auto;
 }

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -166,9 +166,9 @@
                                    EnableHighlighting="@(!string.IsNullOrEmpty(_filter))"
                                    HighlightText="@_filter"
                                    TextVisualizerTitle="@context.Name">
-                            <ContentBeforeValue>
+                            <ContentInButtonArea>
                                 <ExceptionDetails ExceptionText="@context.ExceptionText" />
-                            </ContentBeforeValue>
+                            </ContentInButtonArea>
                         </GridValue>
                     </AspireTemplateColumn>
                 </FluentDataGrid>

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/LogMessageColumnDisplay.razor
@@ -10,9 +10,9 @@
            ValueDescription="@Loc[nameof(StructuredLogs.StructuredLogsMessageColumnHeader)]"
            EnableHighlighting="true"
            HighlightText="@FilterText">
-    <ContentBeforeValue>
+    <ContentInButtonArea>
         <ExceptionDetails ExceptionText="@_exceptionText" />
-    </ContentBeforeValue>
+    </ContentInButtonArea>
 </GridValue>
 
 @code {

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -133,6 +133,7 @@ window.copyTextToClipboard = function (id, text, precopy, postcopy) {
 
     const copyIcon = button.querySelector('.copy-icon');
     const checkmarkIcon = button.querySelector('.checkmark-icon');
+
     const anchoredTooltip = document.querySelector(`fluent-tooltip[anchor="${id}"]`);
     const tooltipDiv = anchoredTooltip ? anchoredTooltip.children[0] : null;
     navigator.clipboard.writeText(text)
@@ -140,8 +141,10 @@ window.copyTextToClipboard = function (id, text, precopy, postcopy) {
             if (tooltipDiv) {
                 tooltipDiv.innerText = postcopy;
             }
-            copyIcon.style.display = 'none';
-            checkmarkIcon.style.display = 'inline';
+            if (copyIcon && checkmarkIcon) {
+                copyIcon.style.display = 'none';
+                checkmarkIcon.style.display = 'inline';
+            }
         })
         .catch(() => {
             if (tooltipDiv) {
@@ -154,8 +157,10 @@ window.copyTextToClipboard = function (id, text, precopy, postcopy) {
             tooltipDiv.innerText = precopy;
         }
 
-        copyIcon.style.display = 'inline';
-        checkmarkIcon.style.display = 'none';
+        if (copyIcon && checkmarkIcon) {
+            copyIcon.style.display = 'inline';
+            checkmarkIcon.style.display = 'none';
+        }
         delete button.dataset.copyTimeout;
    }, 1500);
 };


### PR DESCRIPTION
## Description

Fixes #6130

Exception details are shown behind a button in two places:

1. In the "Message" column of the structured logs table, when an exception exists.
2. In the "Health reports" grid in resource details, when a health report includes exception details.

Previously, the stack trace would be shown in a popup when the mouse hovered over the icon, sort of like a tooltip.

This commit changes the behaviour so that exception details are shown in the existing text visualizer dialog whenever the icon is clicked.

The icon becomes a `FluentButton` for consistency with the menu button to the right of the cell.

Also some optimisations in `GridValue`:

- Don't use `FluentHighlighter` when the text to highlight is empty, which will be the common case.
- Remove `MaxDisplayLength`. We never set this property, and it used space on every `GridValue` instance, and we create a lot of these objects.
- Remove some redundant DOM elements
- Support adding arbitrary buttons to the right-hand side of the area (used for the "exception details" button)

---

Here's how it looks for health checks:

![image](https://github.com/user-attachments/assets/40c1a534-fca5-40f4-837e-4f9d33c77ce0)

Here's how it looks on mouse-over, along with a tooltip. The button appears too close to the text here, but that's consistent with other inline lightweight buttons. It only shows on mouse over. If we add more margin, it looks bad when the mouse isn't hovering over it.

![image](https://github.com/user-attachments/assets/256c61a4-3b11-46f4-867c-36a726ed3cb9)

Clicking the button opens the text visualizer we use throughout the dashboard:

![image](https://github.com/user-attachments/assets/4b83d32f-4555-43f8-a579-b0436cb09551)

Here's how it looks in structured logs:

![image](https://github.com/user-attachments/assets/042764c2-7e4a-422f-a38c-45d1706df2dc)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6230)