### PR TITLE
Use a clearer icon for finished state

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor.cs
@@ -76,8 +76,8 @@ public partial class StateColumnDisplay
             else if (Resource.IsFinishedState())
             {
                 // Process completed successfully.
-                icon = new Icons.Filled.Size16.CheckmarkUnderlineCircle();
-                color = Color.Success;
+                icon = new Icons.Regular.Size16.RecordStop();
+                color = Color.Info;
             }
             else
             {
@@ -94,7 +94,7 @@ public partial class StateColumnDisplay
         else if (Resource.HasNoState())
         {
             icon = new Icons.Filled.Size16.Circle();
-            color = Color.Neutral;
+            color = Color.Info;
         }
         else if (Resource.HealthStatus is not HealthStatus.Healthy)
         {


### PR DESCRIPTION
## Description

Changes the icon and colour used for the "Finished" state.

### Before

![image](https://github.com/user-attachments/assets/7b9335de-c971-485f-9024-f0bb732acf4f)

### After

![image](https://github.com/user-attachments/assets/26d9b79d-1cd0-4860-ae55-b452e5e3b758)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6231)