### PR TITLE
Add empty data text with CSS

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -109,7 +109,7 @@
                                     }
                                     else
                                     {
-                                        <span>&ndash;</span>
+                                        <span class="empty-data"></span>
                                     }
                                 </AspireTemplateColumn>
                                 <AspireTemplateColumn ColumnId="@EndpointsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEndpointsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetEndpointsTooltip(ctx))">

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -421,7 +421,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
 
         if (displayedEndpoints.Count == 0)
         {
-            return "&ndash;";
+            return string.Empty;
         }
 
         if (displayedEndpoints.Count == 1)

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -149,7 +149,7 @@
                                             }
                                             else
                                             {
-                                                <span>&ndash;</span>
+                                                <span class="empty-data"></span>
                                             }
                                         </AspireTemplateColumn>
                                         <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.ActionsColumnHeader)]" Class="no-ellipsis">

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -3,7 +3,7 @@
 
 @if (DisplayedEndpoints.Count == 0)
 {
-    <span>&ndash;</span>
+    <span class="empty-data"></span>
 }
 else if (DisplayedEndpoints.Count == 1)
 {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StartTimeColumnDisplay.razor
@@ -10,7 +10,7 @@
 }
 else
 {
-    <span>&ndash;</span>
+    <span class="empty-data"></span>
 }
 
 @code {

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -664,3 +664,7 @@ fluent-data-grid-cell.no-ellipsis {
     column-gap: 4px;
     align-items: center;
 }
+
+.empty-data::before {
+    content: "-"
+}


### PR DESCRIPTION
## Description

Small tweak to https://github.com/dotnet/aspire/pull/6222 to add the text with CSS. There are a couple of benefits:

* Centralized control over what empty text is
* Screen readers won't attempt to read the text

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6238)