### PR TITLE
Add CORS allowed origins config override to app host

### DIFF
--- a/playground/BrowserTelemetry/BrowserTelemetry.AppHost/Program.cs
+++ b/playground/BrowserTelemetry/BrowserTelemetry.AppHost/Program.cs
@@ -4,7 +4,8 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddProject<Projects.BrowserTelemetry_Web>("web")
-    .WithExternalHttpEndpoints();
+    .WithExternalHttpEndpoints()
+    .WithReplicas(2);
 
 #if !SKIP_DASHBOARD_REFERENCE
 // This project is only added in playground projects to support development/debugging

--- a/playground/BrowserTelemetry/BrowserTelemetry.AppHost/Properties/launchSettings.json
+++ b/playground/BrowserTelemetry/BrowserTelemetry.AppHost/Properties/launchSettings.json
@@ -11,7 +11,8 @@
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "https://localhost:16175",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:17037",
-        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true"
+        "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
+        "DOTNET_DASHBOARD_CORS_ALLOWED_ORIGINS": "*"
       }
     },
     "http": {
@@ -25,7 +26,8 @@
         "DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:16175",
         "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:17037",
         "DOTNET_ASPIRE_SHOW_DASHBOARD_RESOURCES": "true",
-        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "DOTNET_DASHBOARD_CORS_ALLOWED_ORIGINS": "*"
       }
     },
     "generate-manifest": {

--- a/src/Shared/KnownConfigNames.cs
+++ b/src/Shared/KnownConfigNames.cs
@@ -12,5 +12,6 @@ internal static class KnownConfigNames
     public const string DashboardFrontendBrowserToken = "DOTNET_DASHBOARD_FRONTEND_BROWSERTOKEN";
     public const string DashboardResourceServiceClientApiKey = "DOTNET_DASHBOARD_RESOURCESERVICE_APIKEY";
     public const string DashboardUnsecuredAllowAnonymous = "DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS";
+    public const string DashboardCorsAllowedOrigins = "DOTNET_DASHBOARD_CORS_ALLOWED_ORIGINS";
     public const string ResourceServiceEndpointUrl = "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL";
 }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardResourceTests.cs
@@ -279,8 +279,10 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         Assert.Equal("http://localhost:5000", config.Single(e => e.Key == DashboardConfigNames.ResourceServiceUrlName.EnvVarName).Value);
     }
 
-    [Fact]
-    public async Task DashboardResource_OtlpHttpEndpoint_CorsEnvVarSet()
+    [Theory]
+    [InlineData("*")]
+    [InlineData(null)]
+    public async Task DashboardResource_OtlpHttpEndpoint_CorsEnvVarSet(string? explicitCorsAllowedOrigins)
     {
         // Arrange
         using var builder = TestDistributedApplicationBuilder.Create(
@@ -296,7 +298,8 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["ASPNETCORE_URLS"] = "http://localhost",
-            ["DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"] = "http://localhost"
+            ["DOTNET_DASHBOARD_OTLP_HTTP_ENDPOINT_URL"] = "http://localhost",
+            ["DOTNET_DASHBOARD_CORS_ALLOWED_ORIGINS"] = explicitCorsAllowedOrigins
         });
 
         using var app = builder.Build();
@@ -314,12 +317,15 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(dashboard, DistributedApplicationOperation.Run, app.Services);
 
-        Assert.Equal("http://localhost:8081,http://localhost:58080", config.Single(e => e.Key == DashboardConfigNames.DashboardOtlpCorsAllowedOriginsKeyName.EnvVarName).Value);
+        var expectedAllowedOrigins = !string.IsNullOrEmpty(explicitCorsAllowedOrigins) ? explicitCorsAllowedOrigins : "http://localhost:8081,http://localhost:58080";
+        Assert.Equal(expectedAllowedOrigins, config.Single(e => e.Key == DashboardConfigNames.DashboardOtlpCorsAllowedOriginsKeyName.EnvVarName).Value);
         Assert.Equal("*", config.Single(e => e.Key == DashboardConfigNames.DashboardOtlpCorsAllowedHeadersKeyName.EnvVarName).Value);
     }
 
-    [Fact]
-    public async Task DashboardResource_OtlpGrpcEndpoint_CorsEnvVarNotSet()
+    [Theory]
+    [InlineData("*")]
+    [InlineData(null)]
+    public async Task DashboardResource_OtlpGrpcEndpoint_CorsEnvVarNotSet(string? explicitCorsAllowedOrigins)
     {
         // Arrange
         using var builder = TestDistributedApplicationBuilder.Create(
@@ -335,7 +341,8 @@ public class DashboardResourceTests(ITestOutputHelper testOutputHelper)
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["ASPNETCORE_URLS"] = "http://localhost",
-            ["DOTNET_DASHBOARD_OTLP_ENDPOINT_URL"] = "http://localhost"
+            ["DOTNET_DASHBOARD_OTLP_ENDPOINT_URL"] = "http://localhost",
+            ["DOTNET_DASHBOARD_CORS_ALLOWED_ORIGINS"] = explicitCorsAllowedOrigins
         });
 
         using var app = builder.Build();


### PR DESCRIPTION
## Description

The dashboard supports OTLP HTTP and CORS to get telemetry from browser apps. CORS allowed origins are automatically calculated based on resource endpoints.

However, there are some scenarios where automatic CORS endpoints don't work:

- When browsing to the internal, proxy endpoint for a resource.
- When a custom domain is added to the host file and pointed to localhost, browsing to the custom domain.

These origins aren't automatically added and so sending telemetry fails.

The fix in this PR is to add manual dashboard CORS configuration to the app host. When the dashboard resource is configured, the app host manual configuration is simply forwarded to the dashboard. If there is no dashboard configuration then the existing logic is used.

Fixes https://github.com/dotnet/aspire/issues/6249

Fixes customer bug with existing feature. ~Intended for 9.0.~

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6250)