### PR TITLE
Allow aspire dashboard run behind proxy with SSL terminate

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -283,6 +283,8 @@ public sealed class DashboardWebApplication : IAsyncDisposable
             .AddSupportedCultures(supportedCultures)
             .AddSupportedUICultures(supportedCultures));
 
+        _app.UseForwardedHeaders();
+
         WriteVersion(_logger);
 
         _app.Lifetime.ApplicationStarted.Register(() =>


### PR DESCRIPTION
## Description

When aspire run behind a proxy / load balancer with ssl terminate, aspire oidc authn will redirect user to IdP with parameter `redirect_uri=http://aspire.host`.

This PR allows aspire redirect with https `redirect_uri`.

Fixes #5134 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No
