### PR TITLE
Improve trace application order on traces page

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -115,36 +115,22 @@ public partial class TraceDetail : ComponentBase
         }
     }
 
+    private record struct SpanWaterfallViewModelState(SpanWaterfallViewModel? Parent, int Depth, bool Hidden);
+
     private static List<SpanWaterfallViewModel> CreateSpanWaterfallViewModels(OtlpTrace trace, TraceDetailState state)
     {
         var orderedSpans = new List<SpanWaterfallViewModel>();
-        // There should be one root span but just in case, we'll add them all.
-        foreach (var rootSpan in trace.Spans.Where(s => string.IsNullOrEmpty(s.ParentSpanId)).OrderBy(s => s.StartTime))
+
+        TraceHelpers.VisitSpans(trace, (OtlpSpan span, SpanWaterfallViewModelState s) =>
         {
-            AddSelfAndChildren(orderedSpans, rootSpan, depth: 1, hidden: false, state, CreateViewModel);
-        }
-        // Unparented spans.
-        foreach (var unparentedSpan in trace.Spans.Where(s => !string.IsNullOrEmpty(s.ParentSpanId) && s.GetParentSpan() == null).OrderBy(s => s.StartTime))
-        {
-            AddSelfAndChildren(orderedSpans, unparentedSpan, depth: 1, hidden: false, state, CreateViewModel);
-        }
+            var viewModel = CreateViewModel(span, s.Depth, s.Hidden, state);
+            var peers = s.Parent?.Children ?? orderedSpans;
+            peers.Add(viewModel);
+
+            return s with { Depth = s.Depth + 1, Hidden = viewModel.IsHidden || viewModel.IsCollapsed };
+        }, new SpanWaterfallViewModelState(Parent: null, Depth: 1, Hidden: false));
 
         return orderedSpans;
-
-        static SpanWaterfallViewModel AddSelfAndChildren(List<SpanWaterfallViewModel> orderedSpans, OtlpSpan span, int depth, bool hidden, TraceDetailState state, Func<OtlpSpan, int, bool, TraceDetailState, SpanWaterfallViewModel> createViewModel)
-        {
-            var viewModel = createViewModel(span, depth, hidden, state);
-            orderedSpans.Add(viewModel);
-            depth++;
-
-            foreach (var child in span.GetChildSpans().OrderBy(s => s.StartTime))
-            {
-                var childViewModel = AddSelfAndChildren(orderedSpans, child, depth, viewModel.IsHidden || viewModel.IsCollapsed, state, createViewModel);
-                viewModel.Children.Add(childViewModel);
-            }
-
-            return viewModel;
-        }
 
         static SpanWaterfallViewModel CreateViewModel(OtlpSpan span, int depth, bool hidden, TraceDetailState state)
         {

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -115,7 +115,7 @@ public partial class TraceDetail : ComponentBase
         }
     }
 
-    private record struct SpanWaterfallViewModelState(SpanWaterfallViewModel? Parent, int Depth, bool Hidden);
+    private readonly record struct SpanWaterfallViewModelState(SpanWaterfallViewModel? Parent, int Depth, bool Hidden);
 
     private static List<SpanWaterfallViewModel> CreateSpanWaterfallViewModels(OtlpTrace trace, TraceDetailState state)
     {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -1,6 +1,7 @@
 ﻿@page "/traces"
 @page "/traces/resource/{applicationName}"
 
+@using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Otlp.Model
 @using Aspire.Dashboard.Resources
 @using Aspire.Dashboard.Utils
@@ -92,15 +93,15 @@
                             <AspireTemplateColumn ColumnId="@SpansColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Traces.TracesSpansColumnHeader)]">
                                 <FluentOverflow>
                                     <ChildContent>
-                                        @foreach (var item in context.Spans.GroupBy(s => s.Source.Application).OrderBy(g => g.Min(s => s.StartTime)))
+                                        @foreach (var item in TraceHelpers.GetOrderedApplications(context))
                                         {
                                             <FluentOverflowItem>
-                                                <span class="trace-tag trace-service-tag" title="@(GetSpansTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(item.Key)));">
-                                                    @if (item.Any(s => s.Status == OtlpSpanStatusCode.Error))
+                                                <span class="trace-tag trace-service-tag" title="@(GetSpansTooltip(item))" style="border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(item.Application)));">
+                                                    @if (item.ErroredSpans > 0)
                                                     {
                                                         <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon" />
                                                     }
-                                                    @GetResourceName(item.Key) (@item.Count())
+                                                    @GetResourceName(item.Application) (@item.TotalSpans)
                                                 </span>
                                             </FluentOverflowItem>
                                         }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -92,12 +92,12 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
         return tooltip;
     }
 
-    private string GetSpansTooltip(IGrouping<OtlpApplication, OtlpSpan> applicationSpans)
+    private string GetSpansTooltip(TraceHelpers.OrderedApplication applicationSpans)
     {
-        var count = applicationSpans.Count();
-        var errorCount = applicationSpans.Count(s => s.Status == OtlpSpanStatusCode.Error);
+        var count = applicationSpans.TotalSpans;
+        var errorCount = applicationSpans.ErroredSpans;
 
-        var tooltip = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.TracesResourceSpans)], GetResourceName(applicationSpans.Key));
+        var tooltip = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.TracesResourceSpans)], GetResourceName(applicationSpans.Application));
         tooltip += Environment.NewLine + string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Traces.TracesTotalTraces)], count);
         if (errorCount > 0)
         {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -92,7 +92,7 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
         return tooltip;
     }
 
-    private string GetSpansTooltip(TraceHelpers.OrderedApplication applicationSpans)
+    private string GetSpansTooltip(OrderedApplication applicationSpans)
     {
         var count = applicationSpans.TotalSpans;
         var errorCount = applicationSpans.ErroredSpans;

--- a/src/Aspire.Dashboard/Model/TraceHelpers.cs
+++ b/src/Aspire.Dashboard/Model/TraceHelpers.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Otlp.Model;
+
+namespace Aspire.Dashboard.Model;
+
+public static class TraceHelpers
+{
+    public sealed class OrderedApplication(OtlpApplication application, int index, DateTime firstDateTime, int totalSpans, int erroredSpans)
+    {
+        public OtlpApplication Application { get; } = application;
+        public int Index { get; } = index;
+        public DateTime FirstDateTime { get; set; } = firstDateTime;
+        public int TotalSpans { get; set; } = totalSpans;
+        public int ErroredSpans { get; set; } = erroredSpans;
+    }
+
+    /// <summary>
+    /// Get applications for a trace, with grouped information, and ordered using min date.
+    /// It is possible for spans to arrive with dates that are out of order (i.e. child span has earlier
+    /// start date than the parent) so ensure it isn't possible for a child to appear before parent.
+    /// </summary>
+    public static IEnumerable<OrderedApplication> GetOrderedApplications(OtlpTrace trace)
+    {
+        var appFirstTimes = new Dictionary<OtlpApplication, OrderedApplication>();
+
+        // Start from the unparented spans and visit children.
+        foreach (var item in trace.Spans.Where(s => s.GetParentSpan() == null))
+        {
+            Visit(appFirstTimes, currentMinDate: null, item);
+        }
+
+        return appFirstTimes.Select(kvp => kvp.Value)
+            .OrderBy(s => s.FirstDateTime)
+            .ThenBy(s => s.Index);
+
+        static void Visit(Dictionary<OtlpApplication, OrderedApplication> appFirstTimes, DateTime? currentMinDate, OtlpSpan span)
+        {
+            if (currentMinDate == null || currentMinDate < span.StartTime)
+            {
+                currentMinDate = span.StartTime;
+            }
+
+            if (appFirstTimes.TryGetValue(span.Source.Application, out var orderedApp))
+            {
+                if (currentMinDate < orderedApp.FirstDateTime)
+                {
+                    orderedApp.FirstDateTime = currentMinDate.Value;
+                }
+
+                if (span.Status == OtlpSpanStatusCode.Error)
+                {
+                    orderedApp.ErroredSpans++;
+                }
+
+                orderedApp.TotalSpans++;
+            }
+            else
+            {
+                appFirstTimes.Add(
+                    span.Source.Application,
+                    new OrderedApplication(span.Source.Application, appFirstTimes.Count, currentMinDate.Value, totalSpans: 1, erroredSpans: span.Status == OtlpSpanStatusCode.Error ? 1 : 0));
+            }
+
+            foreach (var childSpan in span.GetChildSpans())
+            {
+                Visit(appFirstTimes, currentMinDate.Value, childSpan);
+            }
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Model/TraceHelpers.cs
+++ b/src/Aspire.Dashboard/Model/TraceHelpers.cs
@@ -14,7 +14,7 @@ public static class TraceHelpers
     {
         // TODO: Investigate performance.
         // A trace's spans are stored in one collection and recursively iterated by matching the span id to its parent.
-        // This behavior could could excessive iteration over the span collection in large traces. Consider improving if this causes performance issues.
+        // This behavior could cause excessive iteration over the span collection in large traces. Consider improving if this causes performance issues.
 
         var orderByFunc = static (OtlpSpan s) => s.StartTime;
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -42,7 +42,7 @@ public class OtlpSpan
     public TimeSpan Duration => EndTime - StartTime;
 
     public IEnumerable<OtlpSpan> GetChildSpans() => GetChildSpans(this, Trace.Spans);
-    public static IEnumerable<OtlpSpan> GetChildSpans(OtlpSpan parentSpan, List<OtlpSpan> spans) => spans.Where(s => s.ParentSpanId == parentSpan.SpanId);
+    public static IEnumerable<OtlpSpan> GetChildSpans(OtlpSpan parentSpan, OtlpSpanCollection spans) => spans.Where(s => s.ParentSpanId == parentSpan.SpanId);
     public OtlpSpan? GetParentSpan()
     {
         if (string.IsNullOrEmpty(ParentSpanId))

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpSpan.cs
@@ -41,7 +41,8 @@ public class OtlpSpan
     public OtlpScope Scope { get; }
     public TimeSpan Duration => EndTime - StartTime;
 
-    public IEnumerable<OtlpSpan> GetChildSpans() => Trace.Spans.Where(s => s.ParentSpanId == SpanId);
+    public IEnumerable<OtlpSpan> GetChildSpans() => GetChildSpans(this, Trace.Spans);
+    public static IEnumerable<OtlpSpan> GetChildSpans(OtlpSpan parentSpan, List<OtlpSpan> spans) => spans.Where(s => s.ParentSpanId == parentSpan.SpanId);
     public OtlpSpan? GetParentSpan()
     {
         if (string.IsNullOrEmpty(ParentSpanId))

--- a/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
@@ -1,0 +1,115 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Tests.Shared.Telemetry;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class TraceHelpersTests
+{
+    [Fact]
+    public void GetOrderedApplications_SingleSpan_GroupedResult()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpApplication("app1", "instance1", context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
+        trace.AddSpan(CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
+
+        // Act
+        var results = TraceHelpers.GetOrderedApplications(trace);
+
+        // Assert
+        Assert.Collection(results,
+            g =>
+            {
+                Assert.Equal(app1, g.Application);
+            });
+    }
+
+    [Fact]
+    public void GetOrderedApplications_ChildSpanAfterParentSpan_GroupedResult()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpApplication("app1", "instance", context);
+        var app2 = new OtlpApplication("app2", "instance", context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
+        trace.AddSpan(CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+        trace.AddSpan(CreateSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
+
+        // Act
+        var results = TraceHelpers.GetOrderedApplications(trace);
+
+        // Assert
+        Assert.Collection(results,
+            g =>
+            {
+                Assert.Equal(app1, g.Application);
+            },
+            g =>
+            {
+                Assert.Equal(app2, g.Application);
+            });
+    }
+
+    [Fact]
+    public void GetOrderedApplications_ChildSpanDifferentStartTime_GroupedResult()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpApplication("app1", "instance", context);
+        var app2 = new OtlpApplication("app2", "instance", context);
+        var app3 = new OtlpApplication("app3", "instance", context);
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
+        trace.AddSpan(CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+        trace.AddSpan(CreateSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc)));
+        trace.AddSpan(CreateSpan(app3, trace, scope, spanId: "1-1-1", parentSpanId: "1-1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+        trace.AddSpan(CreateSpan(app3, trace, scope, spanId: "1-2", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+
+        // Act
+        var results = TraceHelpers.GetOrderedApplications(trace);
+
+        // Assert
+        Assert.Collection(results,
+            g =>
+            {
+                Assert.Equal(app1, g.Application);
+            },
+            g =>
+            {
+                Assert.Equal(app3, g.Application);
+            },
+            g =>
+            {
+                Assert.Equal(app2, g.Application);
+            });
+    }
+
+    private static OtlpSpan CreateSpan(OtlpApplication app, OtlpTrace trace, OtlpScope scope, string spanId, string? parentSpanId, DateTime startDate)
+    {
+        return new OtlpSpan(app.GetView([]), trace, scope)
+        {
+            Attributes = [],
+            BackLinks = [],
+            EndTime = DateTime.MaxValue,
+            Events = [],
+            Kind = OtlpSpanKind.Unspecified,
+            Links = [],
+            Name = "Test",
+            ParentSpanId = parentSpanId,
+            SpanId = spanId,
+            StartTime = startDate,
+            State = null,
+            Status = OtlpSpanStatusCode.Unset,
+            StatusMessage = null
+        };
+    }
+}


### PR DESCRIPTION
## Description

The traces page shows a summary of info about it's spans apps . Spans are grouped by app, and then the apps are ordered by its earliest span.

The problem with this is span start dates can be out of order. For example, the start time reported by a .NET app and a browser app could be slightly off, causing a child browser app span to be earlier than its parent server span.

This PR changes the ordering logic so a child can't be ordered before its parent. There are performance improvements that could be made to here, but the old logic wasn't optimized either. Only runs for traces than are rendered to the screen which is limited by virtualization.

Low priority. Post 9.0

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6261)