### PR TITLE
Use ResourceReadyEvent to avoid blocking startup importing redis databases

### DIFF
--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -153,6 +153,15 @@ public static class RedisBuilderExtensions
                                       .WithHttpEndpoint(targetPort: 5540, name: "http")
                                       .ExcludeFromManifest();
 
+            // We need to wait for all endpoints to be allocated before attempting to import databases
+            var endpointsAllocatedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+            {
+                endpointsAllocatedTcs.TrySetResult();
+                return Task.CompletedTask;
+            });
+
             builder.ApplicationBuilder.Eventing.Subscribe<ResourceReadyEvent>(resource, async (e, ct) =>
             {
                 var redisInstances = builder.ApplicationBuilder.Resources.OfType<RedisResource>();
@@ -162,6 +171,9 @@ public static class RedisBuilderExtensions
                     // No-op if there are no Redis resources present.
                     return;
                 }
+
+                // Wait for all endpoints to be allocated before attempting to import databases
+                await endpointsAllocatedTcs.Task.ConfigureAwait(false);
 
                 var redisInsightResource = builder.ApplicationBuilder.Resources.OfType<RedisInsightResource>().Single();
                 var insightEndpoint = redisInsightResource.PrimaryEndpoint;

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -153,7 +153,7 @@ public static class RedisBuilderExtensions
                                       .WithHttpEndpoint(targetPort: 5540, name: "http")
                                       .ExcludeFromManifest();
 
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterResourcesCreatedEvent>(async (e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<ResourceReadyEvent>(resource, async (e, ct) =>
             {
                 var redisInstances = builder.ApplicationBuilder.Resources.OfType<RedisResource>();
 


### PR DESCRIPTION
Replaces https://github.com/dotnet/aspire/pull/6141

## Description

This pull request focuses on ensuring that all endpoints are allocated before attempting to import databases in Redis-related operations. It introduces a mechanism to wait for the allocation of endpoints and modifies the test to verify this behavior.

### Improvements to Redis resource handling:

* [`src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs`](diffhunk://#diff-a5074219d9ede6622333dbc0f6da94c74c45ea8c68faa1c2829b57cd3a614659L156-R165): Added a `TaskCompletionSource` to wait for all endpoints to be allocated before importing databases. Subscribed to `AfterEndpointsAllocatedEvent` to signal when endpoints are ready. [[1]](diffhunk://#diff-a5074219d9ede6622333dbc0f6da94c74c45ea8c68faa1c2829b57cd3a614659L156-R165) [[2]](diffhunk://#diff-a5074219d9ede6622333dbc0f6da94c74c45ea8c68faa1c2829b57cd3a614659R175-R177)

### Test updates:

* [`tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs`](diffhunk://#diff-3b0aa8b65b60aa9db2aff71ccdede3578734eccad1ca79454241c28b3ecc73b3R135-R149): Modified the test to use a `TaskCompletionSource` to wait for the `ResourceReadyEvent` instead of directly waiting for the resource state to be running. This ensures that the database import process is verified correctly.


Fixes https://github.com/dotnet/aspire/issues/6136
Fixes https://github.com/dotnet/aspire/issues/6099

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6308)