### PR TITLE
Move SlowDownMonitoringAsync.

### DIFF
--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -11,6 +12,98 @@ namespace Aspire.Hosting.Tests.Health;
 
 public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
 {
+    [Fact]
+    public async Task HealthCheckIntervalSlowsAfterSteadyHealthyState()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        AutoResetEvent? are = null;
+
+        builder.Services.AddHealthChecks().AddCheck("resource_check", () =>
+        {
+            are?.Set();
+
+            return HealthCheckResult.Healthy();
+        });
+
+        var resource = builder.AddResource(new ParentResource("resource"))
+                              .WithHealthCheck("resource_check");
+
+        using var app = builder.Build();
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        var abortTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        await app.StartAsync(abortTokenSource.Token);
+
+        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        {
+            State = KnownResourceStates.Running
+        });
+        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, abortTokenSource.Token);
+
+        are = new AutoResetEvent(false);
+
+        // Allow one event to through since it could be half way through.
+        are.WaitOne();
+
+        var stopwatch = Stopwatch.StartNew();
+        are.WaitOne();
+        stopwatch.Stop();
+
+        // Delay is 30 seconds but we allow for a (ridiculous) 10 second margin of error.
+        Assert.True(stopwatch.ElapsedMilliseconds > 20000);
+
+        await app.StopAsync(abortTokenSource.Token);
+    }
+
+    [Fact]
+    public async Task HealthCheckIntervalDoesNotSlowBeforeSteadyHealthyState()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        AutoResetEvent? are = null;
+
+        builder.Services.AddHealthChecks().AddCheck("resource_check", () =>
+        {
+            are?.Set();
+
+            return HealthCheckResult.Unhealthy();
+        });
+
+        var resource = builder.AddResource(new ParentResource("resource"))
+                              .WithHealthCheck("resource_check");
+
+        using var app = builder.Build();
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        var abortTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        await app.StartAsync(abortTokenSource.Token);
+
+        await rns.PublishUpdateAsync(resource.Resource, s => s with
+        {
+            State = KnownResourceStates.Running
+        });
+        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, abortTokenSource.Token);
+
+        are = new AutoResetEvent(false);
+
+        // Allow one event to through since it could be half way through.
+        are.WaitOne();
+
+        var stopwatch = Stopwatch.StartNew();
+        are.WaitOne();
+        stopwatch.Stop();
+
+        // When not in a healthy state the delay should be ~3 seconds but
+        // we'll check for 10 seconds to make sure we haven't got down
+        // the 30 second slow path.
+        Assert.True(stopwatch.ElapsedMilliseconds < 10000);
+
+        await app.StopAsync(abortTokenSource.Token);
+    }
+
     [Fact]
     public async Task ResourcesWithoutHealthCheckAnnotationsGetReadyEventFired()
     {


### PR DESCRIPTION
## Description

Previously we were calling this method late in the monitoring loop however after some earlier refactoring we made it less effective. By moving it up to where we are in a steady state it has the chance to have an effect (it internally checks for healthy state and falls through quickly if it isn't in one.

Fixes #6134 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6309)