### PR TITLE
Fix creating temporary dashboard client on startup

### DIFF
--- a/src/Aspire.Dashboard/DashboardWebApplication.cs
+++ b/src/Aspire.Dashboard/DashboardWebApplication.cs
@@ -232,6 +232,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
 
         // Data from the server.
         builder.Services.TryAddScoped<IDashboardClient, DashboardClient>();
+        builder.Services.TryAddSingleton<IDashboardClientStatus, DashboardClientStatus>();
 
         // OTLP services.
         builder.Services.AddGrpc();
@@ -340,7 +341,7 @@ public sealed class DashboardWebApplication : IAsyncDisposable
         {
             if (context.Request.Path.Equals(TargetLocationInterceptor.ResourcesPath, StringComparisons.UrlPath))
             {
-                var client = context.RequestServices.GetRequiredService<IDashboardClient>();
+                var client = context.RequestServices.GetRequiredService<IDashboardClientStatus>();
                 if (!client.IsEnabled)
                 {
                     context.Response.Redirect(TargetLocationInterceptor.StructuredLogsPath);

--- a/src/Aspire.Dashboard/ResourceService/DashboardClientStatus.cs
+++ b/src/Aspire.Dashboard/ResourceService/DashboardClientStatus.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard.Model;
+
+internal sealed class DashboardClientStatus(IOptions<DashboardOptions> dashboardOptions) : IDashboardClientStatus
+{
+    public bool IsEnabled => dashboardOptions.Value.ResourceServiceClient.GetUri() is not null;
+}

--- a/src/Aspire.Dashboard/ResourceService/IDashboardClient.cs
+++ b/src/Aspire.Dashboard/ResourceService/IDashboardClient.cs
@@ -8,17 +8,8 @@ namespace Aspire.Dashboard.Model;
 /// <summary>
 /// Provides data about active resources to external components, such as the dashboard.
 /// </summary>
-public interface IDashboardClient : IAsyncDisposable
+public interface IDashboardClient : IDashboardClientStatus, IAsyncDisposable
 {
-    /// <summary>
-    /// Gets whether this client object is enabled for use.
-    /// </summary>
-    /// <remarks>
-    /// Users of this client should check <see cref="IsEnabled"/> before calling
-    /// any other members of this interface, to avoid exceptions.
-    /// </remarks>
-    bool IsEnabled { get; }
-
     Task WhenConnected { get; }
 
     /// <summary>

--- a/src/Aspire.Dashboard/ResourceService/IDashboardClientStatus.cs
+++ b/src/Aspire.Dashboard/ResourceService/IDashboardClientStatus.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Model;
+
+public interface IDashboardClientStatus
+{
+    /// <summary>
+    /// Gets whether the client object is enabled for use.
+    /// </summary>
+    /// <remarks>
+    /// Users of <see cref="IDashboardClient"/> client should check <see cref="IsEnabled"/> before calling
+    /// any other members of this interface, to avoid exceptions.
+    /// </remarks>
+    bool IsEnabled { get; }
+}

--- a/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Controls/ApplicationNameTests.cs
@@ -21,6 +21,7 @@ public class ApplicationNameTests : TestContext
         Services.AddSingleton<IConfiguration>(new ConfigurationManager());
         Services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
         Services.AddSingleton<IDashboardClient, DashboardClient>();
+        Services.AddSingleton<IDashboardClientStatus, DashboardClientStatus>();
         Services.AddSingleton<BrowserTimeProvider>();
         Services.AddSingleton<IKnownPropertyLookup>(new MockKnownPropertyLookup());
 

--- a/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/DashboardClientAuthTests.cs
@@ -130,6 +130,7 @@ public sealed class DashboardClientAuthTests
             loggerFactory: loggerFactory,
             configuration: new ConfigurationManager(),
             dashboardOptions: Options.Create(options),
+            dashboardClientStatus: new TestDashboardClientStatus(),
             timeProvider: new BrowserTimeProvider(NullLoggerFactory.Instance),
             knownPropertyLookup: new MockKnownPropertyLookup(),
             configureHttpHandler: handler => handler.SslOptions.RemoteCertificateValidationCallback = (sender, cert, chain, sslPolicyErrors) => true);
@@ -157,6 +158,11 @@ public sealed class DashboardClientAuthTests
     private sealed class TestCalls
     {
         public Channel<ReceivedCallInfo<ApplicationInformationRequest>> ApplicationInformationCallsChannel { get; } = Channel.CreateUnbounded<ReceivedCallInfo<ApplicationInformationRequest>>();
+    }
+
+    private sealed class TestDashboardClientStatus : IDashboardClientStatus
+    {
+        public bool IsEnabled => true;
     }
 
     private sealed class MockDashboardService(TestCalls testCalls) : DashboardServiceBase

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/DashboardServerFixture.cs
@@ -57,6 +57,7 @@ public class DashboardServerFixture : IAsyncLifetime
             preConfigureBuilder: builder =>
             {
                 builder.Configuration.AddConfiguration(config);
+                builder.Services.AddSingleton<IDashboardClientStatus, MockDashboardClientStatus>();
                 builder.Services.AddScoped<IDashboardClient, MockDashboardClient>();
             });
 

--- a/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/Playwright/Infrastructure/MockDashboardClient.cs
@@ -8,9 +8,19 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Dashboard.Tests.Integration.Playwright.Infrastructure;
 
+public sealed class MockDashboardClientStatus : IDashboardClientStatus
+{
+    public bool IsEnabled => true;
+}
+
 public sealed class MockDashboardClient : IDashboardClient
 {
     private static readonly BrowserTimeProvider s_timeProvider = new(NullLoggerFactory.Instance);
+
+    public MockDashboardClient(IDashboardClientStatus dashboardClientStatus)
+    {
+        _dashboardClientStatus = dashboardClientStatus;
+    }
 
     public static readonly ResourceViewModel TestResource1 = ModelTestHelpers.CreateResource(
         appName: "TestResource",
@@ -32,7 +42,9 @@ public sealed class MockDashboardClient : IDashboardClient
         }.ToDictionary(),
         state: KnownResourceState.Running);
 
-    public bool IsEnabled => true;
+    private readonly IDashboardClientStatus _dashboardClientStatus;
+
+    public bool IsEnabled => _dashboardClientStatus.IsEnabled;
     public Task WhenConnected => Task.CompletedTask;
     public string ApplicationName => "IntegrationTestApplication";
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/DashboardClientTests.cs
@@ -151,6 +151,11 @@ public sealed class DashboardClientTests
 
     private DashboardClient CreateResourceServiceClient()
     {
-        return new DashboardClient(NullLoggerFactory.Instance, _configuration, _dashboardOptions, s_timeProvider, new MockKnownPropertyLookup());
+        return new DashboardClient(NullLoggerFactory.Instance, _configuration, _dashboardOptions, new TestDashboardClientStatus(), s_timeProvider, new MockKnownPropertyLookup());
+    }
+
+    private sealed class TestDashboardClientStatus : IDashboardClientStatus
+    {
+        public bool IsEnabled => true;
     }
 }


### PR DESCRIPTION
## Description

While testing I noticed that a dashboard client was created and then disposed in some middleware. This happened because the middleware wants to know if the client is enabled or not, so resolves the service.

However, because the client is a scoped service, a new instance is created and then later disposed. Once the dashboard UI is displayed another client is created.

The fix is to split the IsEnabled flag out into its own interface which is resolved to test if the client is enabled in middleware. It's ok to do because it has a singleton lifetime.

Low priority. Post 9.0.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6316)