### PR TITLE
Fix ContainerLifetime.Persistent xml docs

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ContainerLifetimeAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ContainerLifetimeAnnotation.cs
@@ -23,12 +23,8 @@ public enum ContainerLifetime
     /// <para>When an existing container IS found, Aspire MAY re-use it based on the following criteria:</para>
     /// <list type="bullet">
     /// <item>If the container WAS NOT originally created by Aspire, the existing container will be re-used.</item>
-    /// <item>If the container WAS originally created by Aspire:
-    /// <list type="bullet">
-    /// <item>And the <see cref="ContainerResource"/> configuration DOES match the existing container, the existing container will be re-used.</item>
-    /// <item>And the <see cref="ContainerResource"/> configuration DOES NOT match the existing container, the existing container will be stopped
-    /// and a new container created in order to apply the updated configuration.</item>
-    /// </list></item>
+    /// <item>If the container WAS originally created by Aspire, and the <see cref="ContainerResource"/> configuration DOES match the existing container, the existing container will be re-used.</item>
+    /// <item>If the container WAS originally created by Aspire, and the <see cref="ContainerResource"/> configuration DOES NOT match the existing container, the existing container will be stopped and a new container created in order to apply the updated configuration.</item>
     /// </list>
     /// </remarks>
     Persistent,


### PR DESCRIPTION
## Description

I watched some of https://www.youtube.com/watch?v=tSvNLbd72do and noticed the XML comment produced a messed up tooltip.

Before:
![image](https://github.com/user-attachments/assets/2803251e-3850-4578-969f-2d72ab1513c1)

After:
![image](https://github.com/user-attachments/assets/2ec0c920-d8d5-42e5-baea-2d60e4b18c9b)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6334)