### PR TITLE
Update lifecycle command state checks to support additional possible container resource state

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -115,6 +115,6 @@ internal static class CommandsConfigurationExtensions
         static bool IsStopped(string? state) => state is "Exited" or "Finished" or "FailedToStart";
         static bool IsStopping(string? state) => state is "Stopping";
         static bool IsStarting(string? state) => state is "Starting";
-        static bool IsWaiting(string? state) => state is "Waiting";
+        static bool IsWaiting(string? state) => state is "Waiting" or "RuntimeUnhealthy";
     }
 }

--- a/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
@@ -16,6 +16,7 @@ public class ResourceCommandAnnotationTests
     [InlineData(CommandsConfigurationExtensions.StartType, "Finished", ResourceCommandState.Enabled)]
     [InlineData(CommandsConfigurationExtensions.StartType, "FailedToStart", ResourceCommandState.Enabled)]
     [InlineData(CommandsConfigurationExtensions.StartType, "Waiting", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.StartType, "RuntimeUnhealthy", ResourceCommandState.Disabled)]
     [InlineData(CommandsConfigurationExtensions.StopType, "Starting", ResourceCommandState.Hidden)]
     [InlineData(CommandsConfigurationExtensions.StopType, "Stopping", ResourceCommandState.Disabled)]
     [InlineData(CommandsConfigurationExtensions.StopType, "Running", ResourceCommandState.Enabled)]
@@ -23,6 +24,7 @@ public class ResourceCommandAnnotationTests
     [InlineData(CommandsConfigurationExtensions.StopType, "Finished", ResourceCommandState.Hidden)]
     [InlineData(CommandsConfigurationExtensions.StopType, "FailedToStart", ResourceCommandState.Hidden)]
     [InlineData(CommandsConfigurationExtensions.StopType, "Waiting", ResourceCommandState.Hidden)]
+    [InlineData(CommandsConfigurationExtensions.StopType, "RuntimeUnhealthy", ResourceCommandState.Hidden)]
     [InlineData(CommandsConfigurationExtensions.RestartType, "Starting", ResourceCommandState.Disabled)]
     [InlineData(CommandsConfigurationExtensions.RestartType, "Stopping", ResourceCommandState.Disabled)]
     [InlineData(CommandsConfigurationExtensions.RestartType, "Running", ResourceCommandState.Enabled)]
@@ -30,6 +32,7 @@ public class ResourceCommandAnnotationTests
     [InlineData(CommandsConfigurationExtensions.RestartType, "Finished", ResourceCommandState.Disabled)]
     [InlineData(CommandsConfigurationExtensions.RestartType, "FailedToStart", ResourceCommandState.Disabled)]
     [InlineData(CommandsConfigurationExtensions.RestartType, "Waiting", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.RestartType, "RuntimeUnhealthy", ResourceCommandState.Disabled)]
     public void LifeCycleCommands_CommandState(string commandType, string resourceState, ResourceCommandState commandState)
     {
         // Arrange


### PR DESCRIPTION
## Description

The orchestrator is being updated to return a new `RuntimeUnhealthy` state for container resources when the container runtime isn't healthy, however the new state isn't properly reflected in the current lifecycle command status checks. This PR treats the new state as a Waiting state for the lifecycle command state checks (the start command will be disabled, the stop command will be hidden, and the restart command will be disabled).

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6344)