### PR TITLE
Fix incorrect resource lookups

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/ChartContainer.razor.cs
@@ -210,8 +210,8 @@ public partial class ChartContainer : ComponentBase, IAsyncDisposable
                 {
                     var text = v switch
                     {
-                        null => Loc[ControlsStrings.LabelUnset],
-                        { Length: 0 } => Loc[ControlsStrings.LabelEmpty],
+                        null => Loc[nameof(ControlsStrings.LabelUnset)],
+                        { Length: 0 } => Loc[nameof(ControlsStrings.LabelEmpty)],
                         _ => v
                     };
                     return new DimensionValueViewModel

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -11,7 +11,7 @@
 <div class="resource-details-layout">
 
     <FluentToolbar Orientation="Orientation.Horizontal">
-        <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(Resource?.Name)" slot="end">@Loc[Resources.ResourceDetailsViewConsoleLogs]</FluentAnchor>
+        <FluentAnchor Appearance="Appearance.Lightweight" Href="@DashboardUrls.ConsoleLogsUrl(Resource?.Name)" slot="end">@Loc[nameof(Resources.ResourceDetailsViewConsoleLogs)]</FluentAnchor>
 
         @if (ShowSpecOnlyToggle)
         {

--- a/src/Aspire.Dashboard/Components/Controls/TreeMetricSelector.razor
+++ b/src/Aspire.Dashboard/Components/Controls/TreeMetricSelector.razor
@@ -9,7 +9,7 @@
 
 @if (IncludeLabel)
 {
-    <FluentInputLabel Label="@Loc[Dashboard.Resources.Metrics.MetricsInsturementNameGridNameColumnHeader]" ForId="metric-selector" />
+    <FluentInputLabel Label="@Loc[nameof(Dashboard.Resources.Metrics.MetricsInsturementNameGridNameColumnHeader)]" ForId="metric-selector" />
 }
 
 <FluentTreeView Id="metric-selector" Class="metrics-tree" @bind-CurrentSelected="@PageViewModel.SelectedTreeItem" @bind-CurrentSelected:after="HandleSelectedTreeItemChangedAsync">

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor.cs
@@ -82,7 +82,7 @@ public partial class Metrics : IDisposable, IPageWithSessionAndUrlState<Metrics.
         _selectApplication = new SelectViewModel<ResourceTypeDetails>
         {
             Id = null,
-            Name = ControlsStringsLoc[ControlsStrings.LabelNone]
+            Name = ControlsStringsLoc[nameof(ControlsStrings.LabelNone)]
         };
 
         PageViewModel = new MetricsViewModel

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/EndpointsColumnDisplay.razor
@@ -43,7 +43,7 @@ else if (DisplayedEndpoints.Count > 1)
             <div @onclick:stopPropagation="true">
                 <FluentPopover AnchorId="@overflow.IdMoreButton" @bind-Open="_popoverVisible" VerticalThreshold="200" AutoFocus="false">
                     <Header>
-                        @Loc[Resources.Columns.EndpointsColumnDisplayOverflowTitle]
+                        @Loc[nameof(Resources.Columns.EndpointsColumnDisplayOverflowTitle)]
                     </Header>
                     <Body>
                         <div class="endpoint-popup">

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor.cs
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/StateColumnDisplay.razor.cs
@@ -38,12 +38,12 @@ public partial class StateColumnDisplay
             if (resource.TryGetExitCode(out var exitCode) && exitCode is not 0)
             {
                 // Process completed unexpectedly, hence the non-zero code. This is almost certainly an error, so warn users.
-                return string.Format(CultureInfo.CurrentCulture, Loc[Columns.StateColumnResourceExitedUnexpectedly], resource.ResourceType, exitCode);
+                return string.Format(CultureInfo.CurrentCulture, Loc[nameof(Columns.StateColumnResourceExitedUnexpectedly)], resource.ResourceType, exitCode);
             }
             else
             {
                 // Process completed, which may not have been unexpected.
-                return string.Format(CultureInfo.CurrentCulture, Loc[Columns.StateColumnResourceExited], resource.ResourceType);
+                return string.Format(CultureInfo.CurrentCulture, Loc[nameof(Columns.StateColumnResourceExited)], resource.ResourceType);
             }
         }
         else if (resource.KnownState is KnownResourceState.Running && resource.HealthStatus is not HealthStatus.Healthy)
@@ -120,7 +120,7 @@ public partial class StateColumnDisplay
 
         var text = Resource switch
         {
-            { State: null or "" } => Loc[Columns.UnknownStateLabel],
+            { State: null or "" } => Loc[nameof(Columns.UnknownStateLabel)],
             { KnownState: KnownResourceState.Running, HealthStatus: not HealthStatus.Healthy } => $"{Resource.State.Humanize()} ({(Resource.HealthStatus ?? HealthStatus.Unhealthy).Humanize()})",
             _ => Resource.State.Humanize()
         };

--- a/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
+++ b/src/Aspire.Dashboard/Model/KnownPropertyLookup.cs
@@ -22,39 +22,39 @@ public sealed class KnownPropertyLookup : IKnownPropertyLookup
     {
         _resourceProperties =
         [
-            new(KnownProperties.Resource.DisplayName, loc[ResourcesDetailsDisplayNameProperty]),
-            new(KnownProperties.Resource.State, loc[ResourcesDetailsStateProperty]),
-            new(KnownProperties.Resource.StartTime, loc[ResourcesDetailsStartTimeProperty]),
-            new(KnownProperties.Resource.StopTime, loc[ResourcesDetailsStopTimeProperty]),
-            new(KnownProperties.Resource.ExitCode, loc[ResourcesDetailsExitCodeProperty]),
-            new(KnownProperties.Resource.HealthState, loc[ResourcesDetailsHealthStateProperty])
+            new(KnownProperties.Resource.DisplayName, loc[nameof(ResourcesDetailsDisplayNameProperty)]),
+            new(KnownProperties.Resource.State, loc[nameof(ResourcesDetailsStateProperty)]),
+            new(KnownProperties.Resource.StartTime, loc[nameof(ResourcesDetailsStartTimeProperty)]),
+            new(KnownProperties.Resource.StopTime, loc[nameof(ResourcesDetailsStopTimeProperty)]),
+            new(KnownProperties.Resource.ExitCode, loc[nameof(ResourcesDetailsExitCodeProperty)]),
+            new(KnownProperties.Resource.HealthState, loc[nameof(ResourcesDetailsHealthStateProperty)])
         ];
 
         _projectProperties =
         [
             .. _resourceProperties,
-            new(KnownProperties.Project.Path, loc[ResourcesDetailsProjectPathProperty]),
-            new(KnownProperties.Executable.Pid, loc[ResourcesDetailsExecutableProcessIdProperty]),
+            new(KnownProperties.Project.Path, loc[nameof(ResourcesDetailsProjectPathProperty)]),
+            new(KnownProperties.Executable.Pid, loc[nameof(ResourcesDetailsExecutableProcessIdProperty)]),
         ];
 
         _executableProperties =
         [
             .. _resourceProperties,
-            new(KnownProperties.Executable.Path, loc[ResourcesDetailsExecutablePathProperty]),
-            new(KnownProperties.Executable.WorkDir, loc[ResourcesDetailsExecutableWorkingDirectoryProperty]),
-            new(KnownProperties.Executable.Args, loc[ResourcesDetailsExecutableArgumentsProperty]),
-            new(KnownProperties.Executable.Pid, loc[ResourcesDetailsExecutableProcessIdProperty]),
+            new(KnownProperties.Executable.Path, loc[nameof(ResourcesDetailsExecutablePathProperty)]),
+            new(KnownProperties.Executable.WorkDir, loc[nameof(ResourcesDetailsExecutableWorkingDirectoryProperty)]),
+            new(KnownProperties.Executable.Args, loc[nameof(ResourcesDetailsExecutableArgumentsProperty)]),
+            new(KnownProperties.Executable.Pid, loc[nameof(ResourcesDetailsExecutableProcessIdProperty)]),
         ];
 
         _containerProperties =
         [
             .. _resourceProperties,
-            new(KnownProperties.Container.Image, loc[ResourcesDetailsContainerImageProperty]),
-            new(KnownProperties.Container.Id, loc[ResourcesDetailsContainerIdProperty]),
-            new(KnownProperties.Container.Command, loc[ResourcesDetailsContainerCommandProperty]),
-            new(KnownProperties.Container.Args, loc[ResourcesDetailsContainerArgumentsProperty]),
-            new(KnownProperties.Container.Ports, loc[ResourcesDetailsContainerPortsProperty]),
-            new(KnownProperties.Container.Lifetime, loc[ResourcesDetailsContainerLifetimeProperty]),
+            new(KnownProperties.Container.Image, loc[nameof(ResourcesDetailsContainerImageProperty)]),
+            new(KnownProperties.Container.Id, loc[nameof(ResourcesDetailsContainerIdProperty)]),
+            new(KnownProperties.Container.Command, loc[nameof(ResourcesDetailsContainerCommandProperty)]),
+            new(KnownProperties.Container.Args, loc[nameof(ResourcesDetailsContainerArgumentsProperty)]),
+            new(KnownProperties.Container.Ports, loc[nameof(ResourcesDetailsContainerPortsProperty)]),
+            new(KnownProperties.Container.Lifetime, loc[nameof(ResourcesDetailsContainerLifetimeProperty)]),
         ];
     }
 


### PR DESCRIPTION
## Description

I believe this fixes some places where strings would not be localized in the UI for users of supported `en-US` cultures.

When using `IStringLocalizer`, we must use the name of the resource we want to look up. The easiest way to do this is using `nameof` with the generated property for that resource.

Omitting the namespace causes the resource to be looked up and then used as a key for a lookup, which is not correct. The lookup should happen through `IStringLocalizer`, not the generated resource class.

Follows an observation made in https://github.com/dotnet/aspire/pull/6209#discussion_r1803940775

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6348)