### PR TITLE
Rename CommandType to Name on resource command types

### DIFF
--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -10,7 +10,7 @@ for (var i = 0; i < 10; i++)
 
 var serviceBuilder = builder.AddProject<Projects.Stress_ApiService>("stress-apiservice", launchProfileName: null);
 serviceBuilder.WithCommand(
-    type: "icon-test",
+    name: "icon-test",
     displayName: "Icon test",
     executeCommand: (c) =>
     {
@@ -18,7 +18,7 @@ serviceBuilder.WithCommand(
     },
     iconName: "CloudDatabase");
 serviceBuilder.WithCommand(
-    type: "icon-test-highlighted",
+    name: "icon-test-highlighted",
     displayName: "Icon test highlighted",
     executeCommand: (c) =>
     {

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -94,13 +94,13 @@ public sealed class ResourceViewModelNameComparer : IComparer<ResourceViewModel>
     }
 }
 
-[DebuggerDisplay("CommandType = {CommandType}, DisplayName = {DisplayName}")]
+[DebuggerDisplay("Name = {Name}, DisplayName = {DisplayName}")]
 public sealed class CommandViewModel
 {
     private sealed record IconKey(string IconName, IconVariant IconVariant);
     private static readonly ConcurrentDictionary<IconKey, CustomIcon?> s_iconCache = new();
 
-    public string CommandType { get; }
+    public string Name { get; }
     public CommandViewModelState State { get; }
     public string DisplayName { get; }
     public string DisplayDescription { get; }
@@ -110,12 +110,12 @@ public sealed class CommandViewModel
     public string IconName { get; }
     public IconVariant IconVariant { get; }
 
-    public CommandViewModel(string commandType, CommandViewModelState state, string displayName, string displayDescription, string confirmationMessage, Value? parameter, bool isHighlighted, string iconName, IconVariant iconVariant)
+    public CommandViewModel(string name, CommandViewModelState state, string displayName, string displayDescription, string confirmationMessage, Value? parameter, bool isHighlighted, string iconName, IconVariant iconVariant)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(commandType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
 
-        CommandType = commandType;
+        Name = name;
         State = state;
         DisplayName = displayName;
         DisplayDescription = displayDescription;

--- a/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
+++ b/src/Aspire.Dashboard/ResourceService/DashboardClient.cs
@@ -528,7 +528,7 @@ internal sealed class DashboardClient : IDashboardClient
 
         var request = new ResourceCommandRequest()
         {
-            CommandType = command.CommandType,
+            CommandName = command.Name,
             Parameter = command.Parameter,
             ResourceName = resourceName,
             ResourceType = resourceType
@@ -544,7 +544,7 @@ internal sealed class DashboardClient : IDashboardClient
         }
         catch (RpcException ex)
         {
-            _logger.LogError(ex, "Error executing command \"{CommandType}\" on resource \"{ResourceName}\": {StatusCode}", command.CommandType, resourceName, ex.StatusCode);
+            _logger.LogError(ex, "Error executing command \"{CommandName}\" on resource \"{ResourceName}\": {StatusCode}", command.Name, resourceName, ex.StatusCode);
 
             var errorMessage = ex.StatusCode == StatusCode.Unimplemented ? "Command not implemented" : "Unknown error. See logs for details";
 

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -101,7 +101,7 @@ partial class Resource
         ImmutableArray<CommandViewModel> GetCommands()
         {
             return Commands
-                .Select(c => new CommandViewModel(c.CommandType, MapState(c.State), c.DisplayName, c.DisplayDescription, c.ConfirmationMessage, c.Parameter, c.IsHighlighted, c.IconName, MapIconVariant(c.IconVariant)))
+                .Select(c => new CommandViewModel(c.Name, MapState(c.State), c.DisplayName, c.DisplayDescription, c.ConfirmationMessage, c.Parameter, c.IsHighlighted, c.IconName, MapIconVariant(c.IconVariant)))
                 .ToImmutableArray();
             static CommandViewModelState MapState(ResourceCommandState state)
             {

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -8,9 +8,9 @@ namespace Aspire.Hosting.ApplicationModel;
 
 internal static class CommandsConfigurationExtensions
 {
-    internal const string StartType = "resource-start";
-    internal const string StopType = "resource-stop";
-    internal const string RestartType = "resource-restart";
+    internal const string StartCommandName = "resource-start";
+    internal const string StopCommandName = "resource-stop";
+    internal const string RestartCommandName = "resource-restart";
 
     internal static void AddLifeCycleCommands(this IResource resource)
     {
@@ -20,7 +20,7 @@ internal static class CommandsConfigurationExtensions
         }
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
-            type: StartType,
+            name: StartCommandName,
             displayName: "Start",
             executeCommand: async context =>
             {
@@ -52,7 +52,7 @@ internal static class CommandsConfigurationExtensions
             isHighlighted: true));
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
-            type: StopType,
+            name: StopCommandName,
             displayName: "Stop",
             executeCommand: async context =>
             {
@@ -84,7 +84,7 @@ internal static class CommandsConfigurationExtensions
             isHighlighted: true));
 
         resource.Annotations.Add(new ResourceCommandAnnotation(
-            type: RestartType,
+            name: RestartCommandName,
             displayName: "Restart",
             executeCommand: async context =>
             {

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -154,7 +154,7 @@ public sealed record ResourcePropertySnapshot(string Name, object? Value)
 /// <summary>
 /// A snapshot of a resource command.
 /// </summary>
-/// <param name="Type">The type of command. The type uniquely identifies the command.</param>
+/// <param name="Name">The name of command. The name uniquely identifies the command.</param>
 /// <param name="State">The state of the command.</param>
 /// <param name="DisplayName">The display name visible in UI for the command.</param>
 /// <param name="DisplayDescription">
@@ -172,7 +172,7 @@ public sealed record ResourcePropertySnapshot(string Name, object? Value)
 /// <param name="IconName">The icon name for the command. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons</param>
 /// <param name="IconVariant">The icon variant.</param>
 /// <param name="IsHighlighted">A flag indicating whether the command is highlighted in the UI.</param>
-public sealed record ResourceCommandSnapshot(string Type, ResourceCommandState State, string DisplayName, string? DisplayDescription, object? Parameter, string? ConfirmationMessage, string? IconName, IconVariant? IconVariant, bool IsHighlighted);
+public sealed record ResourceCommandSnapshot(string Name, ResourceCommandState State, string DisplayName, string? DisplayDescription, object? Parameter, string? ConfirmationMessage, string? IconName, IconVariant? IconVariant, bool IsHighlighted);
 
 /// <summary>
 /// A report produced by a health check about a resource.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -15,7 +15,7 @@ public sealed class ResourceCommandAnnotation : IResourceAnnotation
     /// Initializes a new instance of the <see cref="ResourceCommandAnnotation"/> class.
     /// </summary>
     public ResourceCommandAnnotation(
-        string type,
+        string name,
         string displayName,
         Func<UpdateCommandStateContext, ResourceCommandState> updateState,
         Func<ExecuteCommandContext, Task<ExecuteCommandResult>> executeCommand,
@@ -26,12 +26,12 @@ public sealed class ResourceCommandAnnotation : IResourceAnnotation
         IconVariant? iconVariant,
         bool isHighlighted)
     {
-        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(name);
         ArgumentNullException.ThrowIfNull(displayName);
         ArgumentNullException.ThrowIfNull(updateState);
         ArgumentNullException.ThrowIfNull(executeCommand);
 
-        Type = type;
+        Name = name;
         DisplayName = displayName;
         UpdateState = updateState;
         ExecuteCommand = executeCommand;
@@ -44,9 +44,9 @@ public sealed class ResourceCommandAnnotation : IResourceAnnotation
     }
 
     /// <summary>
-    /// The type of command. The type uniquely identifies the command.
+    /// The name of command. The name uniquely identifies the command.
     /// </summary>
-    public string Type { get; }
+    public string Name { get; }
 
     /// <summary>
     /// The display name visible in UI.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -413,7 +413,7 @@ public class ResourceNotificationService
 
         foreach (var annotation in resource.Annotations.OfType<ResourceCommandAnnotation>())
         {
-            var existingCommand = FindByType(previousState.Commands, annotation.Type);
+            var existingCommand = FindByName(previousState.Commands, annotation.Name);
 
             if (existingCommand == null)
             {
@@ -457,11 +457,11 @@ public class ResourceNotificationService
 
         return previousState with { Commands = builder.ToImmutable() };
 
-        static ResourceCommandSnapshot? FindByType(ImmutableArray<ResourceCommandSnapshot> commands, string type)
+        static ResourceCommandSnapshot? FindByName(ImmutableArray<ResourceCommandSnapshot> commands, string name)
         {
             for (var i = 0; i < commands.Length; i++)
             {
-                if (commands[i].Type == type)
+                if (commands[i].Name == name)
                 {
                     return commands[i];
                 }
@@ -474,7 +474,7 @@ public class ResourceNotificationService
         {
             var state = annotation.UpdateState(new UpdateCommandStateContext { ResourceSnapshot = previousState, ServiceProvider = serviceProvider });
 
-            return new ResourceCommandSnapshot(annotation.Type, state, annotation.DisplayName, annotation.DisplayDescription, annotation.Parameter, annotation.ConfirmationMessage, annotation.IconName, annotation.IconVariant, annotation.IsHighlighted);
+            return new ResourceCommandSnapshot(annotation.Name, state, annotation.DisplayName, annotation.DisplayDescription, annotation.Parameter, annotation.ConfirmationMessage, annotation.IconName, annotation.IconVariant, annotation.IsHighlighted);
         }
     }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardService.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardService.cs
@@ -160,7 +160,7 @@ internal sealed partial class DashboardService(DashboardServiceData serviceData,
 
     public override async Task<ResourceCommandResponse> ExecuteResourceCommand(ResourceCommandRequest request, ServerCallContext context)
     {
-        var (result, errorMessage) = await serviceData.ExecuteCommandAsync(request.ResourceName, request.CommandType, context.CancellationToken).ConfigureAwait(false);
+        var (result, errorMessage) = await serviceData.ExecuteCommandAsync(request.ResourceName, request.CommandName, context.CancellationToken).ConfigureAwait(false);
         var responseKind = result switch
         {
             DashboardServiceData.ExecuteCommandResult.Success => ResourceCommandResponseKind.Succeeded,

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -116,7 +116,7 @@ internal sealed class DashboardServiceData : IAsyncDisposable
         logger.LogInformation("Executing command '{Type}'.", type);
         if (_resourcePublisher.TryGetResource(resourceId, out _, out var resource))
         {
-            var annotation = resource.Annotations.OfType<ResourceCommandAnnotation>().SingleOrDefault(a => a.Type == type);
+            var annotation = resource.Annotations.OfType<ResourceCommandAnnotation>().SingleOrDefault(a => a.Name == type);
             if (annotation != null)
             {
                 try

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -63,7 +63,7 @@ partial class Resource
 
         foreach (var command in snapshot.Commands)
         {
-            resource.Commands.Add(new ResourceCommand { CommandType = command.Type, DisplayName = command.DisplayName, DisplayDescription = command.DisplayDescription ?? string.Empty, Parameter = ResourceSnapshot.ConvertToValue(command.Parameter), ConfirmationMessage = command.ConfirmationMessage ?? string.Empty, IconName = command.IconName ?? string.Empty, IconVariant = MapIconVariant(command.IconVariant), IsHighlighted = command.IsHighlighted, State = MapCommandState(command.State) });
+            resource.Commands.Add(new ResourceCommand { Name = command.Name, DisplayName = command.DisplayName, DisplayDescription = command.DisplayDescription ?? string.Empty, Parameter = ResourceSnapshot.ConvertToValue(command.Parameter), ConfirmationMessage = command.ConfirmationMessage ?? string.Empty, IconName = command.IconName ?? string.Empty, IconVariant = MapIconVariant(command.IconVariant), IsHighlighted = command.IsHighlighted, State = MapCommandState(command.State) });
         }
 
         if (snapshot.HealthStatus is not null)

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -27,7 +27,7 @@ message ApplicationInformationResponse {
 // using data from this message.
 message ResourceCommand {
     // Unique identifier for the command. Not intended for display.
-    string command_type = 1;
+    string name = 1;
     // The display name of the command, to be shown in the UI. May be localized.
     string display_name = 2;
     // When present, this message must be shown to the user and their confirmation obtained
@@ -64,7 +64,7 @@ enum IconVariant {
 message ResourceCommandRequest {
     // Unique identifier for the command.
     // Copied from the ResourceCommand that this request object is initialized from.
-    string command_type = 1;
+    string command_name = 1;
     // The name of the resource to apply the command to. Matches Resource.name.
     // Copied from the ResourceCommand that this request object is initialized from.
     string resource_name = 2;

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -81,15 +81,18 @@ Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.Key.get -> string!
 Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ConfirmationMessage.get -> string?
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.DisplayDescription.get -> string?
+Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.Name.get -> string!
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.Parameter.get -> object?
-Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ResourceCommandAnnotation(string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>! updateState, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, string? displayDescription, object? parameter, string? confirmationMessage, string? iconName, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant, bool isHighlighted) -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ResourceCommandAnnotation(string! name, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>! updateState, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, string? displayDescription, object? parameter, string? confirmationMessage, string? iconName, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant, bool isHighlighted) -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ConfirmationMessage.get -> string?
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ConfirmationMessage.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.DisplayDescription.get -> string?
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.DisplayDescription.init -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Name.get -> string!
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Name.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Parameter.get -> object?
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Parameter.init -> void
-Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ResourceCommandSnapshot(string! Type, Aspire.Hosting.ApplicationModel.ResourceCommandState State, string! DisplayName, string? DisplayDescription, object? Parameter, string? ConfirmationMessage, string? IconName, Aspire.Hosting.ApplicationModel.IconVariant? IconVariant, bool IsHighlighted) -> void
+Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.ResourceCommandSnapshot(string! Name, Aspire.Hosting.ApplicationModel.ResourceCommandState State, string! DisplayName, string? DisplayDescription, object? Parameter, string? ConfirmationMessage, string? IconName, Aspire.Hosting.ApplicationModel.IconVariant? IconVariant, bool IsHighlighted) -> void
 Aspire.Hosting.ApplicationModel.ResourceNameAttribute
 Aspire.Hosting.ApplicationModel.ResourceNameAttribute.ResourceNameAttribute() -> void
 Aspire.Hosting.ApplicationModel.IconVariant
@@ -101,7 +104,6 @@ Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ExecuteCommand.get -> 
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.IconName.get -> string?
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.IconVariant.get -> Aspire.Hosting.ApplicationModel.IconVariant?
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.IsHighlighted.get -> bool
-Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.Type.get -> string!
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.UpdateState.get -> System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>!
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.DisplayName.get -> string!
@@ -114,8 +116,6 @@ Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IsHighlighted.get -> boo
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.IsHighlighted.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.State.get -> Aspire.Hosting.ApplicationModel.ResourceCommandState
 Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.State.init -> void
-Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Type.get -> string!
-Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot.Type.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandState
 Aspire.Hosting.ApplicationModel.ResourceCommandState.Disabled = 1 -> Aspire.Hosting.ApplicationModel.ResourceCommandState
 Aspire.Hosting.ApplicationModel.ResourceCommandState.Enabled = 0 -> Aspire.Hosting.ApplicationModel.ResourceCommandState
@@ -227,7 +227,7 @@ Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.get
 Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.set -> void
 static Aspire.Hosting.ResourceBuilderExtensions.WaitFor<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WaitForCompletion<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency, int exitCode = 0) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
-static Aspire.Hosting.ResourceBuilderExtensions.WithCommand<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! type, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>? updateState = null, string? displayDescription = null, object? parameter = null, string? confirmationMessage = null, string? iconName = null, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant = null, bool isHighlighted = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithCommand<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! name, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>? updateState = null, string? displayDescription = null, object? parameter = null, string? confirmationMessage = null, string? iconName = null, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant = null, bool isHighlighted = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! key) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHttpHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string? path = null, int? statusCode = null, string? endpointName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHttpsHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string? path = null, int? statusCode = null, string? endpointName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -843,7 +843,7 @@ public static class ResourceBuilderExtensions
     /// </summary>
     /// <typeparam name="T">The type of the resource.</typeparam>
     /// <param name="builder">The resource builder.</param>
-    /// <param name="type">The type of command. The type uniquely identifies the command.</param>
+    /// <param name="name">The name of command. The name uniquely identifies the command.</param>
     /// <param name="displayName">The display name visible in UI.</param>
     /// <param name="executeCommand">
     /// A callback that is executed when the command is executed. The callback is run inside the .NET Aspire host.
@@ -876,7 +876,7 @@ public static class ResourceBuilderExtensions
     /// </remarks>
     public static IResourceBuilder<T> WithCommand<T>(
         this IResourceBuilder<T> builder,
-        string type,
+        string name,
         string displayName,
         Func<ExecuteCommandContext, Task<ExecuteCommandResult>> executeCommand,
         Func<UpdateCommandStateContext, ResourceCommandState>? updateState = null,
@@ -888,12 +888,12 @@ public static class ResourceBuilderExtensions
         bool isHighlighted = false) where T : IResource
     {
         // Replace existing annotation with the same name.
-        var existingAnnotation = builder.Resource.Annotations.OfType<ResourceCommandAnnotation>().SingleOrDefault(a => a.Type == type);
+        var existingAnnotation = builder.Resource.Annotations.OfType<ResourceCommandAnnotation>().SingleOrDefault(a => a.Name == name);
         if (existingAnnotation != null)
         {
             builder.Resource.Annotations.Remove(existingAnnotation);
         }
 
-        return builder.WithAnnotation(new ResourceCommandAnnotation(type, displayName, updateState ?? (c => ResourceCommandState.Enabled), executeCommand, displayDescription, parameter, confirmationMessage, iconName, iconVariant, isHighlighted));
+        return builder.WithAnnotation(new ResourceCommandAnnotation(name, displayName, updateState ?? (c => ResourceCommandState.Enabled), executeCommand, displayDescription, parameter, confirmationMessage, iconName, iconVariant, isHighlighted));
     }
 }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -118,7 +118,7 @@ public class DashboardServiceTests
         var resourceData = Assert.Single(update.InitialData.Resources);
         var commandData = Assert.Single(resourceData.Commands);
 
-        Assert.Equal("TestType", commandData.Name);
+        Assert.Equal("TestName", commandData.Name);
         Assert.Equal("Display name!", commandData.DisplayName);
         Assert.Equal("Display description!", commandData.DisplayDescription);
         Assert.Equal(Value.ForList(Value.ForString("One"), Value.ForString("Two")), commandData.Parameter);

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -82,7 +82,7 @@ public class DashboardServiceTests
         using var applicationBuilder = TestDistributedApplicationBuilder.Create();
         var builder = applicationBuilder.AddResource(testResource);
         builder.WithCommand(
-            type: "TestType",
+            name: "TestName",
             displayName: "Display name!",
             executeCommand: c => Task.FromResult(CommandResults.Success()),
             updateState: c => ApplicationModel.ResourceCommandState.Enabled,
@@ -118,7 +118,7 @@ public class DashboardServiceTests
         var resourceData = Assert.Single(update.InitialData.Resources);
         var commandData = Assert.Single(resourceData.Commands);
 
-        Assert.Equal("TestType", commandData.CommandType);
+        Assert.Equal("TestType", commandData.Name);
         Assert.Equal("Display name!", commandData.DisplayName);
         Assert.Equal("Display description!", commandData.DisplayDescription);
         Assert.Equal(Value.ForList(Value.ForString("One"), Value.ForString("Two")), commandData.Parameter);

--- a/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
@@ -992,9 +992,9 @@ public class ApplicationExecutorTests
     {
         var commandAnnotations = resource.Annotations.OfType<ResourceCommandAnnotation>().ToList();
         Assert.Collection(commandAnnotations,
-            a => Assert.Equal(CommandsConfigurationExtensions.StartType, a.Type),
-            a => Assert.Equal(CommandsConfigurationExtensions.StopType, a.Type),
-            a => Assert.Equal(CommandsConfigurationExtensions.RestartType, a.Type));
+            a => Assert.Equal(CommandsConfigurationExtensions.StartCommandName, a.Name),
+            a => Assert.Equal(CommandsConfigurationExtensions.StopCommandName, a.Name),
+            a => Assert.Equal(CommandsConfigurationExtensions.RestartCommandName, a.Name));
     }
 
     private static ApplicationExecutor CreateAppExecutor(

--- a/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
+++ b/tests/Aspire.Hosting.Tests/ResourceCommandAnnotationTests.cs
@@ -9,38 +9,38 @@ namespace Aspire.Hosting.Tests;
 public class ResourceCommandAnnotationTests
 {
     [Theory]
-    [InlineData(CommandsConfigurationExtensions.StartType, "Starting", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.StartType, "Stopping", ResourceCommandState.Hidden)]
-    [InlineData(CommandsConfigurationExtensions.StartType, "Running", ResourceCommandState.Hidden)]
-    [InlineData(CommandsConfigurationExtensions.StartType, "Exited", ResourceCommandState.Enabled)]
-    [InlineData(CommandsConfigurationExtensions.StartType, "Finished", ResourceCommandState.Enabled)]
-    [InlineData(CommandsConfigurationExtensions.StartType, "FailedToStart", ResourceCommandState.Enabled)]
-    [InlineData(CommandsConfigurationExtensions.StartType, "Waiting", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.StartType, "RuntimeUnhealthy", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.StopType, "Starting", ResourceCommandState.Hidden)]
-    [InlineData(CommandsConfigurationExtensions.StopType, "Stopping", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.StopType, "Running", ResourceCommandState.Enabled)]
-    [InlineData(CommandsConfigurationExtensions.StopType, "Exited", ResourceCommandState.Hidden)]
-    [InlineData(CommandsConfigurationExtensions.StopType, "Finished", ResourceCommandState.Hidden)]
-    [InlineData(CommandsConfigurationExtensions.StopType, "FailedToStart", ResourceCommandState.Hidden)]
-    [InlineData(CommandsConfigurationExtensions.StopType, "Waiting", ResourceCommandState.Hidden)]
-    [InlineData(CommandsConfigurationExtensions.StopType, "RuntimeUnhealthy", ResourceCommandState.Hidden)]
-    [InlineData(CommandsConfigurationExtensions.RestartType, "Starting", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.RestartType, "Stopping", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.RestartType, "Running", ResourceCommandState.Enabled)]
-    [InlineData(CommandsConfigurationExtensions.RestartType, "Exited", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.RestartType, "Finished", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.RestartType, "FailedToStart", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.RestartType, "Waiting", ResourceCommandState.Disabled)]
-    [InlineData(CommandsConfigurationExtensions.RestartType, "RuntimeUnhealthy", ResourceCommandState.Disabled)]
-    public void LifeCycleCommands_CommandState(string commandType, string resourceState, ResourceCommandState commandState)
+    [InlineData(CommandsConfigurationExtensions.StartCommandName, "Starting", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.StartCommandName, "Stopping", ResourceCommandState.Hidden)]
+    [InlineData(CommandsConfigurationExtensions.StartCommandName, "Running", ResourceCommandState.Hidden)]
+    [InlineData(CommandsConfigurationExtensions.StartCommandName, "Exited", ResourceCommandState.Enabled)]
+    [InlineData(CommandsConfigurationExtensions.StartCommandName, "Finished", ResourceCommandState.Enabled)]
+    [InlineData(CommandsConfigurationExtensions.StartCommandName, "FailedToStart", ResourceCommandState.Enabled)]
+    [InlineData(CommandsConfigurationExtensions.StartCommandName, "Waiting", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.StartCommandName, "RuntimeUnhealthy", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.StopCommandName, "Starting", ResourceCommandState.Hidden)]
+    [InlineData(CommandsConfigurationExtensions.StopCommandName, "Stopping", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.StopCommandName, "Running", ResourceCommandState.Enabled)]
+    [InlineData(CommandsConfigurationExtensions.StopCommandName, "Exited", ResourceCommandState.Hidden)]
+    [InlineData(CommandsConfigurationExtensions.StopCommandName, "Finished", ResourceCommandState.Hidden)]
+    [InlineData(CommandsConfigurationExtensions.StopCommandName, "FailedToStart", ResourceCommandState.Hidden)]
+    [InlineData(CommandsConfigurationExtensions.StopCommandName, "Waiting", ResourceCommandState.Hidden)]
+    [InlineData(CommandsConfigurationExtensions.StopCommandName, "RuntimeUnhealthy", ResourceCommandState.Hidden)]
+    [InlineData(CommandsConfigurationExtensions.RestartCommandName, "Starting", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.RestartCommandName, "Stopping", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.RestartCommandName, "Running", ResourceCommandState.Enabled)]
+    [InlineData(CommandsConfigurationExtensions.RestartCommandName, "Exited", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.RestartCommandName, "Finished", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.RestartCommandName, "FailedToStart", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.RestartCommandName, "Waiting", ResourceCommandState.Disabled)]
+    [InlineData(CommandsConfigurationExtensions.RestartCommandName, "RuntimeUnhealthy", ResourceCommandState.Disabled)]
+    public void LifeCycleCommands_CommandState(string commandName, string resourceState, ResourceCommandState commandState)
     {
         // Arrange
         var builder = DistributedApplication.CreateBuilder();
         var resourceBuilder = builder.AddContainer("name", "image");
         resourceBuilder.Resource.AddLifeCycleCommands();
 
-        var startCommand = resourceBuilder.Resource.Annotations.OfType<ResourceCommandAnnotation>().Single(a => a.Type == commandType);
+        var startCommand = resourceBuilder.Resource.Annotations.OfType<ResourceCommandAnnotation>().Single(a => a.Name == commandName);
 
         // Act
         var state = startCommand.UpdateState(new UpdateCommandStateContext


### PR DESCRIPTION
## Description

Feedback from https://github.com/dotnet/aspire/pull/6295#discussion_r1803777740.

Note that this is a source breaking change for people who have implemented the proto when they update the proto the identifer will change name. It's not a wire breaking change because the field id (`1` in this case) is the same.

@joperezr Where should the `commandType` -> `name` breaking change be communicated? The model API is new in 9.0 so I believe can change at this point without breaking change notification.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: 
  - [ ] No
