### PR TITLE
Improve vertical alignment of state text when showing error count

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -1,5 +1,5 @@
 ::deep .unread-logs-errors-link {
-    vertical-align: middle;
+    vertical-align: super;
     --unread-logs-badge-color: #ffffff;
 }
 


### PR DESCRIPTION
## Description

Stops the state cell text from floating up when an error count is shown alongside.

### Before

![image](https://github.com/user-attachments/assets/735314e4-b74a-4a37-8bc8-01d5b4408cf2)

### After

![image](https://github.com/user-attachments/assets/8024fb0e-8422-44fd-9eb3-331d0e65cb47)

Not perfect, but better.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6358)