### PR TITLE
Don't force set health status if there is an initial snapshot

### DIFF
--- a/playground/HealthChecks/HealthChecksSandbox.AppHost/Program.cs
+++ b/playground/HealthChecks/HealthChecksSandbox.AppHost/Program.cs
@@ -45,6 +45,8 @@ IResourceBuilder<TestResource> AddTestResource(string name, HealthStatus status,
             ResourceType = "Test Resource",
             State = "Starting",
             Properties = [],
+            // this is not computed unless there is a health check, so we need to set it manually
+            HealthStatus = status,
             HealthReports = [new HealthReportSnapshot($"{name}_check", status, description, exception)]
         })
         .ExcludeFromManifest();

--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -69,7 +69,7 @@ public partial class ResourceDetails
             _isEndpointsExpanded = GetEndpoints().Any();
             _isEnvironmentVariablesExpanded = _resource.Environment.Any();
             _isVolumesExpanded = _resource.Volumes.Any();
-            _isHealthChecksExpanded = _resource.HealthReports.Any() || _resource.HealthStatus is null; // null means we're waiting for health reports
+            _isHealthChecksExpanded = _resource.HealthReports.Any() || _resource.EffectiveHealthStatus is null; // null means we're waiting for health reports
 
             foreach (var item in SensitiveGridItems)
             {

--- a/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
@@ -62,13 +62,13 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
             icon = new Icons.Filled.Size16.Circle();
             color = Color.Info;
         }
-        else if (resource.HealthStatus is null)
+        else if (resource.EffectiveHealthStatus is null)
         {
             // If we are waiting for a health check, show a progress bar and consider the resource unhealthy
             icon = new Icons.Filled.Size16.CheckmarkCircleWarning();
             color = Color.Warning;
         }
-        else if (resource.HealthStatus is not HealthStatus.Healthy)
+        else if (resource.EffectiveHealthStatus is not HealthStatus.Healthy)
         {
             icon = new Icons.Filled.Size16.CheckmarkCircleWarning();
             color = Color.Warning;
@@ -116,7 +116,7 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
                 return loc.GetString(nameof(Columns.StateColumnResourceExited), resource.ResourceType);
             }
         }
-        else if (resource is { KnownState: KnownResourceState.Running, HealthStatus: not HealthStatus.Healthy })
+        else if (resource is { KnownState: KnownResourceState.Running, EffectiveHealthStatus: not HealthStatus.Healthy })
         {
             // Resource is running but not healthy (initializing).
             return loc[nameof(Columns.RunningAndUnhealthyResourceStateToolTip)];
@@ -136,7 +136,7 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
         return resource switch
         {
             { State: null or "" } => loc[Columns.UnknownStateLabel],
-            { KnownState: KnownResourceState.Running, HealthStatus: not HealthStatus.Healthy } => $"{resource.State.Humanize()} ({(resource.HealthStatus ?? HealthStatus.Unhealthy).Humanize()})",
+            { KnownState: KnownResourceState.Running, EffectiveHealthStatus: not HealthStatus.Healthy } => $"{resource.State.Humanize()} ({(resource.EffectiveHealthStatus ?? HealthStatus.Unhealthy).Humanize()})",
             _ => resource.State.Humanize()
         };
     }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -395,20 +395,22 @@ public class ResourceNotificationService
     /// </summary>
     private static CustomResourceSnapshot UpdateHealthStatus(IResource resource, CustomResourceSnapshot previousState)
     {
-        var hasHealthChecks = resource.TryGetAnnotationsIncludingAncestorsOfType<HealthCheckAnnotation>(out _);
-        var hasInitialSnapshot = resource.TryGetLastAnnotation<ResourceSnapshotAnnotation>(out _);
-
         // A resource is also healthy if it
         // - has a null health status (wasn't set by a health check nor initial snapshot)
         // - has no health check annotations
         // - is in the running state
         // - was not started with an initial snapshot
-        if (previousState.HealthStatus is null
-            && !hasHealthChecks
-            && previousState.State?.Text == KnownResourceStates.Running
-            && !hasInitialSnapshot)
+        if (previousState.HealthStatus is null)
         {
-            return previousState with { HealthStatus = HealthStatus.Healthy };
+            var hasHealthChecks = resource.TryGetAnnotationsIncludingAncestorsOfType<HealthCheckAnnotation>(out _);
+            var hasInitialSnapshot = resource.TryGetLastAnnotation<ResourceSnapshotAnnotation>(out _);
+
+            if (!hasHealthChecks
+                && previousState.State?.Text == KnownResourceStates.Running
+                && !hasInitialSnapshot)
+            {
+                return previousState with { HealthStatus = HealthStatus.Healthy };
+            }
         }
 
         return previousState;

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -399,10 +399,11 @@ public class ResourceNotificationService
         var hasInitialSnapshot = resource.TryGetLastAnnotation<ResourceSnapshotAnnotation>(out _);
 
         // A resource is also healthy if it
+        // - has a null health status (wasn't set by a health check nor initial snapshot)
         // - has no health check annotations
         // - is in the running state
         // - was not started with an initial snapshot
-        if (previousState.HealthStatus is not HealthStatus.Healthy
+        if (previousState.HealthStatus is null
             && !hasHealthChecks
             && previousState.State?.Text == KnownResourceStates.Running
             && !hasInitialSnapshot)

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardServiceTests.cs
@@ -87,20 +87,14 @@ public class DashboardServiceTests
             executeCommand: c => Task.FromResult(CommandResults.Success()),
             updateState: c => ApplicationModel.ResourceCommandState.Enabled,
             displayDescription: "Display description!",
-            parameter: new [] {"One", "Two"},
+            parameter: new[] { "One", "Two" },
             confirmationMessage: "Confirmation message!",
             iconName: "Icon name!",
             iconVariant: ApplicationModel.IconVariant.Filled,
             isHighlighted: true);
 
-        await resourceNotificationService.PublishUpdateAsync(testResource, s =>
-        {
-            return s with { State = new ResourceStateSnapshot("Starting", null) };
-        });
-        await resourceNotificationService.WaitForResourceAsync(testResource.Name, r =>
-        {
-            return r.Snapshot.Commands.Length == 1;
-        });
+        await resourceNotificationService.PublishUpdateAsync(testResource, s => { return s with { State = new ResourceStateSnapshot("Starting", null) }; });
+        await resourceNotificationService.WaitForResourceAsync(testResource.Name, r => { return r.Snapshot.Commands.Length == 1; });
 
         var cts = new CancellationTokenSource();
         var context = TestServerCallContext.Create(cancellationToken: cts.Token);
@@ -126,6 +120,46 @@ public class DashboardServiceTests
         Assert.Equal("Icon name!", commandData.IconName);
         Assert.Equal(ResourceService.Proto.V1.IconVariant.Filled, commandData.IconVariant);
         Assert.True(commandData.IsHighlighted);
+
+        await CancelTokenAndAwaitTask(cts, task);
+    }
+
+    [Fact]
+    public async Task CreateResource_NoChild_WithoutHealthChecks_WithInitialSnapshot_HealthStatusReportedCorrectly()
+    {
+         // Arrange
+        var resourceLoggerService = new ResourceLoggerService();
+        var resourceNotificationService = new ResourceNotificationService(NullLogger<ResourceNotificationService>.Instance, new TestHostApplicationLifetime(), new ServiceCollection().BuildServiceProvider(), resourceLoggerService);
+        await using var dashboardServiceData = new DashboardServiceData(resourceNotificationService, resourceLoggerService, NullLogger<DashboardServiceData>.Instance, new DashboardCommandExecutor(new ServiceCollection().BuildServiceProvider()));
+        var dashboardService = new DashboardService(dashboardServiceData, new TestHostEnvironment(), new TestHostApplicationLifetime(), NullLogger<DashboardService>.Instance);
+
+        var testResource = new TestResource("test-resource");
+        using var builder = TestDistributedApplicationBuilder.Create();
+        builder.AddResource(testResource)
+            .WithInitialState(new CustomResourceSnapshot
+            {
+                ResourceType = string.Empty,
+                Properties = [],
+                HealthStatus = HealthStatus.Degraded,
+            });
+
+        await resourceNotificationService.PublishUpdateAsync(testResource, s => { return s with { State = new ResourceStateSnapshot("Running", null) }; });
+
+        var cts = new CancellationTokenSource();
+        var context = TestServerCallContext.Create(cancellationToken: cts.Token);
+        var writer = new TestServerStreamWriter<WatchResourcesUpdate>(context);
+
+        // Act
+        var task = dashboardService.WatchResources(
+            new WatchResourcesRequest(),
+            writer,
+            context);
+
+        // Assert
+        var initialRead = await writer.ReadNextAsync();
+        var initialSnapshot = Assert.Single(initialRead.InitialData.Resources);
+        Assert.True(initialSnapshot.HasHealthStatus);
+        Assert.Equal(ProtoHealthStatus.Degraded, initialSnapshot.HealthStatus);
 
         await CancelTokenAndAwaitTask(cts, task);
     }


### PR DESCRIPTION
## Description

There was one regression and one red herring from the health check playground project.

Regression: we should not force set the health status to healthy if there is an initial snapshot.

Red herring: if a health check is not run, the health status is not recomputed. Because of this, we should be specifying the health status in the initial snapshot in the playground project resources. 

@JamesNK @drewnoakes 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6367)