### PR TITLE
Update MongoDB.Driver and set upper limit

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -121,7 +121,7 @@
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.10.1" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.10.1" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.29.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="[2.30.0,3.0.0)" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.6" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />


### PR DESCRIPTION
Version 3.0.0 brings breaking changes that are incompatible with the Aspire integration library.

Contributes to #6380
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6381)