### PR TITLE
[release/9.0] Enable signing and mark packages as stable

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,8 +5,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <PreReleaseVersionLabel Condition="'$(SuppressFinalPackageVersion)' != 'true'">rc.2</PreReleaseVersionLabel>
-    <PreReleaseVersionLabel Condition="'$(PreReleaseVersionLabel)' == ''">preview.5</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview.5</PreReleaseVersionLabel>
     <!--
       When running package validation as part of the build, we want to ensure we didn't break the API against the previous
       version of each package. The following property points to the package version that should be used as baseline.
@@ -21,7 +20,7 @@
     <DotNetSdkPreviousVersionForTesting>8.0.403</DotNetSdkPreviousVersionForTesting>
     <UseVSTestRunner>true</UseVSTestRunner>
     <!-- Enable to remove prerelease label. -->
-    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <PropertyGroup>

--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -139,7 +139,7 @@ extends:
 
           - job: Windows
             # timeout accounts for wait times for helix agents up to 30mins
-            timeoutInMinutes: 90
+            timeoutInMinutes: 120
 
             pool:
               name: NetCore1ESPool-Internal
@@ -169,7 +169,7 @@ extends:
           - ${{ if eq(variables._RunAsPublic, True) }}:
             - job: Linux
               # timeout accounts for wait times for helix agents up to 30mins
-              timeoutInMinutes: 90
+              timeoutInMinutes: 120
 
               pool:
                 name: NetCore1ESPool-Internal

--- a/eng/pipelines/common-variables.yml
+++ b/eng/pipelines/common-variables.yml
@@ -28,4 +28,4 @@ variables:
         /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     - name: PostBuildSign
-      value: true
+      value: false

--- a/src/Aspire.Hosting.Azure.Functions/Directory.Build.props
+++ b/src/Aspire.Hosting.Azure.Functions/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-    <PropertyGroup>
-      <!-- This needs to be set to true before importing parent Directory.Build.props -->
-      <!-- Azure Functions support is in preview until the full experience is implemented. -->
-      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    </PropertyGroup>
-  
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  </Project>

--- a/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
+++ b/src/Aspire.Hosting.Azure.WebPubSub/Aspire.Hosting.Azure.WebPubSub.csproj
@@ -8,6 +8,8 @@
     <PackageIconFullPath>$(SharedDir)AzureWebPubSub_256x.png</PackageIconFullPath>
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
+    <!-- This library can't ship stable until Azure.Provisioning.WebPubSub ships stable. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Aspire.Hosting.Azure.WebPubSub/Directory.Build.props
+++ b/src/Aspire.Hosting.Azure.WebPubSub/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- This needs to be set to true before importing parent Directory.Build.props -->
-     <!-- This library can't ship stable until Azure.Provisioning.WebPubSub ships stable. -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-  </PropertyGroup>
-
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-</Project>

--- a/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
+++ b/src/Aspire.Hosting.Elasticsearch/Aspire.Hosting.Elasticsearch.csproj
@@ -6,6 +6,7 @@
     <PackageTags>aspire integration hosting elasticsearch</PackageTags>
     <Description>Elasticsearch support for .NET Aspire.</Description>
     <PackageIconFullPath>$(SharedDir)Elastic_logo.png</PackageIconFullPath>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Aspire.Hosting.Elasticsearch/Directory.Build.props
+++ b/src/Aspire.Hosting.Elasticsearch/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-    <PropertyGroup>
-      <!-- This needs to be set to true before importing parent Directory.Build.props -->
-      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    </PropertyGroup>
-  
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  </Project>

--- a/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
+++ b/src/Aspire.Hosting.Keycloak/Aspire.Hosting.Keycloak.csproj
@@ -5,6 +5,7 @@
     <IsPackable>true</IsPackable>
     <PackageTags>aspire integration hosting keycloak</PackageTags>
     <Description>Keycloak support for .NET Aspire.</Description>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Aspire.Hosting.Keycloak/Directory.Build.props
+++ b/src/Aspire.Hosting.Keycloak/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-    <PropertyGroup>
-      <!-- This needs to be set to true before importing parent Directory.Build.props -->
-      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    </PropertyGroup>
-  
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  </Project>

--- a/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
+++ b/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
@@ -10,6 +10,8 @@
     
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
+    <!-- We need to ingest a stable version of Milvus.Client in order for us to produce stable bits. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
+++ b/src/Aspire.Hosting.Python/Aspire.Hosting.Python.csproj
@@ -6,6 +6,8 @@
     <PackageTags>aspire integration hosting python</PackageTags>
     <Description>Python support for .NET Aspire.</Description>
     <MinCodeCoverage>80</MinCodeCoverage>
+    <!-- In preview until the public API is validated. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Python/Directory.Build.props
+++ b/src/Aspire.Hosting.Python/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-    <PropertyGroup>
-      <!-- This needs to be set to true before importing parent Directory.Build.props -->
-      <!-- In preview until the public API is validated. -->
-      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    </PropertyGroup>
-  
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  </Project>

--- a/src/Components/Aspire.Azure.AI.OpenAI/Aspire.Azure.AI.OpenAI.csproj
+++ b/src/Components/Aspire.Azure.AI.OpenAI/Aspire.Azure.AI.OpenAI.csproj
@@ -9,6 +9,8 @@
     <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
     <!-- Disable package validation as this package hasn't shipped stable yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
+    <!-- In preview until the public API is validated and the Microsoft.Extensions.AI integration is designed.. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Aspire.Azure.AI.OpenAI/Directory.Build.props
+++ b/src/Components/Aspire.Azure.AI.OpenAI/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-    <PropertyGroup>
-      <!-- This needs to be set to true before importing parent Directory.Build.props -->
-      <!-- In preview until the public API is validated and the Microsoft.Extensions.AI integration is designed.. -->
-      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    </PropertyGroup>
-  
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  </Project>

--- a/src/Components/Aspire.Elastic.Clients.Elasticsearch/Aspire.Elastic.Clients.Elasticsearch.csproj
+++ b/src/Components/Aspire.Elastic.Clients.Elasticsearch/Aspire.Elastic.Clients.Elasticsearch.csproj
@@ -8,6 +8,7 @@
     <PackageIconFullPath>$(SharedDir)Elastic_logo.png</PackageIconFullPath>
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Aspire.Elastic.Clients.Elasticsearch/Directory.Build.props
+++ b/src/Components/Aspire.Elastic.Clients.Elasticsearch/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-    <PropertyGroup>
-      <!-- This needs to be set to true before importing parent Directory.Build.props -->
-      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    </PropertyGroup>
-  
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  </Project>

--- a/src/Components/Aspire.Keycloak.Authentication/Aspire.Keycloak.Authentication.csproj
+++ b/src/Components/Aspire.Keycloak.Authentication/Aspire.Keycloak.Authentication.csproj
@@ -7,6 +7,7 @@
     <Description>Configures Keycloak as the authentication provider for ASP.NET Core applications.</Description>
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Aspire.Keycloak.Authentication/Directory.Build.props
+++ b/src/Components/Aspire.Keycloak.Authentication/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-    <PropertyGroup>
-      <!-- This needs to be set to true before importing parent Directory.Build.props -->
-      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    </PropertyGroup>
-  
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  </Project>

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/Aspire.Microsoft.EntityFrameworkCore.Cosmos.csproj
@@ -7,6 +7,8 @@
     <Description>A Microsoft Azure Cosmos DB provider for Entity Framework Core that integrates with Aspire, including connection pooling, logging, and telemetry.</Description>
     <PackageIconFullPath>$(SharedDir)AzureCosmosDB_256x.png</PackageIconFullPath>
     <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
+    <!-- We need to ingest the stable version of EF in order for us to produce stable  bits. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/Aspire.Microsoft.EntityFrameworkCore.SqlServer.csproj
@@ -7,6 +7,8 @@
     <Description>A Microsoft SQL Server provider for Entity Framework Core that integrates with Aspire, including connection pooling, health check, logging, and telemetry.</Description>
     <PackageIconFullPath>$(SharedDir)SQL_256x.png</PackageIconFullPath>
     <IsAotCompatible>false</IsAotCompatible>
+    <!-- We need to ingest the stable version of EF in order for us to produce stable  bits. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Aspire.Milvus.Client/Aspire.Milvus.Client.csproj
+++ b/src/Components/Aspire.Milvus.Client/Aspire.Milvus.Client.csproj
@@ -9,6 +9,7 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn> <!-- Milvus.Client packages are not signed -->
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Aspire.Milvus.Client/Directory.Build.props
+++ b/src/Components/Aspire.Milvus.Client/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-    <PropertyGroup>
-      <!-- This needs to be set to true before importing parent Directory.Build.props -->
-      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    </PropertyGroup>
-  
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  </Project>

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
@@ -6,6 +6,8 @@
     <PackageTags>$(ComponentEfCorePackageTags) postgressql postgres npgsql sql</PackageTags>
     <Description>A PostgreSQL® provider for Entity Framework Core that integrates with Aspire, including connection pooling, health checks, logging, and telemetry.</Description>
     <PackageIconFullPath>$(SharedDir)PostgreSQL_logo.3colors.540x557.png</PackageIconFullPath>
+    <!-- We need to ingest the stable version of EF and npgsql in order for us to produce stable  bits. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Aspire.OpenAI/Aspire.OpenAI.csproj
+++ b/src/Components/Aspire.OpenAI/Aspire.OpenAI.csproj
@@ -8,6 +8,8 @@
     <NoWarn>$(NoWarn);SYSLIB1100;SYSLIB1101</NoWarn>
     <!-- Disable package validation as this package hasn't shipped stable yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
+    <!-- In preview until the public API is validated and the Microsoft.Extensions.AI integration is designed. -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Components/Aspire.OpenAI/Directory.Build.props
+++ b/src/Components/Aspire.OpenAI/Directory.Build.props
@@ -1,9 +1,0 @@
-<Project>
-    <PropertyGroup>
-      <!-- This needs to be set to true before importing parent Directory.Build.props -->
-      <!-- In preview until the public API is validated and the Microsoft.Extensions.AI integration is designed. -->
-      <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
-    </PropertyGroup>
-  
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  </Project>

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -27,12 +27,6 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="ValidatePreReleaseLabelIsCorrectForPreviewPackages"
-          AfterTargets="Pack"
-          Condition="'$(OfficialBuildId)' != '' and '$(SuppressFinalPackageVersion)' == 'true' and !$(PreReleaseVersionLabel.StartsWith('preview'))">
-    <Error Text="The PreReleaseLabel for package '$(MSBuildProjectName)' must start with 'preview' as it has the SuppressFinalPackageVersion flag set. Current label is '$(PreReleaseVersionLabel)'" />
-  </Target>
-
   <!--
   Logic for generating and comparing the ConfigurationSchema.json file
   -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,8 @@
     <SkipArcadeNoWarnCS1591>true</SkipArcadeNoWarnCS1591>
     <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>
     <PackageValidationBaselineVersion Condition="'$(EnablePackageValidation)' == 'true' and '$(PackageValidationBaselineVersion)' == ''">$(BaselineVersionForPackageValidation)</PackageValidationBaselineVersion>
+    <!-- For Aspire.Hosting.Azure* packages, we need to ingest the new Azure.Provisioning stable packages in order for us to produce stable  bits. -->
+    <SuppressFinalPackageVersion Condition="$(MSBuildProjectName.StartsWith('Aspire.Hosting.Azure'))">true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />

--- a/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
+++ b/tests/Shared/RepoTesting/Aspire.RepoTesting.targets
@@ -33,7 +33,7 @@
     `AspireProjectOrPackageReference` - maps to projects in `src/` or `src/Components/`
   -->
 
-  <Import Project="Sdk.props" Sdk="Aspire.AppHost.Sdk" Version="$(PackageVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
+  <Import Project="Sdk.props" Sdk="Aspire.AppHost.Sdk" Version="9.0.0" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
 
   <PropertyGroup>
     <!-- copy by default only when archiving tests, and for test projects that support running out of repo -->
@@ -150,6 +150,6 @@
     <AspireHostingSDKVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</AspireHostingSDKVersion>
   </PropertyGroup>
 
-  <Import Project="Sdk.targets" Sdk="Aspire.AppHost.Sdk" Version="$(PackageVersion)" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
+  <Import Project="Sdk.targets" Sdk="Aspire.AppHost.Sdk" Version="9.0.0" Condition="'$(IsAspireHost)' == 'true' and '$(RepoRoot)' == '' and '$(TestsRunningOutsideOfRepo)' == 'true'" />
 
 </Project>

--- a/tests/Shared/RepoTesting/Directory.Packages.Helix.props
+++ b/tests/Shared/RepoTesting/Directory.Packages.Helix.props
@@ -3,20 +3,20 @@
 
   <ItemGroup Label="Aspire packages">
     <PackageVersion Include="Aspire.Azure.AI.OpenAI" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Data.Tables" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Messaging.EventHubs" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Messaging.ServiceBus" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Messaging.WebPubSub" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Search.Documents" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Security.KeyVault" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Confluent.Kafka" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Azure.Data.Tables" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Azure.Messaging.EventHubs" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Azure.Messaging.ServiceBus" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Azure.Messaging.WebPubSub" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Azure.Search.Documents" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Azure.Security.KeyVault" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Azure.Storage.Blobs" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Azure.Storage.Queues" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Confluent.Kafka" Version="9.0.0" />
     <PackageVersion Include="Aspire.Elastic.Clients.Elasticsearch" Version="$(PackageVersion)" />
 
-    <PackageVersion Include="Aspire.Hosting" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.AWS" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.AWS" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.0.0" />
     <PackageVersion Include="Aspire.Hosting.Azure" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.AppConfiguration" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.ApplicationInsights" Version="$(PackageVersion)" />
@@ -34,53 +34,53 @@
     <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Azure.WebPubSub" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Dapr" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Dapr" Version="9.0.0" />
     <PackageVersion Include="Aspire.Hosting.Elasticsearch" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Garnet" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Kafka" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Garnet" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Kafka" Version="9.0.0" />
     <PackageVersion Include="Aspire.Hosting.Keycloak" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Hosting.Milvus" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.MySql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Nats" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Oracle" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Orleans" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.MongoDB" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.MySql" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Nats" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.NodeJs" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Oracle" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Orleans" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="9.0.0" />
     <PackageVersion Include="Aspire.Hosting.Python" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Qdrant" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.AppHost.Sdk" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Seq" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Hosting.Valkey" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Hosting.Qdrant" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.RabbitMQ" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="9.0.0" />
+    <PackageVersion Include="Aspire.AppHost.Sdk" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Seq" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Hosting.Valkey" Version="9.0.0" />
 
     <PackageVersion Include="Aspire.Keycloak.Authentication" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Microsoft.Data.SqlClient" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Microsoft.Azure.Cosmos" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Microsoft.Data.SqlClient" Version="9.0.0" />
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.Cosmos" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Milvus.Client" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.MongoDB.Driver" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.MySqlConnector" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.NATS.Net" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Npgsql" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.MongoDB.Driver" Version="9.0.0" />
+    <PackageVersion Include="Aspire.MySqlConnector" Version="9.0.0" />
+    <PackageVersion Include="Aspire.NATS.Net" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Npgsql" Version="9.0.0" />
     <PackageVersion Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Oracle.EntityFrameworkCore" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Pomelo.EntityFrameworkCore.MySql" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Qdrant.Client" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.RabbitMQ.Client" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.Seq" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="$(PackageVersion)" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.Oracle.EntityFrameworkCore" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Qdrant.Client" Version="9.0.0" />
+    <PackageVersion Include="Aspire.RabbitMQ.Client" Version="9.0.0" />
+    <PackageVersion Include="Aspire.Seq" Version="9.0.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="9.0.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.DistributedCaching" Version="9.0.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="9.0.0" />
 
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(PackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" Version="$(PackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="$(PackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="$(PackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="For tests">


### PR DESCRIPTION
These changes will enable signing in our builds, as well as marking the packages as stable. Some packages will not be able to be marked stable yet as we need to flow some dependencies yet, so those will be marked as unstable for now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6388)