### PR TITLE
Fix integer increment race condition

### DIFF
--- a/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
+++ b/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
@@ -87,14 +87,14 @@ public class DistributedApplicationBuilderEventingTests
         builder.Eventing.Subscribe<DummyEvent>(async (@event, ct) =>
         {
             await blockSubscriptionExecution.Task;
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             blockAssertionSub1.SetResult();
         });
 
         builder.Eventing.Subscribe<DummyEvent>(async (@event, ct) =>
         {
             await blockSubscriptionExecution.Task;
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             blockAssertionSub2.SetResult();
         });
 

--- a/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
+++ b/tests/Aspire.Hosting.Tests/Eventing/DistributedApplicationBuilderEventingTests.cs
@@ -23,13 +23,13 @@ public class DistributedApplicationBuilderEventingTests
         builder.Eventing.Subscribe<DummyEvent>(async (@event, ct) =>
         {
             blockAssertionTcs.SetResult();
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             await blockFirstSubscriptionTcs.Task;
         });
 
         builder.Eventing.Subscribe<DummyEvent>((@event, ct) =>
         {
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             return Task.CompletedTask;
         });
 
@@ -54,14 +54,14 @@ public class DistributedApplicationBuilderEventingTests
 
         builder.Eventing.Subscribe<DummyEvent>(async (@event, ct) =>
         {
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             blockAssertionSub1.SetResult();
             await blockSubscriptionCompletion.Task;
         });
 
         builder.Eventing.Subscribe<DummyEvent>(async (@event, ct) =>
         {
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             blockAssertionSub2.SetResult();
             await blockSubscriptionCompletion.Task;
         });
@@ -122,14 +122,14 @@ public class DistributedApplicationBuilderEventingTests
         {
             blockAssert1.SetResult();
             await blockEventSub1.Task;
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             blockAssert2.SetResult();
             await blockEventSub2.Task;
         });
 
         builder.Eventing.Subscribe<DummyEvent>((@event, ct) =>
         {
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             blockAssert3.SetResult();
             return Task.CompletedTask;
         });

--- a/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/ResourceHealthCheckServiceTests.cs
@@ -209,7 +209,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var hitCount = 0;
         builder.Services.AddHealthChecks().AddCheck("resource_check", (check) =>
         {
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             throw new InvalidOperationException("Random failure instead of result!");
         });
 
@@ -250,7 +250,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var checkStatus = HealthCheckResult.Unhealthy();
         builder.Services.AddHealthChecks().AddCheck("parent_test", () =>
         {
-            hitCount++;
+            Interlocked.Increment(ref hitCount);
             return checkStatus;
         });
 
@@ -314,7 +314,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var healthCheckHits = 0;
         builder.Services.AddHealthChecks().AddCheck("parent_test", () =>
         {
-            healthCheckHits++;
+            Interlocked.Increment(ref healthCheckHits);
             return HealthCheckResult.Healthy();
         });
 
@@ -327,7 +327,7 @@ public class ResourceHealthCheckServiceTests(ITestOutputHelper testOutputHelper)
         var resourceReadyEventFired = new TaskCompletionSource<ResourceReadyEvent>();
         builder.Eventing.Subscribe<ResourceReadyEvent>(parent.Resource, (@event, ct) =>
         {
-            eventHits++;
+            Interlocked.Increment(ref eventHits);
             return Task.CompletedTask;
         });
 


### PR DESCRIPTION
## Description

Seen in `EventsCanBePublishedNonBlockingConcurrent` test results:

```cs
Assert.Equal() Failure: Values differ
Expected: 2
Actual:   1
```

It looks like events with code `hitCount++` are run conccurent so the test will break if incremented at the same time. Use thread-safe increment.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6389)