### PR TITLE
Update Azure.Provisioning to latest

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <TestcontainersPackageVersion>3.10.0</TestcontainersPackageVersion>
-    <AzureProvisiongVersion>1.0.0-alpha.20241021.5</AzureProvisiongVersion>
+    <AzureProvisiongVersion>1.0.0-alpha.20241024.5</AzureProvisiongVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- AWS SDK for .NET dependencies -->
@@ -39,15 +39,15 @@
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.28.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.6" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20241021.6" />
+    <PackageVersion Include="Azure.Provisioning" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20241021.6" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20241021.6" />
+    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20241024.2" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20241024.2" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.EventHubs" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.KeyVault" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20241021.6" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20241024.2" />
     <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Redis" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Search" Version="$(AzureProvisiongVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <TestcontainersPackageVersion>3.10.0</TestcontainersPackageVersion>
-    <AzureProvisiongVersion>1.0.0-alpha.20241024.5</AzureProvisiongVersion>
+    <AzureProvisiongVersion>1.0.0</AzureProvisiongVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- AWS SDK for .NET dependencies -->
@@ -41,13 +41,13 @@
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.Provisioning" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20241024.2" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20241024.2" />
+    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="$(AzureProvisiongVersion)" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.EventHubs" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.KeyVault" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20241024.2" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Redis" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Search" Version="$(AzureProvisiongVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <TestcontainersPackageVersion>3.10.0</TestcontainersPackageVersion>
-    <AzureProvisiongVersion>1.0.0-beta.1</AzureProvisiongVersion>
+    <AzureProvisiongVersion>1.0.0-alpha.20241018.6</AzureProvisiongVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- AWS SDK for .NET dependencies -->
@@ -41,13 +41,13 @@
     <!-- Azure Management SDK for .NET dependencies -->
     <PackageVersion Include="Azure.Provisioning" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="$(AzureProvisiongVersion)" />
+    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20241018.5" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20241018.5" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.EventHubs" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.KeyVault" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="$(AzureProvisiongVersion)" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20241018.5" />
     <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Redis" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Search" Version="$(AzureProvisiongVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <TestcontainersPackageVersion>3.10.0</TestcontainersPackageVersion>
-    <AzureProvisiongVersion>1.0.0-alpha.20241018.6</AzureProvisiongVersion>
+    <AzureProvisiongVersion>1.0.0-alpha.20241021.2</AzureProvisiongVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- AWS SDK for .NET dependencies -->
@@ -39,15 +39,15 @@
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.28.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.6" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="$(AzureProvisiongVersion)" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20241021.3" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20241018.5" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20241018.5" />
+    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20241021.3" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20241021.3" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.EventHubs" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.KeyVault" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20241018.5" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20241021.3" />
     <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Redis" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Search" Version="$(AzureProvisiongVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <TestcontainersPackageVersion>3.10.0</TestcontainersPackageVersion>
-    <AzureProvisiongVersion>1.0.0-alpha.20241021.2</AzureProvisiongVersion>
+    <AzureProvisiongVersion>1.0.0-alpha.20241021.5</AzureProvisiongVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- AWS SDK for .NET dependencies -->
@@ -39,15 +39,15 @@
     <PackageVersion Include="Microsoft.Azure.SignalR" Version="1.28.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.6" />
     <!-- Azure Management SDK for .NET dependencies -->
-    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20241021.3" />
+    <PackageVersion Include="Azure.Provisioning" Version="1.0.0-alpha.20241021.6" />
     <PackageVersion Include="Azure.Provisioning.AppConfiguration" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20241021.3" />
-    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20241021.3" />
+    <PackageVersion Include="Azure.Provisioning.AppContainers" Version="1.0.0-alpha.20241021.6" />
+    <PackageVersion Include="Azure.Provisioning.ApplicationInsights" Version="1.0.0-alpha.20241021.6" />
     <PackageVersion Include="Azure.Provisioning.CognitiveServices" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.CosmosDB" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.EventHubs" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.KeyVault" Version="$(AzureProvisiongVersion)" />
-    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20241021.3" />
+    <PackageVersion Include="Azure.Provisioning.OperationalInsights" Version="1.0.0-alpha.20241021.6" />
     <PackageVersion Include="Azure.Provisioning.PostgreSql" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Redis" Version="$(AzureProvisiongVersion)" />
     <PackageVersion Include="Azure.Provisioning.Search" Version="$(AzureProvisiongVersion)" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -17,7 +17,6 @@
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
-    <add key="azure-sdk-devfeed" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="dotnet9-transport">
@@ -35,9 +34,6 @@
     </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="*" />
-    </packageSource>
-    <packageSource key="azure-sdk-devfeed">
-      <package pattern="Azure.*" />
     </packageSource>
   </packageSourceMapping>
   <disabledPackageSources>

--- a/NuGet.config
+++ b/NuGet.config
@@ -17,6 +17,7 @@
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet9-transport" value="https://dnceng.pkgs.visualstudio.com/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
+    <add key="azure-sdk-devfeed" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="dotnet9-transport">
@@ -34,6 +35,9 @@
     </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="*" />
+    </packageSource>
+    <packageSource key="azure-sdk-devfeed">
+      <package pattern="Azure.*" />
     </packageSource>
   </packageSourceMapping>
   <disabledPackageSources>

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/Program.cs
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/Program.cs
@@ -37,7 +37,7 @@ builder.AddProject<Projects.AzureContainerApps_ApiService>("api")
            app.ConfigureCustomDomain(customDomain, certificateName);
 
            // Scale to 0
-           app.Template.Value!.Scale.Value!.MinReplicas = 0;
+           app.Template.Scale.MinReplicas = 0;
        });
 
 #if !SKIP_DASHBOARD_REFERENCE

--- a/playground/bicep/BicepSample.AppHost/redis.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/redis.module.bicep
@@ -15,11 +15,11 @@ resource redis 'Microsoft.Cache/redis@2024-03-01' = {
       capacity: 1
     }
     enableNonSslPort: false
+    disableAccessKeyAuthentication: true
     minimumTlsVersion: '1.2'
     redisConfiguration: {
       'aad-enabled': 'true'
     }
-    disableAccessKeyAuthentication: 'true'
   }
   tags: {
     'aspire-resource-name': 'redis'

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -17,7 +17,7 @@ var locationOverride = builder.AddParameter("locationOverride");
 var storage = builder.AddAzureStorage("storage")
     .ConfigureInfrastructure(infrastructure =>
     {
-        var account = infrastructure.GetResources().OfType<StorageAccount>().Single();
+        var account = infrastructure.GetProvisionableResources().OfType<StorageAccount>().Single();
         account.Sku = new StorageSku() { Name = sku.AsProvisioningParameter(infrastructure) };
         account.Location = locationOverride.AsProvisioningParameter(infrastructure);
     });
@@ -30,7 +30,7 @@ var signaturesecret = builder.AddParameter("signaturesecret", secret: true);
 var keyvault = builder.AddAzureKeyVault("mykv")
     .ConfigureInfrastructure(infrastructure =>
 {
-    var keyVault = infrastructure.GetResources().OfType<KeyVaultService>().Single();
+    var keyVault = infrastructure.GetProvisionableResources().OfType<KeyVaultService>().Single();
     var secret = new KeyVaultSecret("mysecret")
     {
         Parent = keyVault,
@@ -55,24 +55,24 @@ var sb = builder.AddAzureServiceBus("servicebus")
     .AddQueue("queue1")
     .ConfigureInfrastructure(infrastructure =>
     {
-        var queue = infrastructure.GetResources().OfType<ServiceBusQueue>().Single(q => q.IdentifierName == "queue1");
+        var queue = infrastructure.GetProvisionableResources().OfType<ServiceBusQueue>().Single(q => q.BicepIdentifier == "queue1");
         queue.MaxDeliveryCount = 5;
-        queue.LockDuration = new StringLiteral("PT5M");
+        queue.LockDuration = new StringLiteralExpression("PT5M");
         // TODO: this should be
         // queue.LockDuration = TimeSpan.FromMinutes(5);
     })
     .AddTopic("topic1")
     .ConfigureInfrastructure(infrastructure =>
     {
-        var topic = infrastructure.GetResources().OfType<ServiceBusTopic>().Single(q => q.IdentifierName == "topic1");
+        var topic = infrastructure.GetProvisionableResources().OfType<ServiceBusTopic>().Single(q => q.BicepIdentifier == "topic1");
         topic.EnablePartitioning = true;
     })
     .AddTopic("topic2")
     .AddSubscription("topic1", "subscription1")
     .ConfigureInfrastructure(infrastructure =>
     {
-        var subscription = infrastructure.GetResources().OfType<ServiceBusSubscription>().Single(q => q.IdentifierName == "subscription1");
-        subscription.LockDuration = new StringLiteral("PT5M");
+        var subscription = infrastructure.GetProvisionableResources().OfType<ServiceBusSubscription>().Single(q => q.BicepIdentifier == "subscription1");
+        subscription.LockDuration = new StringLiteralExpression("PT5M");
         // TODO: this should be
         //subscription.LockDuration = TimeSpan.FromMinutes(5);
         subscription.RequiresSession = true;
@@ -89,7 +89,7 @@ var signalr = builder.AddAzureSignalR("signalr");
 var logAnalyticsWorkspace = builder.AddAzureLogAnalyticsWorkspace("logAnalyticsWorkspace")
     .ConfigureInfrastructure(infrastructure =>
     {
-        var logAnalyticsWorkspace = infrastructure.GetResources().OfType<OperationalInsightsWorkspace>().Single();
+        var logAnalyticsWorkspace = infrastructure.GetProvisionableResources().OfType<OperationalInsightsWorkspace>().Single();
         logAnalyticsWorkspace.Sku = new OperationalInsightsWorkspaceSku()
         {
             Name = OperationalInsightsWorkspaceSkuName.PerNode
@@ -99,7 +99,7 @@ var logAnalyticsWorkspace = builder.AddAzureLogAnalyticsWorkspace("logAnalyticsW
 var appInsights = builder.AddAzureApplicationInsights("appInsights", logAnalyticsWorkspace)
     .ConfigureInfrastructure(infrastructure =>
     {
-        var appInsights = infrastructure.GetResources().OfType<ApplicationInsightsComponent>().Single();
+        var appInsights = infrastructure.GetProvisionableResources().OfType<ApplicationInsightsComponent>().Single();
         appInsights.IngestionMode = ComponentIngestionMode.LogAnalytics;
     });
 

--- a/playground/cdk/CdkSample.AppHost/Program.cs
+++ b/playground/cdk/CdkSample.AppHost/Program.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Azure.Provisioning.ApplicationInsights;
-using Azure.Provisioning.Expressions;
 using Azure.Provisioning.KeyVault;
 using Azure.Provisioning.OperationalInsights;
 using Azure.Provisioning.ServiceBus;
@@ -57,9 +56,7 @@ var sb = builder.AddAzureServiceBus("servicebus")
     {
         var queue = infrastructure.GetProvisionableResources().OfType<ServiceBusQueue>().Single(q => q.BicepIdentifier == "queue1");
         queue.MaxDeliveryCount = 5;
-        queue.LockDuration = new StringLiteralExpression("PT5M");
-        // TODO: this should be
-        // queue.LockDuration = TimeSpan.FromMinutes(5);
+        queue.LockDuration = TimeSpan.FromMinutes(5);
     })
     .AddTopic("topic1")
     .ConfigureInfrastructure(infrastructure =>
@@ -72,9 +69,7 @@ var sb = builder.AddAzureServiceBus("servicebus")
     .ConfigureInfrastructure(infrastructure =>
     {
         var subscription = infrastructure.GetProvisionableResources().OfType<ServiceBusSubscription>().Single(q => q.BicepIdentifier == "subscription1");
-        subscription.LockDuration = new StringLiteralExpression("PT5M");
-        // TODO: this should be
-        //subscription.LockDuration = TimeSpan.FromMinutes(5);
+        subscription.LockDuration = TimeSpan.FromMinutes(5);
         subscription.RequiresSession = true;
     })
     .AddSubscription("topic1", "subscription2")

--- a/playground/cdk/CdkSample.AppHost/cache.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/cache.module.bicep
@@ -15,11 +15,11 @@ resource cache 'Microsoft.Cache/redis@2024-03-01' = {
       capacity: 1
     }
     enableNonSslPort: false
+    disableAccessKeyAuthentication: true
     minimumTlsVersion: '1.2'
     redisConfiguration: {
       'aad-enabled': 'true'
     }
-    disableAccessKeyAuthentication: 'true'
   }
   tags: {
     'aspire-resource-name': 'cache'

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -143,7 +143,7 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                     containerImageParam = AllocateContainerImageParameter();
                 }
 
-                var containerAppResource = new ContainerApp(Infrastructure.NormalizeIdentifierName(resource.Name))
+                var containerAppResource = new ContainerApp(Infrastructure.NormalizeBicepIdentifier(resource.Name))
                 {
                     Name = resource.Name.ToLowerInvariant()
                 };
@@ -701,7 +701,7 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                 {
                     // We resolve the keyvault that represents the storage for secret outputs
                     var parameter = AllocateParameter(SecretOutputExpression.GetSecretOutputKeyVault(secretOutputReference.Resource));
-                    kv = KeyVaultService.FromExisting($"{parameter.IdentifierName}_kv");
+                    kv = KeyVaultService.FromExisting($"{parameter.BicepIdentifier}_kv");
                     kv.Name = parameter;
 
                     KeyVaultRefs[secretOutputReference.Resource.Name] = kv;
@@ -710,8 +710,8 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                 if (!KeyVaultSecretRefs.TryGetValue(secretOutputReference.ValueExpression, out var secret))
                 {
                     // Now we resolve the secret
-                    var secretIdentifierName = Infrastructure.NormalizeIdentifierName($"{kv.IdentifierName}_{secretOutputReference.Name}");
-                    secret = KeyVaultSecret.FromExisting(secretIdentifierName);
+                    var secretBicepIdentifier = Infrastructure.NormalizeBicepIdentifier($"{kv.BicepIdentifier}_{secretOutputReference.Name}");
+                    secret = KeyVaultSecret.FromExisting(secretBicepIdentifier);
                     secret.Name = secretOutputReference.Name;
                     secret.Parent = kv;
 
@@ -721,7 +721,7 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                 // TODO: There should be a better way to do this?
                 return new MemberExpression(
                             new MemberExpression(
-                               new IdentifierExpression(secret.IdentifierName), "properties"),
+                               new IdentifierExpression(secret.BicepIdentifier), "properties"),
                             "secretUri");
             }
 

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -179,7 +179,7 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                 var containerAppContainer = new ContainerAppContainer();
                 template.Containers = [containerAppContainer];
 
-                containerAppContainer.Image = containerImageParam is null ? containerImageName : containerImageParam;
+                containerAppContainer.Image = containerImageParam is null ? containerImageName! : containerImageParam;
                 containerAppContainer.Name = resource.Name;
 
                 AddEnvironmentVariablesAndCommandLineArgs(containerAppContainer);
@@ -483,7 +483,8 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                             {
                                 var managedIdentityParameter = AllocateManagedIdentityIdParameter();
                                 secret.Identity = managedIdentityParameter;
-                                secret.KeyVaultUri = new BicepValue<Uri>(argValue.Expression!);
+                                // TODO: this should be able to use ToUri(), but it hit an issue
+                                secret.KeyVaultUri = new BicepValue<Uri>(((BicepExpression?)argValue)!);
                             }
                             else
                             {
@@ -716,11 +717,7 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                     KeyVaultSecretRefs[secretOutputReference.ValueExpression] = secret;
                 }
 
-                // TODO: There should be a better way to do this?
-                return new MemberExpression(
-                            new MemberExpression(
-                               new IdentifierExpression(secret.BicepIdentifier), "properties"),
-                            "secretUri");
+                return secret.Properties.SecretUri;
             }
 
             private ProvisioningParameter AllocateContainerImageParameter()

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -517,7 +517,6 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                 {
                     BicepValue<string> s => s,
                     string s => s,
-                    BicepValueFormattableString fs => Interpolate(fs),
                     ProvisioningParameter p => p,
                     _ => throw new NotSupportedException("Unsupported value type " + val.GetType())
                 };
@@ -684,7 +683,7 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
                         args[index++] = val;
                     }
 
-                    return (new BicepValueFormattableString(expr.Format, args), finalSecretType);
+                    return (Interpolate(expr.Format, args), finalSecretType);
 
                 }
 
@@ -881,68 +880,45 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
         }
     }
 
-    // REVIEW: BicepFunction.Interpolate is buggy and doesn't handle nested formattable strings correctly
-    // This is a workaround to handle nested formattable strings until the bug is fixed.
-    private static BicepValue<string> Interpolate(BicepValueFormattableString text)
+    private static BicepValue<string> Interpolate(string format, object[] args)
     {
         var bicepStringBuilder = new BicepStringBuilder();
 
-        void ProcessFormattableString(BicepValueFormattableString formattableString, int argumentIndex)
+        var span = format.AsSpan();
+        var skip = 0;
+        var argumentIndex = 0;
+
+        foreach (var match in Regex.EnumerateMatches(span, @"{\d+}"))
         {
-            var span = formattableString.Format.AsSpan();
-            var skip = 0;
+            bicepStringBuilder.Append(span[..(match.Index - skip)].ToString());
 
-            foreach (var match in Regex.EnumerateMatches(span, @"{\d+}"))
+            var argument = args[argumentIndex];
+
+            if (argument is BicepValue<string> bicepValue)
             {
-                bicepStringBuilder.Append(span[..(match.Index - skip)].ToString());
-
-                var argument = formattableString.Values[argumentIndex];
-
-                if (argument is BicepValueFormattableString nested)
-                {
-                    // Inline the nested formattable string
-                    ProcessFormattableString(nested, 0);
-                }
-                else
-                {
-                    if (argument is BicepValue<string> bicepValue)
-                    {
-                        bicepStringBuilder.Append($"{bicepValue}");
-                    }
-                    else if (argument is string s)
-                    {
-                        bicepStringBuilder.Append(s);
-                    }
-                    else if (argument is ProvisioningParameter provisioningParameter)
-                    {
-                        bicepStringBuilder.Append($"{provisioningParameter}");
-                    }
-                    else
-                    {
-                        throw new NotSupportedException($"{argument} is not supported");
-                    }
-                }
-
-                argumentIndex++;
-                span = span[(match.Index + match.Length - skip)..];
-                skip = match.Index + match.Length;
+                bicepStringBuilder.Append($"{bicepValue}");
+            }
+            else if (argument is string s)
+            {
+                bicepStringBuilder.Append(s);
+            }
+            else if (argument is ProvisioningParameter provisioningParameter)
+            {
+                bicepStringBuilder.Append($"{provisioningParameter}");
+            }
+            else
+            {
+                throw new NotSupportedException($"{argument} is not supported");
             }
 
-            bicepStringBuilder.Append(span.ToString());
+            argumentIndex++;
+            span = span[(match.Index + match.Length - skip)..];
+            skip = match.Index + match.Length;
         }
 
-        ProcessFormattableString(text, 0);
+        bicepStringBuilder.Append(span.ToString());
 
         return bicepStringBuilder.Build();
-    }
-
-    /// <summary>
-    /// An object wrapping a format string and values that allows us to inline nested bicep interpolated strings.
-    /// </summary>
-    private sealed class BicepValueFormattableString(string format, object[] values)
-    {
-        public string Format => format;
-        public object[] Values => values;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppsInfrastructure.cs
@@ -896,7 +896,7 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
             {
                 bicepStringBuilder.Append(span[..(match.Index - skip)].ToString());
 
-                var argument = formattableString.GetArgument(argumentIndex);
+                var argument = formattableString.Values[argumentIndex];
 
                 if (argument is BicepValueFormattableString nested)
                 {
@@ -937,16 +937,12 @@ internal sealed class AzureContainerAppsInfrastructure(ILogger<AzureContainerApp
     }
 
     /// <summary>
-    /// A custom FormattableString implementation that allows us to inline nested formattable strings.
+    /// An object wrapping a format string and values that allows us to inline nested bicep interpolated strings.
     /// </summary>
-    private sealed class BicepValueFormattableString(string formatString, object[] values) : FormattableString
+    private sealed class BicepValueFormattableString(string format, object[] values)
     {
-        public override int ArgumentCount => values.Length;
-        public override string Format => formatString;
-        public override object? GetArgument(int index) => values[index];
-        public override object?[] GetArguments() => values;
-        public override string ToString(IFormatProvider? formatProvider) => Format;
-        public override string ToString() => formatString;
+        public string Format => format;
+        public object[] Values => values;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
+++ b/src/Aspire.Hosting.Azure.AppContainers/ContainerAppExtensions.cs
@@ -62,32 +62,32 @@ public static class ContainerAppExtensions
             throw new ArgumentException("Cannot configure custom domain when resource is not parented by ResourceModuleConstruct.", nameof(app));
         }
 
-        var containerAppManagedEnvironmentIdParameter = module.GetResources().OfType<ProvisioningParameter>().Single(
-            p => p.IdentifierName == "outputs_azure_container_apps_environment_id");
+        var containerAppManagedEnvironmentIdParameter = module.GetProvisionableResources().OfType<ProvisioningParameter>().Single(
+            p => p.BicepIdentifier == "outputs_azure_container_apps_environment_id");
         var certificatNameParameter = certificateName.AsProvisioningParameter(module);
         var customDomainParameter = customDomain.AsProvisioningParameter(module);
 
         var bindingTypeConditional = new ConditionalExpression(
             new BinaryExpression(
-                new IdentifierExpression(certificatNameParameter.IdentifierName),
-                BinaryOperator.NotEqual,
-                new StringLiteral(string.Empty)),
-            new StringLiteral("SniEnabled"),
-            new StringLiteral("Disabled")
+                new IdentifierExpression(certificatNameParameter.BicepIdentifier),
+                BinaryBicepOperator.NotEqual,
+                new StringLiteralExpression(string.Empty)),
+            new StringLiteralExpression("SniEnabled"),
+            new StringLiteralExpression("Disabled")
             );
 
         var certificateOrEmpty = new ConditionalExpression(
             new BinaryExpression(
-                new IdentifierExpression(certificatNameParameter.IdentifierName),
-                BinaryOperator.NotEqual,
-                new StringLiteral(string.Empty)),
-            new InterpolatedString(
-                "{0}/managedCertificates/{1}",
+                new IdentifierExpression(certificatNameParameter.BicepIdentifier),
+                BinaryBicepOperator.NotEqual,
+                new StringLiteralExpression(string.Empty)),
+            new InterpolatedStringExpression(
                 [
-                 new IdentifierExpression(containerAppManagedEnvironmentIdParameter.IdentifierName),
-                    new IdentifierExpression(certificatNameParameter.IdentifierName)
+                    new IdentifierExpression(containerAppManagedEnvironmentIdParameter.BicepIdentifier),
+                    new StringLiteralExpression("/managedCertificates/"),
+                    new IdentifierExpression(certificatNameParameter.BicepIdentifier)
                  ]),
-            new NullLiteral()
+            new NullLiteralExpression()
             );
 
         app.Configuration.Value!.Ingress!.Value!.CustomDomains = new BicepList<ContainerAppCustomDomain>()
@@ -95,7 +95,7 @@ public static class ContainerAppExtensions
                 new ContainerAppCustomDomain()
                 {
                     BindingType = bindingTypeConditional,
-                    Name = new IdentifierExpression(customDomainParameter.IdentifierName),
+                    Name = new IdentifierExpression(customDomainParameter.BicepIdentifier),
                     CertificateId = certificateOrEmpty
                 }
            };

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -5,7 +5,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning;
 using Azure.Provisioning.ApplicationInsights;
-using Azure.Provisioning.Expressions;
 using Azure.Provisioning.OperationalInsights;
 
 namespace Aspire.Hosting;
@@ -41,13 +40,13 @@ public static class AzureApplicationInsightsExtensions
         {
             var appTypeParameter = new ProvisioningParameter("applicationType", typeof(string))
             {
-                Value = new StringLiteralExpression("web")
+                Value = "web"
             };
             infrastructure.Add(appTypeParameter);
 
             var kindParameter = new ProvisioningParameter("kind", typeof(string))
             {
-                Value = new StringLiteralExpression("web")
+                Value = "web"
             };
             infrastructure.Add(kindParameter);
 
@@ -89,7 +88,7 @@ public static class AzureApplicationInsightsExtensions
                 infrastructure.AspireResource.Parameters.TryAdd(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, null);
                 var logAnalyticsWorkspaceParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, typeof(string))
                 {
-                    Value = new StringLiteralExpression("web")
+                    Value = "web"
                 };
                 infrastructure.Add(kindParameter);
                 appInsights.WorkspaceResourceId = logAnalyticsWorkspaceParameter;

--- a/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ApplicationInsights/AzureApplicationInsightsExtensions.cs
@@ -41,13 +41,13 @@ public static class AzureApplicationInsightsExtensions
         {
             var appTypeParameter = new ProvisioningParameter("applicationType", typeof(string))
             {
-                Value = new StringLiteral("web")
+                Value = new StringLiteralExpression("web")
             };
             infrastructure.Add(appTypeParameter);
 
             var kindParameter = new ProvisioningParameter("kind", typeof(string))
             {
-                Value = new StringLiteral("web")
+                Value = new StringLiteralExpression("web")
             };
             infrastructure.Add(kindParameter);
 
@@ -67,7 +67,7 @@ public static class AzureApplicationInsightsExtensions
             else if (builder.ExecutionContext.IsRunMode)
             {
                 // ... otherwise if we are in run mode, the provisioner expects us to create one ourselves.
-                var autoInjectedLogAnalyticsWorkspaceName = $"law_{appInsights.IdentifierName}";
+                var autoInjectedLogAnalyticsWorkspaceName = $"law_{appInsights.BicepIdentifier}";
                 var autoInjectedLogAnalyticsWorkspace = new OperationalInsightsWorkspace(autoInjectedLogAnalyticsWorkspaceName)
                 {
                     Sku = new OperationalInsightsWorkspaceSku()
@@ -89,7 +89,7 @@ public static class AzureApplicationInsightsExtensions
                 infrastructure.AspireResource.Parameters.TryAdd(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, null);
                 var logAnalyticsWorkspaceParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.LogAnalyticsWorkspaceId, typeof(string))
                 {
-                    Value = new StringLiteral("web")
+                    Value = new StringLiteralExpression("web")
                 };
                 infrastructure.Add(kindParameter);
                 appInsights.WorkspaceResourceId = logAnalyticsWorkspaceParameter;

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -47,12 +47,12 @@ public static class AzureOpenAIExtensions
 
             infrastructure.Add(new ProvisioningOutput("connectionString", typeof(string))
             {
-                Value = new InterpolatedString(
+                Value = new InterpolatedStringExpression(
                         "Endpoint={0}",
                         [
                             new MemberExpression(
                                 new MemberExpression(
-                                    new IdentifierExpression(cogServicesAccount.IdentifierName),
+                                    new IdentifierExpression(cogServicesAccount.BicepIdentifier),
                                     "properties"),
                                 "endpoint")
                         ])
@@ -71,7 +71,7 @@ public static class AzureOpenAIExtensions
             var cdkDeployments = new List<CognitiveServicesAccountDeployment>();
             foreach (var deployment in resource.Deployments)
             {
-                var cdkDeployment = new CognitiveServicesAccountDeployment(Infrastructure.NormalizeIdentifierName(deployment.Name))
+                var cdkDeployment = new CognitiveServicesAccountDeployment(Infrastructure.NormalizeBicepIdentifier(deployment.Name))
                 {
                     Name = deployment.Name,
                     Parent = cogServicesAccount,

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -5,7 +5,6 @@ using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning;
 using Azure.Provisioning.CognitiveServices;
-using Azure.Provisioning.Expressions;
 using static Azure.Provisioning.Expressions.BicepFunction;
 
 namespace Aspire.Hosting;
@@ -47,17 +46,7 @@ public static class AzureOpenAIExtensions
 
             infrastructure.Add(new ProvisioningOutput("connectionString", typeof(string))
             {
-                Value = new InterpolatedStringExpression(
-                        [
-                            new StringLiteralExpression("Endpoint="),
-                            new MemberExpression(
-                                new MemberExpression(
-                                    new IdentifierExpression(cogServicesAccount.BicepIdentifier),
-                                    "properties"),
-                                "endpoint")
-                        ])
-                // TODO This should be
-                // Value = BicepFunction.Interpolate($"Endpoint={cogServicesAccount.Endpoint}")
+                 Value = Interpolate($"Endpoint={cogServicesAccount.Properties.Endpoint}")
             });
 
             var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));

--- a/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIExtensions.cs
@@ -48,8 +48,8 @@ public static class AzureOpenAIExtensions
             infrastructure.Add(new ProvisioningOutput("connectionString", typeof(string))
             {
                 Value = new InterpolatedStringExpression(
-                        "Endpoint={0}",
                         [
+                            new StringLiteralExpression("Endpoint="),
                             new MemberExpression(
                                 new MemberExpression(
                                     new IdentifierExpression(cogServicesAccount.BicepIdentifier),

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBExtensions.cs
@@ -65,7 +65,7 @@ public static class AzureCosmosExtensions
             List<CosmosDBSqlDatabase> cosmosSqlDatabases = new List<CosmosDBSqlDatabase>();
             foreach (var databaseName in azureResource.Databases)
             {
-                var cosmosSqlDatabase = new CosmosDBSqlDatabase(Infrastructure.NormalizeIdentifierName(databaseName))
+                var cosmosSqlDatabase = new CosmosDBSqlDatabase(Infrastructure.NormalizeBicepIdentifier(databaseName))
                 {
                     Parent = cosmosAccount,
                     Name = databaseName,

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -34,7 +34,7 @@ public static class AzureEventHubsExtensions
         {
             var skuParameter = new ProvisioningParameter("sku", typeof(string))
             {
-                Value = new StringLiteral("Standard")
+                Value = new StringLiteralExpression("Standard")
             };
             infrastructure.Add(skuParameter);
 
@@ -58,7 +58,7 @@ public static class AzureEventHubsExtensions
 
             foreach (var hub in azureResource.Hubs)
             {
-                var hubResource = new EventHub(Infrastructure.NormalizeIdentifierName(hub))
+                var hubResource = new EventHub(Infrastructure.NormalizeBicepIdentifier(hub))
                 {
                     Parent = eventHubsNamespace,
                     Name = hub

--- a/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
+++ b/src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsExtensions.cs
@@ -9,7 +9,6 @@ using Aspire.Hosting.Utils;
 using Azure.Messaging.EventHubs.Producer;
 using Azure.Provisioning;
 using Azure.Provisioning.EventHubs;
-using Azure.Provisioning.Expressions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Aspire.Hosting;
@@ -34,7 +33,7 @@ public static class AzureEventHubsExtensions
         {
             var skuParameter = new ProvisioningParameter("sku", typeof(string))
             {
-                Value = new StringLiteralExpression("Standard")
+                Value = "Standard"
             };
             infrastructure.Add(skuParameter);
 

--- a/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Functions/AzureFunctionsProjectResourceExtensions.cs
@@ -54,7 +54,7 @@ public static class AzureFunctionsProjectResourceExtensions
                     var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
                     var principalIdParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalId, typeof(string));
 
-                    var storageAccount = infrastructure.GetResources().OfType<StorageAccount>().FirstOrDefault(r => r.IdentifierName == storageResourceName)
+                    var storageAccount = infrastructure.GetProvisionableResources().OfType<StorageAccount>().FirstOrDefault(r => r.BicepIdentifier == storageResourceName)
                         ?? throw new InvalidOperationException($"Could not find storage account with '{storageResourceName}' name.");
                     infrastructure.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageAccountContributor, principalTypeParameter, principalIdParameter));
                 };

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -43,14 +43,7 @@ public static class AzureKeyVaultResourceExtensions
 
             infrastructure.Add(new ProvisioningOutput("vaultUri", typeof(string))
             {
-                Value =
-                    new MemberExpression(
-                        new MemberExpression(
-                            new IdentifierExpression(keyVault.BicepIdentifier),
-                            "properties"),
-                        "vaultUri")
-                // TODO: this should be
-                //Value = keyVault.VaultUri
+                Value = keyVault.Properties.VaultUri
             });
 
             keyVault.Tags["aspire-resource-name"] = infrastructure.AspireResource.Name;

--- a/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure.KeyVault/AzureKeyVaultResourceExtensions.cs
@@ -46,7 +46,7 @@ public static class AzureKeyVaultResourceExtensions
                 Value =
                     new MemberExpression(
                         new MemberExpression(
-                            new IdentifierExpression(keyVault.IdentifierName),
+                            new IdentifierExpression(keyVault.BicepIdentifier),
                             "properties"),
                         "vaultUri")
                 // TODO: this should be

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -455,9 +455,9 @@ public static class AzurePostgresExtensions
 
         foreach (var databaseNames in databases)
         {
-            var BicepIdentifier = Infrastructure.NormalizeBicepIdentifier(databaseNames.Key);
+            var bicepIdentifier = Infrastructure.NormalizeBicepIdentifier(databaseNames.Key);
             var databaseName = databaseNames.Value;
-            var pgsqlDatabase = new PostgreSqlFlexibleServerDatabase(BicepIdentifier)
+            var pgsqlDatabase = new PostgreSqlFlexibleServerDatabase(bicepIdentifier)
             {
                 Parent = postgres,
                 Name = databaseName

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresExtensions.cs
@@ -157,7 +157,7 @@ public static class AzurePostgresExtensions
             var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
             var principalNameParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalName, typeof(string));
 
-            var admin = new PostgreSqlFlexibleServerActiveDirectoryAdministrator($"{postgres.IdentifierName}_admin")
+            var admin = new PostgreSqlFlexibleServerActiveDirectoryAdministrator($"{postgres.BicepIdentifier}_admin")
             {
                 Parent = postgres,
                 Name = principalIdParameter,
@@ -167,7 +167,7 @@ public static class AzurePostgresExtensions
 
             // This is a workaround for a bug in the API that requires the parent to be fully resolved
             admin.DependsOn.Add(postgres);
-            foreach (var firewall in infrastructure.GetResources().OfType<PostgreSqlFlexibleServerFirewallRule>())
+            foreach (var firewall in infrastructure.GetProvisionableResources().OfType<PostgreSqlFlexibleServerFirewallRule>())
             {
                 admin.DependsOn.Add(firewall);
             }
@@ -355,7 +355,7 @@ public static class AzurePostgresExtensions
 
                 RemoveActiveDirectoryAuthResources(infrastructure);
 
-                var postgres = infrastructure.GetResources().OfType<PostgreSqlFlexibleServer>().FirstOrDefault(r => r.IdentifierName == azureResource.GetBicepIdentifier())
+                var postgres = infrastructure.GetProvisionableResources().OfType<PostgreSqlFlexibleServer>().FirstOrDefault(r => r.BicepIdentifier == azureResource.GetBicepIdentifier())
                     ?? throw new InvalidOperationException($"Could not find a PostgreSqlFlexibleServer with name {azureResource.Name}.");
 
                 var administratorLogin = new ProvisioningParameter("administratorLogin", typeof(string));
@@ -393,7 +393,7 @@ public static class AzurePostgresExtensions
 
                 foreach (var database in azureResource.Databases)
                 {
-                    var dbSecret = new KeyVaultSecret(Infrastructure.NormalizeIdentifierName(database.Key + "_connectionString"))
+                    var dbSecret = new KeyVaultSecret(Infrastructure.NormalizeBicepIdentifier(database.Key + "_connectionString"))
                     {
                         Parent = keyVault,
                         Name = AzurePostgresFlexibleServerResource.GetDatabaseKeyVaultSecretName(database.Key),
@@ -417,7 +417,7 @@ public static class AzurePostgresExtensions
                 Name = "Standard_B1ms",
                 Tier = PostgreSqlFlexibleServerSkuTier.Burstable
             },
-            Version = new StringLiteral("16"),
+            Version = new StringLiteralExpression("16"),
             HighAvailability = new PostgreSqlFlexibleServerHighAvailability()
             {
                 Mode = PostgreSqlFlexibleServerHighAvailabilityMode.Disabled
@@ -455,9 +455,9 @@ public static class AzurePostgresExtensions
 
         foreach (var databaseNames in databases)
         {
-            var identifierName = Infrastructure.NormalizeIdentifierName(databaseNames.Key);
+            var BicepIdentifier = Infrastructure.NormalizeBicepIdentifier(databaseNames.Key);
             var databaseName = databaseNames.Value;
-            var pgsqlDatabase = new PostgreSqlFlexibleServerDatabase(identifierName)
+            var pgsqlDatabase = new PostgreSqlFlexibleServerDatabase(BicepIdentifier)
             {
                 Parent = postgres,
                 Name = databaseName
@@ -480,13 +480,13 @@ public static class AzurePostgresExtensions
     private static void RemoveActiveDirectoryAuthResources(AzureResourceInfrastructure infrastructure)
     {
         var resourcesToRemove = new List<Provisionable>();
-        foreach (var resource in infrastructure.GetResources())
+        foreach (var resource in infrastructure.GetProvisionableResources())
         {
             if (resource is PostgreSqlFlexibleServerActiveDirectoryAdministrator)
             {
                 resourcesToRemove.Add(resource);
             }
-            else if (resource is ProvisioningOutput output && output.IdentifierName == "connectionString")
+            else if (resource is ProvisioningOutput output && output.BicepIdentifier == "connectionString")
             {
                 resourcesToRemove.Add(resource);
             }

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -240,8 +240,8 @@ public static class AzureRedisExtensions
                keyVault.Name = kvNameParam;
                infrastructure.Add(keyVault);
 
-               redis.RedisConfiguration.Value!.IsAadEnabled.Kind = BicepValueKind.Unset;
-               redis.IsAccessKeyAuthenticationDisabled.Kind = BicepValueKind.Unset;
+               redis.RedisConfiguration.IsAadEnabled.ClearValue();
+               redis.IsAccessKeyAuthenticationDisabled.ClearValue();
 
                var secret = new KeyVaultSecret("connectionString")
                {

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -129,10 +129,7 @@ public static class AzureRedisExtensions
             {
                 IsAadEnabled = "true"
             };
-
-            // TODO: This property should be available from the CDK in the latest version.
-            var disableAccessKeys = BicepValue<string>.DefineProperty(redis, "DisableAccessKeyAuthentication", ["properties", "disableAccessKeyAuthentication"], isOutput: false, isRequired: false);
-            disableAccessKeys.Assign("true");
+            redis.IsAccessKeyAuthenticationDisabled = true;
 
             var principalIdParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalId, typeof(string));
             var principalNameParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalName, typeof(string));
@@ -244,10 +241,7 @@ public static class AzureRedisExtensions
                infrastructure.Add(keyVault);
 
                redis.RedisConfiguration.Value!.IsAadEnabled.Kind = BicepValueKind.Unset;
-
-               // TODO: This property should be available from the CDK in the latest version.
-               var disableAccessKeys = BicepValue<string>.DefineProperty(redis, "DisableAccessKeyAuthentication", ["properties", "disableAccessKeyAuthentication"], isOutput: false, isRequired: false);
-               disableAccessKeys.Kind = BicepValueKind.Unset;
+               redis.IsAccessKeyAuthenticationDisabled.Kind = BicepValueKind.Unset;
 
                var secret = new KeyVaultSecret("connectionString")
                {

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisExtensions.cs
@@ -136,7 +136,7 @@ public static class AzureRedisExtensions
 
             var principalIdParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalId, typeof(string));
             var principalNameParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalName, typeof(string));
-            infrastructure.Add(new RedisCacheAccessPolicyAssignment($"{redis.IdentifierName}_contributor")
+            infrastructure.Add(new RedisCacheAccessPolicyAssignment($"{redis.BicepIdentifier}_contributor")
             {
                 Parent = redis,
                 AccessPolicyName = "Data Contributor",
@@ -233,7 +233,7 @@ public static class AzureRedisExtensions
            {
                RemoveActiveDirectoryAuthResources(infrastructure);
 
-               var redis = infrastructure.GetResources().OfType<CdkRedisResource>().FirstOrDefault(r => r.IdentifierName == builder.Resource.GetBicepIdentifier())
+               var redis = infrastructure.GetProvisionableResources().OfType<CdkRedisResource>().FirstOrDefault(r => r.BicepIdentifier == builder.Resource.GetBicepIdentifier())
                    ?? throw new InvalidOperationException($"Could not find a RedisResource with name {builder.Resource.Name}.");
 
                var kvNameParam = new ProvisioningParameter("keyVaultName", typeof(string));
@@ -292,14 +292,14 @@ public static class AzureRedisExtensions
     private static void RemoveActiveDirectoryAuthResources(AzureResourceInfrastructure infrastructure)
     {
         var resourcesToRemove = new List<Provisionable>();
-        foreach (var resource in infrastructure.GetResources())
+        foreach (var resource in infrastructure.GetProvisionableResources())
         {
             if (resource is RedisCacheAccessPolicyAssignment accessPolicy &&
-                accessPolicy.IdentifierName == $"{infrastructure.AspireResource.GetBicepIdentifier()}_contributor")
+                accessPolicy.BicepIdentifier == $"{infrastructure.AspireResource.GetBicepIdentifier()}_contributor")
             {
                 resourcesToRemove.Add(resource);
             }
-            else if (resource is ProvisioningOutput output && output.IdentifierName == "connectionString")
+            else if (resource is ProvisioningOutput output && output.BicepIdentifier == "connectionString")
             {
                 resourcesToRemove.Add(resource);
             }

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -4,7 +4,6 @@
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure;
 using Azure.Provisioning;
-using Azure.Provisioning.Expressions;
 using Azure.Provisioning.ServiceBus;
 
 namespace Aspire.Hosting;
@@ -28,7 +27,7 @@ public static class AzureServiceBusExtensions
         {
             var skuParameter = new ProvisioningParameter("sku", typeof(string))
             {
-                Value = new StringLiteralExpression("Standard")
+                Value = "Standard"
             };
             infrastructure.Add(skuParameter);
 

--- a/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
+++ b/src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusExtensions.cs
@@ -28,7 +28,7 @@ public static class AzureServiceBusExtensions
         {
             var skuParameter = new ProvisioningParameter("sku", typeof(string))
             {
-                Value = new StringLiteral("Standard")
+                Value = new StringLiteralExpression("Standard")
             };
             infrastructure.Add(skuParameter);
 
@@ -53,7 +53,7 @@ public static class AzureServiceBusExtensions
 
             foreach (var queue in azureResource.Queues)
             {
-                var queueResource = new ServiceBusQueue(Infrastructure.NormalizeIdentifierName(queue))
+                var queueResource = new ServiceBusQueue(Infrastructure.NormalizeBicepIdentifier(queue))
                 {
                     Parent = serviceBusNamespace,
                     Name = queue
@@ -63,7 +63,7 @@ public static class AzureServiceBusExtensions
             var topicDictionary = new Dictionary<string, ServiceBusTopic>();
             foreach (var topic in azureResource.Topics)
             {
-                var topicResource = new ServiceBusTopic(Infrastructure.NormalizeIdentifierName(topic))
+                var topicResource = new ServiceBusTopic(Infrastructure.NormalizeBicepIdentifier(topic))
                 {
                     Parent = serviceBusNamespace,
                     Name = topic
@@ -74,7 +74,7 @@ public static class AzureServiceBusExtensions
             foreach (var subscription in azureResource.Subscriptions)
             {
                 var topic = topicDictionary[subscription.TopicName];
-                var subscriptionResource = new ServiceBusSubscription(Infrastructure.NormalizeIdentifierName(subscription.Name))
+                var subscriptionResource = new ServiceBusSubscription(Infrastructure.NormalizeBicepIdentifier(subscription.Name))
                 {
                     Parent = topic,
                     Name = subscription.Name

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -256,9 +256,9 @@ public static class AzureSqlExtensions
 
         foreach (var databaseNames in databases)
         {
-            var identifierName = Infrastructure.NormalizeIdentifierName(databaseNames.Key);
+            var BicepIdentifier = Infrastructure.NormalizeBicepIdentifier(databaseNames.Key);
             var databaseName = databaseNames.Value;
-            var sqlDatabase = new SqlDatabase(identifierName)
+            var sqlDatabase = new SqlDatabase(BicepIdentifier)
             {
                 Parent = sqlServer,
                 Name = databaseName

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -243,7 +243,7 @@ public static class AzureSqlExtensions
             // When in run mode we inject the users identity and we need to specify
             // the principalType.
             var principalTypeParameter = new ProvisioningParameter(AzureBicepResource.KnownParameters.PrincipalType, typeof(string));
-            sqlServer.Administrators.Value!.PrincipalType = principalTypeParameter;
+            sqlServer.Administrators.PrincipalType = principalTypeParameter;
 
             infrastructure.Add(new SqlFirewallRule("sqlFirewallRule_AllowAllIps")
             {

--- a/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Sql/AzureSqlExtensions.cs
@@ -256,9 +256,9 @@ public static class AzureSqlExtensions
 
         foreach (var databaseNames in databases)
         {
-            var BicepIdentifier = Infrastructure.NormalizeBicepIdentifier(databaseNames.Key);
+            var bicepIdentifier = Infrastructure.NormalizeBicepIdentifier(databaseNames.Key);
             var databaseName = databaseNames.Value;
-            var sqlDatabase = new SqlDatabase(BicepIdentifier)
+            var sqlDatabase = new SqlDatabase(bicepIdentifier)
             {
                 Parent = sqlServer,
                 Name = databaseName

--- a/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
+++ b/src/Aspire.Hosting.Azure.Storage/AzureStorageExtensions.cs
@@ -65,9 +65,9 @@ public static class AzureStorageExtensions
             infrastructure.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageTableDataContributor, principalTypeParameter, principalIdParameter));
             infrastructure.Add(storageAccount.CreateRoleAssignment(StorageBuiltInRole.StorageQueueDataContributor, principalTypeParameter, principalIdParameter));
 
-            infrastructure.Add(new ProvisioningOutput("blobEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.Value!.BlobUri });
-            infrastructure.Add(new ProvisioningOutput("queueEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.Value!.QueueUri });
-            infrastructure.Add(new ProvisioningOutput("tableEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.Value!.TableUri });
+            infrastructure.Add(new ProvisioningOutput("blobEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.BlobUri });
+            infrastructure.Add(new ProvisioningOutput("queueEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.QueueUri });
+            infrastructure.Add(new ProvisioningOutput("tableEndpoint", typeof(string)) { Value = storageAccount.PrimaryEndpoints.TableUri });
         };
 
         var resource = new AzureStorageResource(name, configureInfrastructure);

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -31,7 +31,7 @@ public static class AzureWebPubSubExtensions
             // Supported values are Free_F1 Standard_S1 Premium_P1
             var skuParameter = new ProvisioningParameter("sku", typeof(string))
             {
-                Value = new StringLiteralExpression("Free_F1")
+                Value = "Free_F1"
             };
             infrastructure.Add(skuParameter);
 
@@ -73,7 +73,7 @@ public static class AzureWebPubSubExtensions
                     Properties = new WebPubSubHubProperties()
                 };
 
-                var hubProperties = hub.Properties.Value!;
+                var hubProperties = hub.Properties;
 
                 // invoke the configure from AddEventHandler
                 for (var i = 0; i < hubResource.EventHandlers.Count; i++)
@@ -183,7 +183,7 @@ public static class AzureWebPubSubExtensions
 
         if (authSettings != null)
         {
-            handler.Auth = new BicepValue<UpstreamAuthSettings>(authSettings);
+            handler.Auth = authSettings;
         }
         return handler;
     }

--- a/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
+++ b/src/Aspire.Hosting.Azure.WebPubSub/AzureWebPubSubExtensions.cs
@@ -31,7 +31,7 @@ public static class AzureWebPubSubExtensions
             // Supported values are Free_F1 Standard_S1 Premium_P1
             var skuParameter = new ProvisioningParameter("sku", typeof(string))
             {
-                Value = new StringLiteral("Free_F1")
+                Value = new StringLiteralExpression("Free_F1")
             };
             infrastructure.Add(skuParameter);
 
@@ -66,7 +66,7 @@ public static class AzureWebPubSubExtensions
                 
                 var hubBuilder = setting.Value;
                 var hubResource = hubBuilder;
-                var hub = new WebPubSubHub(Infrastructure.NormalizeIdentifierName(hubResource.Name))
+                var hub = new WebPubSubHub(Infrastructure.NormalizeBicepIdentifier(hubResource.Name))
                 {
                     Name = setting.Key,
                     Parent = service,
@@ -92,7 +92,7 @@ public static class AzureWebPubSubExtensions
                         // otherwise add parameter to the construct
                         var parameter = new ProvisioningParameter($"{hubName}_url_{i}", typeof(string));
                         infrastructure.Add(parameter);
-                        resource.Parameters[parameter.IdentifierName] = urlExpression;
+                        resource.Parameters[parameter.BicepIdentifier] = urlExpression;
                         urlParameter = parameter;
                     }
 

--- a/src/Aspire.Hosting.Azure/AspireV8ResourceNamePropertyResolver.cs
+++ b/src/Aspire.Hosting.Azure/AspireV8ResourceNamePropertyResolver.cs
@@ -16,9 +16,9 @@ namespace Aspire.Hosting.Azure;
 public sealed class AspireV8ResourceNamePropertyResolver : DynamicResourceNamePropertyResolver
 {
     /// <inheritdoc/>
-    public override BicepValue<string>? ResolveName(ProvisioningContext context, Resource resource, ResourceNameRequirements requirements)
+    public override BicepValue<string>? ResolveName(ProvisioningBuildOptions context, ProvisionableResource resource, ResourceNameRequirements requirements)
     {
         var suffix = GetUniqueSuffix(context, resource);
-        return BicepFunction.ToLower(BicepFunction.Take(BicepFunction.Interpolate($"{resource.IdentifierName}{suffix}"), 24));
+        return BicepFunction.ToLower(BicepFunction.Take(BicepFunction.Interpolate($"{resource.BicepIdentifier}{suffix}"), 24));
     }
 }

--- a/src/Aspire.Hosting.Azure/AspireV8ResourceNamePropertyResolver.cs
+++ b/src/Aspire.Hosting.Azure/AspireV8ResourceNamePropertyResolver.cs
@@ -16,9 +16,9 @@ namespace Aspire.Hosting.Azure;
 public sealed class AspireV8ResourceNamePropertyResolver : DynamicResourceNamePropertyResolver
 {
     /// <inheritdoc/>
-    public override BicepValue<string>? ResolveName(ProvisioningBuildOptions context, ProvisionableResource resource, ResourceNameRequirements requirements)
+    public override BicepValue<string>? ResolveName(ProvisioningBuildOptions options, ProvisionableResource resource, ResourceNameRequirements requirements)
     {
-        var suffix = GetUniqueSuffix(context, resource);
+        var suffix = GetUniqueSuffix(options, resource);
         return BicepFunction.ToLower(BicepFunction.Take(BicepFunction.Interpolate($"{resource.BicepIdentifier}{suffix}"), 24));
     }
 }

--- a/src/Aspire.Hosting.Azure/AzureProvisioningOptions.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningOptions.cs
@@ -15,8 +15,8 @@ namespace Aspire.Hosting.Azure;
 public sealed class AzureProvisioningOptions
 {
     /// <summary>
-    /// Gets the <see cref="Azure.Provisioning.ProvisioningContext"/> which contains common settings and
+    /// Gets the <see cref="global::Azure.Provisioning.ProvisioningBuildOptions"/> which contains common settings and
     /// functionality for building Azure resources.
     /// </summary>
-    public ProvisioningBuildOptions ProvisioningContext { get; } = new ProvisioningBuildOptions();
+    public ProvisioningBuildOptions ProvisioningBuildOptions { get; } = new ProvisioningBuildOptions();
 }

--- a/src/Aspire.Hosting.Azure/AzureProvisioningOptions.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningOptions.cs
@@ -18,5 +18,5 @@ public sealed class AzureProvisioningOptions
     /// Gets the <see cref="Azure.Provisioning.ProvisioningContext"/> which contains common settings and
     /// functionality for building Azure resources.
     /// </summary>
-    public ProvisioningContext ProvisioningContext { get; } = new ProvisioningContext();
+    public ProvisioningBuildOptions ProvisioningContext { get; } = new ProvisioningBuildOptions();
 }

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
@@ -20,10 +20,10 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
     public Action<AzureResourceInfrastructure> ConfigureInfrastructure { get; internal set; } = configureInfrastructure;
 
     /// <summary>
-    /// Gets or sets the <see cref="Azure.Provisioning.ProvisioningContext"/> which contains common settings and
+    /// Gets or sets the <see cref="global::Azure.Provisioning.ProvisioningBuildOptions"/> which contains common settings and
     /// functionality for building Azure resources.
     /// </summary>
-    public ProvisioningBuildOptions? ProvisioningContext { get; set; }
+    public ProvisioningBuildOptions? ProvisioningBuildOptions { get; set; }
 
     /// <inheritdoc/>
     public override BicepTemplateFile GetBicepTemplateFile(string? directory = null, bool deleteTemporaryFileOnDispose = true)
@@ -56,7 +56,7 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
         var generationPath = Directory.CreateTempSubdirectory("aspire").FullName;
         var moduleSourcePath = Path.Combine(generationPath, "main.bicep");
 
-        var plan = infrastructure.Build(ProvisioningContext);
+        var plan = infrastructure.Build(ProvisioningBuildOptions);
         var compilation = plan.Compile();
         Debug.Assert(compilation.Count == 1);
         var compiledBicep = compilation.First();

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs
@@ -23,7 +23,7 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
     /// Gets or sets the <see cref="Azure.Provisioning.ProvisioningContext"/> which contains common settings and
     /// functionality for building Azure resources.
     /// </summary>
-    public ProvisioningContext? ProvisioningContext { get; set; }
+    public ProvisioningBuildOptions? ProvisioningContext { get; set; }
 
     /// <inheritdoc/>
     public override BicepTemplateFile GetBicepTemplateFile(string? directory = null, bool deleteTemporaryFileOnDispose = true)
@@ -38,8 +38,8 @@ public class AzureProvisioningResource(string name, Action<AzureResourceInfrastr
         //          put them into a dictionary for quick lookup so we don't need to scan
         //          through the parameter enumerable each time.
         var infrastructureParameters = infrastructure.GetParameters();
-        var distinctInfrastructureParameters = infrastructureParameters.DistinctBy(p => p.IdentifierName);
-        var distinctInfrastructureParametersLookup = distinctInfrastructureParameters.ToDictionary(p => p.IdentifierName);
+        var distinctInfrastructureParameters = infrastructureParameters.DistinctBy(p => p.BicepIdentifier);
+        var distinctInfrastructureParametersLookup = distinctInfrastructureParameters.ToDictionary(p => p.BicepIdentifier);
 
         foreach (var aspireParameter in this.Parameters)
         {

--- a/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureProvisioningResourceExtensions.cs
@@ -69,11 +69,11 @@ public static class AzureProvisioningResourceExtensions
         ArgumentNullException.ThrowIfNull(parameterResourceBuilder);
         ArgumentNullException.ThrowIfNull(infrastructure);
 
-        parameterName ??= Infrastructure.NormalizeIdentifierName(parameterResourceBuilder.Resource.Name);
+        parameterName ??= Infrastructure.NormalizeBicepIdentifier(parameterResourceBuilder.Resource.Name);
 
         infrastructure.AspireResource.Parameters[parameterName] = parameterResourceBuilder.Resource;
 
-        var parameter = infrastructure.GetParameters().FirstOrDefault(p => p.IdentifierName == parameterName);
+        var parameter = infrastructure.GetParameters().FirstOrDefault(p => p.BicepIdentifier == parameterName);
         if (parameter is null)
         {
             parameter = new ProvisioningParameter(parameterName, typeof(string))
@@ -112,7 +112,7 @@ public static class AzureProvisioningResourceExtensions
 
         infrastructure.AspireResource.Parameters[parameterName] = outputReference;
 
-        var parameter = infrastructure.GetParameters().FirstOrDefault(p => p.IdentifierName == parameterName);
+        var parameter = infrastructure.GetParameters().FirstOrDefault(p => p.BicepIdentifier == parameterName);
         if (parameter is null)
         {
             parameter = new ProvisioningParameter(parameterName, typeof(string));

--- a/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceExtensions.cs
@@ -30,5 +30,5 @@ public static class AzureResourceExtensions
     /// <param name="resource">The Azure resource.</param>
     /// <returns>A valid Bicep identifier.</returns>
     public static string GetBicepIdentifier(this IAzureResource resource) =>
-        Infrastructure.NormalizeIdentifierName(resource.Name);
+        Infrastructure.NormalizeBicepIdentifier(resource.Name);
 }

--- a/src/Aspire.Hosting.Azure/AzureResourceInfrastructure.cs
+++ b/src/Aspire.Hosting.Azure/AzureResourceInfrastructure.cs
@@ -30,5 +30,5 @@ public sealed class AzureResourceInfrastructure : Infrastructure
     /// </summary>
     public AzureProvisioningResource AspireResource { get; }
 
-    internal IEnumerable<ProvisioningParameter> GetParameters() => GetResources().OfType<ProvisioningParameter>();
+    internal IEnumerable<ProvisioningParameter> GetParameters() => GetProvisionableResources().OfType<ProvisioningParameter>();
 }

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -83,12 +83,12 @@ internal sealed class AzureProvisioner(
             return;
         }
 
-        // set the ProvisioningContext on the resource, if necessary
+        // set the ProvisioningBuildOptions on the resource, if necessary
         foreach (var r in azureResources)
         {
             if (r.AzureResource is AzureProvisioningResource provisioningResource)
             {
-                provisioningResource.ProvisioningContext = provisioningOptions.Value.ProvisioningContext;
+                provisioningResource.ProvisioningBuildOptions = provisioningOptions.Value.ProvisioningBuildOptions;
             }
         }
 

--- a/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
@@ -17,18 +17,18 @@ Aspire.Hosting.Azure.AspireV8ResourceNamePropertyResolver
 Aspire.Hosting.Azure.AspireV8ResourceNamePropertyResolver.AspireV8ResourceNamePropertyResolver() -> void
 Aspire.Hosting.Azure.AzureProvisioningOptions
 Aspire.Hosting.Azure.AzureProvisioningOptions.AzureProvisioningOptions() -> void
-Aspire.Hosting.Azure.AzureProvisioningOptions.ProvisioningContext.get -> Azure.Provisioning.ProvisioningBuildOptions!
+Aspire.Hosting.Azure.AzureProvisioningOptions.ProvisioningBuildOptions.get -> Azure.Provisioning.ProvisioningBuildOptions!
 Aspire.Hosting.Azure.AzureProvisioningResource.AzureProvisioningResource(string! name, System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>! configureInfrastructure) -> void
 Aspire.Hosting.Azure.AzureProvisioningResource.ConfigureInfrastructure.get -> System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>!
 Aspire.Hosting.Azure.AzureProvisioningResource
-Aspire.Hosting.Azure.AzureProvisioningResource.ProvisioningContext.get -> Azure.Provisioning.ProvisioningBuildOptions?
-Aspire.Hosting.Azure.AzureProvisioningResource.ProvisioningContext.set -> void
+Aspire.Hosting.Azure.AzureProvisioningResource.ProvisioningBuildOptions.get -> Azure.Provisioning.ProvisioningBuildOptions?
+Aspire.Hosting.Azure.AzureProvisioningResource.ProvisioningBuildOptions.set -> void
 Aspire.Hosting.Azure.AzureResourceInfrastructure
 Aspire.Hosting.Azure.AzureResourceInfrastructure.AspireResource.get -> Aspire.Hosting.Azure.AzureProvisioningResource!
 Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig
 Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(System.Collections.Generic.IDictionary<string!, object!>! target, string! connectionName) -> void
 Aspire.Hosting.AzureProvisioningResourceExtensions
-override Aspire.Hosting.Azure.AspireV8ResourceNamePropertyResolver.ResolveName(Azure.Provisioning.ProvisioningBuildOptions! context, Azure.Provisioning.Primitives.ProvisionableResource! resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements) -> Azure.Provisioning.BicepValue<string!>?
+override Aspire.Hosting.Azure.AspireV8ResourceNamePropertyResolver.ResolveName(Azure.Provisioning.ProvisioningBuildOptions! options, Azure.Provisioning.Primitives.ProvisionableResource! resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements) -> Azure.Provisioning.BicepValue<string!>?
 override Aspire.Hosting.Azure.AzureProvisioningResource.GetBicepTemplateFile(string? directory = null, bool deleteTemporaryFileOnDispose = true) -> Aspire.Hosting.Azure.BicepTemplateFile
 override Aspire.Hosting.Azure.AzureProvisioningResource.GetBicepTemplateString() -> string!
 static Aspire.Hosting.AzureBicepResourceExtensions.WithParameter<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, string! name, Aspire.Hosting.ApplicationModel.EndpointReference! value) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!

--- a/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure/PublicAPI.Unshipped.txt
@@ -17,18 +17,18 @@ Aspire.Hosting.Azure.AspireV8ResourceNamePropertyResolver
 Aspire.Hosting.Azure.AspireV8ResourceNamePropertyResolver.AspireV8ResourceNamePropertyResolver() -> void
 Aspire.Hosting.Azure.AzureProvisioningOptions
 Aspire.Hosting.Azure.AzureProvisioningOptions.AzureProvisioningOptions() -> void
-Aspire.Hosting.Azure.AzureProvisioningOptions.ProvisioningContext.get -> Azure.Provisioning.ProvisioningContext!
+Aspire.Hosting.Azure.AzureProvisioningOptions.ProvisioningContext.get -> Azure.Provisioning.ProvisioningBuildOptions!
 Aspire.Hosting.Azure.AzureProvisioningResource.AzureProvisioningResource(string! name, System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>! configureInfrastructure) -> void
 Aspire.Hosting.Azure.AzureProvisioningResource.ConfigureInfrastructure.get -> System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>!
 Aspire.Hosting.Azure.AzureProvisioningResource
-Aspire.Hosting.Azure.AzureProvisioningResource.ProvisioningContext.get -> Azure.Provisioning.ProvisioningContext?
+Aspire.Hosting.Azure.AzureProvisioningResource.ProvisioningContext.get -> Azure.Provisioning.ProvisioningBuildOptions?
 Aspire.Hosting.Azure.AzureProvisioningResource.ProvisioningContext.set -> void
 Aspire.Hosting.Azure.AzureResourceInfrastructure
 Aspire.Hosting.Azure.AzureResourceInfrastructure.AspireResource.get -> Aspire.Hosting.Azure.AzureProvisioningResource!
 Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig
 Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig.ApplyAzureFunctionsConfiguration(System.Collections.Generic.IDictionary<string!, object!>! target, string! connectionName) -> void
 Aspire.Hosting.AzureProvisioningResourceExtensions
-override Aspire.Hosting.Azure.AspireV8ResourceNamePropertyResolver.ResolveName(Azure.Provisioning.ProvisioningContext! context, Azure.Provisioning.Primitives.Resource! resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements) -> Azure.Provisioning.BicepValue<string!>?
+override Aspire.Hosting.Azure.AspireV8ResourceNamePropertyResolver.ResolveName(Azure.Provisioning.ProvisioningBuildOptions! context, Azure.Provisioning.Primitives.ProvisionableResource! resource, Azure.Provisioning.Primitives.ResourceNameRequirements requirements) -> Azure.Provisioning.BicepValue<string!>?
 override Aspire.Hosting.Azure.AzureProvisioningResource.GetBicepTemplateFile(string? directory = null, bool deleteTemporaryFileOnDispose = true) -> Aspire.Hosting.Azure.BicepTemplateFile
 override Aspire.Hosting.Azure.AzureProvisioningResource.GetBicepTemplateString() -> string!
 static Aspire.Hosting.AzureBicepResourceExtensions.WithParameter<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>! builder, string! name, Aspire.Hosting.ApplicationModel.EndpointReference! value) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T!>!

--- a/src/Aspire.Hosting.Azure/Utils/BicepIdentifierHelpers.cs
+++ b/src/Aspire.Hosting.Azure/Utils/BicepIdentifierHelpers.cs
@@ -10,7 +10,7 @@ internal static class BicepIdentifierHelpers
 {
     internal static string ThrowIfInvalid(string name, [CallerArgumentExpression(nameof(name))] string? paramName = null)
     {
-        Infrastructure.ValidateIdentifierName(name, paramName);
+        Infrastructure.ValidateBicepIdentifier(name, paramName);
         return name;
     }
 }

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -246,7 +246,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var cosmos = builder.AddAzureCosmosDB("cosmos")
             .ConfigureInfrastructure(infrastructure =>
             {
-                callbackDatabases = infrastructure.GetResources().OfType<CosmosDBSqlDatabase>();
+                callbackDatabases = infrastructure.GetProvisionableResources().OfType<CosmosDBSqlDatabase>();
             });
         cosmos.AddDatabase("mydatabase");
 
@@ -340,7 +340,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var cosmos = builder.AddAzureCosmosDB("cosmos")
             .ConfigureInfrastructure(infrastructure =>
             {
-                callbackDatabases = infrastructure.GetResources().OfType<CosmosDBSqlDatabase>();
+                callbackDatabases = infrastructure.GetProvisionableResources().OfType<CosmosDBSqlDatabase>();
             });
         cosmos.AddDatabase("mydatabase");
 
@@ -774,8 +774,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var manifest = await ManifestUtils.GetManifest(infrastructure1.Resource);
 
         Assert.NotNull(moduleInfrastructure);
-        var infrastructureParameters = moduleInfrastructure.GetParameters().DistinctBy(x => x.IdentifierName);
-        var infrastructureParametersLookup = infrastructureParameters.ToDictionary(p => p.IdentifierName);
+        var infrastructureParameters = moduleInfrastructure.GetParameters().DistinctBy(x => x.BicepIdentifier);
+        var infrastructureParametersLookup = infrastructureParameters.ToDictionary(p => p.BicepIdentifier);
         Assert.True(infrastructureParametersLookup.ContainsKey("skuName"));
 
         var expectedManifest = """
@@ -813,8 +813,8 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var manifest = await ManifestUtils.GetManifest(infrastructure1.Resource);
 
         Assert.NotNull(moduleInfrastructure);
-        var infrastructureParameters = moduleInfrastructure.GetParameters().DistinctBy(x => x.IdentifierName);
-        var infrastructureParametersLookup = infrastructureParameters.ToDictionary(p => p.IdentifierName);
+        var infrastructureParameters = moduleInfrastructure.GetParameters().DistinctBy(x => x.BicepIdentifier);
+        var infrastructureParametersLookup = infrastructureParameters.ToDictionary(p => p.BicepIdentifier);
         Assert.True(infrastructureParametersLookup.ContainsKey("sku"));
 
         var expectedManifest = """
@@ -1879,7 +1879,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var storage = builder.AddAzureStorage("storage")
             .ConfigureInfrastructure(infrastructure =>
             {
-                var sa = infrastructure.GetResources().OfType<StorageAccount>().Single();
+                var sa = infrastructure.GetProvisionableResources().OfType<StorageAccount>().Single();
                 sa.Sku = new StorageSku()
                 {
                     Name = storagesku.AsProvisioningParameter(infrastructure)
@@ -2037,7 +2037,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var storage = builder.AddAzureStorage("storage")
             .ConfigureInfrastructure(infrastructure =>
             {
-                var sa = infrastructure.GetResources().OfType<StorageAccount>().Single();
+                var sa = infrastructure.GetProvisionableResources().OfType<StorageAccount>().Single();
                 sa.Sku = new StorageSku()
                 {
                     Name = storagesku.AsProvisioningParameter(infrastructure)
@@ -2196,7 +2196,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var storage = builder.AddAzureStorage("storage")
             .ConfigureInfrastructure(infrastructure =>
             {
-                var sa = infrastructure.GetResources().OfType<StorageAccount>().Single();
+                var sa = infrastructure.GetProvisionableResources().OfType<StorageAccount>().Single();
                 sa.Sku = new StorageSku()
                 {
                     Name = storagesku.AsProvisioningParameter(infrastructure)
@@ -2354,7 +2354,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var storage = builder.AddAzureStorage("storage")
             .ConfigureInfrastructure(infrastructure =>
             {
-                var sa = infrastructure.GetResources().OfType<StorageAccount>().Single();
+                var sa = infrastructure.GetProvisionableResources().OfType<StorageAccount>().Single();
                 sa.Sku = new StorageSku()
                 {
                     Name = storagesku.AsProvisioningParameter(infrastructure)
@@ -2514,7 +2514,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var search = builder.AddAzureSearch("search")
             .ConfigureInfrastructure(infrastructure =>
             {
-                var search = infrastructure.GetResources().OfType<SearchService>().Single();
+                var search = infrastructure.GetProvisionableResources().OfType<SearchService>().Single();
                 search.SearchSkuName = sku.AsProvisioningParameter(infrastructure);
             });
 
@@ -2636,11 +2636,11 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         var openai = builder.AddAzureOpenAI("openai")
             .ConfigureInfrastructure(infrastructure =>
             {
-                aiDeployments = infrastructure.GetResources().OfType<CognitiveServicesAccountDeployment>();
+                aiDeployments = infrastructure.GetProvisionableResources().OfType<CognitiveServicesAccountDeployment>();
 
                 if (overrideLocalAuthDefault)
                 {
-                    var account = infrastructure.GetResources().OfType<CognitiveServicesAccount>().Single();
+                    var account = infrastructure.GetProvisionableResources().OfType<CognitiveServicesAccount>().Single();
                     account.Properties.Value!.DisableLocalAuth = false;
                 }
             })
@@ -2781,7 +2781,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         })
         .ConfigureInfrastructure(r =>
         {
-            var vault = r.GetResources().OfType<KeyVaultService>().Single();
+            var vault = r.GetProvisionableResources().OfType<KeyVaultService>().Single();
             Assert.NotNull(vault);
 
             r.Add(new ProvisioningOutput("vaultUri", typeof(string))
@@ -2789,7 +2789,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 Value =
                     new MemberExpression(
                         new MemberExpression(
-                            new IdentifierExpression(vault.IdentifierName),
+                            new IdentifierExpression(vault.BicepIdentifier),
                             "properties"),
                         "vaultUri")
                 // TODO: this should be
@@ -2798,7 +2798,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
         })
         .ConfigureInfrastructure(r =>
         {
-            var vault = r.GetResources().OfType<KeyVaultService>().Single();
+            var vault = r.GetProvisionableResources().OfType<KeyVaultService>().Single();
             Assert.NotNull(vault);
 
             r.Add(new KeyVaultSecret("secret")

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -2641,7 +2641,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
                 if (overrideLocalAuthDefault)
                 {
                     var account = infrastructure.GetProvisionableResources().OfType<CognitiveServicesAccount>().Single();
-                    account.Properties.Value!.DisableLocalAuth = false;
+                    account.Properties.DisableLocalAuth = false;
                 }
             })
             .AddDeployment(new("mymodel", "gpt-35-turbo", "0613", "Basic", 4))
@@ -2786,14 +2786,7 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
 
             r.Add(new ProvisioningOutput("vaultUri", typeof(string))
             {
-                Value =
-                    new MemberExpression(
-                        new MemberExpression(
-                            new IdentifierExpression(vault.BicepIdentifier),
-                            "properties"),
-                        "vaultUri")
-                // TODO: this should be
-                //Value = keyVault.VaultUri
+                Value = vault.Properties.VaultUri
             });
         })
         .ConfigureInfrastructure(r =>

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -651,7 +651,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         builder.AddContainer("api", "myimage")
             .PublishAsAzureContainerApp((module, c) =>
             {
-                Assert.Contains(c, module.GetResources());
+                Assert.Contains(c, module.GetProvisionableResources());
 
                 c.Template.Value!.Scale.Value!.MinReplicas = 0;
             });

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -257,8 +257,8 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
                        Value = value.AsProvisioningParameter(module)
                    };
 
-                   c.Template.Value!.Containers[0].Value!.Env.Add(val);
-                   c.Template.Value!.Scale.Value!.MinReplicas = minReplicas.AsProvisioningParameter(module);
+                   c.Template.Containers[0].Value!.Env.Add(val);
+                   c.Template.Scale.MinReplicas = minReplicas.AsProvisioningParameter(module);
                });
 
         using var app = builder.Build();
@@ -653,7 +653,7 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
             {
                 Assert.Contains(c, module.GetProvisionableResources());
 
-                c.Template.Value!.Scale.Value!.MinReplicas = 0;
+                c.Template.Scale.MinReplicas = 0;
             });
 
         using var app = builder.Build();

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -6,7 +6,9 @@
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
+using Azure.Provisioning;
 using Azure.Provisioning.AppContainers;
+using Azure.Provisioning.Primitives;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using Xunit.Abstractions;
@@ -1163,6 +1165,94 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
         """;
         output.WriteLine(bicep);
         Assert.Equal(expectedBicep, bicep);
+    }
+
+    [Fact]
+    public async Task CanCustomizeWithProvisioningBuildOptions()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.Services.Configure<AzureProvisioningOptions>(options => options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new MyResourceNamePropertyResolver()));
+        builder.AddAzureContainerAppsInfrastructure();
+
+        builder.AddContainer("api1", "myimage");
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var container = Assert.Single(model.GetContainerResources());
+
+        container.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (_, bicep) = await ManifestUtils.GetManifestWithBicep(resource);
+
+        var expectedBicep =
+        """
+        @description('The location for the resource(s) to be deployed.')
+        param location string = resourceGroup().location
+
+        param outputs_azure_container_registry_managed_identity_id string
+
+        param outputs_managed_identity_client_id string
+
+        param outputs_azure_container_apps_environment_id string
+
+        resource api1 'Microsoft.App/containerApps@2024-03-01' = {
+          name: 'api1-my'
+          location: location
+          properties: {
+            configuration: {
+              activeRevisionsMode: 'Single'
+            }
+            environmentId: outputs_azure_container_apps_environment_id
+            template: {
+              containers: [
+                {
+                  image: 'myimage:latest'
+                  name: 'api1'
+                  env: [
+                    {
+                      name: 'AZURE_CLIENT_ID'
+                      value: outputs_managed_identity_client_id
+                    }
+                  ]
+                }
+              ]
+              scale: {
+                minReplicas: 1
+              }
+            }
+          }
+          identity: {
+            type: 'UserAssigned'
+            userAssignedIdentities: {
+              '${outputs_azure_container_registry_managed_identity_id}': { }
+            }
+          }
+        }
+        """;
+        output.WriteLine(bicep);
+        Assert.Equal(expectedBicep, bicep);
+    }
+
+    private sealed class MyResourceNamePropertyResolver : DynamicResourceNamePropertyResolver
+    {
+        public override void ResolveProperties(ProvisionableConstruct construct, ProvisioningBuildOptions options)
+        {
+            if (construct is ContainerApp app)
+            {
+                app.Name = app.Name.Value + "-my";
+            }
+
+            base.ResolveProperties(construct, options);
+        }
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -116,7 +116,6 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
                 }
                 enableNonSslPort: false
                 minimumTlsVersion: '1.2'
-                redisConfiguration: { }
               }
               tags: {
                 'aspire-resource-name': 'redis-cache'

--- a/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureRedisExtensionsTests.cs
@@ -50,11 +50,11 @@ public class AzureRedisExtensionsTests(ITestOutputHelper output)
                   capacity: 1
                 }
                 enableNonSslPort: false
+                disableAccessKeyAuthentication: true
                 minimumTlsVersion: '1.2'
                 redisConfiguration: {
                   'aad-enabled': 'true'
                 }
-                disableAccessKeyAuthentication: 'true'
               }
               tags: {
                 'aspire-resource-name': 'redis-cache'

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -31,6 +32,11 @@ public class AzureResourceOptionsTests(ITestOutputHelper output)
             });
 
             var serviceBus = builder.AddAzureServiceBus("sb");
+
+            // ensure that resources with a hyphen still have a hyphen in the bicep name
+            var sqlDatabase = builder.AddAzureSqlServer("sql-server")
+                .RunAsContainer(x => x.WithLifetime(ContainerLifetime.Persistent))
+                .AddDatabase("evadexdb");
 
             using var app = builder.Build();
             await app.StartAsync();
@@ -72,6 +78,56 @@ public class AzureResourceOptionsTests(ITestOutputHelper output)
                 }
 
                 output serviceBusEndpoint string = sb.properties.serviceBusEndpoint
+                """;
+            output.WriteLine(actualBicep);
+            Assert.Equal(expectedBicep, actualBicep);
+
+            actualBicep = await File.ReadAllTextAsync(Path.Combine(tempDir.FullName, "sql-server.module.bicep"));
+
+            expectedBicep = """
+                @description('The location for the resource(s) to be deployed.')
+                param location string = resourceGroup().location
+
+                param principalId string
+
+                param principalName string
+
+                resource sql_server 'Microsoft.Sql/servers@2021-11-01' = {
+                  name: toLower(take('sql-server${uniqueString(resourceGroup().id)}', 24))
+                  location: location
+                  properties: {
+                    administrators: {
+                      administratorType: 'ActiveDirectory'
+                      login: principalName
+                      sid: principalId
+                      tenantId: subscription().tenantId
+                      azureADOnlyAuthentication: true
+                    }
+                    minimalTlsVersion: '1.2'
+                    publicNetworkAccess: 'Enabled'
+                    version: '12.0'
+                  }
+                  tags: {
+                    'aspire-resource-name': 'sql-server'
+                  }
+                }
+
+                resource sqlFirewallRule_AllowAllAzureIps 'Microsoft.Sql/servers/firewallRules@2021-11-01' = {
+                  name: 'AllowAllAzureIps'
+                  properties: {
+                    endIpAddress: '0.0.0.0'
+                    startIpAddress: '0.0.0.0'
+                  }
+                  parent: sql_server
+                }
+
+                resource evadexdb 'Microsoft.Sql/servers/databases@2021-11-01' = {
+                  name: 'evadexdb'
+                  location: location
+                  parent: sql_server
+                }
+
+                output sqlServerFqdn string = sql_server.properties.fullyQualifiedDomainName
                 """;
             output.WriteLine(actualBicep);
             Assert.Equal(expectedBicep, actualBicep);

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
@@ -27,7 +27,7 @@ public class AzureResourceOptionsTests(ITestOutputHelper output)
         {
             builder.Services.Configure<AzureProvisioningOptions>(options =>
             {
-                options.ProvisioningContext.PropertyResolvers.Insert(0, new AspireV8ResourceNamePropertyResolver());
+                options.ProvisioningContext.InfrastructureResolvers.Insert(0, new AspireV8ResourceNamePropertyResolver());
             });
 
             var serviceBus = builder.AddAzureServiceBus("sb");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureResourceOptionsTests.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.Azure.Tests;
 public class AzureResourceOptionsTests(ITestOutputHelper output)
 {
     /// <summary>
-    /// Ensures that an AzureProvisioningOptions can be configured to modify the ProvisioningContext
+    /// Ensures that an AzureProvisioningOptions can be configured to modify the ProvisioningBuildOptions
     /// used when building the bicep for an Azure resource.
     ///
     /// This uses the .NET Aspire v8.x naming policy, which always calls toLower, appends a unique string with no separator,
@@ -27,7 +27,7 @@ public class AzureResourceOptionsTests(ITestOutputHelper output)
         {
             builder.Services.Configure<AzureProvisioningOptions>(options =>
             {
-                options.ProvisioningContext.InfrastructureResolvers.Insert(0, new AspireV8ResourceNamePropertyResolver());
+                options.ProvisioningBuildOptions.InfrastructureResolvers.Insert(0, new AspireV8ResourceNamePropertyResolver());
             });
 
             var serviceBus = builder.AddAzureServiceBus("sb");

--- a/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
@@ -29,7 +29,7 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         WebPubSubHub? realHub = null;
         var wps = builder.AddAzureWebPubSub("wps1").ConfigureInfrastructure(infrastructure =>
         {
-            realHub = infrastructure.GetResources().OfType<WebPubSubHub>().Single();
+            realHub = infrastructure.GetProvisionableResources().OfType<WebPubSubHub>().Single();
         });
         var hubName = "a-b-c";
         var hub = wps.AddHub(hubName);
@@ -38,7 +38,7 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         var manifest = await ManifestUtils.GetManifestWithBicep(wps.Resource);
         Assert.NotNull(realHub);
         Assert.Equal(hubName, realHub.Name.Value);
-        Assert.Equal("a_b_c", realHub.IdentifierName);
+        Assert.Equal("a_b_c", realHub.BicepIdentifier);
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         var hubName = "abc";
         var wps = builder.AddAzureWebPubSub("wps1").ConfigureInfrastructure(infrastructure =>
         {
-            var hub = infrastructure.GetResources().OfType<WebPubSubHub>().First(i => i.IdentifierName == hubName);
+            var hub = infrastructure.GetProvisionableResources().OfType<WebPubSubHub>().First(i => i.BicepIdentifier == hubName);
             hub.Properties.Value!.AnonymousConnectPolicy = "allow";
         });
         wps.AddHub(hubName);
@@ -280,7 +280,7 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         var serviceA = builder.AddProject<ProjectA>("serviceA", o => o.ExcludeLaunchProfile = true).WithHttpsEndpoint();
         var wps = builder.AddAzureWebPubSub("wps1").ConfigureInfrastructure(infrastructure =>
         {
-            var hub = infrastructure.GetResources().OfType<WebPubSubHub>().First(i => string.Equals(i.IdentifierName, "abc", StringComparison.OrdinalIgnoreCase));
+            var hub = infrastructure.GetProvisionableResources().OfType<WebPubSubHub>().First(i => string.Equals(i.BicepIdentifier, "abc", StringComparison.OrdinalIgnoreCase));
             hub.Properties.Value!.EventHandlers.Add(new WebPubSubEventHandler() { UrlTemplate = "http://fake.com" });
         });
         wps.AddHub("ABC").AddEventHandler($"http://fake1.com");
@@ -358,7 +358,7 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         var url1 = "fake3.com";
         var wps = builder.AddAzureWebPubSub("wps1").ConfigureInfrastructure(infrastructure =>
         {
-            var hub = infrastructure.GetResources().OfType<WebPubSubHub>().First(i => i.IdentifierName == "hub1");
+            var hub = infrastructure.GetProvisionableResources().OfType<WebPubSubHub>().First(i => i.BicepIdentifier == "hub1");
             hub.Properties.Value!.AnonymousConnectPolicy = "allow";
             // allow directly event handler set
             hub.Properties.Value!.EventHandlers.Add(new WebPubSubEventHandler() { UrlTemplate = "http://fake1.com" });

--- a/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureWebPubSubExtensionsTests.cs
@@ -74,9 +74,9 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
             param sku string = 'Free_F1'
 
             param capacity int = 1
-            
+
             param principalId string
-            
+
             param principalType string
 
             resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
@@ -103,7 +103,6 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
 
             resource abc 'Microsoft.SignalRService/webPubSub/hubs@2024-03-01' = {
               name: 'abc'
-              properties: { }
               parent: wps1
             }
 
@@ -120,7 +119,7 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         var wps = builder.AddAzureWebPubSub("wps1").ConfigureInfrastructure(infrastructure =>
         {
             var hub = infrastructure.GetProvisionableResources().OfType<WebPubSubHub>().First(i => i.BicepIdentifier == hubName);
-            hub.Properties.Value!.AnonymousConnectPolicy = "allow";
+            hub.Properties.AnonymousConnectPolicy = "allow";
         });
         wps.AddHub(hubName);
 
@@ -150,9 +149,9 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
             param sku string = 'Free_F1'
 
             param capacity int = 1
-            
+
             param principalId string
-            
+
             param principalType string
 
             resource wps1 'Microsoft.SignalRService/webPubSub@2024-03-01' = {
@@ -281,7 +280,7 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         var wps = builder.AddAzureWebPubSub("wps1").ConfigureInfrastructure(infrastructure =>
         {
             var hub = infrastructure.GetProvisionableResources().OfType<WebPubSubHub>().First(i => string.Equals(i.BicepIdentifier, "abc", StringComparison.OrdinalIgnoreCase));
-            hub.Properties.Value!.EventHandlers.Add(new WebPubSubEventHandler() { UrlTemplate = "http://fake.com" });
+            hub.Properties.EventHandlers.Add(new WebPubSubEventHandler() { UrlTemplate = "http://fake.com" });
         });
         wps.AddHub("ABC").AddEventHandler($"http://fake1.com");
         // Hub name is case insensitive
@@ -359,9 +358,9 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
         var wps = builder.AddAzureWebPubSub("wps1").ConfigureInfrastructure(infrastructure =>
         {
             var hub = infrastructure.GetProvisionableResources().OfType<WebPubSubHub>().First(i => i.BicepIdentifier == "hub1");
-            hub.Properties.Value!.AnonymousConnectPolicy = "allow";
+            hub.Properties.AnonymousConnectPolicy = "allow";
             // allow directly event handler set
-            hub.Properties.Value!.EventHandlers.Add(new WebPubSubEventHandler() { UrlTemplate = "http://fake1.com" });
+            hub.Properties.EventHandlers.Add(new WebPubSubEventHandler() { UrlTemplate = "http://fake1.com" });
         });
         // allow event handler set using a separate call
         // allow mulitple calls, and order matters
@@ -448,7 +447,6 @@ public class AzureWebPubSubExtensionsTests(ITestOutputHelper output)
                   {
                     urlTemplate: 'http://fake2.com'
                     userEventPattern: 'event1'
-                    auth: { }
                   }
                   {
                     urlTemplate: 'http://fake3.com'

--- a/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
+++ b/tests/Aspire.Hosting.Tests/Schema/SchemaTests.cs
@@ -146,7 +146,7 @@ public class SchemaTests
                         builder.AddProject<Projects.ServiceA>("project")
                                .PublishAsAzureContainerApp((infrastructure, app) =>
                                {
-                                   app.Template.Value!.Scale.Value!.MinReplicas = minReplicas.AsProvisioningParameter(infrastructure);
+                                   app.Template.Scale.MinReplicas = minReplicas.AsProvisioningParameter(infrastructure);
                                });
 
                     }
@@ -167,7 +167,7 @@ public class SchemaTests
                         builder.AddContainer("mycontainer", "myimage")
                                .PublishAsAzureContainerApp((infrastructure, app) =>
                                {
-                                   app.Template.Value!.Scale.Value!.MinReplicas = minReplicas.AsProvisioningParameter(infrastructure);
+                                   app.Template.Scale.MinReplicas = minReplicas.AsProvisioningParameter(infrastructure);
                                });
 
                     }

--- a/tests/Shared/WorkloadTesting/data/nuget8.config
+++ b/tests/Shared/WorkloadTesting/data/nuget8.config
@@ -10,7 +10,6 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
-    <add key="azure-sdk-devfeed" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/tests/Shared/WorkloadTesting/data/nuget8.config
+++ b/tests/Shared/WorkloadTesting/data/nuget8.config
@@ -10,6 +10,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+    <add key="azure-sdk-devfeed" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/tests/Shared/nuget-with-package-source-mapping.config
+++ b/tests/Shared/nuget-with-package-source-mapping.config
@@ -10,7 +10,6 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
-    <add key="azure-sdk-devfeed" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="built-local">
@@ -25,9 +24,6 @@
     </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="*" />
-    </packageSource>
-    <packageSource key="azure-sdk-devfeed">
-      <package pattern="Azure.*" />
     </packageSource>
   </packageSourceMapping>
   <disabledPackageSources>

--- a/tests/Shared/nuget-with-package-source-mapping.config
+++ b/tests/Shared/nuget-with-package-source-mapping.config
@@ -10,6 +10,7 @@
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+    <add key="azure-sdk-devfeed" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
     <packageSource key="built-local">
@@ -24,6 +25,9 @@
     </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="*" />
+    </packageSource>
+    <packageSource key="azure-sdk-devfeed">
+      <package pattern="Azure.*" />
     </packageSource>
   </packageSourceMapping>
   <disabledPackageSources>


### PR DESCRIPTION
## Description

Respond to latest renames getting the API ready for GA release.

Fix https://github.com/dotnet/aspire/issues/6376

I'll use this PR until we get stable versions from @tg-msft.

Also fix an issue when using dashes `-` in resource names and using `AspireV8ResourceNamePropertyResolver`. We are prematurely converting the dash to an underscore, and the Azure resource name is not the same as it was in v8. This needs to be fixed together because the APIs we need to fix the issue are being made public in this new Azure.Provisioning version.

Fix #6474

## Checklist

- Is this feature complete?
  - [x] No. Follow-up changes expected. Still need stable versions plus more changes.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Link to aspire-docs issue: https://github.com/dotnet/docs-aspire/issues/1652

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6390)