### PR TITLE
Fix spans not hidden on expand/collapse

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -261,7 +261,7 @@ public partial class TraceDetail : ComponentBase
 
     public SpanDetailsViewModel? SelectedSpan { get; set; }
 
-    private void OnToggleCollapse(SpanWaterfallViewModel viewModel)
+    private async Task OnToggleCollapse(SpanWaterfallViewModel viewModel)
     {
         // View model data is recreated if the trace updates.
         // Persist the collapsed state in a separate list.
@@ -275,6 +275,8 @@ public partial class TraceDetail : ComponentBase
             viewModel.IsCollapsed = true;
             _collapsedSpanIds.Add(viewModel.Span.SpanId);
         }
+
+        await _dataGrid.SafeRefreshDataAsync();
     }
 
     private async Task OnShowPropertiesAsync(SpanWaterfallViewModel viewModel, string? buttonId)


### PR DESCRIPTION
## Description

A FluentUI update changed how data grids are refreshed. The required change to hadn't this wasn't added for expanding/collapsing spans on trace details and it was broken.

Fixes https://github.com/dotnet/aspire/issues/6393

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6394)