### PR TITLE
[ci] Don't run tests on internal pipeline builds

### DIFF
--- a/eng/pipelines/templates/BuildAndTest.yml
+++ b/eng/pipelines/templates/BuildAndTest.yml
@@ -21,7 +21,7 @@ parameters:
     default: false
 
 steps:
-  # Internal pipeline: Build with pack+sign+archive
+  # Internal pipeline: Build with pack+sign
   - ${{ if ne(parameters.runAsPublic, 'true') }}:
     - script: ${{ parameters.buildScript }}
               -restore -build
@@ -29,7 +29,6 @@ steps:
               -sign $(_SignArgs)
               -publish $(_PublishArgs)
               -configuration ${{ parameters.buildConfig }}
-              /p:ArchiveTests=true
               /bl:${{ parameters.repoLogPath }}/build.binlog
               $(_OfficialBuildIdArgs)
               $(_InternalBuildArgs)
@@ -46,7 +45,9 @@ steps:
               $(_OfficialBuildIdArgs)
       displayName: Build
 
-  - ${{ if or(ne(parameters.runAsPublic, 'true'), ne(parameters.runHelixTests, 'true')) }}:
+  # Non-helix tests are run only on the public pipeline
+  - ${{ if and(eq(parameters.runAsPublic, 'true'), ne(parameters.runHelixTests, 'true')) }}:
+    # non-helix tests
     - ${{ if ne(parameters.isWindows, 'true') }}:
       - script: mkdir ${{ parameters.repoArtifactsPath }}/devcert-scripts &&
                 cd ${{ parameters.repoArtifactsPath }}/devcert-scripts &&
@@ -73,7 +74,8 @@ steps:
 
       displayName: Run non-helix tests
 
-  - ${{ if or(ne(parameters.runAsPublic, 'true'), eq(parameters.runHelixTests, 'true')) }}:
+  # Helix tests are run only on the public pipeline
+  - ${{ if and(eq(parameters.runAsPublic, 'true'), eq(parameters.runHelixTests, 'true')) }}:
     - script: ${{ parameters.buildScript }}
               /p:Configuration=${{ parameters.buildConfig }}
               $(_OfficialBuildIdArgs)
@@ -117,24 +119,18 @@ steps:
       continueOnError: true
       condition: always()
 
-  - task: CopyFiles@2
-    inputs:
-      Contents: '${{ parameters.repoArtifactsPath }}/**/*.cobertura.xml'
-      TargetFolder: '${{ parameters.repoArtifactsPath }}/CodeCoverage'
-      flattenFolders: true
-    displayName: Gather code coverage results
-
+  # Code coverage - only on public pipelines
   - ${{ if eq(parameters.runAsPublic, 'true') }}:
+    - task: CopyFiles@2
+      inputs:
+        Contents: '${{ parameters.repoArtifactsPath }}/**/*.cobertura.xml'
+        TargetFolder: '${{ parameters.repoArtifactsPath }}/CodeCoverage'
+        flattenFolders: true
+      displayName: Gather code coverage results
+
     - task: PublishPipelineArtifact@1
       displayName: Publish coverage results (cobertura.xml)
       inputs:
         targetPath: '${{ parameters.repoArtifactsPath }}/CodeCoverage'
         artifactName: '$(Agent.JobName)_CodeCoverageResults'
         publishLocation: 'pipeline'
-
-  - ${{ if ne(parameters.runAsPublic, 'true') }}:
-    - task: 1ES.PublishPipelineArtifact@1
-      displayName: Publish code coverage results
-      inputs:
-        targetPath: '${{ parameters.repoArtifactsPath }}/CodeCoverage'
-        artifactName: '$(Agent.JobName)_CodeCoverageResults'


### PR DESCRIPTION
## Description

Tests for `main` are run on the public pipeline, and are not needed for the internal one where we essentially build the packages to be published.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6413)