### PR TITLE
Make RedisInsight work with WithLifetime(...).

### DIFF
--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Redis;
 using Aspire.Hosting.Utils;
@@ -192,20 +194,50 @@ public static class RedisBuilderExtensions
             return builder;
         }
 
-        static async Task ImportRedisDatabases(ILogger resourceLogger, IEnumerable<RedisResource> redisInstances, HttpClient client, CancellationToken ct)
+        static async Task ImportRedisDatabases(ILogger resourceLogger, IEnumerable<RedisResource> redisInstances, HttpClient client, CancellationToken cancellationToken)
         {
+            var databasesPath = "/api/databases";
+
+            var pipeline = new ResiliencePipelineBuilder().AddRetry(new Polly.Retry.RetryStrategyOptions
+            {
+                Delay = TimeSpan.FromSeconds(2),
+                MaxRetryAttempts = 5,
+            }).Build();
+
             using (var stream = new MemoryStream())
             {
+                // As part of configuring RedisInsight we need to factor in the possibility that the
+                // container resource is being run with persistence turned on. In this case we need
+                // to get the list of existing databases because we might need to delete some.
+                var lookup = await pipeline.ExecuteAsync(async (ctx) =>
+                {
+                    var getDatabasesResponse = await client.GetFromJsonAsync<RedisDatabaseDto[]>(databasesPath, cancellationToken).ConfigureAwait(false);
+                    return getDatabasesResponse?.ToLookup(
+                        i => i.Name ?? throw new InvalidDataException("Database name is missing."),
+                        i => i.Id ?? throw new InvalidDataException("Database ID is missing."));
+                }, cancellationToken).ConfigureAwait(false);
+
+                var databasesToDelete = new List<Guid>();
+
                 using var writer = new Utf8JsonWriter(stream);
 
                 writer.WriteStartArray();
 
                 foreach (var redisResource in redisInstances)
                 {
+                    if (lookup is { } && lookup.Contains(redisResource.Name))
+                    {
+                        // It is possible that there are multiple databases with
+                        // a conflicting name so we delete them all. This just keeps
+                        // track of the specific ID that we need to delete.
+                        databasesToDelete.AddRange(lookup[redisResource.Name]);
+                    }
+
                     if (redisResource.PrimaryEndpoint.IsAllocated)
                     {
                         var endpoint = redisResource.PrimaryEndpoint;
                         writer.WriteStartObject();
+
                         writer.WriteString("host", redisResource.Name);
                         writer.WriteNumber("port", endpoint.TargetPort!.Value);
                         writer.WriteString("name", redisResource.Name);
@@ -218,7 +250,7 @@ public static class RedisBuilderExtensions
                     }
                 }
                 writer.WriteEndArray();
-                await writer.FlushAsync(ct).ConfigureAwait(false);
+                await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
                 stream.Seek(0, SeekOrigin.Begin);
 
                 var content = new MultipartFormDataContent();
@@ -227,23 +259,36 @@ public static class RedisBuilderExtensions
 
                 content.Add(fileContent, "file", "RedisInsight_connections.json");
 
-                var apiUrl = $"/api/databases/import";
-
-                var pipeline = new ResiliencePipelineBuilder().AddRetry(new Polly.Retry.RetryStrategyOptions
-                {
-                    Delay = TimeSpan.FromSeconds(2),
-                    MaxRetryAttempts = 5,
-                }).Build();
+                var apiUrl = $"{databasesPath}/import";
 
                 try
                 {
+                    await pipeline.ExecuteAsync(async (ctx) =>
+                    {
+                        // Create a DELETE request to send to the existing instance of
+                        // RedisInsight with the IDs of the database to delete.
+                        var deleteContent = JsonContent.Create(new
+                        {
+                            ids = databasesToDelete
+                        });
+
+                        var deleteRequest = new HttpRequestMessage(HttpMethod.Delete, databasesPath)
+                        {
+                            Content = deleteContent
+                        };
+
+                        var deleteResponse = await client.SendAsync(deleteRequest, cancellationToken).ConfigureAwait(false);
+                        deleteResponse.EnsureSuccessStatusCode();
+
+                    }, cancellationToken).ConfigureAwait(false);
+
                     await pipeline.ExecuteAsync(async (ctx) =>
                     {
                         var response = await client.PostAsync(apiUrl, content, ctx)
                         .ConfigureAwait(false);
 
                         response.EnsureSuccessStatusCode();
-                    }, ct).ConfigureAwait(false);
+                    }, cancellationToken).ConfigureAwait(false);
 
                 }
                 catch (Exception ex)
@@ -252,6 +297,15 @@ public static class RedisBuilderExtensions
                 }
             };
         }
+    }
+
+    private class RedisDatabaseDto
+    {
+        [JsonPropertyName("id")]
+        public Guid? Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -263,24 +263,27 @@ public static class RedisBuilderExtensions
 
                 try
                 {
-                    await pipeline.ExecuteAsync(async (ctx) =>
+                    if (databasesToDelete.Any())
                     {
-                        // Create a DELETE request to send to the existing instance of
-                        // RedisInsight with the IDs of the database to delete.
-                        var deleteContent = JsonContent.Create(new
+                        await pipeline.ExecuteAsync(async (ctx) =>
                         {
-                            ids = databasesToDelete
-                        });
+                            // Create a DELETE request to send to the existing instance of
+                            // RedisInsight with the IDs of the database to delete.
+                            var deleteContent = JsonContent.Create(new
+                            {
+                                ids = databasesToDelete
+                            });
 
-                        var deleteRequest = new HttpRequestMessage(HttpMethod.Delete, databasesPath)
-                        {
-                            Content = deleteContent
-                        };
+                            var deleteRequest = new HttpRequestMessage(HttpMethod.Delete, databasesPath)
+                            {
+                                Content = deleteContent
+                            };
 
-                        var deleteResponse = await client.SendAsync(deleteRequest, cancellationToken).ConfigureAwait(false);
-                        deleteResponse.EnsureSuccessStatusCode();
+                            var deleteResponse = await client.SendAsync(deleteRequest, cancellationToken).ConfigureAwait(false);
+                            deleteResponse.EnsureSuccessStatusCode();
 
-                    }, cancellationToken).ConfigureAwait(false);
+                        }, cancellationToken).ConfigureAwait(false);
+                    }
 
                     await pipeline.ExecuteAsync(async (ctx) =>
                     {

--- a/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisFunctionalTests.cs
@@ -165,11 +165,11 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
         using var client1 = app1.CreateHttpClient($"{redis1.Resource.Name}-insight", "http");
         var firstRunDatabases = await client1.GetFromJsonAsync<RedisInsightDatabaseModel[]>("/api/databases", cts.Token);
 
-        await app1.StopAsync(cts.Token);
-
         Assert.NotNull(firstRunDatabases);
         Assert.Single(firstRunDatabases);
         Assert.Equal($"{redis1.Resource.Name}", firstRunDatabases[0].Name);
+
+        await app1.StopAsync(cts.Token);
 
         using var builder2 = TestDistributedApplicationBuilder.Create(configure, testOutputHelper);
         builder2.Configuration[$"DcpPublisher:ResourceNameSuffix"] = randomResourceSuffix;
@@ -202,14 +202,12 @@ public class RedisFunctionalTests(ITestOutputHelper testOutputHelper)
         using var client2 = app2.CreateHttpClient($"{redis2.Resource.Name}-insight", "http");
         var secondRunDatabases = await client2.GetFromJsonAsync<RedisInsightDatabaseModel[]>("/api/databases", cts.Token);
 
-        await app2.StopAsync(cts.Token);
-
         Assert.NotNull(secondRunDatabases);
         Assert.Single(secondRunDatabases);
         Assert.Equal($"{redis2.Resource.Name}", secondRunDatabases[0].Name);
         Assert.NotEqual(secondRunDatabases.Single().Id, firstRunDatabases.Single().Id);
 
-        // TODO: Make sure we don't leave the persistent container running around.
+        await app2.StopAsync(cts.Token);
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorProxy.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorProxy.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.Dcp;
+
+namespace Aspire.Hosting.Tests.Dcp;
+
+public class ApplicationExecutorProxy
+{
+    internal ApplicationExecutorProxy(ApplicationExecutor executor)
+    {
+        _executor = executor;
+    }
+
+    private readonly ApplicationExecutor _executor;
+
+    public Task StartResourceAsync(string resourceName, CancellationToken cancellationToken) => _executor.StartResourceAsync(resourceName, cancellationToken);
+
+    public Task StopResourceAsync(string resourceName, CancellationToken cancellationToken) => _executor.StopResourceAsync(resourceName, cancellationToken);
+}

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -6,8 +6,10 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Aspire.Components.Common.Tests;
 using Aspire.Hosting.Dashboard;
+using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Testing;
+using Aspire.Hosting.Tests.Dcp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -75,6 +77,8 @@ public sealed class TestDistributedApplicationBuilder : IDistributedApplicationB
             o.DashboardUrl ??= "http://localhost:8080";
             o.OtlpGrpcEndpointUrl ??= "http://localhost:4317";
         });
+
+        _innerBuilder.Services.AddSingleton<ApplicationExecutorProxy>(sp => new ApplicationExecutorProxy(sp.GetRequiredService<ApplicationExecutor>()));
 
         _innerBuilder.Services.AddHttpClient();
         _innerBuilder.Services.ConfigureHttpClientDefaults(http => http.AddStandardResilienceHandler());


### PR DESCRIPTION
## Description

With this PR, when using `WithRedisInsight(...)` the list of databases will be fetched from the RedisInsight instance and where they overlap with the names of the Redis Instances running already it will delete them so that the subsequent import won't result in duplicated entries.

Fixes #6111

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6425)