### PR TITLE
Multi-target Aspire.Hosting.AppHost

### DIFF
--- a/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
+++ b/src/Aspire.Hosting.AppHost/Aspire.Hosting.AppHost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(AllTargetFrameworks)</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageTags>aspire hosting</PackageTags>
     <Description>Core library and MSBuild logic for .NET Aspire AppHost projects.</Description>

--- a/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
+++ b/src/Aspire.ProjectTemplates/Aspire.ProjectTemplates.csproj
@@ -57,8 +57,7 @@
                       Lines="$([System.IO.File]::ReadAllText('%(TemplateProjectFiles.FullPath)')
                                                  .Replace('!!REPLACE_WITH_LATEST_VERSION!!', '$(PackageVersion)')
                                                  .Replace('!!REPLACE_WITH_ASPNETCORE_9_VERSION!!', '$(MicrosoftAspNetCorePackageVersionForNet9)')
-                                                 .Replace('!!REPLACE_WITH_EXTENSIONS_8_VERSION!!', '$(MicrosoftExtensionsHttpResiliencePackageVersion)')
-                                                 .Replace('!!REPLACE_WITH_EXTENSIONS_9_VERSION!!', '$(MicrosoftExtensionsHttpResiliencePackageVersion)'))"
+                                                 .Replace('!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!', '$(MicrosoftExtensionsHttpResiliencePackageVersion)'))"
                       Overwrite="true" />
   </Target>
 

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/8.2/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/8.2/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_EXTENSIONS_8_VERSION!!" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/9.0/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/9.0/AspireApplication.1.ServiceDefaults/AspireApplication.1.ServiceDefaults.csproj
@@ -10,8 +10,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_EXTENSIONS_8_VERSION!!" Condition=" '$(Framework)' == 'net8.0' " />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_EXTENSIONS_9_VERSION!!" Condition=" '$(Framework)' == 'net9.0' " />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/8.2/Aspire.ServiceDefaults1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/8.2/Aspire.ServiceDefaults1.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_EXTENSIONS_8_VERSION!!" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.0/Aspire.ServiceDefaults1.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.0/Aspire.ServiceDefaults1.csproj
@@ -10,8 +10,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_EXTENSIONS_8_VERSION!!" Condition=" '$(Framework)' == 'net8.0' " />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_EXTENSIONS_9_VERSION!!" Condition=" '$(Framework)' == 'net9.0' " />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/8.2/Aspire-StarterApplication.1.ServiceDefaults/Aspire-StarterApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/8.2/Aspire-StarterApplication.1.ServiceDefaults/Aspire-StarterApplication.1.ServiceDefaults.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_EXTENSIONS_8_VERSION!!" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.ServiceDefaults/Aspire-StarterApplication.1.ServiceDefaults.csproj
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.ServiceDefaults/Aspire-StarterApplication.1.ServiceDefaults.csproj
@@ -10,8 +10,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_EXTENSIONS_8_VERSION!!" Condition=" '$(Framework)' == 'net8.0' " />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_EXTENSIONS_9_VERSION!!" Condition=" '$(Framework)' == 'net9.0' " />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="!!REPLACE_WITH_DOTNET_EXTENSIONS_VERSION!!" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="!!REPLACE_WITH_LATEST_VERSION!!" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />


### PR DESCRIPTION
This way both AppHost and AppHost Test projects get v9 MS.Ext.* packages when the projects target `net9.0`. As it exists today, the AppHost project gets v8 MS.Ext.* packages when targeting `net9.0` and the AppHost Test project gets v9 MS.Ext.* packages when targeting `net9.0

Fix #6429

Also resolve PR feedback. Simplify how Http.Resilience version gets replaced in the templates.

Forward port changes from #6420

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] N/A
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6440)