### PR TITLE
Fixed AddDockerFile to work with compute customization

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/AppWithDocker/Dockerfile
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/AppWithDocker/Dockerfile
@@ -1,0 +1,11 @@
+# Use an official Python runtime as a parent image
+FROM python:3.8-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Run the command to execute app.py when the container starts
+CMD ["python", "app.py"]

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/AppWithDocker/app.py
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/AppWithDocker/app.py
@@ -1,0 +1,6 @@
+import time
+from datetime import datetime
+
+while True:
+    print(datetime.now(), flush=True)
+    time.sleep(3)

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/AzureContainerApps.AppHost.csproj
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/AzureContainerApps.AppHost.csproj
@@ -24,4 +24,8 @@
     <ProjectReference Include="..\AzureContainerApps.ApiService\AzureContainerApps.ApiService.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="AppWithDocker\" />
+  </ItemGroup>
+
 </Project>

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/Program.cs
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/Program.cs
@@ -26,6 +26,11 @@ var blobs = builder.AddAzureStorage("storage")
                    .RunAsEmulator(c => c.WithLifetime(ContainerLifetime.Persistent))
                    .AddBlobs("blobs");
 
+// Testing docker files
+
+builder.AddDockerfile("pythonapp", "AppWithDocker");
+
+// Testing projects
 builder.AddProject<Projects.AzureContainerApps_ApiService>("api")
        .WithExternalHttpEndpoints()
        .WithReference(blobs)

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/aspire-manifest.json
@@ -50,7 +50,7 @@
       ],
       "volumes": [
         {
-          "name": "azurecontainerapps.apphost-43a728061e-cache-data",
+          "name": "azurecontainerapps.apphost-a01ec9bc8d-cache-data",
           "target": "/data",
           "readOnly": false
         }
@@ -84,16 +84,30 @@
       "type": "value.v0",
       "connectionString": "{storage.outputs.blobEndpoint}"
     },
+    "pythonapp": {
+      "type": "container.v1",
+      "build": {
+        "context": "AppWithDocker",
+        "dockerfile": "AppWithDocker/Dockerfile"
+      },
+      "deployment": {
+        "type": "azure.bicep.v0",
+        "path": "pythonapp.module.bicep",
+        "params": {
+          "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+          "outputs_managed_identity_client_id": "{.outputs.MANAGED_IDENTITY_CLIENT_ID}",
+          "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+          "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+          "pythonapp_containerimage": "{pythonapp.containerImage}"
+        }
+      }
+    },
     "api": {
       "type": "project.v1",
       "path": "../AzureContainerApps.ApiService/AzureContainerApps.ApiService.csproj",
       "deployment": {
         "type": "azure.bicep.v0",
         "path": "api.module.bicep",
-        "params": {
-          "certificateName": "{certificateName.value}",
-          "customDomain": "{customDomain.value}"
-        },
         "params": {
           "api_containerport": "{api.containerPort}",
           "storage_outputs_blobendpoint": "{storage.outputs.blobEndpoint}",
@@ -103,7 +117,9 @@
           "outputs_managed_identity_client_id": "{.outputs.MANAGED_IDENTITY_CLIENT_ID}",
           "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
           "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
-          "api_containerimage": "{api.containerImage}"
+          "api_containerimage": "{api.containerImage}",
+          "certificateName": "{certificateName.value}",
+          "customDomain": "{customDomain.value}"
         }
       },
       "env": {

--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/pythonapp.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/pythonapp.module.bicep
@@ -1,0 +1,52 @@
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param outputs_azure_container_registry_managed_identity_id string
+
+param outputs_managed_identity_client_id string
+
+param outputs_azure_container_apps_environment_id string
+
+param outputs_azure_container_registry_endpoint string
+
+param pythonapp_containerimage string
+
+resource pythonapp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'pythonapp'
+  location: location
+  properties: {
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: outputs_azure_container_registry_endpoint
+          identity: outputs_azure_container_registry_managed_identity_id
+        }
+      ]
+    }
+    environmentId: outputs_azure_container_apps_environment_id
+    template: {
+      containers: [
+        {
+          image: pythonapp_containerimage
+          name: 'pythonapp'
+          env: [
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: outputs_managed_identity_client_id
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${outputs_azure_container_registry_managed_identity_id}': { }
+    }
+  }
+}

--- a/src/Aspire.Hosting/ApplicationModel/DockerfileBuildAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/DockerfileBuildAnnotation.cs
@@ -3,11 +3,36 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-internal class DockerfileBuildAnnotation(string contextPath, string dockerfilePath, string? stage) : IResourceAnnotation
+/// <summary>
+/// Represents an annotation for customizing a Dockerfile build.
+/// </summary>
+/// <param name="contextPath">The path to the context directory for the build. </param>
+/// <param name="dockerfilePath">The path to the Dockerfile to use for the build.</param>
+/// <param name="stage">The name of the build stage to use for the build.</param>
+public class DockerfileBuildAnnotation(string contextPath, string dockerfilePath, string? stage) : IResourceAnnotation
 {
+    /// <summary>
+    /// Gets the path to the context directory for the build.
+    /// </summary>
     public string ContextPath => contextPath;
-    public string DockerfilePath = dockerfilePath;
+
+    /// <summary>
+    /// Gets the path to the Dockerfile to use for the build.
+    /// </summary>
+    public string DockerfilePath => dockerfilePath;
+
+    /// <summary>
+    /// Gets the name of the build stage to use for the build.
+    /// </summary>
     public string? Stage => stage;
-    public Dictionary<string, object> BuildArguments { get; } = new();
-    public Dictionary<string, object> BuildSecrets { get; } = new();
+
+    /// <summary>
+    /// Gets the arguments to pass to the build.
+    /// </summary>
+    public Dictionary<string, object> BuildArguments { get; } = [];
+
+    /// <summary>
+    /// Gets the secrets to pass to the build.
+    /// </summary>
+    public Dictionary<string, object> BuildSecrets { get; } = [];
 }

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -1,6 +1,13 @@
 #nullable enable
 Aspire.Hosting.ApplicationModel.ContainerLifetime.Session = 0 -> Aspire.Hosting.ApplicationModel.ContainerLifetime
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.HealthStatus.get -> Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?
+Aspire.Hosting.ApplicationModel.DockerfileBuildAnnotation
+Aspire.Hosting.ApplicationModel.DockerfileBuildAnnotation.BuildArguments.get -> System.Collections.Generic.Dictionary<string!, object!>!
+Aspire.Hosting.ApplicationModel.DockerfileBuildAnnotation.BuildSecrets.get -> System.Collections.Generic.Dictionary<string!, object!>!
+Aspire.Hosting.ApplicationModel.DockerfileBuildAnnotation.ContextPath.get -> string!
+Aspire.Hosting.ApplicationModel.DockerfileBuildAnnotation.DockerfileBuildAnnotation(string! contextPath, string! dockerfilePath, string? stage) -> void
+Aspire.Hosting.ApplicationModel.DockerfileBuildAnnotation.DockerfilePath.get -> string!
+Aspire.Hosting.ApplicationModel.DockerfileBuildAnnotation.Stage.get -> string?
 Aspire.Hosting.ApplicationModel.EndpointNameAttribute
 Aspire.Hosting.ApplicationModel.EndpointNameAttribute.EndpointNameAttribute() -> void
 Aspire.Hosting.ApplicationModel.HealthReportSnapshot

--- a/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureContainerAppsTests.cs
@@ -107,6 +107,114 @@ public class AzureContainerAppsTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task AddDockerfileWithAppsInfrastructureAddsDeploymentTargetWithContainerAppToContainerResources()
+    {
+        var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);
+
+        builder.AddAzureContainerAppsInfrastructure();
+
+        var directory = Directory.CreateTempSubdirectory(".aspire-test");
+
+        // Contents of the Dockerfile are not important for this test
+        File.WriteAllText(Path.Combine(directory.FullName, "Dockerfile"), "");
+
+        builder.AddDockerfile("api", directory.FullName);
+
+        using var app = builder.Build();
+
+        await ExecuteBeforeStartHooksAsync(app, default);
+
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var container = Assert.Single(model.GetContainerResources());
+
+        container.TryGetLastAnnotation<DeploymentTargetAnnotation>(out var target);
+
+        var resource = target?.DeploymentTarget as AzureProvisioningResource;
+
+        Assert.NotNull(resource);
+
+        var (manifest, bicep) = await ManifestUtils.GetManifestWithBicep(resource);
+
+        var m = manifest.ToString();
+
+        var expectedManifest =
+        """
+        {
+          "type": "azure.bicep.v0",
+          "path": "api.module.bicep",
+          "params": {
+            "outputs_azure_container_registry_managed_identity_id": "{.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID}",
+            "outputs_managed_identity_client_id": "{.outputs.MANAGED_IDENTITY_CLIENT_ID}",
+            "outputs_azure_container_apps_environment_id": "{.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID}",
+            "outputs_azure_container_registry_endpoint": "{.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT}",
+            "api_containerimage": "{api.containerImage}"
+          }
+        }
+        """;
+
+        Assert.Equal(expectedManifest, m);
+
+        var expectedBicep =
+        """
+        @description('The location for the resource(s) to be deployed.')
+        param location string = resourceGroup().location
+
+        param outputs_azure_container_registry_managed_identity_id string
+
+        param outputs_managed_identity_client_id string
+
+        param outputs_azure_container_apps_environment_id string
+
+        param outputs_azure_container_registry_endpoint string
+
+        param api_containerimage string
+
+        resource api 'Microsoft.App/containerApps@2024-03-01' = {
+          name: 'api'
+          location: location
+          properties: {
+            configuration: {
+              activeRevisionsMode: 'Single'
+              registries: [
+                {
+                  server: outputs_azure_container_registry_endpoint
+                  identity: outputs_azure_container_registry_managed_identity_id
+                }
+              ]
+            }
+            environmentId: outputs_azure_container_apps_environment_id
+            template: {
+              containers: [
+                {
+                  image: api_containerimage
+                  name: 'api'
+                  env: [
+                    {
+                      name: 'AZURE_CLIENT_ID'
+                      value: outputs_managed_identity_client_id
+                    }
+                  ]
+                }
+              ]
+              scale: {
+                minReplicas: 1
+              }
+            }
+          }
+          identity: {
+            type: 'UserAssigned'
+            userAssignedIdentities: {
+              '${outputs_azure_container_registry_managed_identity_id}': { }
+            }
+          }
+        }
+        """;
+        output.WriteLine(bicep);
+        Assert.Equal(expectedBicep, bicep);
+    }
+
+    [Fact]
     public async Task AddContainerAppsInfrastructureAddsDeploymentTargetWithContainerAppToProjectResources()
     {
         var builder = TestDistributedApplicationBuilder.Create(DistributedApplicationOperation.Publish);


### PR DESCRIPTION
## Description

- We were not detecting containers with the build annotation and reading the image name from a parameter. Instead, it was using the runtime image name which is incorrect.
- Expose DockerfileBuildAnnotation to make this possible.
- Added test and updated the playground with a docker file sample

Fixes #6439

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6442)