### PR TITLE
Use CollectionsMarshal.GetValueRefOrAddDefault to optimize adding to dictionaries

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Aspire.Dashboard.Extensions;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
@@ -314,14 +315,9 @@ public partial class TraceDetail : ComponentBase
 
     private SpanLinkViewModel CreateLinkViewModel(string traceId, string spanId, KeyValuePair<string, string>[] attributes, Dictionary<string, OtlpTrace> traceCache)
     {
-        if (!traceCache.TryGetValue(traceId, out var trace))
-        {
-            trace = TelemetryRepository.GetTrace(traceId);
-            if (trace != null)
-            {
-                traceCache[traceId] = trace;
-            }
-        }
+        ref var trace = ref CollectionsMarshal.GetValueRefOrAddDefault(traceCache, traceId, out _);
+        // Adds to dictionary if not present.
+        trace ??= TelemetryRepository.GetTrace(traceId);
 
         var linkSpan = trace?.Spans.FirstOrDefault(s => s.SpanId == spanId);
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -95,6 +95,7 @@ public class OtlpInstrument
         foreach (var key in keys)
         {
             ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(KnownAttributeValues, key, out _);
+            // Adds to dictionary if not present.
             if (values == null)
             {
                 values = new List<string?>();

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -75,8 +75,8 @@ public class OtlpInstrument
 
         var comparableAttributes = tempAttributes.AsMemory(0, copyCount);
 
-        // Can't use CollectionsMarshal.GetValueRefOrAddDefault here because comparableAttributes here are a view over mutable data.
-        // Need to add dimensions using durable attributes instance. Could improve this .NET 9+ with alternative dictionary views.
+        // Can't use CollectionsMarshal.GetValueRefOrAddDefault here because comparableAttributes is a view over mutable data.
+        // Need to add dimensions using durable attributes instance after scope is created.
         if (!Dimensions.TryGetValue(comparableAttributes, out var dimension))
         {
             dimension = CreateDimensionScope(comparableAttributes);

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpInstrument.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Google.Protobuf.Collections;
 using OpenTelemetry.Proto.Common.V1;
@@ -74,26 +75,29 @@ public class OtlpInstrument
 
         var comparableAttributes = tempAttributes.AsMemory(0, copyCount);
 
+        // Can't use CollectionsMarshal.GetValueRefOrAddDefault here because comparableAttributes here are a view over mutable data.
+        // Need to add dimensions using durable attributes instance. Could improve this .NET 9+ with alternative dictionary views.
         if (!Dimensions.TryGetValue(comparableAttributes, out var dimension))
         {
-            dimension = AddDimensionScope(comparableAttributes);
+            dimension = CreateDimensionScope(comparableAttributes);
+            Dimensions.Add(dimension.Attributes, dimension);
         }
         return dimension;
     }
 
-    private DimensionScope AddDimensionScope(Memory<KeyValuePair<string, string>> comparableAttributes)
+    private DimensionScope CreateDimensionScope(Memory<KeyValuePair<string, string>> comparableAttributes)
     {
         var isFirst = Dimensions.Count == 0;
         var durableAttributes = comparableAttributes.ToArray();
         var dimension = new DimensionScope(Context.Options.MaxMetricsCount, durableAttributes);
-        Dimensions.Add(durableAttributes, dimension);
 
         var keys = KnownAttributeValues.Keys.Union(durableAttributes.Select(a => a.Key)).Distinct();
         foreach (var key in keys)
         {
-            if (!KnownAttributeValues.TryGetValue(key, out var values))
+            ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(KnownAttributeValues, key, out _);
+            if (values == null)
             {
-                KnownAttributeValues.Add(key, values = new List<string?>());
+                values = new List<string?>();
 
                 // If the key is new and there are already dimensions, add an empty value because there are dimensions without this key.
                 if (!isFirst)

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -295,13 +295,13 @@ public sealed class TelemetryRepository
             // an empty instrumentation scope name (unknown).
             var name = scope?.Name ?? string.Empty;
             ref var scopeRef = ref CollectionsMarshal.GetValueRefOrAddDefault(scopes, name, out _);
+            // Adds to dictionary if not present.
             scopeRef ??= (scope != null) ? new OtlpScope(scope, _otlpContext) : OtlpScope.Empty;
             s = scopeRef;
             return true;
         }
         catch (Exception ex)
         {
-            //context.FailureCount += sl.LogRecords.Count;
             _otlpContext.Logger.LogInformation(ex, "Error adding scope.");
             s = null;
             return false;
@@ -353,6 +353,7 @@ public sealed class TelemetryRepository
                             if (!_logSubscriptions.Any(s => s.SubscriptionType == SubscriptionType.Read && (s.ApplicationKey == applicationView.ApplicationKey || s.ApplicationKey == null)))
                             {
                                 ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(_applicationUnviewedErrorLogs, applicationView.ApplicationKey, out _);
+                                // Adds to dictionary if not present.
                                 count++;
                             }
                         }
@@ -580,6 +581,7 @@ public sealed class TelemetryRepository
                     if (value != null)
                     {
                         ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(attributesValues, value, out _);
+                        // Adds to dictionary if not present.
                         count++;
                     }
                 }
@@ -607,6 +609,7 @@ public sealed class TelemetryRepository
                 if (value != null)
                 {
                     ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(attributesValues, value, out _);
+                    // Adds to dictionary if not present.
                     count++;
                 }
             }
@@ -1085,6 +1088,7 @@ public sealed class TelemetryRepository
                 foreach (var knownAttributeValues in instrument.KnownAttributeValues)
                 {
                     ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(allKnownAttributes, knownAttributeValues.Key, out _);
+                    // Adds to dictionary if not present.
                     if (values != null)
                     {
                         values = values.Union(knownAttributeValues.Value).ToList();

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -12,6 +12,7 @@ using Aspire.Dashboard.Otlp.Model;
 using Aspire.Dashboard.Otlp.Model.MetricValues;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.Options;
+using OpenTelemetry.Proto.Common.V1;
 using OpenTelemetry.Proto.Logs.V1;
 using OpenTelemetry.Proto.Metrics.V1;
 using OpenTelemetry.Proto.Resource.V1;
@@ -285,6 +286,28 @@ public sealed class TelemetryRepository
         RaiseSubscriptionChanged(_logSubscriptions);
     }
 
+    private bool TryAddScope(Dictionary<string, OtlpScope> scopes, InstrumentationScope? scope, [NotNullWhen(true)] out OtlpScope? s)
+    {
+        try
+        {
+            // The instrumentation scope information for the spans in this message.
+            // Semantically when InstrumentationScope isn't set, it is equivalent with
+            // an empty instrumentation scope name (unknown).
+            var name = scope?.Name ?? string.Empty;
+            ref var scopeRef = ref CollectionsMarshal.GetValueRefOrAddDefault(scopes, name, out _);
+            scopeRef ??= (scope != null) ? new OtlpScope(scope, _otlpContext) : OtlpScope.Empty;
+            s = scopeRef;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            //context.FailureCount += sl.LogRecords.Count;
+            _otlpContext.Logger.LogInformation(ex, "Error adding scope.");
+            s = null;
+            return false;
+        }
+    }
+
     public void AddLogsCore(AddContext context, OtlpApplicationView applicationView, RepeatedField<ScopeLogs> scopeLogs)
     {
         _logsLock.EnterWriteLock();
@@ -293,23 +316,9 @@ public sealed class TelemetryRepository
         {
             foreach (var sl in scopeLogs)
             {
-                OtlpScope? scope;
-                try
-                {
-                    // The instrumentation scope information for the spans in this message.
-                    // Semantically when InstrumentationScope isn't set, it is equivalent with
-                    // an empty instrumentation scope name (unknown).
-                    var name = sl.Scope?.Name ?? string.Empty;
-                    if (!_logScopes.TryGetValue(name, out scope))
-                    {
-                        scope = (sl.Scope != null) ? new OtlpScope(sl.Scope, _otlpContext) : OtlpScope.Empty;
-                        _logScopes.Add(name, scope);
-                    }
-                }
-                catch (Exception ex)
+                if (!TryAddScope(_logScopes, sl.Scope, out var scope))
                 {
                     context.FailureCount += sl.LogRecords.Count;
-                    _otlpContext.Logger.LogInformation(ex, "Error adding scope.");
                     continue;
                 }
 
@@ -343,14 +352,8 @@ public sealed class TelemetryRepository
                         {
                             if (!_logSubscriptions.Any(s => s.SubscriptionType == SubscriptionType.Read && (s.ApplicationKey == applicationView.ApplicationKey || s.ApplicationKey == null)))
                             {
-                                if (_applicationUnviewedErrorLogs.TryGetValue(applicationView.ApplicationKey, out var count))
-                                {
-                                    _applicationUnviewedErrorLogs[applicationView.ApplicationKey] = ++count;
-                                }
-                                else
-                                {
-                                    _applicationUnviewedErrorLogs.Add(applicationView.ApplicationKey, 1);
-                                }
+                                ref var count = ref CollectionsMarshal.GetValueRefOrAddDefault(_applicationUnviewedErrorLogs, applicationView.ApplicationKey, out _);
+                                count++;
                             }
                         }
 
@@ -770,23 +773,9 @@ public sealed class TelemetryRepository
         {
             foreach (var scopeSpan in scopeSpans)
             {
-                OtlpScope? scope;
-                try
-                {
-                    // The instrumentation scope information for the spans in this message.
-                    // Semantically when InstrumentationScope isn't set, it is equivalent with
-                    // an empty instrumentation scope name (unknown).
-                    var name = scopeSpan.Scope?.Name ?? string.Empty;
-                    if (!_traceScopes.TryGetValue(name, out scope))
-                    {
-                        scope = (scopeSpan.Scope != null) ? new OtlpScope(scopeSpan.Scope, _otlpContext) : OtlpScope.Empty;
-                        _traceScopes.Add(name, scope);
-                    }
-                }
-                catch (Exception ex)
+                if (!TryAddScope(_traceScopes, scopeSpan.Scope, out var scope))
                 {
                     context.FailureCount += scopeSpan.Spans.Count;
-                    _otlpContext.Logger.LogInformation(ex, "Error adding scope.");
                     continue;
                 }
 
@@ -1095,13 +1084,14 @@ public sealed class TelemetryRepository
 
                 foreach (var knownAttributeValues in instrument.KnownAttributeValues)
                 {
-                    if (allKnownAttributes.TryGetValue(knownAttributeValues.Key, out var values))
+                    ref var values = ref CollectionsMarshal.GetValueRefOrAddDefault(allKnownAttributes, knownAttributeValues.Key, out _);
+                    if (values != null)
                     {
-                        allKnownAttributes[knownAttributeValues.Key] = values.Union(knownAttributeValues.Value).ToList();
+                        values = values.Union(knownAttributeValues.Value).ToList();
                     }
                     else
                     {
-                        allKnownAttributes[knownAttributeValues.Key] = knownAttributeValues.Value.ToList();
+                        values = knownAttributeValues.Value.ToList();
                     }
                 }
             }


### PR DESCRIPTION
## Description

Made a pass over dashboard code to see where `CollectionsMarshal.GetValueRefOrAddDefault` could be used. It skips the overhead of trying to find a value and then adding the value if missing.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6443)