### PR TITLE
Don't pass meter descriptions as units

### DIFF
--- a/src/Components/Aspire.Confluent.Kafka/ConfluentKafkaMetrics.cs
+++ b/src/Components/Aspire.Confluent.Kafka/ConfluentKafkaMetrics.cs
@@ -27,9 +27,9 @@ internal sealed class ConfluentKafkaMetrics
     {
         _meter = meterFactory.Create(ConfluentKafkaCommon.MeterName);
 
-        _meter.CreateObservableGauge(Gauges.ReplyQueue, GetReplyQMeasurements, Descriptions.ReplyQueue);
-        _meter.CreateObservableGauge(Gauges.MessageCount, GetMessageCountMeasurements, Descriptions.MessageCount);
-        _meter.CreateObservableGauge(Gauges.MessageSize, GetMessageSizeMeasurements, Descriptions.MessageSize);
+        _meter.CreateObservableGauge(Gauges.ReplyQueue, GetReplyQMeasurements, description: Descriptions.ReplyQueue);
+        _meter.CreateObservableGauge(Gauges.MessageCount, GetMessageCountMeasurements, description: Descriptions.MessageCount);
+        _meter.CreateObservableGauge(Gauges.MessageSize, GetMessageSizeMeasurements, description: Descriptions.MessageSize);
 
         Tx = _meter.CreateCounter<long>(Counters.Tx, Descriptions.Tx);
         TxBytes = _meter.CreateCounter<long>(Counters.TxBytes, Descriptions.TxBytes);

--- a/src/Components/Aspire.Confluent.Kafka/ConfluentKafkaMetrics.cs
+++ b/src/Components/Aspire.Confluent.Kafka/ConfluentKafkaMetrics.cs
@@ -31,14 +31,14 @@ internal sealed class ConfluentKafkaMetrics
         _meter.CreateObservableGauge(Gauges.MessageCount, GetMessageCountMeasurements, description: Descriptions.MessageCount);
         _meter.CreateObservableGauge(Gauges.MessageSize, GetMessageSizeMeasurements, description: Descriptions.MessageSize);
 
-        Tx = _meter.CreateCounter<long>(Counters.Tx, Descriptions.Tx);
-        TxBytes = _meter.CreateCounter<long>(Counters.TxBytes, Descriptions.TxBytes);
-        TxMessages = _meter.CreateCounter<long>(Counters.TxMessages, Descriptions.TxMessages);
-        TxMessageBytes = _meter.CreateCounter<long>(Counters.TxMessageBytes, Descriptions.TxMessageBytes);
-        Rx = _meter.CreateCounter<long>(Counters.Rx, Descriptions.Rx);
-        RxBytes = _meter.CreateCounter<long>(Counters.RxBytes, Descriptions.RxBytes);
-        RxMessages = _meter.CreateCounter<long>(Counters.RxMessages, Descriptions.RxMessages);
-        RxMessageBytes = _meter.CreateCounter<long>(Counters.RxMessageBytes, Descriptions.RxMessageBytes);
+        Tx = _meter.CreateCounter<long>(Counters.Tx, description: Descriptions.Tx);
+        TxBytes = _meter.CreateCounter<long>(Counters.TxBytes, description: Descriptions.TxBytes);
+        TxMessages = _meter.CreateCounter<long>(Counters.TxMessages, description: Descriptions.TxMessages);
+        TxMessageBytes = _meter.CreateCounter<long>(Counters.TxMessageBytes, description: Descriptions.TxMessageBytes);
+        Rx = _meter.CreateCounter<long>(Counters.Rx, description: Descriptions.Rx);
+        RxBytes = _meter.CreateCounter<long>(Counters.RxBytes, description: Descriptions.RxBytes);
+        RxMessages = _meter.CreateCounter<long>(Counters.RxMessages, description: Descriptions.RxMessages);
+        RxMessageBytes = _meter.CreateCounter<long>(Counters.RxMessageBytes, description: Descriptions.RxMessageBytes);
     }
 
     public static class Gauges


### PR DESCRIPTION
## Description

When publishing as prometheus metrics the kafka gauge metrics are exported as

```
# TYPE messaging_kafka_consumer_queue_message_count_Number of ops (callbacks, events, etc) waiting in queue for application to serve with rd_kafka_poll() gauge
# UNIT messaging_kafka_consumer_queue_message_count_Number of ops (callbacks, events, etc) waiting in queue for application to serve with rd_kafka_poll() Number of ops (callbacks, events, etc) waiting in queue for application to serve with rd_kafka_poll()
messaging_kafka_consumer_queue_message_count_Number of ops (callbacks, events, etc) waiting in queue for application to serve with rd_kafka_poll()
```

This may be because the description is passed as a unit.

Fixes #6447

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6448)