### PR TITLE
Add small margin to bottom of details view tables

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -435,6 +435,7 @@ fluent-data-grid-row[row-type=default].hover:hover fluent-button[appearance=stea
 
 .property-grid-container fluent-accordion {
     gap: calc(var(--design-unit) * 2px);
+    margin-bottom: calc(var(--design-unit) * 1px);
     --fill-color: var(--neutral-layer-1);
 }
 


### PR DESCRIPTION
## Description

Add small space between content and bottom of the page:

![image](https://github.com/user-attachments/assets/400ac2e9-d8c9-40f0-bbfe-584511ea7a4d)

## Checklist

- Is this feature complete?
  - [ x Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6449)