### PR TITLE
[release/9.0] Remove Milvus.Client dependency. (#6435)

### DIFF
--- a/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
+++ b/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
@@ -21,7 +21,6 @@
   <ItemGroup>
     <Compile Include="$(SharedDir)StringComparers.cs" Link="Utils\StringComparers.cs" />
     <Compile Include="$(SharedDir)VolumeNameGenerator.cs" Link="Utils\VolumeNameGenerator.cs" />
-    <Compile Include="$(ComponentsDir)Aspire.Milvus.Client\MilvusHealthCheck.cs" Link="MilvusHealthCheck.cs"></Compile>
   </ItemGroup>
 
   <ItemGroup>
@@ -30,9 +29,5 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Aspire.Hosting.Milvus.Tests"></InternalsVisibleTo>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Milvus.Client" />
   </ItemGroup>
 </Project>

--- a/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
+++ b/src/Aspire.Hosting.Milvus/Aspire.Hosting.Milvus.csproj
@@ -10,8 +10,6 @@
     
     <!-- Disable package validation as this package hasn't shipped yet. -->
     <EnablePackageValidation>false</EnablePackageValidation>
-    <!-- We need to ingest a stable version of Milvus.Client in order for us to produce stable bits. -->
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Components.Common.Tests;
-using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Tests.Utils;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Milvus.Client;
 using Xunit;
@@ -200,45 +198,5 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
                 }
             }
         }
-    }
-
-    [Fact]
-    [RequiresDocker]
-    public async Task VerifyWaitForOnMilvusBlocksDependentResources()
-    {
-        var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
-        using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
-
-        var healthCheckTcs = new TaskCompletionSource<HealthCheckResult>();
-        builder.Services.AddHealthChecks().AddAsyncCheck("blocking_check", () =>
-        {
-            return healthCheckTcs.Task;
-        });
-
-        var resource = builder.AddMilvus("resource")
-                              .WithHealthCheck("blocking_check");
-
-        var dependentResource = builder.AddMilvus("dependentresource")
-                                       .WaitFor(resource);
-
-        using var app = builder.Build();
-
-        var pendingStart = app.StartAsync(cts.Token);
-
-        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-
-        await rns.WaitForResourceAsync(resource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Waiting, cts.Token);
-
-        healthCheckTcs.SetResult(HealthCheckResult.Healthy());
-
-        await rns.WaitForResourceHealthyAsync(resource.Resource.Name, cts.Token);
-
-        await rns.WaitForResourceAsync(dependentResource.Resource.Name, KnownResourceStates.Running, cts.Token);
-
-        await pendingStart;
-
-        await app.StopAsync();
     }
 }


### PR DESCRIPTION
Backport of #6435 to release/9.0

## Customer Impact

In `Aspire.Hosting.Milvus` we automatically add a health check when calling `AddMilvus(...)`. This takes a dependency on `Milvus.Client` which does not have a stable release. We've made the decision to remove the apphost-side health check for now.

## Testing

Removed feature and unit test. Existing tests pass.

## Risk

Low.

## Regression?

No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6451)