### PR TITLE
[release/9.0] Make resource HealthStatus computed from HealthReports (#6368)

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
@@ -62,12 +62,6 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
             icon = new Icons.Filled.Size16.Circle();
             color = Color.Info;
         }
-        else if (resource.HealthStatus is null)
-        {
-            // If we are waiting for a health check, show a progress bar and consider the resource unhealthy
-            icon = new Icons.Filled.Size16.CheckmarkCircleWarning();
-            color = Color.Warning;
-        }
         else if (resource.HealthStatus is not HealthStatus.Healthy)
         {
             icon = new Icons.Filled.Size16.CheckmarkCircleWarning();

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -20,6 +20,9 @@ namespace Aspire.Dashboard.Model;
 [DebuggerDisplay("Name = {Name}, ResourceType = {ResourceType}, State = {State}, Properties = {Properties.Count}")]
 public sealed class ResourceViewModel
 {
+    private readonly ImmutableArray<HealthReportViewModel> _healthReports = [];
+    private readonly KnownResourceState? _knownState;
+
     public required string Name { get; init; }
     public required string ResourceType { get; init; }
     public required string DisplayName { get; init; }
@@ -35,14 +38,48 @@ public sealed class ResourceViewModel
     public required FrozenDictionary<string, ResourcePropertyViewModel> Properties { get; init; }
     public required ImmutableArray<CommandViewModel> Commands { get; init; }
     /// <summary>The health status of the resource. <see langword="null"/> indicates that health status is expected but not yet available.</summary>
-    public required HealthStatus? HealthStatus { get; init; }
-    public required ImmutableArray<HealthReportViewModel> HealthReports { get; init; }
-    public KnownResourceState? KnownState { get; init; }
+    public HealthStatus? HealthStatus { get; private set; }
+
+    public required ImmutableArray<HealthReportViewModel> HealthReports
+    {
+        get => _healthReports;
+        init
+        {
+            _healthReports = value;
+            HealthStatus = ComputeHealthStatus(value, KnownState);
+        }
+    }
+
+    public KnownResourceState? KnownState
+    {
+        get => _knownState;
+        init
+        {
+            _knownState = value;
+            HealthStatus = ComputeHealthStatus(_healthReports, value);
+        }
+    }
 
     internal bool MatchesFilter(string filter)
     {
         // TODO let ResourceType define the additional data values we include in searches
         return Name.Contains(filter, StringComparisons.UserTextSearch);
+    }
+
+    internal static HealthStatus? ComputeHealthStatus(ImmutableArray<HealthReportViewModel> healthReports, KnownResourceState? state)
+    {
+        if (state != KnownResourceState.Running)
+        {
+            return null;
+        }
+
+        return healthReports.Length == 0
+            // If there are no health reports and the resource is running, assume it's healthy.
+            ? Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Healthy
+            // If there are health reports, the health status is the minimum of the health status of the reports.
+            // If any of the reports is null (first health check has not returned), the health status is unhealthy.
+            : healthReports.MinBy(r => r.HealthStatus)?.HealthStatus
+              ?? Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy;
     }
 
     public static string GetResourceName(ResourceViewModel resource, IDictionary<string, ResourceViewModel> allResources)

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -49,7 +49,6 @@ partial class Resource
                 KnownState = HasState ? Enum.TryParse(State, out KnownResourceState knownState) ? knownState : null : null,
                 StateStyle = HasStateStyle ? StateStyle : null,
                 Commands = GetCommands(),
-                HealthStatus = HasHealthStatus ? MapHealthStatus(HealthStatus) : null,
                 HealthReports = HealthReports.Select(ToHealthReportViewModel).OrderBy(vm => vm.Name).ToImmutableArray(),
             };
         }

--- a/src/Aspire.Dashboard/Resources/Resources.Designer.cs
+++ b/src/Aspire.Dashboard/Resources/Resources.Designer.cs
@@ -285,7 +285,7 @@ namespace Aspire.Dashboard.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Health State.
+        ///   Looks up a localized string similar to Health state.
         /// </summary>
         public static string ResourcesDetailsHealthStateProperty {
             get {

--- a/src/Aspire.Dashboard/Resources/Resources.resx
+++ b/src/Aspire.Dashboard/Resources/Resources.resx
@@ -233,7 +233,7 @@
     <value>View console logs</value>
   </data>
   <data name="ResourcesDetailsHealthStateProperty" xml:space="preserve">
-    <value>Health State</value>
+    <value>Health state</value>
   </data>
   <data name="ResourcesDetailsStopTimeProperty" xml:space="preserve">
     <value>Stop time</value>

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.cs.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="translated">Stav</target>
+        <source>Health state</source>
+        <target state="needs-review-translation">Stav</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.de.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="new">Health State</target>
+        <source>Health state</source>
+        <target state="new">Health state</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.es.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="new">Health State</target>
+        <source>Health state</source>
+        <target state="new">Health state</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.fr.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="translated">État d’intégrité</target>
+        <source>Health state</source>
+        <target state="needs-review-translation">État d’intégrité</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.it.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="new">Health State</target>
+        <source>Health state</source>
+        <target state="new">Health state</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ja.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="new">Health State</target>
+        <source>Health state</source>
+        <target state="new">Health state</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ko.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="new">Health State</target>
+        <source>Health state</source>
+        <target state="new">Health state</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pl.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="translated">Stan kondycji</target>
+        <source>Health state</source>
+        <target state="needs-review-translation">Stan kondycji</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.pt-BR.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="new">Health State</target>
+        <source>Health state</source>
+        <target state="new">Health state</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.ru.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="new">Health State</target>
+        <source>Health state</source>
+        <target state="new">Health state</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.tr.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="translated">İşlevsel Durum</target>
+        <source>Health state</source>
+        <target state="needs-review-translation">İşlevsel Durum</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hans.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="translated">运行状况状态</target>
+        <source>Health state</source>
+        <target state="needs-review-translation">运行状况状态</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
+++ b/src/Aspire.Dashboard/Resources/xlf/Resources.zh-Hant.xlf
@@ -128,8 +128,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsHealthStateProperty">
-        <source>Health State</source>
-        <target state="new">Health State</target>
+        <source>Health state</source>
+        <target state="new">Health state</target>
         <note />
       </trans-unit>
       <trans-unit id="ResourcesDetailsProjectPathProperty">

--- a/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardServiceData.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Aspire.Hosting.ApplicationModel;
 using Microsoft.Extensions.Logging;
@@ -49,32 +48,9 @@ internal sealed class DashboardServiceData : IDisposable
                     ExitCode = snapshot.ExitCode,
                     State = snapshot.State?.Text,
                     StateStyle = snapshot.State?.Style,
-                    HealthStatus = snapshot.HealthStatus,
-                    HealthReports = GetOrCreateHealthReports(),
+                    HealthReports = snapshot.HealthReports,
                     Commands = snapshot.Commands
                 };
-
-                ImmutableArray<HealthReportSnapshot> GetOrCreateHealthReports()
-                {
-                    if (!resource.TryGetAnnotationsIncludingAncestorsOfType<HealthCheckAnnotation>(out var annotations))
-                    {
-                        return snapshot.HealthReports;
-                    }
-
-                    var enumeratedAnnotations = annotations.ToList();
-                    if (snapshot.HealthReports.Length == enumeratedAnnotations.Count)
-                    {
-                        return snapshot.HealthReports;
-                    }
-
-                    var reportsByKey = snapshot.HealthReports.ToDictionary(report => report.Name);
-                    foreach (var healthCheckAnnotation in enumeratedAnnotations.Where(annotation => !reportsByKey.ContainsKey(annotation.Key)))
-                    {
-                        reportsByKey.Add(healthCheckAnnotation.Key, new HealthReportSnapshot(healthCheckAnnotation.Key, null, null, null));
-                    }
-
-                    return [..reportsByKey.Values];
-                }
             }
 
             var timestamp = DateTime.UtcNow;

--- a/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
+++ b/src/Aspire.Hosting/Dashboard/ResourceSnapshot.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Google.Protobuf.WellKnownTypes;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Aspire.Hosting.Dashboard;
 
@@ -26,7 +25,6 @@ internal abstract class ResourceSnapshot
     public required ImmutableArray<EnvironmentVariableSnapshot> Environment { get; init; }
     public required ImmutableArray<VolumeSnapshot> Volumes { get; init; }
     public required ImmutableArray<UrlSnapshot> Urls { get; init; }
-    public required HealthStatus? HealthStatus { get; init; }
     public required ImmutableArray<HealthReportSnapshot> HealthReports { get; init; }
     public required ImmutableArray<ResourceCommandSnapshot> Commands { get; init; }
 
@@ -45,7 +43,7 @@ internal abstract class ResourceSnapshot
             yield return (KnownProperties.Resource.CreateTime, CreationTimeStamp is null ? Value.ForNull() : Value.ForString(CreationTimeStamp.Value.ToString("O")), IsSensitive: false);
             yield return (KnownProperties.Resource.StartTime, StartTimeStamp is null ? Value.ForNull() : Value.ForString(StartTimeStamp.Value.ToString("O")), IsSensitive: false);
             yield return (KnownProperties.Resource.StopTime, StopTimeStamp is null ? Value.ForNull() : Value.ForString(StopTimeStamp.Value.ToString("O")), IsSensitive: false);
-            yield return (KnownProperties.Resource.HealthState, HealthStatus is null ? Value.ForNull() : Value.ForString(HealthStatus.ToString()), IsSensitive: false);
+            yield return (KnownProperties.Resource.HealthState, CustomResourceSnapshot.ComputeHealthStatus(HealthReports, State) is not { } healthStatus ? Value.ForNull() : Value.ForString(healthStatus.ToString()), IsSensitive: false);
 
             foreach (var property in GetProperties())
             {

--- a/src/Aspire.Hosting/Dashboard/proto/Partials.cs
+++ b/src/Aspire.Hosting/Dashboard/proto/Partials.cs
@@ -66,11 +66,6 @@ partial class Resource
             resource.Commands.Add(new ResourceCommand { Name = command.Name, DisplayName = command.DisplayName, DisplayDescription = command.DisplayDescription ?? string.Empty, Parameter = ResourceSnapshot.ConvertToValue(command.Parameter), ConfirmationMessage = command.ConfirmationMessage ?? string.Empty, IconName = command.IconName ?? string.Empty, IconVariant = MapIconVariant(command.IconVariant), IsHighlighted = command.IsHighlighted, State = MapCommandState(command.State) });
         }
 
-        if (snapshot.HealthStatus is not null)
-        {
-            resource.HealthStatus = MapHealthStatus(snapshot.HealthStatus.Value);
-        }
-
         foreach (var report in snapshot.HealthReports)
         {
             var healthReport = new HealthReport { Key = report.Name, Description = report.Description ?? "", Exception = report.ExceptionText ?? "" };

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -178,7 +178,7 @@ message ResourceProperty {
 
 // Models the full state of an resource (container, executable, project, etc) at a particular point in time.
 message Resource {
-    reserved 8, 9, 10;
+    reserved 8, 9, 10, 16;
     string name = 1;
     string resource_type = 2;
     string display_name = 3;
@@ -208,8 +208,6 @@ message Resource {
     // The set of volumes mounted to the resource. Only applies to containers.
     repeated Volume volumes = 15;
 
-    // The aggregate health state of the resource. Generally reflects data from health_reports, but may differ.
-    optional HealthStatus health_status = 16;
     // Reports from health checks, about this resource.
     repeated HealthReport health_reports = 17;
 

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 #nullable enable
 Aspire.Hosting.ApplicationModel.ContainerLifetime.Session = 0 -> Aspire.Hosting.ApplicationModel.ContainerLifetime
+Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.HealthStatus.get -> Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?
 Aspire.Hosting.ApplicationModel.EndpointNameAttribute
 Aspire.Hosting.ApplicationModel.EndpointNameAttribute.EndpointNameAttribute() -> void
 Aspire.Hosting.ApplicationModel.HealthReportSnapshot
@@ -46,10 +47,7 @@ Aspire.Hosting.ApplicationModel.ContainerNameAnnotation.Name.get -> string!
 Aspire.Hosting.ApplicationModel.ContainerNameAnnotation.Name.set -> void
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.Commands.get -> System.Collections.Immutable.ImmutableArray<Aspire.Hosting.ApplicationModel.ResourceCommandSnapshot!>
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.Commands.init -> void
-Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.HealthStatus.get -> Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?
-Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.HealthStatus.init -> void
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.HealthReports.get -> System.Collections.Immutable.ImmutableArray<Aspire.Hosting.ApplicationModel.HealthReportSnapshot!>
-Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.HealthReports.init -> void
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.StartTimeStamp.get -> System.DateTime?
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.StartTimeStamp.init -> void
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.StopTimeStamp.get -> System.DateTime?

--- a/src/Shared/StringComparers.cs
+++ b/src/Shared/StringComparers.cs
@@ -23,6 +23,8 @@ internal static class StringComparers
     public static StringComparer GridColumn => StringComparer.Ordinal;
     public static StringComparer OtlpAttribute => StringComparer.Ordinal;
     public static StringComparer OtlpFieldValue => StringComparer.OrdinalIgnoreCase;
+    public static StringComparer OtlpSpanId => StringComparer.Ordinal;
+    public static StringComparer HealthReportPropertyValue => StringComparer.Ordinal;
 }
 
 internal static class StringComparisons
@@ -43,4 +45,6 @@ internal static class StringComparisons
     public static StringComparison GridColumn => StringComparison.Ordinal;
     public static StringComparison OtlpAttribute => StringComparison.Ordinal;
     public static StringComparison OtlpFieldValue => StringComparison.OrdinalIgnoreCase;
+    public static StringComparison OtlpSpanId => StringComparison.Ordinal;
+    public static StringComparison HealthReportPropertyValue => StringComparison.Ordinal;
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceStateViewModelTests.cs
@@ -36,7 +36,7 @@ public class ResourceStateViewModelTests
         /* state */ KnownResourceState.Running, null, "Healthy", null,
         /* expected output */ "Running", "CheckmarkCircle", Color.Success, "Running")]
     [InlineData(
-        /* state */ KnownResourceState.Running, null, null, null,
+        /* state */ KnownResourceState.Running, null, "", null,
         /* expected output */ $"Localized:{nameof(Columns.RunningAndUnhealthyResourceStateToolTip)}", "CheckmarkCircleWarning", Color.Warning, "Running (Unhealthy)")]
     [InlineData(
         /* state */ KnownResourceState.Running, null, "Unhealthy", null,
@@ -61,7 +61,7 @@ public class ResourceStateViewModelTests
         string expectedText)
     {
         // Arrange
-        HealthStatus? healthStatus = healthStatusString is null ? null : Enum.Parse<HealthStatus>(healthStatusString);
+        HealthStatus? healthStatus = string.IsNullOrEmpty(healthStatusString) ? null : Enum.Parse<HealthStatus>(healthStatusString);
         var propertiesDictionary = new Dictionary<string, ResourcePropertyViewModel>();
         if (exitCode is not null)
         {
@@ -70,7 +70,8 @@ public class ResourceStateViewModelTests
 
         var resource = ModelTestHelpers.CreateResource(
             state: state,
-            healthStatus: healthStatus,
+            reportHealthStatus: healthStatus,
+            createNullHealthReport: healthStatusString == "",
             stateStyle: stateStyle,
             resourceType: ResourceType,
             properties: propertiesDictionary);

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -1,18 +1,35 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Aspire.Dashboard.Model;
 using Aspire.ResourceService.Proto.V1;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
-
+using DiagnosticsHealthStatus = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
 namespace Aspire.Dashboard.Tests.Model;
 
 public sealed class ResourceViewModelTests
 {
     private static readonly DateTime s_dateTime = new(2000, 12, 30, 23, 59, 59, DateTimeKind.Utc);
     private static readonly BrowserTimeProvider s_timeProvider = new(NullLoggerFactory.Instance);
+
+    [Theory]
+    [InlineData(KnownResourceState.Starting, null, null)]
+    [InlineData(KnownResourceState.Starting, null, new string[]{})]
+    [InlineData(KnownResourceState.Starting, null, new string?[]{null})]
+    // we don't have a Running + HealthReports null case because that's not a valid state - by this point, we will have received the list of HealthReports
+    [InlineData(KnownResourceState.Running, DiagnosticsHealthStatus.Healthy, new string[]{})]
+    [InlineData(KnownResourceState.Running, DiagnosticsHealthStatus.Healthy, new string?[] {"Healthy"})]
+    [InlineData(KnownResourceState.Running, DiagnosticsHealthStatus.Unhealthy, new string?[] {null})]
+    [InlineData(KnownResourceState.Running, DiagnosticsHealthStatus.Degraded, new string?[] {"Healthy", "Degraded"})]
+    public void Resource_WithHealthReportAndState_ReturnsCorrectHealthStatus(KnownResourceState? state, DiagnosticsHealthStatus? expectedStatus, string?[]? healthStatusStrings)
+    {
+        var reports = healthStatusStrings?.Select<string?, HealthReportViewModel>((h, i) => new HealthReportViewModel(i.ToString(), h is null ? null : System.Enum.Parse<DiagnosticsHealthStatus>(h), null, null)).ToImmutableArray() ?? [];
+        var actualStatus = ResourceViewModel.ComputeHealthStatus(reports, state);
+        Assert.Equal(expectedStatus, actualStatus);
+    }
 
     [Fact]
     public void ToViewModel_EmptyEnvVarName_Success()

--- a/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/ResourcePublisherTests.cs
@@ -199,7 +199,6 @@ public class ResourcePublisherTests
             Urls = [],
             Volumes = [],
             Environment = [],
-            HealthStatus = null,
             HealthReports = [],
             Commands = []
         };

--- a/tests/Aspire.Hosting.Tests/Health/HealthStatusTests.cs
+++ b/tests/Aspire.Hosting.Tests/Health/HealthStatusTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Health;
+
+public class HealthStatusTests
+{
+    private const string StartingState = "Starting";
+    private const string RunningState = "Running";
+
+    [Theory]
+    [InlineData(StartingState, null, null)]
+    [InlineData(StartingState, null, new string[]{})]
+    [InlineData(StartingState, null, new string?[]{null})]
+    // we don't have a Running + HealthReports null case because that's not a valid state - by this point, we will have received the list of HealthReports
+    [InlineData(RunningState, HealthStatus.Healthy, new string[]{})]
+    [InlineData(RunningState, HealthStatus.Healthy, new string?[] {"Healthy"})]
+    [InlineData(RunningState, HealthStatus.Unhealthy, new string?[] {null})]
+    [InlineData(RunningState, HealthStatus.Degraded, new string?[] {"Healthy", "Degraded"})]
+    public void Resource_WithHealthReportAndState_ReturnsCorrectHealthStatus(string? state, HealthStatus? expectedStatus, string?[]? healthStatusStrings)
+    {
+        var reports = healthStatusStrings?.Select<string?, HealthReportSnapshot>((h, i) => new HealthReportSnapshot(i.ToString(), h is null ? null : Enum.Parse<HealthStatus>(h), null, null)).ToImmutableArray() ?? [];
+        var actualStatus = CustomResourceSnapshot.ComputeHealthStatus(reports, state);
+        Assert.Equal(expectedStatus, actualStatus);
+    }
+}

--- a/tests/Shared/DashboardModel/ModelTestHelpers.cs
+++ b/tests/Shared/DashboardModel/ModelTestHelpers.cs
@@ -18,7 +18,8 @@ public static class ModelTestHelpers
         Dictionary<string, ResourcePropertyViewModel>? properties = null,
         string? resourceType = null,
         string? stateStyle = null,
-        HealthStatus? healthStatus = null)
+        HealthStatus? reportHealthStatus = null,
+        bool createNullHealthReport = false)
     {
         return new ResourceViewModel
         {
@@ -36,8 +37,7 @@ public static class ModelTestHelpers
             State = state?.ToString(),
             KnownState = state,
             StateStyle = stateStyle,
-            HealthStatus = healthStatus,
-            HealthReports = [],
+            HealthReports = reportHealthStatus is null && !createNullHealthReport ? [] : [new HealthReportViewModel("healthcheck", reportHealthStatus, null, null)],
             Commands = []
         };
     }


### PR DESCRIPTION
Backport of #6368 to release/9.0

## Customer Impact

- Removes the ability to set HealthStatus directly on a resource, and removes the field from the resource service protocol
- Fixes a bug where health reports will not be updated if the overall health of the resource does not change
- Fixes a bug where the health status is not shown in resource details while waiting for health checks to initially run

## Testing

Much manual testing, as well as additional unit tests for computing health status.

## Risk

Medium. It is possible that this breaking change may impact existing projects that set HealthStatus, and may impact customer assumptions during resource updates - for example, resources now start as unhealthy if they are running and wait on a health check, instead of null, as it previously was.

## Regression?

No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6426)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6458)