### PR TITLE
[release/9.0] Reject duplicate span ids

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -214,11 +214,11 @@ app.MapGet("/duplicate-spanid", async () =>
 {
     var traceCreator = new TraceCreator();
 
-    var span1 = traceCreator.CreateActivity("Test 1", "customid");
+    var span1 = traceCreator.CreateActivity("Test 1", "0485b1947fe788bb");
     await Task.Delay(1000);
     span1?.Stop();
 
-    var span2 = traceCreator.CreateActivity("Test 2", "customid");
+    var span2 = traceCreator.CreateActivity("Test 2", "0485b1947fe788bb");
     await Task.Delay(1000);
     span2?.Stop();
 

--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -210,4 +210,19 @@ Long line content: {LongLines}", xmlLarge, xmlWithComments, jsonLarge, jsonWithC
     return "Log with formatted data";
 });
 
+app.MapGet("/duplicate-spanid", async () =>
+{
+    var traceCreator = new TraceCreator();
+
+    var span1 = traceCreator.CreateActivity("Test 1", "customid");
+    await Task.Delay(1000);
+    span1?.Stop();
+
+    var span2 = traceCreator.CreateActivity("Test 2", "customid");
+    await Task.Delay(1000);
+    span2?.Stop();
+
+    return $"Created duplicate span IDs.";
+});
+
 app.Run();

--- a/playground/Stress/Stress.ApiService/TraceCreator.cs
+++ b/playground/Stress/Stress.ApiService/TraceCreator.cs
@@ -14,15 +14,16 @@ public class TraceCreator
 
     private readonly List<Activity> _allActivities = new List<Activity>();
 
-    public Activity? CreateActivity(string name, string? id)
+    public Activity? CreateActivity(string name, string? spandId)
     {
         var activity = s_activitySource.StartActivity(name, ActivityKind.Client);
         if (activity != null)
         {
-            if (id != null)
+            if (spandId != null)
             {
                 // Gross but it's the only way.
-                typeof(Activity).GetField("_id", BindingFlags.NonPublic | BindingFlags.NonPublic)!.SetValue(activity, id);
+                typeof(Activity).GetField("_spanId", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(activity, spandId);
+                typeof(Activity).GetField("_traceId", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(activity, activity.TraceId.ToString());
             }
         }
 

--- a/playground/Stress/Stress.ApiService/TraceCreator.cs
+++ b/playground/Stress/Stress.ApiService/TraceCreator.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Reflection;
 
 namespace Stress.ApiService;
 
@@ -12,6 +13,21 @@ public class TraceCreator
     private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
 
     private readonly List<Activity> _allActivities = new List<Activity>();
+
+    public Activity? CreateActivity(string name, string? id)
+    {
+        var activity = s_activitySource.StartActivity(name, ActivityKind.Client);
+        if (activity != null)
+        {
+            if (id != null)
+            {
+                // Gross but it's the only way.
+                typeof(Activity).GetField("_id", BindingFlags.NonPublic | BindingFlags.NonPublic)!.SetValue(activity, id);
+            }
+        }
+
+        return activity;
+    }
 
     public async Task CreateTraceAsync(int count, bool createChildren)
     {

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -52,10 +52,10 @@ public class OtlpTrace
 
     public void AddSpan(OtlpSpan span)
     {
-        if (Spans.Any(s => s.SpanId == span.SpanId))
-        {
-            throw new InvalidOperationException($"Duplicate span id '{span.SpanId}' detected.");
-        }
+        //if (Spans.Any(s => s.SpanId == span.SpanId))
+        //{
+        //    throw new InvalidOperationException($"Duplicate span id '{span.SpanId}' detected.");
+        //}
 
         var added = false;
         for (var i = Spans.Count - 1; i >= 0; i--)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -52,10 +52,10 @@ public class OtlpTrace
 
     public void AddSpan(OtlpSpan span)
     {
-        //if (Spans.Any(s => s.SpanId == span.SpanId))
-        //{
-        //    throw new InvalidOperationException($"Duplicate span id '{span.SpanId}' detected.");
-        //}
+        if (Spans.Any(s => s.SpanId == span.SpanId))
+        {
+            throw new InvalidOperationException($"Duplicate span id '{span.SpanId}' detected.");
+        }
 
         var added = false;
         for (var i = Spans.Count - 1; i >= 0; i--)

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpTrace.cs
@@ -52,6 +52,11 @@ public class OtlpTrace
 
     public void AddSpan(OtlpSpan span)
     {
+        if (Spans.Any(s => s.SpanId == span.SpanId))
+        {
+            throw new InvalidOperationException($"Duplicate span id '{span.SpanId}' detected.");
+        }
+
         var added = false;
         for (var i = Spans.Count - 1; i >= 0; i--)
         {

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/TraceTests.cs
@@ -91,6 +91,57 @@ public class TraceTests
     }
 
     [Fact]
+    public void AddTraces_DuplicateTraceIds_Reject()
+    {
+        // Arrange
+        var repository = CreateRepository();
+        // Act
+        var addContext = new AddContext();
+        repository.AddTraces(addContext, new RepeatedField<ResourceSpans>()
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10)),
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(5), endTime: s_testTime.AddMinutes(10)),
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10), parentSpanId: "1-1"),
+                        }
+                    }
+                }
+            }
+        });
+        // Assert
+        Assert.Equal(1, addContext.FailureCount);
+        var applications = repository.GetApplications();
+        Assert.Collection(applications,
+            app =>
+            {
+                Assert.Equal("TestService", app.ApplicationName);
+                Assert.Equal("TestId", app.InstanceId);
+            });
+        var traces = repository.GetTraces(new GetTracesRequest
+        {
+            ApplicationKey = applications[0].ApplicationKey,
+            FilterText = string.Empty,
+            StartIndex = 0,
+            Count = 10,
+            Filters = []
+        });
+        Assert.Collection(traces.PagedResult.Items,
+            trace =>
+            {
+                Assert.Equal(2, trace.Spans.Count);
+            });
+    }
+
+    [Fact]
     public void AddTraces_Scope_Multiple()
     {
         // Arrange


### PR DESCRIPTION
## Customer Impact

Duplicate span ids in a trace cause a Blazor error. The error UI is displayed and the page is no longer usable. It's no longer possible to span details.

Azure functions .NET SDK is producing bad data like this: https://github.com/dotnet/aspire/issues/6441

This PR updates Aspire to reject the duplicate span id. This matches behavior of AzMon when it gets bad data.

NOTE: Co-incidentially this change was made in main branch a few days ago: https://github.com/dotnet/aspire/pull/6262. The main PR makes more substantial changes. This PR just takes the duplicate span id fix.

Fixes https://github.com/dotnet/aspire/issues/6441

## Testing

Unit test added.

Manual test before:
![image](https://github.com/user-attachments/assets/9437e9df-40fc-4dfd-a53d-fdbe7635a77b)

Manual test after (span with duplicate id is removed):
![image](https://github.com/user-attachments/assets/84896c3b-68e3-4d4f-9474-6d38aff17d2f)

## Risk

Low. 

## Regression?

Yes. SpanId is now used as a grid row ID in Aspire 9. Previously both spans would have displayed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6471)