### PR TITLE
Add manual repo for duplicate span ids

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -225,4 +225,16 @@ Null content: {NullContent}", xmlLarge, xmlWithComments, xmlWithUrl, jsonLarge, 
     return "Log with formatted data";
 });
 
+app.MapGet("/duplicate-spanid", async () =>
+{
+    var traceCreator = new TraceCreator();
+    var span1 = traceCreator.CreateActivity("Test 1", "0485b1947fe788bb");
+    await Task.Delay(1000);
+    span1?.Stop();
+    var span2 = traceCreator.CreateActivity("Test 2", "0485b1947fe788bb");
+    await Task.Delay(1000);
+    span2?.Stop();
+    return $"Created duplicate span IDs.";
+});
+
 app.Run();


### PR DESCRIPTION
## Description

I added a manual repo for duplicate span ids in 9.0 branch. This is to add it to main.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6475)