### PR TITLE
Add SchedulerHostAddress to DaprSidecarOptions

### DIFF
--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -142,6 +142,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         ModelNamedArg("--resources-path", aggregateResourcesPaths),
                         ModelNamedArg("--run-file", NormalizePath(sidecarOptions?.RunFile)),
                         ModelNamedArg("--runtime-path", NormalizePath(sidecarOptions?.RuntimePath)),
+                        ModelNamedArg("--scheduler-host-address", sidecarOptions?.SchedulerHostAddress),
                         ModelNamedArg("--unix-domain-socket", sidecarOptions?.UnixDomainSocket),
                         PostOptionsArgs(Args(sidecarOptions?.Command)));
 
@@ -264,6 +265,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         context.Writer.TryWriteStringArray("resourcesPath", sidecarOptions?.ResourcesPaths.Select(path => context.GetManifestRelativePath(path)));
                         context.Writer.TryWriteString("runFile", context.GetManifestRelativePath(sidecarOptions?.RunFile));
                         context.Writer.TryWriteString("runtimePath", context.GetManifestRelativePath(sidecarOptions?.RuntimePath));
+                        context.Writer.TryWriteString("schedulerHostAddress", sidecarOptions?.SchedulerHostAddress);
                         context.Writer.TryWriteString("unixDomainSocket", sidecarOptions?.UnixDomainSocket);
 
                         context.Writer.WriteEndObject();

--- a/src/Aspire.Hosting.Dapr/DaprSidecarOptions.cs
+++ b/src/Aspire.Hosting.Dapr/DaprSidecarOptions.cs
@@ -158,6 +158,15 @@ public sealed record DaprSidecarOptions
     public string? RuntimePath { get; init; }
 
     /// <summary>
+    /// Gets or sets the address of the scheduler service.
+    /// </summary>
+    /// <remarks>
+    /// The format is either "hostname" for the default port or "hostname:port" for a custom port.
+    /// The default is "localhost".
+    /// </remarks>
+    public string? SchedulerHostAddress { get; init; }
+
+    /// <summary>
     /// Gets or sets the path to a Unix Domain Socket (UDS) directory.
     /// </summary>
     /// <remarks>

--- a/src/Aspire.Hosting.Dapr/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Dapr/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
-
+Aspire.Hosting.Dapr.DaprSidecarOptions.SchedulerHostAddress.get -> string?
+Aspire.Hosting.Dapr.DaprSidecarOptions.SchedulerHostAddress.init -> void


### PR DESCRIPTION
## Description

I enhanced DaprSidecarOptions by adding the SchedulerHostAddress property. This will allow the developer to specify the host address of the Dapr scheduler service if not running on localhost (for example, if developing using Docker Compose, the scheduler service will be running on a different host).

I enhanced the DaprDistributedApplicationLifecycleHook to pass the --scheduler-host-address parameter to the Dapr sidecar if the DaprSidecarOptions.SchedulerHostAddress property is specified.

Fixes #6477

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6478)