### PR TITLE
Fix path to TestShop.AppHost in contributing.md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,8 +21,8 @@ If you are using Visual Studio:
 
 Otherwise:
 ```shell
-dotnet restore playground/TestShop/AppHost/AppHost.csproj
-dotnet run --project playground/TestShop/AppHost/AppHost.csproj
+dotnet restore playground/TestShop/TestShop.AppHost/TestShop.AppHost.csproj
+dotnet run --project playground/TestShop/TestShop.AppHost/TestShop.AppHost.csproj
 ```
 
 ## View Dashboard


### PR DESCRIPTION
## Description

The instructions in contributing.md for running the TestShop AppHost project had an incorrect path. I corrected the documentation with the correct path so that the instructions are accurate.

Fixes #6479

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6480)