### PR TITLE
Some ContainerExec experimentation.

### DIFF
--- a/src/Aspire.Hosting/ContainerCommandExecutor.cs
+++ b/src/Aspire.Hosting/ContainerCommandExecutor.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Dcp;
+using Aspire.Hosting.Dcp.Model;
+
+namespace Aspire.Hosting;
+
+/// <summary>
+/// TODO
+/// </summary>
+public class ContainerCommandExecutor
+{
+    private readonly IKubernetesService _k8s;
+
+    internal ContainerCommandExecutor(IKubernetesService k8s)
+    {
+        _k8s = k8s;
+    }
+
+    /// <summary>
+    /// TODO:
+    /// </summary>
+    /// <param name="resource"></param>
+    /// <param name="command"></param>
+    /// <param name="args"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task ExecuteAsync(ContainerResource resource, string command, string[] args, CancellationToken cancellationToken = default)
+    {
+        if (!resource.TryGetLastAnnotation<DcpInstancesAnnotation>(out var annotation))
+        {
+            return;
+        }
+
+        var spec = new ContainerExecSpec()
+        {
+            ContainerName = annotation.Instances.First().Name,
+            Command = command,
+            Args = args.ToList()
+        };
+
+        var exec = new ContainerExec(spec);
+        exec.Metadata.Name = "ls";
+        await _k8s.CreateAsync(exec, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Aspire.Hosting/Dcp/Model/GroupVersion.cs
+++ b/src/Aspire.Hosting/Dcp/Model/GroupVersion.cs
@@ -37,5 +37,6 @@ internal static class Dcp
         Schema.Add<Service>(ServiceKind, "services");
         Schema.Add<Endpoint>(EndpointKind, "endpoints");
         Schema.Add<ExecutableReplicaSet>(ExecutableReplicaSetKind, "executablereplicasets");
+        Schema.Add<ContainerExec>(ContainerExecKind, "containerexecs");
     }
 }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -257,6 +257,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
             // DCP stuff
             _innerBuilder.Services.AddSingleton<ApplicationExecutor>();
+            _innerBuilder.Services.AddSingleton<ContainerCommandExecutor>(sp => new ContainerCommandExecutor(sp.GetRequiredService<IKubernetesService>()));
             _innerBuilder.Services.AddSingleton<IDcpDependencyCheckService, DcpDependencyCheck>();
             _innerBuilder.Services.AddHostedService<DcpHostService>();
             _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DcpOptions>, ConfigureDefaultDcpOptions>());

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -160,6 +160,8 @@ Aspire.Hosting.ApplicationModel.WaitAnnotation.WaitType.get -> Aspire.Hosting.Ap
 Aspire.Hosting.ApplicationModel.WaitType
 Aspire.Hosting.ApplicationModel.WaitType.WaitForCompletion = 1 -> Aspire.Hosting.ApplicationModel.WaitType
 Aspire.Hosting.ApplicationModel.WaitType.WaitUntilHealthy = 0 -> Aspire.Hosting.ApplicationModel.WaitType
+Aspire.Hosting.ContainerCommandExecutor
+Aspire.Hosting.ContainerCommandExecutor.ExecuteAsync(Aspire.Hosting.ApplicationModel.ContainerResource! resource, string! command, string![]! args, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Aspire.Hosting.DistributedApplicationBuilder.AppHostPath.get -> string!
 Aspire.Hosting.DistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eventing.IDistributedApplicationEventing!
 Aspire.Hosting.Eventing.DistributedApplicationEventing


### PR DESCRIPTION
Something to look at post 9.0.

This is just a draft PR for some discussion. In the DCP types we have ContainerExec. It allows us to invoke a command against an existing container. I'm thinking it might enable us to do things like run backup/restore commands inside container images.

This would allow for some interesting advanced scenarios such as triggering a backup/restore of a postgres database using something like pg_dump within the container (the file would be copied to a databindmount.

@danegsta @karolz-ms @DamianEdwards @davidfowl @drewnoakes @JamesNK @adamint 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6481)