### PR TITLE
Add commands to stress playground

### DIFF
--- a/playground/Stress/Stress.ApiService/Program.cs
+++ b/playground/Stress/Stress.ApiService/Program.cs
@@ -95,13 +95,19 @@ app.MapGet("/http-client-requests", async (HttpClient client) =>
     return $"Sent requests to {string.Join(';', urls)}";
 });
 
-app.MapGet("/log-message-limit", ([FromServices] ILogger<Program> logger) =>
+app.MapGet("/log-message-limit", async ([FromServices] ILogger<Program> logger) =>
 {
-    const int LogCount = 20_000;
+    const int LogCount = 10_000;
+    const int BatchSize = 10;
 
-    for (var i = 0; i < LogCount; i++)
+    for (var i = 0; i < LogCount / BatchSize; i++)
     {
-        logger.LogInformation("Log entry {LogEntryIndex}", i);
+        for (var j = 0; j < BatchSize; j++)
+        {
+            logger.LogInformation("Log entry {BatchIndex}-{LogEntryIndex}", i, j);
+        }
+
+        await Task.Delay(100);
     }
 
     return $"Created {LogCount} logs.";

--- a/playground/Stress/Stress.ApiService/TraceCreator.cs
+++ b/playground/Stress/Stress.ApiService/TraceCreator.cs
@@ -34,7 +34,7 @@ public class TraceCreator
     {
         var activityStack = new Stack<Activity>();
 
-        for (var i = 0; i < 10; i++)
+        for (var i = 0; i < count; i++)
         {
             if (i > 0)
             {
@@ -54,8 +54,6 @@ public class TraceCreator
             {
                 await CreateChildActivityAsync(name);
             }
-
-            await Task.Delay(Random.Shared.Next(10, 50));
         }
 
         while (activityStack.Count > 0)

--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -37,11 +37,12 @@ for (var i = 1; i <= 30; i++)
     serviceBuilder.WithHttpEndpoint(port, name: $"http-{port}");
 }
 
-serviceBuilder.WithHttpCommand("/write-console", "Write to console", method: HttpMethod.Get);
-serviceBuilder.WithHttpCommand("/increment-counter", "Increment counter", method: HttpMethod.Get);
-serviceBuilder.WithHttpCommand("/big-trace", "Big trace", method: HttpMethod.Get);
-serviceBuilder.WithHttpCommand("/trace-limit", "Trace limit", method: HttpMethod.Get);
-serviceBuilder.WithHttpCommand("/log-message", "Log message", method: HttpMethod.Get);
+serviceBuilder.WithHttpCommand("/write-console", "Write to console", method: HttpMethod.Get, iconName: "ContentViewGalleryLightning");
+serviceBuilder.WithHttpCommand("/increment-counter", "Increment counter", method: HttpMethod.Get, iconName: "ContentViewGalleryLightning");
+serviceBuilder.WithHttpCommand("/big-trace", "Big trace", method: HttpMethod.Get, iconName: "ContentViewGalleryLightning");
+serviceBuilder.WithHttpCommand("/trace-limit", "Trace limit", method: HttpMethod.Get, iconName: "ContentViewGalleryLightning");
+serviceBuilder.WithHttpCommand("/log-message", "Log message", method: HttpMethod.Get, iconName: "ContentViewGalleryLightning");
+serviceBuilder.WithHttpCommand("/log-message-limit", "Log message limit", method: HttpMethod.Get, iconName: "ContentViewGalleryLightning");
 
 builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice");
 

--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -1,7 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.DependencyInjection;
+
 var builder = DistributedApplication.CreateBuilder(args);
+builder.Services.AddHttpClient();
 
 for (var i = 0; i < 10; i++)
 {
@@ -27,11 +30,18 @@ serviceBuilder.WithCommand(
     iconName: "CloudDatabase",
     isHighlighted: true);
 
-for (var i = 0; i < 30; i++)
+serviceBuilder.WithHttpEndpoint(5180, name: $"http");
+for (var i = 1; i <= 30; i++)
 {
     var port = 5180 + i;
     serviceBuilder.WithHttpEndpoint(port, name: $"http-{port}");
 }
+
+serviceBuilder.WithHttpCommand("/write-console", "Write to console", method: HttpMethod.Get);
+serviceBuilder.WithHttpCommand("/increment-counter", "Increment counter", method: HttpMethod.Get);
+serviceBuilder.WithHttpCommand("/big-trace", "Big trace", method: HttpMethod.Get);
+serviceBuilder.WithHttpCommand("/trace-limit", "Trace limit", method: HttpMethod.Get);
+serviceBuilder.WithHttpCommand("/log-message", "Log message", method: HttpMethod.Get);
 
 builder.AddProject<Projects.Stress_TelemetryService>("stress-telemetryservice");
 

--- a/playground/Stress/Stress.AppHost/ResourceBuilderExtensions.cs
+++ b/playground/Stress/Stress.AppHost/ResourceBuilderExtensions.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+
+internal static class ResourceBuilderExtensions
+{
+    /// <summary>
+    /// Adds a command to the resource that sends an HTTP request to the specified path.
+    /// </summary>
+    public static IResourceBuilder<TResource> WithHttpsCommand<TResource>(this IResourceBuilder<TResource> builder,
+        string path,
+        string displayName,
+        HttpMethod? method = default,
+        string? endpointName = default,
+        string? iconName = default)
+        where TResource : IResourceWithEndpoints
+        => WithHttpCommandImpl(builder, path, displayName, endpointName ?? "https", method, "https", iconName);
+
+    /// <summary>
+    /// Adds a command to the resource that sends an HTTP request to the specified path.
+    /// </summary>
+    public static IResourceBuilder<TResource> WithHttpCommand<TResource>(this IResourceBuilder<TResource> builder,
+        string path,
+        string displayName,
+        HttpMethod? method = default,
+        string? endpointName = default,
+        string? iconName = default)
+        where TResource : IResourceWithEndpoints
+        => WithHttpCommandImpl(builder, path, displayName, endpointName ?? "http", method, "http", iconName);
+
+    private static IResourceBuilder<TResource> WithHttpCommandImpl<TResource>(this IResourceBuilder<TResource> builder,
+        string path,
+        string displayName,
+        string endpointName,
+        HttpMethod? method,
+        string expectedScheme,
+        string? iconName = default)
+        where TResource : IResourceWithEndpoints
+    {
+        method ??= HttpMethod.Post;
+
+        var endpoints = builder.Resource.GetEndpoints();
+        var endpoint = endpoints.FirstOrDefault(e => string.Equals(e.EndpointName, endpointName, StringComparison.OrdinalIgnoreCase))
+            ?? throw new DistributedApplicationException($"Could not create HTTP command for resource '{builder.Resource.Name}' as no endpoint named '{endpointName}' was found.");
+
+        var commandType = $"http-{method.Method.ToLowerInvariant()}-{path.ToLowerInvariant()}-request";
+
+        builder.WithCommand(commandType, displayName, async context =>
+        {
+            if (!endpoint.IsAllocated)
+            {
+                return new ExecuteCommandResult { Success = false, ErrorMessage = "Endpoints are not yet allocated." };
+            }
+
+            if (!string.Equals(endpoint.Scheme, expectedScheme, StringComparison.OrdinalIgnoreCase))
+            {
+                return new ExecuteCommandResult { Success = false, ErrorMessage = $"The endpoint named '{endpointName}' on resource '{builder.Resource.Name}' does not have the expected scheme of '{expectedScheme}'." };
+            }
+
+            var uri = new UriBuilder(endpoint.Url) { Path = path }.Uri;
+            var httpClient = context.ServiceProvider.GetRequiredService<IHttpClientFactory>().CreateClient();
+            var request = new HttpRequestMessage(method, uri);
+            try
+            {
+                var response = await httpClient.SendAsync(request, context.CancellationToken);
+                response.EnsureSuccessStatusCode();
+            }
+            catch (Exception ex)
+            {
+                return new ExecuteCommandResult { Success = false, ErrorMessage = ex.Message };
+            }
+            return new ExecuteCommandResult { Success = true };
+        },
+        iconName: iconName,
+        iconVariant: IconVariant.Regular);
+
+        return builder;
+    }
+}


### PR DESCRIPTION
## Description

The stress project has a bunch of APIs for causing certain behavior. For example, `/log-message` logs a message with a bunch of unusual content. This PR adds commands to call the APIs from the dashboard.

@DamianEdwards Some issues I encountered using `WithHttpCommand`:

* Order matters. If commands are added before endpoints then it errors. A fix could be to resolve the endpoint inside the command callback.
* Command name is based on the method. If there are lots of "GET" commands then they're reduced to one. Need a better automatic name (I modified the method to include the URL in the name)
* Needs HttpClientFactory registered. It's not registered in app host by default. Bug or not? An improvement could be to detect if it is registered or not and throw a more friendly error message.

Screenshot:

![image](https://github.com/user-attachments/assets/4b6952fa-5db9-462d-89ed-6bf4914fd80e)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6487)