### PR TITLE
Update Cosmos Hosting documentation with correct nuget package name

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -13,7 +13,7 @@ Provides extension methods and resource definitions for a .NET Aspire AppHost to
 In your AppHost project, install the .NET Aspire Azure Cosmos DB Hosting library with [NuGet](https://www.nuget.org):
 
 ```dotnetcli
-dotnet add package Aspire.Hosting.Azure.Cosmos
+dotnet add package Aspire.Hosting.Azure.CosmosDB
 ```
 
 ## Configure Azure Provisioning for local development
@@ -25,11 +25,11 @@ automatically.
 
 ```json
 {
-    "Azure": {
-      "SubscriptionId": "<your subscription id>",
-      "ResourceGroupPrefix": "<prefix for the resource group>",
-      "Location": "<azure location>"
-    }
+  "Azure": {
+    "SubscriptionId": "<your subscription id>",
+    "ResourceGroupPrefix": "<prefix for the resource group>",
+    "Location": "<azure location>"
+  }
 }
 ```
 
@@ -71,8 +71,8 @@ builder.AddAzureCosmosClient("cosmos");
 
 ## Additional documentation
 
-* https://learn.microsoft.com/azure/cosmos-db/nosql/sdk-dotnet-v3
-* https://github.com/dotnet/aspire/tree/main/src/Components/README.md
+- https://learn.microsoft.com/azure/cosmos-db/nosql/sdk-dotnet-v3
+- https://github.com/dotnet/aspire/tree/main/src/Components/README.md
 
 ## Feedback & contributing
 

--- a/src/Aspire.Hosting.Azure.CosmosDB/README.md
+++ b/src/Aspire.Hosting.Azure.CosmosDB/README.md
@@ -25,11 +25,11 @@ automatically.
 
 ```json
 {
-  "Azure": {
-    "SubscriptionId": "<your subscription id>",
-    "ResourceGroupPrefix": "<prefix for the resource group>",
-    "Location": "<azure location>"
-  }
+    "Azure": {
+      "SubscriptionId": "<your subscription id>",
+      "ResourceGroupPrefix": "<prefix for the resource group>",
+      "Location": "<azure location>"
+    }
 }
 ```
 
@@ -71,8 +71,8 @@ builder.AddAzureCosmosClient("cosmos");
 
 ## Additional documentation
 
-- https://learn.microsoft.com/azure/cosmos-db/nosql/sdk-dotnet-v3
-- https://github.com/dotnet/aspire/tree/main/src/Components/README.md
+* https://learn.microsoft.com/azure/cosmos-db/nosql/sdk-dotnet-v3
+* https://github.com/dotnet/aspire/tree/main/src/Components/README.md
 
 ## Feedback & contributing
 


### PR DESCRIPTION
Simple documentation update, fixing wrong nuget package name in CosmosDb Hosting readme.

The correct nuget package: https://www.nuget.org/packages/Aspire.Hosting.Azure.CosmosDB/9.0.0-rc.1.24511.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6488)