### PR TITLE
Enable devcontainers in repo.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -83,7 +83,7 @@
 			}
 		}
 	},
-	"postCreateCommand": "dotnet restore",
+	"onCreateCommand": "dotnet restore",
 	"postStartCommand": "dotnet dev-certs https --trust"
 
 	// Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,12 @@
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {},
 		"ghcr.io/azure/azure-dev/azd:0": {},
-		"ghcr.io/devcontainers/features/docker-in-docker": {}
+		"ghcr.io/devcontainers/features/docker-in-docker": {},
+		"ghcr.io/devcontainers/features/dotnet": {
+			"additionalVersions": [
+				"8.0.403"
+			]
+		}
 	},
 
 	"containerEnv": {
@@ -18,12 +23,25 @@
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [5000, 5001],
-	// "portsAttributes": {
-	//		"5001": {
-	//			"protocol": "https"
-	//		}
-	// }
+	"forwardPorts": [
+		15887, // playground/waitfor/WaitForSandbox.AppHost
+		5180, // playground/waitfor/WaitForSandbox.ApiService
+		7024 // playground/waitfor/WaitFor.Frontend
+	],
+	"portsAttributes": {
+		"15887": {
+			"label": "WaitForSandbox.AppHost",
+			"protocol": "https"
+		},
+		"5180": {
+			"label": "WaitForSandbox.ApiService",
+			"protocol": "http"
+		},
+		"7024": {
+			"label": "WaitFor.Frontend",
+			"protocol": "https"
+		}
+	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "rm -rf .dotnet && sudo chmod +x dotnet.sh && ./dotnet.sh restore",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,27 +26,43 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
-		15887, // playground/waitfor AppHost
-		5180, // playground/waitfor ApiService
-		7024, // playground/waitfor Frontend
-		15551 // playground/waitfor PGAdmin
+		15887,
+		5180,
+		7024,
+		15551,
+		33803,
+		5350,
+		41567,
+		15306
 	],
 	"portsAttributes": {
-		"15887": {
-			"label": "WaitFor Playground: AppHost",
-			"protocol": "https"
-		},
 		"5180": {
 			"label": "WaitFor Playground: ApiService",
 			"protocol": "http"
+		},
+		"5350": {
+			"label": "Redis Playground: Api Service"
 		},
 		"7024": {
 			"label": "WaitFor Playground: Frontend",
 			"protocol": "https"
 		},
+		"15306": {
+			"label": "Redis Playground: App Host"
+		},
 		"15551": {
 			"label": "WaitFor Playground: PGAdmin",
 			"protocol": "http"
+		},
+		"15887": {
+			"label": "WaitFor Playground: AppHost",
+			"protocol": "https"
+		},
+		"33803": {
+			"label": "Redis Playground: Redis Commander"
+		},
+		"41567": {
+			"label": "Redis Playground: Redis Insight"
 		}
 	},
 	"otherPortsAttributes": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,10 +56,12 @@
 				"ms-azuretools.azure-dev"
 			],
 			"settings": {
-				"remote.autoForwardPorts": false
+				"remote.autoForwardPorts": false,
+				"dotnet.defaultSolution": "Aspire.sln"
 			}
 		}
 	},
+	"postCreateCommand": "dotnet restore",
 	"postStartCommand": "dotnet dev-certs https --trust"
 
 	// Configure tool-specific properties.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+	"name": "C# (.NET)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/dotnet:1-9.0",
+	"features": {
+		"ghcr.io/devcontainers/features/azure-cli:1": {},
+		"ghcr.io/azure/azure-dev/azd:0": {},
+		"ghcr.io/devcontainers/features/docker-in-docker": {}
+	},
+
+	"containerEnv": {
+		"DOTNET_ROOT": "/workspaces/aspire/.dotnet"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001],
+	// "portsAttributes": {
+	//		"5001": {
+	//			"protocol": "https"
+	//		}
+	// }
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "rm -rf .dotnet && sudo chmod +x dotnet.sh && ./dotnet.sh restore",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.csdevkit"
+			]
+		}
+	}
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,12 @@
 		}
 	},
 
+	"hostRequirements": {
+		"cpus": 8,
+		"memory": "32gb",
+		"storage": "64gb"
+	},
+
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,43 +15,52 @@
 		}
 	},
 
-	"containerEnv": {
-		"DOTNET_ROOT": "/workspaces/aspire/.dotnet"
-	},
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
-		15887, // playground/waitfor/WaitForSandbox.AppHost
-		5180, // playground/waitfor/WaitForSandbox.ApiService
-		7024 // playground/waitfor/WaitFor.Frontend
+		15887, // playground/waitfor AppHost
+		5180, // playground/waitfor ApiService
+		7024, // playground/waitfor Frontend
+		15551 // playground/waitfor PGAdmin
 	],
 	"portsAttributes": {
 		"15887": {
-			"label": "WaitForSandbox.AppHost",
+			"label": "WaitFor Playground: AppHost",
 			"protocol": "https"
 		},
 		"5180": {
-			"label": "WaitForSandbox.ApiService",
+			"label": "WaitFor Playground: ApiService",
 			"protocol": "http"
 		},
 		"7024": {
-			"label": "WaitFor.Frontend",
+			"label": "WaitFor Playground: Frontend",
 			"protocol": "https"
+		},
+		"15551": {
+			"label": "WaitFor Playground: PGAdmin",
+			"protocol": "http"
 		}
+	},
+	"otherPortsAttributes": {
+		"onAutoForward": "ignore"
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "rm -rf .dotnet && sudo chmod +x dotnet.sh && ./dotnet.sh restore",
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"ms-dotnettools.csdevkit"
-			]
+				"ms-dotnettools.csdevkit",
+				"ms-azuretools.vscode-bicep",
+				"ms-azuretools.azure-dev"
+			],
+			"settings": {
+				"remote.autoForwardPorts": false
+			}
 		}
-	}
+	},
+	"postStartCommand": "dotnet dev-certs https --trust"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/playground/Redis/Redis.AppHost/Program.cs
+++ b/playground/Redis/Redis.AppHost/Program.cs
@@ -2,8 +2,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var redis = builder.AddRedis("redis")
     .WithDataVolume()
-    .WithRedisCommander()
-    .WithRedisInsight();
+    .WithRedisCommander(c => c.WithHostPort(33803))
+    .WithRedisInsight(c => c.WithHostPort(41567));
 
 var garnet = builder.AddGarnet("garnet")
     .WithDataVolume();

--- a/playground/waitfor/WaitForSandbox.AppHost/Program.cs
+++ b/playground/waitfor/WaitForSandbox.AppHost/Program.cs
@@ -10,11 +10,6 @@ var db = builder.AddAzurePostgresFlexibleServer("pg")
                     c.WithPgAdmin(c =>
                     {
                         c.WithHostPort(15551);
-
-                        // Variables that we are going to need to set when we detect that
-                        // we are run run mode with codespaces.
-                        c.WithEnvironment("PGADMIN_CONFIG_PROXY_X_HOST_COUNT", "1");
-                        c.WithEnvironment("PGADMIN_CONFIG_PROXY_X_PREFIX_COUNT", "1");
                     });
                 })
                 .AddDatabase("db");

--- a/playground/waitfor/WaitForSandbox.AppHost/Program.cs
+++ b/playground/waitfor/WaitForSandbox.AppHost/Program.cs
@@ -7,7 +7,15 @@ var db = builder.AddAzurePostgresFlexibleServer("pg")
                 .WithPasswordAuthentication()
                 .RunAsContainer(c =>
                 {
-                    c.WithPgAdmin();
+                    c.WithPgAdmin(c =>
+                    {
+                        c.WithHostPort(15551);
+
+                        // Variables that we are going to need to set when we detect that
+                        // we are run run mode with codespaces.
+                        c.WithEnvironment("PGADMIN_CONFIG_PROXY_X_HOST_COUNT", "1");
+                        c.WithEnvironment("PGADMIN_CONFIG_PROXY_X_PREFIX_COUNT", "1");
+                    });
                 })
                 .AddDatabase("db");
 

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -4,11 +4,10 @@
 using System.Text;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.Codespaces;
 using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Utils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting;
 
@@ -339,8 +338,8 @@ public static class PostgresBuilderExtensions
         // When running in the context of Codespaces we need to set some additional environment
         // varialbes so that PGAdmin will trust the forwarded headers that Codespaces port
         // forwarding will send.
-        var codespaceOptions = context.ExecutionContext.ServiceProvider.GetRequiredService<IOptions<CodespacesOptions>>();
-        if (context.ExecutionContext.IsRunMode && codespaceOptions.Value.IsCodespace)
+        var config = context.ExecutionContext.ServiceProvider.GetRequiredService<IConfiguration>();
+        if (context.ExecutionContext.IsRunMode && config.GetValue<bool>("CODESPACES", false))
         {
             context.EnvironmentVariables["PGADMIN_CONFIG_PROXY_X_HOST_COUNT"] = "1";
             context.EnvironmentVariables["PGADMIN_CONFIG_PROXY_X_PREFIX_COUNT"] = "1";

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -4,9 +4,11 @@
 using System.Text;
 using System.Text.Json;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Codespaces;
 using Aspire.Hosting.Postgres;
 using Aspire.Hosting.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting;
 
@@ -333,6 +335,16 @@ public static class PostgresBuilderExtensions
         // You need to define the PGADMIN_DEFAULT_EMAIL and PGADMIN_DEFAULT_PASSWORD or PGADMIN_DEFAULT_PASSWORD_FILE environment variables.
         context.EnvironmentVariables.Add("PGADMIN_DEFAULT_EMAIL", "admin@domain.com");
         context.EnvironmentVariables.Add("PGADMIN_DEFAULT_PASSWORD", "admin");
+
+        // When running in the context of Codespaces we need to set some additional environment
+        // varialbes so that PGAdmin will trust the forwarded headers that Codespaces port
+        // forwarding will send.
+        var codespaceOptions = context.ExecutionContext.ServiceProvider.GetRequiredService<IOptions<CodespacesOptions>>();
+        if (context.ExecutionContext.IsRunMode && codespaceOptions.Value.IsCodespace)
+        {
+            context.EnvironmentVariables["PGADMIN_CONFIG_PROXY_X_HOST_COUNT"] = "1";
+            context.EnvironmentVariables["PGADMIN_CONFIG_PROXY_X_PREFIX_COUNT"] = "1";
+        }
     }
 
     /// <summary>

--- a/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
@@ -36,7 +36,7 @@ public class CodespacesOptions
     /// Maps to the CODESPACE_NAME environment variable.
     /// </remarks>
     [MemberNotNullWhenAttribute(true, nameof(IsCodespace))]
-    public string? CodespaceName { get; set; } = null;
+    public string? CodespaceName { get; set; };
 }
 
 internal class ConfigureCodespacesOptions(IConfiguration configuration) : IConfigureOptions<CodespacesOptions>

--- a/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
@@ -26,7 +26,7 @@ public class CodespacesOptions
     /// <remarks>
     /// Maps to the GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN environment variable.
     /// </remarks>
-    [MemberNotNullWhenAttribute(true, nameof(IsCodespace))]
+    [MemberNotNullWhen(true, nameof(IsCodespace))]
     public string? PortForwardingDomain { get; set; } = null;
 
     /// <summary>

--- a/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
@@ -10,7 +10,7 @@ namespace Aspire.Hosting.Codespaces;
 /// <summary>
 /// GitHub Codespaces configuration values.
 /// </summary>
-public class CodespacesOptions
+internal class CodespacesOptions
 {
     /// <summary>
     /// When set to true, the app host is running in a GitHub Codespace.

--- a/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
@@ -27,7 +27,7 @@ public class CodespacesOptions
     /// Maps to the GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN environment variable.
     /// </remarks>
     [MemberNotNullWhen(true, nameof(IsCodespace))]
-    public string? PortForwardingDomain { get; set; } = null;
+    public string? PortForwardingDomain { get; set; };
 
     /// <summary>
     /// When set it is the name of the GitHub Codespace in which the app host is running.

--- a/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
@@ -27,7 +27,7 @@ public class CodespacesOptions
     /// Maps to the GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN environment variable.
     /// </remarks>
     [MemberNotNullWhen(true, nameof(IsCodespace))]
-    public string? PortForwardingDomain { get; set; };
+    public string? PortForwardingDomain { get; set; }
 
     /// <summary>
     /// When set it is the name of the GitHub Codespace in which the app host is running.
@@ -36,7 +36,7 @@ public class CodespacesOptions
     /// Maps to the CODESPACE_NAME environment variable.
     /// </remarks>
     [MemberNotNullWhen(true, nameof(IsCodespace))]
-    public string? CodespaceName { get; set; };
+    public string? CodespaceName { get; set; }
 }
 
 internal class ConfigureCodespacesOptions(IConfiguration configuration) : IConfigureOptions<CodespacesOptions>

--- a/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
@@ -35,7 +35,7 @@ public class CodespacesOptions
     /// <remarks>
     /// Maps to the CODESPACE_NAME environment variable.
     /// </remarks>
-    [MemberNotNullWhenAttribute(true, nameof(IsCodespace))]
+    [MemberNotNullWhen(true, nameof(IsCodespace))]
     public string? CodespaceName { get; set; };
 }
 

--- a/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 namespace Aspire.Hosting.Codespaces;
 
 /// <summary>
-/// GitHub Codespaces configuration valies.
+/// GitHub Codespaces configuration values.
 /// </summary>
 public class CodespacesOptions
 {

--- a/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesOptions.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Codespaces;
+
+/// <summary>
+/// GitHub Codespaces configuration valies.
+/// </summary>
+public class CodespacesOptions
+{
+    /// <summary>
+    /// When set to true, the app host is running in a GitHub Codespace.
+    /// </summary>
+    /// <remarks>
+    /// Maps to the CODESPACE environment variable.
+    /// </remarks>
+    public bool IsCodespace { get; set; }
+
+    /// <summary>
+    /// When set it is the domain suffix used when port forwarding services hosted on the Codespace.
+    /// </summary>
+    /// <remarks>
+    /// Maps to the GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN environment variable.
+    /// </remarks>
+    [MemberNotNullWhenAttribute(true, nameof(IsCodespace))]
+    public string? PortForwardingDomain { get; set; } = null;
+
+    /// <summary>
+    /// When set it is the name of the GitHub Codespace in which the app host is running.
+    /// </summary>
+    /// <remarks>
+    /// Maps to the CODESPACE_NAME environment variable.
+    /// </remarks>
+    [MemberNotNullWhenAttribute(true, nameof(IsCodespace))]
+    public string? CodespaceName { get; set; } = null;
+}
+
+internal class ConfigureCodespacesOptions(IConfiguration configuration) : IConfigureOptions<CodespacesOptions>
+{
+    private const string CodespacesEnvironmentVariable = "CODESPACES";
+    private const string CodespaceNameEnvironmentVariable = "CODESPACE_NAME";
+    private const string GitHubCodespacesPortForwardingDomain = "GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN";
+
+    private string GetRequiredCodespacesConfigurationValue(string key)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(key);
+        return configuration.GetValue<string>(key) ?? throw new DistributedApplicationException($"Codespaces was detected but {key} environment missing.");
+    }
+
+    public void Configure(CodespacesOptions options)
+    {
+        if (!configuration.GetValue<bool>(CodespacesEnvironmentVariable, false))
+        {
+            options.IsCodespace = false;
+            return;
+        }
+
+        options.IsCodespace = true;
+        options.PortForwardingDomain = GetRequiredCodespacesConfigurationValue(GitHubCodespacesPortForwardingDomain);
+        options.CodespaceName = GetRequiredCodespacesConfigurationValue(CodespaceNameEnvironmentVariable);
+    }
+}

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -269,6 +269,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             _innerBuilder.Services.AddSingleton<IKubernetesService, KubernetesService>();
 
             // Codespaces
+            _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<CodespacesOptions>, ConfigureCodespacesOptions>());
             _innerBuilder.Services.AddHostedService<CodespacesUrlRewriter>();
 
             Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.InitializeDcpAnnotations);

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -160,14 +160,6 @@ Aspire.Hosting.ApplicationModel.WaitAnnotation.WaitType.get -> Aspire.Hosting.Ap
 Aspire.Hosting.ApplicationModel.WaitType
 Aspire.Hosting.ApplicationModel.WaitType.WaitForCompletion = 1 -> Aspire.Hosting.ApplicationModel.WaitType
 Aspire.Hosting.ApplicationModel.WaitType.WaitUntilHealthy = 0 -> Aspire.Hosting.ApplicationModel.WaitType
-Aspire.Hosting.Codespaces.CodespacesOptions
-Aspire.Hosting.Codespaces.CodespacesOptions.CodespaceName.get -> string?
-Aspire.Hosting.Codespaces.CodespacesOptions.CodespaceName.set -> void
-Aspire.Hosting.Codespaces.CodespacesOptions.CodespacesOptions() -> void
-Aspire.Hosting.Codespaces.CodespacesOptions.IsCodespace.get -> bool
-Aspire.Hosting.Codespaces.CodespacesOptions.IsCodespace.set -> void
-Aspire.Hosting.Codespaces.CodespacesOptions.PortForwardingDomain.get -> string?
-Aspire.Hosting.Codespaces.CodespacesOptions.PortForwardingDomain.set -> void
 Aspire.Hosting.DistributedApplicationBuilder.AppHostPath.get -> string!
 Aspire.Hosting.DistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eventing.IDistributedApplicationEventing!
 Aspire.Hosting.Eventing.DistributedApplicationEventing

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -160,6 +160,14 @@ Aspire.Hosting.ApplicationModel.WaitAnnotation.WaitType.get -> Aspire.Hosting.Ap
 Aspire.Hosting.ApplicationModel.WaitType
 Aspire.Hosting.ApplicationModel.WaitType.WaitForCompletion = 1 -> Aspire.Hosting.ApplicationModel.WaitType
 Aspire.Hosting.ApplicationModel.WaitType.WaitUntilHealthy = 0 -> Aspire.Hosting.ApplicationModel.WaitType
+Aspire.Hosting.Codespaces.CodespacesOptions
+Aspire.Hosting.Codespaces.CodespacesOptions.CodespaceName.get -> string?
+Aspire.Hosting.Codespaces.CodespacesOptions.CodespaceName.set -> void
+Aspire.Hosting.Codespaces.CodespacesOptions.CodespacesOptions() -> void
+Aspire.Hosting.Codespaces.CodespacesOptions.IsCodespace.get -> bool
+Aspire.Hosting.Codespaces.CodespacesOptions.IsCodespace.set -> void
+Aspire.Hosting.Codespaces.CodespacesOptions.PortForwardingDomain.get -> string?
+Aspire.Hosting.Codespaces.CodespacesOptions.PortForwardingDomain.set -> void
 Aspire.Hosting.DistributedApplicationBuilder.AppHostPath.get -> string!
 Aspire.Hosting.DistributedApplicationBuilder.Eventing.get -> Aspire.Hosting.Eventing.IDistributedApplicationEventing!
 Aspire.Hosting.Eventing.DistributedApplicationEventing

--- a/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
+++ b/tests/Aspire.Hosting.Tests/Codespaces/CodespacesUrlRewriterTests.cs
@@ -15,6 +15,10 @@ public class CodespacesUrlRewriterTests(ITestOutputHelper testOutputHelper)
     public async Task VerifyUrlsRewriterStopsWhenNotInCodespaces()
     {
         using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        // Explicitly disable codespace behavior for this test.
+        builder.Configuration["CODESPACES"] = "false";
+
         builder.Services.AddLogging(logging =>
         {
             logging.AddFakeLogging();


### PR DESCRIPTION
## Description

This is an initial PR to enable devcontainer support in the repo. The goal is to enable the various remote development scenarios (Codespaces, SSH, etc) so that we can test them. This is important because we've added logic to the apphost that can do things like detect it is running in Codespaces and using the Aspire repo under Codespaces is a good way of casually validating everything is working.

![image](https://github.com/user-attachments/assets/d1a8e458-360c-4005-976d-8444116098b8)


## Outstanding issues

- [ ] Dashboard URL shows as localhost:port/login?t=<token>; whilst Codespaces will automatically remap that URL for us when we click on it, the redirect flow (GitHub auth) looses the token in the URL

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Link to aspire-docs issue: 
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6491)