### PR TITLE
Minor improvements to dist app builder config

### DIFF
--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -179,9 +179,17 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
         // account for the path the AppHost is running from to disambiguate between different projects
         // with the same name as seen in https://github.com/dotnet/aspire/issues/5413. For publish scenarios,
         // we want to use a stable hash based only on the project name.
-        var appHostShaBytes = SHA256.HashData(Encoding.UTF8.GetBytes(AppHostPath));
-        var appHostNameShaBytes = SHA256.HashData(Encoding.UTF8.GetBytes(appHostName));
-        var appHostSha = ExecutionContext.IsPublishMode ? Convert.ToHexString(appHostNameShaBytes) : Convert.ToHexString(appHostShaBytes);
+        string appHostSha;
+        if (ExecutionContext.IsPublishMode)
+        {
+            var appHostNameShaBytes = SHA256.HashData(Encoding.UTF8.GetBytes(appHostName));
+            appHostSha = Convert.ToHexString(appHostNameShaBytes);
+        }
+        else
+        {
+            var appHostShaBytes = SHA256.HashData(Encoding.UTF8.GetBytes(AppHostPath));
+            appHostSha = Convert.ToHexString(appHostShaBytes);
+        }
         _innerBuilder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["AppHost:Sha256"] = appHostSha
@@ -241,6 +249,16 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
                         {
                             ["AppHost:ResourceService:AuthMode"] = nameof(ResourceServiceAuthMode.ApiKey),
                             ["AppHost:ResourceService:ApiKey"] = apiKey
+                        }
+                    );
+                }
+                else
+                {
+                    // The dashboard is enabled but is unsecured. Set auth mode config setting to reflect this state.
+                    _innerBuilder.Configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?>
+                        {
+                            ["AppHost:ResourceService:AuthMode"] = nameof(ResourceServiceAuthMode.Unsecured)
                         }
                     );
                 }

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
@@ -103,7 +103,7 @@ public class DistributedApplicationBuilderTests
         using var app = appBuilder.Build();
 
         var config = app.Services.GetRequiredService<IConfiguration>();
-        Assert.Equal(nameof(ResourceServiceAuthMode.Unsecured), config["AppHost:ResourceService:AuthMode"]);
+        Assert.Equal(nameof(ResourceServiceAuthMode.ApiKey), config["AppHost:ResourceService:AuthMode"]);
         Assert.False(string.IsNullOrEmpty(config["AppHost:ResourceService:ApiKey"]));
     }
 

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationBuilderTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Publishing;
@@ -93,6 +94,28 @@ public class DistributedApplicationBuilderTests
 
         var config = app.Services.GetRequiredService<IConfiguration>();
         Assert.Equal(appHostDirectory, config["AppHost:Directory"]);
+    }
+
+    [Fact]
+    public void ResourceServiceConfig_Secured()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder();
+        using var app = appBuilder.Build();
+
+        var config = app.Services.GetRequiredService<IConfiguration>();
+        Assert.Equal(nameof(ResourceServiceAuthMode.Unsecured), config["AppHost:ResourceService:AuthMode"]);
+        Assert.False(string.IsNullOrEmpty(config["AppHost:ResourceService:ApiKey"]));
+    }
+
+    [Fact]
+    public void ResourceServiceConfig_Unsecured()
+    {
+        var appBuilder = DistributedApplication.CreateBuilder(args: [$"{KnownConfigNames.DashboardUnsecuredAllowAnonymous}=true"]);
+        using var app = appBuilder.Build();
+
+        var config = app.Services.GetRequiredService<IConfiguration>();
+        Assert.Equal(nameof(ResourceServiceAuthMode.Unsecured), config["AppHost:ResourceService:AuthMode"]);
+        Assert.True(string.IsNullOrEmpty(config["AppHost:ResourceService:ApiKey"]));
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Some minor things I noticed while looking at app host config

- Don't calculate sha then throw it away
- Explicitly set resource service config to unsecured when unsecured

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6524)