### PR TITLE
Use rc.2 branding on EF Npgsql integration

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -6,6 +6,9 @@
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <PreReleaseVersionLabel>preview.5</PreReleaseVersionLabel>
+    <!-- Aspire.Npgsql.EntityFrameworkCore.PostgreSQL will ship right after our November release, but it has already shipped as rc.1 so
+    we can't 'downgrade' it to preview.5. We will ship it as rc.2 in November and will mark it stable once EF Npgsql dependency ships stable. -->
+    <PrereleaseVersionLabel Condition="'$(MSBuildProjectName)' == 'Aspire.Npgsql.EntityFrameworkCore.PostgreSQL'">rc.2</PrereleaseVersionLabel>
     <!--
       When running package validation as part of the build, we want to ensure we didn't break the API against the previous
       version of each package. The following property points to the package version that should be used as baseline.


### PR DESCRIPTION
## Description

Having EF NpgSql integration produce RC.2 branded prerelease in order to not downgrade from rc1 version during GA release.

cc: @eerhardt 

Fixes #6492 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6537)