### PR TITLE
Move env vars to bottom of resource details

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor
@@ -71,19 +71,6 @@
                     HighlightText="@_filter"
                     GridTemplateColumns="1fr 1.5fr" />
             </FluentAccordionItem>
-            <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsEnvironmentVariablesHeader)]" Expanded="@_isEnvironmentVariablesExpanded">
-                <div slot="end">
-                    <FluentBadge Appearance="Appearance.Neutral" Circular="true">
-                        @FilteredEnvironmentVariables.Count()
-                    </FluentBadge>
-                </div>
-                <PropertyGrid
-                    TItem="EnvironmentVariableViewModel"
-                    Items="@FilteredEnvironmentVariables"
-                    IsValueMaskedChanged="@OnValueMaskedChanged"
-                    HighlightText="@_filter"
-                    GridTemplateColumns="1fr 1.5fr" />
-            </FluentAccordionItem>
             @if (Resource.IsContainer())
             {
                 <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsVolumesHeader)]" Expanded="@_isVolumesExpanded">
@@ -172,6 +159,18 @@
                         </GridValue>
                     </AspireTemplateColumn>
                 </FluentDataGrid>
+            </FluentAccordionItem>
+            <FluentAccordionItem Heading="@ControlStringsLoc[nameof(ControlsStrings.ResourceDetailsEnvironmentVariablesHeader)]" Expanded="@_isEnvironmentVariablesExpanded">
+                <div slot="end">
+                    <FluentBadge Appearance="Appearance.Neutral" Circular="true">
+                        @FilteredEnvironmentVariables.Count()
+                    </FluentBadge>
+                </div>
+                <PropertyGrid TItem="EnvironmentVariableViewModel"
+                              Items="@FilteredEnvironmentVariables"
+                              IsValueMaskedChanged="@OnValueMaskedChanged"
+                              HighlightText="@_filter"
+                              GridTemplateColumns="1fr 1.5fr" />
             </FluentAccordionItem>
         </FluentAccordion>
     </div>


### PR DESCRIPTION
## Description

Env vars, especially for projects, is usually the biggest section in details. Move env var to the bottom of resource details to avoid is hiding other info below it, e.g. health checks.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6552)