### PR TITLE
Don't display telemetry actions when no telemetry

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceActions.razor.cs
@@ -81,44 +81,44 @@ public partial class ResourceActions : ComponentBase
 
         // Show telemetry menu items if there is telemetry for the resource.
         var hasTelemetryApplication = TelemetryRepository.GetApplicationByCompositeName(Resource.Name) != null;
-        var telemetryTooltip = !hasTelemetryApplication ? Loc[nameof(Resources.Resources.ResourceActionTelemetryTooltip)] : string.Empty;
-        _menuItems.Add(new MenuButtonItem { IsDivider = true });
-        _menuItems.Add(new MenuButtonItem
+        if (hasTelemetryApplication)
         {
-            Text = Loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
-            Icon = s_structuredLogsIcon,
-            OnClick = () =>
+            var telemetryTooltip = !hasTelemetryApplication ? Loc[nameof(Resources.Resources.ResourceActionTelemetryTooltip)] : string.Empty;
+            _menuItems.Add(new MenuButtonItem { IsDivider = true });
+            _menuItems.Add(new MenuButtonItem
             {
-                NavigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: GetResourceName(Resource)));
-                return Task.CompletedTask;
-            },
-            Tooltip = telemetryTooltip,
-            IsDisabled = !hasTelemetryApplication
-        });
-        _menuItems.Add(new MenuButtonItem
-        {
-            Text = Loc[nameof(Resources.Resources.ResourceActionTracesText)],
-            Icon = s_tracesIcon,
-            OnClick = () =>
+                Text = Loc[nameof(Resources.Resources.ResourceActionStructuredLogsText)],
+                Icon = s_structuredLogsIcon,
+                OnClick = () =>
+                {
+                    NavigationManager.NavigateTo(DashboardUrls.StructuredLogsUrl(resource: GetResourceName(Resource)));
+                    return Task.CompletedTask;
+                },
+                Tooltip = telemetryTooltip
+            });
+            _menuItems.Add(new MenuButtonItem
             {
-                NavigationManager.NavigateTo(DashboardUrls.TracesUrl(resource: GetResourceName(Resource)));
-                return Task.CompletedTask;
-            },
-            Tooltip = telemetryTooltip,
-            IsDisabled = !hasTelemetryApplication
-        });
-        _menuItems.Add(new MenuButtonItem
-        {
-            Text = Loc[nameof(Resources.Resources.ResourceActionMetricsText)],
-            Icon = s_metricsIcon,
-            OnClick = () =>
+                Text = Loc[nameof(Resources.Resources.ResourceActionTracesText)],
+                Icon = s_tracesIcon,
+                OnClick = () =>
+                {
+                    NavigationManager.NavigateTo(DashboardUrls.TracesUrl(resource: GetResourceName(Resource)));
+                    return Task.CompletedTask;
+                },
+                Tooltip = telemetryTooltip
+            });
+            _menuItems.Add(new MenuButtonItem
             {
-                NavigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: GetResourceName(Resource)));
-                return Task.CompletedTask;
-            },
-            Tooltip = telemetryTooltip,
-            IsDisabled = !hasTelemetryApplication
-        });
+                Text = Loc[nameof(Resources.Resources.ResourceActionMetricsText)],
+                Icon = s_metricsIcon,
+                OnClick = () =>
+                {
+                    NavigationManager.NavigateTo(DashboardUrls.MetricsUrl(resource: GetResourceName(Resource)));
+                    return Task.CompletedTask;
+                },
+                Tooltip = telemetryTooltip
+            });
+        }
 
         // If display is desktop then we display highlighted commands next to the ... button.
         if (ViewportInformation.IsDesktop)


### PR DESCRIPTION
## Description

Before: If a resource doesn't have telemetry then display disabled telemetry menu items
After: If a resource doesn't have telemetry then don't display telemetry menu items

![telemetry-menu-items](https://github.com/user-attachments/assets/1c744ae4-2f33-451b-89e4-86c2c8088bff)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6568)