### PR TITLE
Change URL detection regex to exclude trailing content

### DIFF
--- a/playground/Stress/Stress.ApiService/ConsoleStresser.cs
+++ b/playground/Stress/Stress.ApiService/ConsoleStresser.cs
@@ -82,6 +82,7 @@ public static class ConsoleStresser
         Console.WriteLine("https://www.example.com/path/?query;string");
         Console.WriteLine("https://;www.example.com/");
         Console.WriteLine("https://www;.example.com/");
+        Console.WriteLine("https://www.exa;mple.com/");
 
         Console.Write("\x1b[0m"); // reset color
 

--- a/playground/Stress/Stress.ApiService/ConsoleStresser.cs
+++ b/playground/Stress/Stress.ApiService/ConsoleStresser.cs
@@ -80,6 +80,8 @@ public static class ConsoleStresser
         Console.WriteLine("https://www.example.com/path/with/exclamation!mark");
         Console.WriteLine("https://www.example.com/;path/");
         Console.WriteLine("https://www.example.com/path/?query;string");
+        Console.WriteLine("https://;www.example.com/");
+        Console.WriteLine("https://www;.example.com/");
 
         Console.Write("\x1b[0m"); // reset color
 

--- a/playground/Stress/Stress.ApiService/ConsoleStresser.cs
+++ b/playground/Stress/Stress.ApiService/ConsoleStresser.cs
@@ -78,6 +78,8 @@ public static class ConsoleStresser
         Console.WriteLine("https://www.example.com/path/with/percent%25encoded");
         Console.WriteLine("https://www.example.com/path/with/dollar$sign");
         Console.WriteLine("https://www.example.com/path/with/exclamation!mark");
+        Console.WriteLine("https://www.example.com/;path/");
+        Console.WriteLine("https://www.example.com/path/?query;string");
 
         Console.Write("\x1b[0m"); // reset color
 

--- a/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -34,7 +35,7 @@ public static partial class UrlParser
                 nextCharIndex = urlMatch.Index + urlMatch.Length;
                 var url = text[urlStart..nextCharIndex];
 
-                builder.Append(CultureInfo.InvariantCulture, $"<a target=\"_blank\" href=\"{url}\">{url}</a>");
+                builder.Append(CultureInfo.InvariantCulture, $"<a target=\"_blank\" href=\"{url}\">{WebUtility.HtmlEncode(url)}</a>");
                 urlMatch = urlMatch.NextMatch();
             }
 

--- a/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
+++ b/src/Aspire.Dashboard/ConsoleLogs/UrlParser.cs
@@ -65,17 +65,9 @@ public static partial class UrlParser
     }
 
     // Regular expression that detects http/https URLs in a log entry
-    // Based on the RegEx used in Windows Terminal for the same purpose. Some modifications:
-    // - Can start at a non word boundary. This behavior is similar to how GitHub matches URLs in pretty printed code.
-    // - Limited to only http/https URLs.
-    // - Ignore case. That means it matches URLs starting with http and HTTP.
-    //
-    // Explanation:
-    // https?://                      - http:// or https://
-    // [-A-Za-z0-9+&@#/%?=~_|$!:,.;]* - Any character in the list, matched zero or more times.
-    // [A-Za-z0-9+&@#/%=~_|$]         - Any character in the list, matched exactly once
+    // Based on the RegEx used by GitHub to detect links in content.
     [GeneratedRegex(
-        "https?://[-A-Za-z0-9+&@#/%?=~_|$!:,.;]*[A-Za-z0-9+&@#/%=~_|$]",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+        @"((?<!\+)https?:\/\/(?:www\.)?(?:[-\p{L}.]+?[.@][a-zA-Z\d]{2,}|localhost)(?:[-\w\p{L}.:%+~#*$!?&/=@]*(?:,(?!\s))*?)*)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture)]
     public static partial Regex GenerateUrlRegEx();
 }

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
@@ -71,6 +71,15 @@ public class UrlParserTests
         Assert.Equal(expectedOutput, modifiedText);
     }
 
+    [Fact]
+    public void TryParse_QueryString()
+    {
+        var result = UrlParser.TryParse("https://www.example.com?query=string&param=value", WebUtility.HtmlEncode, out var modifiedText);
+        Assert.True(result);
+
+        Assert.Equal("<a target=\"_blank\" href=\"https://www.example.com?query=string&param=value\">https://www.example.com?query=string&amp;param=value</a>", modifiedText);
+    }
+
     [Theory]
     [InlineData("http://www.localhost:8080")]
     [InlineData("HTTP://WWW.LOCALHOST:8080")]

--- a/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
+++ b/tests/Aspire.Dashboard.Tests/ConsoleLogsTests/UrlParserTests.cs
@@ -40,7 +40,7 @@ public class UrlParserTests
     [InlineData("http://bing.com/", "<a target=\"_blank\" href=\"http://bing.com/\">http://bing.com/</a>")]
     [InlineData("http://bing.com/dir", "<a target=\"_blank\" href=\"http://bing.com/dir\">http://bing.com/dir</a>")]
     [InlineData("http://bing.com/index.aspx", "<a target=\"_blank\" href=\"http://bing.com/index.aspx\">http://bing.com/index.aspx</a>")]
-    [InlineData("http://bing", "<a target=\"_blank\" href=\"http://bing\">http://bing</a>")]
+    [InlineData("http://localhost", "<a target=\"_blank\" href=\"http://localhost\">http://localhost</a>")]
     public void TryParse_SupportedUrlFormats(string input, string? expectedOutput)
     {
         var result = UrlParser.TryParse(input, WebUtility.HtmlEncode, out var modifiedText);
@@ -82,5 +82,18 @@ public class UrlParserTests
         var regex = UrlParser.GenerateUrlRegEx();
         var match = regex.Match(content);
         Assert.Equal("http://www.localhost:8080", match.Value.ToLowerInvariant());
+    }
+
+    [Theory]
+    [InlineData("http://www.localhost:8080!", "http://www.localhost:8080!")]
+    [InlineData("http://www.localhost:8080/path!", "http://www.localhost:8080/path!")]
+    [InlineData("http://www.localhost:8080/path;", "http://www.localhost:8080/path")]
+    [InlineData("http://www.localhost:8080;", "http://www.localhost:8080")]
+    [InlineData("http://www.local;host:8080;", "http://www.local")]
+    public void GenerateUrlRegEx_MatchUrlBeforeContent(string content, string expected)
+    {
+        var regex = UrlParser.GenerateUrlRegEx();
+        var match = regex.Match(content);
+        Assert.Equal(expected, match.Value.ToLowerInvariant());
     }
 }


### PR DESCRIPTION
## Description

URL detection regex was including trailing content in the URL after semi-colon. In some connection strings this would pick up extra values, e.g. content after the URL would be included in `Endpoint=http://myaccount.example.com/;key=abc`.

The new URL is based on GitHub's URL detection for source code. It excludes content after `;` from the URL. This is the same behavior as VS. Technically `;` can be part of a URL, but more commonly it is used as a delimiter for connection strings and collections of URLs.

There isn't a perfect answer here, but the new regex match seems the better alternative. We should be conservative when assuming what content should be in the URL rather than aggressively including too much.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No **TBD**
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6572)