### PR TITLE
Display nested resources in the dashboard

### DIFF
--- a/playground/Stress/Stress.AppHost/Program.cs
+++ b/playground/Stress/Stress.AppHost/Program.cs
@@ -8,7 +8,16 @@ builder.Services.AddHttpClient();
 
 for (var i = 0; i < 10; i++)
 {
-    builder.AddTestResource($"test-{i:0000}");
+    var name = $"test-{i:0000}";
+    var rb = builder.AddTestResource(name);
+    IResource parent = rb.Resource;
+
+    for (int j = 0; j < 3; j++)
+    {
+        name = name + $"-n{j}";
+        var nestedRb = builder.AddNestedResource(name, parent);
+        parent = nestedRb.Resource;
+    }
 }
 
 var serviceBuilder = builder.AddProject<Projects.Stress_ApiService>("stress-apiservice", launchProfileName: null);

--- a/playground/Stress/Stress.AppHost/Stress.AppHost.csproj
+++ b/playground/Stress/Stress.AppHost/Stress.AppHost.csproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\KnownResourceNames.cs" Link="KnownResourceNames.cs" />
+    <Compile Include="$(SharedDir)KnownResourceNames.cs" Link="KnownResourceNames.cs" />
+    <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="KnownProperties.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/playground/Stress/Stress.AppHost/TestResource.cs
+++ b/playground/Stress/Stress.AppHost/TestResource.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using Aspire.Dashboard.Model;
 using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.Logging;
 
@@ -19,6 +20,24 @@ static class TestResourceExtensions
                           Properties = [
                               new("P1", "P2"),
                               new(CustomResourceKnownProperties.Source, "Custom")
+                          ]
+                      })
+                      .ExcludeFromManifest();
+
+        return rb;
+    }
+
+    public static IResourceBuilder<TestNestedResource> AddNestedResource(this IDistributedApplicationBuilder builder, string name, IResource parent)
+    {
+        var rb = builder.AddResource(new TestNestedResource(name, parent))
+                      .WithInitialState(new()
+                      {
+                          ResourceType = "Test Nested Resource",
+                          State = "Starting",
+                          Properties = [
+                              new("P1", "P2"),
+                              new(CustomResourceKnownProperties.Source, "Custom"),
+                              new(KnownProperties.Resource.ParentName, parent.Name)
                           ]
                       })
                       .ExcludeFromManifest();
@@ -80,4 +99,9 @@ internal sealed class TestResourceLifecycleHook(ResourceNotificationService noti
 sealed class TestResource(string name) : Resource(name)
 {
 
+}
+
+sealed class TestNestedResource(string name, IResource parent) : Resource(name), IResourceWithParent
+{
+    public IResource Parent { get; } = parent;
 }

--- a/src/Aspire.Dashboard/Components/Controls/SelectResourceTypes.razor
+++ b/src/Aspire.Dashboard/Components/Controls/SelectResourceTypes.razor
@@ -9,10 +9,9 @@
     <FluentCheckbox Label="@ControlsStringsLoc[nameof(ControlsStrings.LabelAll)]"
                     ThreeState="true"
                     ShowIndeterminate="false"
-                    onkeydown="e => console.log(e)"
                     ThreeStateOrderUncheckToIntermediate="true"
                     @bind-CheckState:get="@AreAllTypesVisible()"
-                    @bind-CheckState:set="@OnAllResourceTypesCheckedChanged"
+                    @bind-CheckState:set="@OnAllResourceTypesCheckedChangedAsync"
                      />
     @foreach (var (resourceType, _) in AllResourceTypes)
     {
@@ -33,7 +32,7 @@
     public required ConcurrentDictionary<string,bool> VisibleResourceTypes { get; set; }
 
     [Parameter, EditorRequired]
-    public required Action<bool?> OnAllResourceTypesCheckedChanged { get; set; }
+    public required Func<bool?, Task> OnAllResourceTypesCheckedChangedAsync { get; set; }
 
     [Parameter, EditorRequired]
     public required Func<string, bool,Task> OnResourceTypeVisibilityChangedAsync { get; set; }

--- a/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor
@@ -12,7 +12,7 @@
             {
                 @PageTitleSection
 
-                <FluentToolbar Orientation="Orientation.Horizontal">
+                <FluentToolbar Class="main-toolbar" Orientation="Orientation.Horizontal">
                     @ToolbarSection
                 </FluentToolbar>
             }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -47,7 +47,7 @@
 
                     <SelectResourceTypes AllResourceTypes="_allResourceTypes"
                                          VisibleResourceTypes="_visibleResourceTypes"
-                                         OnAllResourceTypesCheckedChanged="@(b => AreAllTypesVisible = b)"
+                                         OnAllResourceTypesCheckedChangedAsync="@OnAllResourceTypesCheckedChangedAsync"
                                          AreAllTypesVisible="@(() => AreAllTypesVisible)"
                                          OnResourceTypeVisibilityChangedAsync="@OnResourceTypeVisibilityChangedAsync" />
                 </div>
@@ -59,50 +59,64 @@
                 <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
                 <Body>
                     <SelectResourceTypes
-                        AllResourceTypes="_allResourceTypes"
-                        VisibleResourceTypes="_visibleResourceTypes"
-                        OnAllResourceTypesCheckedChanged="@(b => AreAllTypesVisible = b)"
-                        AreAllTypesVisible="@(() => AreAllTypesVisible)"
-                        OnResourceTypeVisibilityChangedAsync="@OnResourceTypeVisibilityChangedAsync" />
+                    AllResourceTypes="_allResourceTypes"
+                    VisibleResourceTypes="_visibleResourceTypes"
+                    OnAllResourceTypesCheckedChangedAsync="@OnAllResourceTypesCheckedChangedAsync"
+                    AreAllTypesVisible="@(() => AreAllTypesVisible)"
+                    OnResourceTypeVisibilityChangedAsync="@OnResourceTypeVisibilityChangedAsync" />
                 </Body>
             </FluentPopover>
 
             <SummaryDetailsView DetailsTitle="@(SelectedResource != null ? $"{SelectedResource.ResourceType}: {GetResourceName(SelectedResource)}" : null)"
-                                ShowDetails="@showDetailsView"
-                                OnDismiss="@(() => ClearSelectedResourceAsync(causedByUserAction: true))"
-                                SelectedValue="@SelectedResource"
-                                ViewKey="ResourcesList"
-                                OnResize="@(r => _manager.SetWidthFraction(r.Orientation == Orientation.Horizontal ? r.Panel1Fraction : 1))">
+            ShowDetails="@showDetailsView"
+            OnDismiss="@(() => ClearSelectedResourceAsync(causedByUserAction: true))"
+            SelectedValue="@SelectedResource"
+            ViewKey="ResourcesList"
+            OnResize="@(r => _manager.SetWidthFraction(r.Orientation == Orientation.Horizontal ? r.Panel1Fraction : 1))">
                 <Summary>
                     <GridColumnManager @ref="_manager" Columns="@_gridColumns">
-                        <FluentDataGrid ResizeLabel="@AspireFluentDataGridHeaderCell.GetResizeLabel(ControlsStringsLoc)"
-                                        ResizeType="DataGridResizeType.Discrete"
-                                        Virtualize="true"
-                                        GenerateHeader="GenerateHeaderOption.Sticky"
-                                        ItemSize="46"
-                                        Items="@FilteredResources"
-                                        ResizableColumns="true"
-                                        GridTemplateColumns="@_manager.GetGridTemplateColumns()"
-                                        RowClass="GetRowClass"
-                                        Loading="_isLoading"
-                                        ShowHover="true"
-                                        TGridItem="ResourceViewModel"
-                                        ItemKey="@(r => r.Name)"
-                                        OnRowClick="@(r => r.ExecuteOnDefault(d => ShowResourceDetailsAsync(d, buttonId: null)))"
-                                        Class="enable-row-click">
+                        <FluentDataGrid @ref="_dataGrid"
+                        ResizeLabel="@AspireFluentDataGridHeaderCell.GetResizeLabel(ControlsStringsLoc)"
+                        ResizeType="DataGridResizeType.Discrete"
+                        Virtualize="true"
+                        GenerateHeader="GenerateHeaderOption.Sticky"
+                        ItemSize="46"
+                        ItemsProvider="@GetData"
+                        ResizableColumns="true"
+                        GridTemplateColumns="@_manager.GetGridTemplateColumns()"
+                        RowClass="@(r => GetRowClass(r.Resource))"
+                        Loading="_isLoading"
+                        ShowHover="true"
+                        TGridItem="ResourceGridViewModel"
+                        ItemKey="@(r => r.Resource.Name)"
+                        OnRowClick="@(r => r.ExecuteOnDefault(d => ShowResourceDetailsAsync(d.Resource, buttonId: null)))"
+                        Class="main-grid enable-row-click">
                             <ChildContent>
-                                <AspirePropertyColumn ColumnId="@TypeColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.ResourceType)" Sortable="true" Tooltip="true" TooltipText="@(c => c.ResourceType)" />
-                                <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c))">
-                                    <ResourceNameDisplay Resource="context" FilterText="@_filter" FormatName="GetResourceName" />
+                                <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c.Resource))" Class="expand-col">
+                                    @{
+                                        var indent = context.Depth * 16;
+                                    }
+                                    <span class="resources-name-container" style="margin-left: @(indent)px;">
+                                        <span @onclick:stopPropagation="true" class="main-grid-expand-container @(context.IsCollapsed ? "main-grid-collapsed" : "main-grid-expanded")">
+                                            @if (context.Children.Count > 0)
+                                            {
+                                                <FluentButton Appearance="Appearance.Lightweight" Class="main-grid-expand-button" OnClick="@(() => OnToggleCollapse(context))">
+                                                    <FluentIcon Icon="Icons.Regular.Size12.ChevronRight" Color="Color.Neutral" />
+                                                </FluentButton>
+                                            }
+                                        </span>
+                                        <ResourceNameDisplay Resource="context.Resource" FilterText="@_filter" FormatName="GetResourceName" />
+                                    </span>
                                 </AspireTemplateColumn>
-                                <AspireTemplateColumn ColumnId="@StateColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort" Tooltip="true" TooltipText="@(c => ResourceStateViewModel.GetResourceStateTooltip(c, ColumnsLoc))">
-                                    <StateColumnDisplay Resource="@context" UnviewedErrorCounts="@_applicationUnviewedErrorCounts" />
+                                <AspireTemplateColumn ColumnId="@StateColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStateColumnHeader)]" Sortable="true" SortBy="@_stateSort" Tooltip="true" TooltipText="@(c => ResourceStateViewModel.GetResourceStateTooltip(c.Resource, ColumnsLoc))">
+                                    <StateColumnDisplay Resource="@context.Resource" UnviewedErrorCounts="@_applicationUnviewedErrorCounts" />
                                 </AspireTemplateColumn>
-                                <AspireTemplateColumn ColumnId="@StartTimeColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" TooltipText="@(context => context.CreationTimeStamp != null ? FormatHelpers.FormatDateTime(TimeProvider, context.CreationTimeStamp.Value, MillisecondsDisplay.None, CultureInfo.CurrentCulture) : null)" Tooltip="true">
-                                    <StartTimeColumnDisplay Resource="@context" />
+                                <AspireTemplateColumn ColumnId="@StartTimeColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesStartTimeColumnHeader)]" Sortable="true" SortBy="@_startTimeSort" TooltipText="@(context => context.Resource.CreationTimeStamp != null ? FormatHelpers.FormatDateTime(TimeProvider, context.Resource.CreationTimeStamp.Value, MillisecondsDisplay.None, CultureInfo.CurrentCulture) : null)" Tooltip="true">
+                                    <StartTimeColumnDisplay Resource="@context.Resource" />
                                 </AspireTemplateColumn>
-                                <AspireTemplateColumn ColumnId="@SourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetSourceColumnValueAndTooltip(ctx)?.Tooltip)">
-                                    @if (GetSourceColumnValueAndTooltip(context) is { } columnDisplay)
+                                <AspirePropertyColumn ColumnId="@TypeColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesTypeColumnHeader)]" Property="@(c => c.Resource.ResourceType)" Sortable="true" SortBy="@_typeSort" IsDefaultSortColumn="true" Tooltip="true" TooltipText="@(c => c.Resource.ResourceType)" />
+                                <AspireTemplateColumn ColumnId="@SourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetSourceColumnValueAndTooltip(ctx.Resource)?.Tooltip)">
+                                    @if (GetSourceColumnValueAndTooltip(context.Resource) is { } columnDisplay)
                                     {
                                         <SourceColumnDisplay FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip" />
                                     }
@@ -111,17 +125,17 @@
                                         <span class="empty-data"></span>
                                     }
                                 </AspireTemplateColumn>
-                                <AspireTemplateColumn ColumnId="@EndpointsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEndpointsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetEndpointsTooltip(ctx))">
-                                    <EndpointsColumnDisplay Resource="context"
-                                                            HasMultipleReplicas="HasMultipleReplicas(context)"
-                                                            DisplayedEndpoints="GetDisplayedEndpoints(context)" />
+                                <AspireTemplateColumn ColumnId="@EndpointsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesEndpointsColumnHeader)]" Tooltip="true" TooltipText="@(ctx => GetEndpointsTooltip(ctx.Resource))">
+                                    <EndpointsColumnDisplay Resource="context.Resource"
+                                                            HasMultipleReplicas="HasMultipleReplicas(context.Resource)"
+                                                            DisplayedEndpoints="GetDisplayedEndpoints(context.Resource)" />
                                 </AspireTemplateColumn>
                                 <AspireTemplateColumn ColumnId="@ActionsColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesActionsColumnHeader)]" Class="no-ellipsis">
                                     <div class="grid-action-container" @onclick:stopPropagation="true">
-                                        <ResourceActions Commands="@context.Commands"
-                                                         CommandSelected="async (command) => await ExecuteResourceCommandAsync(context, command)"
-                                                         OnViewDetails="@((buttonId) => ShowResourceDetailsAsync(context, buttonId))"
-                                                         Resource="context"
+                                        <ResourceActions Commands="@context.Resource.Commands"
+                                                         CommandSelected="async (command) => await ExecuteResourceCommandAsync(context.Resource, command)"
+                                                         OnViewDetails="@((buttonId) => ShowResourceDetailsAsync(context.Resource, buttonId))"
+                                                         Resource="context.Resource"
                                                          GetResourceName="GetResourceName"
                                                          MaxHighlightedCount="_maxHighlightedCount" />
                                     </div>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -58,12 +58,11 @@
             <FluentPopover AnchorId="typeFilterButton" @bind-Open="_isTypeFilterVisible" AutoFocus="true" FixedPlacement="true">
                 <Header>@Loc[nameof(Dashboard.Resources.Resources.ResourcesResourceTypesHeader)]</Header>
                 <Body>
-                    <SelectResourceTypes
-                    AllResourceTypes="_allResourceTypes"
-                    VisibleResourceTypes="_visibleResourceTypes"
-                    OnAllResourceTypesCheckedChangedAsync="@OnAllResourceTypesCheckedChangedAsync"
-                    AreAllTypesVisible="@(() => AreAllTypesVisible)"
-                    OnResourceTypeVisibilityChangedAsync="@OnResourceTypeVisibilityChangedAsync" />
+                    <SelectResourceTypes AllResourceTypes="_allResourceTypes"
+                                         VisibleResourceTypes="_visibleResourceTypes"
+                                         OnAllResourceTypesCheckedChangedAsync="@OnAllResourceTypesCheckedChangedAsync"
+                                         AreAllTypesVisible="@(() => AreAllTypesVisible)"
+                                         OnResourceTypeVisibilityChangedAsync="@OnResourceTypeVisibilityChangedAsync" />
                 </Body>
             </FluentPopover>
 
@@ -76,21 +75,21 @@
                 <Summary>
                     <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                         <FluentDataGrid @ref="_dataGrid"
-                        ResizeLabel="@AspireFluentDataGridHeaderCell.GetResizeLabel(ControlsStringsLoc)"
-                        ResizeType="DataGridResizeType.Discrete"
-                        Virtualize="true"
-                        GenerateHeader="GenerateHeaderOption.Sticky"
-                        ItemSize="46"
-                        ItemsProvider="@GetData"
-                        ResizableColumns="true"
-                        GridTemplateColumns="@_manager.GetGridTemplateColumns()"
-                        RowClass="@(r => GetRowClass(r.Resource))"
-                        Loading="_isLoading"
-                        ShowHover="true"
-                        TGridItem="ResourceGridViewModel"
-                        ItemKey="@(r => r.Resource.Name)"
-                        OnRowClick="@(r => r.ExecuteOnDefault(d => ShowResourceDetailsAsync(d.Resource, buttonId: null)))"
-                        Class="main-grid enable-row-click">
+                                        ResizeLabel="@AspireFluentDataGridHeaderCell.GetResizeLabel(ControlsStringsLoc)"
+                                        ResizeType="DataGridResizeType.Discrete"
+                                        Virtualize="true"
+                                        GenerateHeader="GenerateHeaderOption.Sticky"
+                                        ItemSize="46"
+                                        ItemsProvider="@GetData"
+                                        ResizableColumns="true"
+                                        GridTemplateColumns="@_manager.GetGridTemplateColumns()"
+                                        RowClass="@(r => GetRowClass(r.Resource))"
+                                        Loading="_isLoading"
+                                        ShowHover="true"
+                                        TGridItem="ResourceGridViewModel"
+                                        ItemKey="@(r => r.Resource.Name)"
+                                        OnRowClick="@(r => r.ExecuteOnDefault(d => ShowResourceDetailsAsync(d.Resource, buttonId: null)))"
+                                        Class="main-grid enable-row-click">
                             <ChildContent>
                                 <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.NameColumnHeader)]" Sortable="true" SortBy="@_nameSort" Tooltip="true" TooltipText="@(c => GetResourceName(c.Resource))" Class="expand-col">
                                     @{

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -67,11 +67,11 @@
             </FluentPopover>
 
             <SummaryDetailsView DetailsTitle="@(SelectedResource != null ? $"{SelectedResource.ResourceType}: {GetResourceName(SelectedResource)}" : null)"
-            ShowDetails="@showDetailsView"
-            OnDismiss="@(() => ClearSelectedResourceAsync(causedByUserAction: true))"
-            SelectedValue="@SelectedResource"
-            ViewKey="ResourcesList"
-            OnResize="@(r => _manager.SetWidthFraction(r.Orientation == Orientation.Horizontal ? r.Panel1Fraction : 1))">
+                                ShowDetails="@showDetailsView"
+                                OnDismiss="@(() => ClearSelectedResourceAsync(causedByUserAction: true))"
+                                SelectedValue="@SelectedResource"
+                                ViewKey="ResourcesList"
+                                OnResize="@(r => _manager.SetWidthFraction(r.Orientation == Orientation.Horizontal ? r.Panel1Fraction : 1))">
                 <Summary>
                     <GridColumnManager @ref="_manager" Columns="@_gridColumns">
                         <FluentDataGrid @ref="_dataGrid"

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Aspire.Dashboard.Extensions;
-
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Utils;
@@ -58,17 +57,25 @@ public partial class Resources : ComponentBase, IAsyncDisposable
     private readonly ConcurrentDictionary<string, ResourceViewModel> _resourceByName = new(StringComparers.ResourceName);
     private readonly ConcurrentDictionary<string, bool> _allResourceTypes = [];
     private readonly ConcurrentDictionary<string, bool> _visibleResourceTypes = new(StringComparers.ResourceName);
+    private readonly List<string> _expandedResourceNames = [];
     private string _filter = "";
     private bool _isTypeFilterVisible;
     private Task? _resourceSubscriptionTask;
     private bool _isLoading = true;
     private string? _elementIdBeforeDetailsViewOpened;
+    private FluentDataGrid<ResourceGridViewModel> _dataGrid = null!;
     private GridColumnManager _manager = null!;
     private int _maxHighlightedCount;
 
     private bool Filter(ResourceViewModel resource) => _visibleResourceTypes.ContainsKey(resource.ResourceType) && (_filter.Length == 0 || resource.MatchesFilter(_filter)) && !resource.IsHiddenState();
 
-    private Task OnResourceTypeVisibilityChangedAsync(string resourceType, bool isVisible)
+    private async Task OnAllResourceTypesCheckedChangedAsync(bool? areAllTypesVisible)
+    {
+        AreAllTypesVisible = areAllTypesVisible;
+        await _dataGrid.SafeRefreshDataAsync();
+    }
+
+    private async Task OnResourceTypeVisibilityChangedAsync(string resourceType, bool isVisible)
     {
         if (isVisible)
         {
@@ -79,7 +86,8 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             _visibleResourceTypes.TryRemove(resourceType, out _);
         }
 
-        return ClearSelectedResourceAsync();
+        await ClearSelectedResourceAsync();
+        await _dataGrid.SafeRefreshDataAsync();
     }
 
     private Task HandleSearchFilterChangedAsync()
@@ -132,21 +140,20 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         }
     }
 
-    private IQueryable<ResourceViewModel>? FilteredResources => _resourceByName.Values.Where(Filter).OrderBy(e => e.ResourceType).ThenBy(e => e, ResourceViewModelNameComparer.Instance).AsQueryable();
-
-    private readonly GridSort<ResourceViewModel> _nameSort = GridSort<ResourceViewModel>.ByAscending(p => p, ResourceViewModelNameComparer.Instance);
-    private readonly GridSort<ResourceViewModel> _stateSort = GridSort<ResourceViewModel>.ByAscending(p => p.State);
-    private readonly GridSort<ResourceViewModel> _startTimeSort = GridSort<ResourceViewModel>.ByDescending(p => p.CreationTimeStamp);
+    private readonly GridSort<ResourceGridViewModel> _nameSort = GridSort<ResourceGridViewModel>.ByAscending(p => p.Resource, ResourceViewModelNameComparer.Instance);
+    private readonly GridSort<ResourceGridViewModel> _stateSort = GridSort<ResourceGridViewModel>.ByAscending(p => p.Resource.State).ThenAscending(p => p.Resource, ResourceViewModelNameComparer.Instance);
+    private readonly GridSort<ResourceGridViewModel> _startTimeSort = GridSort<ResourceGridViewModel>.ByDescending(p => p.Resource.CreationTimeStamp).ThenAscending(p => p.Resource, ResourceViewModelNameComparer.Instance);
+    private readonly GridSort<ResourceGridViewModel> _typeSort = GridSort<ResourceGridViewModel>.ByAscending(p => p.Resource.ResourceType).ThenAscending(p => p.Resource, ResourceViewModelNameComparer.Instance);
 
     protected override async Task OnInitializedAsync()
     {
         _gridColumns = [
-            new GridColumn(Name: TypeColumn, DesktopWidth: "1fr"),
             new GridColumn(Name: NameColumn, DesktopWidth: "1.5fr", MobileWidth: "1.5fr"),
             new GridColumn(Name: StateColumn, DesktopWidth: "1.25fr", MobileWidth: "1.25fr"),
-            new GridColumn(Name: StartTimeColumn, DesktopWidth: "1.5fr"),
-            new GridColumn(Name: SourceColumn, DesktopWidth: "2.5fr"),
-            new GridColumn(Name: EndpointsColumn, DesktopWidth: "2.5fr", MobileWidth: "2fr"),
+            new GridColumn(Name: StartTimeColumn, DesktopWidth: "1fr"),
+            new GridColumn(Name: TypeColumn, DesktopWidth: "1fr"),
+            new GridColumn(Name: SourceColumn, DesktopWidth: "2.25fr"),
+            new GridColumn(Name: EndpointsColumn, DesktopWidth: "2.25fr", MobileWidth: "2fr"),
             new GridColumn(Name: ActionsColumn, DesktopWidth: "minmax(150px, 1.5fr)", MobileWidth: "1fr")
         ];
         _applicationUnviewedErrorCounts = TelemetryRepository.GetApplicationUnviewedErrorLogsCount();
@@ -164,7 +171,7 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             if (ApplicationErrorCountsChanged(newApplicationUnviewedErrorCounts))
             {
                 _applicationUnviewedErrorCounts = newApplicationUnviewedErrorCounts;
-                await InvokeAsync(StateHasChanged);
+                await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
             }
         });
 
@@ -188,9 +195,11 @@ public partial class Resources : ComponentBase, IAsyncDisposable
                     _visibleResourceTypes.TryAdd(resource.ResourceType, true);
                 }
 
-                UpdateMaxHighlightedCount();
                 Debug.Assert(added, "Should not receive duplicate resources in initial snapshot data.");
             }
+
+            UpdateMaxHighlightedCount();
+            await _dataGrid.SafeRefreshDataAsync();
 
             // Listen for updates and apply.
             _resourceSubscriptionTask = Task.Run(async () =>
@@ -218,10 +227,36 @@ public partial class Resources : ComponentBase, IAsyncDisposable
                     }
 
                     UpdateMaxHighlightedCount();
-                    await InvokeAsync(StateHasChanged);
+                    await InvokeAsync(_dataGrid.SafeRefreshDataAsync);
                 }
             });
         }
+    }
+
+    private ValueTask<GridItemsProviderResult<ResourceGridViewModel>> GetData(GridItemsProviderRequest<ResourceGridViewModel> request)
+    {
+        // Get filtered and ordered resources.
+        var filteredResources = _resourceByName.Values
+            .Where(Filter)
+            .Select(r => new ResourceGridViewModel { Resource = r })
+            .AsQueryable();
+        filteredResources = request.ApplySorting(filteredResources);
+
+        // Rearrange resources based on parent information.
+        // This must happen after resources are ordered so nested resources are in the right order.
+        // Collapsed resources are filtered out of results.
+        var orderedResources = ResourceGridViewModel.OrderNestedResources(filteredResources.ToList(), r => !_expandedResourceNames.Contains(r.Name))
+            .Where(r => !r.IsHidden)
+            .ToList();
+
+        // Paging visible resources.
+        var query = orderedResources.Skip(request.StartIndex);
+        if (request.Count != null)
+        {
+            query = query.Take(request.Count.Value);
+        }
+
+        return ValueTask.FromResult(GridItemsProviderResult.From(query.ToList(), orderedResources.Count));
     }
 
     private void UpdateMaxHighlightedCount()
@@ -438,6 +473,24 @@ public partial class Resources : ComponentBase, IAsyncDisposable
         }
 
         return tooltipBuilder.ToString();
+    }
+
+    private async Task OnToggleCollapse(ResourceGridViewModel viewModel)
+    {
+        // View model data is recreated if data updates.
+        // Persist the collapsed state in a separate list.
+        if (viewModel.IsCollapsed)
+        {
+            viewModel.IsCollapsed = false;
+            _expandedResourceNames.Add(viewModel.Resource.Name);
+        }
+        else
+        {
+            viewModel.IsCollapsed = true;
+            _expandedResourceNames.Remove(viewModel.Resource.Name);
+        }
+
+        await _dataGrid.SafeRefreshDataAsync();
     }
 
     private static List<DisplayedEndpoint> GetDisplayedEndpoints(ResourceViewModel resource)

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -32,3 +32,12 @@
 ::deep fluent-data-grid {
     overflow-x: clip;
 }
+
+::deep .resources-name-container {
+    height: 24px;
+    display: inline-block;
+}
+
+::deep .resource-name-text {
+    vertical-align: middle;
+}

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -124,7 +124,7 @@
                                                 ShowHover="true"
                                                 ItemKey="@(r => r.InternalId)"
                                                 OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))"
-                                                Class="enable-row-click">
+                                                Class="main-grid enable-row-click">
                                     <ChildContent>
                                         <AspireTemplateColumn ColumnId="@ResourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.StructuredLogs.StructuredLogsResourceColumnHeader)]" Tooltip="true" TooltipText="@(e => GetResourceName(e.ApplicationView))">
                                             <span style="padding-left:5px; border-left-width: 5px; border-left-style: solid; border-left-color: @(ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.ApplicationView)));">

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -70,7 +70,7 @@
                             <FluentDataGrid @ref="_dataGrid"
                                             Virtualize="true"
                                             GenerateHeader="GenerateHeaderOption.Sticky"
-                                            Class="trace-view-grid enable-row-click"
+                                            Class="main-grid trace-view-grid enable-row-click"
                                             ResizableColumns="true"
                                             ItemsProvider="@GetData"
                                             TGridItem="SpanWaterfallViewModel"
@@ -79,16 +79,15 @@
                                             ShowHover="true"
                                             ItemKey="@(r => r.Span.SpanId)"
                                             OnRowClick="@(r => r.ExecuteOnDefault(d => OnShowPropertiesAsync(d, buttonId: null)))">
-                                <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" UseCustomHeaderTemplate="false" Title="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailNameHeader)]">
-                                    <div class="col-long-content" title="@context.GetTooltip(_applications)">
-                                        @{
-                                            var isServerOrConsumer = context.Span.Kind == OtlpSpanKind.Server || context.Span.Kind == OtlpSpanKind.Consumer;
-                                            // Indent the span name based on the depth of the span.
-                                            var marginLeft = (context.Depth - 1) * 15;
+                                <AspireTemplateColumn ColumnId="@NameColumn" ColumnManager="@_manager" UseCustomHeaderTemplate="false" Title="@Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailNameHeader)]" Tooltip="true" TooltipText="@(c => c.GetTooltip(_applications))" Class="expand-col">
+                                    @{
+                                        var isServerOrConsumer = context.Span.Kind == OtlpSpanKind.Server || context.Span.Kind == OtlpSpanKind.Consumer;
+                                        // Indent the span name based on the depth of the span.
+                                        var marginLeft = (context.Depth - 1) * 15;
 
-                                            // We want to have consistent margin for both client and server spans.
-                                            string spanNameContainerStyle;
-                                            if (!isServerOrConsumer)
+                                        // We want to have consistent margin for both client and server spans.
+                                        string spanNameContainerStyle;
+                                        if (!isServerOrConsumer)
                                             {
                                                 // Client span has 19px extra content:
                                                 // - 5px extra margin-left
@@ -96,66 +95,67 @@
                                                 // - 9px padding-left
                                                 spanNameContainerStyle = $"margin-left: 5px; border-left-color: {ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))}; border-left-width: 5px; border-left-style: solid; padding-left: 9px;";
                                             }
-                                            else
-                                            {
-                                                // Span with icon has 19px extra content:
-                                                // - 16px icon
-                                                // - 3px padding-left
-                                                spanNameContainerStyle = string.Empty;
-                                            }
+                                        else
+                                        {
+                                            // Span with icon has 19px extra content:
+                                            // - 16px icon
+                                            // - 3px padding-left
+                                            spanNameContainerStyle = string.Empty;
                                         }
+                                    }
 
-                                        <span style="margin-left: @(marginLeft)px;">
-                                            <span class="span-collapse-symbol" @onclick="() => OnToggleCollapse(context)" @onclick:stopPropagation="true">
-                                                @if (context.Children.Count > 0)
-                                                {
-                                                    @(context.IsCollapsed ? '+' : '-')
-                                                }
-                                            </span>
-                                            <span class="span-name-container" style="@spanNameContainerStyle">
-                                                @if (isServerOrConsumer)
-                                                {
-                                                    <FluentIcon Class="span-kind-icon"
-                                                                Color="Color.Custom"
-                                                                CustomColor="@ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))"
-                                                                Value="@GetSpanIcon(context.Span)"/>
-                                                }
-
-                                                @if (context.IsError)
-                                                {
-                                                    <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon"/>
-                                                }
-                                                @GetResourceName(context.Span.Source)
-                                                @if (context.HasUninstrumentedPeer)
-                                                {
-                                                    <span class="uninstrumented-peer">
-                                                        @{
-                                                            Icon icon;
-                                                            if (context.Span.Attributes.HasKey("db.system"))
-                                                            {
-                                                                icon = new Icons.Filled.Size16.Database();
-                                                            }
-                                                            else if (context.Span.Attributes.HasKey("messaging.system"))
-                                                            {
-                                                                icon = new Icons.Filled.Size16.Mail();
-                                                            }
-                                                            else
-                                                            {
-                                                                // Everything else.
-                                                                icon = new Icons.Filled.Size16.ArrowCircleRight();
-                                                            }
-                                                        }
-                                                        <FluentIcon
-                                                            Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")"
-                                                            Value="icon"
-                                                            Class="uninstrumented-peer-icon"/>
-                                                        @context.UninstrumentedPeer
-                                                    </span>
-                                                }
-                                                <span class="span-row-name">@SpanWaterfallViewModel.GetDisplaySummary(context.Span)</span>
-                                            </span>
+                                    <span class="span-overview-container" style="margin-left: @(marginLeft)px;">
+                                        <span @onclick:stopPropagation="true" class="main-grid-expand-container @(context.IsCollapsed ? "main-grid-collapsed" : "main-grid-expanded")">
+                                            @if (context.Children.Count > 0)
+                                            {
+                                                <FluentButton Appearance="Appearance.Lightweight" Class="main-grid-expand-button" OnClick="@(() => OnToggleCollapse(context))">
+                                                    <FluentIcon Icon="Icons.Regular.Size12.ChevronRight" Color="Color.Neutral" />
+                                                </FluentButton>
+                                            }
                                         </span>
-                                    </div>
+                                        <span class="span-name-container" style="@spanNameContainerStyle">
+                                            @if (isServerOrConsumer)
+                                            {
+                                                <FluentIcon Class="span-kind-icon"
+                                                            Color="Color.Custom"
+                                                            CustomColor="@ColorGenerator.Instance.GetColorHexByKey(GetResourceName(context.Span.Source))"
+                                                            Value="@GetSpanIcon(context.Span)"/>
+                                            }
+
+                                            @if (context.IsError)
+                                            {
+                                                <FluentIcon Icon="Icons.Filled.Size12.ErrorCircle" Color="Color.Error" Class="trace-tag-icon"/>
+                                            }
+                                            @GetResourceName(context.Span.Source)
+                                            @if (context.HasUninstrumentedPeer)
+                                            {
+                                                <span class="uninstrumented-peer">
+                                                    @{
+                                                        Icon icon;
+                                                        if (context.Span.Attributes.HasKey("db.system"))
+                                                        {
+                                                            icon = new Icons.Filled.Size16.Database();
+                                                        }
+                                                        else if (context.Span.Attributes.HasKey("messaging.system"))
+                                                        {
+                                                            icon = new Icons.Filled.Size16.Mail();
+                                                        }
+                                                        else
+                                                        {
+                                                            // Everything else.
+                                                            icon = new Icons.Filled.Size16.ArrowCircleRight();
+                                                        }
+                                                    }
+                                                    <FluentIcon
+                                                        Style="@($"fill: {ColorGenerator.Instance.GetColorHexByKey(context.UninstrumentedPeer)};")"
+                                                        Value="icon"
+                                                        Class="uninstrumented-peer-icon"/>
+                                                    @context.UninstrumentedPeer
+                                                </span>
+                                            }
+                                            <span class="span-row-name">@SpanWaterfallViewModel.GetDisplaySummary(context.Span)</span>
+                                        </span>
+                                    </span>
                                 </AspireTemplateColumn>
                                 <AspireTemplateColumn ColumnId="@TicksColumn" ColumnManager="@_manager" UseCustomHeaderTemplate="false">
                                     <HeaderCellItemTemplate>

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -70,18 +70,8 @@
     grid-row: 1;
 }
 
-::deep .span-collapse-symbol {
-    display: inline-block;
-    width: 20px;
-    text-align: center;
-    padding: 0px 5px;
-    line-height: 28px;
-    user-select: none;
-}
-
 ::deep .span-name-container {
-    margin-left: -3px;
-    line-height: 28px;
+    vertical-align: middle;
 }
 
 ::deep .span-container {
@@ -154,4 +144,9 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+}
+
+::deep .span-overview-container {
+    height: 24px;
+    display: inline-block;
 }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -78,7 +78,7 @@
                                     ShowHover="true"
                                     ItemKey="@(r => r.TraceId)"
                                     OnRowClick="@(r => r.ExecuteOnDefault(d => NavigationManager.NavigateTo(DashboardUrls.TraceDetailUrl(d.TraceId))))"
-                                    Class="enable-row-click">
+                                    Class="main-grid enable-row-click">
                         <ChildContent>
                             <AspireTemplateColumn ColumnId="@TimestampColumn" ColumnManager="@_manager" Title="@ControlsStringsLoc[nameof(ControlsStrings.TimestampColumnHeader)]" TooltipText="@(context => FormatHelpers.FormatDateTime(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Full, CultureInfo.CurrentCulture))" Tooltip="true">
                                 @FormatHelpers.FormatTimeWithOptionalDate(TimeProvider, context.FirstSpan.StartTime, MillisecondsDisplay.Truncated)

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/ResourceNameDisplay.razor
@@ -6,7 +6,7 @@
 
 @inject IStringLocalizer<Columns> Loc
 
-<span title="@FormatName(Resource)"><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)" /></span>
+<span class="resource-name-text" title="@FormatName(Resource)"><FluentHighlighter HighlightedText="@FilterText" Text="@FormatName(Resource)" /></span>
 
 @if (Resource.Properties.TryGetValue(KnownProperties.Container.Lifetime, out var value) &&
     value.Value.HasStringValue &&

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -108,6 +108,9 @@ public sealed class SpanWaterfallViewModel
     private void UpdateHidden(bool isParentCollapsed = false)
     {
         IsHidden = isParentCollapsed;
-        Children.ForEach(child => child.UpdateHidden(isParentCollapsed || IsCollapsed));
+        foreach (var child in Children)
+        {
+            child.UpdateHidden(isParentCollapsed || IsCollapsed);
+        }
     }
 }

--- a/src/Aspire.Dashboard/Model/ResourceGridViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceGridViewModel.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Dashboard.Model;
+
+[DebuggerDisplay("Resource = {Resource}, Children = {Children.Count}, Depth = {Depth}, IsHidden = {IsHidden}")]
+public sealed class ResourceGridViewModel
+{
+    public required ResourceViewModel Resource { get; init; }
+
+    public List<ResourceGridViewModel> Children { get; } = [];
+    public int Depth { get; set; }
+    public bool IsHidden { get; set; }
+
+    private bool _isCollapsed;
+    public bool IsCollapsed
+    {
+        get => _isCollapsed;
+        set
+        {
+            _isCollapsed = value;
+            UpdateHidden();
+        }
+    }
+
+    private void UpdateHidden(bool isParentCollapsed = false)
+    {
+        IsHidden = isParentCollapsed;
+        foreach (var child in Children)
+        {
+            child.UpdateHidden(isParentCollapsed || IsCollapsed);
+        }
+    }
+
+    public static List<ResourceGridViewModel> OrderNestedResources(List<ResourceGridViewModel> initialGridVMs, Func<ResourceViewModel, bool> isCollapsed)
+    {
+        // This method loops over the list of grid view models to build the nested list.
+        // Apps shouldn't have a huge number of resources so this shouldn't impact performance,
+        // but if that changes then this method will need to be improved.
+
+        var gridViewModels = new List<ResourceGridViewModel>();
+        var depth = 0;
+
+        foreach (var gridVM in initialGridVMs.Where(r => !HasParent(r)))
+        {
+            gridVM.Depth = depth;
+            gridVM.IsCollapsed = isCollapsed(gridVM.Resource);
+            gridVM.IsHidden = false;
+
+            gridViewModels.Add(gridVM);
+
+            AddChildViewModel(gridVM.Resource, gridVM, depth + 1, hidden: gridVM.IsCollapsed);
+        }
+
+        return gridViewModels;
+
+        void AddChildViewModel(ResourceViewModel resource, ResourceGridViewModel parent, int depth, bool hidden)
+        {
+            foreach (var childGridVM in initialGridVMs.Where(r => r.Resource.GetResourcePropertyValue(KnownProperties.Resource.ParentName) == resource.Name))
+            {
+                childGridVM.Depth = depth;
+                childGridVM.IsCollapsed = isCollapsed(childGridVM.Resource);
+                childGridVM.IsHidden = hidden;
+
+                parent.Children.Add(childGridVM);
+                gridViewModels.Add(childGridVM);
+
+                AddChildViewModel(childGridVM.Resource, childGridVM, depth + 1, hidden: childGridVM.IsHidden || childGridVM.IsCollapsed);
+            }
+        }
+
+        bool HasParent(ResourceGridViewModel gridViewModel)
+        {
+            var parentName = gridViewModel.Resource.GetResourcePropertyValue(KnownProperties.Resource.ParentName);
+            if (string.IsNullOrEmpty(parentName))
+            {
+                return false;
+            }
+
+            // Check that the name matches to a resource. Handle the situation where the parent resource is filtered out.
+            return initialGridVMs.Any(r => r.Resource.Name == parentName);
+        }
+    }
+}

--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -66,6 +66,19 @@ public sealed class ResourceViewModel
         return Name.Contains(filter, StringComparisons.UserTextSearch);
     }
 
+    public string? GetResourcePropertyValue(string propertyName)
+    {
+        if (Properties.TryGetValue(propertyName, out var value))
+        {
+            if (value.Value.TryConvertToString(out var s))
+            {
+                return s;
+            }
+        }
+
+        return null;
+    }
+
     internal static HealthStatus? ComputeHealthStatus(ImmutableArray<HealthReportViewModel> healthReports, KnownResourceState? state)
     {
         if (state != KnownResourceState.Running)

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -12,7 +12,7 @@ fluent-toolbar p {
 
 fluent-toolbar[orientation=horizontal] {
     width: 100%;
-    padding-right: calc(var(--design-unit)* 2px);
+    padding-right: calc(var(--design-unit) * 2px);
 }
 
 fluent-toolbar::part(positioning-region) {
@@ -180,9 +180,14 @@ h1 {
          height: 130px;
     }
 
+    fluent-toolbar[orientation=horizontal].main-toolbar {
+        padding-left: calc(var(--design-unit) * 2px);
+        padding-right: calc(var(--design-unit) * 2px);
+    }
+
     /* we want less padding on mobile screens to preserve screen height for other elements */
     .page-header {
-        padding: calc(var(--design-unit) * 1.5px) calc(var(--design-unit) * 0.5px) 0;
+        padding: calc(var(--design-unit) * 1.5px) calc(var(--design-unit) * 2.5px) 0;
         width: fit-content;
     }
 
@@ -195,16 +200,21 @@ h1 {
     }
 }
 
- @media (min-width: 768px) {
+@media (min-width: 768px) {
     #components-reconnect-modal {
         left: 30% !important;
         right: 30% !important;
         height: 105px;
     }
 
-     .page-header {
-         padding: calc(var(--design-unit) * 1.5px) calc(var(--design-unit) * 2.5px);
-     }
+    fluent-toolbar[orientation=horizontal].main-toolbar {
+        padding-left: calc(var(--design-unit) * 4px);
+        padding-right: calc(var(--design-unit) * 2px);
+    }
+
+    .page-header {
+        padding: calc(var(--design-unit) * 1.5px) calc(var(--design-unit) * 4.5px);
+    }
  }
 
 .datagrid-overflow-area,
@@ -493,7 +503,7 @@ fluent-data-grid-row[row-type=default].hover:hover fluent-button[appearance=stea
 
 .total-items-footer {
     padding-top: calc(var(--design-unit) * 2.5px);
-    padding-left: calc(var(--design-unit) * 2.5px);
+    padding-left: calc(var(--design-unit) * 4.5px);
     padding-bottom: calc(var(--design-unit) * 2.5px);
 }
 
@@ -668,4 +678,42 @@ fluent-data-grid-cell.no-ellipsis {
 
 .empty-data::before {
     content: "-"
+}
+
+.main-grid-expand-container {
+    display: inline-block;
+    width: 20px;
+}
+
+.main-grid-expand-container svg {
+    transition: transform 0.1s linear;
+    pointer-events: none;
+}
+
+.main-grid-collapsed svg {
+    transform: rotate(0deg);
+}
+
+.main-grid-expanded svg {
+    transform: rotate(90deg);
+}
+
+.main-grid-expand-button {
+    width: 20px;
+    height: 24px;
+    min-width: 20px;
+    vertical-align: middle;
+}
+
+.main-grid fluent-data-grid-row[row-type='sticky-header'] fluent-data-grid-cell:first-child {
+    margin-left: 8px;
+}
+
+.main-grid fluent-data-grid-row[row-type='default'] fluent-data-grid-cell.expand-col {
+    padding-left: 0;
+    border-left: 0;
+}
+
+.main-grid fluent-data-grid-row[row-type='default'] fluent-data-grid-cell:first-child:not(.expand-col) {
+    margin-left: 8px;
 }

--- a/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
+++ b/src/Aspire.Hosting.Azure/Aspire.Hosting.Azure.csproj
@@ -17,6 +17,9 @@
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessResult.cs" Link="Provisioning\Utils\ProcessResult.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessSpec.cs" Link="Provisioning\Utils\ProcessSpec.cs" />
     <Compile Include="..\Aspire.Hosting\Dcp\Process\ProcessUtil.cs" Link="Provisioning\Utils\ProcessUtil.cs" />
+    <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="Provisioning\Utils\KnownProperties.cs" />
+    <Compile Include="$(SharedDir)CustomResourceSnapshotExtensions.cs" Link="Provisioning\Utils\CustomResourceSnapshotExtensions.cs" />
+    <Compile Include="$(SharedDir)StringComparers.cs" Link="Provisioning\Utils\StringComparers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/AzureProvisioner.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.Azure.Provisioning;
 using Aspire.Hosting.Azure.Utils;
@@ -126,7 +127,11 @@ internal sealed class AzureProvisioner(
             var childResources = _parentChildLookup[resource.Resource];
             foreach (var child in childResources)
             {
-                await notificationService.PublishUpdateAsync(child, stateFactory).ConfigureAwait(false);
+                await notificationService.PublishUpdateAsync(child, s =>
+                {
+                    s = s with { Properties = s.Properties.SetResourceProperty(KnownProperties.Resource.ParentName, resource.Resource.Name) };
+                    return stateFactory(s);
+                }).ConfigureAwait(false);
             }
         }
 

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -120,29 +120,6 @@ public sealed record CustomResourceSnapshot
             : healthReports.MinBy(r => r.Status)?.Status
                 ?? Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy;
     }
-
-    internal static ImmutableArray<ResourcePropertySnapshot> SetResourceProperty(ImmutableArray<ResourcePropertySnapshot> properties, string name, object value)
-    {
-        for (var i = 0; i < properties.Length; i++)
-        {
-            var property = properties[i];
-
-            if (string.Equals(property.Name, name, StringComparisons.ResourcePropertyName))
-            {
-                if (property.Value == value)
-                {
-                    // Unchanged.
-                    return properties;
-                }
-
-                // Set value.
-                return properties.SetItem(i, property with { Value = value });
-            }
-        }
-
-        // Add property.
-        return [.. properties, new ResourcePropertySnapshot(name, value)];
-    }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -120,6 +120,29 @@ public sealed record CustomResourceSnapshot
             : healthReports.MinBy(r => r.Status)?.Status
                 ?? Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy;
     }
+
+    internal static ImmutableArray<ResourcePropertySnapshot> SetResourceProperty(ImmutableArray<ResourcePropertySnapshot> properties, string name, object value)
+    {
+        for (var i = 0; i < properties.Length; i++)
+        {
+            var property = properties[i];
+
+            if (string.Equals(property.Name, name, StringComparisons.ResourcePropertyName))
+            {
+                if (property.Value == value)
+                {
+                    // Unchanged.
+                    return properties;
+                }
+
+                // Set value.
+                return properties.SetItem(i, property with { Value = value });
+            }
+        }
+
+        // Add property.
+        return [.. properties, new ResourcePropertySnapshot(name, value)];
+    }
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Aspire.Hosting.csproj
+++ b/src/Aspire.Hosting/Aspire.Hosting.csproj
@@ -18,6 +18,7 @@
     <Compile Include="$(SharedDir)ChannelExtensions.cs" Link="ChannelExtensions.cs" />
     <Compile Include="$(SharedDir)CircularBuffer.cs" Link="CircularBuffer.cs" />
     <Compile Include="$(SharedDir)CompareHelpers.cs" Link="Utils\CompareHelpers.cs" />
+    <Compile Include="$(SharedDir)CustomResourceSnapshotExtensions.cs" Link="CustomResourceSnapshotExtensions.cs" />
     <Compile Include="$(SharedDir)Model\KnownProperties.cs" Link="Dashboard\KnownProperties.cs" />
     <Compile Include="$(SharedDir)Model\KnownResourceTypes.cs" Link="Dashboard\KnownResourceTypes.cs" />
     <Compile Include="$(SharedDir)IConfigurationExtensions.cs" Link="Utils\IConfigurationExtensions.cs" />

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -218,7 +218,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 State = state,
                 StartTimeStamp = startTimeStamp,
                 StopTimeStamp = stopTimeStamp,
-                Properties = CustomResourceSnapshot.SetResourceProperty(s.Properties, KnownProperties.Resource.ParentName, parentName)
+                Properties = s.Properties.SetResourceProperty(KnownProperties.Resource.ParentName, parentName)
             }).ConfigureAwait(false);
         }
     }

--- a/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/ApplicationExecutor.cs
@@ -209,7 +209,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
     }
 
     // Sets the state of the resource's children
-    async Task SetChildResourceAsync(IResource resource, string? state, DateTime? startTimeStamp, DateTime? stopTimeStamp)
+    async Task SetChildResourceAsync(IResource resource, string parentName, string? state, DateTime? startTimeStamp, DateTime? stopTimeStamp)
     {
         foreach (var child in _parentChildLookup[resource])
         {
@@ -217,7 +217,8 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
             {
                 State = state,
                 StartTimeStamp = startTimeStamp,
-                StopTimeStamp = stopTimeStamp
+                StopTimeStamp = stopTimeStamp,
+                Properties = CustomResourceSnapshot.SetResourceProperty(s.Properties, KnownProperties.Resource.ParentName, parentName)
             }).ConfigureAwait(false);
         }
     }
@@ -438,6 +439,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 {
                     await SetChildResourceAsync(
                         appModelResource,
+                        resource.Metadata.Name,
                         status.State,
                         status.StartupTimestamp?.ToUniversalTime(),
                         status.FinishTimestamp?.ToUniversalTime()).ConfigureAwait(false);
@@ -1533,7 +1535,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
                 })
                 .ConfigureAwait(false);
 
-                await SetChildResourceAsync(cr.ModelResource, state: "Starting", startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
+                await SetChildResourceAsync(cr.ModelResource, cr.DcpResource.Metadata.Name, state: "Starting", startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
 
                 try
                 {
@@ -1552,7 +1554,7 @@ internal sealed class ApplicationExecutor(ILogger<ApplicationExecutor> logger,
 
                     await notificationService.PublishUpdateAsync(cr.ModelResource, s => s with { State = "FailedToStart" }).ConfigureAwait(false);
 
-                    await SetChildResourceAsync(cr.ModelResource, state: "FailedToStart", startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
+                    await SetChildResourceAsync(cr.ModelResource, cr.DcpResource.Metadata.Name, state: "FailedToStart", startTimeStamp: null, stopTimeStamp: null).ConfigureAwait(false);
                 }
             }
 

--- a/src/Shared/CustomResourceSnapshotExtensions.cs
+++ b/src/Shared/CustomResourceSnapshotExtensions.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting;
+
+internal static class CustomResourceSnapshotExtensions
+{
+    internal static ImmutableArray<ResourcePropertySnapshot> SetResourceProperty(this ImmutableArray<ResourcePropertySnapshot> properties, string name, object value)
+    {
+        for (var i = 0; i < properties.Length; i++)
+        {
+            var property = properties[i];
+
+            if (string.Equals(property.Name, name, StringComparisons.ResourcePropertyName))
+            {
+                if (property.Value == value)
+                {
+                    // Unchanged.
+                    return properties;
+                }
+
+                // Set value.
+                return properties.SetItem(i, property with { Value = value });
+            }
+        }
+
+        // Add property.
+        return [.. properties, new ResourcePropertySnapshot(name, value)];
+    }
+}

--- a/src/Shared/Model/KnownProperties.cs
+++ b/src/Shared/Model/KnownProperties.cs
@@ -26,6 +26,7 @@ internal static class KnownProperties
         public const string Source = "resource.source";
         public const string HealthState = "resource.healthState";
         public const string ConnectionString = "resource.connectionString";
+        public const string ParentName = "resource.parentName";
     }
 
     public static class Container

--- a/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/ApplicationExecutorTests.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO.Pipelines;
 using System.Text;
 using System.Threading.Channels;
+using Aspire.Dashboard.Model;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Dcp.Model;
 using Aspire.Hosting.Eventing;
@@ -987,6 +988,50 @@ public class ApplicationExecutorTests
         HasKnownCommandAnnotations(project.Resource);
     }
 
+    [Fact]
+    public async Task ParentPropertySetOnChildResource()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+
+        var parentResource = builder.AddContainer("database", "image");
+        var childResource = builder.AddResource(new CustomChildResource("child", parentResource.Resource));
+
+        var kubernetesService = new TestKubernetesService();
+        using var app = builder.Build();
+        var distributedAppModel = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        var resourceNotificationService = ResourceNotificationServiceTestHelpers.Create();
+
+        var appExecutor = CreateAppExecutor(distributedAppModel, app.Services, kubernetesService: kubernetesService, resourceNotificationService: resourceNotificationService);
+        await appExecutor.RunApplicationAsync();
+
+        string? parentResourceId = null;
+        string? childParentResourceId = null;
+        var watchResourceTask = Task.Run(async () =>
+        {
+            await foreach (var item in resourceNotificationService.WatchAsync())
+            {
+                if (item.Resource == parentResource.Resource)
+                {
+                    parentResourceId = item.ResourceId;
+                }
+                else if (item.Resource == childResource.Resource)
+                {
+                    childParentResourceId = item.Snapshot.Properties.SingleOrDefault(p => p.Name == KnownProperties.Resource.ParentName)?.Value?.ToString();
+                }
+
+                if (parentResourceId != null && childParentResourceId != null)
+                {
+                    return;
+                }
+            }
+        });
+
+        await watchResourceTask.DefaultTimeout();
+
+        Assert.Equal(parentResourceId, childParentResourceId);
+    }
+
     private static void HasKnownCommandAnnotations(IResource resource)
     {
         var commandAnnotations = resource.Annotations.OfType<ResourceCommandAnnotation>().ToList();
@@ -1050,5 +1095,10 @@ public class ApplicationExecutorTests
     {
         public string ProjectPath => "TestProject";
         public LaunchSettings LaunchSettings { get; } = new();
+    }
+
+    private sealed class CustomChildResource(string name, IResource parent) : Resource(name), IResourceWithParent
+    {
+        public IResource Parent => parent;
     }
 }

--- a/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
+++ b/tests/Aspire.Workload.Tests/WorkloadTestsBase.cs
@@ -177,26 +177,29 @@ public partial class WorkloadTestsBase
                 var cellLocs = await rowLoc.Locator("//fluent-data-grid-cell[@role='gridcell']").AllAsync();
 
                 // is the resource name expected?
-                var resourceName = await cellLocs[1].InnerTextAsync();
+                var resourceNameCell = cellLocs[0];
+                var resourceName = await resourceNameCell.InnerTextAsync();
+                resourceName = resourceName.Trim();
                 if (!expectedRowsTable.TryGetValue(resourceName, out var expectedRow))
                 {
-                    Assert.Fail($"Row with unknown name found: {resourceName}");
+                    Assert.Fail($"Row with unknown name found: '{resourceName}'. Expected values: {string.Join(", ", expectedRowsTable.Keys.Select(k => $"'{k}'"))}");
                 }
                 if (foundNames.Contains(resourceName))
                 {
                     continue;
                 }
 
-                AssertEqual(expectedRow.Name, resourceName, $"Name for {resourceName}");
+                AssertEqual(expectedRow.Name, resourceName, $"Name for '{resourceName}'");
 
-                var actualState = await cellLocs[2].InnerTextAsync().ConfigureAwait(false);
+                var stateCell = cellLocs[1];
+                var actualState = await stateCell.InnerTextAsync().ConfigureAwait(false);
                 actualState = actualState.Trim();
                 if (expectedRow.State != actualState && actualState != "Finished" && !actualState.Contains("failed", StringComparison.OrdinalIgnoreCase))
                 {
                     testOutput.WriteLine($"[{expectedRow.Name}] expected state: '{expectedRow.State}', actual state: '{actualState}'");
                     continue;
                 }
-                AssertEqual(expectedRow.State, (await cellLocs[2].InnerTextAsync()).Trim(), $"State for {resourceName}");
+                AssertEqual(expectedRow.State, (await stateCell.InnerTextAsync()).Trim(), $"State for {resourceName}");
 
                 // Match endpoints
 
@@ -233,7 +236,8 @@ public partial class WorkloadTestsBase
                 AssertEqual(expectedEndpoints.Length, matchingEndpoints, $"Expected number of endpoints for {resourceName}");
 
                 // Check 'Source' column
-                AssertEqual(expectedRow.Source, await cellLocs[4].InnerTextAsync(), $"Source for {resourceName}");
+                var sourceCell = cellLocs[4];
+                AssertEqual(expectedRow.Source, await sourceCell.InnerTextAsync(), $"Source for {resourceName}");
 
                 foundRows.Add(expectedRow with { Endpoints = endpointsFound.ToArray() });
                 foundNames.Add(resourceName);


### PR DESCRIPTION
## Description

Automatically nested and collapse child resources that implement `IResourceWithParent`. By default, nested resources are collapsed. Parent information is sent in a resource property called `resource.parentName`. That means no proto changes required.

In test shop playground, `catelogdb` database resource is a child of `postgres` container resource:

![resources-nested](https://github.com/user-attachments/assets/7dadd512-9a0f-4074-887f-1e4abd824584)

Not 100% done yet, need to move some code to better places, add tests, tweak margins and paddings. But good enough to try out.

**Edit: Updated screenshots**

Resources page. Name column title and content is now aligned. I've consistently indented all content on the right by 8px across screens.

![image](https://github.com/user-attachments/assets/e7741dae-e898-41ca-82ae-2f91b28fca29)

Trace detail page. Updated it to use button instead of +/- text. Consistent with resources page.

![image](https://github.com/user-attachments/assets/3f69e423-8d5d-4906-aa07-a74983db38cb)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6589)