### PR TITLE
Rewrite dashboard URL in the console.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -76,7 +76,9 @@
 				"ms-dotnettools.vscodeintellicode-csharp",
 				"ms-azuretools.vscode-bicep",
 				"EditorConfig.EditorConfig",
-				"ms-azuretools.azure-dev"
+				"ms-azuretools.azure-dev",
+				"GitHub.copilot",
+				"GitHub.copilot-chat"
 			],
 			"settings": {
 				"remote.autoForwardPorts": false,

--- a/.gitignore
+++ b/.gitignore
@@ -116,9 +116,6 @@ Session.vim
 .netrwhist
 *~
 
-# Visual Studio Code
-.vscode/
-
 # Private test configuration and binaries.
 config.ps1
 **/IISApplications

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,17 +8,6 @@
             "request": "launch",
             "name": "C#: WaitFor (Debug)",
             "type": "dotnet",
-            "serverReadyAction": {
-                "action": "openExternally",
-
-                // The purpose of this pattern is to extract the dashboard URL from the console output and
-                // use that the launch the dashboard.
-                // Login to the dashboard at https://codespacename-port.app.github.dev/login?t=thetoken
-                "pattern": "Login to the dashboard at (https:\\/\\/[^\\s]+)",
-
-                // This uses the whole captured value to launch the browser.
-                "uriFormat": "%s"
-            },
             "projectPath": "${workspaceFolder}/playground/waitfor/WaitForSandbox.AppHost/WaitForSandbox.AppHost.csproj"
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "request": "launch",
+            "name": "C#: WaitFor (Debug)",
+            "type": "dotnet",
+            "serverReadyAction": {
+                "action": "openExternally",
+
+                // The purpose of this pattern is to extract the dashboard URL from the console output and
+                // use that the launch the dashboard.
+                // Login to the dashboard at https://codespacename-port.app.github.dev/login?t=thetoken
+                "pattern": "Login to the dashboard at (https:\\/\\/[^\\s]+)",
+
+                // This uses the whole captured value to launch the browser.
+                "uriFormat": "%s"
+            },
+            "projectPath": "${workspaceFolder}/playground/waitfor/WaitForSandbox.AppHost/WaitForSandbox.AppHost.csproj"
+        }
+    ]
+}

--- a/src/Aspire.Hosting/Codespaces/CodespacesResourceUrlRewriterService.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesResourceUrlRewriterService.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Hosting.Codespaces;
+
+internal sealed class CodespacesResourceUrlRewriterService(ILogger<CodespacesResourceUrlRewriterService> logger, IOptions<CodespacesOptions> options, CodespacesUrlRewriter codespaceUrlRewriter, ResourceNotificationService resourceNotificationService) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!options.Value.IsCodespace)
+        {
+            logger.LogTrace("Not running in Codespaces, skipping URL rewriting.");
+            return;
+        }
+
+        do
+        {
+            try
+            {
+                var resourceEvents = resourceNotificationService.WatchAsync(stoppingToken);
+
+                await foreach (var resourceEvent in resourceEvents.ConfigureAwait(false))
+                {
+                    Dictionary<UrlSnapshot, UrlSnapshot>? remappedUrls = null;
+
+                    foreach (var originalUrlSnapshot in resourceEvent.Snapshot.Urls)
+                    {
+                        var uri = new Uri(originalUrlSnapshot.Url);
+
+                        if (!originalUrlSnapshot.IsInternal && (uri.Scheme == "http" || uri.Scheme == "https") && uri.Host == "localhost")
+                        {
+                            remappedUrls ??= new();
+
+                            var newUrlSnapshot = originalUrlSnapshot with
+                            {
+                                // The format of GitHub Codespaces URLs comprises the codespace
+                                // name (from the CODESPACE_NAME environment variable, the port,
+                                // and the port forwarding domain (via GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
+                                // which is typically ".app.github.dev". The VSCode instance is typically
+                                // hosted at codespacename.github.dev whereas the forwarded ports
+                                // would be at codespacename-port.app.github.dev.
+                                Url = codespaceUrlRewriter.RewriteUrl(uri)
+                            };
+
+                            remappedUrls.Add(originalUrlSnapshot, newUrlSnapshot);
+                        }
+                    }
+
+                    if (remappedUrls is not null)
+                    {
+                        var transformedUrls = from originalUrl in resourceEvent.Snapshot.Urls
+                                              select remappedUrls.TryGetValue(originalUrl, out var remappedUrl) ? remappedUrl : originalUrl;
+
+                        await resourceNotificationService.PublishUpdateAsync(resourceEvent.Resource, resourceEvent.ResourceId, s => s with
+                        {
+                            Urls = transformedUrls.ToImmutableArray()
+                        }).ConfigureAwait(false);
+                    }
+                }
+            }
+            catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+            {
+                // When debugging sometimes we'll get cancelled here but we don't want
+                // to tear down the loop. We only want to crash out when the service's
+                // cancellation token is signaled.
+                logger.LogTrace(ex, "Codespace URL rewriting loop threw an exception but was ignored.");
+            }
+        } while (!stoppingToken.IsCancellationRequested);
+    }
+}

--- a/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
@@ -13,7 +13,7 @@ internal sealed class CodespacesUrlRewriter(IOptions<CodespacesOptions> options)
 
         if (!options.Value.IsCodespace)
         {
-            throw new InvalidOperationException("Cannot translate URL because not currently running in a GitHub Codespace.");
+            return url;
         }
 
         return RewriteUrl(new Uri(url, UriKind.Absolute));
@@ -23,7 +23,7 @@ internal sealed class CodespacesUrlRewriter(IOptions<CodespacesOptions> options)
     {
         if (!options.Value.IsCodespace)
         {
-            throw new InvalidOperationException("Cannot translate URL because not currently running in a GitHub Codespace.");
+            return uri.ToString();
         }
 
         var codespacesUrl = $"{uri.Scheme}://{options.Value.CodespaceName}-{uri.Port}.{options.Value.PortForwardingDomain}{uri.AbsolutePath}";

--- a/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
+++ b/src/Aspire.Hosting/Codespaces/CodespacesUrlRewriter.cs
@@ -1,76 +1,32 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
-using Aspire.Hosting.ApplicationModel;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Codespaces;
 
-internal sealed class CodespacesUrlRewriter(ILogger<CodespacesUrlRewriter> logger, IOptions<CodespacesOptions> options, ResourceNotificationService resourceNotificationService) : BackgroundService
+internal sealed class CodespacesUrlRewriter(IOptions<CodespacesOptions> options)
 {
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    public string RewriteUrl(string url)
+    {
+        ArgumentNullException.ThrowIfNullOrWhiteSpace(url);
+
+        if (!options.Value.IsCodespace)
+        {
+            throw new InvalidOperationException("Cannot translate URL because not currently running in a GitHub Codespace.");
+        }
+
+        return RewriteUrl(new Uri(url, UriKind.Absolute));
+    }
+
+    public string RewriteUrl(Uri uri)
     {
         if (!options.Value.IsCodespace)
         {
-            logger.LogTrace("Not running in Codespaces, skipping URL rewriting.");
-            return;
+            throw new InvalidOperationException("Cannot translate URL because not currently running in a GitHub Codespace.");
         }
 
-        do
-        {
-            try
-            {
-                var resourceEvents = resourceNotificationService.WatchAsync(stoppingToken);
-
-                await foreach (var resourceEvent in resourceEvents.ConfigureAwait(false))
-                {
-                    Dictionary<UrlSnapshot, UrlSnapshot>? remappedUrls = null;
-
-                    foreach (var originalUrlSnapshot in resourceEvent.Snapshot.Urls)
-                    {
-                        var uri = new Uri(originalUrlSnapshot.Url);
-
-                        if (!originalUrlSnapshot.IsInternal && (uri.Scheme == "http" || uri.Scheme == "https") && uri.Host == "localhost")
-                        {
-                            remappedUrls ??= new();
-
-                            var newUrlSnapshot = originalUrlSnapshot with
-                            {
-                                // The format of GitHub Codespaces URLs comprises the codespace
-                                // name (from the CODESPACE_NAME environment variable, the port,
-                                // and the port forwarding domain (via GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
-                                // which is typically ".app.github.dev". The VSCode instance is typically
-                                // hosted at codespacename.github.dev whereas the forwarded ports
-                                // would be at codespacename-port.app.github.dev.
-                                Url = $"{uri.Scheme}://{options.Value.CodespaceName}-{uri.Port}.{options.Value.PortForwardingDomain}{uri.AbsolutePath}"
-                            };
-
-                            remappedUrls.Add(originalUrlSnapshot, newUrlSnapshot);
-                        }
-                    }
-
-                    if (remappedUrls is not null)
-                    {
-                        var transformedUrls = from originalUrl in resourceEvent.Snapshot.Urls
-                                              select remappedUrls.TryGetValue(originalUrl, out var remappedUrl) ? remappedUrl : originalUrl;
-
-                        await resourceNotificationService.PublishUpdateAsync(resourceEvent.Resource, resourceEvent.ResourceId, s => s with
-                        {
-                            Urls = transformedUrls.ToImmutableArray()
-                        }).ConfigureAwait(false);
-                    }
-                }
-            }
-            catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
-            {
-                // When debugging sometimes we'll get cancelled here but we don't want
-                // to tear down the loop. We only want to crash out when the service's
-                // cancellation token is signaled.
-                logger.LogTrace(ex, "Codespace URL rewriting loop threw an exception but was ignored.");
-            }
-        } while (!stoppingToken.IsCancellationRequested);
+        var codespacesUrl = $"{uri.Scheme}://{options.Value.CodespaceName}-{uri.Port}.{options.Value.PortForwardingDomain}{uri.AbsolutePath}";
+        return codespacesUrl;
     }
 }

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -31,7 +31,6 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
                                              ILoggerFactory loggerFactory,
                                              DcpNameGenerator nameGenerator,
                                              IHostApplicationLifetime hostApplicationLifetime,
-                                             IOptions<CodespacesOptions> codespacesOptions,
                                              CodespacesUrlRewriter codespaceUrlRewriter) : IDistributedApplicationLifecycleHook, IAsyncDisposable
 {
     private Task? _dashboardLogsTask;
@@ -243,12 +242,7 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
                 return;
             }
 
-            var dashboardUrl = firstDashboardUrl.ToString();
-
-            if (codespacesOptions.Value.IsCodespace)
-            {
-                dashboardUrl = codespaceUrlRewriter.RewriteUrl(dashboardUrl);
-            }
+            var dashboardUrl = codespaceUrlRewriter.RewriteUrl(firstDashboardUrl.ToString());
 
             distributedApplicationLogger.LogInformation("Now listening on: {DashboardUrl}", dashboardUrl.TrimEnd('/'));
 

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Serialization;
 using Aspire.Dashboard.ConsoleLogs;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Codespaces;
 using Aspire.Hosting.Dcp;
 using Aspire.Hosting.Lifecycle;
 using Aspire.Hosting.Utils;
@@ -29,7 +30,9 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
                                              ResourceLoggerService resourceLoggerService,
                                              ILoggerFactory loggerFactory,
                                              DcpNameGenerator nameGenerator,
-                                             IHostApplicationLifetime hostApplicationLifetime) : IDistributedApplicationLifecycleHook, IAsyncDisposable
+                                             IHostApplicationLifetime hostApplicationLifetime,
+                                             IOptions<CodespacesOptions> codespacesOptions,
+                                             CodespacesUrlRewriter codespaceUrlRewriter) : IDistributedApplicationLifecycleHook, IAsyncDisposable
 {
     private Task? _dashboardLogsTask;
     private CancellationTokenSource? _dashboardLogsCts;
@@ -235,14 +238,23 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
 
             // We need to print out the url so that dotnet watch can launch the dashboard
             // technically this is too early, but it's late ne
-            if (StringUtils.TryGetUriFromDelimitedString(dashboardUrls, ";", out var firstDashboardUrl))
+            if (!StringUtils.TryGetUriFromDelimitedString(dashboardUrls, ";", out var firstDashboardUrl))
             {
-                distributedApplicationLogger.LogInformation("Now listening on: {DashboardUrl}", firstDashboardUrl.ToString().TrimEnd('/'));
+                return;
             }
+
+            var dashboardUrl = firstDashboardUrl.ToString();
+
+            if (codespacesOptions.Value.IsCodespace)
+            {
+                dashboardUrl = codespaceUrlRewriter.RewriteUrl(dashboardUrl);
+            }
+
+            distributedApplicationLogger.LogInformation("Now listening on: {DashboardUrl}", dashboardUrl.TrimEnd('/'));
 
             if (!string.IsNullOrEmpty(browserToken))
             {
-                LoggingHelpers.WriteDashboardUrl(distributedApplicationLogger, dashboardUrls, browserToken, isContainer: false);
+                LoggingHelpers.WriteDashboardUrl(distributedApplicationLogger, dashboardUrl, browserToken, isContainer: false);
             }
         }));
     }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -288,7 +288,8 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
 
             // Codespaces
             _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<CodespacesOptions>, ConfigureCodespacesOptions>());
-            _innerBuilder.Services.AddHostedService<CodespacesUrlRewriter>();
+            _innerBuilder.Services.AddSingleton<CodespacesUrlRewriter>();
+            _innerBuilder.Services.AddHostedService<CodespacesResourceUrlRewriterService>();
 
             Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.InitializeDcpAnnotations);
         }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -118,7 +118,6 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
             loggerFactory ?? NullLoggerFactory.Instance,
             new DcpNameGenerator(configuration, Options.Create(new DcpOptions())),
             new TestHostApplicationLifetime(),
-            codespacesOptions,
             rewriter
             );
     }

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text.Json;
 using System.Threading.Channels;
+using Aspire.Hosting.Codespaces;
 using Aspire.Hosting.ConsoleLogs;
 using Aspire.Hosting.Dashboard;
 using Aspire.Hosting.Dcp;
@@ -99,8 +100,13 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
         ResourceLoggerService resourceLoggerService,
         ResourceNotificationService resourceNotificationService,
         IConfiguration configuration,
-        ILoggerFactory? loggerFactory = null)
+        ILoggerFactory? loggerFactory = null,
+        IOptions<CodespacesOptions>? codespacesOptions = null
+        )
     {
+        codespacesOptions ??= Options.Create(new CodespacesOptions());
+        var rewriter = new CodespacesUrlRewriter(codespacesOptions);
+
         return new DashboardLifecycleHook(
             configuration,
             Options.Create(new DashboardOptions { DashboardPath = "test.dll" }),
@@ -111,7 +117,10 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
             resourceLoggerService,
             loggerFactory ?? NullLoggerFactory.Instance,
             new DcpNameGenerator(configuration, Options.Create(new DcpOptions())),
-            new TestHostApplicationLifetime());
+            new TestHostApplicationLifetime(),
+            codespacesOptions,
+            rewriter
+            );
     }
 
     public static IEnumerable<object?[]> Data()


### PR DESCRIPTION
## Description

Restructures the codespace URL rewriting a bit to extract the functionality out into a service in DI (which is then used by a resource rewriter service each time a URL resource is updated). We also use this new service to translate the dashboard launch URL so you can just click on the hyperlink.

Fixes #6586 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6591)