### PR TITLE
NO MERGE: Open browser tab from command

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -353,6 +353,10 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             toastParameters.Intent = ToastIntent.Success;
             toastParameters.Icon = GetIntentIcon(ToastIntent.Success);
         }
+        else if (response.Kind == ResourceCommandResponseKind.Action && response.ActionKind == ResourceCommandResponseActionKind.OpenExternal)
+        {
+            await JS.InvokeVoidAsync("window.open", response.Url);
+        }
         else
         {
             toastParameters.Title = string.Format(CultureInfo.InvariantCulture, Loc[nameof(Dashboard.Resources.Resources.ResourceCommandFailed)], messageResourceName, command.DisplayName);

--- a/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceCommandResponseViewModel.cs
@@ -6,6 +6,11 @@ namespace Aspire.Dashboard.Model;
 public class ResourceCommandResponseViewModel
 {
     public required ResourceCommandResponseKind Kind { get; init; }
+
+    public ResourceCommandResponseActionKind? ActionKind { get; init; }
+
+    public string? Url { get; init; }
+
     public string? ErrorMessage { get; init; }
 }
 
@@ -15,5 +20,11 @@ public enum ResourceCommandResponseKind
     Undefined = 0,
     Succeeded = 1,
     Failed = 2,
-    Cancelled = 3
+    Cancelled = 3,
+    Action = 4
+}
+
+public enum ResourceCommandResponseActionKind
+{
+    OpenExternal = 0
 }

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -140,9 +140,11 @@ partial class ResourceCommandResponse
     public ResourceCommandResponseViewModel ToViewModel()
     {
         return new ResourceCommandResponseViewModel()
-        {
-            ErrorMessage = ErrorMessage,
-            Kind = (Dashboard.Model.ResourceCommandResponseKind)Kind
-        };
+                {
+                    ActionKind = (Dashboard.Model.ResourceCommandResponseActionKind)ActionKind,
+                    ErrorMessage = ErrorMessage,
+                    Kind = (Dashboard.Model.ResourceCommandResponseKind)Kind,
+                    Url = Url ?? string.Empty
+                };
     }
 }

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -139,6 +139,19 @@ public static class PostgresBuilderExtensions
         {
             var builderForExistingResource = builder.ApplicationBuilder.CreateResourceBuilder(existingPgAdminResource);
             configureContainer?.Invoke(builderForExistingResource);
+
+            builder.WithCommand("open-pgadmin", "Open PgAdmin", (context) => {
+                var endpoint = builderForExistingResource.GetEndpoint("http");
+
+                var result = new OpenExternalExecuteCommandResult()
+                {
+                    Success = true,
+                    Url = endpoint.Url
+                };
+
+                return Task.FromResult((ExecuteCommandResult)result);
+            });
+
             return builder;
         }
         else
@@ -154,6 +167,18 @@ public static class PostgresBuilderExtensions
                                                  .WithBindMount(Path.GetTempFileName(), "/pgadmin4/servers.json")
                                                  .WithHttpHealthCheck("/browser")
                                                  .ExcludeFromManifest();
+
+                builder.WithCommand("open-pgadmin", "Open PgAdmin", (context) => {
+                    var endpoint = pgAdminContainerBuilder.GetEndpoint("http");
+
+                    var result = new OpenExternalExecuteCommandResult()
+                    {
+                        Success = true,
+                        Url = endpoint.Url
+                    };
+
+                    return Task.FromResult((ExecuteCommandResult)result);
+                });
 
             builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
             {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceCommandAnnotation.cs
@@ -128,7 +128,7 @@ public static class CommandResults
 /// <summary>
 /// The result of executing a command. Returned from <see cref="ResourceCommandAnnotation.ExecuteCommand"/>.
 /// </summary>
-public sealed class ExecuteCommandResult
+public class ExecuteCommandResult
 {
     /// <summary>
     /// A flag that indicates whether the command was successful.
@@ -139,6 +139,24 @@ public sealed class ExecuteCommandResult
     /// An optional error message that can be set when the command is unsuccessful.
     /// </summary>
     public string? ErrorMessage { get; init; }
+}
+
+/// <summary>
+/// TODO:
+/// </summary>
+public sealed class OpenExternalExecuteCommandResult : ExecuteCommandResult
+{
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public required string Url { get; init; }
+}
+
+/// <summary>
+/// TODO:
+/// </summary>
+public sealed class CancelledExecuteCommandResult : ExecuteCommandResult
+{
 }
 
 /// <summary>

--- a/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
+++ b/src/Aspire.Hosting/Dashboard/proto/resource_service.proto
@@ -87,11 +87,18 @@ enum ResourceCommandResponseKind {
     SUCCEEDED = 1;
     FAILED = 2;
     CANCELLED = 3;
+    ACTION = 4;
+}
+
+enum ResourceCommandResponseActionKind {
+    OPEN_EXTERNAL = 0;
 }
 
 message ResourceCommandResponse {
     ResourceCommandResponseKind kind = 1;
     optional string error_message = 2;
+    optional ResourceCommandResponseActionKind actionKind = 3;
+    optional string url = 4;
 }
 
 ////////////////////////////////////////////

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Aspire.Hosting.ApplicationModel.CancelledExecuteCommandResult
+Aspire.Hosting.ApplicationModel.CancelledExecuteCommandResult.CancelledExecuteCommandResult() -> void
 Aspire.Hosting.ApplicationModel.ContainerLifetime.Session = 0 -> Aspire.Hosting.ApplicationModel.ContainerLifetime
 Aspire.Hosting.ApplicationModel.CustomResourceSnapshot.HealthStatus.get -> Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?
 Aspire.Hosting.ApplicationModel.DockerfileBuildAnnotation
@@ -84,6 +86,10 @@ Aspire.Hosting.ApplicationModel.HealthCheckAnnotation
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.HealthCheckAnnotation(string! key) -> void
 Aspire.Hosting.ApplicationModel.HealthCheckAnnotation.Key.get -> string!
 Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport
+Aspire.Hosting.ApplicationModel.OpenExternalExecuteCommandResult
+Aspire.Hosting.ApplicationModel.OpenExternalExecuteCommandResult.OpenExternalExecuteCommandResult() -> void
+Aspire.Hosting.ApplicationModel.OpenExternalExecuteCommandResult.Url.get -> string!
+Aspire.Hosting.ApplicationModel.OpenExternalExecuteCommandResult.Url.init -> void
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.ConfirmationMessage.get -> string?
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.DisplayDescription.get -> string?
 Aspire.Hosting.ApplicationModel.ResourceCommandAnnotation.Name.get -> string!


### PR DESCRIPTION
## Description

This is just a spike on opening a browser tab in response to command defined in the app model executing. The biggest issue with this so far is that opening the tab is blocked by the popup blocker (for good reason).

To solve this problem, I think we are going to want to define a kind of `ResourceUrlCommandAnnotation` or something like that which results in the tab being opened in response to the user initiated click in a browser.

Another issue this PR has which is specific to codespaces it that the URL we insert isn't Codespace forwarding URL aware. So we'll need to be able to inject the URL command annotations after endpoints have been allocated.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6601)