### PR TITLE
Fix resource update causing resource filter to reset

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -209,8 +209,8 @@ public partial class Resources : ComponentBase, IAsyncDisposable
 
                             if (_allResourceTypes.TryAdd(resource.ResourceType, true))
                             {
-                                // If someone has filtered out a resource type then don't display it again because it has been updated.
-                                // Only automatically set resource to visible if it is a new resource.
+                                // If someone has filtered out a resource type then don't remove filter because an update was received.
+                                // Only automatically set resource type to visible if it is a new resource.
                                 _visibleResourceTypes[resource.ResourceType] = true;
                             }
                         }

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -207,8 +207,12 @@ public partial class Resources : ComponentBase, IAsyncDisposable
                                 SelectedResource = resource;
                             }
 
-                            _allResourceTypes[resource.ResourceType] = true;
-                            _visibleResourceTypes[resource.ResourceType] = true;
+                            if (_allResourceTypes.TryAdd(resource.ResourceType, true))
+                            {
+                                // If someone has filtered out a resource type then don't display it again because it has been updated.
+                                // Only automatically set resource to visible if it is a new resource.
+                                _visibleResourceTypes[resource.ResourceType] = true;
+                            }
                         }
                         else if (changeType == ResourceViewModelChangeType.Delete)
                         {


### PR DESCRIPTION
## Description

I noticed that if a filter is applied to resource types then a resource update of the filtered type would automatically remove the filter.

Automatically set resource type to visible if it is a new resource type.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6610)