### PR TITLE
Fix source column displaying executable args

### DIFF
--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -5,17 +5,18 @@
 @inject IStringLocalizer<Resources> ResourcesLoc
 
 <GridValue Value="@Value"
-            ValueToCopy="@ValueToCopy"
-            ValueDescription="@ResourcesLoc[nameof(Resources.ResourcesSourceColumnHeader)]"
-            EnableHighlighting="true"
-            HighlightText="@FilterText"
-            PreCopyToolTip="@Loc[nameof(Columns.SourceColumnDisplayCopyCommandToClipboard)]"
-            ToolTip="@Tooltip"
-            StopClickPropagation="true">
+           ValueToCopy="@ValueToCopy"
+           ValueToVisualize="@ValueToCopy"
+           ValueDescription="@ResourcesLoc[nameof(Resources.ResourcesSourceColumnHeader)]"
+           EnableHighlighting="true"
+           HighlightText="@FilterText"
+           PreCopyToolTip="@Loc[nameof(Columns.SourceColumnDisplayCopyCommandToClipboard)]"
+           ToolTip="@Tooltip"
+           StopClickPropagation="true">
     <ContentAfterValue>
         @if (ContentAfterValue is not null)
         {
-            <span class="subtext">@ContentAfterValue</span>
+            <span class="subtext">&nbsp;@ContentAfterValue</span>
         }
     </ContentAfterValue>
 </GridValue>


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/6585

After:

![image](https://github.com/user-attachments/assets/12d073e2-ab44-4853-a4a1-8385119065ab)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6619)