### PR TITLE
Improve start/stopping/restarting commands by waiting for completion

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor
@@ -1,6 +1,7 @@
 ﻿@using Aspire.Dashboard.Components.CustomIcons
 @using Aspire.Dashboard.Model
 @using Aspire.Dashboard.Resources
+@using Aspire.Dashboard.Utils
 @inherits LayoutComponentBase
 
 <div class="layout" style="@(_isNavMenuOpen ? "overflow: hidden;" : string.Empty)">
@@ -66,7 +67,7 @@
         <FluentMessageBarProvider Section="@MessageBarSection" Class="top-messagebar"/>
     </div>
     <FluentBodyContent Class="custom-body-content body-content">
-        <FluentToastProvider MaxToastCount="3" Timeout="5000" />
+        <FluentToastProvider MaxToastCount="3" Timeout="@ToastHelpers.TimeoutMilliseconds" />
         @Body
     </FluentBodyContent>
 

--- a/src/Aspire.Dashboard/Utils/ToastHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/ToastHelpers.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Utils;
+
+public static class ToastHelpers
+{
+    public const int TimeoutMilliseconds = 5000;
+}

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -8,6 +8,9 @@ namespace Aspire.Hosting.ApplicationModel;
 
 internal static class CommandsConfigurationExtensions
 {
+    // Picked to provide a balance between enough time to start slow resources vs providing a timely timeout.
+    private static readonly TimeSpan s_timeout = TimeSpan.FromSeconds(20);
+
     internal const string StartCommandName = "resource-start";
     internal const string StopCommandName = "resource-stop";
     internal const string RestartCommandName = "resource-restart";
@@ -24,10 +27,17 @@ internal static class CommandsConfigurationExtensions
             displayName: "Start",
             executeCommand: async context =>
             {
-                var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
-
-                await executor.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return CommandResults.Success();
+                return await RunLifeCycleCommandAsync(
+                    async (serviceProvider, ct) =>
+                    {
+                        var applicationExecutor = serviceProvider.GetRequiredService<ApplicationExecutor>();
+                        await applicationExecutor.StartResourceAsync(context.ResourceName, ct).ConfigureAwait(false);
+                    },
+                    context.ServiceProvider,
+                    context.ResourceName,
+                    IsRunning,
+                    s_timeout,
+                    context.CancellationToken).ConfigureAwait(false);
             },
             updateState: context =>
             {
@@ -35,7 +45,7 @@ internal static class CommandsConfigurationExtensions
                 {
                     return ResourceCommandState.Disabled;
                 }
-                else if (IsStopped(context.ResourceSnapshot.State?.Text))
+                else if (IsStartable(context.ResourceSnapshot.State?.Text))
                 {
                     return ResourceCommandState.Enabled;
                 }
@@ -56,10 +66,17 @@ internal static class CommandsConfigurationExtensions
             displayName: "Stop",
             executeCommand: async context =>
             {
-                var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
-
-                await executor.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return CommandResults.Success();
+                return await RunLifeCycleCommandAsync(
+                    async (serviceProvider, ct) =>
+                    {
+                        var applicationExecutor = serviceProvider.GetRequiredService<ApplicationExecutor>();
+                        await applicationExecutor.StopResourceAsync(context.ResourceName, ct).ConfigureAwait(false);
+                    },
+                    context.ServiceProvider,
+                    context.ResourceName,
+                    IsStopped,
+                    s_timeout,
+                    context.CancellationToken).ConfigureAwait(false);
             },
             updateState: context =>
             {
@@ -67,7 +84,7 @@ internal static class CommandsConfigurationExtensions
                 {
                     return ResourceCommandState.Disabled;
                 }
-                else if (!IsStopped(context.ResourceSnapshot.State?.Text) && !IsStarting(context.ResourceSnapshot.State?.Text) && !IsWaiting(context.ResourceSnapshot.State?.Text) && context.ResourceSnapshot.State is not null)
+                else if (!IsStartable(context.ResourceSnapshot.State?.Text) && !IsStarting(context.ResourceSnapshot.State?.Text) && !IsWaiting(context.ResourceSnapshot.State?.Text) && context.ResourceSnapshot.State is not null)
                 {
                     return ResourceCommandState.Enabled;
                 }
@@ -88,15 +105,22 @@ internal static class CommandsConfigurationExtensions
             displayName: "Restart",
             executeCommand: async context =>
             {
-                var executor = context.ServiceProvider.GetRequiredService<ApplicationExecutor>();
-
-                await executor.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                await executor.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
-                return CommandResults.Success();
+                return await RunLifeCycleCommandAsync(
+                    async (serviceProvider, ct) =>
+                    {
+                        var applicationExecutor = serviceProvider.GetRequiredService<ApplicationExecutor>();
+                        await applicationExecutor.StopResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
+                        await applicationExecutor.StartResourceAsync(context.ResourceName, context.CancellationToken).ConfigureAwait(false);
+                    },
+                    context.ServiceProvider,
+                    context.ResourceName,
+                    IsRunning,
+                    s_timeout,
+                    context.CancellationToken).ConfigureAwait(false);
             },
             updateState: context =>
             {
-                if (IsWaiting(context.ResourceSnapshot.State?.Text) || IsStarting(context.ResourceSnapshot.State?.Text) || IsStopping(context.ResourceSnapshot.State?.Text) || IsStopped(context.ResourceSnapshot.State?.Text) || context.ResourceSnapshot.State is null)
+                if (IsWaiting(context.ResourceSnapshot.State?.Text) || IsStarting(context.ResourceSnapshot.State?.Text) || IsStopping(context.ResourceSnapshot.State?.Text) || IsStartable(context.ResourceSnapshot.State?.Text) || context.ResourceSnapshot.State is null)
                 {
                     return ResourceCommandState.Disabled;
                 }
@@ -112,9 +136,60 @@ internal static class CommandsConfigurationExtensions
             iconVariant: IconVariant.Regular,
             isHighlighted: false));
 
-        static bool IsStopped(string? state) => state is "Exited" or "Finished" or "FailedToStart";
+        static bool IsStopped(string? state) => state is "Exited" or "Finished";
+        static bool IsStartable(string? state) => IsStopped(state) || state is "FailedToStart";
         static bool IsStopping(string? state) => state is "Stopping";
         static bool IsStarting(string? state) => state is "Starting";
+        static bool IsRunning(string? state) => state is "Running";
         static bool IsWaiting(string? state) => state is "Waiting" or "RuntimeUnhealthy";
+    }
+
+    internal static async Task<ExecuteCommandResult> RunLifeCycleCommandAsync(
+        Func<IServiceProvider, CancellationToken, Task> action,
+        IServiceProvider serviceProvider,
+        string resourceName,
+        Func<string, bool> isExpectedStateFunc,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout);
+
+        var resourceNotificationService = serviceProvider.GetRequiredService<ResourceNotificationService>();
+
+        try
+        {
+            await action(serviceProvider, cts.Token).ConfigureAwait(false);
+
+            await WaitForResourceAsync(resourceNotificationService, resourceName, isExpectedStateFunc, cts.Token).ConfigureAwait(false);
+
+            cts.Token.ThrowIfCancellationRequested();
+
+            return CommandResults.Success();
+        }
+        catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
+        {
+            return new ExecuteCommandResult
+            {
+                Success = false,
+                ErrorMessage = $"Timeout while waiting for '{resourceName}'."
+            };
+        }
+
+        // This is different from ResourceNotificationService.WaitForResourceAsync implementation because it looks for resourceId instead of name.
+        static async Task<string> WaitForResourceAsync(ResourceNotificationService resourceNotificationService, string resourceId, Func<string, bool> isExpectedStateFunc, CancellationToken cancellationToken = default)
+        {
+            await foreach (var resourceEvent in resourceNotificationService.WatchAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (string.Equals(resourceId, resourceEvent.ResourceId, StringComparisons.ResourceName)
+                    && resourceEvent.Snapshot.State?.Text is { Length: > 0 } statusText
+                    && isExpectedStateFunc(statusText))
+                {
+                    return statusText;
+                }
+            }
+
+            throw new OperationCanceledException($"The operation was cancelled before the resource reached the target states.");
+        }
     }
 }


### PR DESCRIPTION
## Description

* Resource start/stop/restart wait for a notification that the resource's state has changed to the desired state. For example, starting a resource causes the server to wait for a state of "Running".
* Timeout of 20 seconds and then a failure message is displayed.
* Fixed issue with displaying toast update in the dashboard. If a toast has closed then updating it does nothing. Now a toast is updated and its close time is extended if it is still open, or a new toast is shown with the update

Fixes https://github.com/dotnet/aspire/issues/6224

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6625)