### PR TITLE
Move dashboard login URL log message last

### DIFF
--- a/playground/TestShop/BasketService/Repositories/RedisBasketRepository.cs
+++ b/playground/TestShop/BasketService/Repositories/RedisBasketRepository.cs
@@ -36,7 +36,7 @@ public class RedisBasketRepository(ILogger<RedisBasketRepository> logger, IConne
             return null;
         }
 
-        return JsonSerializer.Deserialize<CustomerBasket>(data!, s_jsonSerializerOptions);
+        return JsonSerializer.Deserialize<CustomerBasket>(data.ToString(), s_jsonSerializerOptions);
     }
 
     public async Task<CustomerBasket?> UpdateBasketAsync(CustomerBasket basket)

--- a/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Integration/FrontendBrowserTokenAuthTests.cs
@@ -183,14 +183,6 @@ public class FrontendBrowserTokenAuthTests
             },
             w =>
             {
-                Assert.Equal("Login to the dashboard at {DashboardLoginUrl}", GetValue(w.State, "{OriginalFormat}"));
-
-                var uri = new Uri((string)GetValue(w.State, "DashboardLoginUrl")!, UriKind.Absolute);
-                var queryString = HttpUtility.ParseQueryString(uri.Query);
-                Assert.NotNull(queryString["t"]);
-            },
-            w =>
-            {
                 Assert.Equal("OTLP/gRPC listening on: {OtlpEndpointUri}", GetValue(w.State, "{OriginalFormat}"));
 
                 var uri = new Uri((string)GetValue(w.State, "OtlpEndpointUri")!);
@@ -207,6 +199,14 @@ public class FrontendBrowserTokenAuthTests
             {
                 Assert.Equal("OTLP server is unsecured. Untrusted apps can send telemetry to the dashboard. For more information, visit https://go.microsoft.com/fwlink/?linkid=2267030", GetValue(w.State, "{OriginalFormat}"));
                 Assert.Equal(LogLevel.Warning, w.LogLevel);
+            },
+            w =>
+            {
+                Assert.Equal("Login to the dashboard at {DashboardLoginUrl}", GetValue(w.State, "{OriginalFormat}"));
+
+                var uri = new Uri((string)GetValue(w.State, "DashboardLoginUrl")!, UriKind.Absolute);
+                var queryString = HttpUtility.ParseQueryString(uri.Query);
+                Assert.NotNull(queryString["t"]);
             });
     }
 


### PR DESCRIPTION
## Description

While trying out the standalone dashboard I found that the log message with the login link was hard to find because it was mixed in the middle of other log messages.

This PR moves the login link to the last log message at startup.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6654)