### PR TITLE
Add default count to data grids to avoid getting all data

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.cs
@@ -254,11 +254,9 @@ public partial class Resources : ComponentBase, IAsyncDisposable
             .ToList();
 
         // Paging visible resources.
-        var query = orderedResources.Skip(request.StartIndex);
-        if (request.Count != null)
-        {
-            query = query.Take(request.Count.Value);
-        }
+        var query = orderedResources
+            .Skip(request.StartIndex)
+            .Take(request.Count ?? DashboardUIHelpers.DefaultDataGridResultCount);
 
         return ValueTask.FromResult(GridItemsProviderResult.From(query.ToList(), orderedResources.Count));
     }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor.cs
@@ -105,7 +105,7 @@ public partial class StructuredLogs : IPageWithSessionAndUrlState<StructuredLogs
     private async ValueTask<GridItemsProviderResult<OtlpLogEntry>> GetData(GridItemsProviderRequest<OtlpLogEntry> request)
     {
         ViewModel.StartIndex = request.StartIndex;
-        ViewModel.Count = request.Count;
+        ViewModel.Count = request.Count ?? DashboardUIHelpers.DefaultDataGridResultCount;
 
         var logs = ViewModel.GetLogs();
 

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -84,10 +84,7 @@ public partial class TraceDetail : ComponentBase
         {
             page = page.Skip(request.StartIndex);
         }
-        if (request.Count != null)
-        {
-            page = page.Take(request.Count.Value);
-        }
+        page = page.Take(request.Count ?? DashboardUIHelpers.DefaultDataGridResultCount);
 
         return ValueTask.FromResult(new GridItemsProviderResult<SpanWaterfallViewModel>
         {

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor.cs
@@ -110,7 +110,7 @@ public partial class Traces : IPageWithSessionAndUrlState<Traces.TracesPageViewM
     private async ValueTask<GridItemsProviderResult<OtlpTrace>> GetData(GridItemsProviderRequest<OtlpTrace> request)
     {
         TracesViewModel.StartIndex = request.StartIndex;
-        TracesViewModel.Count = request.Count;
+        TracesViewModel.Count = request.Count ?? DashboardUIHelpers.DefaultDataGridResultCount;
         var traces = TracesViewModel.GetTraces();
 
         if (DashboardOptions.Value.TelemetryLimits.MaxTraceCount == traces.TotalItemCount && !TelemetryRepository.HasDisplayedMaxTraceLimitMessage)

--- a/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
+++ b/src/Aspire.Dashboard/Model/StructuredLogsViewModel.cs
@@ -16,7 +16,7 @@ public class StructuredLogsViewModel
     private ApplicationKey? _applicationKey;
     private string _filterText = string.Empty;
     private int _logsStartIndex;
-    private int? _logsCount;
+    private int _logsCount;
     private LogLevel? _logLevel;
 
     public StructuredLogsViewModel(TelemetryRepository telemetryRepository)
@@ -60,7 +60,7 @@ public class StructuredLogsViewModel
     }
 
     public int StartIndex { get => _logsStartIndex; set => SetValue(ref _logsStartIndex, value); }
-    public int? Count { get => _logsCount; set => SetValue(ref _logsCount, value); }
+    public int Count { get => _logsCount; set => SetValue(ref _logsCount, value); }
     public LogLevel? LogLevel { get => _logLevel; set => SetValue(ref _logLevel, value); }
 
     private void SetValue<T>(ref T field, T value)

--- a/src/Aspire.Dashboard/Model/TracesViewModel.cs
+++ b/src/Aspire.Dashboard/Model/TracesViewModel.cs
@@ -16,7 +16,7 @@ public class TracesViewModel
     private ApplicationKey? _applicationKey;
     private string _filterText = string.Empty;
     private int _startIndex;
-    private int? _count;
+    private int _count;
 
     public TracesViewModel(TelemetryRepository telemetryRepository)
     {
@@ -26,7 +26,7 @@ public class TracesViewModel
     public ApplicationKey? ApplicationKey { get => _applicationKey; set => SetValue(ref _applicationKey, value); }
     public string FilterText { get => _filterText; set => SetValue(ref _filterText, value); }
     public int StartIndex { get => _startIndex; set => SetValue(ref _startIndex, value); }
-    public int? Count { get => _count; set => SetValue(ref _count, value); }
+    public int Count { get => _count; set => SetValue(ref _count, value); }
     public TimeSpan MaxDuration { get; private set; }
     public IReadOnlyList<TelemetryFilter> Filters => _filters;
 

--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -392,18 +392,14 @@ public static class OtlpHelpers
         return sb.ToString();
     }
 
-    public static PagedResult<T> GetItems<T>(IEnumerable<T> results, int startIndex, int? count)
+    public static PagedResult<T> GetItems<T>(IEnumerable<T> results, int startIndex, int count)
     {
         return GetItems<T, T>(results, startIndex, count, null);
     }
 
-    public static PagedResult<TResult> GetItems<TSource, TResult>(IEnumerable<TSource> results, int startIndex, int? count, Func<TSource, TResult>? select)
+    public static PagedResult<TResult> GetItems<TSource, TResult>(IEnumerable<TSource> results, int startIndex, int count, Func<TSource, TResult>? select)
     {
-        var query = results.Skip(startIndex);
-        if (count != null)
-        {
-            query = query.Take(count.Value);
-        }
+        var query = results.Skip(startIndex).Take(count);
         List<TResult> items;
         if (select != null)
         {

--- a/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetLogsContext.cs
@@ -9,6 +9,6 @@ public sealed class GetLogsContext
 {
     public required ApplicationKey? ApplicationKey { get; init; }
     public required int StartIndex { get; init; }
-    public required int? Count { get; init; }
+    public required int Count { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
 }

--- a/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/GetTracesRequest.cs
@@ -9,7 +9,7 @@ public sealed class GetTracesRequest
 {
     public required ApplicationKey? ApplicationKey { get; init; }
     public required int StartIndex { get; init; }
-    public required int? Count { get; init; }
+    public required int Count { get; init; }
     public required string FilterText { get; init; }
     public required List<TelemetryFilter> Filters { get; init; }
 }

--- a/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Dashboard.Utils;
+
+internal static class DashboardUIHelpers
+{
+    // The initial data fetch for a FluentDataGrid doesn't include a count of items to return.
+    // The data grid doesn't specify a count because it doesn't know how many items fit in the UI.
+    // Once it knows the height of items and the height of the grid then it specifies the desired item count
+    // and then virtualization will fetch more data as needed. The problem with this is the initial fetch
+    // could fetch all available data when it doesn't need to.
+    //
+    // If there is no count then default to a limit to avoid getting all data.
+    // Given the size of rows on dashboard grids, 100 rows should always fill the grid on the screen.
+    public const int DefaultDataGridResultCount = 100;
+}


### PR DESCRIPTION
## Description

I noticed that the initial data fetch for structured logs and traces grids didn't provide a limit on data fetched. This causes unnessessary data to be copied.

Fix by providing a default limit.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6664)