### PR TITLE
Fix not unsubscribing in trace detail on navigation

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/Subscription.cs
@@ -1,10 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace Aspire.Dashboard.Otlp.Storage;
 
+[DebuggerDisplay("Name = {Name}, ApplicationKey = {ApplicationKey}, SubscriptionId = {SubscriptionId}")]
 public sealed class Subscription : IDisposable
 {
+    private static int s_subscriptionId;
+
     private readonly Func<Task> _callback;
     private readonly ExecutionContext? _executionContext;
     private readonly TelemetryRepository _telemetryRepository;
@@ -13,9 +18,11 @@ public sealed class Subscription : IDisposable
     private readonly Action _unsubscribe;
     private readonly SemaphoreSlim _lock = new SemaphoreSlim(1, 1);
     private ILogger Logger => _telemetryRepository._otlpContext.Logger;
+    private readonly int _subscriptionId = Interlocked.Increment(ref s_subscriptionId);
 
     private DateTime? _lastExecute;
 
+    public int SubscriptionId => _subscriptionId;
     public ApplicationKey? ApplicationKey { get; }
     public SubscriptionType SubscriptionType { get; }
     public string Name { get; }

--- a/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
+++ b/src/Aspire.Dashboard/Otlp/Storage/TelemetryRepository.cs
@@ -51,6 +51,7 @@ public sealed class TelemetryRepository
 
     // For testing.
     internal List<OtlpSpanLink> SpanLinks => _spanLinks;
+    internal List<Subscription> TracesSubscriptions => _tracesSubscriptions;
 
     public TelemetryRepository(ILoggerFactory loggerFactory, IOptions<DashboardOptions> dashboardOptions)
     {

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -34,6 +34,11 @@ public partial class TraceDetailsTests : TestContext
         // Arrange
         SetupTraceDetailsServices();
 
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+
+        var dimensionManager = Services.GetRequiredService<DimensionManager>();
+        dimensionManager.InvokeOnViewportInformationChanged(viewport);
+
         var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
         telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
         {
@@ -60,7 +65,7 @@ public partial class TraceDetailsTests : TestContext
         var cut = RenderComponent<TraceDetail>(builder =>
         {
             builder.Add(p => p.TraceId, traceId);
-            builder.AddCascadingValue(new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+            builder.AddCascadingValue(viewport);
         });
 
         // Assert

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/TraceDetailsTests.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Aspire.Dashboard.Components.Pages;
+using Aspire.Dashboard.Components.Resize;
+using Aspire.Dashboard.Components.Tests.Shared;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Model.BrowserStorage;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Dashboard.Otlp.Storage;
+using Bunit;
+using Google.Protobuf.Collections;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.FluentUI.AspNetCore.Components;
+using OpenTelemetry.Proto.Trace.V1;
+using Xunit;
+using static Aspire.Tests.Shared.Telemetry.TelemetryTestHelpers;
+
+namespace Aspire.Dashboard.Components.Tests.Pages;
+
+[UseCulture("en-US")]
+public partial class TraceDetailsTests : TestContext
+{
+    private static readonly DateTime s_testTime = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Render_HasTrace_SubscriptionRemovedOnDispose()
+    {
+        // Arrange
+        SetupTraceDetailsServices();
+
+        var telemetryRepository = Services.GetRequiredService<TelemetryRepository>();
+        telemetryRepository.AddTraces(new AddContext(), new RepeatedField<ResourceSpans>
+        {
+            new ResourceSpans
+            {
+                Resource = CreateResource(),
+                ScopeSpans =
+                {
+                    new ScopeSpans
+                    {
+                        Scope = CreateScope(),
+                        Spans =
+                        {
+                            CreateSpan(traceId: "1", spanId: "1-1", startTime: s_testTime.AddMinutes(1), endTime: s_testTime.AddMinutes(10)),
+                            CreateSpan(traceId: "1", spanId: "1-2", startTime: s_testTime.AddMinutes(5), endTime: s_testTime.AddMinutes(10), parentSpanId: "1-1")
+                        }
+                    }
+                }
+            }
+        });
+
+        // Act
+        var traceId = Convert.ToHexString(Encoding.UTF8.GetBytes("1"));
+        var cut = RenderComponent<TraceDetail>(builder =>
+        {
+            builder.Add(p => p.TraceId, traceId);
+            builder.AddCascadingValue(new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false));
+        });
+
+        // Assert
+        Assert.Collection(telemetryRepository.TracesSubscriptions, t =>
+        {
+            Assert.Equal(nameof(TelemetryRepository.OnNewTraces), t.Name);
+        });
+
+        DisposeComponents();
+
+        Assert.Empty(telemetryRepository.TracesSubscriptions);
+    }
+
+    private void SetupTraceDetailsServices()
+    {
+        var version = typeof(FluentMain).Assembly.GetName().Version!;
+
+        var dividerModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Divider/FluentDivider.razor.js", version));
+        dividerModule.SetupVoid("setDividerAriaOrientation");
+
+        var inputLabelModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Label/FluentInputLabel.razor.js", version));
+        inputLabelModule.SetupVoid("setInputAriaLabel", _ => true);
+
+        var dataGridModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/DataGrid/FluentDataGrid.razor.js", version));
+        var gridReference = dataGridModule.SetupModule("init", _ => true);
+        gridReference.SetupVoid("stop", _ => true);
+
+        var anchorModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Anchor/FluentAnchor.razor.js", version));
+
+        var listModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/List/ListComponentBase.razor.js", version));
+
+        var searchModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/Search/FluentSearch.razor.js", version));
+        searchModule.SetupVoid("addAriaHidden", _ => true);
+
+        var keycodeModule = JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/KeyCode/FluentKeyCode.razor.js", version));
+        keycodeModule.Setup<string>("RegisterKeyCode", _ => true);
+
+        JSInterop.SetupVoid("initializeContinuousScroll");
+
+        Services.AddLocalization();
+        Services.AddSingleton<BrowserTimeProvider, TestTimeProvider>();
+        Services.AddSingleton<TelemetryRepository>();
+        Services.AddSingleton<IMessageService, MessageService>();
+        Services.AddSingleton<IOptions<DashboardOptions>>(Options.Create(new DashboardOptions()));
+        Services.AddSingleton<DimensionManager>();
+        Services.AddSingleton<ILogger<StructuredLogs>>(NullLogger<StructuredLogs>.Instance);
+        Services.AddSingleton<IDialogService, DialogService>();
+        Services.AddSingleton<ISessionStorage, TestSessionStorage>();
+        Services.AddSingleton<ILocalStorage, TestLocalStorage>();
+        Services.AddSingleton<ShortcutManager>();
+        Services.AddSingleton<LibraryConfiguration>();
+        Services.AddSingleton<IKeyCodeService, KeyCodeService>();
+    }
+
+    private static string GetFluentFile(string filePath, Version version)
+    {
+        return $"{filePath}?v={version}";
+    }
+}


### PR DESCRIPTION
## Description

The trace detail page isn't unsubscribing from repository updates when navigating away. That causes a memory leak by holding onto the `TraceDetail` page instance from the singleton `TelemetryRepository` instance.

Changes:

* TraceDetail didn't implement dispose. That means navigating away from the page never cleaned up subscriptions.
* `UpdateDetailViewData` created a subscription, but the subscription callback also called `UpdateDetailViewData`. In the right circumstances two subscriptions are created but only one is disposed.
* Added TraceDetail page tests

Profiler showing data leak when repeatedly navigating to and from trace details page:

![image](https://github.com/user-attachments/assets/ae64d47d-c75b-4137-9ef6-00cd46b95576)


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6666)