### PR TITLE
Change ResourceViewModel to use immutable dictionary

### DIFF
--- a/src/Aspire.Dashboard/Model/ResourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceViewModel.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Concurrent;
-using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -35,7 +34,7 @@ public sealed class ResourceViewModel
     public required ImmutableArray<EnvironmentVariableViewModel> Environment { get; init; }
     public required ImmutableArray<UrlViewModel> Urls { get; init; }
     public required ImmutableArray<VolumeViewModel> Volumes { get; init; }
-    public required FrozenDictionary<string, ResourcePropertyViewModel> Properties { get; init; }
+    public required ImmutableDictionary<string, ResourcePropertyViewModel> Properties { get; init; }
     public required ImmutableArray<CommandViewModel> Commands { get; init; }
     /// <summary>The health status of the resource. <see langword="null"/> indicates that health status is expected but not yet available.</summary>
     public HealthStatus? HealthStatus { get; private set; }

--- a/src/Aspire.Dashboard/ResourceService/Partials.cs
+++ b/src/Aspire.Dashboard/ResourceService/Partials.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Frozen;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using Aspire.Dashboard.Model;
@@ -27,8 +26,8 @@ partial class Resource
                 CreationTimeStamp = ValidateNotNull(CreatedAt).ToDateTime(),
                 StartTimeStamp = StartedAt?.ToDateTime(),
                 StopTimeStamp = StoppedAt?.ToDateTime(),
-                Properties = Properties.ToFrozenDictionary(
-                    comparer: StringComparers.ResourcePropertyName,
+                Properties = Properties.ToImmutableDictionary(
+                    keyComparer: StringComparers.ResourcePropertyName,
                     keySelector: property => ValidateNotNull(property.Name),
                     elementSelector: property =>
                     {

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -98,7 +98,7 @@ public sealed class ResourceViewModelTests
 
         // Assert
         Assert.Collection(
-            viewModel.Properties,
+            viewModel.Properties.OrderBy(p => p.Key),
             p =>
             {
                 Assert.Equal("Property1", p.Key);

--- a/tests/Shared/DashboardModel/ModelTestHelpers.cs
+++ b/tests/Shared/DashboardModel/ModelTestHelpers.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Frozen;
 using System.Collections.Immutable;
 using Aspire.Dashboard.Model;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -34,7 +33,7 @@ public static class ModelTestHelpers
             Environment = environment ?? [],
             Urls = urls ?? [],
             Volumes = [],
-            Properties = properties?.ToFrozenDictionary() ?? FrozenDictionary<string, ResourcePropertyViewModel>.Empty,
+            Properties = properties?.ToImmutableDictionary() ?? ImmutableDictionary<string, ResourcePropertyViewModel>.Empty,
             State = state?.ToString(),
             KnownState = state,
             StateStyle = stateStyle,


### PR DESCRIPTION
## Description

I noticed FrozenDictionary showed up in profiling while I was fixing a memory leak - https://github.com/dotnet/aspire/pull/6666

We don't use this type anywhere else, and given that ResourceViewModel can be frequently updated (health checks, wait for, state, etc) a frozen dictionary doesn't seem like a good choice. There is probably more overhead in creating it vs a regular dictionary than time saved looking up its properties in an optimized fashion.

PR changes the type to immutable dictioanry.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6668)