### PR TITLE
Refactor Entra and Key/Password Auth in Redis and Postgres

### DIFF
--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Azure;
@@ -30,6 +31,9 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
     /// </summary>
     internal BicepSecretOutputReference? ConnectionStringSecretOutput { get; set; }
 
+    [MemberNotNullWhen(true, nameof(ConnectionStringSecretOutput))]
+    internal bool UsePasswordAuthentication => ConnectionStringSecretOutput is not null;
+
     /// <summary>
     /// Gets the inner PostgresServerResource resource.
     /// 
@@ -55,8 +59,9 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         InnerResource?.ConnectionStringExpression ??
-            (ConnectionStringSecretOutput is not null ? ReferenceExpression.Create($"{ConnectionStringSecretOutput}") :
-            ReferenceExpression.Create($"{ConnectionStringOutput}"));
+            (UsePasswordAuthentication ?
+                ReferenceExpression.Create($"{ConnectionStringSecretOutput}") :
+                ReferenceExpression.Create($"{ConnectionStringOutput}"));
 
     /// <summary>
     /// A dictionary where the key is the resource name and the value is the database name.

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.Azure;
@@ -28,6 +29,9 @@ public class AzureRedisCacheResource(string name, Action<AzureResourceInfrastruc
     /// </summary>
     internal BicepSecretOutputReference? ConnectionStringSecretOutput { get; set; }
 
+    [MemberNotNullWhen(true, nameof(ConnectionStringSecretOutput))]
+    internal bool UseAccessKeyAuthentication => ConnectionStringSecretOutput is not null;
+
     /// <summary>
     /// Gets the inner Redis resource.
     /// 
@@ -43,7 +47,7 @@ public class AzureRedisCacheResource(string name, Action<AzureResourceInfrastruc
     /// </summary>
     public ReferenceExpression ConnectionStringExpression =>
         InnerResource?.ConnectionStringExpression ??
-            (ConnectionStringSecretOutput is not null ?
+            (UseAccessKeyAuthentication ?
                 ReferenceExpression.Create($"{ConnectionStringSecretOutput}") :
                 ReferenceExpression.Create($"{ConnectionStringOutput}"));
 


### PR DESCRIPTION
## Description

Refactor Azure Redis and PostgreSQL to only have a single ConfigureInfrastructure. Instead of removing resources that were added by the Entra ID code, switch based on whether access key / password auth was enabled or not in one spot.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6677)