### PR TITLE
Fix missing collapse on trace detail

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.cs
@@ -116,81 +116,6 @@ public partial class TraceDetail : ComponentBase
         }
     }
 
-    private readonly record struct SpanWaterfallViewModelState(SpanWaterfallViewModel? Parent, int Depth, bool Hidden);
-
-    private static List<SpanWaterfallViewModel> CreateSpanWaterfallViewModels(OtlpTrace trace, TraceDetailState state)
-    {
-        var orderedSpans = new List<SpanWaterfallViewModel>();
-
-        TraceHelpers.VisitSpans(trace, (OtlpSpan span, SpanWaterfallViewModelState s) =>
-        {
-            var viewModel = CreateViewModel(span, s.Depth, s.Hidden, state);
-            var peers = s.Parent?.Children ?? orderedSpans;
-            peers.Add(viewModel);
-
-            return s with { Depth = s.Depth + 1, Hidden = viewModel.IsHidden || viewModel.IsCollapsed };
-        }, new SpanWaterfallViewModelState(Parent: null, Depth: 1, Hidden: false));
-
-        return orderedSpans;
-
-        static SpanWaterfallViewModel CreateViewModel(OtlpSpan span, int depth, bool hidden, TraceDetailState state)
-        {
-            var traceStart = span.Trace.FirstSpan.StartTime;
-            var relativeStart = span.StartTime - traceStart;
-            var rootDuration = span.Trace.Duration.TotalMilliseconds;
-
-            var leftOffset = relativeStart.TotalMilliseconds / rootDuration * 100;
-            var width = span.Duration.TotalMilliseconds / rootDuration * 100;
-
-            // Figure out if the label is displayed to the left or right of the span.
-            // If the label position is based on whether more than half of the span is on the left or right side of the trace.
-            var labelIsRight = (relativeStart + span.Duration / 2) < (span.Trace.Duration / 2);
-
-            // A span may indicate a call to another service but the service isn't instrumented.
-            var hasPeerService = OtlpHelpers.GetPeerAddress(span.Attributes) != null;
-            var isUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
-            var uninstrumentedPeer = isUninstrumentedPeer ? ResolveUninstrumentedPeerName(span, state.OutgoingPeerResolvers) : null;
-
-            var viewModel = new SpanWaterfallViewModel
-            {
-                Children = [],
-                Span = span,
-                LeftOffset = leftOffset,
-                Width = width,
-                Depth = depth,
-                LabelIsRight = labelIsRight,
-                UninstrumentedPeer = uninstrumentedPeer
-            };
-
-            // Restore hidden/collapsed state to new view model.
-            if (state.CollapsedSpanIds.Contains(span.SpanId))
-            {
-                viewModel.IsCollapsed = true;
-            }
-            if (hidden)
-            {
-                viewModel.IsHidden = true;
-            }
-
-            return viewModel;
-        }
-    }
-
-    private static string? ResolveUninstrumentedPeerName(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
-    {
-        // Attempt to resolve uninstrumented peer to a friendly name from the span.
-        foreach (var resolver in outgoingPeerResolvers)
-        {
-            if (resolver.TryResolvePeerName(span.Attributes, out var name))
-            {
-                return name;
-            }
-        }
-
-        // Fallback to the peer address.
-        return OtlpHelpers.GetPeerAddress(span.Attributes);
-    }
-
     protected override async Task OnParametersSetAsync()
     {
         UpdateDetailViewData();
@@ -219,7 +144,7 @@ public partial class TraceDetail : ComponentBase
             _trace = TelemetryRepository.GetTrace(TraceId);
             if (_trace is { } trace)
             {
-                _spanWaterfallViewModels = CreateSpanWaterfallViewModels(trace, new TraceDetailState(OutgoingPeerResolvers, _collapsedSpanIds));
+                _spanWaterfallViewModels = SpanWaterfallViewModel.Create(trace, new SpanWaterfallViewModel.TraceDetailState(OutgoingPeerResolvers, _collapsedSpanIds));
                 _maxDepth = _spanWaterfallViewModels.Max(s => s.Depth);
 
                 if (_tracesSubscription is null || _tracesSubscription.ApplicationKey != trace.FirstSpan.Source.ApplicationKey)
@@ -338,6 +263,4 @@ public partial class TraceDetail : ComponentBase
         }
         _tracesSubscription?.Dispose();
     }
-
-    private sealed record TraceDetailState(IEnumerable<IOutgoingPeerResolver> OutgoingPeerResolvers, List<string> CollapsedSpanIds);
 }

--- a/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
+++ b/src/Aspire.Dashboard/Model/Otlp/SpanWaterfallViewModel.cs
@@ -113,4 +113,82 @@ public sealed class SpanWaterfallViewModel
             child.UpdateHidden(isParentCollapsed || IsCollapsed);
         }
     }
+
+    private readonly record struct SpanWaterfallViewModelState(SpanWaterfallViewModel? Parent, int Depth, bool Hidden);
+
+    public sealed record TraceDetailState(IEnumerable<IOutgoingPeerResolver> OutgoingPeerResolvers, List<string> CollapsedSpanIds);
+
+    public static List<SpanWaterfallViewModel> Create(OtlpTrace trace, TraceDetailState state)
+    {
+        var orderedSpans = new List<SpanWaterfallViewModel>();
+
+        TraceHelpers.VisitSpans(trace, (OtlpSpan span, SpanWaterfallViewModelState s) =>
+        {
+            var viewModel = CreateViewModel(span, s.Depth, s.Hidden, state);
+            orderedSpans.Add(viewModel);
+
+            s.Parent?.Children.Add(viewModel);
+
+            return s with { Parent = viewModel, Depth = s.Depth + 1, Hidden = viewModel.IsHidden || viewModel.IsCollapsed };
+        }, new SpanWaterfallViewModelState(Parent: null, Depth: 1, Hidden: false));
+
+        return orderedSpans;
+
+        static SpanWaterfallViewModel CreateViewModel(OtlpSpan span, int depth, bool hidden, TraceDetailState state)
+        {
+            var traceStart = span.Trace.FirstSpan.StartTime;
+            var relativeStart = span.StartTime - traceStart;
+            var rootDuration = span.Trace.Duration.TotalMilliseconds;
+
+            var leftOffset = relativeStart.TotalMilliseconds / rootDuration * 100;
+            var width = span.Duration.TotalMilliseconds / rootDuration * 100;
+
+            // Figure out if the label is displayed to the left or right of the span.
+            // If the label position is based on whether more than half of the span is on the left or right side of the trace.
+            var labelIsRight = (relativeStart + span.Duration / 2) < (span.Trace.Duration / 2);
+
+            // A span may indicate a call to another service but the service isn't instrumented.
+            var hasPeerService = OtlpHelpers.GetPeerAddress(span.Attributes) != null;
+            var isUninstrumentedPeer = hasPeerService && span.Kind is OtlpSpanKind.Client or OtlpSpanKind.Producer && !span.GetChildSpans().Any();
+            var uninstrumentedPeer = isUninstrumentedPeer ? ResolveUninstrumentedPeerName(span, state.OutgoingPeerResolvers) : null;
+
+            var viewModel = new SpanWaterfallViewModel
+            {
+                Children = [],
+                Span = span,
+                LeftOffset = leftOffset,
+                Width = width,
+                Depth = depth,
+                LabelIsRight = labelIsRight,
+                UninstrumentedPeer = uninstrumentedPeer
+            };
+
+            // Restore hidden/collapsed state to new view model.
+            if (state.CollapsedSpanIds.Contains(span.SpanId))
+            {
+                viewModel.IsCollapsed = true;
+            }
+            if (hidden)
+            {
+                viewModel.IsHidden = true;
+            }
+
+            return viewModel;
+        }
+    }
+
+    private static string? ResolveUninstrumentedPeerName(OtlpSpan span, IEnumerable<IOutgoingPeerResolver> outgoingPeerResolvers)
+    {
+        // Attempt to resolve uninstrumented peer to a friendly name from the span.
+        foreach (var resolver in outgoingPeerResolvers)
+        {
+            if (resolver.TryResolvePeerName(span.Attributes, out var name))
+            {
+                return name;
+            }
+        }
+
+        // Fallback to the peer address.
+        return OtlpHelpers.GetPeerAddress(span.Attributes);
+    }
 }

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceViewModelTests.cs
@@ -8,6 +8,7 @@ using Google.Protobuf.WellKnownTypes;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using DiagnosticsHealthStatus = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
+
 namespace Aspire.Dashboard.Tests.Model;
 
 public sealed class ResourceViewModelTests

--- a/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/SpanWaterfallViewModelTests.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Dashboard.Model.Otlp;
+using Aspire.Dashboard.Otlp.Model;
+using Aspire.Tests.Shared.Telemetry;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Aspire.Dashboard.Tests.Model;
+
+public sealed class SpanWaterfallViewModelTests
+{
+    [Fact]
+    public void Create_HasChildren_ChildrenPopulated()
+    {
+        // Arrange
+        var context = new OtlpContext { Logger = NullLogger.Instance, Options = new() };
+        var app1 = new OtlpApplication("app1", "instance", context);
+        var app2 = new OtlpApplication("app2", "instance", context);
+
+        var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
+        var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc)));
+
+        // Act
+        var vm = SpanWaterfallViewModel.Create(trace, new SpanWaterfallViewModel.TraceDetailState([], []));
+
+        // Assert
+        Assert.Collection(vm,
+            e =>
+            {
+                Assert.Equal("1", e.Span.SpanId);
+                Assert.Equal("1-1", Assert.Single(e.Children).Span.SpanId);
+            },
+            e =>
+            {
+                Assert.Equal("1-1", e.Span.SpanId);
+                Assert.Empty(e.Children);
+            });
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/TraceHelpersTests.cs
@@ -19,7 +19,7 @@ public sealed class TraceHelpersTests
         var app1 = new OtlpApplication("app1", "instance", context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
-        trace.AddSpan(CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
 
         // Act
         var results = TraceHelpers.GetOrderedApplications(trace);
@@ -41,8 +41,8 @@ public sealed class TraceHelpersTests
         var app2 = new OtlpApplication("app2", "instance", context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
-        trace.AddSpan(CreateSpan(app2, trace, scope, spanId: "1-2", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
-        trace.AddSpan(CreateSpan(app1, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app2, trace, scope, spanId: "1-2", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app1, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
 
         // Act
         var results = TraceHelpers.GetOrderedApplications(trace);
@@ -68,8 +68,8 @@ public sealed class TraceHelpersTests
         var app2 = new OtlpApplication("app2", "instance", context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
-        trace.AddSpan(CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
-        trace.AddSpan(CreateSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 1, DateTimeKind.Utc)));
 
         // Act
         var results = TraceHelpers.GetOrderedApplications(trace);
@@ -96,10 +96,10 @@ public sealed class TraceHelpersTests
         var app3 = new OtlpApplication("app3", "instance", context);
         var trace = new OtlpTrace(new byte[] { 1, 2, 3 });
         var scope = new OtlpScope(TelemetryTestHelpers.CreateScope(), context);
-        trace.AddSpan(CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
-        trace.AddSpan(CreateSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc)));
-        trace.AddSpan(CreateSpan(app3, trace, scope, spanId: "1-1-1", parentSpanId: "1-1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
-        trace.AddSpan(CreateSpan(app3, trace, scope, spanId: "1-2", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app1, trace, scope, spanId: "1", parentSpanId: null, startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app2, trace, scope, spanId: "1-1", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 3, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app3, trace, scope, spanId: "1-1-1", parentSpanId: "1-1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
+        trace.AddSpan(TelemetryTestHelpers.CreateSpan(app3, trace, scope, spanId: "1-2", parentSpanId: "1", startDate: new DateTime(2001, 1, 1, 1, 1, 2, DateTimeKind.Utc)));
 
         // Act
         var results = TraceHelpers.GetOrderedApplications(trace);
@@ -118,25 +118,5 @@ public sealed class TraceHelpersTests
             {
                 Assert.Equal(app2, g.Application);
             });
-    }
-
-    private static OtlpSpan CreateSpan(OtlpApplication app, OtlpTrace trace, OtlpScope scope, string spanId, string? parentSpanId, DateTime startDate)
-    {
-        return new OtlpSpan(app.GetView([]), trace, scope)
-        {
-            Attributes = [],
-            BackLinks = [],
-            EndTime = DateTime.MaxValue,
-            Events = [],
-            Kind = OtlpSpanKind.Unspecified,
-            Links = [],
-            Name = "Test",
-            ParentSpanId = parentSpanId,
-            SpanId = spanId,
-            StartTime = startDate,
-            State = null,
-            Status = OtlpSpanStatusCode.Unset,
-            StatusMessage = null
-        };
     }
 }

--- a/tests/Shared/Telemetry/TelemetryTestHelpers.cs
+++ b/tests/Shared/Telemetry/TelemetryTestHelpers.cs
@@ -285,4 +285,24 @@ internal static class TelemetryTestHelpers
             Logger = logger ?? NullLogger.Instance
         };
     }
+
+    public static OtlpSpan CreateSpan(OtlpApplication app, OtlpTrace trace, OtlpScope scope, string spanId, string? parentSpanId, DateTime startDate)
+    {
+        return new OtlpSpan(app.GetView([]), trace, scope)
+        {
+            Attributes = [],
+            BackLinks = [],
+            EndTime = DateTime.MaxValue,
+            Events = [],
+            Kind = OtlpSpanKind.Unspecified,
+            Links = [],
+            Name = "Test",
+            ParentSpanId = parentSpanId,
+            SpanId = spanId,
+            StartTime = startDate,
+            State = null,
+            Status = OtlpSpanStatusCode.Unset,
+            StatusMessage = null
+        };
+    }
 }


### PR DESCRIPTION
## Description

There was a regression in https://github.com/dotnet/aspire/pull/6261. The children collection on a span view model wasn't populated, which prevented the collapse button from being displayed.

Fixed, and a test added.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6707)