### PR TITLE
Fix triple slash usage of `inheritdoc`.

### DIFF
--- a/src/Aspire.Hosting.Elasticsearch/ElasticsearchBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Elasticsearch/ElasticsearchBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class ElasticsearchBuilderExtensions
     /// Adds an Elasticsearch container resource to the application model.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="ElasticsearchContainerImageTags.Tag"/> tag of the <inheritdoc cref="ElasticsearchContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="ElasticsearchContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="ElasticsearchContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>

--- a/src/Aspire.Hosting.Garnet/GarnetBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Garnet/GarnetBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class GarnetBuilderExtensions
     /// Adds a Garnet container to the application model.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="GarnetContainerImageTags.Tag"/> tag of the <inheritdoc cref="GarnetContainerImageTags.Registry"/>/<inheritdoc cref="GarnetContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="GarnetContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="GarnetContainerImageTags.Registry" path="/summary"/>/<inheritdoc cref="GarnetContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <example>
     /// Use in application host

--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -24,7 +24,7 @@ public static class KafkaBuilderExtensions
     /// Adds a Kafka resource to the application. A container is used for local development.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.Tag"/> tag of the <inheritdoc cref="KafkaContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="KafkaContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency</param>
@@ -83,7 +83,7 @@ public static class KafkaBuilderExtensions
     /// Adds a Kafka UI container to the application.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.KafkaUiTag"/> tag of the <inheritdoc cref="KafkaContainerImageTags.KafkaUiImage"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="KafkaContainerImageTags.KafkaUiTag" path="/summary"/> tag of the <inheritdoc cref="KafkaContainerImageTags.KafkaUiImage" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The Kafka server resource builder.</param>
     /// <param name="configureContainer">Configuration callback for KafkaUI container resource.</param>
@@ -228,7 +228,6 @@ public static class KafkaBuilderExtensions
     /// <summary>
     /// Only need to call this if we want to persistent kafka data
     /// </summary>
-    /// <param name="context"></param>
     private static void ConfigureLogDirs(EnvironmentCallbackContext context)
     {
         context.EnvironmentVariables["KAFKA_LOG_DIRS"] = Target;

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -28,7 +28,7 @@ public static class KeycloakResourceBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
     /// The container exposes port 8080 by default.
-    /// This version of the package defaults to the <inheritdoc cref="KeycloakContainerImageTags.Tag"/> tag of the <inheritdoc cref="KeycloakContainerImageTags.Registry"/>/<inheritdoc cref="KeycloakContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="KeycloakContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="KeycloakContainerImageTags.Registry" path="/summary"/>/<inheritdoc cref="KeycloakContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <example>
     /// Use in application host

--- a/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Milvus/MilvusBuilderExtensions.cs
@@ -32,7 +32,7 @@ public static class MilvusBuilderExtensions
     /// <remarks>
     /// The .NET client library uses the gRPC port by default to communicate and this resource exposes that endpoint.
     /// A web-based administration tool for Milvus can also be added using <see cref="WithAttu"/>.
-    /// This version of the package defaults to the <inheritdoc cref="MilvusContainerImageTags.Tag"/> tag of the <inheritdoc cref="MilvusContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="MilvusContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="MilvusContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency</param>
@@ -108,7 +108,7 @@ public static class MilvusBuilderExtensions
     /// Adds an administration and development platform for Milvus to the application model using Attu.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="MilvusContainerImageTags.AttuTag"/> tag of the <inheritdoc cref="MilvusContainerImageTags.AttuImage"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="MilvusContainerImageTags.AttuTag" path="/summary"/> tag of the <inheritdoc cref="MilvusContainerImageTags.AttuImage" path="/summary"/> container image.
     /// </remarks>
     /// <example>
     /// Use in application host with a Milvus resource

--- a/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MongoDB/MongoDBBuilderExtensions.cs
@@ -25,7 +25,7 @@ public static class MongoDBBuilderExtensions
     /// Adds a MongoDB resource to the application model. A container is used for local development.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="MongoDBContainerImageTags.Tag"/> tag of the <inheritdoc cref="MongoDBContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="MongoDBContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="MongoDBContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -39,6 +39,9 @@ public static class MongoDBBuilderExtensions
     /// <summary>
     /// <inheritdoc cref="AddMongoDB(IDistributedApplicationBuilder, string, int?)"/>
     /// </summary>
+    /// <remarks>
+    /// This version of the package defaults to the <inheritdoc cref="MongoDBContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="MongoDBContainerImageTags.Image" path="/summary"/> container image.
+    /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="port">The host port for MongoDB.</param>
@@ -127,7 +130,7 @@ public static class MongoDBBuilderExtensions
     /// Adds a MongoExpress administration and development platform for MongoDB to the application model.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="MongoDBContainerImageTags.MongoExpressTag"/> tag of the <inheritdoc cref="MongoDBContainerImageTags.MongoExpressImage"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="MongoDBContainerImageTags.MongoExpressTag" path="/summary"/> tag of the <inheritdoc cref="MongoDBContainerImageTags.MongoExpressImage" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The MongoDB server resource builder.</param>
     /// <param name="configureContainer">Configuration callback for Mongo Express container resource.</param>

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -19,7 +19,7 @@ public static class MySqlBuilderExtensions
     /// Adds a MySQL server resource to the application model. For local development a container is used.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="MySqlContainerImageTags.Tag"/> tag of the <inheritdoc cref="MySqlContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="MySqlContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="MySqlContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -85,7 +85,7 @@ public static class MySqlBuilderExtensions
     /// Adds a phpMyAdmin administration and development platform for MySql to the application model.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="MySqlContainerImageTags.PhpMyAdminTag"/> tag of the <inheritdoc cref="MySqlContainerImageTags.PhpMyAdminImage"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="MySqlContainerImageTags.PhpMyAdminTag" path="/summary"/> tag of the <inheritdoc cref="MySqlContainerImageTags.PhpMyAdminImage" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The MySql server resource builder.</param>
     /// <param name="configureContainer">Callback to configure PhpMyAdmin container resource.</param>

--- a/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Nats/NatsBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class NatsBuilderExtensions
     /// This configures a default user name and password for the NATS server.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="NatsContainerImageTags.Tag"/> tag of the <inheritdoc cref="NatsContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="NatsContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="NatsContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -36,6 +36,9 @@ public static class NatsBuilderExtensions
     /// <summary>
     /// Adds a NATS server resource to the application model. A container is used for local development.
     /// </summary>
+    /// <remarks>
+    /// This version of the package defaults to the <inheritdoc cref="NatsContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="NatsContainerImageTags.Image" path="/summary"/> container image.
+    /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
     /// <param name="port">The host port for NATS server.</param>

--- a/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Oracle/OracleDatabaseBuilderExtensions.cs
@@ -18,7 +18,7 @@ public static class OracleDatabaseBuilderExtensions
     /// Adds a Oracle Server resource to the application model. A container is used for local development.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="OracleContainerImageTags.Tag"/> tag of the <inheritdoc cref="OracleContainerImageTags.Registry"/>/<inheritdoc cref="OracleContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="OracleContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="OracleContainerImageTags.Registry" path="/summary"/>/<inheritdoc cref="OracleContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -35,7 +35,7 @@ public static class PostgresBuilderExtensions
     /// extension method then the dependent resource will wait until the Postgres resource is able to service
     /// requests.
     /// </para>
-    /// This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.Tag"/> tag of the <inheritdoc cref="PostgresContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="PostgresContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     public static IResourceBuilder<PostgresServerResource> AddPostgres(this IDistributedApplicationBuilder builder,
         [ResourceName] string name,
@@ -125,7 +125,7 @@ public static class PostgresBuilderExtensions
     /// Adds a pgAdmin 4 administration and development platform for PostgreSQL to the application model.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.PgAdminTag"/> tag of the <inheritdoc cref="PostgresContainerImageTags.PgAdminImage"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.PgAdminTag" path="/summary"/> tag of the <inheritdoc cref="PostgresContainerImageTags.PgAdminImage" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The PostgreSQL server resource builder.</param>
     /// <param name="configureContainer">Callback to configure PgAdmin container resource.</param>
@@ -244,7 +244,7 @@ public static class PostgresBuilderExtensions
     /// Adds an administration and development platform for PostgreSQL to the application model using pgweb.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.PgWebTag"/> tag of the <inheritdoc cref="PostgresContainerImageTags.PgWebImage"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="PostgresContainerImageTags.PgWebTag" path="/summary"/> tag of the <inheritdoc cref="PostgresContainerImageTags.PgWebImage" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The Postgres server resource builder.</param>
     /// <param name="configureContainer">Configuration callback for pgweb container resource.</param>
@@ -336,7 +336,7 @@ public static class PostgresBuilderExtensions
         context.EnvironmentVariables.Add("PGADMIN_DEFAULT_PASSWORD", "admin");
 
         // When running in the context of Codespaces we need to set some additional environment
-        // varialbes so that PGAdmin will trust the forwarded headers that Codespaces port
+        // variables so that PGAdmin will trust the forwarded headers that Codespaces port
         // forwarding will send.
         var config = context.ExecutionContext.ServiceProvider.GetRequiredService<IConfiguration>();
         if (context.ExecutionContext.IsRunMode && config.GetValue<bool>("CODESPACES", false))

--- a/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Qdrant/QdrantBuilderExtensions.cs
@@ -27,7 +27,7 @@ public static class QdrantBuilderExtensions
     /// </summary>
     /// <remarks>
     /// The .NET client library uses the gRPC port by default to communicate and this resource exposes that endpoint.
-    /// This version of the package defaults to the <inheritdoc cref="QdrantContainerImageTags.Tag"/> tag of the <inheritdoc cref="QdrantContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="QdrantContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="QdrantContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency</param>
@@ -125,7 +125,7 @@ public static class QdrantBuilderExtensions
     /// </summary>
     /// <param name="builder">An <see cref="IResourceBuilder{T}"/> for <see cref="ProjectResource"/></param>
     /// <param name="qdrantResource">The Qdrant server resource</param>
-    /// <returns></returns>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
     public static IResourceBuilder<TDestination> WithReference<TDestination>(this IResourceBuilder<TDestination> builder, IResourceBuilder<QdrantServerResource> qdrantResource)
          where TDestination : IResourceWithEnvironment
     {

--- a/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
+++ b/src/Aspire.Hosting.RabbitMQ/RabbitMQBuilderExtensions.cs
@@ -17,7 +17,7 @@ public static class RabbitMQBuilderExtensions
     /// Adds a RabbitMQ container to the application model.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="RabbitMQContainerImageTags.Tag"/> tag of the <inheritdoc cref="RabbitMQContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="RabbitMQContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="RabbitMQContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>
@@ -111,7 +111,7 @@ public static class RabbitMQBuilderExtensions
     /// <remarks>
     /// This method only supports custom tags matching the default RabbitMQ ones for the corresponding management tag to be inferred automatically, e.g. <c>4</c>, <c>4.0-alpine</c>, <c>4.0.2-management-alpine</c>, etc.<br />
     /// Calling this method on a resource configured with an unrecognized image registry, name, or tag will result in a <see cref="DistributedApplicationException"/> being thrown.
-    /// This version of the package defaults to the <inheritdoc cref="RabbitMQContainerImageTags.ManagementTag"/> tag of the <inheritdoc cref="RabbitMQContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="RabbitMQContainerImageTags.ManagementTag" path="/summary"/> tag of the <inheritdoc cref="RabbitMQContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The resource builder.</param>
     /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -34,7 +34,7 @@ public static class RedisBuilderExtensions
     /// extension method then the dependent resource will wait until the Redis resource is able to service
     /// requests.
     /// </para>
-    /// This version of the package defaults to the <inheritdoc cref="RedisContainerImageTags.Tag"/> tag of the <inheritdoc cref="RedisContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="RedisContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="RedisContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     public static IResourceBuilder<RedisResource> AddRedis(this IDistributedApplicationBuilder builder, [ResourceName] string name, int? port = null)
     {

--- a/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
@@ -18,7 +18,7 @@ public static class SeqBuilderExtensions
     /// Adds a Seq server resource to the application model. A container is used for local development.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="SeqContainerImageTags.Tag"/> tag of the <inheritdoc cref="SeqContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="SeqContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="SeqContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name to give the resource.</param>

--- a/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerBuilderExtensions.cs
@@ -16,7 +16,7 @@ public static class SqlServerBuilderExtensions
     /// Adds a SQL Server resource to the application model. A container is used for local development.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="SqlServerContainerImageTags.Tag"/> tag of the <inheritdoc cref="SqlServerContainerImageTags.Registry"/>/<inheritdoc cref="SqlServerContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="SqlServerContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="SqlServerContainerImageTags.Registry" path="/summary"/>/<inheritdoc cref="SqlServerContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>

--- a/src/Aspire.Hosting.Valkey/ValkeyBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Valkey/ValkeyBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class ValkeyBuilderExtensions
     /// Adds a Valkey container to the application model.
     /// </summary>
     /// <remarks>
-    /// This version of the package defaults to the <inheritdoc cref="ValkeyContainerImageTags.Tag"/> tag of the <inheritdoc cref="ValkeyContainerImageTags.Image"/> container image.
+    /// This version of the package defaults to the <inheritdoc cref="ValkeyContainerImageTags.Tag" path="/summary"/> tag of the <inheritdoc cref="ValkeyContainerImageTags.Image" path="/summary"/> container image.
     /// </remarks>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>
     /// <param name="name">The name of the resource. This name will be used as the connection string name when referenced in a dependency.</param>


### PR DESCRIPTION
## Description

Many of the container-based hosting integrations include an `internal` tags class, that stores the various container registry, image and tags. Since these members are `internal` the .NET Aspire API docs doesn't expose them in the rendered API docs. Nor are they available to IntelliSense.

For example, see [`RedisBuilderExtensions.AddRedis` Method: Remarks](https://learn.microsoft.com/dotnet/api/aspire.hosting.redisbuilderextensions.addredis?view=dotnet-aspire-9.0#remarks).

To fix this, when we rely on `<inheritdoc />` we must specify the `path` (XPath) to the desired value. Before my change:

![image](https://github.com/user-attachments/assets/5592913a-ba2c-47c1-bf97-a81b3283c494)

After my change:

![image](https://github.com/user-attachments/assets/39d4d1f1-0c6b-4d6c-bbe8-1e145e056df0)

This will also fix the .NET Aspire API docs too, the next time we release.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6718)