### PR TITLE
Tweak dashboard title padding

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor
@@ -2,10 +2,10 @@
 
 @inject IStringLocalizer<ControlsStrings> Loc
 
-<FluentInputLabel
-    Label="@Loc[nameof(ControlsStrings.ResourceLabel)]"
-    ForId="@_selectId"
-    Orientation="Orientation.Horizontal" />
+<FluentInputLabel Label="@Loc[nameof(ControlsStrings.ResourceLabel)]"
+                  ForId="@_selectId"
+                  Orientation="Orientation.Horizontal"
+                  class="@LabelClass" />
 
 <FluentSelect Items="Resources"
               Id="@_selectId"

--- a/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceSelect.razor.cs
@@ -30,6 +30,9 @@ public partial class ResourceSelect
     [Parameter]
     public bool CanSelectGrouping { get; set; }
 
+    [Parameter]
+    public string? LabelClass { get; set; }
+
     private async Task SelectedResourceChangedCore()
     {
         await SelectedResourceChanged.InvokeAsync(SelectedResource);

--- a/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor
+++ b/src/Aspire.Dashboard/Components/Layout/AspirePageContentLayout.razor
@@ -39,7 +39,7 @@
 
             @if (AddNewlineOnToolbar)
             {
-                <div style="padding-left: calc(var(--design-unit) * 2.5px)">@MobilePageTitleToolbarSection</div>
+                <div style="padding-left: calc(var(--design-unit) * 4.5px)">@MobilePageTitleToolbarSection</div>
             }
         </header>
     }

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -19,7 +19,8 @@
             <ResourceSelect Resources="_resources"
                             AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.ResourceLabel)]"
                             @bind-SelectedResource="PageViewModel.SelectedOption"
-                            @bind-SelectedResource:after="HandleSelectedOptionChangedAsync" />
+                            @bind-SelectedResource:after="HandleSelectedOptionChangedAsync"
+                            LabelClass="toolbar-left" />
 
             @foreach (var command in _highlightedCommands)
             {

--- a/src/Aspire.Dashboard/Components/Pages/Metrics.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Metrics.razor
@@ -26,7 +26,8 @@
                             AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"
                             @bind-SelectedResource="PageViewModel.SelectedApplication"
                             @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync"
-                            CanSelectGrouping="true" />
+                            CanSelectGrouping="true"
+                            LabelClass="toolbar-left" />
             @if (!ViewportInformation.IsDesktop)
             {
                 <FluentIcon slot="end" Icon="Icons.Regular.Size20.Clock" Style="margin-right:5px;"/>

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor.css
@@ -35,5 +35,7 @@
 
 ::deep .resources-name-container {
     height: 24px;
-    display: inline-block;
+    display: inline-flex;
+    vertical-align: middle;
+    align-items: center;
 }

--- a/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/StructuredLogs.razor
@@ -28,7 +28,8 @@
                             AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"
                             @bind-SelectedResource="PageViewModel.SelectedApplication"
                             @bind-SelectedResource:after="HandleSelectedApplicationChangedAsync"
-                            CanSelectGrouping="true" />
+                            CanSelectGrouping="true"
+                            LabelClass="toolbar-left" />
             <FluentSearch @bind-Value="_filter"
                           @bind-Value:after="HandleAfterFilterBindAsync"
                           Immediate="true"

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor
@@ -30,7 +30,7 @@
                 </div>
             </PageTitleSection>
             <ToolbarSection>
-                <div>
+                <div class="toolbar-left">
                     @Loc[nameof(Dashboard.Resources.TraceDetail.TraceDetailTraceStartHeader)] <strong title="@FormatHelpers.FormatDateTime(TimeProvider, _trace.FirstSpan.StartTime, MillisecondsDisplay.Full)">@FormatHelpers.FormatDateTime(TimeProvider, _trace.FirstSpan.StartTime, MillisecondsDisplay.Truncated)</strong>
                 </div>
                 <FluentDivider Role="DividerRole.Presentation" Orientation="Orientation.Vertical" />

--- a/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
+++ b/src/Aspire.Dashboard/Components/Pages/TraceDetail.razor.css
@@ -148,5 +148,6 @@
 
 ::deep .span-overview-container {
     height: 24px;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
 }

--- a/src/Aspire.Dashboard/Components/Pages/Traces.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Traces.razor
@@ -25,7 +25,8 @@
                             AriaLabel="@ControlsStringsLoc[nameof(ControlsStrings.SelectAnApplication)]"
                             @bind-SelectedResource="PageViewModel.SelectedApplication"
                             @bind-SelectedResource:after="HandleSelectedApplicationChanged"
-                            CanSelectGrouping="true" />
+                            CanSelectGrouping="true"
+                            LabelClass="toolbar-left" />
             <FluentSearch @bind-Value="_filter"
                           @bind-Value:after="HandleAfterFilterBindAsync"
                           Immediate="true"

--- a/src/Aspire.Dashboard/wwwroot/css/app.css
+++ b/src/Aspire.Dashboard/wwwroot/css/app.css
@@ -208,7 +208,7 @@ h1 {
     }
 
     fluent-toolbar[orientation=horizontal].main-toolbar {
-        padding-left: calc(var(--design-unit) * 4px);
+        padding-left: calc(var(--design-unit) * 4.5px);
         padding-right: calc(var(--design-unit) * 2px);
     }
 
@@ -250,8 +250,9 @@ fluent-data-grid .loading-content-cell .stack-horizontal {
 }
 
 .top-messagebar {
-    padding: calc(var(--design-unit) * 2px);
-    padding-bottom: 0;
+    padding: calc(var(--design-unit) * 4px);
+    padding-top: calc(var(--design-unit) * 2px);
+    padding-bottom: 0 !important;
 }
 
 .fluent-messagebar.intent-warning {
@@ -682,7 +683,7 @@ fluent-data-grid-cell.no-ellipsis {
 
 .main-grid-expand-container {
     display: inline-block;
-    width: 20px;
+    width: 18px;
 }
 
 .main-grid-expand-container svg {
@@ -699,14 +700,14 @@ fluent-data-grid-cell.no-ellipsis {
 }
 
 .main-grid-expand-button {
-    width: 20px;
+    width: 18px;
     height: 24px;
-    min-width: 20px;
+    min-width: 18px;
     vertical-align: middle;
 }
 
 .main-grid fluent-data-grid-row[row-type='sticky-header'] fluent-data-grid-cell:first-child {
-    margin-left: 8px;
+    margin-left: 5px;
 }
 
 .main-grid fluent-data-grid-row[row-type='default'] fluent-data-grid-cell.expand-col {
@@ -715,5 +716,9 @@ fluent-data-grid-cell.no-ellipsis {
 }
 
 .main-grid fluent-data-grid-row[row-type='default'] fluent-data-grid-cell:first-child:not(.expand-col) {
-    margin-left: 8px;
+    margin-left: 5px;
+}
+
+.toolbar-left {
+    margin-left: 0;
 }


### PR DESCRIPTION
## Description

Slightly reduce the left padding of the dashboard title/toolbar/footer, etc (4px).

After:

![image](https://github.com/user-attachments/assets/db539071-c2ae-4cb0-ae23-b5e3e09f8760)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6722)