### PR TITLE
Add frameworks classifications for templates

### DIFF
--- a/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-mstest/.template.config/template.json
@@ -9,7 +9,8 @@
     "Web API",
     "API",
     "Service",
-    "Test"
+    "Test",
+    "MSTest"
   ],
   "name": ".NET Aspire Test Project (MSTest)",
   "defaultName": "Tests",

--- a/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-nunit/.template.config/template.json
@@ -9,7 +9,8 @@
     "Web API",
     "API",
     "Service",
-    "Test"
+    "Test",
+    "NUnit"
   ],
   "name": ".NET Aspire Test Project (NUnit)",
   "defaultName": "Tests",

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/.template.config/template.json
@@ -9,7 +9,11 @@
     "Web API",
     "API",
     "Service",
-    "Cloud"
+    "Cloud",
+    "Test",
+    "MSTest",
+    "NUnit",
+    "xUnit"
   ],
   "name": ".NET Aspire Starter App",
   "defaultName": "AspireApp",

--- a/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
+++ b/src/Aspire.ProjectTemplates/templates/aspire-xunit/.template.config/template.json
@@ -9,7 +9,8 @@
     "Web API",
     "API",
     "Service",
-    "Test"
+    "Test",
+    "xUnit"
   ],
   "name": ".NET Aspire Test Project (xUnit)",
   "defaultName": "Tests",


### PR DESCRIPTION
## Description

Add framework specific "tags" under the `Classification` as it helps some users who want to filter by `project type` under VS and not only by search:

![image](https://github.com/user-attachments/assets/f55704eb-ba88-4cc4-aa15-0f09b5c4c974)

![image](https://github.com/user-attachments/assets/3b25079a-ce6d-4281-904a-b01564799cd7)


## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6732)