### PR TITLE
Remove deprecated CSS

### DIFF
--- a/src/Aspire.Dashboard/wwwroot/css/highlight.css
+++ b/src/Aspire.Dashboard/wwwroot/css/highlight.css
@@ -47,13 +47,3 @@
 .hljs-strong {
     font-weight: 700;
 }
-
-@media screen and (-ms-high-contrast:active) {
-    .hljs-addition, .hljs-attribute, .hljs-built_in, .hljs-bullet, .hljs-comment, .hljs-link, .hljs-literal, .hljs-meta, .hljs-number, .hljs-params, .hljs-quote, .hljs-string, .hljs-symbol, .hljs-type {
-        color: highlight;
-    }
-
-    .hljs-keyword, .hljs-selector-tag {
-        font-weight: 700;
-    }
-}


### PR DESCRIPTION
## Description

The highlight.js theme we're using has a deprecated CSS feature around  high contrast. We don't have the concept of a high contrast theme so I removed it.

Fixes https://github.com/dotnet/aspire/issues/5279

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6739)