### PR TITLE
Adding nightly dogfooding devcontainer

### DIFF
--- a/.devcontainer/contributing/devcontainer.json
+++ b/.devcontainer/contributing/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
-	"name": "C# (.NET)",
+	"name": ".NET Aspire - Contribute",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/dotnet:dev-9.0-bookworm",
 	"features": {

--- a/.devcontainer/dogfooding-nightly/Dockerfile
+++ b/.devcontainer/dogfooding-nightly/Dockerfile
@@ -1,0 +1,8 @@
+# Base image
+FROM mcr.microsoft.com/devcontainers/dotnet:1-9.0-bookworm
+
+# Pre-create the workspace folder and the NuGet.config file
+RUN mkdir -p /workspaces/dogfood &&\
+    cd /workspaces/dogfood &&\
+    dotnet new nugetconfig &&\
+    dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json -n nightly-feed

--- a/.devcontainer/dogfooding-nightly/devcontainer.json
+++ b/.devcontainer/dogfooding-nightly/devcontainer.json
@@ -1,0 +1,26 @@
+{
+	"name": ".NET Aspire - Dogfood (Nightly)",
+	"build": {
+		"dockerfile": "./Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/azure-cli:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers/features/powershell:1": {},
+		"ghcr.io/azure/azure-dev/azd:0": {}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.csdevkit",
+				"ms-azuretools.vscode-bicep",
+				"GitHub.copilot-chat",
+				"GitHub.copilot"
+			]
+		}
+	},
+	"workspaceFolder": "/workspaces/dogfood",  // Empty directory for clean testing
+	"onCreateCommand": "sudo chown -R vscode:vscode /workspaces/dogfood && dotnet new install Aspire.ProjectTemplates::*-*",
+	"postStartCommand": "dotnet dev-certs https --trust",
+	"forwardPorts": []
+}


### PR DESCRIPTION
## Description

Adds a dogfooding devcontainer that can be used to setup an environment where people can test the latest version of aspire pushed to our nightly feeds. After this one goes in, we can also build one that uses live-built bits.

cc: @mitchdenny 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6767)