### PR TITLE
Fix Azure Provisioning

### DIFF
--- a/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
+++ b/src/Aspire.Hosting.Azure/Provisioning/Provisioners/BicepProvisioner.cs
@@ -121,16 +121,17 @@ internal sealed class BicepProvisioner(
 
         var resourceLogger = loggerService.GetLogger(resource);
 
-        PopulateWellKnownParameters(resource, context);
-
         if (FindFullPathFromPath("az") is not { } azPath)
         {
             throw new AzureCliNotOnPathException();
         }
 
         var template = resource.GetBicepTemplateFile();
-
         var path = template.Path;
+
+        // GetBicepTemplateFile may have added new well-known parameters, so we need
+        // to populate them only after calling GetBicepTemplateFile.
+        PopulateWellKnownParameters(resource, context);
 
         KeyVaultResource? keyVault = null;
 


### PR DESCRIPTION
With Refactor Bicep parameter usage (dotnet/aspire#6683), we changed when "well-known" parameters were added to the AzureBicepResource. Instead of adding them up front in 2 places, we add them during bicep generation (i.e. ConfigureInfrastructure) and then sync the bicep parameters back to Aspire's AzureBicepResource.Parameters.

This broke Azure Provisioning because it is looking for well known parameters before GetBicepTemplateFile is called. It needs to populate the well-known parameters after. You get an error like:

```
Azure.RequestFailedException: Deployment template validation failed: 'The value for the template parameter 'principalType' at line '1' and column '483' is not provided. Please see https://aka.ms/arm-create-parameter-file for usage details.'.
Status: 400 (Bad Request)
```

The fix is to move the calls around so PopulateWellKnownParameters is called after GetBicepTemplateFile.

I didn't see a way to test this in CI easily. I ran through it manually and it works now.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6768)