### PR TITLE
Fix: Update style for the .defaultHidden to resolve Bug: #6750

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -15,14 +15,14 @@
     white-space: nowrap;
 }
 
-::deep .defaultHidden {
+::deep .grid-value .defaultHidden {
     opacity: 0;
     cursor: pointer;
     width: 0;
     display: inline-block;
 }
 
-::deep:hover .defaultHidden, ::deep:focus-within .defaultHidden {
+::deep:hover .grid-value .defaultHidden, ::deep:focus-within .grid-value .defaultHidden {
     opacity: 1;  /* safari has a bug where hover is not always called on an invisible element, so we use opacity instead */
     width: auto;
 }


### PR DESCRIPTION
## Description

The fix is a simple CSS style change. The style for the `.defaultHidden` class was applied on the "layer" above the actual menu item.

![image](https://github.com/user-attachments/assets/1a1306e8-15c0-4ce7-8064-13ddf2c9a280)

Fixes # (issue)

Bug #6750

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [x] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6778)