### PR TITLE
playground: Use netaspire.azurecr.io for getting docker images

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/AppWithDocker/Dockerfile
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/AppWithDocker/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.8-slim
+FROM netaspireci.azurecr.io/library/python:3.8-slim
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
.. in `playground/AzureContainerApps` for `python:3.8-slim`.

Fixes CodeQL warnings.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6803)