### PR TITLE
Fix render of empty elements in Structured Log Details

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -86,8 +86,13 @@ public partial class StructuredLogDetails
 
     private bool ApplyFilter(TelemetryPropertyViewModel vm)
     {
+        if (string.IsNullOrEmpty(vm.Name) || string.IsNullOrEmpty(vm.Value))
+        {
+            return false;
+        }
+
         return vm.Name.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) ||
-            vm.Value?.Contains(_filter, StringComparison.CurrentCultureIgnoreCase) == true;
+            vm.Value.Contains(_filter, StringComparison.CurrentCultureIgnoreCase);
     }
 
     // Sometimes a parent ID is added and the value is 0000000000. Don't display unhelpful IDs.


### PR DESCRIPTION
## Description
There was a problem described in #2967 where an empty inner exception was being rendered.
This code is more generic and only non-empty values will be rendered.

This is the before:
![0](https://github.com/user-attachments/assets/5e452281-4932-4a24-b04d-bb0762bc7859)

This is now the final result (tested only for RabbitMQ):
![0](https://github.com/user-attachments/assets/206723d3-d6bf-4433-8c6f-684b7362d8f7)

Fixes _**partially**_ #2967
## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6821)