### PR TITLE
Fix duplicate message rendering

### DIFF
--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
@@ -125,7 +125,7 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
             return GetEnumerator();
         }
 
-        public int Count => 5;
+        public int Count => 4;
 
         public KeyValuePair<string, object?> this[int index]
         {
@@ -139,24 +139,23 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
 
                 return index switch
                 {
-                    0 => new(EventData.PayloadNames[0], EventData.Payload[0]),
-                    < 5 => GetExData(EventData, index),
+                    < 4 => GetExData(EventData, index),
                     _ => throw new UnreachableException()
                 };
 
                 static KeyValuePair<string, object?> GetExData(EventWrittenEventArgs eventData, int index)
                 {
-                    Debug.Assert(index >= 1 && index <= 4);
+                    Debug.Assert(index >= 0 && index <= 3);
                     Debug.Assert(eventData.Payload?.Count == 2);
                     var exData = eventData.Payload[1] as IDictionary<string, object?>;
                     Debug.Assert(exData is not null && exData.Count == 4);
 
                     return index switch
                     {
-                        1 => new("exception.type", exData["Type"]),
-                        2 => new("exception.message", exData["Message"]),
-                        3 => new("exception.stacktrace", exData["StackTrace"]),
-                        4 => new("exception.innerexception", exData["InnerException"]),
+                        0 => new("exception.type", exData["Type"]),
+                        1 => new("exception.message", exData["Message"]),
+                        2 => new("exception.stacktrace", exData["StackTrace"]),
+                        3 => new("exception.innerexception", exData["InnerException"]),
                         _ => throw new UnreachableException()
                     };
                 }

--- a/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
+++ b/src/Components/Aspire.RabbitMQ.Client/RabbitMQEventSourceLogForwarder.cs
@@ -101,9 +101,8 @@ internal sealed class RabbitMQEventSourceLogForwarder : IDisposable
                 Debug.Assert(EventData.PayloadNames[0] == "message");
                 Debug.Assert(EventData.PayloadNames[1] == "ex");
 
-                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, 5);
-                Debug.Assert(index >= 0 && index <= 3);
-                Debug.Assert(EventData.Payload?.Count == 2);
+                ArgumentOutOfRangeException.ThrowIfNegative(index);  
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
                 var exData = EventData.Payload[1] as IDictionary<string, object?>;
                 Debug.Assert(exData is not null && exData.Count == 4);

--- a/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
+++ b/tests/Aspire.RabbitMQ.Client.Tests/AspireRabbitMQLoggingTests.cs
@@ -130,22 +130,19 @@ public class AspireRabbitMQLoggingTests
         Assert.Equal(logMessage, logs[0].Message);
 
         var errorEvent = Assert.IsAssignableFrom<IReadOnlyList<KeyValuePair<string, object?>>>(logs[0].State);
-        Assert.Equal(5, errorEvent.Count);
+        Assert.Equal(4, errorEvent.Count);
 
-        Assert.Equal("message", errorEvent[0].Key);
-        Assert.Equal(logMessage, errorEvent[0].Value);
+        Assert.Equal("exception.type", errorEvent[0].Key);
+        Assert.Equal("System.InvalidOperationException", errorEvent[0].Value);
 
-        Assert.Equal("exception.type", errorEvent[1].Key);
-        Assert.Equal("System.InvalidOperationException", errorEvent[1].Value);
+        Assert.Equal("exception.message", errorEvent[1].Key);
+        Assert.Equal(exceptionMessage, errorEvent[1].Value);
 
-        Assert.Equal("exception.message", errorEvent[2].Key);
-        Assert.Equal(exceptionMessage, errorEvent[2].Value);
+        Assert.Equal("exception.stacktrace", errorEvent[2].Key);
+        Assert.Contains("AspireRabbitMQLoggingTests.TestException", errorEvent[2].Value?.ToString());
 
-        Assert.Equal("exception.stacktrace", errorEvent[3].Key);
-        Assert.Contains("AspireRabbitMQLoggingTests.TestException", errorEvent[3].Value?.ToString());
-
-        Assert.Equal("exception.innerexception", errorEvent[4].Key);
-        Assert.True(string.IsNullOrEmpty(errorEvent[4].Value?.ToString()));
+        Assert.Equal("exception.innerexception", errorEvent[3].Key);
+        Assert.True(string.IsNullOrEmpty(errorEvent[3].Value?.ToString()));
     }
 
     private sealed class LoggerProvider(TestLogger logger) : ILoggerProvider


### PR DESCRIPTION
## Description
The line that was causing the duplication was:
`0 => new(EventData.PayloadNames[0], EventData.Payload[0])`

So I got rid of it.

Also, I assumed that this line was a part of the `Count` property, which was 5 before, and I reduced it to 4 now.

Based on this, I also slide down the indices of the index switch.


_**Before**_:
![0](https://github.com/user-attachments/assets/60b5af1f-ddf3-4160-af40-52e727a0c265)


_**After**_:
![2024-11-27_15h32_20](https://github.com/user-attachments/assets/c22f0ca2-1ddf-4837-bdc9-fc1fd1e77a2f)

Fixes **_partially_** #2967 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6827)