### PR TITLE
Disables Integrated Security in the ConnectionString when using SQL hosting integrations.

### DIFF
--- a/playground/DatabaseMigration/DatabaseMigration.AppHost/aspire-manifest.json
+++ b/playground/DatabaseMigration/DatabaseMigration.AppHost/aspire-manifest.json
@@ -3,7 +3,7 @@
   "resources": {
     "sql1": {
       "type": "container.v0",
-      "connectionString": "Server={sql1.bindings.tcp.host},{sql1.bindings.tcp.port};User ID=sa;Password={sql1-password.value};TrustServerCertificate=true",
+      "connectionString": "Server={sql1.bindings.tcp.host},{sql1.bindings.tcp.port};User ID=sa;Password={sql1-password.value};TrustServerCertificate=true;Integrated Security=false",
       "image": "mcr.microsoft.com/mssql/server:2022-latest",
       "env": {
         "ACCEPT_EULA": "Y",

--- a/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/SqlServerEndToEnd/SqlServerEndToEnd.AppHost/aspire-manifest.json
@@ -16,7 +16,7 @@
     },
     "sql2": {
       "type": "container.v0",
-      "connectionString": "Server={sql2.bindings.tcp.host},{sql2.bindings.tcp.port};User ID=sa;Password={sql2-password.value};TrustServerCertificate=true",
+      "connectionString": "Server={sql2.bindings.tcp.host},{sql2.bindings.tcp.port};User ID=sa;Password={sql2-password.value};TrustServerCertificate=true;Integrated Security=false",
       "image": "mcr.microsoft.com/mssql/server:2022-latest",
       "env": {
         "ACCEPT_EULA": "Y",

--- a/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
+++ b/src/Aspire.Hosting.SqlServer/SqlServerServerResource.cs
@@ -35,7 +35,7 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
 
     private ReferenceExpression ConnectionString =>
         ReferenceExpression.Create(
-            $"Server={PrimaryEndpoint.Property(EndpointProperty.IPV4Host)},{PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=sa;Password={PasswordParameter};TrustServerCertificate=true");
+            $"Server={PrimaryEndpoint.Property(EndpointProperty.IPV4Host)},{PrimaryEndpoint.Property(EndpointProperty.Port)};User ID=sa;Password={PasswordParameter};TrustServerCertificate=true;Integrated Security=false");
 
     /// <summary>
     /// Gets the connection string expression for the SQL Server.
@@ -57,7 +57,7 @@ public class SqlServerServerResource : ContainerResource, IResourceWithConnectio
     /// Gets the connection string for the SQL Server.
     /// </summary>
     /// <param name="cancellationToken"> A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-    /// <returns>A connection string for the SQL Server in the form "Server=host,port;User ID=sa;Password=password;TrustServerCertificate=true".</returns>
+    /// <returns>A connection string for the SQL Server in the form "Server=host,port;User ID=sa;Password=password;TrustServerCertificate=true;Integrated Security=false".</returns>
     public ValueTask<string?> GetConnectionStringAsync(CancellationToken cancellationToken = default)
     {
         if (this.TryGetLastAnnotation<ConnectionStringRedirectAnnotation>(out var connectionStringAnnotation))

--- a/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureSqlExtensionsTests.cs
@@ -161,15 +161,15 @@ public class AzureSqlExtensionsTests(ITestOutputHelper output)
         Assert.True(sql.Resource.IsContainer(), "The resource should now be a container resource.");
         var serverConnectionString = await sql.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
         Assert.StartsWith("Server=127.0.0.1,12455;User ID=sa;Password=", serverConnectionString);
-        Assert.EndsWith(";TrustServerCertificate=true", serverConnectionString);
+        Assert.EndsWith(";TrustServerCertificate=true;Integrated Security=false", serverConnectionString);
 
         var db1ConnectionString = await db1.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
         Assert.StartsWith("Server=127.0.0.1,12455;User ID=sa;Password=", db1ConnectionString);
-        Assert.EndsWith(";TrustServerCertificate=true;Database=db1", db1ConnectionString);
+        Assert.EndsWith(";TrustServerCertificate=true;Integrated Security=false;Database=db1", db1ConnectionString);
 
         var db2ConnectionString = await db2.Resource.ConnectionStringExpression.GetValueAsync(CancellationToken.None);
         Assert.StartsWith("Server=127.0.0.1,12455;User ID=sa;Password=", db2ConnectionString);
-        Assert.EndsWith(";TrustServerCertificate=true;Database=db2Name", db2ConnectionString);
+        Assert.EndsWith(";TrustServerCertificate=true;Integrated Security=false;Database=db2Name", db2ConnectionString);
     }
 
     [Theory]

--- a/tests/Aspire.Hosting.SqlServer.Tests/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/AddSqlServerTests.cs
@@ -94,8 +94,8 @@ public class AddSqlServerTests
         var connectionStringResource = Assert.Single(appModel.Resources.OfType<SqlServerServerResource>());
         var connectionString = await connectionStringResource.GetConnectionStringAsync(default);
 
-        Assert.Equal("Server=127.0.0.1,1433;User ID=sa;Password=p@ssw0rd1;TrustServerCertificate=true", connectionString);
-        Assert.Equal("Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true", connectionStringResource.ConnectionStringExpression.ValueExpression);
+        Assert.Equal("Server=127.0.0.1,1433;User ID=sa;Password=p@ssw0rd1;TrustServerCertificate=true;Integrated Security=false", connectionString);
+        Assert.Equal("Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true;Integrated Security=false", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
     [Fact]
@@ -118,7 +118,7 @@ public class AddSqlServerTests
         var connectionStringResource = (IResourceWithConnectionString)sqlResource;
         var connectionString = await connectionStringResource.GetConnectionStringAsync();
 
-        Assert.Equal("Server=127.0.0.1,1433;User ID=sa;Password=p@ssw0rd1;TrustServerCertificate=true;Database=mydb", connectionString);
+        Assert.Equal("Server=127.0.0.1,1433;User ID=sa;Password=p@ssw0rd1;TrustServerCertificate=true;Integrated Security=false;Database=mydb", connectionString);
         Assert.Equal("{sqlserver.connectionString};Database=mydb", connectionStringResource.ConnectionStringExpression.ValueExpression);
     }
 
@@ -135,7 +135,7 @@ public class AddSqlServerTests
         var expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver-password.value};TrustServerCertificate=true",
+              "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver-password.value};TrustServerCertificate=true;Integrated Security=false",
               "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}:{{SqlServerContainerImageTags.Tag}}",
               "env": {
                 "ACCEPT_EULA": "Y",
@@ -175,7 +175,7 @@ public class AddSqlServerTests
         var expectedManifest = $$"""
             {
               "type": "container.v0",
-              "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true",
+              "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={pass.value};TrustServerCertificate=true;Integrated Security=false",
               "image": "{{SqlServerContainerImageTags.Registry}}/{{SqlServerContainerImageTags.Image}}:{{SqlServerContainerImageTags.Tag}}",
               "env": {
                 "ACCEPT_EULA": "Y",

--- a/tests/testproject/TestProject.AppHost/aspire-manifest.json
+++ b/tests/testproject/TestProject.AppHost/aspire-manifest.json
@@ -152,7 +152,7 @@
     },
     "sqlserver": {
       "type": "container.v0",
-      "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver-password.value};TrustServerCertificate=true",
+      "connectionString": "Server={sqlserver.bindings.tcp.host},{sqlserver.bindings.tcp.port};User ID=sa;Password={sqlserver-password.value};TrustServerCertificate=true;Integrated Security=false",
       "image": "mcr.microsoft.com/mssql/server:2022-latest",
       "env": {
         "ACCEPT_EULA": "Y",


### PR DESCRIPTION
Disables the _Integrated Windows Authentication_ when using `Aspire.Hosting.SqlServer` & `Aspire.Hosting.Azure.Sql` hosting integrations.

- adds the `Integrated Security=false` parameter to the ConnectionString.

## Description

Kerberos/Integrated Windows authentication is typically used in corporate environments. The SQL Management Studio remembers the last (successful) connection setting. As a developer,[ if I copy the connection string into the "_Additional Connection Settings_" tab](https://learn.microsoft.com/en-us/dotnet/aspire/database/sql-server-integration?tabs=dotnet-cli%2Cssms#connect-to-database-resources) and then click "Connect", I get an error message:

![image](https://github.com/user-attachments/assets/9336e3b6-52c8-4251-9876-f0aede8ecd54)

The additional parameter `Integrated Security=false` ensures that the SQL Management Studio uses the correct connection settings (authentication using username & password). The same probably applies to AzureSqlServer - but I couldn't test that.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes (adapted the previous/existing tests)
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [x] No - I assume that the hosting image (and the connection string) will only be used in development and test environments.
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
