### PR TITLE
YARP Service discovery: do not set host header unless explicitly set in config

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryDestinationResolver.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Yarp/ServiceDiscoveryDestinationResolver.cs
@@ -89,25 +89,12 @@ internal sealed class ServiceDiscoveryDestinationResolver(ServiceEndpointResolve
             }
 
             var name = $"{originalName}[{addressString}]";
-            string? resolvedHost;
+            string? resolvedHost = null;
 
             // Use the configured 'Host' value if it is provided.
             if (!string.IsNullOrEmpty(originalConfig.Host))
             {
                 resolvedHost = originalConfig.Host;
-            }
-            else if (uri.IsLoopback)
-            {
-                // If there is no configured 'Host' value and the address resolves to localhost, do not set a host.
-                // This is to account for non-wildcard development certificate.
-                resolvedHost = null;
-            }
-            else
-            {
-                // Excerpt from RFC 9110 Section 7.2: The "Host" header field in a request provides the host and port information from the target URI [...]
-                // See: https://www.rfc-editor.org/rfc/rfc9110.html#field.host
-                // i.e, use Authority and not Host.
-                resolvedHost = originalUri.Authority;
             }
 
             var config = originalConfig with { Host = resolvedHost, Address = resolvedAddress, Health = healthAddress };

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Yarp.Tests/YarpServiceDiscoveryTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Yarp.Tests/YarpServiceDiscoveryTests.cs
@@ -188,8 +188,7 @@ public class YarpServiceDiscoveryTests
                 }
                 else
                 {
-                    // For non-localhost values, fallback to the input address.
-                    Assert.Equal("basket", a.Host);
+                    Assert.Null(a.Host);
                 }
             });
     }


### PR DESCRIPTION
## Description

The issue is that we set the host header everytime with the short service name: if we do service discovery and find the "real" endpoint behind, we should let `HttpClient` set the host header wit the correct value, instead of forcing the authority of the short url.

Fixes #4605

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6862)