### PR TITLE
Add authentication (username and password) to Aspire.Hosting.Seq containers

### DIFF
--- a/src/Aspire.Hosting.Seq/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Seq/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 #nullable enable
 
+static Aspire.Hosting.SeqBuilderExtensions.WithAuthentication(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SeqResource!>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource!>! username, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.ParameterResource!>! password) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.SeqResource!>!

--- a/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
@@ -14,6 +14,7 @@ public static class SeqBuilderExtensions
     // The path within the container in which Seq stores its data
     private const string SeqContainerDataDirectory = "/data";
 
+    private const string AcceptEulaEnvVarName = "ACCEPT_EULA";
     private const string UserEnvVarName = "SEQ_FIRSTRUN_ADMINUSERNAME";
     private const string PasswordEnvVarName = "SEQ_FIRSTRUN_ADMINPASSWORD";
 
@@ -38,7 +39,7 @@ public static class SeqBuilderExtensions
             .WithHttpEndpoint(port: port, targetPort: 80, name: SeqResource.PrimaryEndpointName)
             .WithImage(SeqContainerImageTags.Image, SeqContainerImageTags.Tag)
             .WithImageRegistry(SeqContainerImageTags.Registry)
-            .WithEnvironment("ACCEPT_EULA", "Y");
+            .WithEnvironment(AcceptEulaEnvVarName, "Y");
 
         return resourceBuilder;
     }

--- a/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Seq/SeqBuilderExtensions.cs
@@ -62,8 +62,8 @@ public static class SeqBuilderExtensions
         ArgumentException.ThrowIfNullOrWhiteSpace(username.Resource.Value, nameof(username));
         ArgumentException.ThrowIfNullOrWhiteSpace(password.Resource.Value, nameof(username));
         return builder
-            .WithEnvironment(UserEnvVarName, username.Resource.Value)
-            .WithEnvironment(PasswordEnvVarName, password.Resource.Value);
+            .WithEnvironment(UserEnvVarName, username)
+            .WithEnvironment(PasswordEnvVarName, password);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description

Opening a draft for feedback/direction - ping @eerhardt 👋 

I loosely followed the corresponding PR for this feature in the MongoDB integration, initially adding optional `username` and `password` arguments to `AddSeq()`.

I felt a bit uneasy about the difference in semantics between these and the similar arguments in `AddMongoDB()`: in that case, omitting the arguments causes default values to be used, including for the password, so the result is still secured. In the Seq case, because the username and password are UI features (not provided to other resources) there seems to be no way to surface generated default values, so when the parameters are omitted authentication is not enabled at all.

To signal the difference in semantics, and to make room for some more detailed XDOCs on behavior, I sketched an `IResourceBuilder<SeqResource>.WithAuthentication()` extension method instead. Not sure if this aligns with how the API is designed or meets discoverability goals, so let me know if parameters on `AddSeq()` would be preferred instead.

I'm also uncertain if/where to add tests for this, so any pointers in that direction would also be appreciated. Cheers! :-)

See https://github.com/dotnet/aspire/issues/6155, 

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [ ] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6878)