### PR TITLE
Handle missing settings.json for Codespaces/Devcontainers

### DIFF
--- a/.devcontainer/contributing/devcontainer.json
+++ b/.devcontainer/contributing/devcontainer.json
@@ -41,7 +41,8 @@
 			"extensions": [
 				"ms-dotnettools.csdevkit",
 				"ms-azuretools.vscode-bicep",
-				"ms-azuretools.azure-dev"
+				"ms-azuretools.azure-dev",
+				"GitHub.copilot"
 			],
 			"settings": {
 				"remote.autoForwardPorts": true,

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -34,7 +34,9 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
                                              IHostApplicationLifetime hostApplicationLifetime,
                                              CodespacesUrlRewriter codespaceUrlRewriter,
                                              IOptions<CodespacesOptions> codespacesOptions,
-                                             IOptions<DevcontainersOptions> devcontainersOptions) : IDistributedApplicationLifecycleHook, IAsyncDisposable
+                                             IOptions<DevcontainersOptions> devcontainersOptions,
+                                             DevcontainerSettingsWriter settingsWriter
+                                             ) : IDistributedApplicationLifecycleHook, IAsyncDisposable
 {
     private Task? _dashboardLogsTask;
     private CancellationTokenSource? _dashboardLogsCts;
@@ -249,7 +251,7 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
 
             if (codespacesOptions.Value.IsCodespace || devcontainersOptions.Value.IsDevcontainer)
             {
-                await DevcontainerPortForwardingHelper.SetPortAttributesAsync(
+                await settingsWriter.SetPortAttributesAsync(
                     firstDashboardUrl.Port,
                     firstDashboardUrl.Scheme,
                     "aspire-dashboard",

--- a/src/Aspire.Hosting/Devcontainers/DevcontainerPortForwardingLifecycleHook.cs
+++ b/src/Aspire.Hosting/Devcontainers/DevcontainerPortForwardingLifecycleHook.cs
@@ -14,12 +14,14 @@ internal sealed class DevcontainerPortForwardingLifecycleHook : IDistributedAppl
     private readonly ILogger _hostingLogger;
     private readonly IOptions<CodespacesOptions> _codespacesOptions;
     private readonly IOptions<DevcontainersOptions> _devcontainersOptions;
+    private readonly DevcontainerSettingsWriter _settingsWriter;
 
-    public DevcontainerPortForwardingLifecycleHook(ILoggerFactory loggerFactory, IOptions<CodespacesOptions> codespacesOptions, IOptions<DevcontainersOptions> devcontainersOptions)
+    public DevcontainerPortForwardingLifecycleHook(ILoggerFactory loggerFactory, IOptions<CodespacesOptions> codespacesOptions, IOptions<DevcontainersOptions> devcontainersOptions, DevcontainerSettingsWriter settingsWriter)
     {
         _hostingLogger = loggerFactory.CreateLogger("Aspire.Hosting");
         _codespacesOptions = codespacesOptions;
         _devcontainersOptions = devcontainersOptions;
+        _settingsWriter = settingsWriter;
     }
 
     public async Task AfterEndpointsAllocatedAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken)
@@ -60,7 +62,7 @@ internal sealed class DevcontainerPortForwardingLifecycleHook : IDistributedAppl
                 //       and writing it each time. Its like this for now beause I need to use the logic
                 //       in a few places (here and when we print out the Dashboard URL) - but will need
                 //       to come back and optimize this to support some kind of batching.
-                await DevcontainerPortForwardingHelper.SetPortAttributesAsync(
+                await _settingsWriter.SetPortAttributesAsync(
                     endpoint.AllocatedEndpoint!.Port,
                     endpoint.UriScheme,
                     $"{resource.Name}-{endpoint.Name}",

--- a/src/Aspire.Hosting/Devcontainers/DevcontainerSettingsWriter.cs
+++ b/src/Aspire.Hosting/Devcontainers/DevcontainerSettingsWriter.cs
@@ -3,30 +3,35 @@
 
 using System.Globalization;
 using System.Text.Json.Nodes;
+using Aspire.Hosting.Devcontainers.Codespaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Aspire.Hosting.Devcontainers;
 
-internal class DevcontainerPortForwardingHelper
+internal class DevcontainerSettingsWriter(ILogger<DevcontainerSettingsWriter> logger, IOptions<CodespacesOptions> codespaceOptions, IOptions<DevcontainersOptions> devcontainerOptions)
 {
     private const string CodespaceSettingsPath = "/home/vscode/.vscode-remote/data/Machine/settings.json";
     private const string LocalDevcontainerSettingsPath = "/home/vscode/.vscode-server/data/Machine/settings.json";
     private const string PortAttributesFieldName = "remote.portsAttributes";
-    private const int WriteLockTimeoutMs = 2000; 
-    private static readonly SemaphoreSlim s_writeLock = new SemaphoreSlim(1);
+    private const int WriteLockTimeoutMs = 2000;
+    private readonly SemaphoreSlim _writeLock = new SemaphoreSlim(1);
 
-    public static async Task SetPortAttributesAsync(int port, string protocol, string label, CancellationToken cancellationToken = default)
+    public async Task SetPortAttributesAsync(int port, string protocol, string label, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNullOrEmpty(protocol);
         ArgumentNullException.ThrowIfNullOrEmpty(label);
 
         var settingsPath = GetSettingsPath();
 
-        var acquired = await s_writeLock.WaitAsync(WriteLockTimeoutMs, cancellationToken).ConfigureAwait(false);
+        var acquired = await _writeLock.WaitAsync(WriteLockTimeoutMs, cancellationToken).ConfigureAwait(false);
 
         if (!acquired)
         {
             throw new DistributedApplicationException($"Failed to acquire semaphore for settings file: {settingsPath}");
         }
+
+        await EnsureSettingsFileExists(settingsPath, cancellationToken).ConfigureAwait(false);
 
         var settingsContent = await File.ReadAllTextAsync(settingsPath, cancellationToken).ConfigureAwait(false);
         var settings = (JsonObject)JsonObject.Parse(settingsContent)!;
@@ -62,24 +67,46 @@ internal class DevcontainerPortForwardingHelper
         settingsContent = settings.ToString();
         await File.WriteAllTextAsync(settingsPath, settingsContent, cancellationToken).ConfigureAwait(false);
 
-        s_writeLock.Release();
+        _writeLock.Release();
 
-        static string GetSettingsPath()
+        string GetSettingsPath()
         {
             // For some reason the machine settings path is different between Codespaces and local Devcontainers
-            // so we probe for it here. We could use options to figure out which one to look for here but that
-            // would require taking a dependency on the options system here which seems like overkill.
-            if (File.Exists(CodespaceSettingsPath))
+            // so we decide which one to use here based on the options.
+            if (codespaceOptions.Value.IsCodespace)
             {
                 return CodespaceSettingsPath;
             }
-            else if (File.Exists(LocalDevcontainerSettingsPath))
+            else if (devcontainerOptions.Value.IsDevcontainer)
             {
                 return LocalDevcontainerSettingsPath;
             }
             else
             {
-                throw new DistributedApplicationException("Could not find a devcontainer settings file.");
+                throw new DistributedApplicationException("Codespaces or Devcontainer not detected.");
+            }
+        }
+
+        async Task EnsureSettingsFileExists(string path, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    // The extra ceremony here is to avoid accidentally overwriting the file if it was
+                    // created after we checked for its existence. If the file exists when we go to write
+                    // it then we will throw and log a warning, but otherwise continue executing.
+                    using var stream = File.Open(path, FileMode.CreateNew);
+                    using var writer = new StreamWriter(stream);
+                    await writer.WriteAsync("{}".AsMemory(), cancellationToken).ConfigureAwait(false);
+                }
+            }
+            catch (IOException ex) when (ex.Message == $"The file '{path}' already exists.")
+            {
+                // This is OK, but it should be rare enough that if it starts happening we probably
+                // want to know about it in logs that end users submit so we know to take a closer
+                // look at what is going on.
+                logger.LogWarning("Race condition detected when creating Devcontainer settings file: {Path}", path)
             }
         }
     }

--- a/src/Aspire.Hosting/Devcontainers/DevcontainerSettingsWriter.cs
+++ b/src/Aspire.Hosting/Devcontainers/DevcontainerSettingsWriter.cs
@@ -106,7 +106,7 @@ internal class DevcontainerSettingsWriter(ILogger<DevcontainerSettingsWriter> lo
                 // This is OK, but it should be rare enough that if it starts happening we probably
                 // want to know about it in logs that end users submit so we know to take a closer
                 // look at what is going on.
-                logger.LogWarning("Race condition detected when creating Devcontainer settings file: {Path}", path)
+                logger.LogWarning("Race condition detected when creating Devcontainer settings file: {Path}", path);
             }
         }
     }

--- a/src/Aspire.Hosting/DistributedApplicationBuilder.cs
+++ b/src/Aspire.Hosting/DistributedApplicationBuilder.cs
@@ -294,6 +294,7 @@ public class DistributedApplicationBuilder : IDistributedApplicationBuilder
             _innerBuilder.Services.AddSingleton<CodespacesUrlRewriter>();
             _innerBuilder.Services.AddHostedService<CodespacesResourceUrlRewriterService>();
             _innerBuilder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<DevcontainersOptions>, ConfigureDevcontainersOptions>());
+            _innerBuilder.Services.AddSingleton<DevcontainerSettingsWriter>();
             _innerBuilder.Services.TryAddLifecycleHook<DevcontainerPortForwardingLifecycleHook>();
 
             Eventing.Subscribe<BeforeStartEvent>(BuiltInDistributedApplicationEventSubscriptionHandlers.InitializeDcpAnnotations);

--- a/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dashboard/DashboardLifecycleHookTests.cs
@@ -108,7 +108,7 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
     {
         codespacesOptions ??= Options.Create(new CodespacesOptions());
         devcontainersOptions ??= Options.Create(new DevcontainersOptions());
-
+        var settingsWriter = new DevcontainerSettingsWriter(NullLogger<DevcontainerSettingsWriter>.Instance, codespacesOptions, devcontainersOptions);
         var rewriter = new CodespacesUrlRewriter(codespacesOptions);
 
         return new DashboardLifecycleHook(
@@ -124,7 +124,8 @@ public class DashboardLifecycleHookTests(ITestOutputHelper testOutputHelper)
             new TestHostApplicationLifetime(),
             rewriter,
             codespacesOptions,
-            devcontainersOptions
+            devcontainersOptions,
+            settingsWriter
             );
     }
 


### PR DESCRIPTION
… handle missing settings.json file.

## Description

This pull request includes several changes to improve handling of what happens when the machine-wide `settings.json` file isn't present. The solution is to detect if the file exists and if it isn't - create it. This required a bunch of other collateral changes which are probably good long-term changes towards improving testability (although I still haven't tackled that yet).

I've also added Copilot to our contributing devcontainer since we would normally expect this to be present in our local VS installs - it's kinda helpful :)

Fixes #6873

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6880)