### PR TITLE
Support Arch Linux default path for dapr cli

### DIFF
--- a/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
+++ b/src/Aspire.Hosting.Dapr/DaprDistributedApplicationLifecycleHook.cs
@@ -216,7 +216,7 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
                         {
                             updatedArgs.AddRange(daprAppChannelAddressArg(endPoint.Value.appEndpoint.Host)());
                         }
-                        if (sidecarOptions?.AppProtocol is null && endPoint is { appEndpoint.IsAllocated: true }) 
+                        if (sidecarOptions?.AppProtocol is null && endPoint is { appEndpoint.IsAllocated: true })
                         {
                             updatedArgs.AddRange(daprAppProtocol(endPoint.Value.protocol)());
                         }
@@ -329,7 +329,10 @@ internal sealed class DaprDistributedApplicationLifecycleHook : IDistributedAppl
             yield return Path.Combine(homePath, "dapr", "dapr");
 
             // Linux & MacOS path:
-            yield return Path.Combine("/usr", "local", "bin", "dapr");
+            yield return "/usr/local/bin/dapr";
+
+            // Arch Linux path:
+            yield return "/usr/bin/dapr";
 
             // MacOS Homebrew path:
             if (OperatingSystem.IsMacOS() && Environment.GetEnvironmentVariable("HOMEBREW_PREFIX") is string homebrewPrefix)


### PR DESCRIPTION
## Description

Arch Linux installs dapr to `/usr/bin/dapr` not `/usr/local/bin/dapr` like most other distros.
Added a simple fix to support Arch.

https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=dapr-cli-git#n41

Can see the path matches up with `/usr/bin`, which is idiomatic for Arch.

## Checklist

- Is this feature complete? Yes
- Are you including unit tests for the changes and scenario tests if relevant? No
- Did you add public API? No
- Does the change make any security assumptions or guarantees? No
- Does the change require an update in our Aspire docs? No
