### PR TITLE
Improvements to setting dashboard culture

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -25,9 +25,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
 
     protected override void OnInitialized()
     {
-        _languageOptions = [.. GlobalizationHelpers.LocalizedCultures
-            .Select(CultureInfo.GetCultureInfo)
-            .OrderBy(c => c.NativeName)];
+        _languageOptions = [.. GlobalizationHelpers.LocalizedCultures.OrderBy(c => c.NativeName)];
 
         _selectedUiCulture = _languageOptions.ToHashSet().TryGetCulture(CultureInfo.CurrentUICulture, matchParent: true, out var matchedCulture)
             ? matchedCulture :

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -27,7 +27,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     {
         _languageOptions = [.. GlobalizationHelpers.LocalizedCultures.OrderBy(c => c.NativeName)];
 
-        _selectedUiCulture = _languageOptions.ToHashSet().TryGetCulture(CultureInfo.CurrentUICulture, matchParent: true, out var matchedCulture)
+        _selectedUiCulture = GlobalizationHelpers.TryGetKnownParentCulture(_languageOptions, CultureInfo.CurrentUICulture, out var matchedCulture)
             ? matchedCulture :
             // Otherwise, Blazor has fallen back to a supported language
             CultureInfo.CurrentUICulture;

--- a/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
 using Aspire.Dashboard.Configuration;
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Utils;
@@ -65,7 +64,7 @@ public static class DashboardEndpointsBuilder
             RequestCulture? requestCulture = null;
             if (acceptLanguage != null)
             {
-                requestCulture = await GlobalizationHelpers.ResolveSetCultureToAcceptedCulture(acceptLanguage, availableCultures).ConfigureAwait(false);
+                requestCulture = await GlobalizationHelpers.ResolveSetCultureToAcceptedCultureAsync(acceptLanguage, availableCultures).ConfigureAwait(false);
             }
             requestCulture ??= new RequestCulture(newLanguage.Name, newLanguage.Name);
 

--- a/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
+++ b/src/Aspire.Dashboard/DashboardEndpointsBuilder.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+using Aspire.Dashboard.Configuration;
+using Aspire.Dashboard.Model;
+using Aspire.Dashboard.Utils;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Aspire.Dashboard;
+
+public static class DashboardEndpointsBuilder
+{
+    public static void MapDashboardApi(this IEndpointRouteBuilder endpoints, DashboardOptions dashboardOptions)
+    {
+        if (dashboardOptions.Frontend.AuthMode == FrontendAuthMode.BrowserToken)
+        {
+            endpoints.MapPost("/api/validatetoken", async (string token, HttpContext httpContext, IOptionsMonitor<DashboardOptions> dashboardOptions) =>
+            {
+                return await ValidateTokenMiddleware.TryAuthenticateAsync(token, httpContext, dashboardOptions).ConfigureAwait(false);
+            });
+
+#if DEBUG
+            // Available in local debug for testing.
+            endpoints.MapGet("/api/signout", async (HttpContext httpContext) =>
+            {
+                await Microsoft.AspNetCore.Authentication.AuthenticationHttpContextExtensions.SignOutAsync(
+                    httpContext,
+                    CookieAuthenticationDefaults.AuthenticationScheme).ConfigureAwait(false);
+                httpContext.Response.Redirect("/");
+            });
+#endif
+        }
+        else if (dashboardOptions.Frontend.AuthMode == FrontendAuthMode.OpenIdConnect)
+        {
+            endpoints.MapPost("/authentication/logout", () => TypedResults.SignOut(authenticationSchemes: [CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme]));
+        }
+
+        endpoints.MapGet("/api/set-language", async (string? language, string? redirectUrl, [FromHeader(Name = "Accept-Language")] string? acceptLanguage, HttpContext httpContext) =>
+        {
+            if (string.IsNullOrEmpty(redirectUrl))
+            {
+                return Results.BadRequest();
+            }
+
+            // The passed in language should be one of the localized cultures.
+            var newLanguage = GlobalizationHelpers.LocalizedCultures.SingleOrDefault(c => string.Equals(c.Name, language, StringComparisons.CultureName));
+            if (newLanguage == null)
+            {
+                return Results.BadRequest();
+            }
+
+            if (!GlobalizationHelpers.ExpandedLocalizedCultures.TryGetValue(newLanguage.Name, out var availableCultures))
+            {
+                return Results.BadRequest();
+            }
+
+            // The passed in language is one of the supported localized cultures. e.g. en, fr, de, etc.
+            // However, if the browser specifies a culture via accept-language header that is compatible with the language, then we want to use that.
+            // For example, the new language is "en" and accept-language is "en-GB", then we want to use "en-GB".
+            RequestCulture? requestCulture = null;
+            if (acceptLanguage != null)
+            {
+                requestCulture = await GlobalizationHelpers.ResolveSetCultureToAcceptedCulture(acceptLanguage, availableCultures).ConfigureAwait(false);
+            }
+            requestCulture ??= new RequestCulture(newLanguage.Name, newLanguage.Name);
+
+            httpContext.Response.Cookies.Append(
+                CookieRequestCultureProvider.DefaultCookieName,
+                CookieRequestCultureProvider.MakeCookieValue(requestCulture),
+                new CookieOptions { Expires = DateTimeOffset.UtcNow.AddYears(1) }); // consistent with theme cookie expiry
+
+            return Results.LocalRedirect(redirectUrl);
+        });
+    }
+}

--- a/tests/Aspire.Dashboard.Tests/GlobalizationHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/GlobalizationHelpersTests.cs
@@ -13,12 +13,15 @@ public class GlobalizationHelpersTests
     public void GetSupportedCultures_IncludesPopularCultures()
     {
         // Act
-        var supportedCultures = GlobalizationHelpers.GetSupportedCultures();
+        var supportedCultures = GlobalizationHelpers.ExpandedLocalizedCultures
+            .SelectMany(kvp => kvp.Value)
+            .Select(c => c.Name)
+            .ToList();
 
         // Assert
         foreach (var localizedCulture in GlobalizationHelpers.LocalizedCultures)
         {
-            Assert.Contains(localizedCulture, supportedCultures);
+            Assert.Contains(localizedCulture.Name, supportedCultures);
         }
 
         // A few cultures we expect to be available

--- a/tests/Aspire.Dashboard.Tests/GlobalizationHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/GlobalizationHelpersTests.cs
@@ -10,7 +10,7 @@ namespace Aspire.Dashboard.Tests;
 public class GlobalizationHelpersTests
 {
     [Fact]
-    public void GetSupportedCultures_IncludesPopularCultures()
+    public void ExpandedLocalizedCultures_IncludesPopularCultures()
     {
         // Act
         var supportedCultures = GlobalizationHelpers.ExpandedLocalizedCultures
@@ -36,12 +36,13 @@ public class GlobalizationHelpersTests
     [InlineData("fr", true, "fr")]
     [InlineData("zh-Hans", true, "zh-Hans")]
     [InlineData("zh-Hant", true, "zh-Hant")]
-    [InlineData("zh-CN", false, null)]
+    [InlineData("zh-CN", true, "zh-Hans")]
     [InlineData("es", false, null)]
-    public void TryGetCulture_VariousCultures_ReturnsExpectedResult(string cultureName, bool expectedResult, string? expectedMatchedCultureName)
+    [InlineData("aa-bb", false, null)]
+    public void TryGetKnownParentCulture_VariousCultures_ReturnsExpectedResult(string cultureName, bool expectedResult, string? expectedMatchedCultureName)
     {
         // Arrange
-        var cultureOptions = new HashSet<CultureInfo>
+        var cultureOptions = new List<CultureInfo>
         {
             new("en"),
             new("fr"),
@@ -51,7 +52,7 @@ public class GlobalizationHelpersTests
         var culture = new CultureInfo(cultureName);
 
         // Act
-        var result = cultureOptions.TryGetCulture(culture, matchParent: true, out var matchedCulture);
+        var result = GlobalizationHelpers.TryGetKnownParentCulture(cultureOptions, culture, out var matchedCulture);
 
         // Assert
         Assert.Equal(expectedResult, result);
@@ -62,6 +63,32 @@ public class GlobalizationHelpersTests
         else
         {
             Assert.Equal(new CultureInfo(expectedMatchedCultureName), matchedCulture);
+        }
+    }
+
+    [Theory]
+    [InlineData("en", "en-US", "en-US")]
+    [InlineData("en", "en-XX", "en")]
+    [InlineData("de", "en-US", null)]
+    [InlineData("zh-Hans", "en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7", "zh-CN")]
+    public async Task ResolveSetCultureToAcceptedCultureAsync_MatchRequestToResult(string requestedLanguage, string acceptLanguage, string? result)
+    {
+        // Arrange
+        var englishCultures = GlobalizationHelpers.ExpandedLocalizedCultures[requestedLanguage];
+
+        // Act
+        var requestCulture = await GlobalizationHelpers.ResolveSetCultureToAcceptedCultureAsync(acceptLanguage, englishCultures);
+
+        // Assert
+        if (result != null)
+        {
+            Assert.NotNull(requestCulture);
+            Assert.Equal(result, requestCulture.Culture.Name);
+            Assert.Equal(result, requestCulture.UICulture.Name);
+        }
+        else
+        {
+            Assert.Null(requestCulture);
         }
     }
 }


### PR DESCRIPTION
## Description

https://github.com/dotnet/aspire/pull/6805 adding setting language. However, it only changed `CultureInfo.CurrentUICulture`, which is what controls the translation language used. Dates and numbers, which use `CultureInfo.CurrentCulture`, still use the local OS settings when converted to text in the dashboard UI. That means if you set the language to French in the UI on an `en-US` machine, dates would be formatted as `MM/dd/yyyy` (`en-US` standard) instead of `dd/MM/yyyy` (`fr` standard). I don't think is what people would expect.

This PR:
* Updates setting language to also change `CultureInfo.CurrentCulture`. It combines the requested language with `accept-language` to try to use OS settings for the language. For example, if `en` is selected, and the browser sends `en-GB` in the header, then the cookie will be set to `en-GB`.
* Moves dashboard minimal APIs to their own file
* Improves resolving the current culture to a parent culture. `zh-CN` now resolves.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6893)