### PR TITLE
Make opening visualizer the default grid value action

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/Chart/PlotlyChart.razor.cs
@@ -33,7 +33,7 @@ public partial class PlotlyChart : ChartBase
     public string ChartDivId { get; } = $"plotly-chart-container-{Interlocked.Increment(ref s_nextChartId)}";
 
     [CascadingParameter]
-    public required ViewportInformation ViewportInformation { get; init; }
+    public required ViewportInformation ViewportInformation { get; set; }
 
     private DotNetObjectReference<ChartInterop>? _chartInteropReference;
     private IJSObjectReference? _jsModule;

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -35,15 +35,6 @@
         </span>
     }
 
-    @{
-        (string, object)[] uncapturedCopyAttributes = [
-            ("alt", PreCopyToolTip),
-            ("title", string.Empty),
-            ("aria-label", Loc[nameof(ControlsStrings.GridValueCopyToClipboard)]),
-            ("tabindex", "0")
-        ];
-    }
-
     @* Button area *@
 
     <div @onclick:stopPropagation="true" class="button-container">

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -50,30 +50,10 @@
 
         <span class="defaultHidden">
             <FluentButton Appearance="Appearance.Lightweight"
-                          Id="@_menuAnchorId"
-                          OnClick="@ToggleMenuOpen">
-                <FluentIcon Icon="Icons.Regular.Size16.MoreHorizontal" />
+                          Disabled="@(ValueToVisualize is null && Value is null)"
+                          OnClick="OpenTextVisualizerAsync">
+                <FluentIcon Icon="Icons.Regular.Size16.SlideSearch" />
             </FluentButton>
-
-            <FluentMenu Anchor="@_menuAnchorId" @bind-Open="_isMenuOpen" VerticalThreshold="170" HorizontalPosition="HorizontalPosition.End">
-                <FluentMenuItem Id="@_copyId"
-                                Disabled="@(ValueToCopy is null && Value is null)"
-                                AdditionalAttributes="@FluentUIExtensions.GetClipboardCopyAdditionalAttributes(ValueToCopy ?? Value, PreCopyToolTip, PostCopyToolTip, uncapturedCopyAttributes)">
-                    <span slot="start">
-                        <FluentIcon Style="vertical-align: text-bottom" Icon="Icons.Regular.Size16.Copy" />
-                    </span>
-                    @PreCopyToolTip
-                </FluentMenuItem>
-
-                <FluentMenuItem Disabled="@(ValueToVisualize is null && Value is null)"
-                                AdditionalAttributes="@FluentUIExtensions.GetOpenTextVisualizerAdditionalAttributes(ValueToVisualize ?? Value!, !string.IsNullOrEmpty(TextVisualizerTitle) ? TextVisualizerTitle : ValueDescription)">
-                    <span slot="start">
-                        <FluentIcon Style="vertical-align: text-bottom" Icon="Icons.Regular.Size16.Open" />
-                    </span>
-
-                    @DialogsLoc[nameof(Dialogs.OpenInTextVisualizer)]
-                </FluentMenuItem>
-            </FluentMenu>
         </span>
 
         @if (ContentInButtonArea is not null)

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor
@@ -46,7 +46,7 @@
 
     @* Button area *@
 
-    <div @onclick:stopPropagation="true">
+    <div @onclick:stopPropagation="true" class="button-container">
 
         <span class="defaultHidden">
             <FluentButton Appearance="Appearance.Lightweight"

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net;
+using Aspire.Dashboard.Components.Dialogs;
 using Aspire.Dashboard.ConsoleLogs;
 using Aspire.Dashboard.Resources;
 using Microsoft.AspNetCore.Components;
@@ -87,17 +88,20 @@ public partial class GridValue
     [Parameter]
     public bool StopClickPropagation { get; set; }
 
+    [CascadingParameter]
+    public required ViewportInformation ViewportInformation { get; set; }
+
     [Inject]
     public required IJSRuntime JS { get; init; }
+
+    [Inject]
+    public required IDialogService DialogService { get; init; }
 
     private readonly Icon _maskIcon = new Icons.Regular.Size16.EyeOff();
     private readonly Icon _unmaskIcon = new Icons.Regular.Size16.Eye();
     private readonly string _cellTextId = $"celltext-{Guid.NewGuid():N}";
-    private readonly string _copyId = $"copy-{Guid.NewGuid():N}";
-    private readonly string _menuAnchorId = $"menu-{Guid.NewGuid():N}";
     private string? _value;
     private string? _formattedValue;
-    private bool _isMenuOpen;
 
     protected override void OnInitialized()
     {
@@ -145,8 +149,8 @@ public partial class GridValue
         await IsMaskedChanged.InvokeAsync(IsMasked);
     }
 
-    private void ToggleMenuOpen()
+    private async Task OpenTextVisualizerAsync()
     {
-        _isMenuOpen = !_isMenuOpen;
+        await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, ValueDescription, Value ?? string.Empty);
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.cs
@@ -41,12 +41,6 @@ public partial class GridValue
     public RenderFragment? ContentInButtonArea { get; set; }
 
     /// <summary>
-    /// If set, copies this value instead of <see cref="Value"/>.
-    /// </summary>
-    [Parameter]
-    public string? ValueToCopy { get; set; }
-
-    /// <summary>
     /// If set, this value is visualized rather than <see cref="Value"/>.
     /// </summary>
     [Parameter]
@@ -151,6 +145,6 @@ public partial class GridValue
 
     private async Task OpenTextVisualizerAsync()
     {
-        await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, ValueDescription, Value ?? string.Empty);
+        await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, ValueDescription, ValueToVisualize ?? Value ?? string.Empty);
     }
 }

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -14,7 +14,7 @@
     margin-left: 0; /* by default there shouldn't be a margin on the button container because it has no contents */
 }
 
-::deep .masking-enabled .button-container, ::deep:hover .button-container, ::deep:focus-within .button-container {
+::deep .masking-enabled .button-container, fluent-data-grid-cell:hover .button-container, fluent-data-grid-cell:focus-within .button-container {
     /* the button container always has contents if masking is enabled or it is hovered over, so display margin */
     margin-left: calc((6 + (var(--design-unit) * var(--density))) * 1px);
 }
@@ -26,7 +26,7 @@
     display: inline-block;
 }
 
-::deep:hover .defaultHidden, ::deep:focus-within .defaultHidden {
+fluent-data-grid-cell:hover .defaultHidden, fluent-data-grid-cell:focus-within .defaultHidden {
     opacity: 1; /* safari has a bug where hover is not always called on an invisible element, so we use opacity instead */
     width: auto;
 }

--- a/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
+++ b/src/Aspire.Dashboard/Components/Controls/GridValue.razor.css
@@ -1,18 +1,22 @@
 .container {
     display: grid;
     grid-template-columns: 1fr auto;
-    gap: calc((6 + (var(--design-unit) * var(--density))) * 1px);
     align-items: center;
-}
-
-.masking-enabled {
-    grid-template-columns: 1fr auto auto;
 }
 
 ::deep .grid-value {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+}
+
+::deep .button-container {
+    margin-left: 0; /* by default there shouldn't be a margin on the button container because it has no contents */
+}
+
+::deep .masking-enabled .button-container, ::deep:hover .button-container, ::deep:focus-within .button-container {
+    /* the button container always has contents if masking is enabled or it is hovered over, so display margin */
+    margin-left: calc((6 + (var(--design-unit) * var(--density))) * 1px);
 }
 
 ::deep .defaultHidden {
@@ -23,6 +27,6 @@
 }
 
 ::deep:hover .defaultHidden, ::deep:focus-within .defaultHidden {
-    opacity: 1;  /* safari has a bug where hover is not always called on an invisible element, so we use opacity instead */
+    opacity: 1; /* safari has a bug where hover is not always called on an invisible element, so we use opacity instead */
     width: auto;
 }

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor
@@ -31,7 +31,6 @@
             IsMasked="@context.IsValueMasked"
             IsMaskedChanged="(isMasked) => OnIsValueMaskedChanged(context, isMasked)"
             TextVisualizerTitle="@context.Name"
-            ValueToCopy="@(context.ValueToCopy ?? context.Value)"
             ValueToVisualize="@(context.ValueToVisualize ?? context.Value)" />
         @ExtraValueContent(context)
     </AspireTemplateColumn>

--- a/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/PropertyGrid.razor.cs
@@ -39,11 +39,6 @@ public interface IPropertyGridItem
     string? Value { get; }
 
     /// <summary>
-    /// Overrides the value to copy. If <see langword="null"/>, <see cref="Value"/> is copied.
-    /// </summary>
-    public string? ValueToCopy => null;
-
-    /// <summary>
     /// Overrides the value to visualize. If <see langword="null"/>, <see cref="Value"/> is visualized.
     /// </summary>
     public string? ValueToVisualize => null;

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -21,7 +21,6 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
     private IDisposable? _locationChangingRegistration;
     private IJSObjectReference? _jsModule;
     private IJSObjectReference? _keyboardHandlers;
-    private IJSObjectReference? _textVisualizerHandler;
     private DotNetObjectReference<ShortcutManager>? _shortcutManagerReference;
     private DotNetObjectReference<MainLayout>? _layoutReference;
     private IDialogReference? _openPageDialog;
@@ -141,7 +140,6 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             _shortcutManagerReference = DotNetObjectReference.Create(ShortcutManager);
             _layoutReference = DotNetObjectReference.Create(this);
             _keyboardHandlers = await JS.InvokeAsync<IJSObjectReference>("window.registerGlobalKeydownListener", _shortcutManagerReference);
-            _textVisualizerHandler = await JS.InvokeAsync<IJSObjectReference>("window.registerOpenTextVisualizerOnClick", _layoutReference);
             ShortcutManager.AddGlobalKeydownListener(this);
         }
     }
@@ -298,11 +296,6 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
             {
                 await JS.InvokeVoidAsync("window.unregisterGlobalKeydownListener", h);
             }
-
-            if (_textVisualizerHandler is not null)
-            {
-                await JS.InvokeVoidAsync("window.unregisterOpenTextVisualizerOnClick", _textVisualizerHandler);
-            }
         }
         catch (JSDisconnectedException)
         {
@@ -312,6 +305,5 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
 
         await JSInteropHelpers.SafeDisposeAsync(_jsModule);
         await JSInteropHelpers.SafeDisposeAsync(_keyboardHandlers);
-        await JSInteropHelpers.SafeDisposeAsync(_textVisualizerHandler);
     }
 }

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.cs
@@ -272,16 +272,6 @@ public partial class MainLayout : IGlobalKeydownListener, IAsyncDisposable
         StateHasChanged();
     }
 
-    [JSInvokable]
-    public async Task OpenTextVisualizerAsync(IJSStreamReference valueStream, string valueDescription)
-    {
-        await using var referenceStream = await valueStream.OpenReadStreamAsync();
-        using var reader = new StreamReader(referenceStream);
-        var value = await reader.ReadToEndAsync();
-
-        await TextVisualizerDialog.OpenDialogAsync(ViewportInformation, DialogService, valueDescription, value);
-    }
-
     public async ValueTask DisposeAsync()
     {
         _shortcutManagerReference?.Dispose();

--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -117,7 +117,7 @@
                                 <AspireTemplateColumn ColumnId="@SourceColumn" ColumnManager="@_manager" Title="@Loc[nameof(Dashboard.Resources.Resources.ResourcesSourceColumnHeader)]" Tooltip="true" TooltipText="@(ctx => ResourceSourceViewModel.GetSourceViewModel(ctx.Resource)?.Tooltip)">
                                     @if (ResourceSourceViewModel.GetSourceViewModel(context.Resource) is { } columnDisplay)
                                     {
-                                        <SourceColumnDisplay FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToCopy="@columnDisplay.ValueToCopy" Tooltip="@columnDisplay.Tooltip" />
+                                        <SourceColumnDisplay FilterText="@_filter" Value="@columnDisplay.Value" ContentAfterValue="@columnDisplay.ContentAfterValue" ValueToVisualize="@columnDisplay.ValueToVisualize" Tooltip="@columnDisplay.Tooltip" />
                                     }
                                     else
                                     {

--- a/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
+++ b/src/Aspire.Dashboard/Components/ResourcesGridColumns/SourceColumnDisplay.razor
@@ -5,8 +5,7 @@
 @inject IStringLocalizer<Resources> ResourcesLoc
 
 <GridValue Value="@Value"
-           ValueToCopy="@ValueToCopy"
-           ValueToVisualize="@ValueToCopy"
+           ValueToVisualize="@ValueToVisualize"
            ValueDescription="@ResourcesLoc[nameof(Resources.ResourcesSourceColumnHeader)]"
            EnableHighlighting="true"
            HighlightText="@FilterText"
@@ -32,7 +31,7 @@
     public required string? ContentAfterValue { get; set; }
 
     [Parameter, EditorRequired]
-    public required string ValueToCopy { get; set; }
+    public required string ValueToVisualize { get; set; }
 
     [Parameter, EditorRequired]
     public required string Tooltip { get; set; }

--- a/src/Aspire.Dashboard/Extensions/FluentUIExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/FluentUIExtensions.cs
@@ -27,20 +27,4 @@ internal static class FluentUIExtensions
 
         return attributes;
     }
-
-    public static Dictionary<string, object> GetOpenTextVisualizerAdditionalAttributes(string textValue, string textValueDescription, params (string Attribute, object Value)[] additionalAttributes)
-    {
-        var attributes = new Dictionary<string, object>(StringComparers.HtmlAttribute)
-        {
-            { "data-text", textValue },
-            { "data-textvisualizer-description", textValueDescription }
-        };
-
-        foreach (var (attribute, value) in additionalAttributes)
-        {
-            attributes.Add(attribute, value);
-        }
-
-        return attributes;
-    }
 }

--- a/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
+++ b/src/Aspire.Dashboard/Model/ResourceEndpointHelpers.cs
@@ -60,7 +60,6 @@ public sealed class DisplayedEndpoint : IPropertyGridItem
     /// </summary>
     string? IPropertyGridItem.Value => null;
 
-    public string? ValueToCopy => Url ?? Text;
     public string? ValueToVisualize => Url ?? Text;
 
     public bool MatchesFilter(string filter)

--- a/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceSourceViewModel.cs
@@ -1,13 +1,13 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Dashboard.Model;
 
-public class ResourceSourceViewModel(string value, string? contentAfterValue, string valueToCopy, string tooltip)
+public class ResourceSourceViewModel(string value, string? contentAfterValue, string valueToVisualize, string tooltip)
 {
     public string Value { get; } = value;
     public string? ContentAfterValue { get; } = contentAfterValue;
-    public string ValueToCopy { get; } = valueToCopy;
+    public string ValueToVisualize { get; } = valueToVisualize;
     public string Tooltip { get; } = tooltip;
 
     internal static ResourceSourceViewModel? GetSourceViewModel(ResourceViewModel resource)
@@ -27,26 +27,26 @@ public class ResourceSourceViewModel(string value, string? contentAfterValue, st
         {
             if (commandLineInfo is { ArgumentsString: { } argumentsString, FullCommandLine: { } fullCommandLine })
             {
-                return new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: argumentsString, valueToCopy: fullCommandLine, tooltip: fullCommandLine);
+                return new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: argumentsString, valueToVisualize: fullCommandLine, tooltip: fullCommandLine);
             }
 
             // default to project path if there is no executable path or executable arguments
-            return new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: commandLineInfo?.ArgumentsString, valueToCopy: projectPath, tooltip: projectPath);
+            return new ResourceSourceViewModel(value: Path.GetFileName(projectPath), contentAfterValue: commandLineInfo?.ArgumentsString, valueToVisualize: projectPath, tooltip: projectPath);
         }
 
         if (executablePath is not null)
         {
-            return new ResourceSourceViewModel(value: Path.GetFileName(executablePath), contentAfterValue: commandLineInfo?.ArgumentsString, valueToCopy: commandLineInfo?.FullCommandLine ?? executablePath, tooltip: commandLineInfo?.FullCommandLine ?? string.Empty);
+            return new ResourceSourceViewModel(value: Path.GetFileName(executablePath), contentAfterValue: commandLineInfo?.ArgumentsString, valueToVisualize: commandLineInfo?.FullCommandLine ?? executablePath, tooltip: commandLineInfo?.FullCommandLine ?? string.Empty);
         }
 
         if (resource.TryGetContainerImage(out var containerImage))
         {
-            return new ResourceSourceViewModel(value: containerImage, contentAfterValue: null, valueToCopy: containerImage, tooltip: containerImage);
+            return new ResourceSourceViewModel(value: containerImage, contentAfterValue: null, valueToVisualize: containerImage, tooltip: containerImage);
         }
 
         if (resource.Properties.TryGetValue(KnownProperties.Resource.Source, out var property) && property.Value is { HasStringValue: true, StringValue: var value })
         {
-            return new ResourceSourceViewModel(value, contentAfterValue: null, valueToCopy: value, tooltip: value);
+            return new ResourceSourceViewModel(value, contentAfterValue: null, valueToVisualize: value, tooltip: value);
         }
 
         return null;

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -324,39 +324,6 @@ window.listenToWindowResize = function(dotnetHelper) {
     window.addEventListener('resize', throttledResizeListener);
 }
 
-window.registerOpenTextVisualizerOnClick = function(layout) {
-    const onClickListener = function (e) {
-        const fluentMenuItem = getFluentMenuItemForTarget(e.target);
-
-        if (!fluentMenuItem) {
-            return;
-        }
-
-        const text = fluentMenuItem.getAttribute("data-text");
-        const description = fluentMenuItem.getAttribute("data-textvisualizer-description");
-
-        if (text && description) {
-            e.stopPropagation();
-
-            // data-text may be larger than the max Blazor message size limit for very large strings
-            // we have to stream it
-            const textAsArray = new TextEncoder().encode(text);
-            const textAsStream = DotNet.createJSStreamReference(textAsArray);
-            layout.invokeMethodAsync("OpenTextVisualizerAsync", textAsStream, description);
-        }
-    }
-
-    document.addEventListener('click', onClickListener);
-
-    return {
-        onClickListener: onClickListener,
-    }
-}
-
-window.unregisterOpenTextVisualizerOnClick = function (obj) {
-    document.removeEventListener('click', obj.onClickListener);
-};
-
 window.setCellTextClickHandler = function (id) {
     var cellTextElement = document.getElementById(id);
     if (!cellTextElement) {

--- a/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
+++ b/tests/Aspire.Dashboard.Tests/Model/ResourceSourceViewModelTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Aspire.Dashboard.Model;
@@ -40,7 +40,7 @@ public class ResourceSourceViewModelTests
             Assert.NotNull(actual);
             Assert.Equal(expected.Value, actual.Value);
             Assert.Equal(expected.ContentAfterValue, actual.ContentAfterValue);
-            Assert.Equal(expected.ValueToCopy, actual.ValueToCopy);
+            Assert.Equal(expected.ValueToVisualize, actual.ValueToVisualize);
             Assert.Equal(expected.Tooltip, actual.Tooltip);
         }
 
@@ -65,7 +65,7 @@ public class ResourceSourceViewModelTests
             new ResourceSourceViewModel(
                 value: "project",
                 contentAfterValue: "arg1 arg2",
-                valueToCopy: "path/to/executable arg1 arg2",
+                valueToVisualize: "path/to/executable arg1 arg2",
                 tooltip: "path/to/executable arg1 arg2"));
 
         // Project without executable arguments
@@ -79,7 +79,7 @@ public class ResourceSourceViewModelTests
             new ResourceSourceViewModel(
                 value: "project",
                 contentAfterValue: null,
-                valueToCopy: "path/to/project",
+                valueToVisualize: "path/to/project",
                 tooltip: "path/to/project"));
 
         // Executable with arguments
@@ -93,7 +93,7 @@ public class ResourceSourceViewModelTests
             new ResourceSourceViewModel(
                 value: "executable",
                 contentAfterValue: "arg1 arg2",
-                valueToCopy: "path/to/executable arg1 arg2",
+                valueToVisualize: "path/to/executable arg1 arg2",
                 tooltip: "path/to/executable arg1 arg2"));
 
         // Container image
@@ -107,7 +107,7 @@ public class ResourceSourceViewModelTests
             new ResourceSourceViewModel(
                 value: "my-container-image",
                 contentAfterValue: null,
-                valueToCopy: "my-container-image",
+                valueToVisualize: "my-container-image",
                 tooltip: "my-container-image"));
 
         // Resource source property
@@ -121,7 +121,7 @@ public class ResourceSourceViewModelTests
             new ResourceSourceViewModel(
                 value: "source-value",
                 contentAfterValue: null,
-                valueToCopy: "source-value",
+                valueToVisualize: "source-value",
                 tooltip: "source-value"));
 
         // Executable path without arguments
@@ -135,7 +135,7 @@ public class ResourceSourceViewModelTests
             new ResourceSourceViewModel(
                 value: "executable",
                 contentAfterValue: null,
-                valueToCopy: "path/to/executable",
+                valueToVisualize: "path/to/executable",
                 tooltip: ""));
 
         return data;


### PR DESCRIPTION
## Description

This PR:

* Replaces grid value menu (has copy and launch visualizer options) with a button that just launches visualizer. The visualizer has a copy button so folks can copy from the dialog.
* Changes visualizer to be launched server side. The previous system seemed very complex for no value. Previous steps: adding attributes to an HTML element, listening for the elements in a document click event, triggering a server method and streaming the element values back to the server, then showing the dialog. @adamint Is there a reason it was implemented this way?
* Changes visualizer launch icon to the same icon displayed in the visualizer
* Fixes masking spacing issue

Fixes https://github.com/dotnet/aspire/issues/6685

![visualizer-launch](https://github.com/user-attachments/assets/db08419e-4e40-45d5-a8f9-1cc6a53fc552)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6900)