### PR TITLE
Fix typo in DevContainers Extension link in machine requirements documentation

### DIFF
--- a/docs/machine-requirements.md
+++ b/docs/machine-requirements.md
@@ -37,7 +37,7 @@ Currently it's only tested with Docker Desktop.
 ### Install VS Code with DevContainers Extension
 
 * [VS Code](https://code.visualstudio.com/Download)
-* [DevContainers Extension](https://marketplace.visualstudio.com/items?itemName=ms-VS Code-remote.remote-containers)
+* [DevContainers Extension](https://marketplace.visualstudio.com/items?itemName=ms-VSCode-remote.remote-containers)
 
 ## (Browser) Codespaces
 


### PR DESCRIPTION
## Description

There's a malformed link in the `Install VS Code with DevContainers Extension` section of the machine requirements documentation.

This is what it looks like **before**:
![before_mr](https://github.com/user-attachments/assets/357dea47-3e84-4092-b7ef-66cfa2e3121e)

This is what it looks like **now**:
![after_mr](https://github.com/user-attachments/assets/91167852-5eac-4664-9138-7ad74548dd31)


**No issue assigned to this**

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6917)