### PR TITLE
Improve command notification to show result if toast has closed

### DIFF
--- a/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
+++ b/src/Aspire.Dashboard/Model/DashboardCommandExecutor.cs
@@ -30,18 +30,51 @@ public sealed class DashboardCommandExecutor(
 
         var messageResourceName = getResourceName(resource);
 
+        // When a resource command starts a toast is immediately shown.
+        // The toast is open for a certain amount of time and then automatically closed.
+        // When the resource command is finished the status is displayed in a toast.
+        // Either the open toast is updated and its time is exteneded, or the a new toast is shown with the finished status.
+        // Because of this logic we need to manage opening and closing the toasts manually.
         var toastParameters = new ToastParameters<CommunicationToastContent>()
         {
             Id = Guid.NewGuid().ToString(),
             Intent = ToastIntent.Progress,
             Title = string.Format(CultureInfo.InvariantCulture, loc[nameof(Dashboard.Resources.Resources.ResourceCommandStarting)], messageResourceName, command.DisplayName),
-            Content = new CommunicationToastContent()
+            Content = new CommunicationToastContent(),
+            Timeout = 0 // App logic will handle closing the toast
         };
 
-        // Show a toast immediately to indicate the command is starting.
-        toastService.ShowCommunicationToast(toastParameters);
+        // Track whether toast is closed by timeout or user action.
+        var toastClosed = false;
+        Action<string?> closeCallback = (id) =>
+        {
+            if (id == toastParameters.Id)
+            {
+                toastClosed = true;
+            }
+        };
 
-        var response = await dashboardClient.ExecuteResourceCommandAsync(resource.Name, resource.ResourceType, command, CancellationToken.None).ConfigureAwait(false);
+        ResourceCommandResponseViewModel response;
+        CancellationTokenSource closeToastCts;
+        try
+        {
+            toastService.OnClose += closeCallback;
+            // Show a toast immediately to indicate the command is starting.
+            toastService.ShowCommunicationToast(toastParameters);
+
+            closeToastCts = new CancellationTokenSource();
+            closeToastCts.Token.Register(() =>
+            {
+                toastService.CloseToast(toastParameters.Id);
+            });
+            closeToastCts.CancelAfter(DashboardUIHelpers.ToastTimeout);
+
+            response = await dashboardClient.ExecuteResourceCommandAsync(resource.Name, resource.ResourceType, command, CancellationToken.None).ConfigureAwait(false);
+        }
+        finally
+        {
+            toastService.OnClose -= closeCallback;
+        }
 
         // Update toast with the result;
         if (response.Kind == ResourceCommandResponseKind.Succeeded)
@@ -60,7 +93,21 @@ public sealed class DashboardCommandExecutor(
             toastParameters.OnPrimaryAction = EventCallback.Factory.Create<ToastResult>(this, () => navigationManager.NavigateTo(DashboardUrls.ConsoleLogsUrl(resource: resource.Name)));
         }
 
-        toastService.UpdateToast(toastParameters.Id, toastParameters);
+        if (!toastClosed)
+        {
+            // Extend cancel time.
+            closeToastCts.CancelAfter(DashboardUIHelpers.ToastTimeout);
+
+            // Update the open toast to display result. This only works if the toast is still open.
+            toastService.UpdateToast(toastParameters.Id, toastParameters);
+        }
+        else
+        {
+            toastParameters.Timeout = null; // Let the toast close automatically.
+
+            // Show toast to display result.
+            toastService.ShowCommunicationToast(toastParameters);
+        }
     }
 
     // Copied from FluentUI.

--- a/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
+++ b/src/Aspire.Dashboard/Utils/DashboardUIHelpers.cs
@@ -17,4 +17,6 @@ internal static class DashboardUIHelpers
 
     // Don't attempt to display more than 2 highlighted commands. Many commands will take up too much space.
     public const int MaxHighlightedCommands = 2;
+
+    public static readonly TimeSpan ToastTimeout = TimeSpan.FromMilliseconds(5000);
 }


### PR DESCRIPTION
## Description

This is the dashboard UI changes from - https://github.com/dotnet/aspire/pull/6625. The server changes in that PR need work, but the dashboard UI stuff can be improved now.

When a command is started a toast is immediately shown. It is open for 5 seconds. When the command is finished the toast is updated to show the result.

Previously if the toast had closed because it ran for more than 5 seconds then the UI wouldn't display the result. This PR improves logic so that if the original toast is still open then it is updated and kept open longer. And if it is closed then a new toast is displayed.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
