### PR TITLE
Consistent language order in dropdown

### DIFF
--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -25,7 +25,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
 
     protected override void OnInitialized()
     {
-        // Order cultures in the dropdown with ordinal culture. This prevents the order of languages changing when the culture changes.
+        // Order cultures in the dropdown with invariant culture. This prevents the order of languages changing when the culture changes.
         _languageOptions = [.. GlobalizationHelpers.LocalizedCultures.OrderBy(c => c.NativeName, StringComparer.InvariantCultureIgnoreCase)];
 
         _selectedUiCulture = GlobalizationHelpers.TryGetKnownParentCulture(_languageOptions, CultureInfo.CurrentUICulture, out var matchedCulture)

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -26,7 +26,7 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
     protected override void OnInitialized()
     {
         // Order cultures in the dropdown with ordinal culture. This prevents the order of languages changing when the culture changes.
-        _languageOptions = [.. GlobalizationHelpers.LocalizedCultures.OrderBy(c => c.NativeName, StringComparer.Ordinal)];
+        _languageOptions = [.. GlobalizationHelpers.LocalizedCultures.OrderBy(c => c.NativeName, StringComparer.InvariantCultureIgnoreCase)];
 
         _selectedUiCulture = GlobalizationHelpers.TryGetKnownParentCulture(_languageOptions, CultureInfo.CurrentUICulture, out var matchedCulture)
             ? matchedCulture :

--- a/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
+++ b/src/Aspire.Dashboard/Components/Dialogs/SettingsDialog.razor.cs
@@ -25,7 +25,8 @@ public partial class SettingsDialog : IDialogContentComponent, IDisposable
 
     protected override void OnInitialized()
     {
-        _languageOptions = [.. GlobalizationHelpers.LocalizedCultures.OrderBy(c => c.NativeName)];
+        // Order cultures in the dropdown with ordinal culture. This prevents the order of languages changing when the culture changes.
+        _languageOptions = [.. GlobalizationHelpers.LocalizedCultures.OrderBy(c => c.NativeName, StringComparer.Ordinal)];
 
         _selectedUiCulture = GlobalizationHelpers.TryGetKnownParentCulture(_languageOptions, CultureInfo.CurrentUICulture, out var matchedCulture)
             ? matchedCulture :


### PR DESCRIPTION
## Description

I noticed the order of languages in the language dropdown changed based on the selected language. We want the order to be consistent here so use the invariant culture to provide a consistent dropdown of values.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6923)