### PR TITLE
Update Npgsql dependency to 9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -116,7 +116,7 @@
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.6" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageVersion Include="NATS.Net" Version="2.5.3" />
-    <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.6" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="9.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLPackageVersion)" />
     <PackageVersion Include="OpenAI" Version="2.1.0-beta.2" />
     <PackageVersion Include="Oracle.EntityFrameworkCore" Version="8.23.60" />
@@ -130,7 +130,7 @@
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />
     <!-- Open Telemetry -->
-    <PackageVersion Include="Npgsql.OpenTelemetry" Version="8.0.6" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="9.0.2" />
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />

--- a/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
+++ b/src/Components/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.csproj
@@ -32,4 +32,10 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
 
+  <!-- Npgsql EF needs to match the same major version as the underlying Npgsql assemblies. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Update="Npgsql.DependencyInjection" VersionOverride="8.0.6" />
+    <PackageReference Update="Npgsql.OpenTelemetry" VersionOverride="8.0.6" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests.csproj
+++ b/tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests/Aspire.Npgsql.EntityFrameworkCore.PostgreSQL.Tests.csproj
@@ -16,4 +16,10 @@
     <PackageReference Include="Testcontainers.PostgreSQL" />
   </ItemGroup>
 
+  <!-- Npgsql EF needs to match the same major version as the underlying Npgsql assemblies. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Npgsql.DependencyInjection" VersionOverride="8.0.6" />
+    <PackageReference Include="Npgsql.OpenTelemetry" VersionOverride="8.0.6" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Shared/WorkloadTesting/BuildEnvironment.cs
+++ b/tests/Shared/WorkloadTesting/BuildEnvironment.cs
@@ -54,16 +54,17 @@ public class BuildEnvironment
     public static BuildEnvironment ForCurrentSdkOnly => s_instance_90.Value;
     public static BuildEnvironment ForCurrentSdkAndPreviousRuntime => s_instance_90_80.Value;
 
-    public static BuildEnvironment ForDefaultFramework { get; } = DefaultTargetFramework switch
-    {
-        TestTargetFramework.Previous => ForPreviousSdkOnly,
+    public static BuildEnvironment ForDefaultFramework =>
+        DefaultTargetFramework switch
+        {
+            TestTargetFramework.Previous => ForPreviousSdkOnly,
 
-        // Use current+previous to allow running tests on helix built with 9.0 sdk
-        // but targeting 8.0 tfm
-        TestTargetFramework.Current => ForCurrentSdkAndPreviousRuntime,
+            // Use current+previous to allow running tests on helix built with 9.0 sdk
+            // but targeting 8.0 tfm
+            TestTargetFramework.Current => ForCurrentSdkAndPreviousRuntime,
 
-        _ => throw new ArgumentOutOfRangeException(nameof(DefaultTargetFramework))
-    };
+            _ => throw new ArgumentOutOfRangeException(nameof(DefaultTargetFramework))
+        };
 
     public BuildEnvironment(bool useSystemDotNet = false, TemplatesCustomHive? templatesCustomHive = default, string sdkDirName = "dotnet-tests")
     {

--- a/tests/testproject/TestProject.IntegrationServiceA/TestProject.IntegrationServiceA.csproj
+++ b/tests/testproject/TestProject.IntegrationServiceA/TestProject.IntegrationServiceA.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -18,6 +18,19 @@
 
   <ItemGroup>
     <PackageReference Include="Polly.Core" />
+
+    <!--
+    Since this project uses both Npgsql and Npgsql.EntityFrameworkCore, we need to ensure they are both the same major version.
+    Aspire.Npgsql uses Npgsql v9, so we need to use Npgsql.EntityFrameworkCore v9 (and target net9.0 as well) to match.
+    -->
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" VersionOverride="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Npgsql supports net8.0 and net9.0, which means we can just update to the latest version and don't need to multi-target or split dependencies.

Fix #6720
Fix #6852
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6946)