### PR TITLE
Update Pomelo MySQL to v9 Preview

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,8 +113,7 @@
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
     <PackageVersion Include="MongoDB.Driver" Version="[2.30.0,3.0.0)" />
     <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
-    <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.6" />
-    <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
+    <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.4.0" />
     <PackageVersion Include="NATS.Net" Version="2.5.3" />
     <PackageVersion Include="Npgsql.DependencyInjection" Version="8.0.6" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(NpgsqlEntityFrameworkCorePostgreSQLPackageVersion)" />
@@ -123,7 +122,7 @@
     <PackageVersion Include="Oracle.ManagedDataAccess.OpenTelemetry" Version="23.6.0" />
     <PackageVersion Include="Polly.Core" Version="8.5.0" />
     <PackageVersion Include="Polly.Extensions" Version="8.5.0" />
-    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.2.efcore.9.0.0" />
     <PackageVersion Include="Qdrant.Client" Version="1.12.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="[6.8.1,7.0.0)" />
     <PackageVersion Include="StackExchange.Redis" Version="2.8.22" />

--- a/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/Aspire.Pomelo.EntityFrameworkCore.MySql.csproj
+++ b/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/Aspire.Pomelo.EntityFrameworkCore.MySql.csproj
@@ -20,9 +20,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
-    <PackageReference Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" VersionOverride="9.0.0" />
+    <PackageReference Include="MySqlConnector.DependencyInjection" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/tests/Aspire.Hosting.MySql.Tests/Aspire.Hosting.MySql.Tests.csproj
+++ b/tests/Aspire.Hosting.MySql.Tests/Aspire.Hosting.MySql.Tests.csproj
@@ -12,4 +12,13 @@
     <ProjectReference Include="..\..\src\Components\Aspire.Pomelo.EntityFrameworkCore.MySql\Aspire.Pomelo.EntityFrameworkCore.MySql.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" VersionOverride="9.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests.csproj
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests.csproj
@@ -20,4 +20,13 @@
     <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" VersionOverride="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" VersionOverride="9.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/EnrichMySqlTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/EnrichMySqlTests.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using MySqlConnector.Logging;
 using OpenTelemetry.Trace;
 using Pomelo.EntityFrameworkCore.MySql.Infrastructure.Internal;
 using Xunit;
@@ -31,12 +30,6 @@ public class EnrichMySqlTests : ConformanceTests
     {
         builder.Services.AddDbContextPool<TestDbContext>((serviceProvider, options) =>
         {
-            // use the legacy method of setting the ILoggerFactory because Pomelo EF Core doesn't use MySqlDataSource
-            if (serviceProvider.GetService<ILoggerFactory>() is { } loggerFactory)
-            {
-                MySqlConnectorLogManager.Provider = new MicrosoftExtensionsLoggingLoggerProvider(loggerFactory);
-            }
-
             options.UseMySql(ConnectionString, DefaultVersion);
         });
         builder.EnrichMySqlDbContext<TestDbContext>(configure);


### PR DESCRIPTION
## Description

This removes use of the legacy global 'MySqlConnectorLogManager.Provider' and uses Microsoft.Extensions.Logging (via MySqlDataSource).

Needed to add VersionOverride for multiple packages due to Microsoft.EntityFrameworkCore.Relational v9.0.0.

Needs MySqlConnector.* 2.4.0 and Pomelo.EntityFrameworkCore.MySql 9.0.0-preview.2.efcore.9.0.0 to be added to approved packages list.

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected; needs to update to RTM version of Pomelo.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No; no changes to existing package functionality.
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/6948)