### PR TITLE
Catch errors when getting from browser storage

### DIFF
--- a/src/Aspire.Dashboard/Model/BrowserStorage/BrowserStorageBase.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/BrowserStorageBase.cs
@@ -5,17 +5,17 @@ using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace Aspire.Dashboard.Model.BrowserStorage;
 
-public abstract class BrowserStorageBase<T> : IBrowserStorage where T : BrowserStorageBase<T>
+public abstract class BrowserStorageBase : IBrowserStorage
 {
     private readonly ProtectedBrowserStorage _protectedBrowserStorage;
 
-    protected BrowserStorageBase(ProtectedBrowserStorage protectedBrowserStorage, ILogger<T> logger)
+    protected BrowserStorageBase(ProtectedBrowserStorage protectedBrowserStorage, ILogger logger)
     {
         _protectedBrowserStorage = protectedBrowserStorage;
         Logger = logger;
     }
 
-    public ILogger<T> Logger { get; }
+    public ILogger Logger { get; }
 
     public async Task<StorageResult<TValue>> GetAsync<TValue>(string key)
     {

--- a/src/Aspire.Dashboard/Model/BrowserStorage/BrowserStorageBase.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/BrowserStorageBase.cs
@@ -5,22 +5,41 @@ using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace Aspire.Dashboard.Model.BrowserStorage;
 
-public abstract class BrowserStorageBase : IBrowserStorage
+public abstract class BrowserStorageBase<T> : IBrowserStorage where T : BrowserStorageBase<T>
 {
     private readonly ProtectedBrowserStorage _protectedBrowserStorage;
 
-    protected BrowserStorageBase(ProtectedBrowserStorage protectedBrowserStorage)
+    protected BrowserStorageBase(ProtectedBrowserStorage protectedBrowserStorage, ILogger<T> logger)
     {
         _protectedBrowserStorage = protectedBrowserStorage;
+        Logger = logger;
     }
 
-    public async Task<StorageResult<T>> GetAsync<T>(string key)
+    public ILogger<T> Logger { get; }
+
+    public async Task<StorageResult<TValue>> GetAsync<TValue>(string key)
     {
-        var result = await _protectedBrowserStorage.GetAsync<T>(key).ConfigureAwait(false);
-        return new StorageResult<T>(result.Success, result.Value);
+        try
+        {
+            // Possible errors here:
+            // - Saved value in storage can't be deserialized to TValue.
+            // - Saved value has a different data protection key than the current one.
+            //   This could happen with values saved to persistent browser and the user upgrades Aspire version, which has a different
+            //   install location and so a different data protection key.
+            //   It could also be caused by standalone dashboard, which creates a new key each run. Leaving the dashboard browser open
+            //   while restarting the container will cause a new data protection key, even with session storage.
+            var result = await _protectedBrowserStorage.GetAsync<TValue>(key).ConfigureAwait(false);
+            return new StorageResult<TValue>(result.Success, result.Value);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Error when reading '{Key}' as {ValueType}.", key, typeof(TValue).Name);
+
+            return new StorageResult<TValue>(false, default);
+        }
     }
 
-    public async Task SetAsync<T>(string key, T value)
+    public async Task SetAsync<TValue>(string key, TValue value)
     {
         await _protectedBrowserStorage.SetAsync(key, value!).ConfigureAwait(false);
     }

--- a/src/Aspire.Dashboard/Model/BrowserStorage/IBrowserStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/IBrowserStorage.cs
@@ -5,6 +5,6 @@ namespace Aspire.Dashboard.Model.BrowserStorage;
 
 public interface IBrowserStorage
 {
-    Task<StorageResult<T>> GetAsync<T>(string key);
-    Task SetAsync<T>(string key, T value);
+    Task<StorageResult<TValue>> GetAsync<TValue>(string key);
+    Task SetAsync<TValue>(string key, TValue value);
 }

--- a/src/Aspire.Dashboard/Model/BrowserStorage/ILocalStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/ILocalStorage.cs
@@ -8,10 +8,10 @@ public interface ILocalStorage : IBrowserStorage
     /// <summary>
     /// Get unprotected data from local storage. This must only be used with non-sensitive data.
     /// </summary>
-    Task<StorageResult<T>> GetUnprotectedAsync<T>(string key);
+    Task<StorageResult<TValue>> GetUnprotectedAsync<TValue>(string key);
 
     /// <summary>
     /// Set unprotected data to local storage. This must only be used with non-sensitive data.
     /// </summary>
-    Task SetUnprotectedAsync<T>(string key, T value);
+    Task SetUnprotectedAsync<TValue>(string key, TValue value);
 }

--- a/src/Aspire.Dashboard/Model/BrowserStorage/LocalBrowserStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/LocalBrowserStorage.cs
@@ -7,7 +7,7 @@ using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Model.BrowserStorage;
 
-public class LocalBrowserStorage : BrowserStorageBase, ILocalStorage
+public class LocalBrowserStorage : BrowserStorageBase<LocalBrowserStorage>, ILocalStorage
 {
     private static readonly JsonSerializerOptions s_options = new()
     {
@@ -16,36 +16,34 @@ public class LocalBrowserStorage : BrowserStorageBase, ILocalStorage
     };
 
     private readonly IJSRuntime _jsRuntime;
-    private readonly ILogger<LocalBrowserStorage> _logger;
 
-    public LocalBrowserStorage(IJSRuntime jsRuntime, ProtectedLocalStorage protectedLocalStorage, ILogger<LocalBrowserStorage> logger) : base(protectedLocalStorage)
+    public LocalBrowserStorage(IJSRuntime jsRuntime, ProtectedLocalStorage protectedLocalStorage, ILogger<LocalBrowserStorage> logger) : base(protectedLocalStorage, logger)
     {
         _jsRuntime = jsRuntime;
-        _logger = logger;
     }
 
-    public async Task<StorageResult<T>> GetUnprotectedAsync<T>(string key)
+    public async Task<StorageResult<TValue>> GetUnprotectedAsync<TValue>(string key)
     {
         var json = await GetJsonAsync(key).ConfigureAwait(false);
 
         if (json == null)
         {
-            return new StorageResult<T>(false, default);
+            return new StorageResult<TValue>(false, default);
         }
 
         try
         {
-            return new StorageResult<T>(true, JsonSerializer.Deserialize<T>(json, s_options));
+            return new StorageResult<TValue>(true, JsonSerializer.Deserialize<TValue>(json, s_options));
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, $"Error when reading '{key}' as {typeof(T).Name} from local browser storage.");
+            Logger.LogWarning(ex, $"Error when reading '{key}' as {typeof(TValue).Name} from local browser storage.");
 
-            return new StorageResult<T>(false, default);
+            return new StorageResult<TValue>(false, default);
         }
     }
 
-    public async Task SetUnprotectedAsync<T>(string key, T value)
+    public async Task SetUnprotectedAsync<TValue>(string key, TValue value)
     {
         var json = JsonSerializer.Serialize(value, s_options);
 

--- a/src/Aspire.Dashboard/Model/BrowserStorage/LocalBrowserStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/LocalBrowserStorage.cs
@@ -7,7 +7,7 @@ using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Model.BrowserStorage;
 
-public class LocalBrowserStorage : BrowserStorageBase<LocalBrowserStorage>, ILocalStorage
+public class LocalBrowserStorage : BrowserStorageBase, ILocalStorage
 {
     private static readonly JsonSerializerOptions s_options = new()
     {

--- a/src/Aspire.Dashboard/Model/BrowserStorage/LocalBrowserStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/LocalBrowserStorage.cs
@@ -37,7 +37,7 @@ public class LocalBrowserStorage : BrowserStorageBase<LocalBrowserStorage>, ILoc
         }
         catch (Exception ex)
         {
-            Logger.LogWarning(ex, $"Error when reading '{key}' as {typeof(TValue).Name} from local browser storage.");
+            Logger.LogWarning(ex, "Error when reading '{Key}' as {ValueType}.", key, typeof(TValue).Name);
 
             return new StorageResult<TValue>(false, default);
         }

--- a/src/Aspire.Dashboard/Model/BrowserStorage/SessionBrowserStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/SessionBrowserStorage.cs
@@ -5,9 +5,9 @@ using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace Aspire.Dashboard.Model.BrowserStorage;
 
-public class SessionBrowserStorage : BrowserStorageBase, ISessionStorage
+public class SessionBrowserStorage : BrowserStorageBase<SessionBrowserStorage>, ISessionStorage
 {
-    public SessionBrowserStorage(ProtectedSessionStorage protectedSessionStorage) : base(protectedSessionStorage)
+    public SessionBrowserStorage(ProtectedSessionStorage protectedSessionStorage, ILogger<SessionBrowserStorage> logger) : base(protectedSessionStorage, logger)
     {
     }
 }

--- a/src/Aspire.Dashboard/Model/BrowserStorage/SessionBrowserStorage.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/SessionBrowserStorage.cs
@@ -5,7 +5,7 @@ using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 namespace Aspire.Dashboard.Model.BrowserStorage;
 
-public class SessionBrowserStorage : BrowserStorageBase<SessionBrowserStorage>, ISessionStorage
+public class SessionBrowserStorage : BrowserStorageBase, ISessionStorage
 {
     public SessionBrowserStorage(ProtectedSessionStorage protectedSessionStorage, ILogger<SessionBrowserStorage> logger) : base(protectedSessionStorage, logger)
     {

--- a/src/Aspire.Dashboard/Model/BrowserStorage/StorageResult.cs
+++ b/src/Aspire.Dashboard/Model/BrowserStorage/StorageResult.cs
@@ -1,6 +1,6 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Aspire.Dashboard.Model.BrowserStorage;
 
-public readonly record struct StorageResult<T>(bool Success, T? Value);
+public readonly record struct StorageResult<TValue>(bool Success, TValue? Value);


### PR DESCRIPTION
## Description

Getting values from session storage can fail if the user upgrades Aspire version, or starts and stops the standalone container, while leaving the browser open. The problem is that session state is preserved (the browser is still open) but the underlying encryption keys have changed. The data's now invalid.

Fix is to ignore errors when getting from session/local storage. In this case the session state is lost, but nothing important is saved there.

Fixes https://github.com/dotnet/aspire/issues/6961

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/7001)