### PR TITLE
Add `DebuggerDisplayAttribute` to `CustomResourceSnapshot` Collections

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -170,7 +170,7 @@ public sealed record UrlSnapshot(string Name, string Url, bool IsInternal);
 /// <param name="Target">The target of the mount.</param>
 /// <param name="MountType">Gets the mount type, such as <see cref="VolumeMountType.Bind"/> or <see cref="VolumeMountType.Volume"/></param>
 /// <param name="IsReadOnly">Whether the volume mount is read-only or not.</param>
-[DebuggerDisplay("{Source}", Name = "{Target}", Type ="{MountType}")]
+[DebuggerDisplay("{Source}", Name = "{Target}")]
 public sealed record VolumeSnapshot(string? Source, string Target, string MountType, bool IsReadOnly);
 
 /// <summary>
@@ -178,7 +178,6 @@ public sealed record VolumeSnapshot(string? Source, string Target, string MountT
 /// </summary>
 /// <param name="ResourceName">The name of the resource the relationship is to.</param>
 /// <param name="Type">The relationship type.</param>
-[DebuggerDisplay("{Type}", Name = "{ResourceName}")]
 public sealed record RelationshipSnapshot(string ResourceName, string Type);
 
 /// <summary>
@@ -226,7 +225,7 @@ public sealed record ResourcePropertySnapshot(string Name, object? Value)
 /// <param name="IconName">The icon name for the command. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons</param>
 /// <param name="IconVariant">The icon variant.</param>
 /// <param name="IsHighlighted">A flag indicating whether the command is highlighted in the UI.</param>
-[DebuggerDisplay(null, Name= "{Name}")]
+[DebuggerDisplay(null, Name = "{Name}")]
 public sealed record ResourceCommandSnapshot(string Name, ResourceCommandState State, string DisplayName, string? DisplayDescription, object? Parameter, string? ConfirmationMessage, string? IconName, IconVariant? IconVariant, bool IsHighlighted);
 
 /// <summary>

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Aspire.Dashboard.Model;
 using Aspire.Hosting.Dcp.Model;
 using HealthStatus = Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus;
@@ -133,6 +134,7 @@ public sealed record CustomResourceSnapshot
 /// </summary>
 /// <param name="Text">The text for the state update. See <see cref="KnownResourceStates"/> for expected values.</param>
 /// <param name="Style">The style for the state update. Use <seealso cref="KnownResourceStateStyles"/> for the supported styles.</param>
+[DebuggerDisplay("{Text}")]
 public sealed record ResourceStateSnapshot(string Text, string? Style)
 {
     /// <summary>
@@ -149,6 +151,7 @@ public sealed record ResourceStateSnapshot(string Text, string? Style)
 /// <param name="Name">The name of the environment variable.</param>
 /// <param name="Value">The value of the environment variable.</param>
 /// <param name="IsFromSpec">Determines if this environment variable was defined in the resource explicitly or computed (for e.g. inherited from the process hierarchy).</param>
+[DebuggerDisplay("{Value}", Name = "{Name}")]
 public sealed record EnvironmentVariableSnapshot(string Name, string? Value, bool IsFromSpec);
 
 /// <summary>
@@ -157,6 +160,7 @@ public sealed record EnvironmentVariableSnapshot(string Name, string? Value, boo
 /// <param name="Name">Name of the url.</param>
 /// <param name="Url">The full uri.</param>
 /// <param name="IsInternal">Determines if this url is internal.</param>
+[DebuggerDisplay("{Url}", Name = "{Name}")]
 public sealed record UrlSnapshot(string Name, string Url, bool IsInternal);
 
 /// <summary>
@@ -166,6 +170,7 @@ public sealed record UrlSnapshot(string Name, string Url, bool IsInternal);
 /// <param name="Target">The target of the mount.</param>
 /// <param name="MountType">Gets the mount type, such as <see cref="VolumeMountType.Bind"/> or <see cref="VolumeMountType.Volume"/></param>
 /// <param name="IsReadOnly">Whether the volume mount is read-only or not.</param>
+[DebuggerDisplay("{Source}", Name = "{Target}", Type ="{MountType}")]
 public sealed record VolumeSnapshot(string? Source, string Target, string MountType, bool IsReadOnly);
 
 /// <summary>
@@ -173,6 +178,7 @@ public sealed record VolumeSnapshot(string? Source, string Target, string MountT
 /// </summary>
 /// <param name="ResourceName">The name of the resource the relationship is to.</param>
 /// <param name="Type">The relationship type.</param>
+[DebuggerDisplay("{Type}", Name = "{ResourceName}")]
 public sealed record RelationshipSnapshot(string ResourceName, string Type);
 
 /// <summary>
@@ -180,6 +186,7 @@ public sealed record RelationshipSnapshot(string ResourceName, string Type);
 /// </summary>
 /// <param name="Name">The name of the property.</param>
 /// <param name="Value">The value of the property.</param>
+[DebuggerDisplay("{Value}", Name = "{Name}")]
 public sealed record ResourcePropertySnapshot(string Name, object? Value)
 {
     /// <summary>
@@ -219,6 +226,7 @@ public sealed record ResourcePropertySnapshot(string Name, object? Value)
 /// <param name="IconName">The icon name for the command. The name should be a valid FluentUI icon name. https://aka.ms/fluentui-system-icons</param>
 /// <param name="IconVariant">The icon variant.</param>
 /// <param name="IsHighlighted">A flag indicating whether the command is highlighted in the UI.</param>
+[DebuggerDisplay(null, Name= "{Name}")]
 public sealed record ResourceCommandSnapshot(string Name, ResourceCommandState State, string DisplayName, string? DisplayDescription, object? Parameter, string? ConfirmationMessage, string? IconName, IconVariant? IconVariant, bool IsHighlighted);
 
 /// <summary>
@@ -228,6 +236,7 @@ public sealed record ResourceCommandSnapshot(string Name, ResourceCommandState S
 /// <param name="Status">The state of the resource, according to the report, or <see langword="null"/> if a health report has not yet been received for this health check.</param>
 /// <param name="Description">An optional description of the report, for display.</param>
 /// <param name="ExceptionText">An optional string containing exception details.</param>
+[DebuggerDisplay("{Status}", Name = "{Name}")]
 public sealed record HealthReportSnapshot(string Name, HealthStatus? Status, string? Description, string? ExceptionText);
 
 /// <summary>


### PR DESCRIPTION
## Description

Adds debugger display attributes to collection types in `CustomResourceSnapshot`.
This makes it easier to view the resource event snapshots in the debugger.

Before:
<img width="1213" alt="before" src="https://github.com/user-attachments/assets/297b0fc1-5136-4fc2-8155-7fda9757a407" />

After:
<img width="1241" alt="after" src="https://github.com/user-attachments/assets/242ec15b-be22-4481-ac3b-7fd0caf4128c" />


The above screenshots were produces with the following code:
```cs
var builder = DistributedApplication.CreateBuilder(args);

var other = builder.AddExecutable("other", "cmd.exe", ".");

var redis = builder.AddRedis("redis")
    .WithDataVolume()
    .WithBindMount("c:\\temp", "/mnt/tmp")
    .WithRelationship(other.Resource, "Relationship Type");

builder.Eventing.Subscribe<ResourceReadyEvent>(redis.Resource, (evt, ct) =>
{
    var _ = Task.Run(async () =>
    {
        await foreach (var resourceEvent in evt.Services.GetRequiredService<ResourceNotificationService>().WatchAsync(ct))
        {
            if (resourceEvent.Resource.Name == "redis")
            {
                // Set Breakpoint Here
            }
        }
    }, ct);

    return Task.CompletedTask;
});

builder.Build().Run();
```

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/7012)