### PR TITLE
Work around warning from InterceptsLocationAttribute

### DIFF
--- a/src/Components/Directory.Build.props
+++ b/src/Components/Directory.Build.props
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <IsAotCompatible>true</IsAotCompatible>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <!-- This is a temporary workaround for https://github.com/dotnet/roslyn/issues/76600. -->
+    <NoWarn>$(NoWarn);CS9270</NoWarn>
 
     <ComponentCommonPackageTags>aspire integration client component cloud</ComponentCommonPackageTags>
     <ComponentCachePackageTags>$(ComponentCommonPackageTags) cache caching</ComponentCachePackageTags>


### PR DESCRIPTION
The 8.0.x version of Microsoft.Extensions.Configuration.Binder is using an old/deprecated approach to the interception feature in Roslyn. Using the latest version of Roslyn produces warnings (which turn into errors in the repo).

Workaround https://github.com/dotnet/roslyn/issues/76641
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/7013)