### PR TITLE
Add MongoDB.Driver v3 client integration package

### DIFF
--- a/Aspire.sln
+++ b/Aspire.sln
@@ -637,6 +637,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceBusWorker", "playgro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceBus.AppHost", "playground\AzureServiceBus\ServiceBus.AppHost\ServiceBus.AppHost.csproj", "{A7EC9111-F3CC-46E8-B95E-3768481D67B4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.MongoDB.Driver.v3", "src\Components\Aspire.MongoDB.Driver.v3\Aspire.MongoDB.Driver.v3.csproj", "{FD53B608-138D-8FB1-AA57-9B8CD42CF13E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.MongoDB.Driver.v3.Tests", "tests\Aspire.MongoDB.Driver.v3.Tests\Aspire.MongoDB.Driver.v3.Tests.csproj", "{223AF8EB-3A4E-E778-4EBD-6E4876C308B6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1667,6 +1671,14 @@ Global
 		{A7EC9111-F3CC-46E8-B95E-3768481D67B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A7EC9111-F3CC-46E8-B95E-3768481D67B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A7EC9111-F3CC-46E8-B95E-3768481D67B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD53B608-138D-8FB1-AA57-9B8CD42CF13E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD53B608-138D-8FB1-AA57-9B8CD42CF13E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD53B608-138D-8FB1-AA57-9B8CD42CF13E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD53B608-138D-8FB1-AA57-9B8CD42CF13E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{223AF8EB-3A4E-E778-4EBD-6E4876C308B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{223AF8EB-3A4E-E778-4EBD-6E4876C308B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{223AF8EB-3A4E-E778-4EBD-6E4876C308B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{223AF8EB-3A4E-E778-4EBD-6E4876C308B6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1973,6 +1985,8 @@ Global
 		{D2938171-1DBB-4E8D-AF16-97F75F1AE6DE} = {D173887B-AF42-4576-B9C1-96B9E9B3D9C0}
 		{162F0B66-E88F-4735-8CE0-BE8950F74CC6} = {D2938171-1DBB-4E8D-AF16-97F75F1AE6DE}
 		{A7EC9111-F3CC-46E8-B95E-3768481D67B4} = {D2938171-1DBB-4E8D-AF16-97F75F1AE6DE}
+		{FD53B608-138D-8FB1-AA57-9B8CD42CF13E} = {27381127-6C45-4B4C-8F18-41FF48DFE4B2}
+		{223AF8EB-3A4E-E778-4EBD-6E4876C308B6} = {C424395C-1235-41A4-BF55-07880A04368C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6DCEDFEC-988E-4CB3-B45B-191EB5086E0C}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
     <PackageVersion Include="AspNetCore.HealthChecks.AzureServiceBus" Version="8.0.1" />
     <PackageVersion Include="AspNetCore.HealthChecks.CosmosDb" Version="8.0.1" />
     <PackageVersion Include="AspNetCore.HealthChecks.Kafka" Version="8.0.1" />
-    <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.MySql" Version="8.0.1" />
     <PackageVersion Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
     <PackageVersion Include="AspNetCore.HealthChecks.Oracle" Version="8.0.1" />
@@ -90,8 +90,8 @@
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.10.3" />
     <PackageVersion Include="Microsoft.FluentUI.AspNetCore.Components.Icons" Version="4.10.3" />
     <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1" />
-    <PackageVersion Include="MongoDB.Driver" Version="[2.30.0,3.0.0)" />
-    <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.1.0" />
+    <PackageVersion Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0" />
     <PackageVersion Include="MySqlConnector.DependencyInjection" Version="2.3.6" />
     <PackageVersion Include="MySqlConnector.Logging.Microsoft.Extensions.Logging" Version="2.1.0" />
     <PackageVersion Include="NATS.Net" Version="2.5.3" />

--- a/playground/mongo/Mongo.ApiService/Mongo.ApiService.csproj
+++ b/playground/mongo/Mongo.ApiService/Mongo.ApiService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AspireProjectOrPackageReference Include="Aspire.MongoDB.Driver" />
+    <AspireProjectOrPackageReference Include="Aspire.MongoDB.Driver.v3" />
 
     <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
   </ItemGroup>

--- a/src/Components/Aspire.MongoDB.Driver.v3/Aspire.MongoDB.Driver.v3.csproj
+++ b/src/Components/Aspire.MongoDB.Driver.v3/Aspire.MongoDB.Driver.v3.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
@@ -6,28 +6,36 @@
     <PackageTags>$(ComponentDatabasePackageTags) MongoDB</PackageTags>
     <PackageIconFullPath>$(SharedDir)MongoDB_300px.png</PackageIconFullPath>
     <Description>A generic MongoDB client that integrates with Aspire.</Description>
-    <!-- MongoDB.Driver.Core.Extensions.DiagnosticSources and AspNetCore.HealthChecks.MongoDb packages are not signed -->
-    <NoWarn>$(NoWarn);CS8002</NoWarn>
-    <DefineConstants>$(DefineConstants);MONGODB_V2</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <MinCodeCoverage>86</MinCodeCoverage>
+    <!-- MongoDB.Driver.Core.Extensions.DiagnosticSources is not signed -->
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
+    <!-- Disable package validation as this package hasn't shipped yet. -->
+    <EnablePackageValidation>false</EnablePackageValidation>
+
+    <!-- Keep the same assembly name as the main library. -->
+    <AssemblyName>Aspire.MongoDB.Driver</AssemblyName>
+    <!-- PackageId defaults to AssemblyName, so need to reset it. -->
+    <PackageId>$(MSBuildProjectName)</PackageId>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Aspire.MongoDB.Driver\AspireMongoDBDriverExtensions.cs" />
+    <Compile Include="..\Aspire.MongoDB.Driver\AssemblyInfo.cs" />
+    <Compile Include="..\Aspire.MongoDB.Driver\MongoDBSettings.cs" />
+    <None Include="..\Aspire.MongoDB.Driver\README.md" Pack="true" PackagePath="\" />
+
     <Compile Include="..\Common\ConfigurationSchemaAttributes.cs" Link="ConfigurationSchemaAttributes.cs" />
     <Compile Include="..\Common\HealthChecksExtensions.cs" Link="HealthChecksExtensions.cs" />
     <Compile Include="..\Common\ConnectionStringValidation.cs" Link="ConnectionStringValidation.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" VersionOverride="[8.1.0,9.0.0)" />
-    <PackageReference Include="MongoDB.Driver" VersionOverride="[2.30.0,3.0.0)" />
+    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" />
+    <PackageReference Include="MongoDB.Driver" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
-    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" VersionOverride="[1.5.0,2.0.0)" />
+    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>
 

--- a/src/Components/Aspire.MongoDB.Driver.v3/ConfigurationSchema.json
+++ b/src/Components/Aspire.MongoDB.Driver.v3/ConfigurationSchema.json
@@ -1,0 +1,63 @@
+{
+  "definitions": {
+    "logLevel": {
+      "properties": {
+        "MongoDB": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "MongoDB.Command": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "MongoDB.Connection": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "MongoDB.Internal": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "MongoDB.SDAM": {
+          "$ref": "#/definitions/logLevelThreshold"
+        },
+        "MongoDB.ServerSelection": {
+          "$ref": "#/definitions/logLevelThreshold"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "Aspire": {
+      "type": "object",
+      "properties": {
+        "MongoDB": {
+          "type": "object",
+          "properties": {
+            "Driver": {
+              "type": "object",
+              "properties": {
+                "ConnectionString": {
+                  "type": "string",
+                  "description": "Gets or sets the connection string of the MongoDB database to connect to."
+                },
+                "DisableHealthChecks": {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the MongoDB health check is disabled or not.",
+                  "default": false
+                },
+                "DisableTracing": {
+                  "type": "boolean",
+                  "description": "Gets or sets a boolean value that indicates whether the OpenTelemetry tracing is disabled or not.",
+                  "default": false
+                },
+                "HealthCheckTimeout": {
+                  "type": "integer",
+                  "description": "Gets or sets a integer value that indicates the MongoDB health check timeout in milliseconds."
+                }
+              },
+              "description": "Provides the client configuration settings for connecting to a MongoDB database using MongoDB driver."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Components/Aspire.MongoDB.Driver.v3/PublicAPI.Shipped.txt
+++ b/src/Components/Aspire.MongoDB.Driver.v3/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Components/Aspire.MongoDB.Driver.v3/PublicAPI.Unshipped.txt
+++ b/src/Components/Aspire.MongoDB.Driver.v3/PublicAPI.Unshipped.txt
@@ -1,0 +1,14 @@
+#nullable enable
+Aspire.MongoDB.Driver.MongoDBSettings
+Aspire.MongoDB.Driver.MongoDBSettings.ConnectionString.get -> string?
+Aspire.MongoDB.Driver.MongoDBSettings.ConnectionString.set -> void
+Aspire.MongoDB.Driver.MongoDBSettings.DisableHealthChecks.get -> bool
+Aspire.MongoDB.Driver.MongoDBSettings.DisableHealthChecks.set -> void
+Aspire.MongoDB.Driver.MongoDBSettings.DisableTracing.get -> bool
+Aspire.MongoDB.Driver.MongoDBSettings.DisableTracing.set -> void
+Aspire.MongoDB.Driver.MongoDBSettings.HealthCheckTimeout.get -> int?
+Aspire.MongoDB.Driver.MongoDBSettings.HealthCheckTimeout.set -> void
+Aspire.MongoDB.Driver.MongoDBSettings.MongoDBSettings() -> void
+Microsoft.Extensions.Hosting.AspireMongoDBDriverExtensions
+static Microsoft.Extensions.Hosting.AspireMongoDBDriverExtensions.AddKeyedMongoDBClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! name, System.Action<Aspire.MongoDB.Driver.MongoDBSettings!>? configureSettings = null, System.Action<MongoDB.Driver.MongoClientSettings!>? configureClientSettings = null) -> void
+static Microsoft.Extensions.Hosting.AspireMongoDBDriverExtensions.AddMongoDBClient(this Microsoft.Extensions.Hosting.IHostApplicationBuilder! builder, string! connectionName, System.Action<Aspire.MongoDB.Driver.MongoDBSettings!>? configureSettings = null, System.Action<MongoDB.Driver.MongoClientSettings!>? configureClientSettings = null) -> void

--- a/src/Components/Aspire.MongoDB.Driver/AspireMongoDBDriverExtensions.cs
+++ b/src/Components/Aspire.MongoDB.Driver/AspireMongoDBDriverExtensions.cs
@@ -169,7 +169,12 @@ public static class AspireMongoDBDriverExtensions
         builder.TryAddHealthCheck(
             healthCheckName,
             healthCheck => healthCheck.AddMongoDb(
+#if MONGODB_V2
                 settings.ConnectionString,
+#else
+                sp => sp.GetRequiredService<IMongoClient>(),
+                _ => MongoUrl.Create(settings.ConnectionString).DatabaseName,
+#endif
                 healthCheckName,
                 null,
                 null,
@@ -194,7 +199,7 @@ public static class AspireMongoDBDriverExtensions
         configureClientSettings?.Invoke(clientSettings);
 
         clientSettings.LoggingSettings ??= new LoggingSettings(serviceProvider.GetService<ILoggerFactory>());
-        
+
         var aspireVersion = typeof(MongoDBSettings).Assembly.GetName().Version?.ToString();
         if (clientSettings.LibraryInfo != null)
         {
@@ -204,7 +209,7 @@ public static class AspireMongoDBDriverExtensions
         {
             clientSettings.LibraryInfo = new LibraryInfo("aspire", aspireVersion);
         }
-        
+
         return new MongoClient(clientSettings);
     }
 

--- a/src/Components/Aspire.MongoDB.Driver/AspireMongoDBDriverExtensions.cs
+++ b/src/Components/Aspire.MongoDB.Driver/AspireMongoDBDriverExtensions.cs
@@ -95,7 +95,8 @@ public static class AspireMongoDBDriverExtensions
 
         builder.AddMongoDatabase(settings.ConnectionString, serviceKey);
         builder.AddHealthCheck(
-            serviceKey is null ? "MongoDB.Driver" : $"MongoDB.Driver_{connectionName}",
+            connectionName,
+            serviceKey,
             settings);
     }
 
@@ -158,7 +159,8 @@ public static class AspireMongoDBDriverExtensions
 
     private static void AddHealthCheck(
         this IHostApplicationBuilder builder,
-        string healthCheckName,
+        string connectionName,
+        object? serviceKey,
         MongoDBSettings settings)
     {
         if (settings.DisableHealthChecks || string.IsNullOrWhiteSpace(settings.ConnectionString))
@@ -166,13 +168,16 @@ public static class AspireMongoDBDriverExtensions
             return;
         }
 
+        var healthCheckName = serviceKey is null ? "MongoDB.Driver" : $"MongoDB.Driver_{connectionName}";
         builder.TryAddHealthCheck(
             healthCheckName,
             healthCheck => healthCheck.AddMongoDb(
 #if MONGODB_V2
                 settings.ConnectionString,
 #else
-                sp => sp.GetRequiredService<IMongoClient>(),
+                serviceKey is null
+                    ? sp => sp.GetRequiredService<IMongoClient>()
+                    : sp => sp.GetRequiredKeyedService<IMongoClient>(serviceKey),
                 _ => MongoUrl.Create(settings.ConnectionString).DatabaseName,
 #endif
                 healthCheckName,

--- a/tests/Aspire.Hosting.MongoDB.Tests/Aspire.Hosting.MongoDB.Tests.csproj
+++ b/tests/Aspire.Hosting.MongoDB.Tests/Aspire.Hosting.MongoDB.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aspire.Hosting.MongoDB\Aspire.Hosting.MongoDB.csproj" />
-    <ProjectReference Include="..\..\src\Components\Aspire.MongoDB.Driver\Aspire.MongoDB.Driver.csproj" />
+    <ProjectReference Include="..\..\src\Components\Aspire.MongoDB.Driver.v3\Aspire.MongoDB.Driver.v3.csproj" />
     <ProjectReference Include="..\Aspire.Hosting.Tests\Aspire.Hosting.Tests.csproj" />
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />

--- a/tests/Aspire.MongoDB.Driver.Tests/Aspire.MongoDB.Driver.Tests.csproj
+++ b/tests/Aspire.MongoDB.Driver.Tests/Aspire.MongoDB.Driver.Tests.csproj
@@ -10,6 +10,10 @@
     <None Include="$(RepoRoot)src\Components\Aspire.MongoDB.Driver\ConfigurationSchema.json" CopyToOutputDirectory="PreserveNewest" />
 
     <ProjectReference Include="..\..\src\Components\Aspire.MongoDB.Driver\Aspire.MongoDB.Driver.csproj" />
+    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" VersionOverride="[8.1.0,9.0.0)" />
+    <PackageReference Include="MongoDB.Driver" VersionOverride="[2.30.0,3.0.0)" />
+    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" VersionOverride="[1.5.0,2.0.0)" />
+
     <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
 
     <PackageReference Include="TestContainers.MongoDb" />

--- a/tests/Aspire.MongoDB.Driver.v3.Tests/Aspire.MongoDB.Driver.v3.Tests.csproj
+++ b/tests/Aspire.MongoDB.Driver.v3.Tests/Aspire.MongoDB.Driver.v3.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(RepoRoot)src\Components\Aspire.MongoDB.Driver\ConfigurationSchema.json" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Include="$(RepoRoot)src\Aspire.Hosting.MongoDB\MongoDBContainerImageTags.cs" />
+
+    <Compile Include="..\Aspire.MongoDB.Driver.Tests\AspireMongoDBDriverExtensionsTests.cs" />
+    <Compile Include="..\Aspire.MongoDB.Driver.Tests\ConformanceTests.cs" />
+    <Compile Include="..\Aspire.MongoDB.Driver.Tests\MongoDbContainerFixture.cs" />
+    <Compile Include="..\Aspire.MongoDB.Driver.Tests\MongoDBDriverPublicApiTests.cs" />
+
+    <ProjectReference Include="..\..\src\Components\Aspire.MongoDB.Driver.v3\Aspire.MongoDB.Driver.v3.csproj" />
+    <ProjectReference Include="..\Aspire.Components.Common.Tests\Aspire.Components.Common.Tests.csproj" />
+
+    <PackageReference Include="TestContainers.MongoDb" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Shared/RepoTesting/Directory.Packages.Helix.props
+++ b/tests/Shared/RepoTesting/Directory.Packages.Helix.props
@@ -63,6 +63,7 @@
     <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Milvus.Client" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.MongoDB.Driver" Version="$(PackageVersion)" />
+    <PackageVersion Include="Aspire.MongoDB.Driver.v3" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.MySqlConnector" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.NATS.Net" Version="$(PackageVersion)" />
     <PackageVersion Include="Aspire.Npgsql" Version="$(PackageVersion)" />


### PR DESCRIPTION
## Description

MongoDB.Driver shipped a version `3.0.0` that has binary breaking changes such that we can't build a single library that can load in both v2.x and v3.x. To continue supporting new versions of MongoDB.Driver, we need to add a new component Aspire.MongoDB.Driver.v3 that will work with the new version of MongoDB.Driver. See #3956 for the strategy to deal with these breaking changes.

Fix #6380

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [x] No
        - Link to aspire-docs issue: https://github.com/dotnet/docs-aspire/issues/2360
