### PR TITLE
Add debugger display to CustomResourceSnapshot

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -12,6 +12,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// An immutable snapshot of the state of a resource.
 /// </summary>
+[DebuggerDisplay("ResourceType = {ResourceType}, State = {State?.Text}, HealthStatus = {HealthStatus?.ToString(),nq}, Properties = {Properties.Length}")]
 public sealed record CustomResourceSnapshot
 {
     private readonly ImmutableArray<HealthReportSnapshot> _healthReports = [];

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -12,7 +12,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// An immutable snapshot of the state of a resource.
 /// </summary>
-[DebuggerDisplay("ResourceType = {ResourceType}, State = {State?.Text}, HealthStatus = {HealthStatus?.ToString(),nq}, Properties = {Properties.Length}")]
+[DebuggerDisplay("ResourceType = {ResourceType,nq}, State = {State?.Text,nq}, HealthStatus = {HealthStatus?.ToString(),nq}, Properties = {Properties.Length}")]
 public sealed record CustomResourceSnapshot
 {
     private readonly ImmutableArray<HealthReportSnapshot> _healthReports = [];


### PR DESCRIPTION
## Description

Follow up to https://github.com/dotnet/aspire/pull/7012. Improves debugger display of the overall `CustomResourceSnapshot`.

Before:
![image](https://github.com/user-attachments/assets/298ea29a-6e7f-477c-92a3-d5106c683501)

After:
![image](https://github.com/user-attachments/assets/d983a873-f972-4da9-98ec-6bac8b1459ef)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
