### PR TITLE
Reset details scroll position

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Utils;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -24,6 +25,9 @@ public partial class ResourceDetails
 
     [Inject]
     public required NavigationManager NavigationManager { get; init; }
+
+    [Inject]
+    public required IJSRuntime JS { get; init; }
 
     private bool IsSpecOnlyToggleDisabled => !Resource.Environment.All(i => !i.FromSpec) && !GetResourceProperties(ordered: false).Any(static vm => vm.KnownProperty is null);
 
@@ -78,6 +82,7 @@ public partial class ResourceDetails
 
     private string _filter = "";
     private bool? _isMaskAllChecked;
+    private bool _dataChanged;
 
     private bool IsMaskAllChecked
     {
@@ -99,6 +104,7 @@ public partial class ResourceDetails
             }
 
             _resource = Resource;
+            _dataChanged = true;
 
             // Collapse details sections when they have no data.
             _isEndpointsExpanded = GetEndpoints().Any();
@@ -119,6 +125,19 @@ public partial class ResourceDetails
                     item.IsValueMasked = !_unmaskedItemNames.Contains(item.Name);
                 }
             }
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_dataChanged)
+        {
+            if (!firstRender)
+            {
+                await JS.InvokeVoidAsync("scrollToTop", ".property-grid-container");
+            }
+
+            _dataChanged = false;
         }
     }
 

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -8,6 +8,7 @@ using Aspire.Dashboard.Otlp.Storage;
 using Aspire.Dashboard.Utils;
 using Microsoft.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -24,6 +25,9 @@ public partial class SpanDetails : IDisposable
 
     [Inject]
     public required TelemetryRepository TelemetryRepository { get; init; }
+
+    [Inject]
+    public required IJSRuntime JS { get; init; }
 
     private IQueryable<TelemetryPropertyViewModel> FilteredItems =>
         ViewModel.Properties.Where(ApplyFilter).AsQueryable();
@@ -50,6 +54,8 @@ public partial class SpanDetails : IDisposable
 
     private string _filter = "";
     private List<TelemetryPropertyViewModel> _contextAttributes = null!;
+    private bool _dataChanged;
+    private SpanDetailsViewModel? _viewModel;
 
     private readonly CancellationTokenSource _cts = new();
 
@@ -61,27 +67,46 @@ public partial class SpanDetails : IDisposable
 
     protected override void OnParametersSet()
     {
-        _contextAttributes =
-        [
-            new TelemetryPropertyViewModel { Name = "Source", Key = KnownSourceFields.NameField, Value = ViewModel.Span.Scope.ScopeName }
-        ];
-        if (!string.IsNullOrEmpty(ViewModel.Span.Scope.Version))
+        if (!ReferenceEquals(ViewModel, _viewModel))
         {
-            _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "Version", Key = KnownSourceFields.VersionField, Value = ViewModel.Span.Scope.Version });
-        }
-        if (!string.IsNullOrEmpty(ViewModel.Span.ParentSpanId))
-        {
-            _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "ParentId", Key = KnownTraceFields.ParentIdField, Value = ViewModel.Span.ParentSpanId });
-        }
-        if (!string.IsNullOrEmpty(ViewModel.Span.TraceId))
-        {
-            _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "TraceId", Key = KnownTraceFields.TraceIdField, Value = ViewModel.Span.TraceId });
-        }
+            _viewModel = ViewModel;
+            _dataChanged = true;
 
-        // Collapse details sections when they have no data.
-        _isSpanEventsExpanded = ViewModel.Span.Events.Any();
-        _isSpanLinksExpanded = ViewModel.Span.Links.Any();
-        _isSpanBacklinksExpanded = ViewModel.Span.BackLinks.Any();
+            _contextAttributes =
+            [
+                new TelemetryPropertyViewModel { Name = "Source", Key = KnownSourceFields.NameField, Value = _viewModel.Span.Scope.ScopeName }
+            ];
+            if (!string.IsNullOrEmpty(_viewModel.Span.Scope.Version))
+            {
+                _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "Version", Key = KnownSourceFields.VersionField, Value = _viewModel.Span.Scope.Version });
+            }
+            if (!string.IsNullOrEmpty(_viewModel.Span.ParentSpanId))
+            {
+                _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "ParentId", Key = KnownTraceFields.ParentIdField, Value = _viewModel.Span.ParentSpanId });
+            }
+            if (!string.IsNullOrEmpty(_viewModel.Span.TraceId))
+            {
+                _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "TraceId", Key = KnownTraceFields.TraceIdField, Value = _viewModel.Span.TraceId });
+            }
+
+            // Collapse details sections when they have no data.
+            _isSpanEventsExpanded = _viewModel.Span.Events.Any();
+            _isSpanLinksExpanded = _viewModel.Span.Links.Any();
+            _isSpanBacklinksExpanded = _viewModel.Span.BackLinks.Any();
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_dataChanged)
+        {
+            if (!firstRender)
+            {
+                await JS.InvokeVoidAsync("scrollToTop", ".property-grid-container");
+            }
+
+            _dataChanged = false;
+        }
     }
 
     public async Task OnViewDetailsAsync(SpanLinkViewModel linkVM)

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -96,14 +96,14 @@ public partial class StructuredLogDetails
         }
     }
 
-    private static void MoveAttributes(List<TelemetryPropertyViewModel> source, List<TelemetryPropertyViewModel> desintation, Func<TelemetryPropertyViewModel, bool> predicate)
+    private static void MoveAttributes(List<TelemetryPropertyViewModel> source, List<TelemetryPropertyViewModel> destination, Func<TelemetryPropertyViewModel, bool> predicate)
     {
-        var insertStart = desintation.Count;
+        var insertStart = destination.Count;
         for (var i = source.Count - 1; i >= 0; i--)
         {
             if (predicate(source[i]))
             {
-                desintation.Insert(insertStart, source[i]);
+                destination.Insert(insertStart, source[i]);
                 source.RemoveAt(i);
             }
         }

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -4,6 +4,7 @@
 using Aspire.Dashboard.Model;
 using Aspire.Dashboard.Model.Otlp;
 using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace Aspire.Dashboard.Components.Controls;
 
@@ -14,6 +15,9 @@ public partial class StructuredLogDetails
 
     [Inject]
     public required BrowserTimeProvider TimeProvider { get; init; }
+
+    [Inject]
+    public required IJSRuntime JS { get; init; }
 
     internal IQueryable<TelemetryPropertyViewModel> FilteredItems =>
         _logEntryAttributes.Where(ApplyFilter).AsQueryable();
@@ -29,6 +33,8 @@ public partial class StructuredLogDetails
             .Where(ApplyFilter).AsQueryable();
 
     private string _filter = "";
+    private bool _dataChanged;
+    private StructureLogsDetailsViewModel? _viewModel;
 
     private List<TelemetryPropertyViewModel> _logEntryAttributes = null!;
     private List<TelemetryPropertyViewModel> _contextAttributes = null!;
@@ -36,39 +42,58 @@ public partial class StructuredLogDetails
 
     protected override void OnParametersSet()
     {
-        // Move some attributes to separate lists, e.g. exception attributes to their own list.
-        // Remaining attributes are displayed along side the message.
-        var attributes = ViewModel.LogEntry.Attributes
-            .Select(a => new TelemetryPropertyViewModel { Name = a.Key, Key = $"unknown-{a.Key}", Value = a.Value })
-            .ToList();
-
-        _contextAttributes =
-        [
-            new TelemetryPropertyViewModel { Name ="Category", Key = KnownStructuredLogFields.CategoryField, Value = ViewModel.LogEntry.Scope.ScopeName }
-        ];
-        MoveAttributes(attributes, _contextAttributes, a => a.Name is "event.name" or "logrecord.event.id" or "logrecord.event.name");
-        if (HasTelemetryBaggage(ViewModel.LogEntry.TraceId))
+        if (!ReferenceEquals(ViewModel, _viewModel))
         {
-            _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "TraceId", Key = KnownStructuredLogFields.TraceIdField, Value = ViewModel.LogEntry.TraceId });
-        }
-        if (HasTelemetryBaggage(ViewModel.LogEntry.SpanId))
-        {
-            _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "SpanId", Key = KnownStructuredLogFields.SpanIdField, Value = ViewModel.LogEntry.SpanId });
-        }
-        if (HasTelemetryBaggage(ViewModel.LogEntry.ParentId))
-        {
-            _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "ParentId", Key = KnownStructuredLogFields.ParentIdField, Value = ViewModel.LogEntry.ParentId });
-        }
+            _viewModel = ViewModel;
+            _dataChanged = true;
 
-        _exceptionAttributes = [];
-        MoveAttributes(attributes, _exceptionAttributes, a => a.Name.StartsWith("exception.", StringComparison.OrdinalIgnoreCase));
+            // Move some attributes to separate lists, e.g. exception attributes to their own list.
+            // Remaining attributes are displayed along side the message.
+            var attributes = _viewModel.LogEntry.Attributes
+                .Select(a => new TelemetryPropertyViewModel { Name = a.Key, Key = $"unknown-{a.Key}", Value = a.Value })
+                .ToList();
 
-        _logEntryAttributes =
-        [
-            new TelemetryPropertyViewModel { Name = "Level", Key = KnownStructuredLogFields.LevelField, Value = ViewModel.LogEntry.Severity.ToString() },
-            new TelemetryPropertyViewModel { Name = "Message", Key = KnownStructuredLogFields.MessageField, Value = ViewModel.LogEntry.Message },
-            .. attributes,
-        ];
+            _contextAttributes =
+            [
+                new TelemetryPropertyViewModel { Name ="Category", Key = KnownStructuredLogFields.CategoryField, Value = _viewModel.LogEntry.Scope.ScopeName }
+            ];
+            MoveAttributes(attributes, _contextAttributes, a => a.Name is "event.name" or "logrecord.event.id" or "logrecord.event.name");
+            if (HasTelemetryBaggage(_viewModel.LogEntry.TraceId))
+            {
+                _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "TraceId", Key = KnownStructuredLogFields.TraceIdField, Value = _viewModel.LogEntry.TraceId });
+            }
+            if (HasTelemetryBaggage(_viewModel.LogEntry.SpanId))
+            {
+                _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "SpanId", Key = KnownStructuredLogFields.SpanIdField, Value = _viewModel.LogEntry.SpanId });
+            }
+            if (HasTelemetryBaggage(_viewModel.LogEntry.ParentId))
+            {
+                _contextAttributes.Add(new TelemetryPropertyViewModel { Name = "ParentId", Key = KnownStructuredLogFields.ParentIdField, Value = _viewModel.LogEntry.ParentId });
+            }
+
+            _exceptionAttributes = [];
+            MoveAttributes(attributes, _exceptionAttributes, a => a.Name.StartsWith("exception.", StringComparison.OrdinalIgnoreCase));
+
+            _logEntryAttributes =
+            [
+                new TelemetryPropertyViewModel { Name = "Level", Key = KnownStructuredLogFields.LevelField, Value = _viewModel.LogEntry.Severity.ToString() },
+                new TelemetryPropertyViewModel { Name = "Message", Key = KnownStructuredLogFields.MessageField, Value = _viewModel.LogEntry.Message },
+                .. attributes,
+            ];
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_dataChanged)
+        {
+            if (!firstRender)
+            {
+                await JS.InvokeVoidAsync("scrollToTop", ".property-grid-container");
+            }
+
+            _dataChanged = false;
+        }
     }
 
     private static void MoveAttributes(List<TelemetryPropertyViewModel> source, List<TelemetryPropertyViewModel> desintation, Func<TelemetryPropertyViewModel, bool> predicate)

--- a/src/Aspire.Dashboard/wwwroot/js/app.js
+++ b/src/Aspire.Dashboard/wwwroot/js/app.js
@@ -340,6 +340,13 @@ window.setCellTextClickHandler = function (id) {
     });
 };
 
+window.scrollToTop = function (selector) {
+    var element = document.querySelector(selector);
+    if (element) {
+        element.scrollTop = 0;
+    }
+};
+
 // taken from https://learn.microsoft.com/en-us/aspnet/core/blazor/file-downloads?view=aspnetcore-8.0#download-from-a-stream
 window.downloadStreamAsFile = async function (fileName, contentStreamReference) {
     const arrayBuffer = await contentStreamReference.arrayBuffer();
@@ -351,4 +358,4 @@ window.downloadStreamAsFile = async function (fileName, contentStreamReference) 
     anchorElement.click();
     anchorElement.remove();
     URL.revokeObjectURL(url);
-}
+};

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -39,6 +39,8 @@ internal static class ResourceSetupHelpers
 
         var keycodeModule = context.JSInterop.SetupModule(GetFluentFile("./_content/Microsoft.FluentUI.AspNetCore.Components/Components/KeyCode/FluentKeyCode.razor.js", version));
         keycodeModule.Setup<string>("RegisterKeyCode", _ => true);
+
+        context.JSInterop.SetupVoid("scrollToTop", _ => true);
     }
 
     private static string GetFluentFile(string filePath, Version version)


### PR DESCRIPTION
## Description

Switching details item while the details view is open (e.g. clicking between resources on resources page) doesn't reset the scroll position. The reason this happens is Blazor rerenders the content of the scroll container, but leaves the container unchanged, preserving scroll position.

The user impact of this bug is if you view a resource's details, scroll down in the details, then click another resource, the other resource is also scrolled. This bug also impacts log and span details.

This PR tracks when the data has changed, and invokes JS to reset the details view scrollbar to the top after render.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
