### PR TITLE
Fix CosmosDb sample endpoint in xml docs

### DIFF
--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/ConfigurationSchema.json
@@ -25,7 +25,7 @@
                     "AccountEndpoint": {
                       "type": "string",
                       "format": "uri",
-                      "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.queue.core.windows.net\"."
+                      "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
                     },
                     "ConnectionString": {
                       "type": "string",

--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/MicrosoftAzureCosmosSettings.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/MicrosoftAzureCosmosSettings.cs
@@ -25,7 +25,7 @@ public sealed class MicrosoftAzureCosmosSettings
 
     /// <summary>
     /// A <see cref="Uri"/> referencing the Azure Cosmos DB Endpoint.
-    /// This is likely to be similar to "https://{account_name}.queue.core.windows.net".
+    /// This is likely to be similar to "https://{account_name}.documents.azure.com".
     /// </summary>
     /// <remarks>
     /// Must not contain shared access signature.

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/ConfigurationSchema.json
@@ -43,7 +43,7 @@
                     "AccountEndpoint": {
                       "type": "string",
                       "format": "uri",
-                      "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.queue.core.windows.net\"."
+                      "description": "A 'System.Uri' referencing the Azure Cosmos DB Endpoint. This is likely to be similar to \"https://{account_name}.documents.azure.com\"."
                     },
                     "ConnectionString": {
                       "type": "string",

--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosSettings.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/EntityFrameworkCoreCosmosSettings.cs
@@ -17,7 +17,7 @@ public sealed class EntityFrameworkCoreCosmosSettings
 
     /// <summary>
     /// A <see cref="Uri"/> referencing the Azure Cosmos DB Endpoint.
-    /// This is likely to be similar to "https://{account_name}.queue.core.windows.net".
+    /// This is likely to be similar to "https://{account_name}.documents.azure.com".
     /// </summary>
     /// <remarks>
     /// Must not contain shared access signature.


### PR DESCRIPTION
## Description

I believe this was taken from storage queues. I followed the patter from https://learn.microsoft.com/en-us/rest/api/cosmos-db/cosmosdb-resource-uri-syntax-for-rest instead.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
