### PR TITLE
Fix Kafka tests to not use dockerhub

### DIFF
--- a/tests/Aspire.Confluent.Kafka.Tests/KafkaContainerFixture.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/KafkaContainerFixture.cs
@@ -4,6 +4,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using Aspire.Components.Common.Tests;
+using Aspire.Hosting;
 using Docker.DotNet.Models;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
@@ -16,7 +17,7 @@ public partial class KafkaContainerFixture : IAsyncLifetime
 {
     private sealed partial class ConfluentLocalKafkaBuilder : ContainerBuilder<ConfluentLocalKafkaBuilder, KafkaContainer, KafkaConfiguration>
     {
-        public const string KafkaImage = Hosting.KafkaContainerImageTags.Image + ":" + Hosting.KafkaContainerImageTags.Tag;
+        public const string KafkaImage = $"{ComponentTestConstants.AspireTestContainerRegistry}/{KafkaContainerImageTags.Image}:{KafkaContainerImageTags.Tag}";
 
         public const ushort KafkaPort = 9092;
 

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelMetricsTests.cs
@@ -69,7 +69,7 @@ public class OtelMetricsTests
             ? host.Services.GetRequiredKeyedService<IProducer<string, string>>(key)
             : host.Services.GetRequiredService<IProducer<string, string>>())
         {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 5; i++)
             {
                 producer.Produce(topic, new Message<string, string>()
                 {

--- a/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
+++ b/tests/Aspire.Confluent.Kafka.Tests/OtelTracesTests.cs
@@ -70,7 +70,7 @@ public class OtelTracesTests
             ? host.Services.GetRequiredKeyedService<IProducer<string, string>>(key)
             : host.Services.GetRequiredService<IProducer<string, string>>())
         {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 5; i++)
             {
                 producer.Produce(topic, new Message<string, string>()
                 {
@@ -83,7 +83,7 @@ public class OtelTracesTests
             await producer.FlushAsync();
         }
 
-        Assert.Equal(100, activities.Where(x => x.OperationName == $"{topic} publish").Count());
+        Assert.Equal(5, activities.Where(x => x.OperationName == $"{topic} publish").Count());
 
         activities.Clear();
 
@@ -112,7 +112,7 @@ public class OtelTracesTests
             }
         }
 
-        Assert.Equal(100, activities.Where(x => x.OperationName == $"{topic} receive").Count());
+        Assert.Equal(5, activities.Where(x => x.OperationName == $"{topic} receive").Count());
 
         await host.StopAsync();
     }


### PR DESCRIPTION
Dockerhub has a rate limit so we can't use it in CI.