### PR TITLE
Add KeycloakRealmResource and AddRealm method

### DIFF
--- a/src/Aspire.Hosting.Keycloak/KeycloakRealmResource.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakRealmResource.cs
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.Keycloak;
+
+/// <summary>
+/// Represents a Keycloak Realm resource.
+/// </summary>
+/// <param name="name">The name of the realm resource.</param>
+/// <param name="realmName">The name of the realm.</param>
+/// <param name="parent">The Keycloak server resource associated with this database.</param>
+public sealed class KeycloakRealmResource(string name, string realmName, KeycloakResource parent) : Resource(name), IResourceWithParent<KeycloakResource>, IResourceWithConnectionString
+{
+    private EndpointReference? _parentEndpoint;
+    private EndpointReference ParentEndpoint => _parentEndpoint ??= new(Parent, "http");
+
+    /// <inheritdoc/>
+    public ReferenceExpression ConnectionStringExpression => ReferenceExpression.Create($"{ParentEndpoint.Property(EndpointProperty.Url)}/realms/{RealmName}/");
+
+    /// <summary>
+    /// Gets the issuer expression for the Keycloak realm.
+    /// </summary>
+    public ReferenceExpression IssuerExpression => ReferenceExpression.Create(
+        $"{ParentEndpoint.Property(EndpointProperty.Url)}/realms/{RealmName}");
+
+    /// <summary>
+    /// Gets or sets the metadata address for the Keycloak realm.
+    /// </summary>
+    public string MetadataAddress { get; set; } = ".well-known/openid-configuration";
+
+    /// <summary>
+    /// Gets the metadata address expression for the Keycloak realm.
+    /// </summary>
+    public ReferenceExpression MetadataAddressExpression => ReferenceExpression.Create($"{ConnectionStringExpression}{MetadataAddress}");
+
+    /// <summary>
+    /// Gets or sets the 'authorization_endpoint' for the Keycloak realm.
+    /// </summary>
+    public string AuthorizationEndpoint { get; set; } = "protocol/openid-connect/auth";
+
+    /// <summary>
+    /// Gets the 'authorization_endpoint' expression for the Keycloak realm.
+    /// </summary>
+    public ReferenceExpression AuthorizationEndpointExpression => ReferenceExpression.Create($"{ConnectionStringExpression}{AuthorizationEndpoint}");
+
+    /// <summary>
+    /// Gets or sets the 'token_endpoint' for the Keycloak realm.
+    /// </summary>
+    public string TokenEndpoint { get; set; } = "protocol/openid-connect/token";
+
+    /// <summary>
+    /// Gets the 'token_endpoint' expression for the Keycloak realm.
+    /// </summary>
+    public ReferenceExpression TokenEndpointExpression => ReferenceExpression.Create($"{ConnectionStringExpression}{TokenEndpoint}");
+
+    /// <summary>
+    /// Gets or sets the 'introspection_endpoint' for the Keycloak realm.
+    /// </summary>
+    public string IntrospectionEndpoint { get; set; } = "protocol/openid-connect/token/introspect";
+
+    /// <summary>
+    /// Gets the 'introspection_endpoint' expression for the Keycloak realm.
+    /// </summary>
+    public ReferenceExpression IntrospectionEndpointExpression => ReferenceExpression.Create($"{ConnectionStringExpression}{IntrospectionEndpoint}");
+
+    /// <summary>
+    /// Gets or sets 'user_info_endpoint' for the Keycloak realm.
+    /// </summary>
+    public string UserInfoEndpoint { get; set; } = "protocol/openid-connect/userinfo";
+
+    /// <summary>
+    /// Gets 'user_info_endpoint' expression for the Keycloak realm.
+    /// </summary>
+    public ReferenceExpression UserInfoEndpointExpression => ReferenceExpression.Create($"{ConnectionStringExpression}{UserInfoEndpoint}");
+
+    /// <summary>
+    /// Gets or sets the 'end_session_endpoint' for the Keycloak realm.
+    /// </summary>
+    public string EndSessionEndpoint { get; set; } = "protocol/openid-connect/logout";
+
+    /// <summary>
+    /// Gets the 'end_session_endpoint' expression for the Keycloak realm.
+    /// </summary>
+    public ReferenceExpression EndSessionEndpointExpression => ReferenceExpression.Create($"{ConnectionStringExpression}{EndSessionEndpoint}");
+
+    /// <summary>
+    /// Gets or sets the 'registration_endpoint' for the Keycloak realm.
+    /// </summary>
+    public string RegistrationEndpoint { get; set; } = "clients-registrations/openid-connect";
+
+    /// <summary>
+    /// Gets the 'registration_endpoint' expression for the Keycloak realm.
+    /// </summary>
+    public ReferenceExpression RegistrationEndpointExpression => ReferenceExpression.Create($"{ConnectionStringExpression}{RegistrationEndpoint}");
+
+    /// <inheritdoc/>
+    public KeycloakResource Parent { get; } = parent;
+
+    /// <summary>
+    /// Gets the name of the realm.
+    /// </summary>
+    public string RealmName { get; } = realmName;
+}

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -181,16 +181,23 @@ public static class KeycloakResourceBuilderExtensions
     /// <param name="builder">The Keycloak server resource builder.</param>
     /// <param name="name">The name of the realm.</param>
     /// <param name="realmName">The name of the realm. If not provided, the resource name will be used.</param>
+    /// <param name="import">The directory containing the realm import files or a single import file.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{KeycloakRealmResource}"/>.</returns>
     public static IResourceBuilder<KeycloakRealmResource> AddRealm(
         this IResourceBuilder<KeycloakResource> builder,
         string name,
-        string? realmName = null)
+        string? realmName = null,
+        string? import = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
         // Use the resource name as the realm name if it's not provided
         realmName ??= name;
+
+        if (import is not null)
+        {
+            builder.WithRealmImport(import);
+        }
 
         var keycloakRealm = new KeycloakRealmResource(name, realmName, builder.Resource);
 

--- a/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Keycloak/KeycloakResourceBuilderExtensions.cs
@@ -174,4 +174,26 @@ public static class KeycloakResourceBuilderExtensions
 
         throw new InvalidOperationException($"The realm import file or directory '{importFullPath}' does not exist.");
     }
+
+    /// <summary>
+    /// Adds a Keycloak Realm to the application model from a <see cref="IResourceBuilder{KeycloakRealmResource}"/>.
+    /// </summary>
+    /// <param name="builder">The Keycloak server resource builder.</param>
+    /// <param name="name">The name of the realm.</param>
+    /// <param name="realmName">The name of the realm. If not provided, the resource name will be used.</param>
+    /// <returns>A reference to the <see cref="IResourceBuilder{KeycloakRealmResource}"/>.</returns>
+    public static IResourceBuilder<KeycloakRealmResource> AddRealm(
+        this IResourceBuilder<KeycloakResource> builder,
+        string name,
+        string? realmName = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Use the resource name as the realm name if it's not provided
+        realmName ??= name;
+
+        var keycloakRealm = new KeycloakRealmResource(name, realmName, builder.Resource);
+
+        return builder.ApplicationBuilder.AddResource(keycloakRealm);
+    }
 }

--- a/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Keycloak.Tests/KeycloakPublicApiTests.cs
@@ -40,6 +40,49 @@ public class KeycloakPublicApiTests
     }
 
     [Fact]
+    public void CtorKeycloakRealmResourceShouldThrowWhenNameIsNull()
+    {
+        string name = null!;
+        var realmName = "realm1";
+        var builder = TestDistributedApplicationBuilder.Create();
+        var adminPassword = builder.AddParameter("Password");
+        var parent = new KeycloakResource("keycloak", default(ParameterResource?), adminPassword.Resource);
+
+        var action = () => new KeycloakRealmResource(name, realmName, parent);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Fact]
+    public void CtorMongoKeycloakRealmResourceShouldThrowWhenRealmNameIsNull()
+    {
+        var name = "keycloak";
+        string realmName = null!;
+        var builder = TestDistributedApplicationBuilder.Create();
+        var adminPassword = builder.AddParameter("Password");
+        var parent = new KeycloakResource("keycloak", default(ParameterResource?), adminPassword.Resource);
+
+        var action = () => new KeycloakRealmResource(name, realmName, parent);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(realmName), exception.ParamName);
+    }
+
+    [Fact]
+    public void CtorMongoKeycloakRealmResourceShouldThrowWhenDatabaseParentIsNull()
+    {
+        var name = "keycloak";
+        var realmName = "realm1";
+        KeycloakResource parent = null!;
+
+        var action = () => new KeycloakRealmResource(name, realmName, parent);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(parent), exception.ParamName);
+    }
+
+    [Fact]
     public void AddKeycloakShouldThrowWhenBuilderIsNull()
     {
         IDistributedApplicationBuilder builder = null!;
@@ -211,5 +254,30 @@ public class KeycloakPublicApiTests
         Assert.Equal($"/opt/keycloak/data/import/{file}", containerAnnotation.Target);
         Assert.Equal(ContainerMountType.BindMount, containerAnnotation.Type);
         Assert.Equal(isReadOnly ?? false, containerAnnotation.IsReadOnly);
+    }
+
+    [Fact]
+    public void AddRealmShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<KeycloakResource> builder = null!;
+        const string name = "realm1";
+
+        var action = () => builder.AddRealm(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddRealmShouldThrowWhenNameIsNull()
+    {
+        var builderResource = TestDistributedApplicationBuilder.Create();
+        var MongoDB = builderResource.AddKeycloak("realm1");
+        string name = null!;
+
+        var action = () => MongoDB.AddRealm(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
     }
 }


### PR DESCRIPTION
## Description

This PR introduces a new `AddRealm` method in the `KeycloakResourceBuilderExtensions` class, enabling the addition of Keycloak Realm resources to the application model. The method constructs a `KeycloakRealmResource` using an `IResourceBuilder<KeycloakResource>`, a realm name, and an optional realm name parameter.

Additionally, a new `KeycloakRealmResource` class is defined, which includes properties for various Keycloak endpoints and their expressions, along with a constructor and detailed XML documentation.

Changes to `PublicAPI.Unshipped.txt` reflect the inclusion of the new method and class in the public API.

Fixes #5092

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [x] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
