### PR TITLE
Remove major version updates to runtime, aspnetcore, and efcore packages from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,13 +23,19 @@ updates:
       # Pinned versions that should not be updated
       - dependency-name: "Microsoft.CodeAnalysis.CSharp"
       # don't update across major versions of NetPlatform dependencies. We need to do that manually
-      - dependency-name: Microsoft.AspNetCore.*
+      - dependency-name: "MicrosoftAspNetCore"
         update-types:
           - version-update:semver-major
-      - dependency-name: Microsoft.EntityFrameworkCore.*
+      - dependency-name: "MicrosoftEntityFrameworkCore*"
         update-types:
           - version-update:semver-major
-      - dependency-name: Microsoft.Extensions.*
+      - dependency-name: "MicrosoftExtensions*"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "Npgsql*"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "System*"
         update-types:
           - version-update:semver-major
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,22 +22,6 @@ updates:
       - dependency-name: "Microsoft.Build.NoTargets"
       # Pinned versions that should not be updated
       - dependency-name: "Microsoft.CodeAnalysis.CSharp"
-      # don't update across major versions of NetPlatform dependencies. We need to do that manually
-      - dependency-name: "MicrosoftAspNetCore"
-        update-types:
-          - version-update:semver-major
-      - dependency-name: "MicrosoftEntityFrameworkCore*"
-        update-types:
-          - version-update:semver-major
-      - dependency-name: "MicrosoftExtensions*"
-        update-types:
-          - version-update:semver-major
-      - dependency-name: "Npgsql*"
-        update-types:
-          - version-update:semver-major
-      - dependency-name: "System*"
-        update-types:
-          - version-update:semver-major
     groups:
       Azure:
         patterns:
@@ -61,9 +45,16 @@ updates:
           - "Microsoft.AspNetCore.*"
           - "Microsoft.EntityFrameworkCore.*"
           - "Microsoft.Extensions.*"
+          - "System.*"
+        update-types:
+          - 'minor'
+          - 'patch'
       Npgsql:
         patterns:
           - "Npgsql.*"
+        update-types:
+          - 'minor'
+          - 'patch'
       MicrosoftDotNet:
         patterns:
           - "Microsoft.DotNet.*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,9 +31,6 @@ updates:
       AspNetCoreHealthChecks:
         patterns:
           - "AspNetCore.HealthChecks.*"
-      EntityFrameworkCore:
-        patterns:
-          - "Microsoft.EntityFrameworkCore.*"
       FluentUi:
         patterns:
           - "Microsoft.FluentUI.*"
@@ -43,10 +40,6 @@ updates:
       Orleans:
         patterns:
           - "Microsoft.Orleans*"
-      NetPlatform:
-        patterns:
-          - "Microsoft.AspNetCore.*"
-          - "Microsoft.Extensions.*"
       Npgsql:
         patterns:
           - "Npgsql.*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,16 @@ updates:
       - dependency-name: "Microsoft.Build.NoTargets"
       # Pinned versions that should not be updated
       - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+      # don't update across major versions of NetPlatform dependencies. We need to do that manually
+      - dependency-name: Microsoft.AspNetCore.*
+        update-types:
+          - version-update:semver-major
+      - dependency-name: Microsoft.EntityFrameworkCore.*
+        update-types:
+          - version-update:semver-major
+      - dependency-name: Microsoft.Extensions.*
+        update-types:
+          - version-update:semver-major
     groups:
       Azure:
         patterns:
@@ -40,6 +50,11 @@ updates:
       Orleans:
         patterns:
           - "Microsoft.Orleans*"
+      NetPlatform:
+        patterns:
+          - "Microsoft.AspNetCore.*"
+          - "Microsoft.EntityFrameworkCore.*"
+          - "Microsoft.Extensions.*"
       Npgsql:
         patterns:
           - "Npgsql.*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,17 @@ updates:
       - dependency-name: "Microsoft.Build.NoTargets"
       # Pinned versions that should not be updated
       - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+      # NetPlatform dependencies shouldn't update across major versions
+      - dependency-name: "Microsoft.AspNetCore.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.EntityFrameworkCore.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "System.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Npgsql.*"
+        update-types: ["version-update:semver-major"]
     groups:
       Azure:
         patterns:


### PR DESCRIPTION
These versions are all split in our dependencies based on TFM, and dependabot doesn't handle that situation well.