### PR TITLE
Fix some issues around port forwarding:

### DIFF
--- a/.devcontainer/contributing/devcontainer.json
+++ b/.devcontainer/contributing/devcontainer.json
@@ -46,7 +46,7 @@
 			],
 			"settings": {
 				"remote.autoForwardPorts": true,
-				"remote.autoForwardPortsSource": "output",
+				"remote.autoForwardPortsSource": "hybrid",
 				"dotnet.defaultSolution": "Aspire.sln"
 			}
 		}

--- a/.devcontainer/contributing/devcontainer.json
+++ b/.devcontainer/contributing/devcontainer.json
@@ -47,6 +47,9 @@
 			"settings": {
 				"remote.autoForwardPorts": true,
 				"remote.autoForwardPortsSource": "hybrid",
+				"remote.otherPortsAttributes": {
+					"onAutoForward": "ignore"
+				},
 				"dotnet.defaultSolution": "Aspire.sln"
 			}
 		}

--- a/.devcontainer/dogfooding-nightly/devcontainer.json
+++ b/.devcontainer/dogfooding-nightly/devcontainer.json
@@ -19,7 +19,10 @@
 			],
 			"settings": {
 				"remote.autoForwardPorts": true,
-				"remote.autoForwardPortsSource": "hybrid"
+				"remote.autoForwardPortsSource": "hybrid",
+				"remote.otherPortsAttributes": {
+					"onAutoForward": "ignore"
+				}
 			}
 		}
 	},

--- a/.devcontainer/dogfooding-nightly/devcontainer.json
+++ b/.devcontainer/dogfooding-nightly/devcontainer.json
@@ -19,7 +19,7 @@
 			],
 			"settings": {
 				"remote.autoForwardPorts": true,
-				"remote.autoForwardPortsSource": "output"
+				"remote.autoForwardPortsSource": "hybrid"
 			}
 		}
 	},

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -254,7 +254,8 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
                 await settingsWriter.SetPortAttributesAsync(
                     firstDashboardUrl.Port,
                     firstDashboardUrl.Scheme,
-                    "aspire-dashboard",
+                    $"aspire-dashboard-{firstDashboardUrl.Scheme}",
+                    openBrowser: true,
                     context.CancellationToken).ConfigureAwait(false);
             }
 

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -257,6 +257,8 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
                     $"aspire-dashboard-{firstDashboardUrl.Scheme}",
                     openBrowser: true,
                     context.CancellationToken).ConfigureAwait(false);
+
+                distributedApplicationLogger.LogInformation("Port forwarding: {Url}", firstDashboardUrl);
             }
 
             distributedApplicationLogger.LogInformation("Now listening on: {DashboardUrl}", dashboardUrl.TrimEnd('/'));

--- a/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
+++ b/src/Aspire.Hosting/Dashboard/DashboardLifecycleHook.cs
@@ -146,12 +146,12 @@ internal sealed class DashboardLifecycleHook(IConfiguration configuration,
             // technically this is too early
             if (StringUtils.TryGetUriFromDelimitedString(dashboardOptions.Value.DashboardUrl, ";", out var firstDashboardUrl))
             {
-                settingsWriter.SetPortAttributesAsync(
+                settingsWriter.AddPortForward(
                                 firstDashboardUrl.ToString(),
                                 firstDashboardUrl.Port,
                                 firstDashboardUrl.Scheme,
                                 $"aspire-dashboard-{firstDashboardUrl.Scheme}",
-                                openBrowser: true).ConfigureAwait(false);
+                                openBrowser: true);
             }
         }
 

--- a/src/Aspire.Hosting/Devcontainers/DevcontainerPortForwardingLifecycleHook.cs
+++ b/src/Aspire.Hosting/Devcontainers/DevcontainerPortForwardingLifecycleHook.cs
@@ -49,12 +49,11 @@ internal sealed class DevcontainerPortForwardingLifecycleHook : IDistributedAppl
                     continue;
                 }
 
-                await _settingsWriter.SetPortAttributesAsync(
+                _settingsWriter.AddPortForward(
                     endpoint.AllocatedEndpoint!.UriString,
                     endpoint.AllocatedEndpoint!.Port,
                     endpoint.UriScheme,
-                    $"{resource.Name}-{endpoint.Name}",
-                    openBrowser: false).ConfigureAwait(false);
+                    $"{resource.Name}-{endpoint.Name}");
             }
         }
 

--- a/src/Aspire.Hosting/Devcontainers/DevcontainerPortForwardingLifecycleHook.cs
+++ b/src/Aspire.Hosting/Devcontainers/DevcontainerPortForwardingLifecycleHook.cs
@@ -66,6 +66,7 @@ internal sealed class DevcontainerPortForwardingLifecycleHook : IDistributedAppl
                     endpoint.AllocatedEndpoint!.Port,
                     endpoint.UriScheme,
                     $"{resource.Name}-{endpoint.Name}",
+                    openBrowser: false,
                     cancellationToken).ConfigureAwait(false);
 
                 _hostingLogger.LogInformation("Port forwarding: {Url}", endpoint.AllocatedEndpoint!.UriString);

--- a/src/Aspire.Hosting/Devcontainers/DevcontainerPortForwardingLifecycleHook.cs
+++ b/src/Aspire.Hosting/Devcontainers/DevcontainerPortForwardingLifecycleHook.cs
@@ -34,15 +34,6 @@ internal sealed class DevcontainerPortForwardingLifecycleHook : IDistributedAppl
 
         foreach (var resource in appModel.Resources)
         {
-            if (resource.Name == KnownResourceNames.AspireDashboard)
-            {
-                // We don't configure the dashboard here because if we print out the URL
-                // the dashboard will launch immediately but it hasn't actually started
-                // which would lead to a poor experience. So we'll let the dashboard
-                // URL writing logic call the helper directly.
-                continue;
-            }
-
             if (resource is not IResourceWithEndpoints resourceWithEndpoints)
             {
                 continue;
@@ -58,19 +49,15 @@ internal sealed class DevcontainerPortForwardingLifecycleHook : IDistributedAppl
                     continue;
                 }
 
-                // TODO: This is inefficient because we are opening the file, parsing it, updating it
-                //       and writing it each time. Its like this for now beause I need to use the logic
-                //       in a few places (here and when we print out the Dashboard URL) - but will need
-                //       to come back and optimize this to support some kind of batching.
                 await _settingsWriter.SetPortAttributesAsync(
+                    endpoint.AllocatedEndpoint!.UriString,
                     endpoint.AllocatedEndpoint!.Port,
                     endpoint.UriScheme,
                     $"{resource.Name}-{endpoint.Name}",
-                    openBrowser: false,
-                    cancellationToken).ConfigureAwait(false);
-
-                _hostingLogger.LogInformation("Port forwarding: {Url}", endpoint.AllocatedEndpoint!.UriString);
+                    openBrowser: false).ConfigureAwait(false);
             }
         }
+
+        await _settingsWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Aspire.Hosting/Devcontainers/DevcontainerSettingsWriter.cs
+++ b/src/Aspire.Hosting/Devcontainers/DevcontainerSettingsWriter.cs
@@ -67,7 +67,7 @@ internal class DevcontainerSettingsWriter(ILogger<DevcontainerSettingsWriter> lo
 
             var settingsContent = await File.ReadAllTextAsync(settingsPath, cancellationToken).ConfigureAwait(false);
             var settings = (JsonObject)JsonObject.Parse(settingsContent)!;
-            
+
             JsonObject? portsAttributes;
             if (!settings.TryGetPropertyValue(PortAttributesFieldName, out var portsAttributesNode))
             {
@@ -90,7 +90,7 @@ internal class DevcontainerSettingsWriter(ILogger<DevcontainerSettingsWriter> lo
             //         }
             //     }
             // }
-            
+
             var portsByLabel = (from props in portsAttributes
                                 let attrs = props.Value as JsonObject
                                 let forwardedPort = props.Key


### PR DESCRIPTION
## Description

- Make sure there aren't duplicate labels when written to settings files

- Mark auto forward action for dashboard as open browser and other endpoints as silent.

- Default to hybrid mode for auto port forward. We want to detect ports from the output, but we also want to tear down the portforward when the process dies.

Fixes #7147
Fixes #7148 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [x] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
