### PR TITLE
Remove extra supplied "--" in AddNpmApp with args

### DIFF
--- a/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
+++ b/src/Aspire.Hosting.NodeJs/NodeExtensions.cs
@@ -56,7 +56,7 @@ public static class NodeAppHostingExtension
         ArgumentNullException.ThrowIfNull(scriptName);
 
         string[] allArgs = args is { Length: > 0 }
-            ? ["run", scriptName, "--", .. args]
+            ? ["run", scriptName, .. args]
             : ["run", scriptName];
 
         workingDirectory = PathNormalizer.NormalizePathForCurrentPlatform(Path.Combine(builder.AppHostDirectory, workingDirectory));

--- a/tests/Aspire.Hosting.NodeJs.Tests/NodeJsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/NodeJsPublicApiTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Aspire.Hosting.Tests.Utils;
 using Xunit;
 
 namespace Aspire.Hosting.NodeJs.Tests;
@@ -100,18 +101,24 @@ public class NodeJsPublicApiTests
     }
 
     [Fact]
-    public void AddNpmAppShouldSetArgsWhenProvided()
+    public async Task AddNpmAppShouldSetArgsWhenProvided()
     {
         var builder = DistributedApplication.CreateBuilder();
         var name = "npmapp";
         var workingDirectory = ".\\app";
         var scriptName = "start";
-        string[] args = ["--port 8080"];
+        string[] args = ["--port", "8080"];
 
-        var npmApp =
-            builder.AddNpmApp(name: name, workingDirectory: workingDirectory, scriptName: scriptName, args: args);
+        var npmApp = builder
+            .AddNpmApp(name: name, workingDirectory: workingDirectory, scriptName: scriptName, args: args);
 
-        Assert.Equal("run start --port 8080", npmApp.Resource.Command);
+        var npmArgs = await ArgumentEvaluator.GetArgumentListAsync(npmApp.Resource);
+
+        Assert.Collection(npmArgs,
+            arg => Assert.Equal("run", arg),
+            arg => Assert.Equal("start", arg),
+            arg => Assert.Equal("--port", arg),
+            arg => Assert.Equal("8080", arg));
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.NodeJs.Tests/NodeJsPublicApiTests.cs
+++ b/tests/Aspire.Hosting.NodeJs.Tests/NodeJsPublicApiTests.cs
@@ -100,6 +100,21 @@ public class NodeJsPublicApiTests
     }
 
     [Fact]
+    public void AddNpmAppShouldSetArgsWhenProvided()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var name = "npmapp";
+        var workingDirectory = ".\\app";
+        var scriptName = "start";
+        string[] args = ["--port 8080"];
+
+        var npmApp =
+            builder.AddNpmApp(name: name, workingDirectory: workingDirectory, scriptName: scriptName, args: args);
+
+        Assert.Equal("run start --port 8080", npmApp.Resource.Command);
+    }
+
+    [Fact]
     public void CtorNodeAppResourceShouldThrowWhenNameIsNull()
     {
         string name = null!;


### PR DESCRIPTION
## Description

Removes the extra '--' in the AddNpmApp method when args are supplied.

Fixes #5934 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
