### PR TITLE
Allow the ResourceReadyEvent to block waiters

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -62,6 +62,11 @@ public sealed record CustomResourceSnapshot
     public int? ExitCode { get; init; }
 
     /// <summary>
+    /// A flag indicating whether the resource ready event has completed.
+    /// </summary>
+    internal bool ResourceCompletedEventFired { get; init; }
+
+    /// <summary>
     /// Gets the health status of the resource.
     /// </summary>
     /// <remarks>

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -64,7 +64,7 @@ public sealed record CustomResourceSnapshot
     /// <summary>
     /// A flag indicating whether the resource ready event has completed.
     /// </summary>
-    internal bool ResourceCompletedEventFired { get; init; }
+    internal Task? ResourceReadyEventTask { get; init; }
 
     /// <summary>
     /// Gets the health status of the resource.

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -62,9 +62,9 @@ public sealed record CustomResourceSnapshot
     public int? ExitCode { get; init; }
 
     /// <summary>
-    /// A flag indicating whether the resource ready event has completed.
+    /// A snapshot of the event that indicates the resource is ready.
     /// </summary>
-    internal Task? ResourceReadyEventTask { get; init; }
+    internal EventSnapshot? ResourceReadyEvent { get; init; }
 
     /// <summary>
     /// Gets the health status of the resource.
@@ -134,6 +134,12 @@ public sealed record CustomResourceSnapshot
                 ?? Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy;
     }
 }
+
+/// <summary>
+/// A snapshot of an event.
+/// </summary>
+/// <param name="EventTask">The task the represents the result of executing the event.</param>
+internal record EventSnapshot(Task EventTask);
 
 /// <summary>
 /// A snapshot of the resource state

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -163,7 +163,10 @@ public class ResourceNotificationService : IDisposable
 
         // Now wait for the resource ready event to be executed.
         resourceLogger.LogInformation("Waiting for resource ready to execute for '{Name}'.", dependency.Name);
-        await WaitForResourceAsync(dependency.Name, re => re.Snapshot.ResourceCompletedEventFired, cancellationToken: cancellationToken).ConfigureAwait(false);
+        resourceEvent = await WaitForResourceAsync(dependency.Name, re => re.Snapshot.ResourceReadyEventTask is { } t && t.IsCompleted, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // Observe the result of the resource ready event task
+        await resourceEvent.Snapshot.ResourceReadyEventTask!.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         resourceLogger.LogInformation("Finished waiting for resource '{Name}'.", dependency.Name);
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -161,6 +161,10 @@ public class ResourceNotificationService : IDisposable
             await WaitForResourceHealthyAsync(dependency.Name, cancellationToken).ConfigureAwait(false);
         }
 
+        // Now wait for the resource ready event to be executed.
+        resourceLogger.LogInformation("Waiting for resource ready to execute for '{Name}'.", dependency.Name);
+        await WaitForResourceAsync(dependency.Name, re => re.Snapshot.ResourceCompletedEventFired, cancellationToken: cancellationToken).ConfigureAwait(false);
+
         resourceLogger.LogInformation("Finished waiting for resource '{Name}'.", dependency.Name);
 
         static bool IsContinuableState(CustomResourceSnapshot snapshot) =>

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -163,10 +163,10 @@ public class ResourceNotificationService : IDisposable
 
         // Now wait for the resource ready event to be executed.
         resourceLogger.LogInformation("Waiting for resource ready to execute for '{Name}'.", dependency.Name);
-        resourceEvent = await WaitForResourceAsync(dependency.Name, re => re.Snapshot.ResourceReadyEventTask is { } t && t.IsCompleted, cancellationToken: cancellationToken).ConfigureAwait(false);
+        resourceEvent = await WaitForResourceAsync(dependency.Name, re => re.Snapshot.ResourceReadyEvent is not null, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         // Observe the result of the resource ready event task
-        await resourceEvent.Snapshot.ResourceReadyEventTask!.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await resourceEvent.Snapshot.ResourceReadyEvent!.EventTask.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         resourceLogger.LogInformation("Finished waiting for resource '{Name}'.", dependency.Name);
 

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -55,11 +55,14 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                 // Execute the publish and store the task so that waiters can await it and observe the result.
                 var task = eventing.PublishAsync(resourceReadyEvent, cancellationToken);
 
+                // Suppress exceptions, we just want to make sure that the event is completed.
+                await task.ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
+
                 await resourceNotificationService.PublishUpdateAsync(resource, s => s with
                 {
-                    ResourceReadyEventTask = task
+                    ResourceReadyEvent = new(task)
                 })
-                    .ConfigureAwait(false);
+                .ConfigureAwait(false);
             },
             cancellationToken);
         }

--- a/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/TestDistributedApplicationBuilder.cs
@@ -108,7 +108,7 @@ public sealed class TestDistributedApplicationBuilder : IDistributedApplicationB
     public TestDistributedApplicationBuilder WithTestAndResourceLogging(ITestOutputHelper testOutputHelper)
     {
         Services.AddXunitLogging(testOutputHelper);
-        Services.AddHostedService<ResourceLoggerForwarderService>();
+        Services.Insert(0, ServiceDescriptor.Singleton<IHostedService, ResourceLoggerForwarderService>());
         Services.AddLogging(builder =>
         {
             builder.AddFilter("Aspire.Hosting", LogLevel.Trace);


### PR DESCRIPTION
## Description

When trying to write code that runs after a resource becomes healthy but before waiters are unblocked it requires complex coordination and a deep understanding of the resource lifecycle. This defaults to blocking waiters until the event is ready, allows users to build pretty nice experiences without complex coordination logic across resources.

Fixes #7164

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [x] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
