### PR TITLE
Rename projectDirectory to appDirectory in AddPythonApp

### DIFF
--- a/src/Aspire.Hosting.Python/PythonAppResource.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResource.cs
@@ -12,9 +12,9 @@ namespace Aspire.Hosting.Python;
 /// </summary>
 /// <param name="name">The name of the resource.</param>
 /// <param name="executablePath">The path to the executable used to run the python app.</param>
-/// <param name="projectDirectory">The path to the directory containing the python app.</param>
-public class PythonAppResource(string name, string executablePath, string projectDirectory)
-    : ExecutableResource(ThrowIfNull(name), ThrowIfNull(executablePath), ThrowIfNull(projectDirectory)), IResourceWithServiceDiscovery
+/// <param name="appDirectory">The path to the directory containing the python app.</param>
+public class PythonAppResource(string name, string executablePath, string appDirectory)
+    : ExecutableResource(ThrowIfNull(name), ThrowIfNull(executablePath), ThrowIfNull(appDirectory)), IResourceWithServiceDiscovery
 {
     private static string ThrowIfNull([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         => argument ?? throw new ArgumentNullException(paramName);

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -71,7 +71,7 @@ public static class PythonAppResourceBuilderExtensions
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/> to add the resource to.</param>
     /// <param name="name">The name of the resource.</param>
     /// <param name="appDirectory">The path to the directory containing the python app files.</param>
-    /// <param name="scriptPath">The path to the script relative to the project directory to run.</param>
+    /// <param name="scriptPath">The path to the script to run, relative to the app directory.</param>
     /// <param name="virtualEnvironmentPath">Path to the virtual environment.</param>
     /// <param name="scriptArgs">The arguments for the script.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
@@ -130,12 +130,12 @@ public static class PythonAppResourceBuilderExtensions
 
         var resourceBuilder = builder.AddResource(resource).WithArgs(context =>
         {
-            // If the project is to be automatically instrumented, add the instrumentation executable arguments first.
+            // If the app is to be automatically instrumented, add the instrumentation executable arguments first.
             if (!string.IsNullOrEmpty(instrumentationExecutable))
             {
                 AddOpenTelemetryArguments(context);
 
-                // Add the python executable as the next argument so we can run the project.
+                // Add the python executable as the next argument so we can run the app.
                 context.Args.Add(pythonExecutable!);
             }
 

--- a/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Python/PythonAppResourceBuilderExtensions.cs
@@ -18,19 +18,19 @@ public static class PythonAppResourceBuilderExtensions
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/> to add the resource to.</param>
     /// <param name="name">The name of the resource.</param>
     /// <param name="appDirectory">The path to the directory containing the python app files.</param>
-    /// <param name="scriptPath">The path to the script relative to the project directory to run.</param>
+    /// <param name="scriptPath">The path to the script relative to the app directory to run.</param>
     /// <param name="scriptArgs">The arguments for the script.</param>
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
     /// <para>
-    /// The virtual environment must be initialized before running the project. By default the virtual environment folder is expected
-    /// to be named <c>.venv</c> and be located in the project directory. If the virtual environment is located in a different directory
+    /// The virtual environment must be initialized before running the app. By default the virtual environment folder is expected
+    /// to be named <c>.venv</c> and be located in the app directory. If the virtual environment is located in a different directory
     /// this default can be specified by using the <see cref="AddPythonApp(IDistributedApplicationBuilder, string, string, string, string, string[])"/>
     /// overload of this method.
     /// </para>
     /// <para>
-    /// The virtual environment is setup individually for each project to allow each project to use a different version of
-    /// Python and dependencies. To setup a virtual environment use the <c>python -m venv .venv</c> command in the project
+    /// The virtual environment is setup individually for each app to allow each app to use a different version of
+    /// Python and dependencies. To setup a virtual environment use the <c>python -m venv .venv</c> command in the app
     /// directory. This will create a virtual environment in the <c>.venv</c> directory.
     /// </para>
     /// <para>
@@ -38,20 +38,20 @@ public static class PythonAppResourceBuilderExtensions
     /// script and then use the <c>pip install -r requirements.txt</c> command to restore dependencies.
     /// </para>
     /// <para>
-    /// To receive traces, logs, and metrics from the python project in the dashboard, the project must be instrumented with OpenTelemetry.
-    /// You can instrument your project by adding the <c>opentelemetry-distro</c>, and <c>opentelemetry-exporter-otlp</c> to
-    /// your Python project.
+    /// To receive traces, logs, and metrics from the python app in the dashboard, the app must be instrumented with OpenTelemetry.
+    /// You can instrument your app by adding the <c>opentelemetry-distro</c>, and <c>opentelemetry-exporter-otlp</c> to
+    /// your Python app.
     /// </para>
     /// <example>
-    /// Add a python app or executable to the application model. In this example the python code entry point is located in the <c>PythonProject</c> directory
+    /// Add a python app or executable to the application model. In this example the python code entry point is located in the <c>PythonApp</c> directory
     /// if this path is relative then it is assumed to be relative to the AppHost directory, and the virtual environment path if relative
-    /// is relative to the project directory. In the example below, if the app host directory is <c>$HOME/repos/MyApp/src/MyApp.AppHost</c> then
-    /// the ProjectPath would be <c>$HOME/repos/MyApp/src/MyApp.AppHost/PythonProject</c> and the virtual environment path (defaulted) would
-    /// be <c>$HOME/repos/MyApp/src/MyApp.AppHost/PythonProject/.venv</c>.
+    /// is relative to the app directory. In the example below, if the app host directory is <c>$HOME/repos/MyApp/src/MyApp.AppHost</c> then
+    /// the AppPath would be <c>$HOME/repos/MyApp/src/MyApp.AppHost/PythonApp</c> and the virtual environment path (defaulted) would
+    /// be <c>$HOME/repos/MyApp/src/MyApp.AppHost/PythonApp/.venv</c>.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
-    /// builder.AddPythonApp("python-project", "PythonProject", "main.py");
+    /// builder.AddPythonApp("python-app", "PythonApp", "main.py");
     ///
     /// builder.Build().Run();
     /// </code>
@@ -77,8 +77,8 @@ public static class PythonAppResourceBuilderExtensions
     /// <returns>A reference to the <see cref="IResourceBuilder{T}"/>.</returns>
     /// <remarks>
     /// <para>
-    /// The virtual environment is setup individually for each project to allow each project to use a different version of
-    /// Python and dependencies. To setup a virtual environment use the <c>python -m venv .venv</c> command in the project
+    /// The virtual environment is setup individually for each app to allow each app to use a different version of
+    /// Python and dependencies. To setup a virtual environment use the <c>python -m venv .venv</c> command in the app
     /// directory. This will create a virtual environment in the <c>.venv</c> directory (where <c>.venv</c> is the name of your
     /// virtual environment directory).
     /// </para>
@@ -87,20 +87,20 @@ public static class PythonAppResourceBuilderExtensions
     /// script and then use the <c>pip install -r requirements.txt</c> command to restore dependencies.
     /// </para>
     /// <para>
-    /// To receive traces, logs, and metrics from the python project in the dashboard, the project must be instrumented with OpenTelemetry.
-    /// You can instrument your project by adding the <c>opentelemetry-distro</c>, and <c>opentelemetry-exporter-otlp</c> to
-    /// your Python project.
+    /// To receive traces, logs, and metrics from the python app in the dashboard, the app must be instrumented with OpenTelemetry.
+    /// You can instrument your app by adding the <c>opentelemetry-distro</c>, and <c>opentelemetry-exporter-otlp</c> to
+    /// your Python app.
     /// </para>
     /// <example>
-    /// Add a python app or executable to the application model. In this example the python code is located in the <c>PythonProject</c> directory
+    /// Add a python app or executable to the application model. In this example the python code is located in the <c>PythonApp</c> directory
     /// if this path is relative then it is assumed to be relative to the AppHost directory, and the virtual environment path if relative
-    /// is relative to the project directory. In the example below, if the app host directory is <c>$HOME/repos/MyApp/src/MyApp.AppHost</c> then
-    /// the ProjectPath would be <c>$HOME/repos/MyApp/src/MyApp.AppHost/PythonProject</c> and the virtual environment path (defaulted) would
-    /// be <c>$HOME/repos/MyApp/src/MyApp.AppHost/PythonProject/.venv</c>.
+    /// is relative to the app directory. In the example below, if the app host directory is <c>$HOME/repos/MyApp/src/MyApp.AppHost</c> then
+    /// the AppPath would be <c>$HOME/repos/MyApp/src/MyApp.AppHost/PythonApp</c> and the virtual environment path (defaulted) would
+    /// be <c>$HOME/repos/MyApp/src/MyApp.AppHost/PythonApp/.venv</c>.
     /// <code lang="csharp">
     /// var builder = DistributedApplication.CreateBuilder(args);
     ///
-    /// builder.AddPythonApp("python-project", "PythonProject", "main.py");
+    /// builder.AddPythonApp("python-app", "PythonApp", "main.py");
     ///
     /// builder.Build().Run();
     /// </code>
@@ -124,9 +124,9 @@ public static class PythonAppResourceBuilderExtensions
 
         var instrumentationExecutable = virtualEnvironment.GetExecutable("opentelemetry-instrument");
         var pythonExecutable = virtualEnvironment.GetRequiredExecutable("python");
-        var projectExecutable = instrumentationExecutable ?? pythonExecutable;
+        var appExecutable = instrumentationExecutable ?? pythonExecutable;
 
-        var resource = new PythonAppResource(name, projectExecutable, appDirectory);
+        var resource = new PythonAppResource(name, appExecutable, appDirectory);
 
         var resourceBuilder = builder.AddResource(resource).WithArgs(context =>
         {

--- a/tests/Aspire.Hosting.Python.Tests/PythonPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Python.Tests/PythonPublicApiTests.cs
@@ -13,9 +13,9 @@ public class PythonPublicApiTests
     {
         string name = null!;
         const string executablePath = "/src/python";
-        const string projectDirectory = "/data/python";
+        const string appDirectory = "/data/python";
 
-        var action = () => new PythonAppResource(name, executablePath, projectDirectory);
+        var action = () => new PythonAppResource(name, executablePath, appDirectory);
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
@@ -26,25 +26,25 @@ public class PythonPublicApiTests
     {
         const string name = "Python";
         string executablePath = null!;
-        const string projectDirectory = "/data/python";
+        const string appDirectory = "/data/python";
 
-        var action = () => new PythonAppResource(name, executablePath, projectDirectory);
+        var action = () => new PythonAppResource(name, executablePath, appDirectory);
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(executablePath), exception.ParamName);
     }
 
     [Fact]
-    public void CtorPythonAppResourceShouldThrowWhenProjectDirectoryIsNull()
+    public void CtorPythonAppResourceShouldThrowWhenAppDirectoryIsNull()
     {
         const string name = "Python";
         const string executablePath = "/src/python";
-        string projectDirectory = null!;
+        string appDirectory = null!;
 
-        var action = () => new PythonAppResource(name, executablePath, projectDirectory);
+        var action = () => new PythonAppResource(name, executablePath, appDirectory);
 
         var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(projectDirectory), exception.ParamName);
+        Assert.Equal(nameof(appDirectory), exception.ParamName);
     }
 
     [Fact]
@@ -52,13 +52,13 @@ public class PythonPublicApiTests
     {
         IDistributedApplicationBuilder builder = null!;
         const string name = "Python";
-        const string projectDirectory = "/src/python";
+        const string appDirectory = "/src/python";
         const string scriptPath = "scripts";
         string[] scriptArgs = ["--traces"];
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             scriptArgs);
 
@@ -71,13 +71,13 @@ public class PythonPublicApiTests
     {
         var builder = TestDistributedApplicationBuilder.Create();
         string name = null!;
-        const string projectDirectory = "/src/python";
+        const string appDirectory = "/src/python";
         const string scriptPath = "scripts";
         string[] scriptArgs = ["--traces"];
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             scriptArgs);
 
@@ -86,22 +86,22 @@ public class PythonPublicApiTests
     }
 
     [Fact]
-    public void AddPythonAppShouldThrowWhenProjectDirectoryIsNull()
+    public void AddPythonAppShouldThrowWhenAppDirectoryIsNull()
     {
         var builder = TestDistributedApplicationBuilder.Create();
         const string name = "Python";
-        string projectDirectory = null!;
+        string appDirectory = null!;
         const string scriptPath = "scripts";
         string[] scriptArgs = ["--traces"];
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             scriptArgs);
 
         var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(projectDirectory), exception.ParamName);
+        Assert.Equal(nameof(appDirectory), exception.ParamName);
     }
 
     [Fact]
@@ -109,13 +109,13 @@ public class PythonPublicApiTests
     {
         var builder = TestDistributedApplicationBuilder.Create();
         const string name = "Python";
-        const string projectDirectory = "/src/python";
+        const string appDirectory = "/src/python";
         string scriptPath = null!;
         string[] scriptArgs = ["--traces"];
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             scriptArgs);
 
@@ -128,13 +128,13 @@ public class PythonPublicApiTests
     {
         var builder = TestDistributedApplicationBuilder.Create();
         const string name = "Python";
-        const string projectDirectory = "/src/python";
+        const string appDirectory = "/src/python";
         const string scriptPath = "scripts";
         string[] scriptArgs = null!;
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             scriptArgs);
 
@@ -147,14 +147,14 @@ public class PythonPublicApiTests
     {
         IDistributedApplicationBuilder builder = null!;
         const string name = "Python";
-        const string projectDirectory = "/src/python";
+        const string appDirectory = "/src/python";
         const string scriptPath = "scripts";
         var virtualEnvironmentPath = ".venv";
         string[] scriptArgs = ["--traces"]; ;
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             virtualEnvironmentPath,
             scriptArgs);
@@ -168,14 +168,14 @@ public class PythonPublicApiTests
     {
         var builder = TestDistributedApplicationBuilder.Create();
         string name = null!;
-        const string projectDirectory = "/src/python";
+        const string appDirectory = "/src/python";
         const string scriptPath = "scripts";
         const string virtualEnvironmentPath = ".venv";
         string[] scriptArgs = ["--traces"]; ;
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             virtualEnvironmentPath,
             scriptArgs);
@@ -185,24 +185,24 @@ public class PythonPublicApiTests
     }
 
     [Fact]
-    public void AddPythonAppWithVirtualEnvironmentPathShouldThrowWhenProjectDirectoryIsNull()
+    public void AddPythonAppWithVirtualEnvironmentPathShouldThrowWhenAppDirectoryIsNull()
     {
         var builder = TestDistributedApplicationBuilder.Create();
         const string name = "Python";
-        string projectDirectory = null!;
+        string appDirectory = null!;
         const string scriptPath = "scripts";
         const string virtualEnvironmentPath = ".venv";
         string[] scriptArgs = ["--traces"]; ;
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             virtualEnvironmentPath,
             scriptArgs);
 
         var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(projectDirectory), exception.ParamName);
+        Assert.Equal(nameof(appDirectory), exception.ParamName);
     }
 
     [Fact]
@@ -210,14 +210,14 @@ public class PythonPublicApiTests
     {
         var builder = TestDistributedApplicationBuilder.Create();
         const string name = "Python";
-        const string projectDirectory = "/src/python";
+        const string appDirectory = "/src/python";
         string scriptPath = null!;
         const string virtualEnvironmentPath = ".venv";
         string[] scriptArgs = ["--traces"]; ;
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             virtualEnvironmentPath,
             scriptArgs);
@@ -231,14 +231,14 @@ public class PythonPublicApiTests
     {
         var builder = TestDistributedApplicationBuilder.Create();
         const string name = "Python";
-        const string projectDirectory = "/src/python";
+        const string appDirectory = "/src/python";
         const string scriptPath = "scripts";
         string virtualEnvironmentPath = null!;
         string[] scriptArgs = ["--traces"]; ;
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             virtualEnvironmentPath,
             scriptArgs);
@@ -252,14 +252,14 @@ public class PythonPublicApiTests
     {
         var builder = TestDistributedApplicationBuilder.Create();
         const string name = "Python";
-        const string projectDirectory = "/src/python";
+        const string appDirectory = "/src/python";
         const string scriptPath = "scripts";
         const string virtualEnvironmentPath = ".venv";
         string[] scriptArgs = null!;
 
         var action = () => builder.AddPythonApp(
             name,
-            projectDirectory,
+            appDirectory,
             scriptPath,
             virtualEnvironmentPath,
             scriptArgs);


### PR DESCRIPTION
## Description

Renames the projectDirectory parameter to appDirectory in AddPythonApp.

Fixes #6242 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
