### PR TITLE
Set EnvironmentCallbackContext.Logger to NullLogger by default

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
+++ b/src/Aspire.Hosting/ApplicationModel/EnvironmentCallbackContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aspire.Hosting.ApplicationModel;
 
@@ -26,7 +27,7 @@ public class EnvironmentCallbackContext(DistributedApplicationExecutionContext e
     /// <summary>
     /// An optional logger to use for logging.
     /// </summary>
-    public ILogger? Logger { get; set; }
+    public ILogger Logger { get; set; } = NullLogger.Instance;
 
     /// <summary>
     /// Gets the execution context associated with this invocation of the AppHost.

--- a/src/Aspire.Hosting/PublicAPI.Shipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Shipped.txt
@@ -142,7 +142,7 @@ Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.CancellationToken.get
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.EnvironmentCallbackContext(Aspire.Hosting.DistributedApplicationExecutionContext! executionContext, System.Collections.Generic.Dictionary<string!, object!>? environmentVariables = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.EnvironmentVariables.get -> System.Collections.Generic.Dictionary<string!, object!>!
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.ExecutionContext.get -> Aspire.Hosting.DistributedApplicationExecutionContext!
-Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.Logger.get -> Microsoft.Extensions.Logging.ILogger?
+Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.Logger.get -> Microsoft.Extensions.Logging.ILogger!
 Aspire.Hosting.ApplicationModel.EnvironmentCallbackContext.Logger.set -> void
 Aspire.Hosting.ApplicationModel.EnvironmentVariableSnapshot
 Aspire.Hosting.ApplicationModel.EnvironmentVariableSnapshot.EnvironmentVariableSnapshot(string! Name, string? Value, bool IsFromSpec) -> void


### PR DESCRIPTION
## Description

Sets `EnvironmentCallbackContext.Logger` to `NullLogger` by default.

Fixes #4517 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
