### PR TITLE
Only reset details scroll position if the viewed item changes

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/ResourceDetails.razor.cs
@@ -99,15 +99,15 @@ public partial class ResourceDetails
     {
         if (!ReferenceEquals(Resource, _resource))
         {
-            // Reset masking when the resource changes.
+            // Reset masking and set data changed flag when the resource changes.
             if (!string.Equals(Resource.Name, _resource?.Name, StringComparisons.ResourceName))
             {
                 _isMaskAllChecked = true;
                 _unmaskedItemNames.Clear();
+                _dataChanged = true;
             }
 
             _resource = Resource;
-            _dataChanged = true;
 
             // Collapse details sections when they have no data.
             _isEndpointsExpanded = GetEndpoints().Any();

--- a/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/SpanDetails.razor.cs
@@ -77,8 +77,13 @@ public partial class SpanDetails : IDisposable
     {
         if (!ReferenceEquals(ViewModel, _viewModel))
         {
+            // Only set data changed flag if the item being view changes.
+            if (!string.Equals(ViewModel.Span.SpanId, _viewModel?.Span.SpanId, StringComparisons.OtlpSpanId))
+            {
+                _dataChanged = true;
+            }
+
             _viewModel = ViewModel;
-            _dataChanged = true;
 
             _contextAttributes =
             [

--- a/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/StructuredLogDetails.razor.cs
@@ -44,8 +44,13 @@ public partial class StructuredLogDetails
     {
         if (!ReferenceEquals(ViewModel, _viewModel))
         {
+            // Only set data changed flag if the item being view changes.
+            if (ViewModel.LogEntry.InternalId != _viewModel?.LogEntry.InternalId)
+            {
+                _dataChanged = true;
+            }
+
             _viewModel = ViewModel;
-            _dataChanged = true;
 
             // Move some attributes to separate lists, e.g. exception attributes to their own list.
             // Remaining attributes are displayed along side the message.


### PR DESCRIPTION
## Description

A bug I noticed while testing other fuctionality:

PR https://github.com/dotnet/aspire/pull/7040 updated the UI to reset details scroll position when changing the viewed item. However, it would also update the scroll position to the top if the viewed item was refreshed, e.g. a resource state changes.

Only reset the scroll position when the viewed item changes.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
