### PR TITLE
Default KeyValue with a missing value to empty string

### DIFF
--- a/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
+++ b/src/Aspire.Dashboard/Otlp/Model/OtlpHelpers.cs
@@ -89,11 +89,19 @@ public static class OtlpHelpers
 
     public static string ToHexString(this ByteString bytes)
     {
+        ArgumentNullException.ThrowIfNull(bytes);
+
         return ToHexString(bytes.Memory);
     }
 
-    public static string GetString(this AnyValue value) =>
-        value.ValueCase switch
+    public static string GetString(this AnyValue? value)
+    {
+        if (value == null)
+        {
+            return string.Empty;
+        }
+
+        return value.ValueCase switch
         {
             AnyValue.ValueOneofCase.StringValue => value.StringValue,
             AnyValue.ValueOneofCase.IntValue => value.IntValue.ToString(CultureInfo.InvariantCulture),
@@ -105,6 +113,7 @@ public static class OtlpHelpers
             AnyValue.ValueOneofCase.None => string.Empty,
             _ => value.ToString(),
         };
+    }
 
     private static JsonNode? ConvertAnyValue(AnyValue value)
     {

--- a/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpHelpersTests.cs
+++ b/tests/Aspire.Dashboard.Tests/TelemetryRepositoryTests/OtlpHelpersTests.cs
@@ -58,6 +58,19 @@ public class OtlpHelpersTests
     }
 
     [Fact]
+    public void GetString_NullValue()
+    {
+        // Arrange
+        AnyValue? anyValue = null;
+
+        // Act
+        var s = anyValue.GetString();
+
+        // Assert
+        Assert.Equal("", s);
+    }
+
+    [Fact]
     public void GetString_ArrayValue()
     {
         // Arrange


### PR DESCRIPTION
## Description

User reported issue:

![image](https://github.com/user-attachments/assets/3dbc6a1b-d260-49c8-b3a2-40d582db2f14)

I think it is caused by the client sending a `KeyValue` attribute without any value. There are a couple of options we could take: error and don't record log entry, don't add attribute, or add attribute with empty string.

I chose to fix by defaulting no value to an empty string.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
