### PR TITLE
Remove app bar item horizontal padding

### DIFF
--- a/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor
+++ b/src/Aspire.Dashboard/Components/Layout/DesktopNavMenu.razor
@@ -4,7 +4,7 @@
 @inject IStringLocalizer<Layout> Loc
 @inject IDashboardClient DashboardClient
 
-<FluentAppBar PopoverShowSearch="false">
+<FluentAppBar PopoverShowSearch="false" Class="desktop-nav-menu">
     @if (DashboardClient.IsEnabled)
     {
         <FluentAppBarItem

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -233,3 +233,11 @@
         margin-left: 0;
     }
 }
+
+::deep .desktop-nav-menu > .fluent-appbar-item {
+    /* FluentAppBarItems have a default width. However, we have a wide range of widths
+       in content depending on the language (ie, from traces to seguimientos) so should allow
+       the app bar to fit its content. This means that the width of the app bar will be different for some
+       languages. */
+    width: unset;
+}

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -234,10 +234,9 @@
     }
 }
 
-::deep .desktop-nav-menu > .fluent-appbar-item {
+::deep .desktop-nav-menu > .fluent-appbar-item > .fluentui-counterbadge-container > a > .stack-vertical {
     /* FluentAppBarItems have a default width. However, we have a wide range of widths
-       in content depending on the language (ie, from traces to seguimientos) so should allow
-       the app bar to fit its content. This means that the width of the app bar will be different for some
-       languages. */
-    width: unset;
+       in content depending on the language (ie, from traces to seguimientos) so remove the default
+       horizontal padding to allow for more text  */
+    padding: calc(var(--design-unit) * 1px) 0;
 }

--- a/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
+++ b/src/Aspire.Dashboard/Components/Layout/MainLayout.razor.css
@@ -236,7 +236,8 @@
 
 ::deep .desktop-nav-menu > .fluent-appbar-item > .fluentui-counterbadge-container > a > .stack-vertical {
     /* FluentAppBarItems have a default width. However, we have a wide range of widths
-       in content depending on the language (ie, from traces to seguimientos) so remove the default
-       horizontal padding to allow for more text  */
-    padding: calc(var(--design-unit) * 1px) 0;
+       in content depending on the language (ie, from traces to seguimientos).
+       Remove the default horizontal padding to allow for more text  */
+    padding-left: 0;
+    padding-right: 0;
 }


### PR DESCRIPTION
## Description

Nav bar items were being cut off due to a default app bar item width. Since there's a wide range of text lengths for these strings based on language, I un-set the width to allow the app bar width to flex to fit content.

**Before**
english:
![image](https://github.com/user-attachments/assets/06bb538f-e2b0-454d-86af-4f1cca014a7b)

spanish:
![image](https://github.com/user-attachments/assets/247fdaee-c960-4a3f-8de2-e8e9e4f32922)


**After**
english (slightly narrower):
![image](https://github.com/user-attachments/assets/c13de23a-f261-432b-85b5-c63aec3fcc4a)

spanish (wider):
![image](https://github.com/user-attachments/assets/986a189a-0eca-4aa0-b882-79e411c66f9a)

There is one extreme (Russian), I'm not sure what to do with this. Maybe setting a max width? @JamesNK 
![image](https://github.com/user-attachments/assets/956cc9fb-a73d-4419-a172-dcb6a4c3d253)


Fixes #6935 

## Checklist

- Is this feature complete?
  - [X] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [X] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [X] No
