### PR TITLE
Add detailed Docker container information to pre/post test run commands

### DIFF
--- a/tests/helix/send-to-helix-inner.proj
+++ b/tests/helix/send-to-helix-inner.proj
@@ -124,8 +124,8 @@
 
   <ItemGroup Condition="'$(HasDocker)' == 'true'">
     <HelixPreCommand Include="docker info" />
-    <HelixPreCommand Include="docker ps" />
     <HelixPreCommand Include="docker container ls --all" />
+    <HelixPreCommand Include="docker container ls --all --format json" />
     <HelixPreCommand Include="$(_ShutdownDockerContainersCommand)" />
     <HelixPreCommand Include="docker volume ls" />
     <HelixPreCommand Include="$(_DeleteDockerVolumesCommand)" />
@@ -133,6 +133,7 @@
     <HelixPreCommand Include="docker network prune -f" />
 
     <HelixPostCommand Include="docker container ls --all" />
+    <HelixPreCommand Include="docker container ls --all --format json" />
     <HelixPostCommand Include="docker volume ls" />
     <HelixPostCommand Include="docker network ls" />
   </ItemGroup>


### PR DESCRIPTION
The detailed info includes network connections in particular, which will help us diagnose lingering "default-aspire-network" networks.

