### PR TITLE
Add snapshot version tracking and improve logging

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -18,6 +18,8 @@ public sealed record CustomResourceSnapshot
     private readonly ImmutableArray<HealthReportSnapshot> _healthReports = [];
     private readonly ResourceStateSnapshot? _state;
 
+    internal long Id { get; set; }
+
     /// <summary>
     /// The type of the resource.
     /// </summary>

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -21,7 +21,7 @@ public sealed record CustomResourceSnapshot
     /// <summary>
     /// Monotonically increasing version number for the snapshot.
     /// </summary>
-    internal long Version { get; set; }
+    internal long Version { get; init; }
 
     /// <summary>
     /// The type of the resource.

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -18,7 +18,10 @@ public sealed record CustomResourceSnapshot
     private readonly ImmutableArray<HealthReportSnapshot> _healthReports = [];
     private readonly ResourceStateSnapshot? _state;
 
-    internal long Id { get; set; }
+    /// <summary>
+    /// Monotonically increasing version number for the snapshot.
+    /// </summary>
+    internal long Version { get; set; }
 
     /// <summary>
     /// The type of the resource.

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -375,7 +375,7 @@ public class ResourceNotificationService : IDisposable
             var newState = stateFactory(previousState);
 
             // Increment the snapshot version, this is a per resource version.
-            newState = newState with { Version = notificationState.LastVersion++ };
+            newState = newState with { Version = notificationState.GetNextVersion() };
 
             newState = UpdateCommands(resource, newState);
 
@@ -570,7 +570,8 @@ public class ResourceNotificationService : IDisposable
     /// </summary>
     private sealed class ResourceNotificationState
     {
-        public long LastVersion { get; set; } = 1;
+        private long _lastVersion = 1;
+        public long GetNextVersion() => _lastVersion++;
         public CustomResourceSnapshot? LastSnapshot { get; set; }
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -23,6 +23,7 @@ public class ResourceNotificationService : IDisposable
     private readonly IServiceProvider _serviceProvider;
     private readonly CancellationTokenSource _disposing = new();
     private readonly ResourceLoggerService _resourceLoggerService;
+    private static int s_id;
 
     private Action<ResourceEvent>? OnResourceUpdated { get; set; }
 
@@ -370,7 +371,7 @@ public class ResourceNotificationService : IDisposable
             var newState = stateFactory(previousState);
 
             // Increment the snapshot id
-            newState = newState with { Id = previousState.Id + 1 };
+            newState = newState with { Id = Interlocked.Increment(ref s_id) };
 
             newState = UpdateCommands(resource, newState);
 

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -340,6 +340,8 @@ public class ResourceNotificationService : IDisposable
                 // Skip events that are older than the max version we have seen so far. This avoids duplicates.
                 if (versionsSeen.TryGetValue((item.Resource, item.ResourceId), out var maxVersionSeen) && item.Snapshot.Version <= maxVersionSeen)
                 {
+                    // We can remove the version from the seen list since we have seen it already.
+                    // We only care about events we have returned to the caller
                     versionsSeen.Remove((item.Resource, item.ResourceId));
                     continue;
                 }


### PR DESCRIPTION
- Introduced a new `Id` property in `CustomResourceSnapshot` for unique identification of snapshots.
- Updated `WatchAsync` to filter resource events based on the maximum snapshot ID.
- Modified `PublishUpdateAsync` to increment the snapshot ID for new states.
- Enhanced logging in `PublishUpdateAsync` to include the new snapshot ID for better traceability.
