### PR TITLE
Support resource restart in ResourceHealthCheckService

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceHealthyEvent.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceHealthyEvent.cs
@@ -11,7 +11,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="resource">The resource that is in a ready state.</param>
 /// <param name="services">The service provider for the app host.</param>
 /// <remarks>
-/// This event is only fired once per resource the first time it transitions to a ready state.
+/// This event is only fired the first time a resource transitions to a ready state after starting.
 /// </remarks>
 public class ResourceReadyEvent(IResource resource, IServiceProvider services) : IDistributedApplicationResourceEvent
 {

--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -437,6 +437,9 @@ public class ResourceNotificationService : IDisposable
                     }},
                     Properties = {{
                     {Properties}
+                    }},
+                    HealthReports = {{
+                    {HealthReports}
                     }}
                     """,
                     newState.Version,
@@ -451,7 +454,8 @@ public class ResourceNotificationService : IDisposable
                     newState.ExitCode,
                     string.Join(", ", newState.Urls.Select(u => $"{u.Name} = {u.Url}")),
                     string.Join(Environment.NewLine, newState.EnvironmentVariables.Select(e => $"{e.Name} = {e.Value}")),
-                    string.Join(Environment.NewLine, newState.Properties.Select(p => $"{p.Name} = {Stringify(p.Value)}")));
+                    string.Join(Environment.NewLine, newState.Properties.Select(p => $"{p.Name} = {Stringify(p.Value)}")),
+                    string.Join(Environment.NewLine, newState.HealthReports.Select(p => $"{p.Name} = {p.Status}")));
 
                 static string Stringify(object? o) => o switch
                 {

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -14,29 +14,75 @@ namespace Aspire.Hosting.Health;
 internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> logger, ResourceNotificationService resourceNotificationService, HealthCheckService healthCheckService, IServiceProvider services, IDistributedApplicationEventing eventing, TimeProvider timeProvider) : BackgroundService
 {
     private readonly Dictionary<string, ResourceEvent> _latestEvents = new();
+    private readonly Dictionary<string, ResourceMonitorState> _resourcesStartedMonitoring = new();
+
+    internal class ResourceMonitorState(CancellationToken serviceStoppingToken)
+    {
+        private readonly CancellationTokenSource _cts = CancellationTokenSource.CreateLinkedTokenSource(serviceStoppingToken);
+
+        public CancellationToken CancellationToken => _cts.Token;
+
+        public void StopResourceMonitor()
+        {
+            _cts.Cancel();
+            _cts.Dispose();
+        }
+    }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var resourcesStartedMonitoring = new HashSet<string>();
-
         try
         {
             var resourceEvents = resourceNotificationService.WatchAsync(stoppingToken);
 
+            // Watch for resource notifications and start and stop health monitoring based on the state of the resource.
             await foreach (var resourceEvent in resourceEvents.ConfigureAwait(false))
             {
-                _latestEvents[resourceEvent.Resource.Name] = resourceEvent;
+                var resourceName = resourceEvent.Resource.Name;
 
-                if (!resourcesStartedMonitoring.Contains(resourceEvent.Resource.Name) && resourceEvent.Snapshot.State?.Text == KnownResourceStates.Running)
+                _latestEvents[resourceName] = resourceEvent;
+
+                if (resourceEvent.Snapshot.State?.Text == KnownResourceStates.Running)
                 {
-                    _ = Task.Run(() => MonitorResourceHealthAsync(resourceEvent, stoppingToken), stoppingToken);
-                    resourcesStartedMonitoring.Add(resourceEvent.Resource.Name);
+                    lock (_resourcesStartedMonitoring)
+                    {
+                        if (!_resourcesStartedMonitoring.TryGetValue(resourceName, out var state))
+                        {
+                            // This is the first time we've seen this resource in a running state, so we need to start monitoring it.
+                            _resourcesStartedMonitoring[resourceName] = state = new ResourceMonitorState(stoppingToken);
+                            _ = Task.Run(() => MonitorResourceHealthAsync(resourceEvent, state.CancellationToken), state.CancellationToken);
+                        }
+                    }
+                }
+                else if (KnownResourceStates.TerminalStates.Contains(resourceEvent.Snapshot.State?.Text))
+                {
+                    lock (_resourcesStartedMonitoring)
+                    {
+                        if (_resourcesStartedMonitoring.TryGetValue(resourceName, out var state))
+                        {
+                            logger.LogDebug("Health monitoring for resource '{Resource}' stopping.", resourceName);
+
+                            // The resource is in a terminal state, so we can stop monitoring it.
+                            state.StopResourceMonitor();
+                            _resourcesStartedMonitoring.Remove(resourceName);
+                        }
+                    }
                 }
             }
         }
         catch (OperationCanceledException)
         {
             // This was expected as the token was canceled
+        }
+    }
+
+    // Internal for testing.
+    internal ResourceMonitorState? GetResourceMonitorState(string resourceName)
+    {
+        lock (_resourcesStartedMonitoring)
+        {
+            _resourcesStartedMonitoring.TryGetValue(resourceName, out var state);
+            return state;
         }
     }
 

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -25,7 +25,6 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
         public void StopResourceMonitor()
         {
             _cts.Cancel();
-            _cts.Dispose();
         }
     }
 


### PR DESCRIPTION
## Description

Changes:

* Health checks are stopped when the resource is in a terminal state, e.g. exited, finished.
* Health checks can be restarted after stopped.
* ResourceReadyEvent is now fired the first time a resource becomes ready after starting. That means restarting a resource and it becoming healthy again causes ResourceReadyEvent to fire again.

Fixes https://github.com/dotnet/aspire/issues/6385
Fixes https://github.com/dotnet/aspire/issues/6450
Fixes https://github.com/dotnet/aspire/issues/7011

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
