### PR TITLE
Add ContainerRuntimeInitializationTimeout to abort startup when container runtime stays unhealthy for too long

### DIFF
--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -159,7 +159,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         var cfg = hostBuilderOptions.Configuration ??= new();
         var additionalConfig = new Dictionary<string, string?>
         {
-            ["DcpPublisher:ContainerRuntimeInitializationTimeout"] = "00:00:10",
+            ["DcpPublisher:ContainerRuntimeInitializationTimeout"] = "00:00:30",
             ["DcpPublisher:RandomizePorts"] = "true",
             ["DcpPublisher:DeleteResourcesOnShutdown"] = "true",
             ["DcpPublisher:ResourceNameSuffix"] = $"{Random.Shared.Next():x}",

--- a/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
+++ b/src/Aspire.Hosting.Testing/DistributedApplicationFactory.cs
@@ -159,6 +159,7 @@ public class DistributedApplicationFactory(Type entryPoint, string[] args) : IDi
         var cfg = hostBuilderOptions.Configuration ??= new();
         var additionalConfig = new Dictionary<string, string?>
         {
+            ["DcpPublisher:ContainerRuntimeInitializationTimeout"] = "00:00:10",
             ["DcpPublisher:RandomizePorts"] = "true",
             ["DcpPublisher:DeleteResourcesOnShutdown"] = "true",
             ["DcpPublisher:ResourceNameSuffix"] = $"{Random.Shared.Next():x}",

--- a/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
@@ -191,7 +191,7 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
             logger.LogDebug("The error from the container runtime check was: {Error}", error);
             if (throwIfUnhealthy)
             {
-                throw new InvalidOperationException($"Container runtime '{containerRuntime}' could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.");
+                throw new DistributedApplicationException($"Container runtime '{containerRuntime}' could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.");
             }
         }
         else if (!running)
@@ -213,13 +213,12 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
                 messageFormat.Append("Ensure that the container runtime is running.");
             }
 
-            var errorMessage = messageFormat.ToString();
-            logger.LogWarning(errorMessage, containerRuntime);
+            logger.LogWarning(messageFormat.ToString(), containerRuntime);
 
             logger.LogDebug("The error from the container runtime check was: {Error}", error);
             if (throwIfUnhealthy)
             {
-                throw new InvalidOperationException(errorMessage.Replace("{Runtime}", containerRuntime));
+                throw new DistributedApplicationException(messageFormat.Replace("{Runtime}", containerRuntime).ToString());
             }
         }
     }

--- a/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
+++ b/src/Aspire.Hosting/Dcp/DcpDependencyCheck.cs
@@ -27,12 +27,12 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
         _dcpOptions = dcpOptions.Value;
     }
 
-    public async Task<DcpInfo?> GetDcpInfoAsync(CancellationToken cancellationToken = default)
+    public async Task<DcpInfo?> GetDcpInfoAsync(bool force = false, CancellationToken cancellationToken = default)
     {
         await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            if (_checkDone)
+            if (_checkDone && !force)
             {
                 return _dcpInfo;
             }
@@ -172,7 +172,7 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
         }
     }
 
-    internal static void CheckDcpInfoAndLogErrors(ILogger logger, DcpOptions options, DcpInfo dcpInfo)
+    internal static void CheckDcpInfoAndLogErrors(ILogger logger, DcpOptions options, DcpInfo dcpInfo, bool throwIfUnhealthy = false)
     {
         var containerRuntime = options.ContainerRuntime;
         if (string.IsNullOrEmpty(containerRuntime))
@@ -186,14 +186,18 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
 
         if (!installed)
         {
-            logger.LogWarning("Container runtime '{runtime}' could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.", containerRuntime);
+            logger.LogWarning("Container runtime '{Runtime}' could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.", containerRuntime);
 
-            logger.LogDebug("The error from the container runtime check was: {error}", error);
+            logger.LogDebug("The error from the container runtime check was: {Error}", error);
+            if (throwIfUnhealthy)
+            {
+                throw new InvalidOperationException($"Container runtime '{containerRuntime}' could not be found. See https://aka.ms/dotnet/aspire/containers for more details on supported container runtimes.");
+            }
         }
         else if (!running)
         {
             var messageFormat = new StringBuilder();
-            messageFormat.Append("Container runtime '{runtime}' was found but appears to be unhealthy. ");
+            messageFormat.Append("Container runtime '{Runtime}' was found but appears to be unhealthy. ");
 
             if (string.Equals(containerRuntime, "docker", StringComparison.OrdinalIgnoreCase))
             {
@@ -209,9 +213,14 @@ internal sealed partial class DcpDependencyCheck : IDcpDependencyCheckService
                 messageFormat.Append("Ensure that the container runtime is running.");
             }
 
-            logger.LogWarning(messageFormat.ToString(), containerRuntime);
+            var errorMessage = messageFormat.ToString();
+            logger.LogWarning(errorMessage, containerRuntime);
 
-            logger.LogDebug("The error from the container runtime check was: {error}", error);
+            logger.LogDebug("The error from the container runtime check was: {Error}", error);
+            if (throwIfUnhealthy)
+            {
+                throw new InvalidOperationException(errorMessage.Replace("{Runtime}", containerRuntime));
+            }
         }
     }
 }

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -129,7 +129,7 @@ internal sealed class DcpExecutor : IDcpExecutor
     {
         AspireEventSource.Instance.DcpModelCreationStart();
 
-        _dcpInfo = await _dcpDependencyCheckService.GetDcpInfoAsync(cancellationToken).ConfigureAwait(false);
+        _dcpInfo = await _dcpDependencyCheckService.GetDcpInfoAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
         Debug.Assert(_dcpInfo is not null, "DCP info should not be null at this point");
 

--- a/src/Aspire.Hosting/Dcp/DcpOptions.cs
+++ b/src/Aspire.Hosting/Dcp/DcpOptions.cs
@@ -69,6 +69,17 @@ internal sealed class DcpOptions
 
     public int KubernetesConfigReadRetryIntervalMilliseconds { get; set; } = 100;
 
+    /// <summary>
+    /// The duration to wait for the container runtime to become healthy before aborting startup.
+    /// </summary>
+    /// <remarks>
+    /// A value of zero, which is the default value, indicates that the application will not wait for the container
+    /// runtime to become healthy.
+    /// If this property has a value greater than zero, the application will abort startup if the container runtime
+    /// does not become healthy within the specified timeout.
+    /// </remarks>
+    public TimeSpan ContainerRuntimeInitializationTimeout { get; set; }
+
     public TimeSpan ServiceStartupWatchTimeout { get; set; } = TimeSpan.FromSeconds(10);
 }
 
@@ -170,6 +181,7 @@ internal class ConfigureDefaultDcpOptions(
 
         options.RandomizePorts = dcpPublisherConfiguration.GetValue(nameof(options.RandomizePorts), options.RandomizePorts);
         options.ServiceStartupWatchTimeout = configuration.GetValue("DOTNET_ASPIRE_SERVICE_STARTUP_WATCH_TIMEOUT", options.ServiceStartupWatchTimeout);
+        options.ContainerRuntimeInitializationTimeout = dcpPublisherConfiguration.GetValue(nameof(options.ContainerRuntimeInitializationTimeout), options.ContainerRuntimeInitializationTimeout);
     }
 
     private static string? GetMetadataValue(IEnumerable<AssemblyMetadataAttribute>? assemblyMetadata, string key)

--- a/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
+++ b/src/Aspire.Hosting/Dcp/IDcpDependencyCheckService.cs
@@ -7,7 +7,7 @@ namespace Aspire.Hosting.Dcp;
 
 internal interface IDcpDependencyCheckService
 {
-    Task<DcpInfo?> GetDcpInfoAsync(CancellationToken cancellationToken = default);
+    Task<DcpInfo?> GetDcpInfoAsync(bool force = false, CancellationToken cancellationToken = default);
 }
 
 internal sealed class DcpInfo

--- a/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/OtlpConfigurationExtensions.cs
@@ -64,7 +64,7 @@ public static class OtlpConfigurationExtensions
 
             // Set the service name and instance id to the resource name and UID. Values are injected by DCP.
             var dcpDependencyCheckService = context.ExecutionContext.ServiceProvider.GetRequiredService<IDcpDependencyCheckService>();
-            var dcpInfo = await dcpDependencyCheckService.GetDcpInfoAsync(context.CancellationToken).ConfigureAwait(false);
+            var dcpInfo = await dcpDependencyCheckService.GetDcpInfoAsync(cancellationToken: context.CancellationToken).ConfigureAwait(false);
             context.EnvironmentVariables["OTEL_RESOURCE_ATTRIBUTES"] = "service.instance.id={{- index .Annotations \"" + CustomResource.OtelServiceInstanceIdAnnotation + "\" -}}";
             context.EnvironmentVariables["OTEL_SERVICE_NAME"] = "{{- index .Annotations \"" + CustomResource.OtelServiceNameAnnotation + "\" -}}";
 

--- a/tests/Aspire.Hosting.Tests/Dcp/TestDcpDependencyCheckService.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/TestDcpDependencyCheckService.cs
@@ -6,7 +6,7 @@ using Aspire.Hosting.Dcp;
 namespace Aspire.Hosting.Tests.Dcp;
 internal sealed class TestDcpDependencyCheckService : IDcpDependencyCheckService
 {
-    public Task<DcpInfo?> GetDcpInfoAsync(CancellationToken cancellationToken = default)
+    public Task<DcpInfo?> GetDcpInfoAsync(bool force = false, CancellationToken cancellationToken = default)
     {
         var dcpInfo = new DcpInfo
         {


### PR DESCRIPTION
## Description

In integration testing scenarios, there is typically no human operator around to monitor the dashboard to observe and fix transient errors such as the container runtime (eg, docker or podman) being unavailable. Currently, tests will hang in these cases. This PR addresses this by adding a new `TimeSpan` property `DcpOptions.ContainerRuntimeInitializationTimeout` (default 10s), accessible by configuring `DcpPublisher:ContainerRuntimeInitializationTimeout`.

Fixes #6790

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
