### PR TITLE
Use BeforeResourceStartedEvent instead of AfterEndpointsAllocatedEvent when scheduling setup before resource creation

### DIFF
--- a/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Kafka/KafkaBuilderExtensions.cs
@@ -110,19 +110,16 @@ public static class KafkaBuilderExtensions
                 .WithHttpEndpoint(targetPort: KafkaUIPort)
                 .ExcludeFromManifest();
 
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(kafkaUi, (e, ct) =>
             {
                 var kafkaResources = builder.ApplicationBuilder.Resources.OfType<KafkaServerResource>();
 
                 int i = 0;
                 foreach (var kafkaResource in kafkaResources)
                 {
-                    if (kafkaResource.InternalEndpoint.IsAllocated)
-                    {
-                        var endpoint = kafkaResource.InternalEndpoint;
-                        int index = i;
-                        kafkaUiBuilder.WithEnvironment(context => ConfigureKafkaUIContainer(context, endpoint, index));
-                    }
+                    var endpoint = kafkaResource.InternalEndpoint;
+                    int index = i;
+                    kafkaUiBuilder.WithEnvironment(context => ConfigureKafkaUIContainer(context, endpoint, index));
 
                     i++;
                 }

--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -112,7 +112,7 @@ public static class MySqlBuilderExtensions
                                                 .WithBindMount(configurationTempFileName, "/etc/phpmyadmin/config.user.inc.php")
                                                 .ExcludeFromManifest();
 
-        builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+        builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(phpMyAdminContainer, (e, ct) =>
         {
             var mySqlInstances = builder.ApplicationBuilder.Resources.OfType<MySqlServerResource>();
 
@@ -125,18 +125,15 @@ public static class MySqlBuilderExtensions
             if (mySqlInstances.Count() == 1)
             {
                 var singleInstance = mySqlInstances.Single();
-                if (singleInstance.PrimaryEndpoint.IsAllocated)
+                var endpoint = singleInstance.PrimaryEndpoint;
+                phpMyAdminContainerBuilder.WithEnvironment(context =>
                 {
-                    var endpoint = singleInstance.PrimaryEndpoint;
-                    phpMyAdminContainerBuilder.WithEnvironment(context =>
-                    {
-                        // PhpMyAdmin assumes MySql is being accessed over a default Aspire container network and hardcodes the resource address
-                        // This will need to be refactored once updated service discovery APIs are available
-                        context.EnvironmentVariables.Add("PMA_HOST", $"{endpoint.Resource.Name}:{endpoint.TargetPort}");
-                        context.EnvironmentVariables.Add("PMA_USER", "root");
-                        context.EnvironmentVariables.Add("PMA_PASSWORD", singleInstance.PasswordParameter.Value);
-                    });
-                }
+                    // PhpMyAdmin assumes MySql is being accessed over a default Aspire container network and hardcodes the resource address
+                    // This will need to be refactored once updated service discovery APIs are available
+                    context.EnvironmentVariables.Add("PMA_HOST", $"{endpoint.Resource.Name}:{endpoint.TargetPort}");
+                    context.EnvironmentVariables.Add("PMA_USER", "root");
+                    context.EnvironmentVariables.Add("PMA_PASSWORD", singleInstance.PasswordParameter.Value);
+                });
             }
             else
             {
@@ -149,20 +146,17 @@ public static class MySqlBuilderExtensions
                 writer.WriteLine();
                 foreach (var mySqlInstance in mySqlInstances)
                 {
-                    if (mySqlInstance.PrimaryEndpoint.IsAllocated)
-                    {
-                        var endpoint = mySqlInstance.PrimaryEndpoint;
-                        writer.WriteLine("$i++;");
-                        // PhpMyAdmin assumes MySql is being accessed over a default Aspire container network and hardcodes the resource address
-                        // This will need to be refactored once updated service discovery APIs are available
-                        writer.WriteLine($"$cfg['Servers'][$i]['host'] = '{endpoint.Resource.Name}:{endpoint.TargetPort}';");
-                        writer.WriteLine($"$cfg['Servers'][$i]['verbose'] = '{mySqlInstance.Name}';");
-                        writer.WriteLine($"$cfg['Servers'][$i]['auth_type'] = 'cookie';");
-                        writer.WriteLine($"$cfg['Servers'][$i]['user'] = 'root';");
-                        writer.WriteLine($"$cfg['Servers'][$i]['password'] = '{mySqlInstance.PasswordParameter.Value}';");
-                        writer.WriteLine($"$cfg['Servers'][$i]['AllowNoPassword'] = true;");
-                        writer.WriteLine();
-                    }
+                    var endpoint = mySqlInstance.PrimaryEndpoint;
+                    writer.WriteLine("$i++;");
+                    // PhpMyAdmin assumes MySql is being accessed over a default Aspire container network and hardcodes the resource address
+                    // This will need to be refactored once updated service discovery APIs are available
+                    writer.WriteLine($"$cfg['Servers'][$i]['host'] = '{endpoint.Resource.Name}:{endpoint.TargetPort}';");
+                    writer.WriteLine($"$cfg['Servers'][$i]['verbose'] = '{mySqlInstance.Name}';");
+                    writer.WriteLine($"$cfg['Servers'][$i]['auth_type'] = 'cookie';");
+                    writer.WriteLine($"$cfg['Servers'][$i]['user'] = 'root';");
+                    writer.WriteLine($"$cfg['Servers'][$i]['password'] = '{mySqlInstance.PasswordParameter.Value}';");
+                    writer.WriteLine($"$cfg['Servers'][$i]['AllowNoPassword'] = true;");
+                    writer.WriteLine();
                 }
                 writer.WriteLine("$cfg['DefaultServer'] = 1;");
                 writer.WriteLine("?>");

--- a/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
+++ b/src/Aspire.Hosting.PostgreSQL/PostgresBuilderExtensions.cs
@@ -155,7 +155,7 @@ public static class PostgresBuilderExtensions
                                                  .WithHttpHealthCheck("/browser")
                                                  .ExcludeFromManifest();
 
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(pgAdminContainer, (e, ct) =>
             {
                 var serverFileMount = pgAdminContainer.Annotations.OfType<ContainerMountAnnotation>().Single(v => v.Target == "/pgadmin4/servers.json");
                 var postgresInstances = builder.ApplicationBuilder.Resources.OfType<PostgresServerResource>();
@@ -177,23 +177,20 @@ public static class PostgresBuilderExtensions
 
                 foreach (var postgresInstance in postgresInstances)
                 {
-                    if (postgresInstance.PrimaryEndpoint.IsAllocated)
-                    {
-                        var endpoint = postgresInstance.PrimaryEndpoint;
+                    var endpoint = postgresInstance.PrimaryEndpoint;
 
-                        writer.WriteStartObject($"{serverIndex}");
-                        writer.WriteString("Name", postgresInstance.Name);
-                        writer.WriteString("Group", "Servers");
-                        // PgAdmin assumes Postgres is being accessed over a default Aspire container network and hardcodes the resource address
-                        // This will need to be refactored once updated service discovery APIs are available
-                        writer.WriteString("Host", endpoint.Resource.Name);
-                        writer.WriteNumber("Port", (int)endpoint.TargetPort!);
-                        writer.WriteString("Username", postgresInstance.UserNameParameter?.Value ?? "postgres");
-                        writer.WriteString("SSLMode", "prefer");
-                        writer.WriteString("MaintenanceDB", "postgres");
-                        writer.WriteString("PasswordExecCommand", $"echo '{postgresInstance.PasswordParameter.Value}'"); // HACK: Generating a pass file and playing around with chmod is too painful.
-                        writer.WriteEndObject();
-                    }
+                    writer.WriteStartObject($"{serverIndex}");
+                    writer.WriteString("Name", postgresInstance.Name);
+                    writer.WriteString("Group", "Servers");
+                    // PgAdmin assumes Postgres is being accessed over a default Aspire container network and hardcodes the resource address
+                    // This will need to be refactored once updated service discovery APIs are available
+                    writer.WriteString("Host", endpoint.Resource.Name);
+                    writer.WriteNumber("Port", (int)endpoint.TargetPort!);
+                    writer.WriteString("Username", postgresInstance.UserNameParameter?.Value ?? "postgres");
+                    writer.WriteString("SSLMode", "prefer");
+                    writer.WriteString("MaintenanceDB", "postgres");
+                    writer.WriteString("PasswordExecCommand", $"echo '{postgresInstance.PasswordParameter.Value}'"); // HACK: Generating a pass file and playing around with chmod is too painful.
+                    writer.WriteEndObject();
 
                     serverIndex++;
                 }
@@ -293,7 +290,7 @@ public static class PostgresBuilderExtensions
 
             pgwebContainerBuilder.WithRelationship(builder.Resource, "PgWeb");
 
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>(async (e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(pgwebContainer, async (e, ct) =>
             {
                 var adminResource = builder.ApplicationBuilder.Resources.OfType<PgWebContainerResource>().Single();
                 var serverFileMount = adminResource.Annotations.OfType<ContainerMountAnnotation>().Single(v => v.Target == "/.pgweb/bookmarks");

--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -95,7 +95,7 @@ public static class RedisBuilderExtensions
                                       .WithHttpEndpoint(targetPort: 8081, name: "http")
                                       .ExcludeFromManifest();
 
-            builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((e, ct) =>
+            builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(resource, (e, ct) =>
             {
                 var redisInstances = builder.ApplicationBuilder.Resources.OfType<RedisResource>();
 
@@ -109,13 +109,10 @@ public static class RedisBuilderExtensions
 
                 foreach (var redisInstance in redisInstances)
                 {
-                    if (redisInstance.PrimaryEndpoint.IsAllocated)
-                    {
-                        // Redis Commander assumes Redis is being accessed over a default Aspire container network and hardcodes the resource address
-                        // This will need to be refactored once updated service discovery APIs are available
-                        var hostString = $"{(hostsVariableBuilder.Length > 0 ? "," : string.Empty)}{redisInstance.Name}:{redisInstance.Name}:{redisInstance.PrimaryEndpoint.TargetPort}:0";
-                        hostsVariableBuilder.Append(hostString);
-                    }
+                    // Redis Commander assumes Redis is being accessed over a default Aspire container network and hardcodes the resource address
+                    // This will need to be refactored once updated service discovery APIs are available
+                    var hostString = $"{(hostsVariableBuilder.Length > 0 ? "," : string.Empty)}{redisInstance.Name}:{redisInstance.Name}:{redisInstance.PrimaryEndpoint.TargetPort}:0";
+                    hostsVariableBuilder.Append(hostString);
                 }
 
                 resourceBuilder.WithEnvironment("REDIS_HOSTS", hostsVariableBuilder.ToString());

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -857,6 +857,7 @@ public static class ResourceBuilderExtensions
 
         var endpoint = builder.Resource.GetEndpoint(endpointName);
 
+        Uri? uri = null;
         builder.ApplicationBuilder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>((@event, ct) =>
         {
             if (!endpoint.Exists)
@@ -869,12 +870,6 @@ public static class ResourceBuilderExtensions
                 throw new DistributedApplicationException($"The endpoint '{endpointName}' on resource '{builder.Resource.Name}' was not using the '{desiredScheme}' scheme.");
             }
 
-            return Task.CompletedTask;
-        });
-
-        Uri? uri = null;
-        builder.ApplicationBuilder.Eventing.Subscribe<BeforeResourceStartedEvent>(builder.Resource, (@event, ct) =>
-        {
             var baseUri = new Uri(endpoint.Url, UriKind.Absolute);
             uri = new Uri(baseUri, path);
             return Task.CompletedTask;

--- a/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
@@ -240,9 +240,9 @@ public class AddMySqlTests
         // Add fake allocated endpoints.
         mysql.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var myAdmin = builder.Resources.Single(r => r.Name.EndsWith("-phpmyadmin"));
+
+        await builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(myAdmin, app.Services));
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(myAdmin, DistributedApplicationOperation.Run, TestServiceProvider.Instance);
 
@@ -281,7 +281,7 @@ public class AddMySqlTests
         using var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+        builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(myAdmin, app.Services));
 
         using var stream = File.OpenRead(volume.Source!);
         var fileContents = new StreamReader(stream).ReadToEnd();

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -465,7 +465,7 @@ public class AddPostgresTests
 
         using var app = builder.Build();
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+        await builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(pgadmin, app.Services));
 
         using var stream = File.OpenRead(volume.Source!);
         var document = JsonDocument.Parse(stream);
@@ -513,7 +513,7 @@ public class AddPostgresTests
         using var app = builder.Build();
         var appModel = app.Services.GetRequiredService<DistributedApplicationModel>();
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
+        await builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(pgadmin, app.Services));
 
         var bookMarkFiles = Directory.GetFiles(volume.Source!).OrderBy(f => f).ToArray();
 

--- a/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/AddRedisTests.cs
@@ -213,9 +213,9 @@ public class AddRedisTests
         // Add fake allocated endpoints.
         redis.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new(app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var commander = builder.Resources.Single(r => r.Name.EndsWith("-commander"));
+
+        await builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(commander, app.Services));
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             commander,
@@ -237,9 +237,9 @@ public class AddRedisTests
         redis1.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5001));
         redis2.WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 5002, "host2"));
 
-        await builder.Eventing.PublishAsync<AfterEndpointsAllocatedEvent>(new (app.Services, app.Services.GetRequiredService<DistributedApplicationModel>()));
-
         var commander = builder.Resources.Single(r => r.Name.EndsWith("-commander"));
+
+        await builder.Eventing.PublishAsync<BeforeResourceStartedEvent>(new(commander, app.Services));
 
         var config = await EnvironmentVariableEvaluator.GetEnvironmentVariablesAsync(
             commander,


### PR DESCRIPTION
## Description

We're using the `AfterEndpointsAllocatedEvent` in several places as a callback to do setup before resources are created. While it's true that historically `AfterEndpointsAllocatedEvent` has always been triggered before resources are created, that's mainly due to a limitation in the endpoints model (we don't currently support dynamically allocated host ports for un-proxied container endpoints).

The appropriate event to schedule additional model configuration before a resource is created is `BeforeResourceStartedEvent` which is sent just before the resource is created.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
