### PR TITLE
Change CosmosDB Entra Auth to use data plane roles

### DIFF
--- a/playground/AzureContainerApps/AzureContainerApps.AppHost/account.module.bicep
+++ b/playground/AzureContainerApps/AzureContainerApps.AppHost/account.module.bicep
@@ -38,14 +38,19 @@ resource db 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
   parent: account
 }
 
-resource account_DocumentDBAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(account.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450'))
+resource account_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-08-15' existing = {
+  name: '00000000-0000-0000-0000-000000000002'
+  parent: account
+}
+
+resource account_roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-08-15' = {
+  name: guid(principalId, account_roleDefinition.id, account.id)
   properties: {
     principalId: principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450')
-    principalType: principalType
+    roleDefinitionId: account_roleDefinition.id
+    scope: account.id
   }
-  scope: account
+  parent: account
 }
 
 output connectionString string = account.properties.documentEndpoint

--- a/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
+++ b/playground/CosmosEndToEnd/CosmosEndToEnd.AppHost/cosmos.module.bicep
@@ -54,14 +54,19 @@ resource entries 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@
   parent: db
 }
 
-resource cosmos_DocumentDBAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(cosmos.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450'))
+resource cosmos_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-08-15' existing = {
+  name: '00000000-0000-0000-0000-000000000002'
+  parent: cosmos
+}
+
+resource cosmos_roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-08-15' = {
+  name: guid(principalId, cosmos_roleDefinition.id, cosmos.id)
   properties: {
     principalId: principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450')
-    principalType: principalType
+    roleDefinitionId: cosmos_roleDefinition.id
+    scope: cosmos.id
   }
-  scope: cosmos
+  parent: cosmos
 }
 
 output connectionString string = cosmos.properties.documentEndpoint

--- a/playground/bicep/BicepSample.AppHost/cosmos.module.bicep
+++ b/playground/bicep/BicepSample.AppHost/cosmos.module.bicep
@@ -38,14 +38,19 @@ resource db3 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
   parent: cosmos
 }
 
-resource cosmos_DocumentDBAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(cosmos.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450'))
+resource cosmos_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-08-15' existing = {
+  name: '00000000-0000-0000-0000-000000000002'
+  parent: cosmos
+}
+
+resource cosmos_roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-08-15' = {
+  name: guid(principalId, cosmos_roleDefinition.id, cosmos.id)
   properties: {
     principalId: principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450')
-    principalType: principalType
+    roleDefinitionId: cosmos_roleDefinition.id
+    scope: cosmos.id
   }
-  scope: cosmos
+  parent: cosmos
 }
 
 output connectionString string = cosmos.properties.documentEndpoint

--- a/playground/cdk/CdkSample.AppHost/cosmos.module.bicep
+++ b/playground/cdk/CdkSample.AppHost/cosmos.module.bicep
@@ -38,14 +38,19 @@ resource cosmosdb 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15
   parent: cosmos
 }
 
-resource cosmos_DocumentDBAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(cosmos.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450'))
+resource cosmos_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-08-15' existing = {
+  name: '00000000-0000-0000-0000-000000000002'
+  parent: cosmos
+}
+
+resource cosmos_roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-08-15' = {
+  name: guid(principalId, cosmos_roleDefinition.id, cosmos.id)
   properties: {
     principalId: principalId
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450')
-    principalType: principalType
+    roleDefinitionId: cosmos_roleDefinition.id
+    scope: cosmos.id
   }
-  scope: cosmos
+  parent: cosmos
 }
 
 output connectionString string = cosmos.properties.documentEndpoint

--- a/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
+++ b/tests/Aspire.Hosting.Azure.Tests/AzureBicepResourceTests.cs
@@ -437,14 +437,19 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: mydatabase
             }
 
-            resource cosmos_DocumentDBAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-              name: guid(cosmos.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450'))
+            resource cosmos_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-08-15' existing = {
+              name: '00000000-0000-0000-0000-000000000002'
+              parent: cosmos
+            }
+
+            resource cosmos_roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-08-15' = {
+              name: guid(principalId, cosmos_roleDefinition.id, cosmos.id)
               properties: {
                 principalId: principalId
-                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450')
-                principalType: principalType
+                roleDefinitionId: cosmos_roleDefinition.id
+                scope: cosmos.id
               }
-              scope: cosmos
+              parent: cosmos
             }
 
             output connectionString string = cosmos.properties.documentEndpoint
@@ -662,14 +667,19 @@ public class AzureBicepResourceTests(ITestOutputHelper output)
               parent: mydatabase
             }
 
-            resource cosmos_DocumentDBAccountContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-              name: guid(cosmos.id, principalId, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450'))
+            resource cosmos_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-08-15' existing = {
+              name: '00000000-0000-0000-0000-000000000002'
+              parent: cosmos
+            }
+
+            resource cosmos_roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-08-15' = {
+              name: guid(principalId, cosmos_roleDefinition.id, cosmos.id)
               properties: {
                 principalId: principalId
-                roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '5bd9cd88-fe45-4216-938b-f97437e15450')
-                principalType: principalType
+                roleDefinitionId: cosmos_roleDefinition.id
+                scope: cosmos.id
               }
-              scope: cosmos
+              parent: cosmos
             }
 
             output connectionString string = cosmos.properties.documentEndpoint


### PR DESCRIPTION
## Description

We currently use the control plane `DocumentDBAccountContributor` role, which doesn't work to add/update/remove items.

Instead of adding the control plane role, assign the data plane contributor role when provisioning the CosmosDB account.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] Yes
    - If yes, have you done a threat model and had a security review?
      - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
