### PR TITLE
Add support for CosmosDB triggers in Functions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -161,6 +161,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" Version="6.3.6" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDb" Version="4.11.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" Version="1.1.0-preview6" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/AzureFunctionsEndToEnd.ApiService.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/AzureFunctionsEndToEnd.ApiService.csproj
@@ -15,6 +15,7 @@
     <AspireProjectOrPackageReference Include="Aspire.Azure.Storage.Queues" />
     <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.EventHubs" />
     <AspireProjectOrPackageReference Include="Aspire.Azure.Messaging.ServiceBus" />
+    <AspireProjectOrPackageReference Include="Aspire.Microsoft.Azure.Cosmos" />
   </ItemGroup>
 
 </Project>

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
@@ -4,10 +4,10 @@ using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
 #if !SKIP_UNSTABLE_EMULATORS
 using Azure.Messaging.ServiceBus;
+using Microsoft.Azure.Cosmos;
 #endif
 using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
-using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.ApiService/Program.cs
@@ -7,6 +7,8 @@ using Azure.Messaging.ServiceBus;
 #endif
 using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,6 +19,7 @@ builder.AddAzureBlobClient("blob");
 builder.AddAzureEventHubProducerClient("eventhubs", static settings => settings.EventHubName = "myhub");
 #if !SKIP_UNSTABLE_EMULATORS
 builder.AddAzureServiceBusClient("messaging");
+builder.AddAzureCosmosClient("cosmosdb");
 #endif
 
 var app = builder.Build();
@@ -64,6 +67,17 @@ app.MapGet("/publish/asb", async (ServiceBusClient client, CancellationToken can
     await sender.SendMessageAsync(message, cancellationToken);
     return Results.Ok("Message sent to Azure Service Bus.");
 });
+
+app.MapGet("/publish/cosmosdb", async (CosmosClient cosmosClient) =>
+{
+    var db = cosmosClient.GetDatabase("mydatabase");
+    var container = db.GetContainer("mycontainer");
+
+    var entry = new Entry { Id = Guid.NewGuid().ToString(), Text = RandomString(20) };
+    await container.CreateItemAsync(entry);
+
+    return Results.Ok("Document created in Azure Cosmos DB.");
+});
 #endif
 
 app.MapGet("/", async (HttpClient client) =>
@@ -75,3 +89,12 @@ app.MapGet("/", async (HttpClient client) =>
 app.MapDefaultEndpoints();
 
 app.Run();
+
+public class Entry
+{
+    [JsonProperty("id")]
+    public required string Id { get; set; }
+
+    [JsonProperty("text")]
+    public string Text { get; set; } = string.Empty;
+}

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/AzureFunctionsEndToEnd.AppHost.csproj
@@ -14,6 +14,7 @@
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.EventHubs" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.Storage" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.ServiceBus" />
+    <AspireProjectOrPackageReference Include="Aspire.Hosting.Azure.CosmosDb" />
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
   </ItemGroup>
 

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/Program.cs
@@ -6,6 +6,10 @@ var blob = storage.AddBlobs("blob");
 var eventHubs = builder.AddAzureEventHubs("eventhubs").RunAsEmulator().WithHub("myhub");
 #if !SKIP_UNSTABLE_EMULATORS
 var serviceBus = builder.AddAzureServiceBus("messaging").RunAsEmulator().WithQueue("myqueue");
+var cosmosDb = builder.AddAzureCosmosDB("cosmosdb")
+    .RunAsEmulator()
+    .WithDatabase("mydatabase", (database)
+        => database.Containers.AddRange([new("mycontainer", "/id")]));
 #endif
 
 var funcApp = builder.AddAzureFunctionsProject<Projects.AzureFunctionsEndToEnd_Functions>("funcapp")
@@ -13,6 +17,7 @@ var funcApp = builder.AddAzureFunctionsProject<Projects.AzureFunctionsEndToEnd_F
     .WithReference(eventHubs).WaitFor(eventHubs)
 #if !SKIP_UNSTABLE_EMULATORS
     .WithReference(serviceBus).WaitFor(serviceBus)
+    .WithReference(cosmosDb).WaitFor(cosmosDb)
 #endif
     .WithReference(blob)
     .WithReference(queue);
@@ -21,6 +26,7 @@ builder.AddProject<Projects.AzureFunctionsEndToEnd_ApiService>("apiservice")
     .WithReference(eventHubs).WaitFor(eventHubs)
 #if !SKIP_UNSTABLE_EMULATORS
     .WithReference(serviceBus).WaitFor(serviceBus)
+    .WithReference(cosmosDb).WaitFor(cosmosDb)
 #endif
     .WithReference(queue)
     .WithReference(blob)

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/aspire-manifest.json
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/aspire-manifest.json
@@ -35,6 +35,15 @@
         "principalId": ""
       }
     },
+    "cosmosdb": {
+      "type": "azure.bicep.v0",
+      "connectionString": "{cosmosdb.outputs.connectionString}",
+      "path": "cosmosdb.module.bicep",
+      "params": {
+        "principalType": "",
+        "principalId": ""
+      }
+    },
     "funcstorage67c6c": {
       "type": "azure.bicep.v0",
       "path": "funcstorage67c6c.module.bicep",
@@ -66,6 +75,8 @@
         "Aspire__Azure__Messaging__EventHubs__EventHubBufferedProducerClient__eventhubs__FullyQualifiedNamespace": "{eventhubs.outputs.eventHubsEndpoint}",
         "messaging__fullyQualifiedNamespace": "{messaging.outputs.serviceBusEndpoint}",
         "Aspire__Azure__Messaging__ServiceBus__messaging__FullyQualifiedNamespace": "{messaging.outputs.serviceBusEndpoint}",
+        "cosmosdb__accountEndpoint": "{cosmosdb.outputs.connectionString}",
+        "Aspire__Microsoft__Azure__Cosmos__cosmosdb__AccountEndpoint": "{cosmosdb.outputs.connectionString}",
         "blob__blobServiceUri": "{storage.outputs.blobEndpoint}",
         "blob__queueServiceUri": "{storage.outputs.queueEndpoint}",
         "Aspire__Azure__Storage__Blobs__blob__ServiceUri": "{storage.outputs.blobEndpoint}",
@@ -100,6 +111,7 @@
         "HTTP_PORTS": "{apiservice.bindings.http.targetPort}",
         "ConnectionStrings__eventhubs": "{eventhubs.connectionString}",
         "ConnectionStrings__messaging": "{messaging.connectionString}",
+        "ConnectionStrings__cosmosdb": "{cosmosdb.connectionString}",
         "ConnectionStrings__queue": "{queue.connectionString}",
         "ConnectionStrings__blob": "{blob.connectionString}",
         "services__funcapp__http__0": "{funcapp.bindings.http.url}",

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/cosmosdb.module.bicep
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.AppHost/cosmosdb.module.bicep
@@ -1,0 +1,88 @@
+@description('The location for the resource(s) to be deployed.')
+param location string = resourceGroup().location
+
+param principalType string
+
+param principalId string
+
+resource cosmosdb 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
+  name: take('cosmosdb-${uniqueString(resourceGroup().id)}', 44)
+  location: location
+  properties: {
+    locations: [
+      {
+        locationName: location
+        failoverPriority: 0
+      }
+    ]
+    consistencyPolicy: {
+      defaultConsistencyLevel: 'Session'
+    }
+    databaseAccountOfferType: 'Standard'
+    disableLocalAuth: true
+  }
+  kind: 'GlobalDocumentDB'
+  tags: {
+    'aspire-resource-name': 'cosmosdb'
+  }
+}
+
+resource mydatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-08-15' = {
+  name: 'mydatabase'
+  location: location
+  properties: {
+    resource: {
+      id: 'mydatabase'
+    }
+  }
+  parent: cosmosdb
+}
+
+resource mycontainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
+  name: 'mycontainer'
+  location: location
+  properties: {
+    resource: {
+      id: 'mycontainer'
+      partitionKey: {
+        paths: [
+          '/id'
+        ]
+      }
+    }
+  }
+  parent: mydatabase
+}
+
+resource leases 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-08-15' = {
+  name: 'leases'
+  location: location
+  properties: {
+    resource: {
+      id: 'leases'
+      partitionKey: {
+        paths: [
+          '/id'
+        ]
+      }
+    }
+  }
+  parent: mydatabase
+}
+
+resource cosmosdb_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-08-15' existing = {
+  name: '00000000-0000-0000-0000-000000000002'
+  parent: cosmosdb
+}
+
+resource cosmosdb_roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-08-15' = {
+  name: guid(principalId, cosmosdb_roleDefinition.id, cosmosdb.id)
+  properties: {
+    principalId: principalId
+    roleDefinitionId: cosmosdb_roleDefinition.id
+    scope: cosmosdb.id
+  }
+  parent: cosmosdb
+}
+
+output connectionString string = cosmosdb.properties.documentEndpoint

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/AzureFunctionsEndToEnd.Functions.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventHubs" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDb" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.OpenTelemetry" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" />

--- a/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyCosmosDbTrigger.cs
+++ b/playground/AzureFunctionsEndToEnd/AzureFunctionsEndToEnd.Functions/MyCosmosDbTrigger.cs
@@ -1,0 +1,20 @@
+#if !SKIP_UNSTABLE_EMULATORS
+using System.Reflection.Metadata;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace AspirePlusFunctions.Functions;
+
+public class MyCosmosDbTrigger(ILogger<MyCosmosDbTrigger> logger)
+{
+    [Function(nameof(MyCosmosDbTrigger))]
+    public void Run([CosmosDBTrigger(
+        databaseName: "mydatabase",
+        containerName: "mycontainer",
+        CreateLeaseContainerIfNotExists = true,
+        Connection = "cosmosdb")] IReadOnlyList<Document> input)
+    {
+        logger.LogInformation("C# cosmosdb trigger function processed: {Count} messages", input.Count);
+    }
+}
+#endif

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -14,7 +14,8 @@ namespace Aspire.Hosting;
 public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructure> configureInfrastructure) :
     AzureProvisioningResource(name, configureInfrastructure),
     IResourceWithConnectionString,
-    IResourceWithEndpoints
+    IResourceWithEndpoints,
+    IResourceWithAzureFunctionsConfig
 {
     internal List<CosmosDBDatabase> Databases { get; } = [];
 
@@ -27,7 +28,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
 
     /// <summary>
     /// Gets the "connectionString" output reference from the bicep template for the Azure Cosmos DB resource.
-    /// 
+    ///
     /// This is used when Entra ID authentication is used. The connection string is an output of the bicep template.
     /// </summary>
     public BicepOutputReference ConnectionStringOutput => new("connectionString", this);
@@ -61,4 +62,22 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
             ReferenceExpression.Create($"{ConnectionStringSecretOutput}") :
             ReferenceExpression.Create($"{ConnectionStringOutput}");
 
+    /// <inheritdoc />
+    public void ApplyAzureFunctionsConfiguration(IDictionary<string, object> target, string connectionName)
+    {
+        if (IsEmulator || UseAccessKeyAuthentication)
+        {
+            // Injected to support Azure Functions listener initialization.
+            target[$"{connectionName}"] = ConnectionStringExpression;
+            // Injected to support Aspire client integration for CosmosDB in Azure Functions projects.
+            target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__ConnectionString"] = ConnectionStringExpression;
+        }
+        else
+        {
+            // Injected to support Azure Functions listener initialization.
+            target[$"{connectionName}__accountEndpoint"] = ConnectionStringExpression;
+            // Injected to support Aspire client integration for CosmosDB in Azure Functions projects.
+            target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__AccountEndpoint"] = ConnectionStringExpression;
+        }
+    }
 }

--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -68,7 +68,7 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
         if (IsEmulator || UseAccessKeyAuthentication)
         {
             // Injected to support Azure Functions listener initialization.
-            target[$"{connectionName}"] = ConnectionStringExpression;
+            target[connectionName] = ConnectionStringExpression;
             // Injected to support Aspire client integration for CosmosDB in Azure Functions projects.
             target[$"Aspire__Microsoft__Azure__Cosmos__{connectionName}__ConnectionString"] = ConnectionStringExpression;
         }

--- a/src/Aspire.Hosting.Azure.CosmosDB/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure.CosmosDB/PublicAPI.Unshipped.txt
@@ -12,6 +12,7 @@ Aspire.Hosting.Azure.CosmosDB.CosmosDBDatabase.Containers.get -> System.Collecti
 Aspire.Hosting.Azure.CosmosDB.CosmosDBDatabase.CosmosDBDatabase(string! name) -> void
 Aspire.Hosting.Azure.CosmosDB.CosmosDBDatabase.Name.get -> string!
 Aspire.Hosting.Azure.CosmosDB.CosmosDBDatabase.Name.set -> void
+Aspire.Hosting.AzureCosmosDBResource.ApplyAzureFunctionsConfiguration(System.Collections.Generic.IDictionary<string!, object!>! target, string! connectionName) -> void
 Aspire.Hosting.AzureCosmosDBResource.AzureCosmosDBResource(string! name, System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>! configureInfrastructure) -> void
 Aspire.Hosting.AzureCosmosDBResource.ConnectionStringOutput.get -> Aspire.Hosting.Azure.BicepOutputReference!
 static Aspire.Hosting.AzureCosmosExtensions.RunAsPreviewEmulator(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.AzureCosmosDBResource!>! builder, System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureCosmosDBEmulatorResource!>!>? configureContainer = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.AzureCosmosDBResource!>!


### PR DESCRIPTION
## Description

Adds support for CosmosDB-based triggers to Azure Functions. Tested with the following:

- Entra ID-based CosmosDB connection
- Access key-based CosmosDB connection

Ran into issues testing with classic emulator on Windows but putting this out in the meanwhile. Marked CosmosDB as an unstable emulator since it's long startup times seem to be timing out the E2E tests locally.

The preview emulator doesn't yet support the change feed feature that the CosmosDB trigger takes a dependency on.

Contributes to #7087 

## Checklist

- Is this feature complete?
  - [ ] Yes. Ready to ship.
  - [X] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [X] Yes
  - [ ] No
- Did you add public API?
  - [X] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [X] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [X] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [X] No
- Does the change require an update in our Aspire docs?
  - [X] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [X] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
