### PR TITLE
Mark resource auth type public

### DIFF
--- a/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
+++ b/src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBResource.cs
@@ -39,8 +39,11 @@ public class AzureCosmosDBResource(string name, Action<AzureResourceInfrastructu
     /// </summary>
     internal BicepSecretOutputReference? ConnectionStringSecretOutput { get; set; }
 
+    /// <summary>
+    /// Gets a value indicating whether the resource uses access key authentication.
+    /// </summary>
     [MemberNotNullWhen(true, nameof(ConnectionStringSecretOutput))]
-    internal bool UseAccessKeyAuthentication => ConnectionStringSecretOutput is not null;
+    public bool UseAccessKeyAuthentication => ConnectionStringSecretOutput is not null;
 
     /// <summary>
     /// Gets a value indicating whether the Azure Cosmos DB resource is running in the local emulator.

--- a/src/Aspire.Hosting.Azure.CosmosDB/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure.CosmosDB/PublicAPI.Unshipped.txt
@@ -14,6 +14,7 @@ Aspire.Hosting.Azure.CosmosDB.CosmosDBDatabase.Name.get -> string!
 Aspire.Hosting.Azure.CosmosDB.CosmosDBDatabase.Name.set -> void
 Aspire.Hosting.AzureCosmosDBResource.AzureCosmosDBResource(string! name, System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>! configureInfrastructure) -> void
 Aspire.Hosting.AzureCosmosDBResource.ConnectionStringOutput.get -> Aspire.Hosting.Azure.BicepOutputReference!
+Aspire.Hosting.AzureCosmosDBResource.UseAccessKeyAuthentication.get -> bool
 static Aspire.Hosting.AzureCosmosExtensions.RunAsPreviewEmulator(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.AzureCosmosDBResource!>! builder, System.Action<Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureCosmosDBEmulatorResource!>!>? configureContainer = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.AzureCosmosDBResource!>!
 static Aspire.Hosting.AzureCosmosExtensions.WithDataExplorer(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureCosmosDBEmulatorResource!>! builder, int? port = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureCosmosDBEmulatorResource!>!
 static Aspire.Hosting.AzureCosmosExtensions.WithAccessKeyAuthentication(this Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.AzureCosmosDBResource!>! builder) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.AzureCosmosDBResource!>!

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -30,9 +30,12 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
     /// This is set when password authentication is used. The connection string is stored in a secret in the Azure Key Vault.
     /// </summary>
     internal BicepSecretOutputReference? ConnectionStringSecretOutput { get; set; }
+    /// <summary>
+    /// Gets a value indicating whether the resource uses password authentication.
+    /// </summary>
 
     [MemberNotNullWhen(true, nameof(ConnectionStringSecretOutput))]
-    internal bool UsePasswordAuthentication => ConnectionStringSecretOutput is not null;
+    public bool UsePasswordAuthentication => ConnectionStringSecretOutput is not null;
 
     /// <summary>
     /// Gets the inner PostgresServerResource resource.

--- a/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs
@@ -33,7 +33,6 @@ public class AzurePostgresFlexibleServerResource(string name, Action<AzureResour
     /// <summary>
     /// Gets a value indicating whether the resource uses password authentication.
     /// </summary>
-
     [MemberNotNullWhen(true, nameof(ConnectionStringSecretOutput))]
     public bool UsePasswordAuthentication => ConnectionStringSecretOutput is not null;
 

--- a/src/Aspire.Hosting.Azure.PostgreSQL/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure.PostgreSQL/PublicAPI.Unshipped.txt
@@ -11,6 +11,7 @@ Aspire.Hosting.Azure.AzurePostgresFlexibleServerResource
 Aspire.Hosting.Azure.AzurePostgresFlexibleServerResource.AzurePostgresFlexibleServerResource(string! name, System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>! configureInfrastructure) -> void
 Aspire.Hosting.Azure.AzurePostgresFlexibleServerResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
 Aspire.Hosting.Azure.AzurePostgresFlexibleServerResource.Databases.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+Aspire.Hosting.Azure.AzurePostgresFlexibleServerResource.UsePasswordAuthentication.get -> bool
 Aspire.Hosting.Azure.AzurePostgresResource.AzurePostgresResource(Aspire.Hosting.ApplicationModel.PostgresServerResource! innerResource, System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>! configureInfrastructure) -> void
 override Aspire.Hosting.Azure.AzurePostgresFlexibleServerDatabaseResource.Annotations.get -> Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection!
 override Aspire.Hosting.Azure.AzurePostgresFlexibleServerResource.Annotations.get -> Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection!

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
@@ -30,7 +30,7 @@ public class AzureRedisCacheResource(string name, Action<AzureResourceInfrastruc
     internal BicepSecretOutputReference? ConnectionStringSecretOutput { get; set; }
 
     /// <summary>
-    /// Whether the resource uses access key authentication.
+    /// Gets a value indicating whether the resource uses access key authentication.
     /// </summary>
     [MemberNotNullWhen(true, nameof(ConnectionStringSecretOutput))]
     public bool UseAccessKeyAuthentication => ConnectionStringSecretOutput is not null;

--- a/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
+++ b/src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs
@@ -29,8 +29,11 @@ public class AzureRedisCacheResource(string name, Action<AzureResourceInfrastruc
     /// </summary>
     internal BicepSecretOutputReference? ConnectionStringSecretOutput { get; set; }
 
+    /// <summary>
+    /// Whether the resource uses access key authentication.
+    /// </summary>
     [MemberNotNullWhen(true, nameof(ConnectionStringSecretOutput))]
-    internal bool UseAccessKeyAuthentication => ConnectionStringSecretOutput is not null;
+    public bool UseAccessKeyAuthentication => ConnectionStringSecretOutput is not null;
 
     /// <summary>
     /// Gets the inner Redis resource.

--- a/src/Aspire.Hosting.Azure.Redis/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting.Azure.Redis/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@
 Aspire.Hosting.Azure.AzureRedisCacheResource
 Aspire.Hosting.Azure.AzureRedisCacheResource.AzureRedisCacheResource(string! name, System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>! configureInfrastructure) -> void
 Aspire.Hosting.Azure.AzureRedisCacheResource.ConnectionStringExpression.get -> Aspire.Hosting.ApplicationModel.ReferenceExpression!
+Aspire.Hosting.Azure.AzureRedisCacheResource.UseAccessKeyAuthentication.get -> bool
 Aspire.Hosting.Azure.AzureRedisResource.AzureRedisResource(Aspire.Hosting.ApplicationModel.RedisResource! innerResource, System.Action<Aspire.Hosting.Azure.AzureResourceInfrastructure!>! configureInfrastructure) -> void
 override Aspire.Hosting.Azure.AzureRedisCacheResource.Annotations.get -> Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection!
 static Aspire.Hosting.AzureRedisExtensions.AddAzureRedis(this Aspire.Hosting.IDistributedApplicationBuilder! builder, string! name) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.Azure.AzureRedisCacheResource!>!


### PR DESCRIPTION
## Recreated from https://github.com/dotnet/aspire/pull/7135

Make UseAccessKeyAuthentication public so that it is accessible for package extensibility

## Description

When extending on the Azure.Redis package (e.g. https://github.com/CommunityToolkit/Aspire/pull/371) there needs to be a way to determine early (outside of ConfigureInfrastructure) whether the Redis has been configured with AccessKeyAuthentication in order to configure appropriate parameters and outputs

Fixes # (issue)
Have not yet created an issue 
## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [] Yes
  - [x] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [x] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
