### PR TITLE
Enable metric exemplars by default in Aspire 9.0 templates

### DIFF
--- a/playground/TestShop/TestShop.ServiceDefaults/Extensions.cs
+++ b/playground/TestShop/TestShop.ServiceDefaults/Extensions.cs
@@ -47,7 +47,8 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
+                    .AddRuntimeInstrumentation()
+                    .SetExemplarFilter(ExemplarFilterType.TraceBased);
             })
             .WithTracing(tracing =>
             {

--- a/src/Aspire.ProjectTemplates/templates/aspire-empty/9.0/AspireApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-empty/9.0/AspireApplication.1.ServiceDefaults/Extensions.cs
@@ -54,7 +54,8 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
+                    .AddRuntimeInstrumentation()
+                    .SetExemplarFilter(ExemplarFilterType.TraceBased);
             })
             .WithTracing(tracing =>
             {

--- a/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.0/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-servicedefaults/9.0/Extensions.cs
@@ -54,7 +54,8 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
+                    .AddRuntimeInstrumentation()
+                    .SetExemplarFilter(ExemplarFilterType.TraceBased);
             })
             .WithTracing(tracing =>
             {

--- a/src/Aspire.ProjectTemplates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
+++ b/src/Aspire.ProjectTemplates/templates/aspire-starter/9.0/Aspire-StarterApplication.1.ServiceDefaults/Extensions.cs
@@ -54,7 +54,8 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
+                    .AddRuntimeInstrumentation()
+                    .SetExemplarFilter(ExemplarFilterType.TraceBased);
             })
             .WithTracing(tracing =>
             {

--- a/tests/TestingAppHost1/TestingAppHost1.ServiceDefaults/Extensions.cs
+++ b/tests/TestingAppHost1/TestingAppHost1.ServiceDefaults/Extensions.cs
@@ -56,7 +56,8 @@ public static class Extensions
             {
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .AddRuntimeInstrumentation();
+                    .AddRuntimeInstrumentation()
+                    .SetExemplarFilter(ExemplarFilterType.TraceBased);
             })
             .WithTracing(tracing =>
             {


### PR DESCRIPTION
## Description

My previous changes only enable metric exemplars for the playground apps. This set of changes updates the 9.0 Aspire templates to enable metric exemplars by default.

Fixes #4839 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
