### PR TITLE
Refactor health check service to be more responsive

### DIFF
--- a/Aspire.sln
+++ b/Aspire.sln
@@ -635,6 +635,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.MongoDB.Driver.v3", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.MongoDB.Driver.v3.Tests", "tests\Aspire.MongoDB.Driver.v3.Tests\Aspire.MongoDB.Driver.v3.Tests.csproj", "{223AF8EB-3A4E-E778-4EBD-6E4876C308B6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Stress.Empty", "playground\Stress\Stress.Empty\Stress.Empty.csproj", "{6C4B55AD-5D98-452D-B71D-CAF628E822B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1665,6 +1667,10 @@ Global
 		{223AF8EB-3A4E-E778-4EBD-6E4876C308B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{223AF8EB-3A4E-E778-4EBD-6E4876C308B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{223AF8EB-3A4E-E778-4EBD-6E4876C308B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C4B55AD-5D98-452D-B71D-CAF628E822B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C4B55AD-5D98-452D-B71D-CAF628E822B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C4B55AD-5D98-452D-B71D-CAF628E822B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C4B55AD-5D98-452D-B71D-CAF628E822B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1970,5 +1976,9 @@ Global
 		{3E8597D1-27D6-4523-94C9-EB1501BEC0B3} = {E6985EED-47E3-4EAC-8222-074E5410CEDC}
 		{FD53B608-138D-8FB1-AA57-9B8CD42CF13E} = {27381127-6C45-4B4C-8F18-41FF48DFE4B2}
 		{223AF8EB-3A4E-E778-4EBD-6E4876C308B6} = {C424395C-1235-41A4-BF55-07880A04368C}
+		{6C4B55AD-5D98-452D-B71D-CAF628E822B0} = {CFDA7AC5-251C-43C7-B334-71AE8040A147}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {47DCFECF-5631-4BDE-A1EC-BE41E90F60C4}
 	EndGlobalSection
 EndGlobal

--- a/playground/Stress/Stress.AppHost/Stress.AppHost.csproj
+++ b/playground/Stress/Stress.AppHost/Stress.AppHost.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <AspireProjectOrPackageReference Include="Aspire.Hosting.AppHost" />
     <ProjectReference Include="..\Stress.ApiService\Stress.ApiService.csproj" />
+    <ProjectReference Include="..\Stress.Empty\Stress.Empty.csproj" />
     <ProjectReference Include="..\Stress.TelemetryService\Stress.TelemetryService.csproj" />
   </ItemGroup>
 

--- a/playground/Stress/Stress.Empty/Program.cs
+++ b/playground/Stress/Stress.Empty/Program.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddServiceDefaults();
+
+var app = builder.Build();
+
+app.Run();

--- a/playground/Stress/Stress.Empty/Stress.Empty.csproj
+++ b/playground/Stress/Stress.Empty/Stress.Empty.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Playground.ServiceDefaults\Playground.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -61,7 +61,8 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
     }
 
     // Internal for testing.
-    internal static readonly TimeSpan s_healthyHealthCheckInterval = TimeSpan.FromSeconds(30);
+    internal TimeSpan HealthyHealthCheckInterval { get; set; } = TimeSpan.FromSeconds(30);
+    internal TimeSpan NonHealthyHealthCheckStepInterval { get; set; } = TimeSpan.FromSeconds(1);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -218,8 +219,8 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
             // Long delay if the resource is healthy.
             // Non-heathy delay increases with each consecutive non-healthy report.
             var delayInterval = nonHealthyReportCount == 0
-                ? s_healthyHealthCheckInterval
-                : TimeSpan.FromSeconds(Math.Min(5, nonHealthyReportCount));
+                ? HealthyHealthCheckInterval
+                : NonHealthyHealthCheckStepInterval * Math.Min(5, nonHealthyReportCount);
 
             logger.LogTrace("Resource '{Resource}' health check monitoring loop starting delay of {DelayInterval}.", resource.Name, delayInterval);
 

--- a/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
+++ b/src/Aspire.Hosting/Health/ResourceHealthCheckService.cs
@@ -125,8 +125,6 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                     continue;
                 }
 
-                currentEvent = state.LatestEvent;
-
                 var report = await healthCheckService.CheckHealthAsync(
                     r => registrationKeysToCheck.Contains(r.Name),
                     cancellationToken
@@ -146,7 +144,9 @@ internal class ResourceHealthCheckService(ILogger<ResourceHealthCheckService> lo
                     nonHealthyReportCount++;
                 }
 
-                if (ContainsAnyHealthReportChange(report, state.LatestEvent.Snapshot.HealthReports))
+                currentEvent = state.LatestEvent;
+
+                if (ContainsAnyHealthReportChange(report, currentEvent.Snapshot.HealthReports))
                 {
                     await resourceNotificationService.PublishUpdateAsync(resource, s =>
                     {


### PR DESCRIPTION
## Description

Fixes https://github.com/dotnet/aspire/issues/6112

The health check service immediately checks health when a resource moves to a running state. However, if the intial report is unhealthy then it waits 5 seconds before checking again. This PR refactors the health check service to be more responsive.

* If a health report isn't healthy then the delay interval starts at 1 second and increases by 1 second per failure up to the existing 5 sec. Healthy delay is still 30 seconds.
* Refactored the health check loop to use an instant interrupt instead of polling the state once per second. The `DelayAsync` method is complicated, but the actual health monitoring loop is much simpler.
* Allow setting the health delays from tests so time based tests run a lot faster. No more 30 second tests.
* No more blocking in tests: `AutoResetEvent` 👎 

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
