### PR TITLE
Fix messy state changes on resource restart

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1775,8 +1775,8 @@ internal sealed class DcpExecutor : IDcpExecutor
                 }, cancellationToken).ConfigureAwait(false);
             }
 
-            // Raise event after resource has been deleted. This is required the event sets the status to "Starting" and resources being
-            // deleted will temporarily override the status to a terminal state.
+            // Raise event after resource has been deleted. This is required because the event sets the status to "Starting" and resources being
+            // deleted will temporarily override the status to a terminal state, such as "Exited".
             await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, matchingResource.ModelResource, matchingResource.DcpResource.Metadata.Name)).ConfigureAwait(false);
 
             await _kubernetesService.CreateAsync(resource, cancellationToken).ConfigureAwait(false);

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1696,8 +1696,6 @@ internal sealed class DcpExecutor : IDcpExecutor
 
         try
         {
-            await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, matchingResource.ModelResource, matchingResource.DcpResource.Metadata.Name)).ConfigureAwait(false);
-
             switch (matchingResource.DcpResource)
             {
                 case Container c:
@@ -1776,6 +1774,10 @@ internal sealed class DcpExecutor : IDcpExecutor
                     }
                 }, cancellationToken).ConfigureAwait(false);
             }
+
+            // Raise event after resource has been deleted. This is required the event sets the status to "Starting" and resources being
+            // deleted will temporarily override the status to a terminal state.
+            await _executorEvents.PublishAsync(new OnResourceStartingContext(cancellationToken, resourceType, matchingResource.ModelResource, matchingResource.DcpResource.Metadata.Name)).ConfigureAwait(false);
 
             await _kubernetesService.CreateAsync(resource, cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Description

A restarted resource's state is set to `Starting` when an event is raised, but deleting the resource in DCP switches it back to a terminal state, e.g. `Exited`. Looks messy in the dashboard.

Fix is to delete the resource and then raise the resource starting event.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
