### PR TITLE
Add check to make sure version is valid before comparing to avoid issues with wildcard or fixed versions

### DIFF
--- a/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
+++ b/src/Aspire.AppHost.Sdk/SDK/Sdk.in.targets
@@ -77,7 +77,12 @@
       <_AppHostVersion>%(_AppHostPackageReference.Version)</_AppHostVersion>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(_AppHostVersion)' != '' and $([MSBuild]::VersionLessThan('$(_AppHostVersion)', '8.2.0'))">
+    <PropertyGroup Condition="'$(_AppHostVersion)' != ''">
+      <!-- Check if the version is in the format major.minor.patch -->
+      <_IsValidVersion>$([System.Text.RegularExpressions.Regex]::IsMatch('$(_AppHostVersion)', '^\d+\.\d+\.\d+$'))</_IsValidVersion>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_AppHostVersion)' != '' and '$(_IsValidVersion)' == 'true' and $([MSBuild]::VersionLessThan('$(_AppHostVersion)', '8.2.0'))">
       <!-- If we find the version to Aspire.Hosting.AppHost package but it is lower than 8.2.0, then we fall back
       to use the Dashboard and DCP packages that match the version of the installed workload for backwards compatibility.
       This results in the same behavior that we had before moving Dashboard and DCP out of the workload, since the version

--- a/tests/Aspire.Workload.Tests/BuildAndRunTemplateTests.cs
+++ b/tests/Aspire.Workload.Tests/BuildAndRunTemplateTests.cs
@@ -164,16 +164,15 @@ public partial class BuildAndRunTemplateTests : WorkloadTestsBase
     public async Task CreateAndModifyAspireAppHostTemplate(string version)
     {
         string id = GetNewProjectId(prefix: $"aspire_apphost_{version.Replace("*", "wildcard").Replace("[", "").Replace("]", "")}");
-        await using var project = await AspireProject.CreateNewTemplateProjectAsync(id, "aspire-apphost", _testOutput, buildEnvironment: BuildEnvironment.ForDefaultFramework);
+        await using var project = await AspireProject.CreateNewTemplateProjectAsync(id, "aspire-apphost", _testOutput, buildEnvironment: BuildEnvironment.ForDefaultFramework, addEndpointsHook: false);
 
         ModifyProjectFile(project, version);
 
-        await project.BuildAsync();
-        await project.StartAppHostAsync();
+        await project.BuildAsync(workingDirectory: project.RootDir);
 
         static void ModifyProjectFile(AspireProject project, string version)
         {
-            var projectName = Directory.GetFiles(project.AppHostProjectDirectory, "*.csproj").FirstOrDefault();
+            var projectName = Directory.GetFiles(project.RootDir, "*.csproj").FirstOrDefault();
             Assert.False(string.IsNullOrEmpty(projectName));
 
             var projectContents = File.ReadAllText(projectName);


### PR DESCRIPTION
Fixes #7102 
Fixes #7194 

## Description

This should add a check to the aspire sdk to guard against edge cases for folks using versions with wildcards (like 9.*) or exact versions like `[9.0.0]`.

Fixes # (issue)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
