### PR TITLE
Remove unused replica set code from DcpExecutor

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -712,13 +712,13 @@ internal sealed class DcpExecutor : IDcpExecutor
 
     private async Task CreateContainersAndExecutablesAsync(CancellationToken cancellationToken)
     {
-        var toCreate = _appResources.Where(r => r.DcpResource is Container || r.DcpResource is Executable || r.DcpResource is ExecutableReplicaSet);
+        var toCreate = _appResources.Where(r => r.DcpResource is Container || r.DcpResource is Executable);
         AddAllocatedEndpointInfo(toCreate);
 
         await _executorEvents.PublishAsync(new OnEndpointsAllocatedContext(cancellationToken)).ConfigureAwait(false);
 
         var containersTask = CreateContainersAsync(toCreate.Where(ar => ar.DcpResource is Container), cancellationToken);
-        var executablesTask = CreateExecutablesAsync(toCreate.Where(ar => ar.DcpResource is Executable || ar.DcpResource is ExecutableReplicaSet), cancellationToken);
+        var executablesTask = CreateExecutablesAsync(toCreate.Where(ar => ar.DcpResource is Executable), cancellationToken);
 
         await Task.WhenAll(containersTask, executablesTask).ConfigureAwait(false);
     }
@@ -1016,12 +1016,8 @@ internal sealed class DcpExecutor : IDcpExecutor
                 spec = exe.Spec;
                 createResource = async () => await _kubernetesService.CreateAsync(exe, cancellationToken).ConfigureAwait(false);
                 break;
-            case ExecutableReplicaSet ers:
-                spec = ers.Spec.Template.Spec;
-                createResource = async () => await _kubernetesService.CreateAsync(ers, cancellationToken).ConfigureAwait(false);
-                break;
             default:
-                throw new InvalidOperationException($"Expected an Executable-like resource, but got {er.DcpResource.Kind} instead");
+                throw new InvalidOperationException($"Expected an Executable resource, but got {er.DcpResource.Kind} instead");
         }
 
         var failedToApplyArgs = false;
@@ -1597,10 +1593,6 @@ internal sealed class DcpExecutor : IDcpExecutor
 
         static bool HasMultipleReplicas(CustomResource resource)
         {
-            if (resource is ExecutableReplicaSet ers && ers.Spec.Replicas > 1)
-            {
-                return true;
-            }
             if (resource is Executable exe && exe.Metadata.Annotations.TryGetValue(CustomResource.ResourceReplicaCount, out var value) && int.TryParse(value, CultureInfo.InvariantCulture, out var replicas) && replicas > 1)
             {
                 return true;
@@ -1667,10 +1659,6 @@ internal sealed class DcpExecutor : IDcpExecutor
                 patch = CreatePatch(e, obj => obj.Spec.Stop = true);
                 await _kubernetesService.PatchAsync(e, patch, cancellationToken).ConfigureAwait(false);
                 break;
-            case ExecutableReplicaSet rs:
-                patch = CreatePatch(rs, obj => obj.Spec.Replicas = 0);
-                await _kubernetesService.PatchAsync(rs, patch, cancellationToken).ConfigureAwait(false);
-                break;
             default:
                 throw new InvalidOperationException($"Unexpected resource type: {matchingResource.DcpResource.GetType().FullName}");
         }
@@ -1703,12 +1691,6 @@ internal sealed class DcpExecutor : IDcpExecutor
                     break;
                 case Executable e:
                     await StartExecutableOrContainerAsync(e).ConfigureAwait(false);
-                    break;
-                case ExecutableReplicaSet rs:
-                    var replicas = matchingResource.ModelResource.GetReplicaCount();
-                    var patch = CreatePatch(rs, obj => obj.Spec.Replicas = replicas);
-
-                    await _kubernetesService.PatchAsync(rs, patch, cancellationToken).ConfigureAwait(false);
                     break;
                 default:
                     throw new InvalidOperationException($"Unexpected resource type: {matchingResource.DcpResource.GetType().FullName}");


### PR DESCRIPTION
## Description

ReplicaSets were replaced by multiple executable resources a few releases ago. This PR removes legacy code.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No