### PR TITLE
Fix hide/show timestamp button and default to hidden

### DIFF
--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor
@@ -19,7 +19,7 @@
                                 @{
                                     var hasPrefix = false;
                                 }
-                                @if (!HideTimestamp && context.Timestamp is { } timestamp)
+                                @if (ShowTimestamp && context.Timestamp is { } timestamp)
                                 {
                                     hasPrefix = true;
                                     <span class="timestamp" title="@FormatHelpers.FormatDateTime(TimeProvider, timestamp, MillisecondsDisplay.Full, CultureInfo.CurrentCulture)">@GetDisplayTimestamp(timestamp)</span>

--- a/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
+++ b/src/Aspire.Dashboard/Components/Controls/LogViewer.razor.cs
@@ -32,7 +32,7 @@ public sealed partial class LogViewer
     public LogEntries? LogEntries { get; set; } = null!;
 
     [Parameter]
-    public bool HideTimestamp { get; set; }
+    public bool ShowTimestamp { get; set; }
 
     protected override void OnParametersSet()
     {

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor
@@ -79,7 +79,7 @@
         </MobilePageTitleToolbarSection>
 
         <MainSection>
-            <LogViewer LogEntries="@_logEntries" HideTimestamp="@_hideTimestamp" />
+            <LogViewer LogEntries="@_logEntries" ShowTimestamp="@_showTimestamp" />
         </MainSection>
     </AspirePageContentLayout>
 </div>

--- a/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
+++ b/src/Aspire.Dashboard/Components/Pages/ConsoleLogs.razor.cs
@@ -92,7 +92,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
     private readonly List<MenuButtonItem> _resourceMenuItems = new();
 
     // State
-    private bool _hideTimestamp;
+    private bool _showTimestamp;
     public ConsoleLogsViewModel PageViewModel { get; set; } = null!;
 
     public string BasePath => DashboardUrls.ConsoleLogBasePath;
@@ -106,9 +106,9 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         PageViewModel = new ConsoleLogsViewModel { SelectedOption = _noSelection, SelectedResource = null, Status = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsLoadingResources)] };
 
         var timestampStorageResult = await LocalStorage.GetUnprotectedAsync<ConsoleLogConsoleSettings>(BrowserStorageKeys.ConsoleLogConsoleSettings);
-        if (timestampStorageResult.Value?.HideTimestamp is { } hideTimestamp)
+        if (timestampStorageResult.Value?.ShowTimestamp is { } showTimestamp)
         {
-            _hideTimestamp = hideTimestamp;
+            _showTimestamp = showTimestamp;
         }
 
         var loadingTcs = new TaskCompletionSource();
@@ -268,11 +268,11 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
             Icon = new Icons.Regular.Size16.ArrowDownload()
         });
 
-        if (_hideTimestamp)
+        if (!_showTimestamp)
         {
             _logsMenuItems.Add(new()
             {
-                OnClick = () => ToggleTimestampAsync(hideTimestamp: false),
+                OnClick = () => ToggleTimestampAsync(showTimestamp: true),
                 Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampShow)],
                 Icon = new Icons.Regular.Size16.CalendarClock()
             });
@@ -281,7 +281,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         {
             _logsMenuItems.Add(new()
             {
-                OnClick = () => ToggleTimestampAsync(hideTimestamp: true),
+                OnClick = () => ToggleTimestampAsync(showTimestamp: false),
                 Text = Loc[nameof(Dashboard.Resources.ConsoleLogs.ConsoleLogsTimestampHide)],
                 Icon = new Icons.Regular.Size16.DismissSquareMultiple()
             });
@@ -314,11 +314,12 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
         }
     }
 
-    private async Task ToggleTimestampAsync(bool hideTimestamp)
+    private async Task ToggleTimestampAsync(bool showTimestamp)
     {
-        await LocalStorage.SetUnprotectedAsync(BrowserStorageKeys.ConsoleLogConsoleSettings, new ConsoleLogConsoleSettings(HideTimestamp: hideTimestamp));
-        _hideTimestamp = hideTimestamp;
+        await LocalStorage.SetUnprotectedAsync(BrowserStorageKeys.ConsoleLogConsoleSettings, new ConsoleLogConsoleSettings(ShowTimestamp: showTimestamp));
+        _showTimestamp = showTimestamp;
 
+        UpdateMenuButtons();
         StateHasChanged();
     }
 
@@ -548,7 +549,7 @@ public sealed partial class ConsoleLogs : ComponentBase, IAsyncDisposable, IPage
 
     public record ConsoleLogsPageState(string? SelectedResource);
 
-    public record ConsoleLogConsoleSettings(bool HideTimestamp);
+    public record ConsoleLogConsoleSettings(bool ShowTimestamp);
 
     public Task UpdateViewModelFromQueryAsync(ConsoleLogsViewModel viewModel)
     {


### PR DESCRIPTION
## Description

There was a regression in https://github.com/dotnet/aspire/pull/7220 that causes the menu to not update when toggling between show and hide. Fixed.

Also, changed the default timestamp state to hidden. This matches what GitHub actions does in its console output, with show timestamps defaulted to off:

![image](https://github.com/user-attachments/assets/d5a958d3-2472-46fd-b251-5a22911a6f86)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [ ] Yes
  - [x] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
