### PR TITLE
Fix resource filter not adding new values on update

### DIFF
--- a/src/Aspire.Dashboard/Components/Pages/Resources.razor
+++ b/src/Aspire.Dashboard/Components/Pages/Resources.razor
@@ -43,9 +43,9 @@
             {
                 <div>
                     <ResourceFilters
-                        ResourceStates="@_resourceStatesToVisibility"
-                        ResourceTypes="@_resourceTypesToVisibility"
-                        ResourceHealthStates="@_resourceHealthStatusesToVisibility"
+                        ResourceStates="@ResourceStatesToVisibility"
+                        ResourceTypes="@ResourceTypesToVisibility"
+                        ResourceHealthStates="@ResourceHealthStatusesToVisibility"
                         OnAllFilterVisibilityCheckedChangedAsync="@OnAllFilterVisibilityCheckedChangedAsync"
                         OnResourceFilterVisibilityChangedAsync="@OnResourceFilterVisibilityChangedAsync" />
                 </div>
@@ -60,9 +60,9 @@
                            Class="resources-filter-popup">
                 <Body>
                 <ResourceFilters
-                        ResourceStates="@_resourceStatesToVisibility"
-                        ResourceTypes="@_resourceTypesToVisibility"
-                        ResourceHealthStates="@_resourceHealthStatusesToVisibility"
+                        ResourceStates="@ResourceStatesToVisibility"
+                        ResourceTypes="@ResourceTypesToVisibility"
+                        ResourceHealthStates="@ResourceHealthStatusesToVisibility"
                         OnAllFilterVisibilityCheckedChangedAsync="@OnAllFilterVisibilityCheckedChangedAsync"
                         OnResourceFilterVisibilityChangedAsync="@OnResourceFilterVisibilityChangedAsync" />
                 </Body>

--- a/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Pages/ResourcesTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Threading.Channels;
 using Aspire.Dashboard.Components.Resize;
 using Aspire.Dashboard.Components.Tests.Shared;
 using Aspire.Dashboard.Model;
@@ -16,30 +17,122 @@ namespace Aspire.Dashboard.Components.Tests.Pages;
 public partial class ResourcesTests : TestContext
 {
     [Fact]
-    public void Test()
+    public void UpdateResources_FiltersUpdated()
     {
         // Arrange
         var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource(
+                "Resource1",
+                "Type1",
+                "Running",
+                ImmutableArray.Create(new HealthReportViewModel("Null", null, "Description1", null))),
+        };
+        var channel = Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>();
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: () => channel);
         ResourceSetupHelpers.SetupResourcesPage(
             this,
             viewport,
-            [
-                CreateResource(
-                    "Resource1",
-                    "Type1",
-                    "Running",
-                    ImmutableArray.Create(new HealthReportViewModel("Null", null, "Description1", null))),
+            dashboardClient);
+
+        var cut = RenderComponent<Components.Pages.Resources>(builder =>
+        {
+            builder.AddCascadingValue(viewport);
+        });
+
+        // Assert 1
+        Assert.Collection(cut.Instance.ResourceTypesToVisibility.OrderBy(kvp => kvp.Key),
+            kvp =>
+            {
+                Assert.Equal("Type1", kvp.Key);
+                Assert.True(kvp.Value);
+            });
+        Assert.Collection(cut.Instance.ResourceStatesToVisibility.OrderBy(kvp => kvp.Key),
+            kvp =>
+            {
+                Assert.Equal("Running", kvp.Key);
+                Assert.True(kvp.Value);
+            });
+        Assert.Collection(cut.Instance.ResourceHealthStatusesToVisibility.OrderBy(kvp => kvp.Key),
+            kvp =>
+            {
+                Assert.Equal("Unhealthy", kvp.Key);
+                Assert.True(kvp.Value);
+            });
+
+        // Act
+        channel.Writer.TryWrite([
+            new ResourceViewModelChange(
+                ResourceViewModelChangeType.Upsert,
                 CreateResource(
                     "Resource2",
                     "Type2",
                     "Running",
-                    ImmutableArray.Create(new HealthReportViewModel("Healthy", HealthStatus.Healthy, "Description2", null))),
-                CreateResource(
-                    "Resource3",
-                    "Type3",
-                    "Stopping",
-                    ImmutableArray.Create(new HealthReportViewModel("Degraded", HealthStatus.Degraded, "Description3", null))),
+                    ImmutableArray.Create(new HealthReportViewModel("Healthy", HealthStatus.Healthy, "Description2", null))))
             ]);
+
+        cut.WaitForState(() => cut.Instance.GetFilteredResources().Count() == 2);
+
+        // Assert 2
+        Assert.Collection(cut.Instance.ResourceTypesToVisibility.OrderBy(kvp => kvp.Key),
+            kvp =>
+            {
+                Assert.Equal("Type1", kvp.Key);
+                Assert.True(kvp.Value);
+            },
+            kvp =>
+            {
+                Assert.Equal("Type2", kvp.Key);
+                Assert.True(kvp.Value);
+            });
+        Assert.Collection(cut.Instance.ResourceStatesToVisibility.OrderBy(kvp => kvp.Key),
+            kvp =>
+            {
+                Assert.Equal("Running", kvp.Key);
+                Assert.True(kvp.Value);
+            });
+        Assert.Collection(cut.Instance.ResourceHealthStatusesToVisibility.OrderBy(kvp => kvp.Key),
+            kvp =>
+            {
+                Assert.Equal("Healthy", kvp.Key);
+                Assert.True(kvp.Value);
+            },
+            kvp =>
+            {
+                Assert.Equal("Unhealthy", kvp.Key);
+                Assert.True(kvp.Value);
+            });
+    }
+
+    [Fact]
+    public void FilterResources()
+    {
+        // Arrange
+        var viewport = new ViewportInformation(IsDesktop: true, IsUltraLowHeight: false, IsUltraLowWidth: false);
+        var initialResources = new List<ResourceViewModel>
+        {
+            CreateResource(
+                "Resource1",
+                "Type1",
+                "Running",
+                ImmutableArray.Create(new HealthReportViewModel("Null", null, "Description1", null))),
+            CreateResource(
+                "Resource2",
+                "Type2",
+                "Running",
+                ImmutableArray.Create(new HealthReportViewModel("Healthy", HealthStatus.Healthy, "Description2", null))),
+            CreateResource(
+                "Resource3",
+                "Type3",
+                "Stopping",
+                ImmutableArray.Create(new HealthReportViewModel("Degraded", HealthStatus.Degraded, "Description3", null))),
+        };
+        var dashboardClient = new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>);
+        ResourceSetupHelpers.SetupResourcesPage(
+            this,
+            viewport,
+            dashboardClient);
 
         var cut = RenderComponent<Components.Pages.Resources>(builder =>
         {

--- a/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
+++ b/tests/Aspire.Dashboard.Components.Tests/Shared/ResourceSetupHelpers.cs
@@ -50,7 +50,7 @@ internal static class ResourceSetupHelpers
         context.JSInterop.SetupVoid("scrollToTop", _ => true);
     }
 
-    public static void SetupResourcesPage(TestContext context, ViewportInformation viewport, IList<ResourceViewModel> initialResources)
+    public static void SetupResourcesPage(TestContext context, ViewportInformation viewport, IDashboardClient? dashboardClient = null)
     {
         var version = typeof(FluentMain).Assembly.GetName().Version!;
 
@@ -93,7 +93,7 @@ internal static class ResourceSetupHelpers
         context.Services.AddSingleton<IKeyCodeService, KeyCodeService>();
         context.Services.AddFluentUIComponents();
         context.Services.AddScoped<DashboardCommandExecutor, DashboardCommandExecutor>();
-        context.Services.AddSingleton<IDashboardClient>(new TestDashboardClient(isEnabled: true, initialResources: initialResources, resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>));
+        context.Services.AddSingleton<IDashboardClient>(dashboardClient ?? new TestDashboardClient(isEnabled: true, initialResources: [], resourceChannelProvider: Channel.CreateUnbounded<IReadOnlyList<ResourceViewModelChange>>));
 
         var dimensionManager = context.Services.GetRequiredService<DimensionManager>();
         dimensionManager.InvokeOnViewportInformationChanged(viewport);


### PR DESCRIPTION
## Description

Fixes regression from https://github.com/dotnet/aspire/pull/6925. It didn't update the filters with new values as resources updated. Stopping a resource would cause it to disappear:

1. Filter only allows Starting and Running
2. Resource is updated to Stopping. Filter isn't updated to view.
3. Resource disappears from UI.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
