### PR TITLE
Fix AddParameter usage in tests

### DIFF
--- a/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
+++ b/tests/Aspire.Hosting.Containers.Tests/WithDockerfileTests.cs
@@ -25,8 +25,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
 
         var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync(includeSecrets: true);
 
-        var parameter = builder.AddParameter("secret", secret: true);
         builder.Configuration["Parameters:secret"] = "open sesame from env";
+        var parameter = builder.AddParameter("secret", secret: true);
 
         builder.AddContainer("testcontainer", "testimage")
                .WithHttpEndpoint(targetPort: 80)
@@ -160,8 +160,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         });
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var parameter = builder.AddParameter("message");
         builder.Configuration["Parameters:message"] = "hello";
+        var parameter = builder.AddParameter("message");
 
         var container = builder.AddContainer("testcontainer", "testimage")
                                .WithHttpEndpoint(targetPort: 80)
@@ -208,8 +208,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         });
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var parameter = builder.AddParameter("message");
         builder.Configuration["Parameters:message"] = "hello";
+        var parameter = builder.AddParameter("message");
 
         var container = builder.AddDockerfile("testcontainer", tempContextPath, tempDockerfilePath, "runner")
                                .WithHttpEndpoint(targetPort: 80)
@@ -255,8 +255,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         });
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var parameter = builder.AddParameter("secret", secret: true);
         builder.Configuration["Parameters:secret"] = "open sesame";
+        var parameter = builder.AddParameter("secret", secret: true);
 
         var container = builder.AddContainer("testcontainer", "testimage")
                                .WithHttpEndpoint(targetPort: 80)
@@ -301,8 +301,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
         });
         builder.Services.AddLogging(b => b.AddXunit(testOutputHelper));
 
-        var parameter = builder.AddParameter("secret", secret: true);
         builder.Configuration["Parameters:secret"] = "open sesame";
+        var parameter = builder.AddParameter("secret", secret: true);
 
         var container = builder.AddDockerfile("testcontainer", tempContextPath, tempDockerfilePath)
                                .WithHttpEndpoint(targetPort: 80)
@@ -344,8 +344,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
 
         var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
 
-        var parameter = builder.AddParameter("message");
         builder.Configuration["Parameters:message"] = "hello";
+        var parameter = builder.AddParameter("message");
 
         builder.AddContainer("testcontainer", "testimage")
                .WithHttpEndpoint(targetPort: 80)
@@ -415,8 +415,8 @@ public class WithDockerfileTests(ITestOutputHelper testOutputHelper)
 
         var (tempContextPath, tempDockerfilePath) = await CreateTemporaryDockerfileAsync();
 
-        var parameter = builder.AddParameter("message");
         builder.Configuration["Parameters:message"] = "hello";
+        var parameter = builder.AddParameter("message");
 
         builder.AddDockerfile("testcontainer", tempContextPath, tempDockerfilePath)
                .WithHttpEndpoint(targetPort: 80)

--- a/tests/Aspire.Hosting.Elasticsearch.Tests/AddElasticsearchTests.cs
+++ b/tests/Aspire.Hosting.Elasticsearch.Tests/AddElasticsearchTests.cs
@@ -76,9 +76,8 @@ public class AddElasticsearchTests
     public async Task AddElasticsearchContainerAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "pass";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "pass");
         appBuilder.AddElasticsearch("elasticsearch",pass);
 
         using var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchFunctionalTests.cs
@@ -149,8 +149,7 @@ public class ElasticsearchFunctionalTests(ITestOutputHelper testOutputHelper)
             }
 
             using var builder2 = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
-            var passwordParameter2 = builder2.AddParameter("pwd");
-            builder2.Configuration["Parameters:pwd"] = password;
+            var passwordParameter2 = builder2.AddParameter("pwd", password);
             var elasticsearch2 = builder2.AddElasticsearch("elasticsearch", passwordParameter2);
 
             if (useVolume)

--- a/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Elasticsearch.Tests/ElasticsearchPublicApiTests.cs
@@ -74,8 +74,7 @@ public class ElasticsearchPublicApiTests
     public void CtorElasticsearchResourceShouldThrowWhenNameIsNull()
     {
         var builder = new DistributedApplicationBuilder([]);
-        builder.Configuration["Parameters:Password"] = "p@ssw0rd1";
-        var password = builder.AddParameter("Password");
+        var password = builder.AddParameter("Password", "p@ssw0rd1");
         const string name = null!;
 
         var action = () => new ElasticsearchResource(name, password.Resource);

--- a/tests/Aspire.Hosting.Milvus.Tests/AddMilvusTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/AddMilvusTests.cs
@@ -17,9 +17,8 @@ public class AddMilvusTests
     public void AddMilvusWithDefaultsAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:apikey"] = "pass";
 
-        var pass = appBuilder.AddParameter("apikey");
+        var pass = appBuilder.AddParameter("apikey", "pass");
         appBuilder.AddMilvus("my-milvus", apiKey: pass);
 
         using var app = appBuilder.Build();
@@ -48,9 +47,8 @@ public class AddMilvusTests
     public void AddMilvusAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:apikey"] = "pass";
 
-        var pass = appBuilder.AddParameter("apikey");
+        var pass = appBuilder.AddParameter("apikey", "pass");
         appBuilder.AddMilvus("my-milvus", apiKey: pass);
 
         using var app = appBuilder.Build();
@@ -80,8 +78,7 @@ public class AddMilvusTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
 
-        appBuilder.Configuration["Parameters:apikey"] = "pass";
-        var pass = appBuilder.AddParameter("apikey");
+        var pass = appBuilder.AddParameter("apikey", "pass");
 
         var milvus = appBuilder.AddMilvus("my-milvus", pass)
                                  .WithEndpoint("grpc", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", MilvusPortGrpc));
@@ -97,8 +94,7 @@ public class AddMilvusTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
 
-        appBuilder.Configuration["Parameters:apikey"] = "pass";
-        var pass = appBuilder.AddParameter("apikey");
+        var pass = appBuilder.AddParameter("apikey", "pass");
 
         var milvus = appBuilder.AddMilvus("my-milvus", pass)
             .WithEndpoint("grpc", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", MilvusPortGrpc));
@@ -130,8 +126,7 @@ public class AddMilvusTests
     public async Task VerifyManifest()
     {
         var appBuilder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions() { Args = new string[] { "--publisher", "manifest" } });
-        appBuilder.Configuration["Parameters:apikey"] = "pass";
-        var pass = appBuilder.AddParameter("apikey");
+        var pass = appBuilder.AddParameter("apikey", "pass");
         var milvus = appBuilder.AddMilvus("milvus", pass);
         var db1 = milvus.AddDatabase("db1");
 
@@ -181,8 +176,7 @@ public class AddMilvusTests
     {
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        builder.Configuration["Parameters:apikey"] = "pass";
-        var pass = builder.AddParameter("apikey");
+        var pass = builder.AddParameter("apikey", "pass");
 
         var milvus = builder.AddMilvus("my-milvus", grpcPort: 5503, apiKey: pass);
 

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusFunctionalTests.cs
@@ -130,8 +130,7 @@ public class MilvusFunctionalTests(ITestOutputHelper testOutputHelper)
             }
 
             using var builder2 = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
-            var passwordParameter = builder2.AddParameter("pwd");
-            builder2.Configuration["Parameters:pwd"] = password;
+            var passwordParameter = builder2.AddParameter("pwd", password);
 
             var milvus2 = builder2.AddMilvus("milvus2", passwordParameter);
             var db2 = milvus2.AddDatabase("milvusdb2", dbname);

--- a/tests/Aspire.Hosting.Milvus.Tests/MilvusPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Milvus.Tests/MilvusPublicApiTests.cs
@@ -25,8 +25,7 @@ public class MilvusPublicApiTests
     public void AddMilvusContainerShouldThrowWhenNameIsNull()
     {
         var builder = DistributedApplication.CreateBuilder([]);
-        builder.Configuration["Parameters:ApiKey"] = "root:Milvus";
-        var apiKey = builder.AddParameter("ApiKey");
+        var apiKey = builder.AddParameter("ApiKey", "root:Milvus");
         string name = null!;
 
         var action = () => builder.AddMilvus(name, apiKey);
@@ -39,8 +38,7 @@ public class MilvusPublicApiTests
     public void AddDatabaseShouldThrowWhenNameIsNull()
     {
         var builder = DistributedApplication.CreateBuilder([]);
-        builder.Configuration["Parameters:ApiKey"] = "root:Milvus";
-        var apiKey = builder.AddParameter("ApiKey");
+        var apiKey = builder.AddParameter("ApiKey", "root:Milvus");
 
         var milvus = builder.AddMilvus("Milvus", apiKey);
         string name = null!;
@@ -101,8 +99,7 @@ public class MilvusPublicApiTests
     public void WithDataBindMountShouldThrowWhenSourceIsNull()
     {
         var builder = DistributedApplication.CreateBuilder([]);
-        builder.Configuration["Parameters:ApiKey"] = "root:Milvus";
-        var apiKey = builder.AddParameter("ApiKey");
+        var apiKey = builder.AddParameter("ApiKey", "root:Milvus");
 
         var milvus = builder.AddMilvus("Milvus", apiKey);
         string source = null!;
@@ -128,8 +125,7 @@ public class MilvusPublicApiTests
     public void WithConfigurationBindMountShouldThrowWhenConfigurationFilePathIsNull()
     {
         var builder = DistributedApplication.CreateBuilder([]);
-        builder.Configuration["Parameters:ApiKey"] = "root:Milvus";
-        var apiKey = builder.AddParameter("ApiKey");
+        var apiKey = builder.AddParameter("ApiKey", "root:Milvus");
 
         var milvus = builder.AddMilvus("Milvus", apiKey);
         string configurationFilePath = null!;

--- a/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MongoDB.Tests/MongoDbFunctionalTests.cs
@@ -170,8 +170,7 @@ public class MongoDbFunctionalTests(ITestOutputHelper testOutputHelper)
             }
 
             using var builder2 = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
-            var passwordParameter2 = builder2.AddParameter("pwd");
-            builder2.Configuration["Parameters:pwd"] = password;
+            var passwordParameter2 = builder2.AddParameter("pwd", password);
 
             var mongodb2 = builder2.AddMongoDB("mongodb", password: passwordParameter2);
             var db2 = mongodb2.AddDatabase(dbName);

--- a/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/AddMySqlTests.cs
@@ -74,9 +74,8 @@ public class AddMySqlTests
     public async Task AddMySqlAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "pass";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "pass");
         appBuilder.AddMySql("mysql", pass, 1234);
 
         using var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlFunctionalTests.cs
@@ -206,8 +206,7 @@ public class MySqlFunctionalTests(ITestOutputHelper testOutputHelper)
             }
 
             using var builder2 = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
-            var passwordParameter2 = builder2.AddParameter("pwd");
-            builder2.Configuration["Parameters:pwd"] = password;
+            var passwordParameter2 = builder2.AddParameter("pwd", password);
 
             var mysql2 = builder2.AddMySql("mysql", passwordParameter2);
             var db2 = mysql2.AddDatabase(mySqlDbName);

--- a/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Nats.Tests/NatsFunctionalTests.cs
@@ -111,11 +111,9 @@ public class NatsFunctionalTests(ITestOutputHelper testOutputHelper)
         var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
 
         using var builder = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
-        builder.Configuration["Parameters:user"] = "user";
-        builder.Configuration["Parameters:pass"] = "password";
 
-        var usernameParameter = builder.AddParameter("user");
-        var passwordParameter = builder.AddParameter("pass");
+        var usernameParameter = builder.AddParameter("user", "user");
+        var passwordParameter = builder.AddParameter("pass", "password");
 
         var nats = builder.AddNats("nats", userName: usernameParameter, password: passwordParameter);
 

--- a/tests/Aspire.Hosting.Oracle.Tests/AddOracleTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/AddOracleTests.cs
@@ -73,9 +73,8 @@ public class AddOracleTests
     public async Task AddOracleAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "pass";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "pass");
         appBuilder.AddOracle("orcl", pass, 1234);
 
         using var app = appBuilder.Build();
@@ -155,9 +154,8 @@ public class AddOracleTests
     public async Task AddDatabaseToOracleDatabaseAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "pass";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "pass");
         appBuilder.AddOracle("oracle", pass, 1234).AddDatabase("db");
 
         using var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
+++ b/tests/Aspire.Hosting.Oracle.Tests/OracleFunctionalTests.cs
@@ -167,8 +167,7 @@ public class OracleFunctionalTests(ITestOutputHelper testOutputHelper)
             }
 
             using var builder2 = TestDistributedApplicationBuilder.Create(o => { }, testOutputHelper);
-            var passwordParameter2 = builder2.AddParameter("pwd");
-            builder2.Configuration["Parameters:pwd"] = password;
+            var passwordParameter2 = builder2.AddParameter("pwd", password);
 
             var oracle2 = builder2.AddOracle("oracle", passwordParameter2);
 

--- a/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
+++ b/tests/Aspire.Hosting.PostgreSQL.Tests/AddPostgresTests.cs
@@ -98,9 +98,8 @@ public class AddPostgresTests
     public async Task AddPostgresAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "pass";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "pass");
         appBuilder.AddPostgres("myPostgres", password: pass, port: 1234);
 
         using var app = appBuilder.Build();
@@ -189,9 +188,8 @@ public class AddPostgresTests
     public async Task AddDatabaseToPostgresAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "pass";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "pass");
         appBuilder.AddPostgres("postgres", password: pass, port: 1234).AddDatabase("db");
 
         using var app = appBuilder.Build();

--- a/tests/Aspire.Hosting.Qdrant.Tests/AddQdrantTests.cs
+++ b/tests/Aspire.Hosting.Qdrant.Tests/AddQdrantTests.cs
@@ -109,9 +109,8 @@ public class AddQdrantTests
     public async Task AddQdrantAddsAnnotationMetadata()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "pass";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "pass");
         appBuilder.AddQdrant("my-qdrant", apiKey: pass);
 
         using var app = appBuilder.Build();
@@ -152,8 +151,7 @@ public class AddQdrantTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
 
-        appBuilder.Configuration["Parameters:pass"] = "pass";
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "pass");
 
         var qdrant = appBuilder.AddQdrant("my-qdrant", pass)
                                  .WithEndpoint("grpc", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 6334));
@@ -169,8 +167,7 @@ public class AddQdrantTests
     {
         var appBuilder = DistributedApplication.CreateBuilder();
 
-        appBuilder.Configuration["Parameters:pass"] = "pass";
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "pass");
 
         var qdrant = appBuilder.AddQdrant("my-qdrant", pass)
             .WithEndpoint("grpc", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 6334))

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/AddRabbitMQTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/AddRabbitMQTests.cs
@@ -92,9 +92,8 @@ public class AddRabbitMQTests
     public async Task RabbitMQCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "p@ssw0rd1";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "p@ssw0rd1");
         appBuilder
             .AddRabbitMQ("rabbit", password: pass)
             .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 27011));

--- a/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
+++ b/tests/Aspire.Hosting.RabbitMQ.Tests/RabbitMQFunctionalTests.cs
@@ -169,8 +169,7 @@ public class RabbitMQFunctionalTests(ITestOutputHelper testOutputHelper)
             testOutputHelper.WriteLine($"Starting the second run with the same volume/mount");
 
             using var builder2 = TestDistributedApplicationBuilder.CreateWithTestContainerRegistry(testOutputHelper);
-            var passwordParameter2 = builder2.AddParameter("pwd");
-            builder2.Configuration["Parameters:pwd"] = password;
+            var passwordParameter2 = builder2.AddParameter("pwd", password);
 
             var rabbitMQ2 = builder2.AddRabbitMQ("rabbitMQ", password: passwordParameter2);
 

--- a/tests/Aspire.Hosting.SqlServer.Tests/AddSqlServerTests.cs
+++ b/tests/Aspire.Hosting.SqlServer.Tests/AddSqlServerTests.cs
@@ -80,9 +80,8 @@ public class AddSqlServerTests
     public async Task SqlServerCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "p@ssw0rd1";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "p@ssw0rd1");
         appBuilder
             .AddSqlServer("sqlserver", pass)
             .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1433));
@@ -102,9 +101,8 @@ public class AddSqlServerTests
     public async Task SqlServerDatabaseCreatesConnectionString()
     {
         var appBuilder = DistributedApplication.CreateBuilder();
-        appBuilder.Configuration["Parameters:pass"] = "p@ssw0rd1";
 
-        var pass = appBuilder.AddParameter("pass");
+        var pass = appBuilder.AddParameter("pass", "p@ssw0rd1");
         appBuilder
             .AddSqlServer("sqlserver", pass)
             .WithEndpoint("tcp", e => e.AllocatedEndpoint = new AllocatedEndpoint(e, "localhost", 1433))


### PR DESCRIPTION
When adding the parameter first, and then setting the config, it accidently works because an exception is thrown at first and then the value is retrieved later when the config is set.

Fix this by ensuring the configuration is set first, before calling AddParameter.

For hosting tests for hosting integrations that aren't part of the core/base APIs, I changed the tests to be simple and just pass the constant value into AddParameter.

This is a follow-up to https://github.com/dotnet/aspire/pull/7297.
