### PR TITLE
Don't wait for parameter/connection string resources

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceNotificationService.cs
@@ -264,6 +264,14 @@ public class ResourceNotificationService : IDisposable
         var pendingDependencies = new List<Task>();
         foreach (var waitAnnotation in waitAnnotations)
         {
+            if (waitAnnotation.Resource is ParameterResource or ResourceWithConnectionStringSurrogate)
+            {
+                // Parameters and connection string resources are inert and don't need to be waited on.
+                // If we add support for parameter resources that can be waited on, we can remove this check.
+                // As of right now, we don't support waiting on parameter resources.
+                continue;
+            }
+
             var pendingDependency = waitAnnotation.WaitType switch
             {
                 WaitType.WaitUntilHealthy => WaitUntilHealthyAsync(resource, waitAnnotation.Resource, cancellationToken),

--- a/tests/Aspire.Hosting.Tests/WaitForTests.cs
+++ b/tests/Aspire.Hosting.Tests/WaitForTests.cs
@@ -81,6 +81,45 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task WaitingForParameterResourceCompletesImmediately()
+    {
+        using var builder = TestDistributedApplicationBuilder.Create(testOutputHelper);
+
+        builder.Configuration["ConnectionStrings:cs"] = "cs-value";
+
+        // This test waits for a parameter, a connection string, and a custom resource.
+        // The only thing being waited on should be the custom resource.
+
+        var dependency = builder.AddResource(new CustomResource("test"));
+        var cs = builder.AddConnectionString("cs");
+        var param = builder.AddParameter("param", "value");
+        var nginx = builder.AddContainer("nginx", "mcr.microsoft.com/cbl-mariner/base/nginx", "1.22")
+                           .WaitFor(cs)
+                           .WaitFor(param)
+                           .WaitFor(dependency);
+
+        using var app = builder.Build();
+
+        var rns = app.Services.GetRequiredService<ResourceNotificationService>();
+
+        using var startupCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
+        var startTask = app.StartAsync(startupCts.Token);
+
+        using var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
+        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
+
+        await rns.PublishUpdateAsync(dependency.Resource, s => s with
+        {
+            State = KnownResourceStates.Running
+        });
+
+        // Notice we don't need to move the parameter or connection string to a running state
+        await startTask;
+
+        await app.StopAsync();
+    }
+
+    [Fact]
     [RequiresDocker]
     public async Task EnsureDependentResourceMovesIntoWaitingState()
     {
@@ -106,7 +145,7 @@ public class WaitForTests(ITestOutputHelper testOutputHelper)
         var waitingStateCts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.LongTimeoutDuration);
 
         var rns = app.Services.GetRequiredService<ResourceNotificationService>();
-        await rns.WaitForResourceAsync(nginx.Resource.Name, "Waiting", waitingStateCts.Token);
+        await rns.WaitForResourceAsync(nginx.Resource.Name, KnownResourceStates.Waiting, waitingStateCts.Token);
 
         // Now that we know we successfully entered the Waiting state, we can swap
         // the dependency into a running state which will unblock startup and


### PR DESCRIPTION
## Description

Parameter resources do not have a lifecycle and it's not possible to wait on them today, yet this hangs. This PR special cases those for now but that's not the long-term solution. We need [a design](https://github.com/dotnet/aspire/issues/6040) to let the system know when resources do or don't have a lifecycle (or we need to be able to detect terminal states). I chose to unblock this scenario for now with simpler code because it affects a key scenario: Using existing resources.

Fixes #6858

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
