### PR TITLE
Refactor to reuse polly pipelines and avoid 20 second test time

### DIFF
--- a/src/Aspire.Hosting/Dcp/AppResource.cs
+++ b/src/Aspire.Hosting/Dcp/AppResource.cs
@@ -13,6 +13,7 @@ internal class AppResource : IResourceReference
     public IResource ModelResource { get; }
     public CustomResource DcpResource { get; }
     public string DcpResourceName => DcpResource.Metadata.Name;
+    public bool IsStartingOrHasStarted { get; set; }
     public virtual List<ServiceAppResource> ServicesProduced { get; } = [];
     public virtual List<ServiceAppResource> ServicesConsumed { get; } = [];
 

--- a/src/Aspire.Hosting/Dcp/AppResource.cs
+++ b/src/Aspire.Hosting/Dcp/AppResource.cs
@@ -13,7 +13,6 @@ internal class AppResource : IResourceReference
     public IResource ModelResource { get; }
     public CustomResource DcpResource { get; }
     public string DcpResourceName => DcpResource.Metadata.Name;
-    public bool IsStartingOrHasStarted { get; set; }
     public virtual List<ServiceAppResource> ServicesProduced { get; } = [];
     public virtual List<ServiceAppResource> ServicesConsumed { get; } = [];
 

--- a/src/Aspire.Hosting/Dcp/DcpPipelineBuilder.cs
+++ b/src/Aspire.Hosting/Dcp/DcpPipelineBuilder.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Retry;
+using Polly.Timeout;
+
+namespace Aspire.Hosting.Dcp;
+
+internal static class DcpPipelineBuilder
+{
+    public static ResiliencePipeline BuildDeleteRetryPipeline(ILogger logger)
+    {
+        var ensureDeleteRetryStrategy = new RetryStrategyOptions()
+        {
+            BackoffType = DelayBackoffType.Exponential,
+            Delay = TimeSpan.FromMilliseconds(200),
+            UseJitter = true,
+            MaxRetryAttempts = 10, // Cumulative time for all attempts amounts to about 15 seconds
+            MaxDelay = TimeSpan.FromSeconds(3),
+            ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+            OnRetry = (retry) =>
+            {
+                logger.LogDebug("Retrying check for deleted resource. Attempt: {Attempt}. Error message: {ErrorMessage}", retry.AttemptNumber, retry.Outcome.Exception?.Message);
+                return ValueTask.CompletedTask;
+            }
+        };
+
+        var execution = new ResiliencePipelineBuilder().AddRetry(ensureDeleteRetryStrategy).Build();
+        return execution;
+    }
+
+    public static ResiliencePipeline BuildCreateServiceRetryPipeline(DcpOptions dcpOptions, ILogger logger)
+    {
+        var withTimeout = new TimeoutStrategyOptions()
+        {
+            Timeout = dcpOptions.ServiceStartupWatchTimeout
+        };
+
+        var tryTwice = new RetryStrategyOptions()
+        {
+            BackoffType = DelayBackoffType.Constant,
+            MaxDelay = TimeSpan.FromSeconds(1),
+            UseJitter = true,
+            MaxRetryAttempts = 1,
+            ShouldHandle = new PredicateBuilder().Handle<Exception>(),
+            OnRetry = (retry) =>
+            {
+                logger.LogDebug(
+                    retry.Outcome.Exception,
+                    "Watching for service port allocation ended with an error after {WatchDurationMs} (iteration {Iteration})",
+                    retry.Duration.TotalMilliseconds,
+                    retry.AttemptNumber
+                );
+                return ValueTask.CompletedTask;
+            }
+        };
+
+        var execution = new ResiliencePipelineBuilder().AddRetry(tryTwice).AddTimeout(withTimeout).Build();
+        return execution;
+    }
+
+    public static ResiliencePipeline BuildWatchResourcePipeline(ILogger logger)
+    {
+        var retryUntilCancelled = new RetryStrategyOptions()
+        {
+            ShouldHandle = new PredicateBuilder().HandleInner<EndOfStreamException>(),
+            BackoffType = DelayBackoffType.Exponential,
+            MaxRetryAttempts = int.MaxValue,
+            UseJitter = true,
+            MaxDelay = TimeSpan.FromSeconds(30),
+            OnRetry = (retry) =>
+            {
+                logger.LogDebug(
+                    retry.Outcome.Exception,
+                    "Long poll watch operation was ended by server after {LongPollDurationInMs} milliseconds (iteration {Iteration}).",
+                    retry.Duration.TotalMilliseconds,
+                    retry.AttemptNumber
+                    );
+                return ValueTask.CompletedTask;
+            }
+        };
+
+        var pipeline = new ResiliencePipelineBuilder().AddRetry(retryUntilCancelled).Build();
+        return pipeline;
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
+++ b/tests/Aspire.Hosting.Tests/Dcp/DcpExecutorTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Polly;
 using Xunit;
 
 namespace Aspire.Hosting.Tests.Dcp;
@@ -972,6 +973,10 @@ public class DcpExecutorTests
         });
 
         var appExecutor = CreateAppExecutor(distributedAppModel, kubernetesService: kubernetesService, events: dcpEvents);
+
+        // Set a custom pipeline without retries or delays to avoid waiting.
+        appExecutor.DeleteResourceRetryPipeline = new ResiliencePipelineBuilder().Build();
+
         await appExecutor.RunApplicationAsync();
 
         var dcpCtr = Assert.Single(kubernetesService.CreatedResources.OfType<Container>());


### PR DESCRIPTION
## Description

Small optimization to reuse polly pipelines. Pipelines now created once rather than each time they're used.

Also `DcpExecutorTests.ErrorIfResourceNotDeletedBeforeRestart` was taking 20 seconds to run because of retries. Setting an empty pipeline allows it to complete immediately.

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
