### PR TITLE
Add `WithExplicitStart` to conditionally not start some resources

### DIFF
--- a/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
+++ b/src/Aspire.Dashboard/Extensions/ResourceViewModelExtensions.cs
@@ -37,6 +37,11 @@ internal static class ResourceViewModelExtensions
         return resource.KnownState is KnownResourceState.RuntimeUnhealthy;
     }
 
+    public static bool IsNotStarted(this ResourceViewModel resource)
+    {
+        return resource.KnownState is KnownResourceState.NotStarted;
+    }
+
     public static bool IsUnknownState(this ResourceViewModel resource) => resource.KnownState is KnownResourceState.Unknown;
 
     public static bool HasNoState(this ResourceViewModel resource) => string.IsNullOrEmpty(resource.State);

--- a/src/Aspire.Dashboard/Model/KnownResourceState.cs
+++ b/src/Aspire.Dashboard/Model/KnownResourceState.cs
@@ -15,5 +15,6 @@ public enum KnownResourceState
     Waiting,
     Stopping,
     Unknown,
-    RuntimeUnhealthy
+    RuntimeUnhealthy,
+    NotStarted
 }

--- a/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
+++ b/src/Aspire.Dashboard/Model/ResourceStateViewModel.cs
@@ -48,7 +48,7 @@ internal class ResourceStateViewModel(string text, Icon icon, Color color)
                 color = Color.Warning;
             }
         }
-        else if (resource.IsUnusableTransitoryState() || resource.IsUnknownState())
+        else if (resource.IsUnusableTransitoryState() || resource.IsUnknownState() || resource.IsNotStarted())
         {
             icon = new Icons.Filled.Size16.CircleHint(); // A dashed, hollow circle.
             color = Color.Info;

--- a/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CommandsConfigurationExtensions.cs
@@ -117,10 +117,10 @@ internal static class CommandsConfigurationExtensions
 
         // Treat "Unknown" as stopped so the command to start the resource is available when "Unknown".
         // There is a situation where a container can be stopped with this state: https://github.com/dotnet/aspire/issues/5977
-        static bool IsStopped(string? state) => state is "Exited" or "Finished" or "FailedToStart" or "Unknown";
-        static bool IsStopping(string? state) => state is "Stopping";
-        static bool IsStarting(string? state) => state is "Starting";
-        static bool IsWaiting(string? state) => state is "Waiting";
-        static bool IsRuntimeUnhealthy(string? state) => state is "RuntimeUnhealthy";
+        static bool IsStopped(string? state) => KnownResourceStates.TerminalStates.Contains(state) || state == KnownResourceStates.NotStarted || state == "Unknown";
+        static bool IsStopping(string? state) => state == KnownResourceStates.Stopping;
+        static bool IsStarting(string? state) => state == KnownResourceStates.Starting;
+        static bool IsWaiting(string? state) => state == KnownResourceStates.Waiting;
+        static bool IsRuntimeUnhealthy(string? state) => state == KnownResourceStates.RuntimeUnhealthy;
     }
 }

--- a/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
+++ b/src/Aspire.Hosting/ApplicationModel/CustomResourceSnapshot.cs
@@ -351,6 +351,11 @@ public static class KnownResourceStates
     public static readonly string Waiting = nameof(Waiting);
 
     /// <summary>
+    /// The not started state. Useful for showing the resource was created without being started.
+    /// </summary>
+    public static readonly string NotStarted = nameof(NotStarted);
+
+    /// <summary>
     /// List of terminal states.
     /// </summary>
     public static readonly IReadOnlyList<string> TerminalStates = [Finished, FailedToStart, Exited];

--- a/src/Aspire.Hosting/ApplicationModel/ExplicitStartupAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExplicitStartupAnnotation.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
-/// Represents a wait relationship between two resources.
+/// Represents an annotation for instructing the resource not to be started with the app host.
 /// </summary>
 [DebuggerDisplay("Type = {GetType().Name,nq}")]
 public sealed class ExplicitStartupAnnotation : IResourceAnnotation

--- a/src/Aspire.Hosting/ApplicationModel/ExplicitStartupAnnotation.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ExplicitStartupAnnotation.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Aspire.Hosting.ApplicationModel;
+
+/// <summary>
+/// Represents a wait relationship between two resources.
+/// </summary>
+[DebuggerDisplay("Type = {GetType().Name,nq}")]
+public sealed class ExplicitStartupAnnotation : IResourceAnnotation
+{
+}

--- a/src/Aspire.Hosting/Dcp/AppResource.cs
+++ b/src/Aspire.Hosting/Dcp/AppResource.cs
@@ -16,6 +16,8 @@ internal class AppResource : IResourceReference
     public virtual List<ServiceAppResource> ServicesProduced { get; } = [];
     public virtual List<ServiceAppResource> ServicesConsumed { get; } = [];
 
+    public bool IsInitialized { get; set; }
+
     public AppResource(IResource modelResource, CustomResource dcpResource)
     {
         ModelResource = modelResource;

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -1240,6 +1240,11 @@ internal sealed class DcpExecutor : IDcpExecutor
 
             foreach (var cr in containerResources)
             {
+                if (cr.ModelResource.TryGetLastAnnotation<ExplicitStartupAnnotation>(out _))
+                {
+                    continue;
+                }
+
                 tasks.Add(CreateContainerAsyncCore(cr, cancellationToken));
             }
 

--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -932,8 +932,7 @@ internal sealed class DcpExecutor : IDcpExecutor
                     {
                         if (er.ModelResource.TryGetAnnotationsOfType<ExplicitStartupAnnotation>(out _))
                         {
-                            var newState = "NotStarted";
-                            await _executorEvents.PublishAsync(new OnResourceChangedContext(cancellationToken, resourceType, resource, er.DcpResource.Metadata.Name, new ResourceStatus(newState, null, null), s => s with { State = new ResourceStateSnapshot(newState, null) })).ConfigureAwait(false);
+                            await _executorEvents.PublishAsync(new OnResourceChangedContext(cancellationToken, resourceType, resource, er.DcpResource.Metadata.Name, new ResourceStatus(KnownResourceStates.NotStarted, null, null), s => s with { State = new ResourceStateSnapshot(KnownResourceStates.NotStarted, null) })).ConfigureAwait(false);
                             continue;
                         }
 
@@ -1253,9 +1252,7 @@ internal sealed class DcpExecutor : IDcpExecutor
             {
                 if (cr.ModelResource.TryGetLastAnnotation<ExplicitStartupAnnotation>(out _))
                 {
-                    var newState = "NotStarted";
-                    await _executorEvents.PublishAsync(new OnResourceChangedContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResourceName, new ResourceStatus(newState, null, null), s => s with { State = new ResourceStateSnapshot(newState, null) })).ConfigureAwait(false);
-
+                    await _executorEvents.PublishAsync(new OnResourceChangedContext(cancellationToken, KnownResourceTypes.Container, cr.ModelResource, cr.DcpResourceName, new ResourceStatus(KnownResourceStates.NotStarted, null, null), s => s with { State = new ResourceStateSnapshot(KnownResourceStates.NotStarted, null) })).ConfigureAwait(false);
                     continue;
                 }
 

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -17,6 +17,8 @@ Aspire.Hosting.ApplicationModel.EndpointNameAttribute
 Aspire.Hosting.ApplicationModel.EndpointNameAttribute.EndpointNameAttribute() -> void
 Aspire.Hosting.ApplicationModel.ExcludeLaunchProfileAnnotation
 Aspire.Hosting.ApplicationModel.ExcludeLaunchProfileAnnotation.ExcludeLaunchProfileAnnotation() -> void
+Aspire.Hosting.ApplicationModel.ExplicitStartupAnnotation
+Aspire.Hosting.ApplicationModel.ExplicitStartupAnnotation.ExplicitStartupAnnotation() -> void
 Aspire.Hosting.ApplicationModel.HealthReportSnapshot
 Aspire.Hosting.ApplicationModel.HealthReportSnapshot.Description.get -> string?
 Aspire.Hosting.ApplicationModel.HealthReportSnapshot.Description.init -> void
@@ -273,6 +275,7 @@ Aspire.Hosting.DistributedApplicationExecutionContextOptions.ServiceProvider.set
 static Aspire.Hosting.ResourceBuilderExtensions.WaitFor<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WaitForCompletion<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, Aspire.Hosting.ApplicationModel.IResourceBuilder<Aspire.Hosting.ApplicationModel.IResource!>! dependency, int exitCode = 0) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithCommand<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! name, string! displayName, System.Func<Aspire.Hosting.ApplicationModel.ExecuteCommandContext!, System.Threading.Tasks.Task<Aspire.Hosting.ApplicationModel.ExecuteCommandResult!>!>! executeCommand, System.Func<Aspire.Hosting.ApplicationModel.UpdateCommandStateContext!, Aspire.Hosting.ApplicationModel.ResourceCommandState>? updateState = null, string? displayDescription = null, object? parameter = null, string? confirmationMessage = null, string? iconName = null, Aspire.Hosting.ApplicationModel.IconVariant? iconVariant = null, bool isHighlighted = false) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
+static Aspire.Hosting.ResourceBuilderExtensions.WithExplicitStart<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string! key) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHttpHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string? path = null, int? statusCode = null, string? endpointName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!
 static Aspire.Hosting.ResourceBuilderExtensions.WithHttpsHealthCheck<T>(this Aspire.Hosting.ApplicationModel.IResourceBuilder<T>! builder, string? path = null, int? statusCode = null, string? endpointName = null) -> Aspire.Hosting.ApplicationModel.IResourceBuilder<T>!

--- a/src/Aspire.Hosting/PublicAPI.Unshipped.txt
+++ b/src/Aspire.Hosting/PublicAPI.Unshipped.txt
@@ -284,6 +284,7 @@ static Aspire.Hosting.Utils.VolumeNameGenerator.Generate<T>(Aspire.Hosting.Appli
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Exited -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.FailedToStart -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Finished -> string!
+static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.NotStarted -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Running -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.RuntimeUnhealthy -> string!
 static readonly Aspire.Hosting.ApplicationModel.KnownResourceStates.Starting -> string!

--- a/src/Aspire.Hosting/ResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting/ResourceBuilderExtensions.cs
@@ -734,6 +734,32 @@ public static class ResourceBuilderExtensions
     }
 
     /// <summary>
+    /// Adds a <see cref="ExplicitStartupAnnotation" /> annotation to the resource so it doesn't automatically start
+    /// with the app host startup.
+    /// </summary>
+    /// <typeparam name="T">The type of the resource.</typeparam>
+    /// <param name="builder">The resource builder.</param>
+    /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+    /// <remarks>
+    /// <para>This method is useful when a resource shouldn't automatically start when the app host starts.</para>
+    /// </remarks>
+    /// <example>
+    /// The database clean up tool project isn't started with the app host.
+    /// The resource start command can be used to run it ondemand later.
+    /// <code lang="C#">
+    /// var builder = DistributedApplication.CreateBuilder(args);
+    /// var pgsql = builder.AddPostgres("postgres");
+    /// builder.AddProject&lt;Projects.CleanUpDatabase&gt;("dbcleanuptool")
+    ///        .WithReference(pgsql)
+    ///        .WithExplicitStart();
+    /// </code>
+    /// </example>
+    public static IResourceBuilder<T> WithExplicitStart<T>(this IResourceBuilder<T> builder) where T : IResource
+    {
+        return builder.WithAnnotation(new ExplicitStartupAnnotation());
+    }
+
+    /// <summary>
     /// Waits for the dependency resource to enter the Exited or Finished state before starting the resource.
     /// </summary>
     /// <typeparam name="T">The type of the resource.</typeparam>


### PR DESCRIPTION
## Description

`WithExplicitStart` adds a annotation that instructs DCP not to start the resource. Resources with this attribute have the `NotStarted` state. The dashboard knows about this state and gives it an appropriate icon and enables the start command.

![explicitstart](https://github.com/user-attachments/assets/1b6503dd-8f3d-48cb-b6d3-a6ee0a5aa450)

Fixes https://github.com/dotnet/aspire/issues/5879

TODO:

- [x] Tests

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [x] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [x] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [x] Yes
      - [ ] No
  - [ ] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [ ] No
