### PR TITLE
DistributedApplicationTests improvements

### DIFF
--- a/src/Aspire.Hosting/Dcp/DcpExecutor.cs
+++ b/src/Aspire.Hosting/Dcp/DcpExecutor.cs
@@ -27,7 +27,7 @@ using Polly;
 
 namespace Aspire.Hosting.Dcp;
 
-internal sealed class DcpExecutor : IDcpExecutor
+internal sealed class DcpExecutor : IDcpExecutor, IAsyncDisposable
 {
     private const string DebugSessionPortVar = "DEBUG_SESSION_PORT";
     private const string DefaultAspireNetworkName = "default-aspire-network";
@@ -58,6 +58,7 @@ internal sealed class DcpExecutor : IDcpExecutor
     private readonly ConcurrentDictionary<string, (CancellationTokenSource Cancellation, Task Task)> _logStreams = new();
     private DcpInfo? _dcpInfo;
     private Task? _resourceWatchTask;
+    private int _stopped;
 
     private readonly record struct LogInformationEntry(string ResourceName, bool? LogsAvailable, bool? HasSubscribers);
     private readonly Channel<LogInformationEntry> _logInformationChannel = Channel.CreateUnbounded<LogInformationEntry>(
@@ -136,6 +137,11 @@ internal sealed class DcpExecutor : IDcpExecutor
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
+        if (Interlocked.CompareExchange(ref _stopped, 1, 0) != 0)
+        {
+            return; // Already stopped/stop in progress.
+        }
+
         _shutdownCancellation.Cancel();
         var tasks = new List<Task>();
         if (_resourceWatchTask is { } resourceTask)
@@ -180,6 +186,11 @@ internal sealed class DcpExecutor : IDcpExecutor
         {
             _logger.LogDebug(ex, "Application orchestrator could not be stopped programmatically.");
         }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
     }
 
     private void WatchResourceChanges()

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -154,11 +154,12 @@ public class DistributedApplicationTests
     [Fact]
     public async Task ExplicitStart_StartResource()
     {
-        using var testProgram = CreateTestProgram();
+        const string testName = "explicit-start-resource";
+        using var testProgram = CreateTestProgram(testName);
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
-        var notStartedResourceName = "servicea";
-        var dependentResourceName = "serviceb";
+        var notStartedResourceName = $"{testName}-servicea";
+        var dependentResourceName = $"{testName}-serviceb";
 
         testProgram.ServiceABuilder.WithExplicitStart();
         testProgram.ServiceBBuilder.WaitFor(testProgram.ServiceABuilder);

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -45,7 +45,7 @@ public class DistributedApplicationTests
     {
         var exceptionMessage = "Exception from lifecycle hook to prove it ran!";
 
-        using var testProgram = CreateTestProgram();
+        using var testProgram = CreateTestProgram("lifecycle-hook-executed-async");
         testProgram.AppBuilder.Services.AddLifecycleHook((sp) =>
         {
             return new CallbackLifecycleHook((appModel, cancellationToken) =>
@@ -73,7 +73,7 @@ public class DistributedApplicationTests
 
         var signal = (FirstHookExecuted: false, SecondHookExecuted: false);
 
-        using var testProgram = CreateTestProgram();
+        using var testProgram = CreateTestProgram("multiple-lifecycle-hooks");
 
         // Lifecycle hook 1
         testProgram.AppBuilder.Services.AddLifecycleHook((sp) =>
@@ -112,11 +112,11 @@ public class DistributedApplicationTests
     [Fact]
     public async Task StartResourceForcesStart()
     {
-        using var testProgram = CreateTestProgram();
+        using var testProgram = CreateTestProgram("force-resource-start");
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
         testProgram.AppBuilder.Services.AddHealthChecks().AddCheck("dummy_healthcheck", () => HealthCheckResult.Unhealthy());
 
-        var dependentResourceName = "serviceb";
+        var dependentResourceName = "force-resource-start-serviceb";
 
         testProgram.ServiceABuilder.WithHealthCheck("dummy_healthcheck");
         testProgram.ServiceBBuilder.WaitFor(testProgram.ServiceABuilder);
@@ -198,7 +198,7 @@ public class DistributedApplicationTests
     {
         var exceptionMessage = "Exception from lifecycle hook to prove it ran!";
 
-        using var testProgram = CreateTestProgram();
+        using var testProgram = CreateTestProgram("lifecycle-hook-executed-sync");
         testProgram.AppBuilder.Services.AddLifecycleHook((sp) =>
         {
             return new CallbackLifecycleHook((appModel, cancellationToken) =>
@@ -217,7 +217,7 @@ public class DistributedApplicationTests
     [Fact]
     public void TryAddWillNotAddTheSameLifecycleHook()
     {
-        using var testProgram = CreateTestProgram();
+        using var testProgram = CreateTestProgram("lifecycle-hook-duplicates");
 
         var callback1 = (IServiceProvider sp) => new DummyLifecycleHook();
         testProgram.AppBuilder.Services.TryAddLifecycleHook(callback1);
@@ -235,7 +235,7 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task AllocatedPortsAssignedAfterHookRuns()
     {
-        using var testProgram = CreateTestProgram();
+        using var testProgram = CreateTestProgram("ports-assigned-after-hook-runs");
         var tcs = new TaskCompletionSource<DistributedApplicationModel>(TaskCreationOptions.RunContinuationsAsynchronously);
         testProgram.AppBuilder.Services.AddLifecycleHook(sp => new CheckAllocatedEndpointsLifecycleHook(tcs));
 
@@ -270,7 +270,7 @@ public class DistributedApplicationTests
     {
         var replicaCount = 3;
 
-        using var testProgram = CreateTestProgram();
+        using var testProgram = CreateTestProgram("multi-replica-svcs");
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         testProgram.ServiceBBuilder.WithReplicas(replicaCount);
@@ -323,12 +323,12 @@ public class DistributedApplicationTests
     [Fact]
     [RequiresDocker]
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
-    public async Task VerifyDockerAppWorks()
+    public async Task VerifyContainerArgs()
     {
-        using var testProgram = CreateTestProgram();
+        using var testProgram = CreateTestProgram("verify-container-args");
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
-        testProgram.AppBuilder.AddContainer("redis-cli", "redis")
+        testProgram.AppBuilder.AddContainer("verify-container-args-redis", "redis")
             .WithArgs("redis-cli", "-h", "host.docker.internal", "-p", "9999", "MONITOR")
             .WithContainerRuntimeArgs("--add-host", "testlocalhost:127.0.0.1");
 
@@ -355,11 +355,12 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task VerifyContainerStopStartWorks()
     {
-        using var testProgram = CreateTestProgram(randomizePorts: false);
+        using var testProgram = CreateTestProgram("container-start-stop", randomizePorts: false);
 
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
-        testProgram.AppBuilder.AddContainer("redis0", "redis")
+        const string containerName = "container-start-stop-redis";
+        testProgram.AppBuilder.AddContainer(containerName, "redis")
             .WithEndpoint(targetPort: 6379, name: "tcp", env: "REDIS_PORT");
 
         await using var app = testProgram.Build();
@@ -380,7 +381,7 @@ public class DistributedApplicationTests
         using var cts = AsyncTestHelpers.CreateDefaultTimeoutTokenSource(TestConstants.DefaultOrchestratorTestLongTimeout);
         var token = cts.Token;
 
-        var containerPattern = $"redis0-{ReplicaIdRegex}-{suffix}";
+        var containerPattern = $"{containerName}-{ReplicaIdRegex}-{suffix}";
         var redisContainer = await KubernetesHelper.GetResourceByNameMatchAsync<Container>(kubernetes, containerPattern, r => r.Status?.State == ContainerState.Running, token).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         Assert.NotNull(redisContainer);
 
@@ -407,7 +408,8 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task VerifyExecutableStopStartWorks()
     {
-        using var testProgram = CreateTestProgram(randomizePorts: false);
+        const string testName = "executable-start-stop";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false);
 
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
@@ -419,7 +421,7 @@ public class DistributedApplicationTests
 
         await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
-        var executablePattern = $"servicea-{ReplicaIdRegex}-{suffix}";
+        var executablePattern = $"{testName}-servicea-{ReplicaIdRegex}-{suffix}";
         var serviceA = await KubernetesHelper.GetResourceByNameMatchAsync<Executable>(kubernetes, executablePattern, r => r.Status?.State == ExecutableState.Running).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         Assert.NotNull(serviceA);
 
@@ -441,17 +443,18 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task SpecifyingEnvPortInEndpointFlowsToEnv()
     {
-        using var testProgram = CreateTestProgram(randomizePorts: false);
+        const string testName = "ports-flow-to-env";
+        using var testProgram = CreateTestProgram(testName, randomizePorts: false);
 
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         testProgram.ServiceABuilder
             .WithHttpEndpoint(name: "http0", env: "PORT0");
 
-        testProgram.AppBuilder.AddContainer("redis0", "redis")
+        testProgram.AppBuilder.AddContainer($"{testName}-redis", "redis")
             .WithEndpoint(targetPort: 6379, name: "tcp", env: "REDIS_PORT");
 
-        testProgram.AppBuilder.AddNodeApp("nodeapp", "fakePath")
+        testProgram.AppBuilder.AddNodeApp($"{testName}-nodeapp", "fakePath")
             .WithHttpEndpoint(port: 5031, env: "PORT");
 
         await using var app = testProgram.Build();
@@ -461,25 +464,25 @@ public class DistributedApplicationTests
         await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
-        var redisContainer = await KubernetesHelper.GetResourceByNameMatchAsync<Container>(kubernetes, $"redis0-{ReplicaIdRegex}-{suffix}", r => r.Status?.EffectiveEnv is not null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+        var redisContainer = await KubernetesHelper.GetResourceByNameMatchAsync<Container>(kubernetes, $"{testName}-redis-{ReplicaIdRegex}-{suffix}", r => r.Status?.EffectiveEnv is not null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         Assert.NotNull(redisContainer);
 
-        var serviceA = await KubernetesHelper.GetResourceByNameAsync<Executable>(kubernetes, "servicea", suffix!, r => r.Status?.EffectiveEnv is not null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+        var serviceA = await KubernetesHelper.GetResourceByNameAsync<Executable>(kubernetes, $"{testName}-servicea", suffix!, r => r.Status?.EffectiveEnv is not null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         Assert.NotNull(serviceA);
 
-        var nodeApp = await KubernetesHelper.GetResourceByNameMatchAsync<Executable>(kubernetes, $"nodeapp-{ReplicaIdRegex}-{suffix}", r => r.Status?.EffectiveEnv is not null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+        var nodeApp = await KubernetesHelper.GetResourceByNameMatchAsync<Executable>(kubernetes, $"{testName}-nodeapp-{ReplicaIdRegex}-{suffix}", r => r.Status?.EffectiveEnv is not null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         Assert.NotNull(nodeApp);
 
         Assert.Equal("redis:latest", redisContainer.Spec.Image);
         Assert.Equal("6379", GetEnv(redisContainer.Spec.Env, "REDIS_PORT"));
         Assert.Equal("6379", GetEnv(redisContainer.Status!.EffectiveEnv, "REDIS_PORT"));
 
-        Assert.Equal($"{{{{- portForServing \"servicea-http0-{suffix}\" -}}}}", GetEnv(serviceA.Spec.Env, "PORT0"));
+        Assert.Equal($"{{{{- portForServing \"{testName}-servicea-http0-{suffix}\" -}}}}", GetEnv(serviceA.Spec.Env, "PORT0"));
         var serviceAPortValue = GetEnv(serviceA.Status!.EffectiveEnv, "PORT0");
         Assert.False(string.IsNullOrEmpty(serviceAPortValue));
         Assert.NotEqual(0, int.Parse(serviceAPortValue, CultureInfo.InvariantCulture));
 
-        Assert.Equal($"{{{{- portForServing \"nodeapp-{suffix}\" -}}}}", GetEnv(nodeApp.Spec.Env, "PORT"));
+        Assert.Equal($"{{{{- portForServing \"{testName}-nodeapp-{suffix}\" -}}}}", GetEnv(nodeApp.Spec.Env, "PORT"));
         var nodeAppPortValue = GetEnv(nodeApp.Status!.EffectiveEnv, "PORT");
         Assert.False(string.IsNullOrEmpty(nodeAppPortValue));
         Assert.NotEqual(0, int.Parse(nodeAppPortValue, CultureInfo.InvariantCulture));
@@ -497,13 +500,14 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task StartAsync_DashboardAuthConfig_PassedToDashboardProcess()
     {
+        const string testName = "dashboard-auth-config";
         var browserToken = "ThisIsATestToken";
         var args = new string[] {
             "ASPNETCORE_URLS=http://localhost:0",
             "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:0",
             $"DOTNET_DASHBOARD_FRONTEND_BROWSERTOKEN={browserToken}"
         };
-        using var testProgram = CreateTestProgram(args: args, disableDashboard: false);
+        using var testProgram = CreateTestProgram(testName, args: args, disableDashboard: false);
 
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
@@ -537,12 +541,13 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task StartAsync_UnsecuredAllowAnonymous_PassedToDashboardProcess()
     {
+        const string testName = "dashboard-allow-anonymous";
         var args = new string[] {
             "ASPNETCORE_URLS=http://localhost:0",
             "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL=http://localhost:0",
             "DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true"
         };
-        using var testProgram = CreateTestProgram(args: args, disableDashboard: false);
+        using var testProgram = CreateTestProgram(testName, args: args, disableDashboard: false);
 
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
@@ -573,10 +578,11 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task VerifyDockerWithEntrypointWorks()
     {
-        using var testProgram = CreateTestProgram();
+        const string testName = "docker-entrypoint";
+        using var testProgram = CreateTestProgram(testName);
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
-        testProgram.AppBuilder.AddContainer("redis-cli", "redis")
+        testProgram.AppBuilder.AddContainer($"{testName}-redis", "redis")
             .WithEntrypoint("bob");
 
         await using var app = testProgram.Build();
@@ -586,7 +592,7 @@ public class DistributedApplicationTests
         var s = app.Services.GetRequiredService<IKubernetesService>();
 
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
-        var redisContainer = await KubernetesHelper.GetResourceByNameMatchAsync<Container>(s, $"redis-cli-{ReplicaIdRegex}-{suffix}",
+        var redisContainer = await KubernetesHelper.GetResourceByNameMatchAsync<Container>(s, $"{testName}-redis-{ReplicaIdRegex}-{suffix}",
             r => r.Status?.State == ContainerState.FailedToStart && (r.Status?.Message.Contains("bob") ?? false)).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         Assert.NotNull(redisContainer);
@@ -601,11 +607,12 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task VerifyDockerWithBindMountWorksWithAbsolutePaths()
     {
-        using var testProgram = CreateTestProgram();
+        const string testName = "docker-bindmount-absolute";
+        using var testProgram = CreateTestProgram(testName);
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         var sourcePath = Path.GetFullPath("/etc/path-here");
-        testProgram.AppBuilder.AddContainer("redis-cli", "redis")
+        testProgram.AppBuilder.AddContainer($"{testName}-redis", "redis")
             .WithBindMount(sourcePath, "path-here");
 
         await using var app = testProgram.Build();
@@ -617,7 +624,7 @@ public class DistributedApplicationTests
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
         var redisContainer = await KubernetesHelper.GetResourceByNameMatchAsync<Container>(
                 s,
-                $"redis-cli-{ReplicaIdRegex}-{suffix}", r => r.Spec.VolumeMounts != null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+                $"{testName}-redis-{ReplicaIdRegex}-{suffix}", r => r.Spec.VolumeMounts != null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         Assert.NotNull(redisContainer.Spec.VolumeMounts);
         Assert.NotEmpty(redisContainer.Spec.VolumeMounts);
@@ -631,10 +638,11 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task VerifyDockerWithBindMountWorksWithRelativePaths()
     {
-        using var testProgram = CreateTestProgram();
+        const string testName = "docker-bindmount-relative";
+        using var testProgram = CreateTestProgram(testName);
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
-        testProgram.AppBuilder.AddContainer("redis-cli", "redis")
+        testProgram.AppBuilder.AddContainer($"{testName}-redis", "redis")
             .WithBindMount("etc/path-here", "path-here");
 
         await using var app = testProgram.Build();
@@ -646,7 +654,7 @@ public class DistributedApplicationTests
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
         var redisContainer = await KubernetesHelper.GetResourceByNameMatchAsync<Container>(
             s,
-            $"redis-cli-{ReplicaIdRegex}-{suffix}", r => r.Spec.VolumeMounts != null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+            $"{testName}-redis-{ReplicaIdRegex}-{suffix}", r => r.Spec.VolumeMounts != null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         Assert.NotNull(redisContainer.Spec.VolumeMounts);
         Assert.NotEmpty(redisContainer.Spec.VolumeMounts);
@@ -661,11 +669,12 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task VerifyDockerWithVolumeWorksWithName()
     {
-        using var testProgram = CreateTestProgram();
+        const string testName = "docker-volume";
+        using var testProgram = CreateTestProgram(testName);
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
-        testProgram.AppBuilder.AddContainer("redis-cli", "redis")
-            .WithVolume("test-volume-name", "/path-here");
+        testProgram.AppBuilder.AddContainer($"{testName}-redis", "redis")
+            .WithVolume($"{testName}-volume", "/path-here");
 
         await using var app = testProgram.Build();
 
@@ -676,11 +685,11 @@ public class DistributedApplicationTests
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
         var redisContainer = await KubernetesHelper.GetResourceByNameMatchAsync<Container>(
                 s,
-                $"redis-cli-{ReplicaIdRegex}-{suffix}", r => r.Spec.VolumeMounts != null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
+                $"{testName}-redis-{ReplicaIdRegex}-{suffix}", r => r.Spec.VolumeMounts != null).DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
 
         Assert.NotNull(redisContainer.Spec.VolumeMounts);
         Assert.NotEmpty(redisContainer.Spec.VolumeMounts);
-        Assert.Equal("test-volume-name", redisContainer.Spec.VolumeMounts[0].Source);
+        Assert.Equal($"{testName}-volume", redisContainer.Spec.VolumeMounts[0].Source);
 
         await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
     }
@@ -690,7 +699,8 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task KubernetesHasResourceNameForContainersAndExes()
     {
-        using var testProgram = CreateTestProgram(includeIntegrationServices: true);
+        const string testName = "kube-resource-names";
+        using var testProgram = CreateTestProgram(testName, includeIntegrationServices: true);
         testProgram.AppBuilder.Services.AddLogging(b => b.AddXunit(_testOutputHelper));
 
         await using var app = testProgram.Build();
@@ -701,17 +711,17 @@ public class DistributedApplicationTests
 
         var expectedExeResources = new HashSet<string>()
         {
-            "servicea",
-            "serviceb",
-            "servicec",
-            "workera",
-            "integrationservicea"
+            $"{testName}-servicea",
+            $"{testName}-serviceb",
+            $"{testName}-servicec",
+            $"{testName}-workera",
+            $"{testName}-integrationservicea"
         };
 
         var expectedContainerResources = new HashSet<string>()
         {
-            "redis",
-            "postgres"
+            $"{testName}-redis",
+            $"{testName}-postgres"
         };
 
         await foreach (var resource in s.WatchAsync<Container>().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout))
@@ -747,7 +757,8 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task ReplicasAndProxylessEndpointThrows()
     {
-        using var testProgram = CreateTestProgram();
+        const string testName = "replicas-no-proxyless-endpoints";
+        using var testProgram = CreateTestProgram(testName);
         testProgram.ServiceABuilder.WithReplicas(2).WithEndpoint("http", endpoint =>
         {
             endpoint.IsProxied = false;
@@ -758,14 +769,15 @@ public class DistributedApplicationTests
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync()).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
-        Assert.Equal($"Resource 'servicea-{suffix}' uses multiple replicas and a proxy-less endpoint 'http'. These features do not work together.", ex.Message);
+        Assert.Equal($"Resource '{testName}-servicea-{suffix}' uses multiple replicas and a proxy-less endpoint 'http'. These features do not work together.", ex.Message);
     }
 
     [Fact]
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task ProxylessEndpointWithoutPortThrows()
     {
-        using var testProgram = CreateTestProgram();
+        const string testName = "proxyess-endpoint-without-port";
+        using var testProgram = CreateTestProgram(testName);
         testProgram.ServiceABuilder.WithEndpoint("http", endpoint =>
         {
             endpoint.Port = null;
@@ -777,14 +789,15 @@ public class DistributedApplicationTests
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync()).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
-        Assert.Equal($"Service 'servicea-{suffix}' needs to specify a port for endpoint 'http' since it isn't using a proxy.", ex.Message);
+        Assert.Equal($"Service '{testName}-servicea-{suffix}' needs to specify a port for endpoint 'http' since it isn't using a proxy.", ex.Message);
     }
 
     [Fact]
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task ProxylessEndpointWorks()
     {
-        using var testProgram = CreateTestProgram();
+        const string testName = "proxyless-endpoint-works";
+        using var testProgram = CreateTestProgram(testName);
 
         testProgram.ServiceABuilder
             .WithEndpoint("http", e =>
@@ -798,7 +811,7 @@ public class DistributedApplicationTests
         await using var app = testProgram.Build();
         await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
 
-        var client = app.CreateHttpClientWithResilience("servicea", "http");
+        var client = app.CreateHttpClientWithResilience($"{testName}-servicea", "http");
 
         var result = await client.GetStringAsync("pid").DefaultTimeout(TestConstants.DefaultOrchestratorTestLongTimeout);
         Assert.NotNull(result);
@@ -819,7 +832,8 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4599", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task ProxylessAndProxiedEndpointBothWorkOnSameResource()
     {
-        using var testProgram = CreateTestProgram();
+        const string testName = "proxyless-and-proxied-endpoints";
+        using var testProgram = CreateTestProgram(testName);
 
         testProgram.ServiceABuilder
             .WithEndpoint("http", e =>
@@ -886,19 +900,20 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task ProxylessContainerCanBeReferenced()
     {
+        const string testName = "proxyless-container";
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var redis = builder.AddRedis("redis", 1234).WithEndpoint("tcp", endpoint =>
+        var redis = builder.AddRedis($"{testName}-redis", 1234).WithEndpoint("tcp", endpoint =>
         {
             endpoint.IsProxied = false;
         });
 
         // Since port is not specified, this instance will use the container target port (6379) as the host port.
-        var redisNoPort = builder.AddRedis("redisNoPort").WithEndpoint("tcp", endpoint =>
+        var redisNoPort = builder.AddRedis($"{testName}-redisNoPort").WithEndpoint("tcp", endpoint =>
         {
             endpoint.IsProxied = false;
         });
-        var servicea = builder.AddProject<Projects.ServiceA>("servicea")
+        var servicea = builder.AddProject<Projects.ServiceA>($"{testName}-servicea")
             .WithReference(redis)
             .WithReference(redisNoPort);
 
@@ -917,18 +932,18 @@ public class DistributedApplicationTests
 
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
         Assert.NotNull(suffix);
-        var service = Assert.Single(exeList.Where(c => "servicea".Equals(c.AppModelResourceName) && c.Name().Contains(suffix)));
-        var env = Assert.Single(service.Spec.Env!.Where(e => e.Name == "ConnectionStrings__redis"));
+        var service = Assert.Single(exeList.Where(c => $"{testName}-servicea".Equals(c.AppModelResourceName) && c.Name().Contains(suffix)));
+        var env = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redis"));
         Assert.Equal("localhost:1234", env.Value);
 
         var list = await s.ListAsync<Container>().DefaultTimeout();
-        var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(),$"redis-{ReplicaIdRegex}-{suffix}"))) ;
+        var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(),$"{testName}-redis-{ReplicaIdRegex}-{suffix}"))) ;
         Assert.Equal(1234, Assert.Single(redisContainer.Spec.Ports!).HostPort);
 
-        var otherRedisEnv = Assert.Single(service.Spec.Env!.Where(e => e.Name == "ConnectionStrings__redisNoPort"));
+        var otherRedisEnv = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redisNoPort"));
         Assert.Equal("localhost:6379", otherRedisEnv.Value);
 
-        var otherRedisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"redisNoPort-{ReplicaIdRegex}-{suffix}")));
+        var otherRedisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redisNoPort-{ReplicaIdRegex}-{suffix}")));
         Assert.Equal(6379, Assert.Single(otherRedisContainer.Spec.Ports!).HostPort);
 
         await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
@@ -938,18 +953,19 @@ public class DistributedApplicationTests
     [RequiresDocker]
     public async Task WithEndpointProxySupportDisablesProxies()
     {
+        const string testName = "endpoint-proxy-support";
         using var builder = TestDistributedApplicationBuilder.Create();
 
 #pragma warning disable ASPIREPROXYENDPOINTS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        var redis = builder.AddRedis("redis", 1234).WithEndpointProxySupport(false);
+        var redis = builder.AddRedis($"{testName}-redis", 1234).WithEndpointProxySupport(false);
 #pragma warning restore ASPIREPROXYENDPOINTS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         // Since port is not specified, this instance will use the container target port (6379) as the host port.
 #pragma warning disable ASPIREPROXYENDPOINTS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        var redisNoPort = builder.AddRedis("redisNoPort").WithEndpointProxySupport(false);
+        var redisNoPort = builder.AddRedis($"{testName}-redisNoPort").WithEndpointProxySupport(false);
 #pragma warning restore ASPIREPROXYENDPOINTS001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-        var servicea = builder.AddProject<Projects.ServiceA>("servicea")
+        var servicea = builder.AddProject<Projects.ServiceA>($"{testName}-servicea")
             .WithReference(redis)
             .WithReference(redisNoPort);
 
@@ -972,18 +988,18 @@ public class DistributedApplicationTests
 
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
         Assert.NotNull(suffix);
-        var service = Assert.Single(exeList.Where(c => "servicea".Equals(c.AppModelResourceName) && c.Name().Contains(suffix)));
-        var env = Assert.Single(service.Spec.Env!.Where(e => e.Name == "ConnectionStrings__redis"));
+        var service = Assert.Single(exeList.Where(c => $"{testName}-servicea".Equals(c.AppModelResourceName) && c.Name().Contains(suffix)));
+        var env = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redis"));
         Assert.Equal("localhost:1234", env.Value);
 
         var list = await s.ListAsync<Container>().DefaultTimeout();
-        var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(),$"redis-{ReplicaIdRegex}-{suffix}"))) ;
+        var redisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(),$"{testName}-redis-{ReplicaIdRegex}-{suffix}"))) ;
         Assert.Equal(1234, Assert.Single(redisContainer.Spec.Ports!).HostPort);
 
-        var otherRedisEnv = Assert.Single(service.Spec.Env!.Where(e => e.Name == "ConnectionStrings__redisNoPort"));
+        var otherRedisEnv = Assert.Single(service.Spec.Env!.Where(e => e.Name == $"ConnectionStrings__{testName}-redisNoPort"));
         Assert.Equal("localhost:6379", otherRedisEnv.Value);
 
-        var otherRedisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"redisNoPort-{ReplicaIdRegex}-{suffix}")));
+        var otherRedisContainer = Assert.Single(list.Where(c => Regex.IsMatch(c.Name(), $"{testName}-redisNoPort-{ReplicaIdRegex}-{suffix}")));
         Assert.Equal(6379, Assert.Single(otherRedisContainer.Spec.Ports!).HostPort);
 
         await app.StopAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
@@ -994,9 +1010,10 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task ProxylessContainerWithoutPortThrows()
     {
+        const string testName = "proxyless-container-without-ports";
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        var redis = builder.AddContainer("dummyRedis", "redis").WithEndpoint("tcp", endpoint =>
+        var redis = builder.AddContainer($"{testName}-redis", "redis").WithEndpoint("tcp", endpoint =>
         {
             endpoint.IsProxied = false;
         });
@@ -1005,7 +1022,7 @@ public class DistributedApplicationTests
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync()).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
-        Assert.Equal($"The endpoint 'tcp' for container resource 'dummyRedis-{suffix}' must specify the TargetPort value", ex.Message);
+        Assert.Equal($"The endpoint 'tcp' for container resource '{testName}-redis-{suffix}' must specify the TargetPort value", ex.Message);
     }
 
     [Fact]
@@ -1013,9 +1030,10 @@ public class DistributedApplicationTests
     [ActiveIssue("https://github.com/dotnet/aspire/issues/4651", typeof(PlatformDetection), nameof(PlatformDetection.IsRunningOnCI))]
     public async Task AfterResourcesCreatedLifecycleHookWorks()
     {
+        const string testName = "lifecycle-hook-after-resource-created";
         using var builder = TestDistributedApplicationBuilder.Create();
 
-        builder.AddRedis("redis");
+        builder.AddRedis($"{testName}-redis");
         builder.Services.TryAddLifecycleHook<KubernetesTestLifecycleHook>();
 
         using var app = builder.Build();
@@ -1051,11 +1069,13 @@ public class DistributedApplicationTests
     }
 
     private static TestProgram CreateTestProgram(
+        string testName,
         string[]? args = null,
         bool includeIntegrationServices = false,
         bool disableDashboard = true,
         bool randomizePorts = true) =>
         TestProgram.Create<DistributedApplicationTests>(
+            testName,
             args,
             includeIntegrationServices: includeIntegrationServices,
             disableDashboard: disableDashboard,

--- a/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
+++ b/tests/Aspire.Hosting.Tests/DistributedApplicationTests.cs
@@ -767,7 +767,7 @@ public class DistributedApplicationTests
 
         await using var app = testProgram.Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync()).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout));
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
         Assert.Equal($"Resource '{testName}-servicea-{suffix}' uses multiple replicas and a proxy-less endpoint 'http'. These features do not work together.", ex.Message);
     }
@@ -787,7 +787,7 @@ public class DistributedApplicationTests
 
         await using var app = testProgram.Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync()).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout));
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
         Assert.Equal($"Service '{testName}-servicea-{suffix}' needs to specify a port for endpoint 'http' since it isn't using a proxy.", ex.Message);
     }
@@ -1020,7 +1020,7 @@ public class DistributedApplicationTests
 
         using var app = builder.Build();
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => app.StartAsync()).DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await app.StartAsync().DefaultTimeout(TestConstants.DefaultOrchestratorTestTimeout));
         var suffix = app.Services.GetRequiredService<IOptions<DcpOptions>>().Value.ResourceNameSuffix;
         Assert.Equal($"The endpoint 'tcp' for container resource '{testName}-redis-{suffix}' must specify the TargetPort value", ex.Message);
     }


### PR DESCRIPTION
This change does 3 things

1. Stops killing DCP process when `DcpExecutor.RunApplicationAsync()` throws (which makes some `DistributedApplicationExecutor` tests hang).
2. Makes `DistributedApplicationExecutor` tests use unique names for resources they create (in particular, Containers). This should help diagnose any leaking resources.
3. Disposes of DcpExecutor when `DistributedApplication` is disposed. This means only executing tests have DCP instances running, and as soon as a test completes, the associated DCP instance goes through the shutdown. This in turn minimizes resource consumption on the machine, in particular there will be less Docker containers/networks at any given time.