### PR TITLE
Fix AddConnectionString for tests

### DIFF
--- a/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ParameterResource.cs
@@ -6,7 +6,7 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <summary>
 /// Represents a parameter resource.
 /// </summary>
-public sealed class ParameterResource : Resource, IManifestExpressionProvider, IValueProvider
+public class ParameterResource : Resource, IManifestExpressionProvider, IValueProvider
 {
     private string? _value;
     private bool _hasValue;

--- a/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
+++ b/src/Aspire.Hosting/ApplicationModel/ResourceWithConnectionStringSurrogate.cs
@@ -3,14 +3,21 @@
 
 namespace Aspire.Hosting.ApplicationModel;
 
-internal sealed class ResourceWithConnectionStringSurrogate(ParameterResource innerResource, string? environmentVariableName) : IResourceWithConnectionString
+internal sealed class ResourceWithConnectionStringSurrogate : ParameterResource, IResourceWithConnectionString
 {
-    public string Name => innerResource.Name;
+    private readonly string? _environmentVariableName;
 
-    public ResourceAnnotationCollection Annotations => innerResource.Annotations;
+    public ResourceWithConnectionStringSurrogate(string name, Func<ParameterDefault?, string> callback, string? environmentVariableName) : base(name, callback, secret: true)
+    {
+        _environmentVariableName = environmentVariableName;
 
-    public string? ConnectionStringEnvironmentVariable => environmentVariableName;
+        IsConnectionString = true;
+    }
+
+    string IManifestExpressionProvider.ValueExpression => $"{{{Name}.connectionString}}";
+
+    public string? ConnectionStringEnvironmentVariable => _environmentVariableName;
 
     public ReferenceExpression ConnectionStringExpression =>
-        ReferenceExpression.Create($"{innerResource}");
+        ReferenceExpression.Create($"{this}");
 }

--- a/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
+++ b/tests/Aspire.Hosting.Testing.Tests/TestingFactoryTests.cs
@@ -32,6 +32,15 @@ public class TestingFactoryTests(DistributedApplicationFixture<Projects.TestingA
 
     [Fact]
     [RequiresDocker]
+    public async Task CanGetConnectionStringFromAddConnectionString()
+    {
+        // Get a connection string from a resource
+        var connectionString = await _app.GetConnectionStringAsync("cs");
+        Assert.Equal("testconnection", connectionString);
+    }
+
+    [Fact]
+    [RequiresDocker]
     public void CanGetResources()
     {
         var appModel = _app.Services.GetRequiredService<DistributedApplicationModel>();

--- a/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
+++ b/tests/TestingAppHost1/TestingAppHost1.AppHost/Program.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+builder.Configuration["ConnectionStrings:cs"] = "testconnection";
+
+builder.AddConnectionString("cs");
 builder.AddRedis("redis1");
 builder.AddProject<Projects.TestingAppHost1_MyWebApp>("mywebapp1")
     .WithEndpoint("http", ea => ea.IsProxied = false)


### PR DESCRIPTION
## Description

- Calling AddConnectionString would add a parameter resource the wrap it in surrogate. That's fine if nothing looks at the "runtime type" and always looks at the contract. The testing infrastructure has a method GetConnectionStringAsync that takes a resource name and it explodes in this case since the runtime type does not implement IResourceWithConnectionString. This fixes it by implementing that adding the surrogate directly as a parameter resource.

- Added tests

Fixes #7138

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
- Did you add public API?
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [x] No
- Does the change require an update in our Aspire docs?
  - [x] No
