### PR TITLE
Periodically restart watching DCP resources to avoid event interruptions

### DIFF
--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -266,7 +266,7 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
                 restartCancellationToken);
         }, TimeSpan.FromMinutes(5));
 
-        await foreach (var item in result.ConfigureAwait(false))
+        await foreach (var item in result.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             yield return item;
         }

--- a/src/Aspire.Hosting/Dcp/KubernetesService.cs
+++ b/src/Aspire.Hosting/Dcp/KubernetesService.cs
@@ -270,38 +270,6 @@ internal sealed class KubernetesService(ILogger<KubernetesService> logger, IOpti
         {
             yield return item;
         }
-
-        /*
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            using var watchCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            watchCancellationSource.CancelAfter(TimeSpan.FromMinutes(5));
-
-            var result = await ExecuteWithRetry(
-                DcpApiOperationType.Watch,
-                resourceType,
-                (kubernetes) =>
-                {
-                    var responseTask = string.IsNullOrEmpty(namespaceParameter)
-                        ? kubernetes.CustomObjects.ListClusterCustomObjectWithHttpMessagesAsync(
-                            GroupVersion.Group,
-                            GroupVersion.Version,
-                            resourceType,
-                            watch: true,
-                            cancellationToken: watchCancellationSource.Token)
-                        : kubernetes.CustomObjects.ListNamespacedCustomObjectWithHttpMessagesAsync(
-                            GroupVersion.Group,
-                            GroupVersion.Version,
-                            namespaceParameter,
-                            resourceType,
-                            watch: true,
-                            cancellationToken: watchCancellationSource.Token);
-
-                    return responseTask.WatchAsync<T, object>(null, watchCancellationSource.Token);
-                },
-                RetryOnConnectivityAndConflictErrors,
-                watchCancellationSource.Token).ConfigureAwait(false);
-        }*/
     }
 
     public Task<Stream> GetLogStreamAsync<T>(

--- a/src/Aspire.Hosting/Utils/PeriodicRestartAsyncEnumerable.cs
+++ b/src/Aspire.Hosting/Utils/PeriodicRestartAsyncEnumerable.cs
@@ -73,7 +73,7 @@ internal static class PeriodicRestartAsyncEnumerable
     /// <param name="restartInterval">How often should we get a new enumerable from the factory</param>
     /// <param name="cancellationToken">Stop all enumeration once this is cancelled</param>
     /// <returns>An <see cref="IAsyncEnumerable{T}"/> of items returned by the inner iterables</returns>
-    public static async IAsyncEnumerable<T> CreateAsync<T>(Func<T?, CancellationToken, Task<IAsyncEnumerable<T>>> enumerableFactory, TimeSpan restartInterval, [EnumeratorCancellation] CancellationToken cancellationToken) where T : class
+    public static async IAsyncEnumerable<T> CreateAsync<T>(Func<T?, CancellationToken, Task<IAsyncEnumerable<T>>> enumerableFactory, TimeSpan restartInterval, [EnumeratorCancellation] CancellationToken cancellationToken) where T : class?
     {
         T? lastValue = null;
         while (!cancellationToken.IsCancellationRequested)

--- a/src/Aspire.Hosting/Utils/PeriodicRestartAsyncEnumerable.cs
+++ b/src/Aspire.Hosting/Utils/PeriodicRestartAsyncEnumerable.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Aspire.Hosting.Utils;
+
+/// <summary>
+/// An <see cref="IAsyncEnumerable{T}"/> that periodically restarts an inner enumerable after a timeout.
+/// We specifically need this for the DCP resource watch enumerable, as the WatchAsync call can be
+/// unreliable when running long enough (30+ minutes). The watch stops receiving new events, but
+/// no cancellation (or other exception) is thrown. The simple fix is to periodically restart the watch
+/// with the only downside being that we'll receive a duplicate of the latest resource state every time
+/// we re-enable the watch.
+/// </summary>
+/// <typeparam name="T">The inner enumerated type</typeparam>
+internal sealed class PeriodicRestartAsyncEnumerable<T> : IAsyncEnumerable<T>
+{
+    private readonly Func<CancellationToken, Task<IAsyncEnumerable<T>>> _enumerableFactory;
+    private readonly TimeSpan _restartTimeout;
+
+    /// <summary>
+    /// Creates an <see cref="IAsyncEnumerable{T}"/> that wraps an inner enumerable factory with periodic restart of the inner enumerable.
+    /// </summary>
+    /// <param name="enumerableFactory">A factory method that returns a new inner <see cref="IAsyncEnumerable{T}"/></param>
+    /// <param name="restartTimeout">How often should the inner enumerable be restarted</param>
+    public PeriodicRestartAsyncEnumerable(Func<CancellationToken, Task<IAsyncEnumerable<T>>> enumerableFactory, TimeSpan restartTimeout)
+    {
+        _enumerableFactory = enumerableFactory;
+        _restartTimeout = restartTimeout;
+    }
+
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        return new PeriodicRestartAsyncEnumerator(_enumerableFactory, _restartTimeout, cancellationToken);
+    }
+
+    public sealed class PeriodicRestartAsyncEnumerator : IAsyncEnumerator<T>
+    {
+        private readonly Func<CancellationToken, Task<IAsyncEnumerable<T>>> _enumerableFactory;
+        private readonly TimeSpan _restartTimeout;
+        private readonly CancellationToken _cancellationToken;
+        private IAsyncEnumerator<T>? _innerEnumerator;
+        private CancellationTokenSource? _restartCts;
+
+        public PeriodicRestartAsyncEnumerator(Func<CancellationToken, Task<IAsyncEnumerable<T>>> enumerableFactory, TimeSpan restartTimeout, CancellationToken cancellationToken)
+        {
+            _enumerableFactory = enumerableFactory;
+            _restartTimeout = restartTimeout;
+            _cancellationToken = cancellationToken;
+        }
+
+        public T Current => _innerEnumerator!.Current;
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Exchange(ref _restartCts, null)?.Dispose();
+            if (_innerEnumerator is not null)
+            {
+                return _innerEnumerator.DisposeAsync();
+            }
+            else
+            {
+                return ValueTask.CompletedTask;
+            }
+        }
+
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            if (_innerEnumerator == null)
+            {
+                var newRetryCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken);
+                var oldRetryCts = Interlocked.Exchange(ref _restartCts, newRetryCts);
+                oldRetryCts?.Cancel();
+                oldRetryCts?.Dispose();
+
+                newRetryCts.CancelAfter(_restartTimeout);
+                var enumerable = await _enumerableFactory(newRetryCts.Token).ConfigureAwait(false);
+                var oldEnumerator = Interlocked.Exchange(ref _innerEnumerator, enumerable.GetAsyncEnumerator(newRetryCts.Token));
+                if (oldEnumerator is not null)
+                {
+                    await oldEnumerator.DisposeAsync().ConfigureAwait(false);
+                }
+            }
+
+            try
+            {
+                return await _innerEnumerator.MoveNextAsync().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!_cancellationToken.IsCancellationRequested)
+            {
+                // If only the retry token cancelled, we want to restart enumerating the sequence
+                var newRetryCts = CancellationTokenSource.CreateLinkedTokenSource(_cancellationToken);
+                var oldRetryCts = Interlocked.Exchange(ref _restartCts, newRetryCts);
+                oldRetryCts?.Cancel();
+                oldRetryCts?.Dispose();
+
+                newRetryCts.CancelAfter(_restartTimeout);
+
+                var enumerable = await _enumerableFactory(newRetryCts.Token).ConfigureAwait(false);
+
+                await Interlocked.Exchange(ref _innerEnumerator, enumerable.GetAsyncEnumerator(newRetryCts.Token)).DisposeAsync().ConfigureAwait(false);
+
+                return await _innerEnumerator.MoveNextAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Aspire.Hosting/Utils/PeriodicRestartAsyncEnumerable.cs
+++ b/src/Aspire.Hosting/Utils/PeriodicRestartAsyncEnumerable.cs
@@ -52,7 +52,8 @@ internal sealed class PeriodicRestartAsyncEnumerable<T> : IAsyncEnumerable<T>
 
         public ValueTask DisposeAsync()
         {
-            Interlocked.Exchange(ref _restartCts, null)?.Dispose();
+            _restartCts?.Dispose();
+            _restartCts = null;
             if (_innerEnumerator is not null)
             {
                 return _innerEnumerator.DisposeAsync();

--- a/tests/Aspire.Hosting.Tests/Utils/PeriodicRestartAsyncEnumerableTests.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/PeriodicRestartAsyncEnumerableTests.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Aspire.Hosting.Utils;
+using Xunit;
+
+namespace Aspire.Hosting.Tests.Utils;
+
+public class PeriodicRestartAsyncEnumerableTests
+{
+    [Fact]
+    public async Task CancellingMainTokenCancelsEnumerable()
+    {
+        using var cts = new CancellationTokenSource();
+        var enumerable = new PeriodicRestartAsyncEnumerable<int>((cancellationToken) => Task.FromResult(RepeatingAsyncEnumerable(1, TimeSpan.FromMilliseconds(10), cancellationToken)), TimeSpan.FromMilliseconds(750));
+        cts.CancelAfter(TimeSpan.FromMilliseconds(250));
+        var start = DateTime.UtcNow;
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in enumerable.WithCancellation(cts.Token))
+            {
+                if (DateTime.UtcNow - start > TimeSpan.FromMilliseconds(500))
+                {
+                    Assert.Fail("expected cancellation before 500ms");
+                }
+            }
+        });
+    }
+
+    private static int s_totalEnumerablesRun;
+    private static int s_activeRunningEnumerables;
+
+    [Fact]
+    public async Task EnumerableIsRecreatedPeriodically()
+    {
+        using var cts = new CancellationTokenSource();
+        var enumerable = new PeriodicRestartAsyncEnumerable<int>((cancellationToken) => Task.FromResult(CountingAsyncEnumerable(1, TimeSpan.FromMilliseconds(10), cancellationToken)), TimeSpan.FromMilliseconds(100));
+        cts.CancelAfter(TimeSpan.FromMilliseconds(300));
+        var start = DateTime.UtcNow;
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var _ in enumerable.WithCancellation(cts.Token))
+            {
+                if (DateTime.UtcNow - start > TimeSpan.FromMilliseconds(500))
+                {
+                    Assert.Fail("expected cancellation before 500ms");
+                }
+            }
+        });
+
+        Assert.True(s_totalEnumerablesRun > 1, "expected additional iteration runs");
+        Assert.True(s_activeRunningEnumerables == 0, "expected all enumerables to be ended after cancellation");
+    }
+
+    static async IAsyncEnumerable<int> RepeatingAsyncEnumerable(int value, TimeSpan delay, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            yield return value;
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    static async IAsyncEnumerable<int> CountingAsyncEnumerable(int value, TimeSpan delay, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref s_totalEnumerablesRun);
+        Interlocked.Increment(ref s_activeRunningEnumerables);
+
+        try
+        {
+            await foreach (var innerValue in RepeatingAsyncEnumerable(value, delay, cancellationToken))
+            {
+                yield return innerValue;
+            }
+        }
+        finally
+        {
+            Interlocked.Decrement(ref s_activeRunningEnumerables);
+        }
+    }
+}

--- a/tests/Aspire.Hosting.Tests/Utils/PeriodicRestartAsyncEnumerableTests.cs
+++ b/tests/Aspire.Hosting.Tests/Utils/PeriodicRestartAsyncEnumerableTests.cs
@@ -13,16 +13,18 @@ public class PeriodicRestartAsyncEnumerableTests
     public async Task CancellingMainTokenCancelsEnumerable()
     {
         using var cts = new CancellationTokenSource();
-        var enumerable = new PeriodicRestartAsyncEnumerable<int>((cancellationToken) => Task.FromResult(RepeatingAsyncEnumerable(1, TimeSpan.FromMilliseconds(10), cancellationToken)), TimeSpan.FromMilliseconds(750));
-        cts.CancelAfter(TimeSpan.FromMilliseconds(250));
+        cts.CancelAfter(TimeSpan.FromSeconds(1));
         var start = DateTime.UtcNow;
+
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
-            await foreach (var _ in enumerable.WithCancellation(cts.Token))
+            var innerFactory = (int? lastValue, CancellationToken cancellationToken) => Task.FromResult(CountingAsyncEnumerable(0, TimeSpan.FromMilliseconds(50), cancellationToken));
+
+            await foreach (var _ in PeriodicRestartAsyncEnumerable.CreateAsync(innerFactory, restartInterval: TimeSpan.FromSeconds(2), cancellationToken: cts.Token).ConfigureAwait(false))
             {
-                if (DateTime.UtcNow - start > TimeSpan.FromMilliseconds(500))
+                if (DateTime.UtcNow - start > TimeSpan.FromSeconds(2))
                 {
-                    Assert.Fail("expected cancellation before 500ms");
+                    Assert.Fail("expected cancellation after 1 second");
                 }
             }
         });
@@ -35,16 +37,17 @@ public class PeriodicRestartAsyncEnumerableTests
     public async Task EnumerableIsRecreatedPeriodically()
     {
         using var cts = new CancellationTokenSource();
-        var enumerable = new PeriodicRestartAsyncEnumerable<int>((cancellationToken) => Task.FromResult(CountingAsyncEnumerable(1, TimeSpan.FromMilliseconds(10), cancellationToken)), TimeSpan.FromMilliseconds(100));
-        cts.CancelAfter(TimeSpan.FromMilliseconds(300));
+        cts.CancelAfter(TimeSpan.FromSeconds(1));
         var start = DateTime.UtcNow;
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
         {
-            await foreach (var _ in enumerable.WithCancellation(cts.Token))
+            var innerFactory = (int? lastValue, CancellationToken cancellationToken) => Task.FromResult(RefCountingAsyncEnumerable(0, TimeSpan.FromMilliseconds(10), cancellationToken));
+
+            await foreach (var _ in PeriodicRestartAsyncEnumerable.CreateAsync(innerFactory, restartInterval: TimeSpan.FromMilliseconds(100), cancellationToken: cts.Token).ConfigureAwait(false))
             {
-                if (DateTime.UtcNow - start > TimeSpan.FromMilliseconds(500))
+                if (DateTime.UtcNow - start > TimeSpan.FromSeconds(2))
                 {
-                    Assert.Fail("expected cancellation before 500ms");
+                    Assert.Fail("expected cancellation after 1 second");
                 }
             }
         });
@@ -53,25 +56,26 @@ public class PeriodicRestartAsyncEnumerableTests
         Assert.True(s_activeRunningEnumerables == 0, "expected all enumerables to be ended after cancellation");
     }
 
-    static async IAsyncEnumerable<int> RepeatingAsyncEnumerable(int value, TimeSpan delay, [EnumeratorCancellation] CancellationToken cancellationToken)
+    static async IAsyncEnumerable<int> CountingAsyncEnumerable(int start, TimeSpan delay, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        var value = start;
         while (!cancellationToken.IsCancellationRequested)
         {
-            yield return value;
+            yield return value++;
             await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
         }
 
         cancellationToken.ThrowIfCancellationRequested();
     }
 
-    static async IAsyncEnumerable<int> CountingAsyncEnumerable(int value, TimeSpan delay, [EnumeratorCancellation] CancellationToken cancellationToken)
+    static async IAsyncEnumerable<int> RefCountingAsyncEnumerable(int start, TimeSpan delay, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         Interlocked.Increment(ref s_totalEnumerablesRun);
         Interlocked.Increment(ref s_activeRunningEnumerables);
 
         try
         {
-            await foreach (var innerValue in RepeatingAsyncEnumerable(value, delay, cancellationToken))
+            await foreach (var innerValue in CountingAsyncEnumerable(start, delay, cancellationToken).ConfigureAwait(false))
             {
                 yield return innerValue;
             }


### PR DESCRIPTION
## Description

It turns out that the Kubernetes client watch call can periodically stop responding if left running long enough (15+ minutes). No cancellation is thrown, but the watch connection simply stops receiving any new resource state from DCP. A simple workaround is to periodically restart the watch stream on a reasonable interval. This does result in duplicate state being received (the latest state will be returned by the watch stream when re-initialized even if that status has already been processed by Aspire, our event handling should be resilient enough to deal with this without an issue).

Fixes #7167

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
    - If yes, did you have an API Review for it?
      - [ ] Yes
      - [ ] No
    - Did you add `<remarks />` and `<code />` elements on your triple slash comments?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change make any security assumptions or guarantees?
  - [ ] Yes
    - If yes, have you done a threat model and had a security review?
      - [ ] Yes
      - [ ] No
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
    - Is this introducing a breaking change?
      - [ ] Yes
        - Link to aspire-docs issue (please use this [`breaking-change` template](https://github.com/dotnet/docs-aspire/issues/new?template=04-breaking-change.yml)):
      - [ ] No
        - Link to aspire-docs issue (please use this [`doc-idea` template](https://github.com/dotnet/docs-aspire/issues/new?template=02-docs-request.yml)):
  - [x] No
